### PR TITLE
Add support for specifying legal documents outside Weblate

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -568,6 +568,17 @@ Defaults to 0.
     :ref:`rate-limit`,
     :ref:`rate-ip`
 
+.. setting:: LEGAL_URL
+
+LEGAL_URL
+---------
+
+.. versionadded:: 3.5
+
+URL where your Weblate instance shows it's legal documents. This is useful if
+you host your legal documents outside Weblate for embedding inside Weblate
+please see :ref:`legal`.
+
 .. setting:: LOGIN_REQUIRED_URLS
 
 LOGIN_REQUIRED_URLS

--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -159,7 +159,11 @@ var _rollbarConfig = {
             <li><a href="{% url 'contact' %}">{% trans "Contact" %}</a></li>
             <li><a href="{% url 'about' %}">{% blocktrans %}About Weblate{% endblocktrans %}</a></li>
             <li><a href="{% url 'keys' %}">{% blocktrans %}Weblate keys{% endblocktrans %}</a></li>
-            {% if has_legal %}<li><a href="{% url 'legal:index' %}">{% trans "Legal" %}</a></li>{% endif %}
+            {% if has_legal %}
+            <li><a href="{% url 'legal:index' %}">{% trans "Legal" %}</a></li>
+            {% elif legal_url %}
+            <li><a href="{{ legal_url }}">{% trans "Legal" %}</a></li>
+            {% endif %}
             <li><a href="{% documentation 'index' %}">{% trans "Documentation" %}</a></li>
             {% if status_url %}<li><a href="{{ status_url }}">{% trans "Service status" %}</a></li>{% endif %}
           </ul>

--- a/weblate/trans/context_processors.py
+++ b/weblate/trans/context_processors.py
@@ -46,6 +46,7 @@ CONTEXT_SETTINGS = [
     'ENABLE_HOOKS',
     'REGISTRATION_OPEN',
     'STATUS_URL',
+    'LEGAL_URL',
     # Hosted Weblate integration
     'PAYMENT_ENABLED',
 ]

--- a/weblate/trans/models/conf.py
+++ b/weblate/trans/models/conf.py
@@ -135,6 +135,9 @@ class WeblateConf(AppConf):
     # URL with status monitoring
     STATUS_URL = None
 
+    # URL with legal docs
+    LEGAL_URL = None
+
     # Use simple language codes for default language/country combinations
     SIMPLIFY_LANGUAGES = True
 


### PR DESCRIPTION
This is lightweight variant to using legal app.

Fixes https://github.com/WeblateOrg/docker/issues/76

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
