### PR TITLE
fix sap translation hub to run on python 3

### DIFF
--- a/weblate/machinery/saptranslationhub.py
+++ b/weblate/machinery/saptranslationhub.py
@@ -59,10 +59,16 @@ class SAPTranslationHub(MachineTranslation):
                 settings.MT_SAP_USERNAME,
                 settings.MT_SAP_PASSWORD
             )
-            request.add_header(
-                'Authorization',
-                'Basic ' + base64.b64encode(credentials.encode('utf-8'))
-            )
+            if six.PY2:
+                request.add_header(
+                    'Authorization',
+                    'Basic ' + base64.b64encode(credentials.encode('utf-8'))
+                )
+            else:
+                request.add_header(
+                    'Authorization',
+                    'Basic ' + base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
+                )
 
     def download_languages(self):
         """Get all available languages from SAP Translation Hub"""

--- a/weblate/machinery/saptranslationhub.py
+++ b/weblate/machinery/saptranslationhub.py
@@ -59,16 +59,12 @@ class SAPTranslationHub(MachineTranslation):
                 settings.MT_SAP_USERNAME,
                 settings.MT_SAP_PASSWORD
             )
-            if six.PY2:
-                request.add_header(
-                    'Authorization',
-                    'Basic ' + base64.b64encode(credentials.encode('utf-8'))
-                )
-            else:
-                request.add_header(
-                    'Authorization',
-                    'Basic ' + base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
-                )
+            request.add_header(
+                'Authorization',
+                'Basic ' + base64.b64encode(
+                    credentials.encode('utf-8')
+                ).decode('utf-8')
+            )
 
     def download_languages(self):
         """Get all available languages from SAP Translation Hub"""

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -579,6 +579,9 @@ class MachineTranslationTest(TestCase):
         self.assert_translate(machine, empty=True)
 
     @override_settings(MT_SAP_BASE_URL='http://sth.example.com/')
+    @override_settings(MT_SAP_SANDBOX_APIKEY='http://sandbox.example.com')
+    @override_settings(MT_SAP_USERNAME='username')
+    @override_settings(MT_SAP_PASSWORD='password')
     @httpretty.activate
     def test_saptranslationhub(self):
         machine = self.get_machine(SAPTranslationHub)


### PR DESCRIPTION
the translation hub translation engine was not able to be run on python 3
