### PR TITLE
Document an important limitation for Android format

### DIFF
--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -127,6 +127,8 @@ location than others :file:`res/values/strings.xml`.
     
     The `string-array` that points to the `string` elements should be stored in a different 
     file, and not localized.
+    
+    This script may help pre-process your existing strings.xml files and translations: https://gist.github.com/paour/11291062
 
 .. _apple:
 


### PR DESCRIPTION
And provide a script to pre-process strings.xml and existing translations to break `<string-array>` blocks into references to `<string>` elements.
