### PR TITLE
Fix IndexError when no translation subprojects are defined

### DIFF
--- a/weblate/trans/management/commands/__init__.py
+++ b/weblate/trans/management/commands/__init__.py
@@ -57,6 +57,8 @@ class WeblateCommand(BaseCommand):
         Memory effective iteration over units.
         """
         units = self.get_units(*args, **options).order_by('pk')
+        if not units:
+            return
 
         current = 0
         last = units.order_by('-pk')[0].pk


### PR DESCRIPTION
Hi Michal

`manage.py rebuild_index --all` and probably other commands calling **iterate_units** fail with the following exception when no translation subprojects are defined:

<pre>
Traceback (most recent call last):
    File "/var/lib/openshift/547092145973caf7a700001c/app-root/runtime/repo//openshift/manage.py", line 33, in <module>
      execute_from_command_line(sys.argv)
    File "/var/lib/openshift/547092145973caf7a700001c/python/virtenv/lib/python2.7/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
      utility.execute()
    File "/var/lib/openshift/547092145973caf7a700001c/python/virtenv/lib/python2.7/site-packages/django/core/management/__init__.py", line 377, in execute
      self.fetch_command(subcommand).run_from_argv(self.argv)
    File "/var/lib/openshift/547092145973caf7a700001c/python/virtenv/lib/python2.7/site-packages/django/core/management/base.py", line 288, in run_from_argv
      self.execute(*args, **options.__dict__)
    File "/var/lib/openshift/547092145973caf7a700001c/python/virtenv/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
      output = self.handle(*args, **options)
    File "/var/lib/openshift/547092145973caf7a700001c/app-root/runtime/repo/weblate/trans/management/commands/rebuild_index.py", line 57, in handle
      for unit in self.iterate_units(*args, **options):
    File "/var/lib/openshift/547092145973caf7a700001c/app-root/runtime/repo/weblate/trans/management/commands/__init__.py", line 62, in iterate_units
      last = units.order_by('-pk')[0].pk
    File "/var/lib/openshift/547092145973caf7a700001c/python/virtenv/lib/python2.7/site-packages/django/db/models/query.py", line 177, in __getitem__
      return list(qs)[0]
  IndexError: list index out of range
</pre>


This pull request should fix this.

Kind regards
  Daniel
