### PR TITLE
change to pip3 to match container's version

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /srv
 # TODO: put some new dependencies here
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 ENTRYPOINT
 


### PR DESCRIPTION
docker container previously moved to python3 as shown here: https://github.com/WeblateOrg/docker/commit/2ff9f50
There is still an issue executing the application within the container, but pip is no longer "missing".

Signed-off-by: Harold Gray <haroldgray3@gmail.com>