### PR TITLE
Add a configuration option to make the translation length limit based on the source string optional

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -571,6 +571,15 @@ URL where your Weblate instance shows it's legal documents. This is useful if
 you host your legal documents outside Weblate for embedding inside Weblate
 please see :ref:`legal`.
 
+.. setting:: LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH
+
+LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH
+-----------------------------------------
+
+By default the length of a given translation is limited to the length of the source string * 10 characters. Set this option to False to allow longer translations (up to 10.000 characters) irrespective of the source length.
+
+Defaults to True.
+
 .. setting:: LOGIN_REQUIRED_URLS
 
 LOGIN_REQUIRED_URLS

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -653,6 +653,11 @@ ENABLE_HOOKS = True
 # Number of nearby messages to show in each direction
 NEARBY_MESSAGES = 5
 
+# By default the length of a given translation is limited to the length of
+# the source string * 10 characters. Set this option to False to allow longer
+# translations (up to 10.000 characters)
+LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH = True
+
 # Use simple language codes for default language/country combinations
 SIMPLIFY_LANGUAGES = True
 

--- a/weblate/trans/models/conf.py
+++ b/weblate/trans/models/conf.py
@@ -88,6 +88,9 @@ class WeblateConf(AppConf):
     # URL with legal docs
     LEGAL_URL = None
 
+    # Disable length limitations calculated from the source string length
+    LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH = True
+
     # Is the site using https
     ENABLE_HTTPS = False
 

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1010,8 +1010,10 @@ class Unit(models.Model, LoggerMixin):
                     return int(flag[11:])
                 except ValueError:
                     continue
-        # Fallback to reasonably big value
-        return max(100, len(self.get_source_plurals()[0]) * 10)
+        if settings.LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH:
+            # Fallback to reasonably big value
+            return max(100, len(self.get_source_plurals()[0]) * 10)
+        return 10000
 
     def get_target_hash(self):
         return calculate_hash(None, self.target)

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -28,6 +28,7 @@ from django.core.management.color import no_style
 from django.db import connection
 from django.http.request import HttpRequest
 from django.test import TestCase, LiveServerTestCase
+from django.test.utils import override_settings
 
 from weblate.auth.models import User, Group
 from weblate.checks.models import Check
@@ -334,6 +335,37 @@ class UnitTest(ModelTestCase):
         unit = Unit.objects.all()[0]
         unit.flags = 'no-wrap, ignore-same'
         self.assertEqual(unit.all_flags, {'no-wrap', 'ignore-same'})
+
+    def test_get_max_length_no_pk(self):
+        unit = Unit.objects.all()[0]
+        unit.pk = False
+        self.assertEqual(unit.get_max_length(), 10000)
+
+    def test_get_max_length_empty_source_default_fallback(self):
+        unit = Unit.objects.all()[0]
+        unit.pk = True
+        unit.source = ''
+        self.assertEqual(unit.get_max_length(), 100)
+
+    def test_get_max_length_default_fallback(self):
+        unit = Unit.objects.all()[0]
+        unit.pk = True
+        unit.source = 'My test source'
+        self.assertEqual(unit.get_max_length(), 140)
+
+    @override_settings(LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH=False)
+    def test_get_max_length_empty_source_disabled_default_fallback(self):
+        unit = Unit.objects.all()[0]
+        unit.pk = True
+        unit.source = ''
+        self.assertEqual(unit.get_max_length(), 10000)
+
+    @override_settings(LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH=False)
+    def test_get_max_length_disabled_default_fallback(self):
+        unit = Unit.objects.all()[0]
+        unit.pk = True
+        unit.source = 'My test source'
+        self.assertEqual(unit.get_max_length(), 10000)
 
 
 class WhiteboardMessageTest(ModelTestCase):


### PR DESCRIPTION
Use case:

When translating language files which are key value based with short keys like "home.description" and a long translation Weblate currently limits the length of the translation to max(100, source.length * 10), in this example 160 chars. To avoid adding a manual max-length constraint to all keys tapping into this case the option LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH can be set to false. If it's set to false the calculation will be skipped and instead translations up to 10.000 characters are allowed.

Signed-off-by: Enno Woortmann <enno.woortmann@web.de>

Before submitting pull request, please ensure that:

- [ x ] Every commit has message which describes it
- [ x ] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ x ] Any code changes come with testcase
- [ x ] Any new functionality is covered by user documentation
