### PR TITLE
Mail sender should not use submitter's email address

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -64,7 +64,7 @@ def mail_admins_sender(subject, message, sender, fail_silently=False,
 
     mail = EmailMultiAlternatives(
         u'%s%s' % (settings.EMAIL_SUBJECT_PREFIX, subject),
-        message, sender, [a[1] for a in settings.ADMINS],
+        message, settings.DEFAULT_FROM_EMAIL, [a[1] for a in settings.ADMINS],
         connection=connection
     )
 


### PR DESCRIPTION
This is a quick fix.

Any better approach?

Either `settings.DEFAULT_FROM_EMAIL` or `settings.SERVER_EMAIL`
