### PR TITLE
explicitly launching dev container with python3

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -18,6 +18,7 @@ RUN pip3 install -r requirements.txt
 
 ENTRYPOINT
 
-CMD sh -c "./manage.py migrate \
-    && ./manage.py createadmin --update --password admin \
-    && ./manage.py runserver 0.0.0.0:8080"
+# Container "FROM" debian:stretch and includes python2.7. Explicitly picking python3 as weblate:edge installs pip3
+CMD sh -c "python3 manage.py migrate \
+    && python3 manage.py createadmin --update --password admin \
+    && python3 manage.py runserver 0.0.0.0:8080"


### PR DESCRIPTION
Previously choosing python version ambiguously and defaulting to python2.7 as is configured in the container layer above. pip3 installed packages could not be found by python2.7 and it never found the django dependency.

I'm off to bed for now, but I will revisit tomorrow with the aim of getting the dev container to work. :)
Thanks for your patience as I slowly learn python.

Signed-off-by: Harold Gray <haroldgray3@gmail.com>