### PR TITLE
Add copy to clipboard featue

### DIFF
--- a/weblate/templates/format-translation.html
+++ b/weblate/templates/format-translation.html
@@ -8,6 +8,13 @@
     <h5 class="list-group-item-heading"><strong>{{ item.title }}</strong></h5>
     {% endif %}
     <div class="list-group-item-text" lang="{{ language.code }}" dir="{{ language.direction }}">{{ item.content }}</div>
+    {% if unit %}
+    <div class="row">
+      <div class="col-md-12">
+        <button type="button" class="btn btn-default btn-xs pull-right" data-clipboard-text="{{ item.copy }}">Copy to clipboard</button>
+      </div>
+    </div>
+    {% endif %}
   </div>
   {% endfor %}
 </div>

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -196,6 +196,9 @@ def format_translation(value, language, plural=None, diff=None,
         # HTML escape
         value = escape(force_text(raw_value))
 
+        # Content of the Copy to clipboard button
+        copy = value
+
         # Format diff if there is any
         value = fmt_diff(value, diff, idx)
 
@@ -222,12 +225,13 @@ def format_translation(value, language, plural=None, diff=None,
         # Join paragraphs
         content = mark_safe(newline.join(paras))
 
-        parts.append({'title': title, 'content': content})
+        parts.append({'title': title, 'content': content, 'copy': copy})
 
     return {
         'simple': simple,
         'items': parts,
         'language': language,
+        'unit': unit,
     }
 
 


### PR DESCRIPTION
This closes #2470.

I fixed issues of my previous pull request. 

- The button works in zen mode
- Now copy to clipboard button has the same content as the "Copy" button.
- The button now has more appropriate color and looks fine with long texts (the picture shows it).

![fix](https://user-images.githubusercontent.com/17688608/51930394-8b311280-240b-11e9-8139-5c8eeefd5735.png)
