### PR TITLE
Component: Show origin from translation-finder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ jellyfish>=0.6.1
 openpyxl>=2.5.0
 celery>=4.0
 celery-batches>=0.2
-translation-finder>=1.0
+translation-finder>=1.4
 pathlib2; python_version < '3.4'
 html2text>=2018.1.9
 # The only reason for this strict dependency is same dep in translate-toolkit

--- a/weblate/templates/trans/discover-choice.html
+++ b/weblate/templates/trans/discover-choice.html
@@ -1,2 +1,2 @@
 {% load i18n %}
-<strong>{% trans "File format" %}</strong> <code>{{ file_format_name }}</code>, <strong>{% trans "Filemask" %}</strong> <code>{{ filemask }}</code><br />
+<strong>{% trans "File format" %}</strong> <code>{{ file_format_name }}</code>, <strong>{% trans "Filemask" %}</strong> <code>{{ filemask }}</code>{% if origin %}({{ origin }}){% endif %}<br />

--- a/weblate/utils/requirements.py
+++ b/weblate/utils/requirements.py
@@ -191,7 +191,7 @@ def get_versions():
     result.append(get_single(
         'translation-finder',
         'https://github.com/WeblateOrg/translation-finder',
-        '1.0',
+        '1.4',
     ))
 
     result.append(get_single(


### PR DESCRIPTION
This requires translation-finder 1.3 which exposes such metadata.

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
