### PR TITLE
Added support for django-cache-machine for most used models

### DIFF
--- a/ci/requirements-scrutinizer.txt
+++ b/ci/requirements-scrutinizer.txt
@@ -10,6 +10,7 @@ django-crispy-forms>=1.4.0
 oauthlib>=0.6.3
 django_compressor>=1.5.0,!=2.0
 djangorestframework>=3.3
+git+git://github.com/Vince300/django-cache-machine.git#egg=django-cache-machine
 # Copy of requirements-optional.txt without python_version modifiers
 pyuca>=1.1
 pyLibravatar

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ django-crispy-forms>=1.4.0
 oauthlib>=0.6.3
 django_compressor>=1.5.0,!=2.0
 djangorestframework>=3.3
+git+git://github.com/Vince300/django-cache-machine.git#egg=django-cache-machine

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -37,6 +37,7 @@ from weblate.trans.mixins import PercentMixin
 from weblate.appsettings import SIMPLIFY_LANGUAGES
 from weblate.logger import LOGGER
 
+from caching.base import CachingManager, CachingMixin
 
 def get_plural_type(code, pluralequation):
     '''
@@ -80,7 +81,7 @@ def get_english_lang():
         return 65535
 
 
-class LanguageManager(models.Manager):
+class LanguageManager(CachingManager):
     # pylint: disable=W0232
 
     _default_lang = None
@@ -365,7 +366,7 @@ def setup_lang(sender, **kwargs):
 
 
 @python_2_unicode_compatible
-class Language(models.Model, PercentMixin):
+class Language(models.Model, PercentMixin, CachingMixin):
     PLURAL_CHOICES = (
         (data.PLURAL_NONE, 'None'),
         (data.PLURAL_ONE_OTHER, 'One/other (classic plural)'),

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -42,6 +42,8 @@ from weblate.trans.mixins import PercentMixin, URLMixin, PathMixin
 from weblate.trans.site import get_site_url
 from weblate.trans.data import data_dir
 
+from caching.base import CachingManager, CachingMixin
+
 
 def get_acl_cache_key(user):
     """Returns key for per user ACL cache"""
@@ -52,7 +54,7 @@ def get_acl_cache_key(user):
     return ':'.join((user_id, 'useracl'))
 
 
-class ProjectManager(models.Manager):
+class ProjectManager(CachingManager):
     # pylint: disable=W0232
 
     def get_acl_ids(self, user):
@@ -80,7 +82,7 @@ class ProjectManager(models.Manager):
 
 
 @python_2_unicode_compatible
-class Project(models.Model, PercentMixin, URLMixin, PathMixin):
+class Project(models.Model, PercentMixin, URLMixin, PathMixin, CachingMixin):
     name = models.CharField(
         verbose_name=ugettext_lazy('Project name'),
         max_length=100,

--- a/weblate/trans/models/subproject.py
+++ b/weblate/trans/models/subproject.py
@@ -69,6 +69,7 @@ from weblate.accounts.models import (
 )
 from weblate.trans.models.changes import Change
 
+from caching.base import CachingManager, CachingMixin
 
 DEFAULT_COMMIT_MESSAGE = (
     'Translated using Weblate (%(language_name)s)\n\n'
@@ -96,7 +97,7 @@ MERGE_CHOICES = (
 )
 
 
-class SubProjectManager(models.Manager):
+class SubProjectManager(CachingManager):
     # pylint: disable=W0232
 
     def prefetch(self):
@@ -113,7 +114,7 @@ class SubProjectManager(models.Manager):
 
 
 @python_2_unicode_compatible
-class SubProject(models.Model, PercentMixin, URLMixin, PathMixin):
+class SubProject(models.Model, PercentMixin, URLMixin, PathMixin, CachingMixin):
     name = models.CharField(
         verbose_name=ugettext_lazy('Component name'),
         max_length=100,

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -51,8 +51,10 @@ from weblate.accounts.models import notify_new_string, get_author_name
 from weblate.trans.models.changes import Change
 from weblate.trans.checklists import TranslationChecklist
 
+from caching.base import CachingManager, CachingMixin
 
-class TranslationManager(models.Manager):
+
+class TranslationManager(CachingManager):
     # pylint: disable=W0232
 
     def prefetch(self):
@@ -122,7 +124,7 @@ class TranslationManager(models.Manager):
 
 
 @python_2_unicode_compatible
-class Translation(models.Model, URLMixin, PercentMixin, LoggerMixin):
+class Translation(models.Model, URLMixin, PercentMixin, LoggerMixin, CachingMixin):
     subproject = models.ForeignKey('SubProject')
     language = models.ForeignKey(Language)
     revision = models.CharField(max_length=100, default='', blank=True)

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -68,7 +68,6 @@ def more_like_queue(pk, source, top, queue):
     result = more_like(pk, source, top)
     queue.put(result)
 
-
 class UnitManager(models.Manager):
     # pylint: disable=W0232
 
@@ -465,10 +464,8 @@ class Unit(models.Model, LoggerMixin):
             return
 
         # Ensure we track source string
-        source_info, source_created = Source.objects.get_or_create(
-            checksum=self.checksum,
-            subproject=self.translation.subproject
-        )
+        source_info, source_created = \
+            Source.objects.get_by_checksum(self.checksum, self.translation.subproject)
         contentsum_changed = self.contentsum != contentsum
 
         # Store updated values
@@ -1053,10 +1050,10 @@ class Unit(models.Model, LoggerMixin):
         Returns related source string object.
         """
         if self._source_info is None:
-            self._source_info = Source.objects.get(
-                checksum=self.checksum,
-                subproject=self.translation.subproject
-            )
+            self._source_info = Source.objects.get_by_checksum(
+                self.checksum,
+                self.translation.subproject,
+                create=False)
         return self._source_info
 
     def get_secondary_units(self, user):


### PR DESCRIPTION
This PR is a potential fix for #1160. A few things to note:
- django-cache-machine requires a cache to be setup
- .values and .values_list is broken on Django 1.7+ with django-cache-machine, as described in https://github.com/django-cache-machine/django-cache-machine/issues/116. requirements.txt has been updated to use https://github.com/Vince300/django-cache-machine instead of the released version, but this fix is not generic.
