### PR TITLE
Fix install_addon breaks on addons without form

### DIFF
--- a/weblate/addons/management/commands/install_addon.py
+++ b/weblate/addons/management/commands/install_addon.py
@@ -50,7 +50,7 @@ class Command(WeblateComponentCommand):
 
     def handle(self, *args, **options):
         try:
-            addon = ADDONS[options['addon']]
+            addon = ADDONS[options['addon']]()
         except KeyError:
             raise CommandError('Addon not found: {}'.format(options['addon']))
         try:

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -402,6 +402,16 @@ class CommandTest(ViewTestCase):
         output = StringIO()
         call_command(
             'install_addon', '--all',
+            '--addon', 'weblate.flags.same_edit',
+            stdout=output,
+            stderr=output,
+        )
+        self.assertIn(
+            'Can not install on Test/Test',
+            output.getvalue()
+        )
+        call_command(
+            'install_addon', '--all',
             '--addon', 'weblate.gettext.customize',
             '--configuration', '{"width":77}',
             stdout=output,


### PR DESCRIPTION
Without this patch, the newly added testcase breaks on:

```
======================================================================
ERROR: test_install_addon (weblate.addons.tests.CommandTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sunner/weblate/weblate/addons/tests.py", line 407, in test_install_addon
    stderr=output,
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/__init__.py", line 141, in call_command
    return command.execute(*args, **defaults)
  File "/home/sunner/weblate/weblate/trans/management/commands/__init__.py", line 42, in execute
    super(WeblateCommand, self).execute(*args, **options)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 335, in execute
    output = self.handle(*args, **options)
  File "/home/sunner/weblate/weblate/addons/management/commands/install_addon.py", line 62, in handle
    if not form.is_valid():
AttributeError: 'NoneType' object has no attribute 'is_valid'

----------------------------------------------------------------------
```

Ensured that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation - **no new function**
