### PR TITLE
Fix celery worker doc

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -699,7 +699,7 @@ useful when debugging or developing):
 
 .. code-block:: sh
 
-   celery --app weblate worker --loglevel info --beat
+   celery worker --app weblate --loglevel info --beat
 
 Most likely you will want to run Celery as a daemon and that is covered by
 :doc:`celery:userguide/daemonizing`.


### PR DESCRIPTION
The command, `worker`, must be the first argument.

Tested on celery 4.2.1 (windowlicker)

Signed-off-by: Sun Zhigang <sunner@gmail.com>

Ensured that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase - **no code changed**
- [ ] Any new functionality is covered by user documentation - **no new functionality**
