### PR TITLE
Update install.rst

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -58,9 +58,12 @@ you can use apt-get:
 
     apt-get install python-requests-oauthlib python-six python-openid
 
+If you are running Debian jessie or above, you can install python-social-auth
+by executing 
 
-There is one library not available in Debian so far, so it is recommended to
-install it using pip:
+    apt-get install python-social-auth
+    
+For Debian 7.0 (wheezy) or older, it is recommended to install it using pip:
 
 .. code-block:: sh
 


### PR DESCRIPTION
python-social-auth is now available in the Debian repositories. 
# apt-cache policy python-social-auth

python-social-auth:
  Installed: (none)
  Candidate: 0.1.23+gita65b385769-1
  Version table:
     0.1.23+gita65b385769-1 0
        500 http://http.debian.net/debian/ jessie/main amd64 Packages

Note, I wasn't able to test this with Ubuntu, so this still needs to be updated with current Ubuntu information.
