### PR TITLE
Fixed issue with wrong permissions for id_rsa on openshift

### DIFF
--- a/.s2i/action_hooks/deploy
+++ b/.s2i/action_hooks/deploy
@@ -23,6 +23,10 @@ else
     powershift image setup
 fi
 
+echo "-----> Set chmod 600 for id_rsa keys."
+
+chmod 600 /opt/app-root/data/ssh/id_rsa
+
 # This is due to known python bug: https://bugzilla.redhat.com/show_bug.cgi?id=1430327
 if [ -n ${LD_LIBRARY_PATH}; then
   export LD_LIBRARY_PATH="/opt/rh/rh-python35/root/usr/lib64:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
By default, openshift storage has `chmod 660` for all files, but for git and ssh this level of permission on  `id_rsa` file is to wide, so we need to change it after openshift setup script is run.