### PR TITLE
add minimal oauthlib requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ lxml>=3.1.0
 Pillow
 python-dateutil
 python-social-auth>=0.1.17,<0.1.24
+oauthlib>=0.6.3


### PR DESCRIPTION
I get ImportError at /accounts/register/ and /account/login/

```
cannot import name is_secure_transport
../site-packages/requests_oauthlib/oauth2_auth.py in <module>, line 3
```

which seems to be related to https://github.com/requests/requests-oauthlib/issues/139
Upgrading `oauthlib` does help.
