### PR TITLE
Show empty files as fully translated

### DIFF
--- a/weblate/trans/tests/test_util.py
+++ b/weblate/trans/tests/test_util.py
@@ -19,7 +19,7 @@
 #
 
 from unittest import TestCase
-from weblate.trans.util import cleanup_repo_url
+from weblate.trans.util import cleanup_repo_url, translation_percent
 
 
 class HideCredentialsTest(TestCase):
@@ -54,3 +54,26 @@ class HideCredentialsTest(TestCase):
             ),
             'hg::https://bitbucket.org/sumwars/sumwars-code'
         )
+
+
+class TranslationPercentTest(TestCase):
+    def test_common(self):
+        self.assertAlmostEqual(translation_percent(2, 4), 50.0)
+
+    def test_empty(self):
+        self.assertAlmostEqual(translation_percent(0, 0), 100.0)
+
+    def test_none(self):
+        self.assertAlmostEqual(translation_percent(0, None), 0.0)
+
+    def test_untranslated_file(self):
+        self.assertAlmostEqual(translation_percent(0, 100), 0.0)
+
+    def test_almost_untranslated_file(self):
+        self.assertAlmostEqual(translation_percent(1, 10000000000), 0.1)
+
+    def test_translated_file(self):
+        self.assertAlmostEqual(translation_percent(100, 100), 100.0)
+
+    def test_almost_translated_file(self):
+        self.assertAlmostEqual(translation_percent(99999999, 100000000), 99.9)

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -107,7 +107,9 @@ def get_distinct_translations(units):
 
 def translation_percent(translated, total):
     """Return translation percentage."""
-    if total == 0 or total is None:
+    if total == 0:
+        return 100.0
+    if total is None:
         return 0.0
     perc = round(1000 * translated / total) / 10.0
     # Avoid displaying misleading rounded 0.0% or 100.0%


### PR DESCRIPTION
Empty components (like .po files without translation units) shows in the Dashboard as 0%.
This was happening to us after importing automatically many .po files extracted from files that are expected to be empty in some cases.