### PR TITLE
Rename Quality checks flags to Translation flags

### DIFF
--- a/docs/admin/checks.rst
+++ b/docs/admin/checks.rst
@@ -23,15 +23,12 @@ in the :setting:`AUTOFIX_LIST`, see :ref:`custom-modules`.
 
 .. _custom-checks:
 
-Customizing checks
-------------------
+Customizing behavior
+--------------------
 
-Fine tuning existing checks
-+++++++++++++++++++++++++++
-
-You can fine tune checks for each source string (in source strings review, see
-:ref:`additional`) or in the :ref:`component` (:guilabel:`Quality checks
-flags`); here is a list of flags currently accepted:
+You can fine tune Weblate behavior (mostly checks) for each source string (in
+source strings review, see :ref:`additional`) or in the :ref:`component`
+(:guilabel:`Translation flags`); here is a list of flags currently accepted:
 
 ``rst-text``
     Treat text as RST document, effects :ref:`check-same`.
@@ -115,7 +112,7 @@ These flags are understood both in :ref:`component` settings, per source string
 settings and in translation file itself (eg. in GNU Gettext).
 
 Writing own checks
-++++++++++++++++++
+------------------
 
 Weblate comes with wide range of quality checks (see :ref:`checks`), though
 they might not 100% cover all you want to check. The list of performed checks

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -215,8 +215,8 @@ Suggestion voting
     Enable voting for suggestions, see :ref:`voting`.
 Autoaccept suggestions
     Automatically accept voted suggestions, see :ref:`voting`.
-Quality checks flags
-    Additional flags to pass to quality checks, see :ref:`custom-checks`.
+Translation flags
+    Customization of quality checks and other Weblate behavior, see :ref:`custom-checks`.
 Translation license
     License of this translation.
 License URL

--- a/docs/admin/translating.rst
+++ b/docs/admin/translating.rst
@@ -82,12 +82,17 @@ You can change string priority, strings with higher priority are offered first
 for translation. This can be useful for prioritizing translation of strings
 which are seen first by users or are otherwise important.
 
-Quaity check flags
-++++++++++++++++++
+Translation flags
++++++++++++++++++
 
 .. versionadded:: 2.4
 
-Default set of quality check flags is determined from the translation
+.. versionchanged:: 3.3
+
+      Previously this was called :guilabel:`Quaity checks flags`, but as it no
+      longer configures only checks, the name was changed to be more generic.
+
+Default set of traslation flags is determined from the translation
 :ref:`component` and the translation file. However, you might want to customize
 this per source string and you have the option here.
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1224,14 +1224,14 @@ class ContextForm(forms.Form):
 
 class CheckFlagsForm(forms.Form):
     flags = forms.CharField(
-        label=_('Check flags'),
+        label=_('Translation flags'),
         required=False,
     )
 
     def __init__(self, *args, **kwargs):
         super(CheckFlagsForm, self).__init__(*args, **kwargs)
         self.fields['flags'].help_text = ugettext(
-            'Please enter a comma separated list of check flags, '
+            'Please enter a comma separated list of translation flags, '
             'see <a href="{url}">documentation</a> for more details.'
         ).format(
             url=get_doc_url('admin/checks', 'custom-checks')

--- a/weblate/trans/migrations/0001_squashed_0143_auto_20180609_1655.py
+++ b/weblate/trans/migrations/0001_squashed_0143_auto_20180609_1655.py
@@ -127,7 +127,7 @@ class Migration(migrations.Migration):
                 ('enable_suggestions', models.BooleanField(default=True, help_text='Whether to allow translation suggestions at all.', verbose_name='Enable suggestions')),
                 ('suggestion_voting', models.BooleanField(default=False, help_text='Whether users can vote for suggestions.', verbose_name='Suggestion voting')),
                 ('suggestion_autoaccept', models.PositiveSmallIntegerField(default=0, help_text='Automatically accept suggestions with this number of votes, use 0 to disable.', validators=[weblate.trans.validators.validate_autoaccept], verbose_name='Autoaccept suggestions')),
-                ('check_flags', models.TextField(blank=True, default='', help_text='Additional comma-separated flags to influence quality checks, check documentation for possible values.', validators=[weblate.trans.validators.validate_check_flags], verbose_name='Quality checks flags')),
+                ('check_flags', models.TextField(blank=True, default='', help_text='Additional comma-separated flags to influence quality checks, check documentation for possible values.', validators=[weblate.trans.validators.validate_check_flags], verbose_name='Translation flags')),
                 ('project', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='trans.Project', verbose_name='Project')),
             ],
             options={

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -283,7 +283,7 @@ class Component(models.Model, URLMixin, PathMixin):
         validators=[validate_autoaccept],
     )
     check_flags = models.TextField(
-        verbose_name=ugettext_lazy('Quality checks flags'),
+        verbose_name=ugettext_lazy('Translation flags'),
         default='',
         help_text=ugettext_lazy(
             'Additional comma-separated flags to influence quality checks, '

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -276,8 +276,8 @@ class ComponentTest(RepoTestCase):
         component = self.create_link()
         self.verify_component(component, 3, 'cs', 4)
 
-    def test_check_flags(self):
-        """Check flags validation."""
+    def test_flags(self):
+        """Translation flags validation."""
         component = self.create_component()
         component.full_clean()
 

--- a/weblate/trans/views/source.py
+++ b/weblate/trans/views/source.py
@@ -154,7 +154,7 @@ def edit_context(request, pk):
 @require_POST
 @login_required
 def edit_check_flags(request, pk):
-    """Change source string check flags."""
+    """Change source string flags."""
     source = get_object_or_404(Source, pk=pk)
 
     if not request.user.has_perm('source.edit', source.component):
@@ -165,7 +165,7 @@ def edit_check_flags(request, pk):
         source.check_flags = form.cleaned_data['flags']
         source.save()
     else:
-        messages.error(request, _('Failed to change check flags!'))
+        messages.error(request, _('Failed to change translation flags!'))
     return redirect_next(request.POST.get('next'), source.get_absolute_url())
 
 


### PR DESCRIPTION
These no longer configure only flags, so better to have generic name.

Fixes #2310

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
