### PR TITLE
Fix possible error on mass state change

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1036,7 +1036,7 @@ class Unit(models.Model, LoggerMixin):
             self.target = new_target
         else:
             self.target = join_plural(new_target)
-        if bool(max(new_target)):
+        if new_target and bool(max(new_target)):
             self.state = new_state
         else:
             self.state = STATE_EMPTY


### PR DESCRIPTION
I had a 500 error while performing a mass state change. I can't tell exactly why it happened but I've run the mass state change right after I've reverted some commits followed by a rebase, so I guess some index were invalid or something.
Anyway, I think it still a good idea to do some action if the `new_target` parameter is empty and not just throw an exception.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation