### PR TITLE
Formats: Export unit flags to xliff and gettext

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ weblate 3.9
 
 Not yet released.
 
+* Include Weblate metadata in downloaded files.
+
 weblate 3.8
 -----------
 

--- a/docs/user/files.rst
+++ b/docs/user/files.rst
@@ -16,6 +16,10 @@ Translatable files can be downloaded using the :guilabel:`Download source file`
 in the :guilabel:`Files` menu, producing a copy of the file as it is stored
 in upstream version control system.
 
+You can either download the original file as is or converted into one of widely
+used localization formats. The converted files will be enriched with data
+provided in Weblate such as additional context, comments or flags.
+
 Several file formats are available, including a compiled file
 to use in your choice of application (for example ``.mo`` files for GNU Gettext) using
 the :guilabel:`Files`.

--- a/weblate/formats/exporters.py
+++ b/weblate/formats/exporters.py
@@ -151,6 +151,10 @@ class BaseExporter(object):
         note = self.string_filter(unit.comment)
         if note:
             output.addnote(note, origin='developer')
+        # In Weblate context
+        note = self.string_filter(unit.source_info.context)
+        if context:
+            output.addnote(note, origin='developer')
 
         # Store flags
         if unit.all_flags:

--- a/weblate/formats/exporters.py
+++ b/weblate/formats/exporters.py
@@ -158,6 +158,12 @@ class BaseExporter(object):
         # Comments
         for comment in unit.get_comments():
             output.addnote(comment.comment, origin='translator')
+        # Suggestions
+        for suggestion in unit.suggestions:
+            output.addnote(
+                'Suggested in Weblate: {}'.format(suggestion.target),
+                origin='translator'
+            )
 
         # Store flags
         if unit.all_flags:

--- a/weblate/formats/exporters.py
+++ b/weblate/formats/exporters.py
@@ -155,6 +155,9 @@ class BaseExporter(object):
         note = self.string_filter(unit.source_info.context)
         if context:
             output.addnote(note, origin='developer')
+        # Comments
+        for comment in unit.get_comments():
+            output.addnote(comment.comment, origin='translator')
 
         # Store flags
         if unit.all_flags:

--- a/weblate/formats/tests/test_exporters.py
+++ b/weblate/formats/tests/test_exporters.py
@@ -33,7 +33,14 @@ from weblate.formats.exporters import (
 )
 from weblate.formats.helpers import BytesIOMode
 from weblate.lang.models import Language, Plural
-from weblate.trans.models import Component, Dictionary, Project, Translation, Unit
+from weblate.trans.models import (
+    Component,
+    Dictionary,
+    Project,
+    Source,
+    Translation,
+    Unit,
+)
 from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
 
 
@@ -106,6 +113,7 @@ class PoExporterTest(TestCase):
         # Fake file format to avoid need for actual files
         translation.store = EmptyFormat(BytesIOMode('', b''))
         unit = Unit(translation=translation, id_hash=-1, **kwargs)
+        unit.__dict__['source_info'] = Source(check_flags='max-length:200')
         exporter = self.get_exporter(lang, translation=translation)
         exporter.add_unit(unit)
         return self.check_export(exporter)

--- a/weblate/formats/tests/test_exporters.py
+++ b/weblate/formats/tests/test_exporters.py
@@ -39,6 +39,7 @@ from weblate.trans.models import (
     Dictionary,
     Project,
     Source,
+    Suggestion,
     Translation,
     Unit,
 )
@@ -124,6 +125,9 @@ class PoExporterTest(TestCase):
         unit.__dict__['source_info'] = Source(**source_info)
         if source_info:
             unit.get_comments = fake_get_comments
+            unit.__dict__['suggestions'] = [
+                Suggestion(target='Weblate translator suggestion')
+            ]
         exporter = self.get_exporter(lang, translation=translation)
         exporter.add_unit(unit)
         return self.check_export(exporter)
@@ -188,6 +192,8 @@ class PoExporterTest(TestCase):
         if self._has_comments:
             self.assertIn(b'Context in Weblate', result)
             self.assertIn(b'Weblate translator comment', result)
+            self.assertIn(b'Suggested in Weblate', result)
+            self.assertIn(b'Weblate translator suggestion', result)
 
     def setUp(self):
         self.exporter = self.get_exporter()


### PR DESCRIPTION
We already partly did this for gettext, it is now complete including
inherited flags from source or component.

Issue #1194

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
