### PR TITLE
RFC: Use singular/plural for languages with just one plural

### DIFF
--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -300,8 +300,8 @@ PLURAL_MAPPINGS = (
 PLURAL_NAMES = {
     PLURAL_NONE: ('',),
     PLURAL_ONE_OTHER: (
-        pgettext_lazy('Plural form description', 'One'),
-        pgettext_lazy('Plural form description', 'Other'),
+        pgettext_lazy('Plural form description', 'Singular'),
+        pgettext_lazy('Plural form description', 'Plural'),
     ),
     PLURAL_ONE_FEW_OTHER: (
         pgettext_lazy('Plural form description', 'One'),


### PR DESCRIPTION
Currenly Weblate consistetnly names plurals based on CLDR naming, so
depending on how many plurals language has each plural form will get one
of following labels: Zero, One, Two, Few, Many, Other

While this works fine for the more complex languages, showing just
Singular/Plural for simple languages with just one plural might make it
easier to understand.

Current displaying:

![screenshot_2018-12-08 hello gettext - italian](https://user-images.githubusercontent.com/212189/49686291-a742c280-faf2-11e8-84ae-5582c9651c17.png)

This PR changes it to:

![screenshot_2018-12-08 hello gettext - italian 1](https://user-images.githubusercontent.com/212189/49686295-b6297500-faf2-11e8-94ea-e1f6251d84bd.png)

