### PR TITLE
Mention a dependency to libfreetype6.

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -98,20 +98,20 @@ Most requirements can be also installed using pip installer:
 
     pip install -r requirements.txt
 
-Also you will need header files for ``python-dev``, ``libxml2`` and ``libxslt``
-to compile some of the required Python modules.
+Also you will need header files for ``python-dev``, ``libxml2``, ``libxslt``
+and ``libfreetype6`` to compile some of the required Python modules.
 
 On Debian or Ubuntu you can install them using:
 
 .. code-block:: sh
 
-    apt-get install libxml2-dev libxslt-dev python-dev
+    apt-get install libxml2-dev libxslt-dev libfreetype6-dev python-dev
 
 On openSUSE or SLES you can install them using:
 
 .. code-block:: sh
 
-    zypper install libxslt-devel libxml2-devel python-devel
+    zypper install libxslt-devel libxml2-devel freetype-devel python-devel
 
 .. _file-permissions:
 


### PR DESCRIPTION
Libfreetype6 is essentially a dependency to compile Pillow with libfreetype support. Without this library, the activity graphs are broken and the following traceback appears in the logs:

```
  Traceback (most recent call last):
    File "/var/www/weblate-venv/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
      response = wrapped_callback(request, *callback_args, **callback_kwargs)
    File "/var/www/weblate/weblate/trans/views/charts.py", line 122, in monthly_activity
      return render_activity(activity)
    File "/var/www/weblate/weblate/trans/views/charts.py", line 52, in render_activity
      font = get_font(11)
    File "/var/www/weblate/weblate/trans/fonts.py", line 695, in get_font
      size
    File "/var/www/weblate-venv/local/lib/python2.7/site-packages/PIL/ImageFont.py", line 228, in truetype
      return FreeTypeFont(font, size, index, encoding)
    File "/var/www/weblate-venv/local/lib/python2.7/site-packages/PIL/ImageFont.py", line 131, in __init__
      self.font = core.getfont(font, size, index, encoding)
    File "/var/www/weblate-venv/local/lib/python2.7/site-packages/PIL/ImageFont.py", line 42, in __getattr__
      raise ImportError("The _imagingft C module is not installed")
  ImportError: The _imagingft C module is not installed
```
