### PR TITLE
Add copy to clipboard feature

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ weblate 3.5
 
 Released on ? 2019.
 
+* Improved performance of built in translation memory.
+
 weblate 3.4
 -----------
 

--- a/weblate/addons/models.py
+++ b/weblate/addons/models.py
@@ -174,7 +174,7 @@ def pre_commit(sender, translation, author, **kwargs):
         translation.component, EVENT_PRE_COMMIT
     )
     for addon in addons:
-        component.log_info('running pre_commit addon: %s', addon.name)
+        translation.log_info('running pre_commit addon: %s', addon.name)
         addon.addon.pre_commit(translation, author)
 
 
@@ -184,7 +184,7 @@ def post_commit(sender, translation, **kwargs):
         translation.component, EVENT_POST_COMMIT
     )
     for addon in addons:
-        component.log_info('running post_commit addon: %s', addon.name)
+        translation.log_info('running post_commit addon: %s', addon.name)
         addon.addon.post_commit(translation)
 
 
@@ -194,7 +194,7 @@ def post_add(sender, translation, **kwargs):
         translation.component, EVENT_POST_ADD
     )
     for addon in addons:
-        component.log_info('running post_add addon: %s', addon.name)
+        translation.log_info('running post_add addon: %s', addon.name)
         addon.addon.post_add(translation)
 
 
@@ -204,7 +204,7 @@ def unit_pre_create_handler(sender, unit, **kwargs):
         unit.translation.component, EVENT_UNIT_PRE_CREATE
     )
     for addon in addons:
-        component.log_info('running unit_pre_create addon: %s', addon.name)
+        unit.translation.log_info('running unit_pre_create addon: %s', addon.name)
         addon.addon.unit_pre_create(unit)
 
 
@@ -215,7 +215,7 @@ def unit_post_save_handler(sender, instance, created, **kwargs):
         instance.translation.component, EVENT_UNIT_POST_SAVE
     )
     for addon in addons:
-        component.log_info('running unit_post_save addon: %s', addon.name)
+        instance.translation.log_info('running unit_post_save addon: %s', addon.name)
         addon.addon.unit_post_save(instance, created)
 
 
@@ -225,5 +225,5 @@ def store_post_load_handler(sender, translation, store, **kwargs):
         translation.component, EVENT_STORE_POST_LOAD
     )
     for addon in addons:
-        component.log_info('running store_post_load addon: %s', addon.name)
+        translation.log_info('running store_post_load addon: %s', addon.name)
         addon.addon.store_post_load(translation, store)

--- a/weblate/locale/nb/LC_MESSAGES/django.po
+++ b/weblate/locale/nb/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: Weblate 3.4\n"
 "Report-Msgid-Bugs-To: weblate@lists.cihar.com\n"
 "POT-Creation-Date: 2019-01-17 19:10+0000\n"
-"PO-Revision-Date: 2019-01-18 12:37+0000\n"
+"PO-Revision-Date: 2019-01-25 18:31+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/weblate/"
 "master/nb_NO/>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.4-dev\n"
+"X-Generator: Weblate 3.4\n"
 
 #: weblate/accounts/avatar.py:122
 msgctxt "No known user"
@@ -5789,7 +5789,7 @@ msgid ""
 "You probably want to enable adding of new translations."
 msgstr ""
 "Basefilen for nye oversettelser brukes ikke på grunn av "
-"komponentinnstillinger. Du ønsker sannsynligvis å gjøre det mulig at nye "
+"komponentinnstillingene. Du ønsker sannsynligvis å gjøre det mulig at nye "
 "oversettelser legges til automatisk."
 
 #: weblate/templates/trans/alert/updatefailure.html:4
@@ -5835,8 +5835,6 @@ msgid "I understand the consequences, delete this translation"
 msgstr "Jeg forstår konsekvensene, slett denne oversettelsen"
 
 #: weblate/templates/trans/embed-alert.html:5
-#, fuzzy
-#| msgid "There are currently no translation components."
 msgid "There are some alerts on this component"
 msgstr "Denne komponenten har noen varslinger"
 
@@ -5846,8 +5844,6 @@ msgid "Translation is licensed under free license according to FSF."
 msgstr "Oversettelsen er lisensiert under fri lisens ifølge FSF."
 
 #: weblate/templates/trans/embed-alert.html:12
-#, fuzzy
-#| msgid "Translated content has to be released under libre software license."
 msgid "Translation is licensed under OSI approved license."
 msgstr "Oversettelse lisensiert under OSI-godkjent lisens."
 

--- a/weblate/memory/storage.py
+++ b/weblate/memory/storage.py
@@ -95,6 +95,7 @@ class TranslationMemory(WhooshIndex):
             schema=self.index.schema,
             group=qparser.OrGroup.factory(0.9),
             termclass=query.FuzzyTerm,
+            plugins=[],
         )
         self.searcher = None
         self.comparer = Comparer()

--- a/weblate/static/robots.txt
+++ b/weblate/static/robots.txt
@@ -31,4 +31,5 @@ Disallow: /avatar/
 Disallow: /access/
 Disallow: /user/
 Disallow: /contact/
+Disallow: /sso-login/
 Sitemap: sitemap.xml

--- a/weblate/templates/format-translation.html
+++ b/weblate/templates/format-translation.html
@@ -7,7 +7,9 @@
     {% if item.title %}
     <h5 class="list-group-item-heading"><strong>{{ item.title }}</strong></h5>
     {% endif %}
+    {% if checksum %}
     <div class="pull-right"><button type="button" data-clipboard-target="#source{{ checksum }}{{ forloop.counter0 }}" class="btn btn-danger btn-xs" data-clipboard-text>Copy to clipboard</button></div>
+    {% endif %}
     <div id="source{{ checksum }}{{ forloop.counter0 }}" class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
   </div>
   {% endfor %}

--- a/weblate/templates/format-translation.html
+++ b/weblate/templates/format-translation.html
@@ -7,7 +7,8 @@
     {% if item.title %}
     <h5 class="list-group-item-heading"><strong>{{ item.title }}</strong></h5>
     {% endif %}
-    <div class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
+    <div class="pull-right"><button type="button" data-clipboard-target="#source{{ forloop.counter0 }}" class="btn btn-danger btn-xs" data-clipboard-text>Copy to clipboard</button></div>
+    <div id="source{{ forloop.counter0 }}" class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
   </div>
   {% endfor %}
 </div>

--- a/weblate/templates/format-translation.html
+++ b/weblate/templates/format-translation.html
@@ -7,8 +7,8 @@
     {% if item.title %}
     <h5 class="list-group-item-heading"><strong>{{ item.title }}</strong></h5>
     {% endif %}
-    <div class="pull-right"><button type="button" data-clipboard-target="#source{{ forloop.counter0 }}" class="btn btn-danger btn-xs" data-clipboard-text>Copy to clipboard</button></div>
-    <div id="source{{ forloop.counter0 }}" class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
+    <div class="pull-right"><button type="button" data-clipboard-target="#source{{ checksum }}{{ forloop.counter0 }}" class="btn btn-danger btn-xs" data-clipboard-text>Copy to clipboard</button></div>
+    <div id="source{{ checksum }}{{ forloop.counter0 }}" class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
   </div>
   {% endfor %}
 </div>

--- a/weblate/templates/format-translation.html
+++ b/weblate/templates/format-translation.html
@@ -7,10 +7,14 @@
     {% if item.title %}
     <h5 class="list-group-item-heading"><strong>{{ item.title }}</strong></h5>
     {% endif %}
-    {% if checksum %}
-    <div class="pull-right"><button type="button" data-clipboard-target="#source{{ checksum }}{{ forloop.counter0 }}" class="btn btn-danger btn-xs" data-clipboard-text>Copy to clipboard</button></div>
-    {% endif %}
     <div id="source{{ checksum }}{{ forloop.counter0 }}" class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
+    {% if checksum %}
+    <div class="row">
+      <div class="col-md-12">
+        <button type="button" class="btn btn-default btn-xs pull-right" data-clipboard-target="#source{{ checksum }}{{ forloop.counter0 }}" data-clipboard-text>Copy to clipboard</button>
+      </div>
+    </div>
+    {% endif %}
   </div>
   {% endfor %}
 </div>

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -224,10 +224,15 @@ def format_translation(value, language, plural=None, diff=None,
 
         parts.append({'title': title, 'content': content})
 
+    checksum = ''
+    if unit is not None:
+        checksum = unit.checksum
+
     return {
         'simple': simple,
         'items': parts,
         'language': language,
+        'checksum': checksum,
     }
 
 


### PR DESCRIPTION
This closes #2470. 
I added the button inside the list-group-item element, because in case of multiple source strings I just didn't know where else to put it. An attached picture illustrates the changes.
![fix](https://user-images.githubusercontent.com/17688608/51785838-1476e980-216d-11e9-8749-c36bd2b2c373.png)

That's my very first PR, and I'm sorry in advance for any screw ups.
