### PR TITLE
HIDE_REPO_CREDENTIALS in settings_example.py

### DIFF
--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -617,6 +617,9 @@ SECURE_HSTS_SECONDS = 0
 SECURE_HSTS_PRELOAD = False
 SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 
+# Protect repository credentials from users
+HIDE_REPO_CREDENTIALS = True
+
 # URL of login
 LOGIN_URL = '{0}/accounts/login/'.format(URL_PREFIX)
 


### PR DESCRIPTION
Ideally this should be True by default, but as this should be part of any sane config I think it's fit to have it here for now.

Related to #2393 