### PR TITLE
Don't check optional deps on OpenShift.

### DIFF
--- a/weblate/requirements.py
+++ b/weblate/requirements.py
@@ -25,6 +25,7 @@ from weblate.trans.vcs import GitRepository, HgRepository
 import importlib
 import sys
 import django
+import os
 
 
 def get_version_module(module, name, url, optional=False):
@@ -224,7 +225,10 @@ def check_requirements():
     '''
     Performs check on requirements and raises an exception on error.
     '''
-    versions = get_versions() + get_optional_versions()
+    if not os.environ.has_key('OPENSHIFT_REPO_DIR'):
+        versions = get_versions() + get_optional_versions()
+    else:
+        versions = get_versions()
     failure = False
 
     for version in versions:


### PR DESCRIPTION
Hi Michal

Commit 9ad0514 requires certain versions of the optional dependencies even if they are not installed. Because OpenShift has a very old version of Mercurial preinstalled installation of Weblate now fails. Please find a possible fix in this pull request. Not sure if this is right way though.

Daniel
