### PR TITLE
Add JSON format

### DIFF
--- a/weblate/trans/formats.py
+++ b/weblate/trans/formats.py
@@ -780,6 +780,7 @@ class AndroidFormat(FileFormat):
 
 register_fileformat(AndroidFormat)
 
+
 class JSONFormat(FileFormat):
     name = _('JSON file')
     format_id = 'json'


### PR DESCRIPTION
In docs you wrote that formats from translate-toolkit also supported, but it seems that it need additional implementation. This small patch adds support for JSON files from translate-toolkit. I checked it with bunch of json key-value pairs files and it works.
I wrote some tests also, but not sure I did it correctly.
