### PR TITLE
Remove Babel dependency

### DIFF
--- a/ci/requirements-scrutinizer.txt
+++ b/ci/requirements-scrutinizer.txt
@@ -3,7 +3,6 @@
 # - without python_version modifiers
 # - without PyAML and tesserocr
 pyuca>=1.1
-Babel
 chardet
 python-memcached
 python-bidi>=0.4.0

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -78,8 +78,6 @@ user-agents (>= 1.1.0)
     https://github.com/selwin/python-user-agents
 pyuca (>= 1.1) (optional for proper sorting of strings)
     https://github.com/jtauber/pyuca
-Babel (optional for Android resources support)
-    http://babel.pocoo.org/
 phply (optional for PHP support)
     https://github.com/viraptor/phply
 Database backend
@@ -210,7 +208,7 @@ system Python libraries.
         
         pip install Weblate
         # Optional deps
-        pip install pytz python-bidi PyYAML Babel pyuca
+        pip install pytz python-bidi PyYAML pyuca
 
 5. Create your settings (in our example it would be in 
    :file:`/tmp/weblate/lib/python2.7/site-packages/weblate/settings.py`
@@ -273,7 +271,7 @@ install them you can use apt-get:
 
     apt-get install python-pip python-django translate-toolkit \
         python-whoosh python-pil \
-        python-babel git mercurial \
+        git mercurial \
         python-django-compressor python-django-crispy-forms \
         python-djangorestframework python-dateutil python-celery
 
@@ -364,7 +362,7 @@ Most of requirements are available either directly in openSUSE or in
     zypper install python-Django translate-toolkit \
         python-Whoosh python-Pillow \
         python-social-auth-core python-social-auth-app-django \
-        python-babel Git mercurial python-pyuca \
+        Git mercurial python-pyuca \
         python-dateutil python-celery
 
     # Optional for database backend

--- a/docs/admin/quick.rst
+++ b/docs/admin/quick.rst
@@ -64,7 +64,7 @@ development server.
         
         pip install Weblate
         # Optional deps
-        pip install pytz python-bidi PyYAML Babel pyuca
+        pip install pytz python-bidi PyYAML pyuca
 
 #. Copy the file :file:`/tmp/weblate/lib/python2.7/site-packages/weblate/settings-example.py`
    to :file:`/tmp/weblate/lib/python2.7/site-packages/weblate/settings.py`

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 pyuca>=1.1
 pytz>=2015.1
-Babel
 phply
 chardet
 Mercurial>=2.8; python_version < '3.0'


### PR DESCRIPTION
It was used in older translate-toolkit versions, but it should not be
required now.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
