### PR TITLE
Component: Improve commit pending performance

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -410,9 +410,9 @@ class Translation(models.Model, URLMixin, LoggerMixin):
             pk=self.stats.last_author
         ).get_author_name(email)
 
-    def commit_pending(self, reason, request, skip_push=False):
+    def commit_pending(self, reason, request, skip_push=False, force=False):
         """Commit any pending changes."""
-        if not self.unit_set.filter(pending=True).exists():
+        if not force and not self.unit_set.filter(pending=True).exists():
             return False
 
         self.log_info('committing pending changes (%s)', reason)

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -698,6 +698,29 @@ class ComponentErrorTest(RepoTestCase):
             self.component.clean()
 
 
+class LinkedEditTest(ViewTestCase):
+    def create_component(self):
+        return self.create_link()
+
+    def test_linked(self):
+        # Grab current revision
+        start_rev = self.component.repository.last_revision
+
+        # Translate all units
+        request = self.factory.get('/')
+        request.user = self.user
+        for unit in Unit.objects.iterator():
+            unit.translate(request, 'test', STATE_TRANSLATED)
+
+        # No commit now
+        self.assertEqual(start_rev, self.component.repository.last_revision)
+
+        # Commit pending changes
+        self.component.commit_pending('test', None)
+        self.assertNotEqual(start_rev, self.component.repository.last_revision)
+        self.assertEqual(4, self.component.repository.count_outgoing())
+
+
 class ComponentEditTest(ViewTestCase):
     """Test for error handling"""
     @staticmethod


### PR DESCRIPTION
In case of many linked components, going one translation by one just to
figure out if there is something to commit is slow. We can better
directly filter translations for the ones with pending units.

Issue #2670

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
