### PR TITLE
automatic translation via machine translation

### DIFF
--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -242,3 +242,20 @@ This feature can be useful in several situations like consolidating translation
 between different components (eg. website and application) or when
 bootstrapping translation for new component using existing translations
 (translation memory).
+
+.. _auto-translation-mt:
+
+Automatic translation via machine translation
+---------------------------------------------
+
+Weblate can also be used to automatically fetch translations from activated
+machine translation services. This tool is called :guilabel:`Automatic translation` 
+and is accessible in the :guilabel:`Tools` menu.
+
+You can choose which machine translations engines you want to use as source and how to handle
+conflicts.
+
+This feature can be useful in several situations like consolidating translation
+between different components (eg. website and application) or when
+bootstrapping translation for new component using existing translations
+(translation memory).

--- a/weblate/static/robots.txt
+++ b/weblate/static/robots.txt
@@ -22,6 +22,7 @@ Disallow: /zen/
 Disallow: /download/
 Disallow: /upload/
 Disallow: /auto-translate/
+Disallow: /auto-translate-mt/
 Disallow: /new-lang/
 Disallow: /add-user/
 Disallow: /delete-user/

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -198,6 +198,10 @@
 
 {% if autoform %}
 <div class="tab-pane" id="auto">
+<div class="container-fluid">
+<div class="row">
+
+<div class="col-lg-6">
 <form action="{% url 'auto_translation' project=object.subproject.project.slug subproject=object.subproject.slug lang=object.language.code %}" method="post" enctype="multipart/form-data" data-persist="auto-translation">
 <div class="panel panel-primary">
 <div class="panel-heading"><h4 class="panel-title">{% trans "Automatic translation" %}</h4></div>
@@ -211,6 +215,26 @@
 </div>
 </div>
 </form>
+</div>
+
+<div class="col-lg-6">
+<form action="{% url 'auto_translation_mt' project=object.subproject.project.slug subproject=object.subproject.slug lang=object.language.code %}" method="post" enctype="multipart/form-data" data-persist="auto-translation-mt">
+<div class="panel panel-primary">
+<div class="panel-heading"><h4 class="panel-title">{% trans "Automatic translation via machine translation" %}</h4></div>
+<div class="panel-body">
+<p>{% trans "Automatic translation via machine translation uses active machine translation engines to get the best possible translations and applies them in this project." %}</p>
+{% csrf_token %}
+{{ automtform|crispy }}
+</div>
+<div class="panel-footer">
+<input type="submit" value="{% trans "Process" %}" class="btn btn-default" />
+</div>
+</div>
+</form>
+</div>
+
+</div>
+</div>
 </div>
 {% endif %}
 

--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -92,7 +92,7 @@ def auto_translate(user, translation, source, inconsistent, overwrite,
 
     return updated
 
-def auto_translate_mt(user, translation, engines, threshold, inconsistent, 
+def auto_translate_mt(user, translation, engines, threshold, inconsistent,
                       overwrite):
     """Perform automatic translation based on machine translation."""
     updated = 0

--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -23,6 +23,7 @@ from django.db import transaction
 
 from weblate.permissions.helpers import can_access_project
 from weblate.trans.models import Unit, Change, SubProject
+from weblate.trans.machine import MACHINE_TRANSLATION_SERVICES
 from weblate.utils.state import STATE_TRANSLATED
 
 
@@ -78,7 +79,90 @@ def auto_translate(user, translation, source, inconsistent, overwrite,
             # Copy translation
             unit.state = update.state
             unit.target = update.target
-            # Create signle change object for whole merge
+            # Create single change object for whole merge
+            Change.objects.create(
+                action=Change.ACTION_AUTO,
+                unit=unit,
+                user=user,
+                author=user
+            )
+            # Save unit to backend
+            unit.save_backend(None, False, False, user=user)
+            updated += 1
+
+    return updated
+
+def auto_translate_mt(user, translation, engines, threshold, inconsistent, 
+                      overwrite):
+    """Perform automatic translation based on machine translation."""
+    updated = 0
+
+    if inconsistent:
+        units = translation.unit_set.filter_type(
+            'check:inconsistent',
+            translation.subproject.project,
+            translation.language,
+        )
+    elif overwrite:
+        units = translation.unit_set.all()
+    else:
+        units = translation.unit_set.filter(
+            state__lt=STATE_TRANSLATED,
+        )
+
+    # get the translations (optimized: first WeblateMT, then others)
+    for unit in units.iterator():
+        # a list to store all found translations
+        results = []
+
+        # check if weblate is in the chosen engines
+        if 'weblate' in engines:
+            translation_service = MACHINE_TRANSLATION_SERVICES['weblate']
+            result = translation_service.translate(
+                unit.translation.language.code,
+                unit.get_source_plurals()[0],
+                unit,
+                user
+            )
+
+            for item in result:
+                results.append((item['quality'], item['text'], item['service']))
+
+        # use the other machine translation services if weblate did not
+        # find anything or has not been chosen
+        if 'weblate' not in engines or not results:
+            for engine in engines:
+                # skip weblate
+                if 'weblate' == engine:
+                    continue
+
+                translation_service = MACHINE_TRANSLATION_SERVICES[engine]
+                result = translation_service.translate(
+                    unit.translation.language.code,
+                    unit.get_source_plurals()[0],
+                    unit,
+                    user
+                )
+
+                for item in result:
+                    results.append((item['quality'], item['text'], item['service']))
+
+        if not results:
+            continue
+
+        # sort the list descending - the best result will be on top
+        results.sort(key=lambda tup: tup[0], reverse=True)
+
+        # take the "best" result and check the quality score
+        result = results[0]
+        if result[0] < threshold:
+            continue
+
+        with transaction.atomic():
+            # Copy translation
+            unit.state = STATE_TRANSLATED
+            unit.target = result[1]
+            # Create single change object for whole merge
             Change.objects.create(
                 action=Change.ACTION_AUTO,
                 unit=unit,

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -30,6 +30,7 @@ from crispy_forms.bootstrap import TabHolder, Tab, InlineRadios
 
 from django import forms
 from django.core.exceptions import PermissionDenied
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.utils.translation import (
     ugettext_lazy as _, ugettext, pgettext_lazy, pgettext
 )
@@ -52,6 +53,7 @@ from weblate.trans.models.source import PRIORITY_CHOICES
 from weblate.trans.models.unit import (
     STATE_TRANSLATED, STATE_FUZZY, STATE_APPROVED, STATE_EMPTY,
 )
+from weblate.trans.machine import MACHINE_TRANSLATION_SERVICES
 from weblate.permissions.helpers import (
     can_author_translation, can_overwrite_translation, can_translate,
     can_suggest, can_add_translation, can_mass_add_translation, can_review,
@@ -925,6 +927,35 @@ class AutoForm(forms.Form):
 
         self.fields['subproject'].choices = \
             [('', _('All components in current project'))] + choices
+
+
+class AutoMtForm(forms.Form):
+    """Automatic translation (machine translation) form."""
+    overwrite = forms.BooleanField(
+        label=_('Overwrite strings'),
+        required=False,
+        initial=False
+    )
+    inconsistent = forms.BooleanField(
+        label=_('Replace inconsistent'),
+        required=False,
+        initial=False
+    )
+    engines = forms.MultipleChoiceField(
+        label=_('Machine translation engines to use'),
+        choices=[]
+    )
+    threshold = forms.IntegerField(
+        label=_("Score threshold"),
+        initial=80,
+        min_value=1,
+        max_value=100
+    )
+
+    def __init__(self, obj, user, *args, **kwargs):
+        super(AutoMtForm, self).__init__(*args, **kwargs)
+        self.fields['engines'].choices = \
+            [(s, MACHINE_TRANSLATION_SERVICES[s].name) for s in list(MACHINE_TRANSLATION_SERVICES.keys())]
 
 
 class CommaSeparatedIntegerField(forms.Field):

--- a/weblate/trans/tests/test_autotranslate.py
+++ b/weblate/trans/tests/test_autotranslate.py
@@ -178,3 +178,70 @@ class AutoTranslationTest(ViewTestCase):
             'test',
             'xxx',
         )
+
+
+class AutoTranslationMtTest(ViewTestCase):
+    def setUp(self):
+        super(AutoTranslationMtTest, self).setUp()
+        # Need extra power
+        self.user.is_superuser = True
+        self.user.save()
+        self.subproject3 = SubProject.objects.create(
+            name='Test 3',
+            slug='test-3',
+            project=self.project,
+            repo=self.git_repo_path,
+            push=self.git_repo_path,
+            vcs='git',
+            filemask='po/*.po',
+            template='',
+            file_format='po',
+            new_base='',
+            allow_translation_propagation=False,
+        )
+
+    def test_none(self):
+        """Test for automatic translation with no content."""
+        url = reverse('auto_translation_mt', kwargs=self.kw_translation)
+        response = self.client.post(
+            url
+        )
+        self.assertRedirects(response, self.translation_url)
+
+    def make_different(self):
+        self.edit_unit(
+            'Hello, world!\n',
+            'Nazdar svete!\n'
+        )
+
+    def perform_auto(self, expected=1, **kwargs):
+        self.make_different()
+        params = {'project': 'test', 'lang': 'cs', 'subproject': 'test-3'}
+        url = reverse('auto_translation_mt', kwargs=params)
+        response = self.client.post(url, kwargs, follow=True)
+        if expected == 1:
+            self.assertContains(
+                response,
+                'Automatic translation completed, 1 string was updated.',
+            )
+        else:
+            self.assertContains(
+                response,
+                'Automatic translation completed, no strings were updated.',
+            )
+
+        self.assertRedirects(response, reverse('translation', kwargs=params))
+        # Check we've translated something
+        translation = self.subproject3.translation_set.get(language_code='cs')
+        translation.invalidate_cache()
+        self.assertEqual(translation.stats.translated, expected)
+
+    def test_different(self):
+        """Test for automatic translation with different content."""
+        self.perform_auto(engines=['weblate'], threshold=80)
+
+    def test_inconsistent(self):
+        self.perform_auto(0, inconsistent='1', engines=['weblate'], threshold=80)
+
+    def test_overwrite(self):
+        self.perform_auto(overwrite='1', engines=['weblate'], threshold=80)

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -44,7 +44,7 @@ from weblate.requirements import get_versions, get_optional_versions
 from weblate.lang.models import Language
 from weblate.trans.forms import (
     get_upload_form, SearchForm, SiteSearchForm,
-    AutoForm, ReviewForm, get_new_language_form,
+    AutoForm, AutoMtForm, ReviewForm, get_new_language_form,
     ReportsForm, ReplaceForm, NewUnitForm,
 )
 from weblate.permissions.helpers import (
@@ -427,8 +427,10 @@ def show_translation(request, project, subproject, lang):
     # Is user allowed to do automatic translation?
     if can_automatic_translation(request.user, obj.subproject.project):
         autoform = AutoForm(obj, request.user)
+        automtform = AutoMtForm(obj, request.user)
     else:
         autoform = None
+        automtform = None
 
     # Search form for everybody
     search_form = SearchForm()
@@ -454,6 +456,7 @@ def show_translation(request, project, subproject, lang):
             'project': obj.subproject.project,
             'form': form,
             'autoform': autoform,
+            'automtform': automtform,
             'search_form': search_form,
             'review_form': review_form,
             'replace_form': replace_form,

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -42,14 +42,14 @@ from weblate.trans.models import Unit, Change, Comment, Suggestion, Dictionary
 from weblate.trans.autofixes import fix_target
 from weblate.trans.forms import (
     TranslationForm, ZenTranslationForm, SearchForm, InlineWordForm,
-    MergeForm, AutoForm, AntispamForm, CommentForm, RevertForm, NewUnitForm,
+    MergeForm, AutoForm, AutoMtForm, AntispamForm, CommentForm, RevertForm, NewUnitForm,
 )
 from weblate.trans.views.helper import (
     get_translation, import_message, show_form_errors,
 )
 from weblate.trans.checks import CHECKS
 from weblate.trans.util import join_plural, render, redirect_next
-from weblate.trans.autotranslate import auto_translate
+from weblate.trans.autotranslate import auto_translate, auto_translate_mt
 from weblate.permissions.helpers import (
     can_translate, can_suggest, can_accept_suggestion, can_delete_suggestion,
     can_vote_suggestion, can_delete_comment, can_automatic_translation,
@@ -618,6 +618,42 @@ def auto_translation(request, project, subproject, lang):
         autoform.cleaned_data['subproject'],
         autoform.cleaned_data['inconsistent'],
         autoform.cleaned_data['overwrite']
+    )
+
+    import_message(
+        request, updated,
+        _('Automatic translation completed, no strings were updated.'),
+        ungettext(
+            'Automatic translation completed, %d string was updated.',
+            'Automatic translation completed, %d strings were updated.',
+            updated
+        )
+    )
+
+    return redirect(translation)
+
+
+@require_POST
+@login_required
+def auto_translation_mt(request, project, subproject, lang):
+    translation = get_translation(request, project, subproject, lang)
+    project = translation.subproject.project
+    if not can_automatic_translation(request.user, project):
+        raise PermissionDenied()
+
+    automtform = AutoMtForm(translation, request.user, request.POST)
+
+    if translation.subproject.locked or not automtform.is_valid():
+        messages.error(request, _('Failed to process form!'))
+        return redirect(translation)
+
+    updated = auto_translate_mt(
+        request.user,
+        translation,
+        automtform.cleaned_data['engines'],
+        automtform.cleaned_data['threshold'],
+        automtform.cleaned_data['inconsistent'],
+        automtform.cleaned_data['overwrite']
     )
 
     import_message(

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -222,6 +222,11 @@ urlpatterns = [
         name='auto_translation',
     ),
     url(
+        r'^auto-translate-mt/' + TRANSLATION + '$',
+        weblate.trans.views.edit.auto_translation_mt,
+        name='auto_translation_mt',
+    ),
+    url(
         r'^replace/' + PROJECT + '$',
         weblate.trans.views.search.search_replace,
         name='replace',


### PR DESCRIPTION
Added this feature into the automatic translation view. Calling the function from the view works as expected.

I touched/modified all files I am aware of, but there has been a few places where I did not know what to do:

- urls.py (ehance the regexp `r'^projects/' + TRANSLATION + 'auto/$',` by the -mt one): I did not find out if that extension is needed
- test_autotranslate.py: I did add some basic unit tests, but to do some more detailed testing I could not find out how the test model looks like
- command line execution: I did not understand how this exactly works and how I should implement this feature to the command line functions

beside that I changed everything I was aware of