### PR TITLE
Add batch target check operation

### DIFF
--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -32,6 +32,7 @@ class Check(object):
     default_disabled = False
     severity = 'info'
     enable_check_value = False
+    batch_update = False
 
     def get_identifier(self):
         return self.check_id

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+from django.db.models import Count
 from django.utils.translation import ugettext_lazy as _
 from weblate.checks.base import TargetCheck
 from weblate.utils.state import STATE_TRANSLATED
@@ -74,6 +75,21 @@ class ConsistencyCheck(TargetCheck):
     )
     ignore_untranslated = False
     severity = 'warning'
+    batch_update = True
+
+    def check_target_project(self, project):
+        """Batch check for whole project."""
+        from weblate.trans.models import Unit
+        return Unit.objects.filter(
+            translation__component__project=project,
+            translation__component__allow_translation_propagation=True,
+        ).values(
+            'content_hash', 'translation__language'
+        ).annotate(
+            Count('target', distinct=True)
+        ).filter(
+            target__count__gt=1
+        )
 
     def check_target_unit(self, sources, targets, unit):
         # Do not check consistency if user asked not to have it

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -844,11 +844,7 @@ class Unit(models.Model, LoggerMixin):
             # Delete all checks if only message with this source is fuzzy
             if not same_source_exists:
                 return {}, True
-            elif 'inconsistent' in CHECKS:
-                # Consistency check checks across more translations
-                return {'inconsistent': CHECKS['inconsistent']}, False
-        else:
-            return {x: y for x, y in CHECKS.data.items() if y.target}, True
+        return {x: y for x, y in CHECKS.data.items() if y.target}, True
 
     def run_checks(self, same_state=True, same_content=True, is_new=False):
         """Update checks for this unit."""

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -831,6 +831,9 @@ class Unit(models.Model, LoggerMixin):
             # Run only source checks on template, this is done later
             return {}, True
         elif (not same_state or is_new) and self.state < STATE_TRANSLATED:
+            # The consistency check will be run as batch
+            if is_new and self.is_batch_update:
+                return {}, False
             # Check whether there is any message with same source
             same_source_exists = False
             for unit in self.same_source_units:


### PR DESCRIPTION
For some checks it is better to perform them once after translations are
imported as they do heavy database queries which can be done more
effectively globally on the database side. The typical use case is
consistency check which triggers way too many queries when executed for
each unit, but it's relatively cheap when done globally.

Fixes #2318

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
