### PR TITLE
Keep "SystemRoot" in get_clean_env()

### DIFF
--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -138,7 +138,7 @@ def get_clean_env(extra=None):
     }
     if extra is not None:
         environ.update(extra)
-    variables = ('PATH', 'LD_LIBRARY_PATH')
+    variables = ('PATH', 'LD_LIBRARY_PATH', 'SystemRoot')
     for var in variables:
         if var in os.environ:
             environ[var] = os.environ[var]


### PR DESCRIPTION
We are using a Windows server. For some reason Weblate was not able to call git. When updating the repository I got the following error:

```
ERROR webportal/trunk: failed to update repository: Error in GnuTLS initialization: Failed to acquire random data.
fatal: unable to access 'http://************:********@****************/translation.git/': Couldn't resolve host '************' (128)
```

Calling `git fetch origin` worked perfectly fine.
Allowing the environment variable *SystemRoot* to be passed to git solves this problem.

---

`python manage.py list_versions`returns the following list:

 * Weblate weblate-2.18-245-g4e3b780ee
 * Python 3.5.2
 * Django 2.0.1
 * six 1.11.0
 * social-auth-core 1.6.0
 * social-auth-app-django 2.1.0
 * django-appconf 1.0.2
 * Translate Toolkit 2.2.5
 * Whoosh 2.7.4
 * defusedxml 0.5.0
 * Git 2.11.0.windows.1
 * Pillow (PIL) 1.1.7
 * dateutil 2.6.1
 * lxml 4.1.1
 * django-crispy-forms 1.7.0
 * compressor 2.2
 * djangorestframework 3.7.7
 * user-agents 1.1.0
 * pytz 2017.3
 * git-svn 2.11.0.windows.1
 * Database backends: django.db.backends.mysql
