### PR TITLE
Clarify supported states for XLIFF format

### DIFF
--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -210,17 +210,20 @@ is one of many standards in this area.
 
 XLIFF is usually used as bilingual, but Weblate supports it as monolingual as well.
 
-Translations marked for review
-++++++++++++++++++++++++++++++
+Translations states
++++++++++++++++++++
 
-.. versionchanged:: 2.18
+The ``state`` attribute in the file is completely ignored. It cannot be read and it
+cannot be written by Weblate. That means that a unit is considered translated as
+soon as a ``<target>`` element exists.
 
-    Since version 2.18 Weblate differentiates approved and fuzzy states, so
-    it should work as expected with Xliff. You still might apply note below in
-    cases where you don't want to use review process in Weblate.
+Also if the translation unit has ``approved="yes"`` it will be imported into Weblate
+as approved, anything else will be imported as waiting for review (which matches XLIFF
+specification).
 
-If the translation unit doesn't have ``approved="yes"`` it will be imported into
-Weblate as needing review (which matches XLIFF specification).
+That means that when using XLIFF format, it is strongly recommended to enable Weblate
+review process, in order to see and change the approved state of units.
+See :ref:`reviews`.
 
 Similarly on importing such files, you should choose
 :guilabel:`Import as translated` under


### PR DESCRIPTION
Previous documentation incorrectly mentioned "fuzzy" which is a concept that
does not exists in XLIFF and was also replaced in Weblate by "Needs editing".

More importantly it was very unclear that the `state` attribute is never used
at all. But instead only `approved` attribute is used. That lead to even more
confusion for the reader.

The following tables show all possibles cases in both directions:

## From XLIFF file to Weblate

| XLIFF file            | Weblate       |
|-----------------------|---------------|
| absence of `<target>` | Empty         |
| absence of `approved` | Needs editing |
| `approved="no"`       | Needs editing |
| `approved="yes"`      | Approved      |

## From Weblate to XLIFF file

| Weblate            | XLIFF file       |
|--------------------|------------------|
| Needs editing      | `approved="no"`  |
| Waiting for review | `approved="no"`  |
| Approved           | `approved="yes"` |

This should address the questions raised in
https://github.com/WeblateOrg/weblate/issues/1040#issuecomment-433366326

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
