### PR TITLE
Some style for the progressbar

### DIFF
--- a/media/css/style.css
+++ b/media/css/style.css
@@ -96,6 +96,8 @@ td.toolbar a {
 div.progress {
     width: 20em;
     height: 1em;
+    background: #ddd;
+    border: 1px solid #aaa;
 }
 span.plural {
     font-size: smaller;


### PR DESCRIPTION
The progress bars for the language statistics appear to be open-ended, which IMO is not visually pleasing. Here I've added a border around the whole progress bar and some background for the "untranslated" part of the bar.
