### PR TITLE
Add Netease Sight translate service

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -854,6 +854,28 @@ MyMemory user id for private translation memory, use together with :setting:`MT_
    :ref:`mymemory`, :ref:`machine-translation-setup`, :ref:`machine-translation`,
    `MyMemory: API key generator <https://mymemory.translated.net/doc/keygen.php>`_
 
+.. setting:: MT_NETEASE_KEY
+
+MT_NETEASE_KEY
+--------------
+
+App key for Netease Sight API, you can register at https://sight.netease.com/
+
+.. seealso::
+
+   :ref:`netease-translate`, :ref:`machine-translation-setup`, :ref:`machine-translation`
+
+.. setting:: MT_NETEASE_SECRET
+
+MT_NETEASE_SECRET
+-----------------
+
+App secret for Netease Sight API, you can register at https://sight.netease.com/
+
+.. seealso::
+
+   :ref:`netease-translate`, :ref:`machine-translation-setup`, :ref:`machine-translation`
+
 .. setting:: MT_TMSERVER
 
 MT_TMSERVER

--- a/docs/admin/machine.rst
+++ b/docs/admin/machine.rst
@@ -224,6 +224,27 @@ To enable this service, add ``weblate.machinery.mymemory.MyMemoryTranslation`` t
     :setting:`MT_MYMEMORY_KEY`,
     `MyMemory website <https://mymemory.translated.net/>`_
 
+.. _netease-translate:
+
+Netease Sight API machine translation
+-------------------------------------
+
+.. versionadded:: 3.3
+
+Machine translation service provided by Netease.
+
+This service uses an API and you need to obtain key and secret from Netease.
+
+To enable this service, add ``weblate.machinery.youdao.NeteaseSightTranslation`` to
+:setting:`MT_SERVICES` and set :setting:`MT_NETEASE_KEY` and
+:setting:`MT_NETEASE_SECRET`.
+
+.. seealso::
+
+    :setting:`MT_NETEASE_KEY`,
+    :setting:`MT_NETEASE_SECRET`
+    `Netease Sight Translation Platform <https://sight.netease.com/>`_
+
 .. _tmserver:
 
 tmserver

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -82,14 +82,25 @@ class MachineTranslation(object):
         """Hook for backends to allow add authentication headers to request."""
         return
 
-    def json_req(self, url, http_post=False, skip_auth=False, raw=False,
+    def json_req(self, url, http_post=False, skip_auth=False, raw=False, json_body=False,
                  **kwargs):
         """Perform JSON request."""
+
+        # JSON body requires using POST
+        if json_body:
+            http_post = True
+
         # Encode params
         if kwargs:
-            params = urlencode(kwargs)
+            if json_body:
+                params = json.dumps(kwargs)
+            else:
+                params = urlencode(kwargs)
         else:
-            params = ''
+            if json_body:
+                params = '{}'
+            else:
+                params = ''
 
         # Store for exception handling
         self.request_url = url

--- a/weblate/machinery/models.py
+++ b/weblate/machinery/models.py
@@ -74,6 +74,10 @@ class WeblateConf(AppConf):
     YOUDAO_ID = None
     YOUDAO_SECRET = None
 
+    # Netease
+    NETEASE_KEY = None
+    NETEASE_SECRET = None
+
     # List of machine translations
     SERVICES = (
         'weblate.machinery.weblatetm.WeblateTranslation',

--- a/weblate/machinery/netease.py
+++ b/weblate/machinery/netease.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright ©2018 Sun Zhigang <hzsunzhigang@corp.netease.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
+from weblate.machinery.base import (
+    MachineTranslation, MachineTranslationError, MissingConfiguration
+)
+
+import time
+import random
+from hashlib import sha1
+
+NETEASE_API_ROOT = 'https://jianwai.netease.com/api/text/trans'
+
+
+class NeteaseSightTranslation(MachineTranslation):
+    """Netease Sight API machine translation support."""
+    name = 'Netease Sight'
+    max_score = 90
+
+    # Map codes used by Netease Sight to codes used by Weblate
+    language_map = {
+        'zh_Hans': 'zh',
+    }
+
+    def __init__(self):
+        """Check configuration."""
+        super(NeteaseSightTranslation, self).__init__()
+        if settings.MT_NETEASE_KEY is None:
+            raise MissingConfiguration(
+                'Netease Sight Translate requires app key'
+            )
+        if settings.MT_NETEASE_SECRET is None:
+            raise MissingConfiguration(
+                'Netease Sight Translate requires app secret'
+            )
+
+    def download_languages(self):
+        """List of supported languages."""
+        return [
+            'zh',
+            'en',
+        ]
+
+    def authenticate(self, request):
+        """Hook for backends to allow add authentication headers to request."""
+        # Override to add required headers.
+
+        nonce = str(random.randint(1000, 99999999))
+        timestamp = str(int(1000 * time.time()))
+
+        sign = settings.MT_NETEASE_SECRET + nonce + timestamp
+        sign = sign.encode('utf-8')
+        sign = sha1(sign).hexdigest()
+
+        request.add_header('Content-Type', 'application/json')
+        request.add_header('appkey', settings.MT_NETEASE_KEY)
+        request.add_header('nonce', nonce)
+        request.add_header('timestamp', timestamp)
+        request.add_header('signature', sign)
+
+    def download_translations(self, source, language, text, unit, user):
+        """Download list of possible translations from a service."""
+        response = self.json_req(
+            NETEASE_API_ROOT,
+            http_post=True,
+            json_body=True,
+            lang=source,
+            content=text,
+        )
+
+        if not response['success']:
+            raise MachineTranslationError(response['message'])
+
+        translation = response['relatedObject']['content'][0]['transContent']
+
+        return [(translation, self.max_score, _(self.name), text)]

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -522,6 +522,7 @@ if not HAVE_SYSLOG:
 #     'weblate.machinery.microsoft.MicrosoftCognitiveTranslation',
 #     'weblate.machinery.microsoftterminology.MicrosoftTerminologyService',
 #     'weblate.machinery.mymemory.MyMemoryTranslation',
+#     'weblate.machinery.netease.NeteaseSightTranslation',
 #     'weblate.machinery.tmserver.AmagamaTranslation',
 #     'weblate.machinery.tmserver.TMServerTranslation',
 #     'weblate.machinery.yandex.YandexTranslation',
@@ -561,6 +562,10 @@ MT_BAIDU_SECRET = None
 # Youdao Zhiyun app key and secret
 MT_YOUDAO_ID = None
 MT_YOUDAO_SECRET = None
+
+# Netease Sight (Jianwai) app key and secret
+MT_NETEASE_KEY = None
+MT_NETEASE_SECRET = None
 
 # API key for Yandex Translate API
 MT_YANDEX_KEY = None


### PR DESCRIPTION
Netease Sight (https://sight.netease.com/) supports Chinese and English.

It requires posting arguments in json format. Therefore, added one parameter to json_req():

> json_body=False

Signed-off-by: Sun Zhigang <sunner@gmail.com>

Ensured that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
