### PR TITLE
differentiate between “Weblate” and “Weblate similarity” in machine translation table

### DIFF
--- a/weblate/trans/machine/weblatetm.py
+++ b/weblate/trans/machine/weblatetm.py
@@ -27,12 +27,12 @@ from weblate.trans.machine.base import MachineTranslation
 from weblate.trans.models.unit import Unit
 
 
-def format_unit_match(unit, quality):
+def format_unit_match(name, unit, quality):
     """Format unit to translation service result."""
     return (
         unit.get_target_plurals()[0],
         quality,
-        'Weblate ({0})'.format(force_text(unit.translation.subproject)),
+        '{0} ({1})'.format(force_text(name), force_text(unit.translation.subproject)),
         unit.get_source_plurals()[0],
     )
 
@@ -55,7 +55,7 @@ class WeblateTranslation(WeblateBase):
         matching_units = Unit.objects.same_source(unit)
 
         return [
-            format_unit_match(munit, 100)
+            format_unit_match(self.name, munit, 100)
             for munit in matching_units
             if can_access_project(user, munit.translation.subproject.project)
         ]
@@ -70,7 +70,7 @@ class WeblateSimilarTranslation(WeblateBase):
         matching_units = Unit.objects.more_like_this(unit)
 
         return [
-            format_unit_match(munit, 50)
+            format_unit_match(self.name, munit, 50)
             for munit in matching_units
             if can_access_project(user, munit.translation.subproject.project)
         ]


### PR DESCRIPTION
to get the difference of the two machine-translation-engines, show their names in the table instead of a static “Weblate”
