### PR TITLE
github/issue template: do not launch new containers to report versions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -29,6 +29,6 @@ On Git checkout:
 Using docker-compose:
 
 ```
-docker-compose run --rm weblate list_versions
-docker-compose run --rm weblate check --deploy
+docker-compose exec weblate weblate list_versions
+docker-compose exec weblate weblate check --deploy
 ```


### PR DESCRIPTION
using run would launch another instance of postgres and redis,

this not needed and not sure how well postgres handles concurrent writes from different process to same data store.