### PR TITLE
Fix openshift deployment to not trigger sqlite on build

### DIFF
--- a/openshift3/persistent-mysql.json
+++ b/openshift3/persistent-mysql.json
@@ -164,7 +164,33 @@
                             "kind": "ImageStreamTag",
                             "namespace": "openshift",
                             "name": "python:${PYTHON_VERSION}"
-                        }
+                        },
+                        "env": [
+                            {
+                                "name": "OPENSHIFT_APP_NAME",
+                                "value": "weblate"
+                            },
+                            {
+                                "name": "OPENSHIFT_MYSQL_DB_URL",
+                                "value": "mysql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${APPLICATION_NAME}-db:3306/weblate"
+                            },
+                            {
+                                "name": "OPENSHIFT_MYSQL_DB_USERNAME",
+                                "value": "${DATABASE_USERNAME}"
+                            },
+                            {
+                                "name": "OPENSHIFT_MYSQL_DB_PASSWORD",
+                                "value": "${DATABASE_PASSWORD}"
+                            },
+                            {
+                                "name": "OPENSHIFT_MYSQL_DB_HOST",
+                                "value": "${APPLICATION_NAME}-db"
+                            },
+                            {
+                                "name": "OPENSHIFT_MYSQL_DB_PORT",
+                                "value": "3306"
+                            }
+                        ]
                     }
                 },
                 "output": {

--- a/openshift3/persistent-postgresql.json
+++ b/openshift3/persistent-postgresql.json
@@ -164,7 +164,33 @@
                             "kind": "ImageStreamTag",
                             "namespace": "openshift",
                             "name": "python:${PYTHON_VERSION}"
-                        }
+                        },
+                        "env": [
+                            {
+                              "name": "OPENSHIFT_APP_NAME",
+                              "value": "weblate"
+                            },
+                            {
+                                "name": "OPENSHIFT_POSTGRESQL_DB_URL",
+                                "value": "postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${APPLICATION_NAME}-db:5432/weblate"
+                            },
+                            {
+                                "name": "OPENSHIFT_POSTGRESQL_DB_USERNAME",
+                                "value": "${DATABASE_USERNAME}"
+                            },
+                            {
+                                "name": "OPENSHIFT_POSTGRESQL_DB_PASSWORD",
+                                "value": "${DATABASE_PASSWORD}"
+                            },
+                            {
+                                "name": "OPENSHIFT_POSTGRESQL_DB_HOST",
+                                "value": "${APPLICATION_NAME}-db"
+                            },
+                            {
+                                "name": "OPENSHIFT_POSTGRESQL_DB_PORT",
+                                "value": "5432"
+                            }
+                        ]
                     }
                 },
                 "output": {


### PR DESCRIPTION
This fixes https://github.com/WeblateOrg/weblate/issues/2675, where on build sqlite was actually triggered, instead of psql/mysql. 
This bug affected only build stage, on deployment correct database was used.