### PR TITLE
Spelling: colors indicate → color indicates

### DIFF
--- a/weblate/templates/addons/squash_help.html
+++ b/weblate/templates/addons/squash_help.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 
 <p>
-{% trans "All Weblate commits from all components within this repository will be squashed." %}
+{% trans "Weblate commits from components within this repository will be squashed." %}
 </p>
 <p>
-{% trans 'Resulting commits will include all original commit messages, but lose commit authorship, unless "Per author" is selected, or you customize the commit message to include it.' %}
+{% trans 'Original commit messages are kept, but authorship is lost unless "Per author" is selected or the commit message is customized to include it.' %}
 </p>

--- a/weblate/templates/ratelimit.html
+++ b/weblate/templates/ratelimit.html
@@ -2,7 +2,7 @@
 {% load translations %}
 
 {% documentation_icon 'user/translating' 'user-rate' right=True %}
-{% trans "You have recently performed too many operations, so your request is carried out a bit slower." %}
+{% trans "Your request was rejected because you have performed too many operations recently." %}
 {% if do_logout %}
 {% trans "You have been logged out, please log in and try again later." %}
 {% else %}

--- a/weblate/templates/ratelimit.html
+++ b/weblate/templates/ratelimit.html
@@ -2,7 +2,7 @@
 {% load translations %}
 
 {% documentation_icon 'user/translating' 'user-rate' right=True %}
-{% trans "You have recently performed too many operations and your request has been rate limited." %}
+{% trans "You have recently performed too many operations, so your request is carried out a bit slower." %}
 {% if do_logout %}
 {% trans "You have been logged out, please log in and try again later." %}
 {% else %}

--- a/weblate/templates/replace.html
+++ b/weblate/templates/replace.html
@@ -19,7 +19,7 @@
 {% show_message "info" msg %}
 
 {% if limited %}
-{% trans "There are too many matches for this search. Showing and replacing only first 250 ones. To replace remaining ones, please perform the replacement again." as msg %}
+{% trans "Showing and replacing only the first 250 matches. Perform the replacement again to replace more entries." as msg %}
 {% show_message "warning" msg %}
 {% endif %}
 

--- a/weblate/templates/snippets/legend-button.html
+++ b/weblate/templates/snippets/legend-button.html
@@ -3,7 +3,7 @@
 
 <i class="fa fa-info-circle html-tooltip {{ group_css }}" data-toggle="tooltip" data-placement="bottom">
 <div class="tooltip-content hidden">
-  <p>{% trans "Progress bar colors indicate translation state:" %}</p>
+  <p>{% trans "Progress bar color indicates translation state:" %}</p>
   <ul class="legend">
     <li>
 {% with approved=100 %}

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1646,7 +1646,7 @@ class ComponentProjectForm(ComponentNameForm):
 
 class ComponentZipCreateForm(ComponentProjectForm):
     zipfile = forms.FileField(
-        label=_('ZIP file with translations'),
+        label=_('ZIP file containing translations'),
         validators=[FileExtensionValidator(allowed_extensions=['zip'])],
         widget=forms.FileInput(attrs={'accept': '.zip,application/zip'})
     )
@@ -1983,7 +1983,7 @@ class BulkStateForm(forms.Form):
 
 class ContributorAgreementForm(forms.Form):
     confirm = forms.BooleanField(
-        label=_("I agree with the contributor agreement"),
+        label=_("I accept the contributor agreement"),
         required=True
     )
     next = forms.CharField(
@@ -2021,7 +2021,7 @@ class DeleteForm(forms.Form):
     def clean(self):
         if self.cleaned_data.get('confirm') != self.obj.full_slug:
             raise ValidationError(
-                _('The translation name does not match the one to delete!')
+                _('The translation name does not match the one marked for deletion!')
             )
 
 

--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -186,7 +186,7 @@ class RepositoryChanges(BaseAlert):
 
 @register
 class MissingLicense(BaseAlert):
-    verbose = _('License information missing.')
+    verbose = _('License info missing.')
 
 
 @register

--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -191,12 +191,12 @@ class MissingLicense(BaseAlert):
 
 @register
 class AddonScriptError(MultiAlert):
-    verbose = _('Error when executing addon.')
+    verbose = _('Could not run addon.')
 
 
 @register
 class MsgmergeAddonError(MultiAlert):
-    verbose = _('Error when executing addon.')
+    verbose = _('Could not run addon.')
 
 
 @register

--- a/weblate/wladmin/sites.py
+++ b/weblate/wladmin/sites.py
@@ -185,7 +185,7 @@ class WeblateAdminSite(AdminSite):
     @never_cache
     def logout(self, request, extra_context=None):
         if request.method == 'POST':
-            messages.info(request, _('Thanks for using Weblate!'))
+            messages.info(request, _('Thank you for using Weblate.'))
             request.current_app = self.name
             return LogoutView.as_view(
                 next_page=reverse('admin:login')


### PR DESCRIPTION
My rationale is that the indicated state is not multicoloured, so colour indicates is always correct, whereas colours indicate can be misinterpreted.