### PR TITLE
add a human-readable alias for Korean

### DIFF
--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -346,7 +346,7 @@ LOCALE_ALIASES = {
     'schinese': 'zh_Hans',
     'chinese_zh': 'zh_Hant',
     'tchinese': 'zh_Hant',
-    'korean': 'ko_KR',
+    'korean': 'ko',
     'dutch_be': 'nl_BE',
     'english': 'en',
     'english-uk': 'en_GB',

--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -346,6 +346,7 @@ LOCALE_ALIASES = {
     'schinese': 'zh_Hans',
     'chinese_zh': 'zh_Hant',
     'tchinese': 'zh_Hant',
+    'korean': 'ko_KR',
     'dutch_be': 'nl_BE',
     'english': 'en',
     'english-uk': 'en_GB',


### PR DESCRIPTION
Hi, this is a human-readable alias for Korean language
