### PR TITLE
added visualization for machine translation score

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -256,15 +256,15 @@ function processMachineTranslation(data) {
             newRow.append($('<td/>').text(el.service));
             /* Quality score as bar with the text */
             newRow.append($(
-                '<td>' + 
-                '<div class="progress">' +
-                '<div class="progress-bar ' + 
+                '<td>' +
+                '<div class="progress" title="' + el.quality + ' / 100">' +
+                '<div class="progress-bar ' +
                 ( el.quality >= 70 ? 'progress-bar-success' : el.quality >= 50 ? 'progress-bar-warning' : 'progress-bar-danger' ) + '"' +
                 ' role="progressbar" aria-valuenow="' + el.quality + '"' +
-                ' aria-valuemin="0" aria-valuemax="100" style="width: ' + el.quality + '%;" title="' + el.quality + '%"></div>' +
+                ' aria-valuemin="0" aria-valuemax="100" style="width: ' + el.quality + '%;"></div>' +
                 '</div>' +
                 '</td>'
-            ));            
+            ));
             /* Translators: Verb for copy operation */
             newRow.append($(
                 '<td>' +

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -254,6 +254,17 @@ function processMachineTranslation(data) {
             newRow.append($('<td/>').attr('class', 'target').attr('lang', data.lang).attr('dir', data.dir).text(el.text));
             newRow.append($('<td/>').text(el.source));
             newRow.append($('<td/>').text(el.service));
+            /* Quality score as bar with the text */
+            newRow.append($(
+                '<td>' + 
+                '<div class="progress">' +
+                '<div class="progress-bar ' + 
+                ( el.quality >= 70 ? 'progress-bar-success' : el.quality >= 50 ? 'progress-bar-warning' : 'progress-bar-danger' ) + '"' +
+                ' role="progressbar" aria-valuenow="' + el.quality + '"' +
+                ' aria-valuemin="0" aria-valuemax="100" style="width: ' + el.quality + '%;" title="' + el.quality + '%"></div>' +
+                '</div>' +
+                '</td>'
+            ));            
             /* Translators: Verb for copy operation */
             newRow.append($(
                 '<td>' +

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -345,6 +345,7 @@
 <th>{% trans "Translation" %}</th>
 <th>{% trans "Source" %}</th>
 <th>{% trans "Service" %}</th>
+<th>{% trans "Quality" %}</th>
 <th>
 <i id="mt-loading" class="fa fa-spinner fa-spin pull-right flip" style="display:none;"></i>
 </th>


### PR DESCRIPTION
in the machine translation tab there is a new column with a progress bar
indicating the quality score of the machine translation

commit for WeblateOrg/weblate#1785