### PR TITLE
[RFC - not to directly merge] First try on commands from API

### DIFF
--- a/weblate/api/urls.py
+++ b/weblate/api/urls.py
@@ -25,6 +25,9 @@ from django.conf.urls import url, include
 from weblate.api.views import (
     ProjectViewSet, ComponentViewSet, TranslationViewSet, LanguageViewSet,
 )
+from weblate.api.views import (
+    MaintenanceListView, MaintenanceActionView,
+)
 from weblate.api.routers import WeblateRouter
 
 # Routers provide an easy way of automatically determining the URL conf.
@@ -58,5 +61,16 @@ urlpatterns = [
     url(
         r'^api-auth/',
         include('rest_framework.urls', namespace='rest_framework')
-    )
+    ),
+]
+
+urlpatterns += [
+    url(
+        r"^maintenance/$",
+        MaintenanceListView.as_view({'get': 'list'}),
+    ),
+    url(
+        r"^maintenance/(?P<action>[\w_]+)/$",
+        MaintenanceActionView.as_view({'get': 'exec_manage'}),
+    ),
 ]


### PR DESCRIPTION
In the mailing list we discussed on launching some of the `manage.py` maintenance commands from the REST API. This schema has come to light in order to be able to deploy weblate on a cluster where we can only have a single writer worker.

This is a first quick approach and I would love feedback to know if I should go on this way. I will obviously do the tests and documentation but first I wanted some kind of feedback.

There is a missing feature of enabling tokenized auth on the `/api/maintenance/x` methods.
