### PR TITLE
[FIX] serializers: Delete unnecesary True

### DIFF
--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -177,7 +177,7 @@ class ComponentSerializer(RemovableSerializer):
         """Remove VCS properties if user has no permission for that"""
         result = super(ComponentSerializer, self).to_representation(instance)
         user = self.context['request'].user
-        if not can_see_git_repository(user, instance.project) or True:
+        if not can_see_git_repository(user, instance.project):
             result['vcs'] = None
             result['repo'] = None
             result['branch'] = None


### PR DESCRIPTION
The code deleted `or True` causes that ever the response return an empty answer

```python
result['vcs'] = None
result['repo'] = None
result['branch'] = None
result['filemask'] = None
```
The comprobation of the permision is made on `not can_see_git_repository(user, instance.project)`

So the code `or True` is unnecessary