### PR TITLE
Add "Copy" button to secondary languages

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -211,7 +211,7 @@ function initEditor() {
     $('.copy-text').click(function (e) {
         var $this = $(this);
         $this.button('loading');
-        $this.parents('.translation-item').find('.translation-editor').val(
+        $this.parents('.translation-form').find('.translation-editor').eq($this.data('index')).val(
             $.parseJSON($this.data('content'))
         );
         autosize.update($('.translation-editor'));

--- a/weblate/templates/format-translation.html
+++ b/weblate/templates/format-translation.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% if simple %}
 <span lang="{{ language.code }}" dir="{{ language.direction }}">{{ items.0.content }}</span>
 {% else %}
@@ -5,7 +6,18 @@
   {% for item in items %}
   <div class="list-group-item">
     {% if item.title %}
-    <h5 class="list-group-item-heading"><strong>{{ item.title }}</strong></h5>
+    <h5 class="list-group-item-heading">
+      <strong>{{ item.title }}</strong>
+      {% if copy_to %}
+        <button class="btn btn-xs btn-default copy-text"
+                title="{% trans "Use as translation" %}"
+                data-checksum="{{ copy_to }}"
+                data-index="{{ forloop.counter0 }}"
+                data-content="{{ item.encoded }}">
+          <i class="fa fa-clipboard"></i> {% trans "Copy" %}
+        </button>
+      {% endif %}
+    </h5>
     {% endif %}
     <div class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
   </div>

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -98,15 +98,26 @@
     {% if secondary %}
     {% for secondary_unit in secondary %}
     <div class="form-group">
-    <label>{{ secondary_unit.translation.language }}</label>
+    <label>
+      {{ secondary_unit.translation.language }}
+      {% if unit.translation.plural.number == 1 %}
+        <button class="btn btn-xs btn-default copy-text"
+                title="{% trans "Use as translation" %}"
+                data-checksum="{{ unit.checksum }}"
+                data-index="0"
+                data-content="{{ secondary_unit.target|json_dumps }}">
+          <i class="fa fa-clipboard"></i> {% trans "Copy" %}
+        </button>
+      {% endif %}
+    </label>
     {% can_translate user secondary_unit as user_can_edit_secondary %}
     {% if user_can_edit_secondary %}
     <a title="{% trans "Edit string" %}"href="{{ secondary_unit.get_absolute_url }}"><i class="fa fa-pencil"></i></a>
     {% endif %}
     {% if user.profile.hide_source_secondary %}
-    {% format_translation secondary_unit.target secondary_unit.translation.language secondary_unit.translation.plural search_match=search_query num_plurals=unit.translation.plural.number unit=unit %}
+    {% format_translation secondary_unit.target secondary_unit.translation.language secondary_unit.translation.plural search_match=search_query num_plurals=unit.translation.plural.number unit=unit copy_to=unit.checksum %}
     {% else %}
-    {% format_translation secondary_unit.target secondary_unit.translation.language secondary_unit.translation.plural %}
+    {% format_translation secondary_unit.target secondary_unit.translation.language secondary_unit.translation.plural copy_to=unit.checksum %}
     {% endif %}
     </div>
     {% endfor %}

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -97,7 +97,7 @@ PLURALS_TEMPLATE = '''
 </p>
 '''
 COPY_TEMPLATE = '''
-data-loading-text="{0}" data-checksum="{1}" data-content="{2}"
+data-loading-text="{0}" data-checksum="{1}" data-content="{2}" data-index="{3}"
 '''
 
 
@@ -230,7 +230,8 @@ class PluralTextarea(forms.Textarea):
         extra_params = COPY_TEMPLATE.format(
             escape(ugettext('Loading…')),
             unit.checksum,
-            escape(json.dumps(source))
+            escape(json.dumps(source)),
+            str(idx)
         )
         groups.append(
             GROUP_TEMPLATE.format(

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -20,6 +20,7 @@
 
 from __future__ import unicode_literals
 
+import json
 import re
 
 from datetime import date
@@ -154,7 +155,7 @@ def fmt_search(value, search_match, match):
 @register.inclusion_tag('format-translation.html')
 def format_translation(value, language, plural=None, diff=None,
                        search_match=None, simple=False, num_plurals=2,
-                       unit=None, match='search'):
+                       unit=None, match='search', copy_to=None):
     """Nicely formats translation text possibly handling plurals or diff."""
     # Split plurals to separate strings
     plurals = split_plural(value)
@@ -209,12 +210,13 @@ def format_translation(value, language, plural=None, diff=None,
         # Join paragraphs
         content = mark_safe(newline.join(paras))
 
-        parts.append({'title': title, 'content': content})
+        parts.append({'title': title, 'content': content, 'encoded': json.dumps(content)})
 
     return {
         'simple': simple,
         'items': parts,
         'language': language,
+        'copy_to': copy_to
     }
 
 
@@ -437,6 +439,12 @@ def naturaltime_future(value, now):
         return ungettext(
             '%(count)s hour from now', '%(count)s hours from now', count
         ) % {'count': count}
+
+
+@register.filter
+def json_dumps(value):
+    print(repr(value))
+    return json.dumps(value)
 
 
 @register.filter


### PR DESCRIPTION
I just did my first translations with Weblate.

In our scenario, we do translate to two very similar language variants -- informal German and formal German. As a wild guess, they differ in ~20% of our strings. Before we used Weblate, I used translate one of them first with POEdit and then open the other, copy all strings from the first as fuzzy translations and start from there.

With Weblate, I do see the other language variant as a secondary language, which is great. However, I currently need do manually copy the text down into the input field, which needs lots of mouse movement. I thought it would be great to have a "Copy" button for the secondary languages similar to the one already there for the source language.

I implemented this in this PR. The code is a bit less clean and short than I expected it to be because I wanted to support plural forms as well. It works well now, but if you think it should be implemented another way, please let me know.

![2018-03-08-155508_1421x543_scrot](https://user-images.githubusercontent.com/64280/37157756-e645aa38-22e9-11e8-842e-4439aa71403a.png)

![2018-03-08-155515_1420x808_scrot](https://user-images.githubusercontent.com/64280/37157757-e717e066-22e9-11e8-96b7-e2d9a5ddb758.png)

---

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
  - Unsure how to do a test case for this, happy for any guidance
- [ ] Any new functionality is covered by user documentation
  - Is this necessary here?