### PR TITLE
Spelling: "All commits made with Weblate"

### DIFF
--- a/weblate/templates/about/keys.html
+++ b/weblate/templates/about/keys.html
@@ -43,7 +43,7 @@
 
   <div class="panel-body">
 {% if gpg_key %}
-  <p>{% blocktrans %}All commits made by Weblate are signed with the GPG key {{ gpg_key_id }}, for which the corresponding public key is found below.{% endblocktrans %}</p>
+  <p>{% blocktrans %}All commits made with Weblate are signed with the GPG key {{ gpg_key_id }}, for which the corresponding public key is found below.{% endblocktrans %}</p>
   <div class="list-group-item pre-scrollable">
   {{ gpg_key|linebreaks }}
   </div>


### PR DESCRIPTION
This clarifies that it is a commit sent using Weblate, as opposed to on behalf of Weblate itself.