### PR TITLE
Use unittest2 to support testing with Python26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-registration>=0.8
 Whoosh>=2.3
 Translate-Toolkit>=1.9.0
 lxml>=3.1.0
+unittest2

--- a/trans/tests/machine.py
+++ b/trans/tests/machine.py
@@ -21,7 +21,7 @@
 from django.test import TestCase
 from trans.tests.views import ViewTestCase
 from trans.models.unit import Unit
-import unittest
+import unittest2
 from trans.machine.dummy import DummyTranslation
 from trans.machine.glosbe import GlosbeTranslation
 from trans.machine.mymemory import MyMemoryTranslation
@@ -73,7 +73,7 @@ class MachineTranslationTest(TestCase):
         machine = ApertiumTranslation()
         self.assertIsInstance(machine.translate('es', 'world', None), list)
 
-    @unittest.skipUnless(microsoft_translation_supported(),
+    @unittest2.skipUnless(microsoft_translation_supported(),
                          'missing credentials')
     def test_microsoft(self):
         machine = MicrosoftTranslation()


### PR DESCRIPTION
When running the test, I get a ton a failures:

```
Ran 975 tests in 479.136s
FAILED (failures=65, errors=57, skipped=3)
```

Is this normal?
