### PR TITLE
Use 'fetch' instead of 'pull' in documentation

### DIFF
--- a/docs/admin/continuous.rst
+++ b/docs/admin/continuous.rst
@@ -199,7 +199,7 @@ example ``https://hosted.weblate.org/hooks/pagure/``). This can be done in
 Automatically updating repositories nightly
 +++++++++++++++++++++++++++++++++++++++++++
 
-Weblate does automatically pull remote repositories nightly to improve
+Weblate does automatically fetch remote repositories nightly to improve
 performance when merging changes later. You can optionally turn this into doing
 nightly merges as well by enabling :setting:`AUTO_UPDATE`.
 


### PR DESCRIPTION
When talking about git the action 'pull' is essentially a fetch + merge. This has tripped me up when reading the documentation and was only made clear to me when reading related issues.

Weblate actually only does a nightly 'fetch' (updating the repository information) and requires additional config to do a merge as well.

Before submitting pull request, please ensure that:

- [ ] Every commit has message which describes it
- [ ] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation
