### PR TITLE
Pass Request to authenticate

### DIFF
--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -567,6 +567,7 @@ class LoginForm(forms.Form):
                     _('Too many authentication attempts!')
                 )
             self.user_cache = authenticate(
+                self.request,
                 username=username,
                 password=password
             )


### PR DESCRIPTION
To conform to Django 1.11+ need to pass self.request here so that underlying authentication models get it.

https://docs.djangoproject.com/en/2.0/topics/auth/default/#django.contrib.auth.authenticate

If this is not the case here or is not correct please inform and I will make changes to the underlying authentication model instead

https://docs.djangoproject.com/en/2.0/topics/auth/customizing/#authentication-backends