### PR TITLE
Formats: Move store validation to separate method

### DIFF
--- a/weblate/formats/auto.py
+++ b/weblate/formats/auto.py
@@ -56,6 +56,7 @@ def try_load(filename, content, original_format, template_store):
                     BytesIOMode(filename, content),
                     template_store
                 )
+                result.check_valid()
                 # Skip if there is not translated unit
                 # this can easily happen when importing bilingual
                 # storage which can be monolingual as well
@@ -65,7 +66,9 @@ def try_load(filename, content, original_format, template_store):
                 failure = error
         if file_format.monolingual in (False, None):
             try:
-                return file_format.parse(BytesIOMode(filename, content))
+                result = file_format.parse(BytesIOMode(filename, content))
+                result.check_valid()
+                return result
             except Exception as error:
                 failure = error
 

--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -29,6 +29,7 @@ from copy import deepcopy
 
 import six
 from django.utils.functional import cached_property
+from django.utils.translation import ugettext as _
 
 from weblate.utils.hash import calculate_hash
 
@@ -215,10 +216,11 @@ class TranslationFormat(object):
         self.template_store = template_store
         self.is_template = is_template
 
-        # Check store validity
+    def check_valid(self):
+        """Check store validity."""
         if not self.is_valid():
             raise ValueError(
-                'Invalid file format {0}'.format(repr(self.store))
+                _('Failed to load strings from the file, try choosing other format.')
             )
 
     def get_filenames(self):

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1244,8 +1244,9 @@ class Component(models.Model, URLMixin, PathMixin):
         translations = {}
         languages = {}
         try:
-            self.template_store
-        except FileParseError as exc:
+            if self.has_template():
+                self.template_store.check_valid()
+        except (FileParseError, ValueError) as exc:
             self.log_warning(
                 'skipping update due to error in parsing template: %s', exc
             )
@@ -1454,7 +1455,7 @@ class Component(models.Model, URLMixin, PathMixin):
             try:
                 self.file_format_cls.parse(
                     os.path.join(dir_path, match), self.template_store
-                )
+                ).check_valid()
             except Exception as error:
                 errors.append('{0}: {1}'.format(match, str(error)))
         if errors:
@@ -1506,8 +1507,8 @@ class Component(models.Model, URLMixin, PathMixin):
                 raise ValidationError({'template': msg})
 
             try:
-                self.template_store
-            except FileParseError as exc:
+                self.template_store.check_valid()
+            except (FileParseError, ValueError) as exc:
                 msg = _('Could not parse translation base file: %s') % str(exc)
                 raise ValidationError({'template': msg})
 

--- a/weblate/trans/tests/test_files.py
+++ b/weblate/trans/tests/test_files.py
@@ -434,6 +434,18 @@ class ExportTest(ViewTestCase):
             '; charset=utf-8'
         )
 
+    def test_export_xlsx_empty(self):
+        response = self.export_format('xlsx', type='check:inconsistent')
+        self.assertEqual(
+            response['Content-Disposition'],
+            'attachment; filename=test-test-cs.xlsx'
+        )
+        self.assertEqual(
+            response['Content-Type'],
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            '; charset=utf-8'
+        )
+
     def test_export_invalid(self):
         response = self.export_format('invalid')
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
We do not want to perform the validation in all cases, in some places
it's valid to have an empty file (for example in export).
