### PR TITLE
use msgcat for .po/.pot files diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,10 @@
 .gitattributes export-ignore
 scripts export-ignore
 appliance export-ignore
+
+# make .po/.pot files less noisy, need to configure git first:
+# $ git config diff.msgcat.textconv "msgcat --no-location --no-wrap --sort-output"
+# to enable caching in "notes/textconv/msgcat":
+# $ git config diff.msgcat.cachetextconv true
+*.pot diff=msgcat
+*.po diff=msgcat


### PR DESCRIPTION
adds diff filter for .po and .pot files.

before it can be used git needs to be configured:

```
git config diff.msgcat.textconv "msgcat --no-location --no-wrap --sort-output"
```

if you wish to cache callouts of msgcat in `notes/textconv/msgcat`:
```
git config diff.msgcat.cachetextconv true
```