### PR TITLE
Apertium API keys not used any more

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -422,9 +422,9 @@ URL of the Apertium APy server, see http://wiki.apertium.org/wiki/Apertium-apy
 MT_APERTIUM_KEY
 ---------------
 
-API key for Apertium Web Service, you can register at http://api.apertium.org/register.jsp
+API key for Apertium Web Service, currently not used.
 
-Not needed when running own Apertium APy server.
+Not needed at all when running own Apertium APy server.
 
 .. seealso::
    

--- a/docs/admin/machine.rst
+++ b/docs/admin/machine.rst
@@ -35,8 +35,8 @@ limited set of languages.
 
 The recommended way how to use Apertium is to run own Apertium APy server.
 
-Alternatively you can use Apertium server, but you should get API key from
-them, otherwise number of requests is rate limited.
+Alternatively you can use https://www.apertium.org/apy if you don't expect 
+to make too many requests.
 
 To enable this service, add ``weblate.trans.machine.apertium.ApertiumAPYTranslation`` to
 :setting:`MACHINE_TRANSLATION_SERVICES`.


### PR DESCRIPTION
The old api (see http://wiki.apertium.org/wiki/Old_Apertium_web_service ) required keys, but the new one doesn't (it might in the future, but we haven't had any abuse so far). The old service might still run, sometimes, but it's recommended to either run your own APY server or use https://www.apertium.org/apy/ for single-users
