### PR TITLE
autofix: fix ReplaceTrailingDotsWithEllipsis to accept empty source strings

### DIFF
--- a/trans/autofixes/chars.py
+++ b/trans/autofixes/chars.py
@@ -30,7 +30,7 @@ class ReplaceTrailingDotsWithEllipsis(AutoFix):
     name = _('Trailing ellipsis')
 
     def fix_single_target(self, target, source, unit):
-        if (len(source) > 0 and source[-1] == u'…' and target.endswith('...')):
+        if (source and source[-1] == u'…' and target.endswith('...')):
             return u'%s…' % target[:-3], True
         return target, False
 


### PR DESCRIPTION
Having the ReplaceTrailingDotsWithEllipsis autofix enabled results in an _IndexError: string index out of range_ error whenever an empty source string is used (which is unlikely, but not technically impossible).

This patch solves this problem by first checking for non-emptiness of the source string.
