### PR TITLE
docs: fix typo in LDAP auth example

### DIFF
--- a/docs/admin/deployments.rst
+++ b/docs/admin/deployments.rst
@@ -395,7 +395,7 @@ LDAP
 
         environment:
           WEBLATE_AUTH_LDAP_SERVER_URI: ldap://ldap.example.org
-          WEBLATE_AUTH_LDAP_USER_DN_TEMPLATE=uid=%(user)s,ou=People,dc=example,dc: net
+          WEBLATE_AUTH_LDAP_USER_DN_TEMPLATE: uid=%(user)s,ou=People,dc=example,dc: net
           # map weblate 'full_name' to ldap 'name' and weblate 'email' attribute to 'mail' ldap attribute.
           # another example that can be used with OpenLDAP: 'full_name:cn,email:mail'
           WEBLATE_AUTH_LDAP_USER_ATTR_MAP: full_name:name,email:mail


### PR DESCRIPTION
A very minor fix.