### PR TITLE
Spelling: msgid of translated messages → strings

### DIFF
--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -122,7 +122,7 @@ class GettextCustomizeForm(BaseAddonForm):
 
 class MsgmergeForm(BaseAddonForm):
     previous = forms.BooleanField(
-        label=_('Keep previous msgids of translated messages'),
+        label=_('Keep previous msgids of translated strings'),
         required=False,
         initial=True,
     )


### PR DESCRIPTION
If not, what messages are translated?