### PR TITLE
Cache checks list while importing component

### DIFF
--- a/weblate/trans/models/source.py
+++ b/weblate/trans/models/source.py
@@ -119,13 +119,18 @@ class Source(models.Model):
             project = self.component.project
 
         # Fetch old checks
-        old_checks = set(
-            Check.objects.filter(
-                content_hash=content_hash,
-                project=project,
-                language=None
-            ).values_list('check', flat=True)
-        )
+        if self.component.checks_cache is not None:
+            old_checks = self.component.checks_cache.get(
+                (content_hash, None), []
+            )
+        else:
+            old_checks = set(
+                Check.objects.filter(
+                    content_hash=content_hash,
+                    project=project,
+                    language=None
+                ).values_list('check', flat=True)
+            )
         create = []
 
         # Run all source checks

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -710,12 +710,15 @@ class Unit(models.Model, LoggerMixin):
         )
 
     def checks(self):
-        """Return all checks for this unit (even ignored)."""
+        """Return all checks names for this unit (even ignored)."""
+        if self.translation.component.checks_cache is not None:
+            key = (self.content_hash, self.translation.language_id)
+            return self.translation.component.checks_cache.get(key, [])
         return Check.objects.filter(
             content_hash=self.content_hash,
             project=self.translation.component.project,
             language=self.translation.language
-        )
+        ).values_list('check', flat=True)
 
     def source_checks(self):
         """Return all source checks for this unit (even ignored)."""
@@ -775,7 +778,7 @@ class Unit(models.Model, LoggerMixin):
         content_hash = self.content_hash
         project = self.translation.component.project
         language = self.translation.language
-        old_checks = set(self.checks().values_list('check', flat=True))
+        old_checks = set(self.checks())
         create = []
 
         # Run all target checks

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -647,7 +647,7 @@ class EditComplexTest(ViewTestCase):
         self.assertEqual(unit.translation.stats.allchecks, 1)
 
         # Ignore check
-        check_id = unit.checks()[0].id
+        check_id = unit.active_checks()[0].id
         response = self.client.get(
             reverse('js-ignore-check', kwargs={'check_id': check_id})
         )


### PR DESCRIPTION
This avoids needs to fetch checks for every unit during update, heavily
reducing import time.