### PR TITLE
Improve display of unit flags, do not show `fuzzy` flag

### DIFF
--- a/trans/formats.py
+++ b/trans/formats.py
@@ -94,7 +94,9 @@ class FileUnit(object):
         # Remove '#, ' prefix for nicer display
         # (can be present more than once due to multiple lines joined)
         flags = flags.replace('#, ', '')
-        return flags
+        # Split and join again to find and remove 'fuzzy'
+        flags = flags.split(',')
+        return ', '.join(f.strip() for f in flags if f != 'fuzzy')
 
     def get_comments(self):
         '''


### PR DESCRIPTION
Relates to #275 and #276 and hopefully addresses both. It's quite a bit of code for this small feature now, but I hope it won't be called that often.
Not sure how to update the stores in question either, I tested this by repeatedly applying changes to strings. If there is a way of "refreshing" what is displayed without changing the translation, should it be triggered for this change?
