### PR TITLE
Use less intrusive style for displaying unit flags

### DIFF
--- a/weblate/html/translate.html
+++ b/weblate/html/translate.html
@@ -139,7 +139,7 @@
 {% if unit.flags %}
 <tr>
 <th>{% trans "Flags" %}</th>
-<td>{{ unit.flags }}</td>
+<td><span class="legend">{{ unit.flags }}</span></td>
 </tr>
 {% endif %}
 <tr><td></td><td>


### PR DESCRIPTION
Those usually are not main priority for translators, so the goal is to focus more on comments and file location hints. Legend seems like a nice fit with smaller text and gray color instead of black, but of course it slightly kills semantics.

Another issue i currently have with this is how ugly it looks. For instance, a .po line like this

``` po
#, fuzzy, python-format
```

doesn't add much value by showing the (pretty confusing) `#,` which in this case looks like a list of three items.
1. Do we need to display `fuzzy` as flag again even if we have the checkbox right on top of it?
2. Can the `#,` be dropped or does this break other formats (haven't checked the ttk code there)?
3. The multi-line thing outlined below

Consider

``` po
#, python-format
#, fuzzy
```

which shows as `Flags: #, python-format , #, fuzzy`
