### PR TITLE
fix systemd service example : remove use of /bin/sh

### DIFF
--- a/examples/celery-weblate.service
+++ b/examples/celery-weblate.service
@@ -13,14 +13,17 @@ ExecStartPre=/bin/mkdir -p /var/run/celery
 ExecStartPre=/bin/chown -R weblate /var/run/celery/
 ExecStartPre=/bin/mkdir -p /var/log/celery
 ExecStartPre=/bin/chown -R weblate /var/log/celery/
-ExecStart=/bin/sh -c '${CELERY_BIN} multi start ${CELERYD_NODES} \
+
+# please note surrounding environment variables with braces has a specific meaning.
+# When surrounded by braces, variable content is not split around spaces.
+ExecStart=${CELERY_BIN} multi start $CELERYD_NODES \
   -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
-ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait ${CELERYD_NODES} \
+  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} $CELERYD_OPTS
+ExecStop=${CELERY_BIN} multi stopwait $CELERYD_NODES \
   --pidfile=${CELERYD_PID_FILE}'
-ExecReload=/bin/sh -c '${CELERY_BIN} multi restart ${CELERYD_NODES} \
+ExecReload=${CELERY_BIN} multi restart $CELERYD_NODES \
   -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
+  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} $CELERYD_OPTS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I had trouble with usage of /bin/sh in systemd celery service. The pid wasn't the good one for systemd because of  /bin/sh call to interpret celery command line. Since I found it is not necessary by using environment variable without braces, I'd like to propose this enhancement.

(It seems celery team could be also notified)