### PR TITLE
Add support for XLIFF placeholders

### DIFF
--- a/weblate/trans/tests/test_xliff_placeholders.py
+++ b/weblate/trans/tests/test_xliff_placeholders.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2012 - 2018 Michal Čihař <michal@cihar.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Tests for XLIFF rich string.
+"""
+
+from django.test import TestCase
+
+from weblate.trans.util import xliff_string_to_rich, rich_to_xliff_string
+from translate.storage.placeables.strelem import StringElem
+
+
+class XliffPlaceholdersTest(TestCase):
+
+    def test_bidirectional_xliff_string(self):
+        cases = [
+            'foo <x id="INTERPOLATION" equiv-text="{{ angularExpression }}"/> bar',
+            '',
+            'hello world',
+            'hello <p>world</p>'
+        ]
+
+        for string in cases:
+            rich = xliff_string_to_rich(string)
+            self.assertTrue(isinstance(rich, list))
+            self.assertTrue(isinstance(rich[0], StringElem))
+
+            final_string = rich_to_xliff_string(rich)
+            self.assertEqual(string, final_string)

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -33,6 +33,8 @@ from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.http import is_safe_url
 from django.utils.translation import ugettext as _, ugettext_lazy
+from translate.storage.placeables.lisa import parse_xliff, strelem_to_xml
+from lxml import etree
 
 try:
     import pyuca  # pylint: disable=import-error
@@ -284,3 +286,31 @@ def redirect_next(next_url, fallback):
             not next_url.startswith('/')):
         return redirect(fallback)
     return HttpResponseRedirect(next_url)
+
+
+def xliff_string_to_rich(string):
+    """XLIFF string to StringElement
+
+    Transform a string containing XLIFF placeholders as XML
+    into a rich content (StringElement)
+    """
+
+    return [parse_xliff(string)]
+
+
+def rich_to_xliff_string(string_elements):
+    """StringElement to XLIFF string
+
+    Transform rich content (StringElement) into
+    a string with placeholder kept as XML
+    """
+
+    result = ''
+    for string_element in string_elements:
+        xml = etree.Element(u'e')
+        strelem_to_xml(xml, string_element)
+        string_xml = etree.tostring(xml, encoding="unicode")
+        string_without_wrapping_element = string_xml[3:][:-4]
+        result += string_without_wrapping_element
+
+    return result


### PR DESCRIPTION
This is a work in progress and unit tests will be added and squashed when ready. But I wanted to double-check if I am going in the right direction before progressing further.

Given this XLIFF unit:

```xml
<trans-unit id="id-1">
    <source xml:space="preserve">source "<x id="INTERPOLATION" equiv-text="{{ angularExpression }}"/>", source.</source>
    <target xml:space="preserve">target "<x id="INTERPOLATION" equiv-text="{{ angularExpression }}"/>", target.</target>
</trans-unit>
```

I store in DB the placeholder preserved as XML. So something like the following (after translation of target), note the absence of flags:

![image](https://user-images.githubusercontent.com/72603/47784836-f448b180-dd5a-11e8-9824-681782539d46.png)

In Weblate, it will look like that:

![image](https://user-images.githubusercontent.com/72603/47785093-c152ed80-dd5b-11e8-84e9-fc298bd2ad42.png)


Interestingly I did not implement any checks, but the placeholder are still highlighted. So I guess we don't need to do anything for that part ?

Does it look good to you ? should I keep going by fixing/adding unit tests ?

Fixes #490
Fixes #1535

Before submitting pull request, please ensure that:

- [ ] Every commit has message which describes it
- [ ] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation
