### PR TITLE
ignore SublimeText files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ weblate-*.tar.*
 /tags
 /django
 .idea/*
+*.sublime-*
 /Weblate.egg-info/
 /build/


### PR DESCRIPTION
adds .gitignore rule for ignoring SublimeText files in project directory
