### PR TITLE
Remove '%' in untranslated column

### DIFF
--- a/weblate/templates/list-translations.html
+++ b/weblate/templates/list-translations.html
@@ -35,7 +35,7 @@
 </th>
 <td class="progress-cell">{% translation_progress trans %}</td>
 <td class="percent">{{ percent }}%</td>
-<td class="percent col-untranslated" style="display: none">{{ untranslated }}%</td>
+<td class="percent col-untranslated" style="display: none">{{ untranslated }}</td>
 <td class="percent col-words" title="{% blocktrans count words=trans.stats.nottranslated_words %}{{ words }} word to translate!{% plural %}{{ words }} words to translate!{% endblocktrans %}" >{{ trans.stats.translated_words_percent }}%</td>
 <td class="percent col-fuzzy">
 {% if fuzzy > 0 and translate_url %}


### PR DESCRIPTION
This column actually displays number of untranslated strings, so either remove '%' or display percentage. But displaying percentage may be redondant with 'translated' column.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
