### PR TITLE
checks: fix empty source and target strings causing exceptions.

### DIFF
--- a/trans/checks/base.py
+++ b/trans/checks/base.py
@@ -65,10 +65,11 @@ class Check(object):
         '''
         Generic checker for chars presence.
         '''
-        if len(target) == 0 or len(source) == 0:
+        try:
+            src = source[pos]
+            tgt = target[pos]
+        except:
             return False
-        src = source[pos]
-        tgt = target[pos]
         return (
             (src in chars and tgt not in chars)
             or (src not in chars and tgt in chars)

--- a/trans/checks/chars.py
+++ b/trans/checks/chars.py
@@ -81,9 +81,9 @@ class EndSpaceCheck(TargetCheck):
         # One letter things are usually decimal/thousand separators
         if len(source) <= 1 and len(target) <= 1:
             return False
-        if self.is_language(unit, ['fr', 'br']):
-            if len(target) == 0:
+        if not source or not target:
                 return False
+        if self.is_language(unit, ['fr', 'br']):
             if source[-1] in [':', '!', '?'] and target[-1] == ' ':
                 return False
 
@@ -105,6 +105,8 @@ class EndStopCheck(TargetCheck):
 
     def check_single(self, source, target, unit, cache_slot):
         if len(source) <= 4 and len(target) <= 4:
+            return False
+        if not source:
             return False
         if self.is_language(unit, ['ja']) and source[-1] in [':', ';']:
             # Japanese sentence might need to end with full stop
@@ -136,9 +138,9 @@ class EndColonCheck(TargetCheck):
     colon_fr = (' :', '&nbsp;:', u' :')
 
     def check_single(self, source, target, unit, cache_slot):
+        if not source or not target:
+            return False
         if self.is_language(unit, ['fr', 'br']):
-            if len(target) == 0 or len(source) == 0:
-                return False
             if source[-1] == ':':
                 # Accept variant with trailing space as well
                 if target[-1] == ' ':
@@ -176,7 +178,7 @@ class EndQuestionCheck(TargetCheck):
     question_el = ('?', ';', ';')
 
     def check_single(self, source, target, unit, cache_slot):
-        if len(target) == 0 or len(source) == 0:
+        if not source or not target:
             return False
         if self.is_language(unit, ['fr', 'br']):
             if source[-1] != '?':
@@ -209,15 +211,13 @@ class EndExclamationCheck(TargetCheck):
     exclamation_fr = (' !', '&nbsp;!', u' !', ' ! ', '&nbsp;! ', u' ! ')
 
     def check_single(self, source, target, unit, cache_slot):
-        if len(source) == 0:
+        if not source or not target:
             return False
         if self.is_language(unit, ['eu']):
             if source[-1] == '!':
                 if u'¡' in target and u'!' in target:
                     return False
         if self.is_language(unit, ['fr', 'br']):
-            if len(target) == 0:
-                return False
             if source[-1] == '!':
                 if target[-2:] not in self.exclamation_fr:
                     return True
@@ -239,6 +239,8 @@ class EndEllipsisCheck(TargetCheck):
     description = _('Source and translation do not both end with an ellipsis')
 
     def check_single(self, source, target, unit, cache_slot):
+        if not target:
+            return False
         # Allow ... to be translated into ellipsis
         if source.endswith('...') and target[-1] == u'…':
             return False


### PR DESCRIPTION
Things went wrong when taking the last character of an empty string in trans.checks.chars, which would throw an IndexError. That has also been causing nijel/weblate#320.

trans.checks.base does not check the positions it receives either, so might throw an IndexError as well (although I have not observed that yet). Since positions can be quite complex (positive, negative and lists of both), I opted for a try/catch approach for graceful degradation.
