### PR TITLE
Add event `unit_post_save` for use with addons

### DIFF
--- a/weblate/addons/events.py
+++ b/weblate/addons/events.py
@@ -27,6 +27,7 @@ EVENT_POST_COMMIT = 4
 EVENT_POST_ADD = 5
 EVENT_UNIT_PRE_CREATE = 6
 EVENT_STORE_POST_LOAD = 7
+EVENT_UNIT_POST_SAVE = 8
 
 EVENT_CHOICES = (
     (EVENT_POST_PUSH, 'post push'),
@@ -35,5 +36,6 @@ EVENT_CHOICES = (
     (EVENT_POST_COMMIT, 'post commit'),
     (EVENT_POST_ADD, 'post add'),
     (EVENT_UNIT_PRE_CREATE, 'unit post create'),
+    (EVENT_UNIT_POST_SAVE, 'unit post save'),
     (EVENT_STORE_POST_LOAD, 'store post load'),
 )


### PR DESCRIPTION
This adds new event handler when unit is updated. One specific use case is to call an addon when translation (or unit) state is updated from "Waiting for Review" to "Approved". This uses built-in Django signal `django.db.models.post_save` and filters sender if of class `Unit`.

P.S. This is my first time contributing to open-source would be glad to know how to do it properly. I have missing tests and will be pushed in a while.