### PR TITLE
Spelling: a unique, CAPTCHA, Leave empty

### DIFF
--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -109,7 +109,7 @@ class UsernameField(forms.CharField):
         super(UsernameField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
-        """Username validation, requires unique name."""
+        """Username validation, requires a unique name."""
         if value is None:
             return None
         if value is not None:
@@ -480,7 +480,7 @@ class CaptchaForm(forms.Form):
         ) % self.captcha.display
 
     def clean_captcha(self):
-        """Validation for captcha."""
+        """Validation for CAPTCHA."""
         if (self.fresh or
                 not self.captcha.validate(self.cleaned_data['captcha'])):
             self.generate_captcha()
@@ -512,7 +512,7 @@ class PasswordConfirmForm(EmptyConfirmForm):
     password = PasswordField(
         label=_("Current password"),
         help_text=_(
-            'Keep the field empty if you have not yet set your password.'
+            'Leave empty if you have not yet set a password.'
         ),
         required=False,
     )


### PR DESCRIPTION
Registered a new account and found the description of a field right next to it to be redundant.
It seems to me like this change is not a problem for blind/visually impaired users.
Also, accepting any password, and just disregarding it means it could be omitted altogether.

CAPTCHA, as per https://en.wikipedia.org/wiki/CAPTCHA