### PR TITLE
make South installation optional

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -33,7 +33,6 @@ from django.utils import translation as django_translation
 from django.template.loader import render_to_string
 from django.core.mail import EmailMultiAlternatives
 
-from south.signals import post_migrate
 from social.apps.django_app.default.models import UserSocialAuth
 
 from weblate.lang.models import Language
@@ -706,8 +705,6 @@ def remove_user(user):
     user.social_auth.all().delete()
 
 
-@receiver(post_syncdb)
-@receiver(post_migrate)
 def sync_create_groups(sender, app, **kwargs):
     '''
     Create groups on syncdb.
@@ -715,6 +712,11 @@ def sync_create_groups(sender, app, **kwargs):
     if (app == 'accounts'
             or getattr(app, '__name__', '') == 'weblate.accounts.models'):
         create_groups(False)
+
+post_syncdb.connect(sync_create_groups)
+if 'south' in settings.INSTALLED_APPS:
+    from south.signals import post_migrate
+    post_migrate.connect(sync_create_groups)
 
 
 @receiver(post_save, sender=User)

--- a/weblate/requirements.py
+++ b/weblate/requirements.py
@@ -24,6 +24,7 @@ from distutils.version import LooseVersion
 from weblate.trans.vcs import GitRepository
 import importlib
 import sys
+import django
 
 
 def get_version_module(module, name, url, optional=False):
@@ -139,13 +140,14 @@ def get_versions():
 
     name = 'South'
     url = 'http://south.aeracode.org/'
-    mod = get_version_module('south', name, url)
-    result.append((
-        name,
-        url,
-        mod.__version__,
-        '1.0',
-    ))
+    if django.VERSION < (1, 7, 0):
+        mod = get_version_module('south', name, url)
+        result.append((
+            name,
+            url,
+            mod.__version__,
+            '1.0',
+        ))
 
     name = 'Pillow (PIL)'
     url = 'http://python-imaging.github.io/'

--- a/weblate/trans/__init__.py
+++ b/weblate/trans/__init__.py
@@ -18,11 +18,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from south.signals import post_migrate
-from django.dispatch import receiver
+from django.conf import settings
 
 
-@receiver(post_migrate)
 def create_permissions_compat(app, **kwargs):
     '''
     Creates permissions like syncdb would if we were not using South
@@ -30,7 +28,6 @@ def create_permissions_compat(app, **kwargs):
     See http://south.aeracode.org/ticket/211
     '''
     from django.db.models import get_app, get_models
-    from django.conf import settings
     from django.contrib.auth.management import create_permissions
     if app in ('trans', 'lang', 'accounts'):
         try:
@@ -40,3 +37,7 @@ def create_permissions_compat(app, **kwargs):
         except AttributeError as error:
             # See https://code.djangoproject.com/ticket/20442
             print 'Failed to create permission objects: {0}'.format(error)
+
+if 'south' in settings.INSTALLED_APPS:
+    from south.signals import post_migrate
+    post_migrate.connect(create_permissions_compat)


### PR DESCRIPTION
South installation is optional for Django 1.7 and it is not in requirements.txt, yet south package still was required to be importable in source code. 
