### PR TITLE
Changed hash algorithm from md5 to sha256

### DIFF
--- a/weblate/trans/ssh.py
+++ b/weblate/trans/ssh.py
@@ -77,7 +77,7 @@ def is_key_line(key):
 def parse_hosts_line(line):
     """Parse single hosts line into tuple host, key fingerprint."""
     host, keytype, key = line.strip().split(None, 3)[:3]
-    fp_plain = hashlib.md5(b64decode(key)).hexdigest()
+    fp_plain = hashlib.sha256(b64decode(key)).hexdigest()
     fingerprint = ':'.join(
         [a + b for a, b in zip(fp_plain[::2], fp_plain[1::2])]
     )


### PR DESCRIPTION
The b64decode function throws a binaascii.Error exception if the key isn't 4-padded. Since you haven't run into issues yet, I assumed the key is guaranteed to be correctly padded and didn't add extra checks.

Among the myriad of ways to hash a key using sha256, the one that works perfectly and makes the least possible changes to the existing code would be to merely replace hashlib.md5 with hashlib.sha256.
I've done so and unittested the function with varying key lengths (multiples of 4 obviously) and nothing breaks.

Also, sorry about the 3 commits. This is my first contribution to OSS and I didn't know about the sign-off necessity.