### PR TITLE
add --recurse-submodules to git clone on install

### DIFF
--- a/docs/admin/deployments.rst
+++ b/docs/admin/deployments.rst
@@ -26,7 +26,7 @@ The following examples assume you have a working Docker environment, with
 
    .. code-block:: sh
 
-        git clone https://github.com/WeblateOrg/docker-compose.git weblate-docker
+        git clone --recurse-submodules https://github.com/WeblateOrg/docker-compose.git weblate-docker
         cd weblate-docker
 
 2. Create a :file:`docker-compose.override.yml` file with your settings.


### PR DESCRIPTION
Actually, using only `git clone https://github.com/WeblateOrg/docker-compose.git weblate-docker` does not clone the submodule `docker-compose`.

We should add `--recurse-submodules` to avoid to have an empty `docker-compose` folder.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
