### PR TITLE
Fix incorrect link to GitHub authentication.

### DIFF
--- a/docs/admin/deployments.rst
+++ b/docs/admin/deployments.rst
@@ -252,7 +252,7 @@ Authentication settings
 .. envvar:: WEBLATE_SOCIAL_AUTH_GITHUB_KEY
 .. envvar:: WEBLATE_SOCIAL_AUTH_GITHUB_SECRET
 
-    Enables :ref:`google_auth`.
+    Enables :ref:`github_auth`.
 
 .. envvar:: WEBLATE_SOCIAL_AUTH_BITBUCKET_KEY
 .. envvar:: WEBLATE_SOCIAL_AUTH_BITBUCKET_SECRET


### PR DESCRIPTION
Was a reference to google_auth but these vars are for GitHub.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
