### PR TITLE
Fix link to install documentation, and update options requirement for easy pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ http://weblate.readthedocs.org/.
 Installation and setup instructions are provided in our manual, check
 quick setup guide:
 
-http://weblate.readthedocs.org/en/latest/quick.html
+http://weblate.readthedocs.org/en/latest/admin/quick.html
 
 ## Bugs
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,2 +1,4 @@
+-r requirements.txt
 PyICU
 pyLibravatar
+pydns


### PR DESCRIPTION
Fixed broken link in readme.
Added -r to include requirements.txt from requirements-optional.txt
Add pydns pyLibravatar depends on it but did not install it for me.
