### PR TITLE
Add all iso-codes gettext domains to blacklist

### DIFF
--- a/scripts/generate-language-data
+++ b/scripts/generate-language-data
@@ -120,9 +120,11 @@ for row in LANGUAGES:
 # iso-codes
 process_iso('639-2')
 process_iso('639-3')
+process_iso('639-5')
 process_iso('15924')
 process_iso('3166-1')
 process_iso('3166-2')
+process_iso('3166-3')
 process_iso('4217')
 
 SKIP = (


### PR DESCRIPTION
Hi Michal,

you might want to complete the iso-codes gettext domains for this blacklist.

Regards,
Tobias
