### PR TITLE
Fix test_create_android and other aresource-related tests

### DIFF
--- a/ttkit/aresource.py
+++ b/ttkit/aresource.py
@@ -41,7 +41,7 @@ class AndroidResourceUnit(base.TranslationUnit):
 
     @classmethod
     def createfromxmlElement(cls, element):
-        term = cls(None, xmlelement = element)
+        term = cls(None, xmlelement=element)
         return term
 
     def __init__(self, source, empty=False, xmlelement=None, **kwargs):
@@ -73,12 +73,12 @@ class AndroidResourceUnit(base.TranslationUnit):
         return self.xmlelement.get("name")
 
     def unescape(self, text):
-        '''
+        """
         Remove escaping from Android resource.
 
         Code stolen from android2po
         <https://github.com/miracle2k/android2po>
-        '''
+        """
         # Return text for empty elements
         if text is None:
             return ''
@@ -108,7 +108,7 @@ class AndroidResourceUnit(base.TranslationUnit):
                 if not active_quote or c is EOF:
                     # Replace by a single space, will get rid of
                     # non-significant newlines/tabs etc.
-                    text[i-space_count : i] = ' '
+                    text[i - space_count: i] = ' '
                     i -= space_count - 1
                 space_count = 0
             elif space_count == 1:
@@ -118,7 +118,7 @@ class AndroidResourceUnit(base.TranslationUnit):
                 # it will be considered significant on import. So,
                 # make sure that this kind of whitespace is always a
                 # standard space.
-                text[i-1] = ' '
+                text[i - 1] = ' '
                 space_count = 0
             else:
                 space_count = 0
@@ -158,16 +158,16 @@ class AndroidResourceUnit(base.TranslationUnit):
                         # in the clauses below without issue.
                         pass
                     elif c == 'n' or c == 'N':
-                        text[i-1 : i+1] = '\n' # an actual newline
+                        text[i - 1: i + 1] = '\n'  # an actual newline
                         i -= 1
                     elif c == 't' or c == 'T':
-                        text[i-1 : i+1] = '\t' # an actual tab
+                        text[i - 1: i + 1] = '\t'  # an actual tab
                         i -= 1
                     elif c == ' ':
-                        text[i-1 : i+1] = ' ' # an actual space
+                        text[i - 1: i + 1] = ' '  # an actual space
                         i -= 1
                     elif c in '"\'@':
-                        text[i-1 : i] = '' # remove the backslash
+                        text[i - 1: i] = ''  # remove the backslash
                         i -= 1
                     elif c == 'u':
                         # Unicode sequence. Android is nice enough to deal
@@ -180,10 +180,11 @@ class AndroidResourceUnit(base.TranslationUnit):
                         # prefixing the missing digits with zeros.
                         # Note: max(len()) is needed in the slice due to
                         # trailing ``None`` element.
-                        max_slice = min(i+5, len(text)-1)
-                        codepoint_str = "".join(text[i+1 : max_slice])
+                        max_slice = min(i + 5, len(text) - 1)
+                        codepoint_str = "".join(text[i + 1: max_slice])
                         if len(codepoint_str) < 4:
-                            codepoint_str = u"0" * (4-len(codepoint_str)) + codepoint_str
+                            codepoint_str = u"0" * (
+                                4 - len(codepoint_str)) + codepoint_str
                         try:
                             # We can't trust int() to raise a ValueError,
                             # it will ignore leading/trailing whitespace.
@@ -193,11 +194,11 @@ class AndroidResourceUnit(base.TranslationUnit):
                         except ValueError:
                             raise ValueError('bad unicode escape sequence')
 
-                        text[i-1 : max_slice] = codepoint
+                        text[i - 1: max_slice] = codepoint
                         i -= 1
                     else:
                         # All others, remove, like Android does as well.
-                        text[i-1 : i+1] = ''
+                        text[i - 1: i + 1] = ''
                         i -= 1
                     active_escape = False
 
@@ -207,9 +208,10 @@ class AndroidResourceUnit(base.TranslationUnit):
         return "".join(text[:-1])
 
     def escape(self, text, add_quote=True):
-        '''
-        Escape all the characters which need to be escaped in an Android XML file.
-        '''
+        """
+        Escape all the characters which need to be escaped in an Android XML
+        file.
+        """
         if text is None:
             return
         if len(text) == 0:
@@ -227,7 +229,10 @@ class AndroidResourceUnit(base.TranslationUnit):
         if text.startswith('@'):
             text = '\\@' + text[1:]
         # Quote strings with more whitespace
-        if add_quote and (text[0] in WHITESPACE or text[-1] in WHITESPACE or len(MULTIWHITESPACE.findall(text)) > 0):
+        if add_quote and (
+                            text[0] in WHITESPACE or text[-1] in WHITESPACE
+                or len(
+                        MULTIWHITESPACE.findall(text)) > 0):
             return '"%s"' % text
         return text
 
@@ -235,7 +240,7 @@ class AndroidResourceUnit(base.TranslationUnit):
         super(AndroidResourceUnit, self).setsource(source)
 
     def getsource(self, lang=None):
-        if (super(AndroidResourceUnit, self).source is None):
+        if super(AndroidResourceUnit, self).source is None:
             return self.target
         else:
             return super(AndroidResourceUnit, self).source
@@ -280,7 +285,9 @@ class AndroidResourceUnit(base.TranslationUnit):
         # Grab inner text
         target = self.unescape(self.xmlelement.text or u'')
         # Include markup as well
-        target += u''.join([data.forceunicode(etree.tostring(child, encoding='utf-8')) for child in self.xmlelement.iterchildren()])
+        target += u''.join(
+            [data.forceunicode(etree.tostring(child, encoding='utf-8')) for
+             child in self.xmlelement.iterchildren()])
         return target
 
     target = property(gettarget, settarget)
@@ -294,14 +301,15 @@ class AndroidResourceUnit(base.TranslationUnit):
             self.xmlelement.addprevious(etree.Comment(text))
         else:
             return super(AndroidResourceUnit, self).addnote(text, origin=origin,
-                                                 position=position)
+                                                            position=position)
 
     def getnotes(self, origin=None):
         if origin in ['programmer', 'developer', 'source code', None]:
             comments = []
-            if (self.xmlelement is not None):
+            if self.xmlelement is not None:
                 prevSibling = self.xmlelement.getprevious()
-                while ((prevSibling is not None) and (prevSibling.tag is etree.Comment)):
+                while ((prevSibling is not None) and (
+                            prevSibling.tag is etree.Comment)):
                     comments.insert(0, prevSibling.text)
                     prevSibling = prevSibling.getprevious()
 
@@ -310,9 +318,11 @@ class AndroidResourceUnit(base.TranslationUnit):
             return super(AndroidResourceUnit, self).getnotes(origin)
 
     def removenotes(self):
-        if ((self.xmlelement is not None) and (self.xmlelement.getparent is not None)):
+        if ((self.xmlelement is not None) and (
+                    self.xmlelement.getparent is not None)):
             prevSibling = self.xmlelement.getprevious()
-            while ((prevSibling is not None) and (prevSibling.tag is etree.Comment)):
+            while ((prevSibling is not None) and (
+                        prevSibling.tag is etree.Comment)):
                 prevSibling.getparent().remove(prevSibling)
                 prevSibling = self.xmlelement.getprevious()
 
@@ -323,7 +333,7 @@ class AndroidResourceUnit(base.TranslationUnit):
                               encoding='utf-8')
 
     def __eq__(self, other):
-        return (str(self) == str(other))
+        return str(self) == str(other)
 
 
 class AndroidResourceFile(lisa.LISAfile):


### PR DESCRIPTION
They were failing with NameError.

Example:

```
ERROR: test_import_aresource (weblate.trans.tests.test_commands.ImportProjectTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/tests/test_commands.py", line 89, in test_import_aresource
    base_file_template='android/values/strings.xml',
  File "/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 161, in call_command
    return klass.execute(*args, **defaults)
  File "/usr/lib/python2.7/site-packages/django/core/management/base.py", line 255, in execute
    output = self.handle(*args, **options)
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/management/commands/import_project.py", line 177, in handle
    options['file_format'], options['base_file_template']
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/management/commands/import_project.py", line 248, in import_initial
    filemask=filemask.replace('**', match)
  File "/usr/lib/python2.7/site-packages/django/db/models/manager.py", line 149, in create
    return self.get_query_set().create(**kwargs)
  File "/usr/lib/python2.7/site-packages/django/db/models/query.py", line 416, in create
    obj.save(force_insert=True, using=self.db)
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/subproject.py", line 1073, in save
    self.create_translations()
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/subproject.py", line 796, in create_translations
    self, code, path, force, request=request
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/translation.py", line 64, in check_sync
    translation.check_sync(force, request=request)
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/translation.py", line 530, in check_sync
    for unit in self.store.all_units():
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/translation.py", line 426, in store
    self._store = self.load_store()
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/translation.py", line 410, in load_store
    self.subproject.template_store
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/subproject.py", line 1156, in template_store
    self._template_store = self.load_template_store()
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/models/subproject.py", line 1143, in load_template_store
    self.get_template_filename(),
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/formats.py", line 349, in load
    return cls.parse_store(storefile)
  File "/home/vrusinov/PycharmProjects/weblate/weblate/trans/formats.py", line 359, in parse_store
    'ttkit.%s' % module_name
  File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/vrusinov/PycharmProjects/weblate/ttkit/aresource.py", line 328, in <module>
    class AndroidResourceFile(lisa.LISAfile):
  File "/home/vrusinov/PycharmProjects/weblate/ttkit/aresource.py", line 331, in AndroidResourceFile
    Name = _("Android String Resource")
NameError: name '_' is not defined
```
