### PR TITLE
fix: do not ignore exception in msgmerge fixes #2813

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -215,6 +215,8 @@ class BaseAddon(object):
                 'output': output,
                 'error': str(err),
             })
+        except Exception as err:
+            component.log_error('failed to exec %s: %s', err.cmd, err.output)
 
     def trigger_alerts(self, component):
         if self.alerts:


### PR DESCRIPTION
I could not figure out how to run the unit tests.

But the msgmerge addon fails silently,  the `except (OSError, subprocess.CalledProcessError) as err:`
is not working as expected and CalledProcessError is never caught.
This causes msgmerge to fail on the first translation and not do the rest.

To test it,  try introducing an error in the pot,  for example duplicate entries:

```
msgid "Duplicate string"
msgstr ""

msgid "Duplicate string"
msgstr ""
```

You will see it will fail msgmerge with the first po,  but it will not report an error and it will skip all other po files.
