### PR TITLE
incosistent permissions in template fixed

### DIFF
--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -256,7 +256,7 @@
 </div>
 {% endif %}
 
-{% if object.is_template and object.component.file_format_cls.can_add_unit and user_can_add_unit %}
+{% if object.is_template and user_can_add_unit %}
 <div class="tab-pane" id="new">
 <form action="{% url 'new-unit' project=object.component.project.slug component=object.component.slug lang=object.language.code %}" method="post">
 <div class="panel panel-primary">


### PR DESCRIPTION
Made rules of rendering the body same as rendering the button 
https://github.com/WeblateOrg/weblate/blob/master/weblate/templates/translation.html#L63-L65

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation
