### PR TITLE
Disable text selection on badges

### DIFF
--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -255,6 +255,7 @@ td .list-group {
 	-moz-border-radius: .3em;
 	-webkit-border-radius: .3em;
 	border-radius: .3em;
+	user-select: none;
 }
 .zen-unit:nth-child(even) {
     background-color: #f9f9f9;


### PR DESCRIPTION
Goal is to avoid translator copying the '1' and '2' indicators from the source string when using text selection instead of 'Copy' button

I don't think this warrants a test case...

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation
