### PR TITLE
setting module import to explicitly

### DIFF
--- a/weblate/settings_dev.py
+++ b/weblate/settings_dev.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from settings_example import *
+from weblate.settings_example import *
 
 #
 # Django settings for Weblate development.


### PR DESCRIPTION
Signed-off-by: Harold Gray <haroldgray3@gmail.com>

Was getting `ImportError: No module named 'settings_example’`. Set the import to explicitly pull from `weblate.settings_example`.

Dev docker container seems to be working now.