### PR TITLE
Fix a typo in openshipft deployment

### DIFF
--- a/.s2i/action_hooks/deploy
+++ b/.s2i/action_hooks/deploy
@@ -23,12 +23,12 @@ else
     powershift image setup
 fi
 
-echo "-----> Set chmod 600 for id_rsa keys."
+echo " -----> Set chmod 600 for id_rsa keys."
 
 chmod 600 /opt/app-root/data/ssh/id_rsa
 
 # This is due to known python bug: https://bugzilla.redhat.com/show_bug.cgi?id=1430327
-if [ -n ${LD_LIBRARY_PATH}; then
+if [ -n ${LD_LIBRARY_PATH} ]; then
   export LD_LIBRARY_PATH="/opt/rh/rh-python35/root/usr/lib64:${LD_LIBRARY_PATH}"
 else
   export LD_LIBRARY_PATH="/opt/rh/rh-python35/root/usr/lib64"


### PR DESCRIPTION
Just found another bug in deployment script. Missing `]`.