### PR TITLE
Added python-dev to list of required packages for pip installation.

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -94,20 +94,20 @@ Most requirements can be also installed using pip installer:
 
     pip install -r requirements.txt
 
-Also you will need header files for ``libxml2`` and ``libxslt`` to compile some
-of the required Python modules.
+Also you will need header files for ``python-dev``, ``libxml2`` and ``libxslt`` to compile some
+of the required Python modules. 
 
 On Debian or Ubuntu you can install them using:
 
 .. code-block:: sh
 
-    apt-get install libxml2-dev libxslt-dev
+    apt-get install libxml2-dev libxslt-dev python-dev
 
 On openSUSE or SLES you can install them using:
 
 .. code-block:: sh
 
-    zypper install libxslt-devel libxml2-devel
+    zypper install libxslt-devel libxml2-devel python-devel
 
 .. _file-permissions:
 


### PR DESCRIPTION
Fixes  #451, at least for requirements.txt. 
