### PR TITLE
Allow custom location of MO files

### DIFF
--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -46,6 +46,27 @@ class BaseAddonForm(forms.Form):
         return self._addon.instance
 
 
+class GenerateMoForm(BaseAddonForm):
+    path = forms.CharField(
+        label=_('Path of generated MO file'),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(GenerateMoForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout = Layout(
+            Field('path'),
+        )
+
+    def test_render(self, value):
+        translation = self._addon.instance.component.translation_set.all()[0]
+        validate_render(value, translation=translation)
+
+    def clean_path(self):
+        self.test_render(self.cleaned_data['path'])
+        return self.cleaned_data['path']
+
 class GenerateForm(BaseAddonForm):
     filename = forms.CharField(
         label=_('Name of generated file'),

--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -70,17 +70,18 @@ class GenerateMoAddon(GettextBaseAddon):
         output = translation.get_filename()[:-2] + 'mo'
 
         if self.instance.configuration['path']:
-             mo_name = os.path.basename(output)
-             if mo_name:
-                 mo_path = os.path.dirname(output)
-                 if not mo_path:
-                    mo_path = ''
+            mo_name = os.path.basename(output)
+            if mo_name:
+                mo_path = os.path.dirname(output)
+                if not mo_path:
+                   mo_path = ''
 
-                 output = os.path.join(
-                     mo_path,
-                     self.instance.configuration['path'],
-                     mo_name
-                 )
+                output = os.path.join(
+                    mo_path,
+                    self.instance.configuration['path'],
+                    mo_name
+                )
+
         with open(output, 'wb') as handle:
             handle.write(exporter.serialize())
         translation.addon_commit_files.append(output)

--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -74,7 +74,7 @@ class GenerateMoAddon(GettextBaseAddon):
             if mo_name:
                 mo_path = os.path.dirname(output)
                 if not mo_path:
-                   mo_path = ''
+                    mo_path = ''
 
                 output = os.path.join(
                     mo_path,


### PR DESCRIPTION
Signed-off-by: netniV <netniv@hotmail.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation

Unfortunately the documentation mentioned nothing about the latter two requests so I haven't done those.  This functionality allows you to customise the path to the MO files which may not always be in the same folder as the PO files.

For example, cacti stores it's MO files in /locales/LC_MESSAGES but stores the PO/POT files in /locales/po/.  This change allows you to customise the output by either entering a full path or a relative path (eg, ../LC_MESSAGES)