### PR TITLE
allow multiple commits with gerrit

### DIFF
--- a/weblate/trans/vcs.py
+++ b/weblate/trans/vcs.py
@@ -667,7 +667,7 @@ class GitWithGerritRepository(GitRepository):
 
     def push(self):
         try:
-            self.execute(['review'])
+            self.execute(['review', '--yes'])
         except RepositoryException as error:
             if error.retcode == 1:
                 # Nothing to push


### PR DESCRIPTION
'git review' needs --yes as an argument to push commits silently if there is more than one commit.

From ‘man git-review’: “-y, --yes : Indicate that you do, in fact, understand if you are submitting more than one patch.”
