### PR TITLE
e-mail → email

### DIFF
--- a/weblate/templates/accounts/email-sent.html
+++ b/weblate/templates/accounts/email-sent.html
@@ -21,11 +21,11 @@
   <div class="panel-body">
 
 {% if is_reset %}
-<p>{% blocktrans %}Shortly you should receive an e-mail containing a confirmation link. Click it to reset your password.{% endblocktrans %}</p>
+<p>{% blocktrans %}Shortly you should receive an email containing a confirmation link. Click it to reset your password.{% endblocktrans %}</p>
 {% elif is_remove %}
-<p>{% blocktrans %}Shortly you should receive an e-mail containing a confirmation link. Click it to remove your account.{% endblocktrans %}</p>
+<p>{% blocktrans %}Shortly you should receive an email containing a confirmation link. Click it to remove your account.{% endblocktrans %}</p>
 {% else %}
-<p>{% blocktrans %}Thank you for registering. Click the confirmation link you receive by e-mail to complete the registration.{% endblocktrans %}</p>
+<p>{% blocktrans %}Thank you for registering. Click the confirmation link you receive by email to complete the registration.{% endblocktrans %}</p>
 {% endif %}
 
 <p>{% blocktrans %}If the confirmation link expires before you get to use it, register again.{% endblocktrans %}</p>


### PR DESCRIPTION
Consistent spelling of email.

As "French Coordinator OTF/LocLab" said at https://hosted.weblate.org/translate/weblate/master/da/?type=comments&offset=4: "We have 18 occurrences for "email" and 4 for "e-mail". To be consistent, should read "email" everywhere."