### PR TITLE
Add support for pushing to GitLab using merge requests.

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -510,6 +510,20 @@ updates.
    :ref:`github-push`,
    :ref:`hub-setup`
 
+
+.. setting:: GITLAB_USERNAME
+
+GITLAB_USERNAME
+---------------
+
+GitLab username that will be used to send merge requests for translation
+updates.
+
+.. seealso::
+
+   :ref:`gitlab-push`,
+   :ref:`lab-setup`
+
 .. setting:: GOOGLE_ANALYTICS_ID
 
 GOOGLE_ANALYTICS_ID
@@ -1128,8 +1142,8 @@ custom VCS backends using this.
       'weblate.vcs.git.GitRepository',
    )
 
-.. seealso:: 
-   
+.. seealso::
+
    :ref:`vcs`
 
 .. setting:: WEBLATE_ADDONS

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -369,6 +369,16 @@ Generic settings
        :ref:`github-push`,
        :ref:`hub-setup`
 
+.. envvar:: WEBLATE_GITLAB_USERNAME
+
+    Configures GitLab username for GitLab merge-requests by changing
+    :setting:`GITLAB_USERNAME`
+
+    .. seealso::
+
+       :ref:`gitlab-push`
+       :ref:`lab-setup`
+
 .. envvar:: WEBLATE_SIMPLIFY_LANGUAGES
 
     Configures the language simplification policy, see :setting:`SIMPLIFY_LANGUAGES`.
@@ -575,7 +585,7 @@ instance when running Weblate in Docker.
     The Redis database number, defaults to ``1``.
 
 .. envvar:: REDIS_PASSWORD
-   
+
     The Redis server password, not used by default.
 
 .. envvar:: REDIS_TLS
@@ -774,6 +784,28 @@ The username passed for credentials must be the same as :setting:`GITHUB_USERNAM
 
     :ref:`github-push`,
     :ref:`hub-setup`
+
+
+Lab setup
+---------
+
+In order to use GitLab's merge-request feature, you must initialize ``lab``
+configuration by entering the weblate contained and executing ``lab``
+command. For example:
+
+.. code-block:: sh
+
+        docker-compose exec --user weblate weblate bash
+        cd
+        HOME=/app/data/home lab
+
+The access_token passed for lab configuratoin must be same as :setting:`GITLAB_USERNAME`.
+
+.. seealso::
+
+     :ref:`gitlab-push`
+     :ref:`lab-setup`
+
 
 Select your machine - local or cloud providers
 ----------------------------------------------

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -344,3 +344,68 @@ monolingual translations).
 In the background Weblate creates Git repository for you and all changes are
 tracked in in. In case you decide later to use VCS to store the translations,
 it's already within Weblate and you can base on that.
+
+.. _vcs-gitlab:
+
+GitLab
+------
+
+.. versionadded:: 3.9
+
+This just adds a thin layer on top of :ref:`vcs-git` to allow pushing
+translation changes as merge requests instead of pushing directly to the
+repository. It currently uses the `lab`_ tool to do the push.
+
+There is no need to use this access Git repositories, ordinary :ref:`vcs-git`
+works the same, the only difference is how pushing to a repository is
+handled. With :ref:`vcs-git` changes are pushed directly to the repository,
+while :ref:`vcs-gitlab` creates merge request.
+
+.. _gitlab-push:
+
+Pushing changes to GitLab as merge request
+++++++++++++++++++++++++++++++++++++++++++
+
+If you are translating a project that is hosted on GitLab and don't want to
+push translations to the repository, you can have them sent as a merge request.
+
+You need to configure the `lab`_ command line tool and set
+:setting:`GITLAB_USERNAME` for this to work.
+
+.. seealso::
+
+   :setting:`GITLAB_USERNAME`, :ref:`lab-setup` for configuration instructions
+
+.. _lab-setup:
+
+Setting up lab
+++++++++++++++
+
+:ref:`gitlab-push` requires a configured `lab`_ installation on your
+server. Follow the installation instructions at
+https://github.com/zaquestion/lab#installation and perform and run it without
+any arguments to finish configuration, for example:
+
+.. code-block:: sh
+
+    # DATA_DIR is set in Weblate settings.py, set it accordingy.
+    # Is is /app/data in Docker
+    $ HOME=${DATA_DIR}/home lab
+    Enter GitLab host (default: https://gitlab.com):
+    Create a token here: https://gitlab.com/profile/personal_access_tokens
+    Enter default GitLab token (scope: api):
+    Config saved to ~/.config/lab.hcl
+
+
+The `lab`_ will ask you for your GitLab access token, retrieve a token and
+store it into :file:`~/.config/lab.hcl`. The file has to be readable by user
+running Weblate.
+
+
+.. note::
+
+    Use the username you configured :guilabel:`lab` with as
+    :setting:`GITLAB_USERNAME` (:envvar:`WEBLATE_GITLAB_USERNAME` for the
+    Docker image).
+
+.. _lab: https://github.com/zaquestion/lab

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -206,6 +206,10 @@ TEMPLATES = [
 # Please see the documentation for more details.
 GITHUB_USERNAME = None
 
+# GitLab username for sending merge requests.
+# Please see the documentation for more details.
+GITLAB_USERNAME = None
+
 # Authentication configuration
 AUTHENTICATION_BACKENDS = (
     'social_core.backends.email.EmailAuth',

--- a/weblate/trans/models/_conf.py
+++ b/weblate/trans/models/_conf.py
@@ -94,6 +94,9 @@ class WeblateConf(AppConf):
     # GitHub username for sending pull requests
     GITHUB_USERNAME = None
 
+    # GitLab username for sending merge requests
+    GITLAB_USERNAME = None
+
     # Default committer
     DEFAULT_COMMITER_EMAIL = 'noreply@weblate.org'
     DEFAULT_COMMITER_NAME = 'Weblate'

--- a/weblate/trans/tests/data/lab
+++ b/weblate/trans/tests/data/lab
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Fake lab implementation for use in testsuite
+
+case "$1" in
+    mr) exit 0;;
+    fork) git remote add test $(git config --get remote.origin.url); exit 0;;
+esac
+
+git "$@"

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -517,25 +517,9 @@ class GitMergeRequestBase(GitRepository):
             return False
         return super(GitMergeRequestBase, cls).is_supported()
 
-    def create_pull_request(self, origin_branch, fork_branch):
-        """Create pull request to merge branch in forked repository into
-        branch of remote repository.
-        """
-        cmd = [
-            'pull-request',
-            '-f',
-            '-h',
-            '{0}:{1}'.format(settings.GITHUB_USERNAME, fork_branch),
-            '-b',
-            origin_branch,
-            '-m',
-            settings.DEFAULT_PULL_MESSAGE,
-        ]
-        self.execute(cmd)
-
     def push_to_fork(self, local_branch, fork_branch):
         """Push given local branch to branch in forked repository."""
-        cmd_push = ['push', '--force', settings.GITHUB_USERNAME]
+        cmd_push = ['push', '--force', self._username]
         self.execute(cmd_push + ['{0}:{1}'.format(local_branch, fork_branch)])
 
     def fork(self):
@@ -598,7 +582,7 @@ class GithubRepository(GitMergeRequestBase):
         cmd = [
             'pull-request',
             '-f',
-            '-h', '{0}:{1}'.format(settings.GITHUB_USERNAME, fork_branch),
+            '-h', '{0}:{1}'.format(self._username, fork_branch),
             '-b', origin_branch,
             '-m', settings.DEFAULT_PULL_MESSAGE,
         ]

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -503,31 +503,19 @@ class SubversionRepository(GitRepository):
         self.execute(['svn', 'dcommit', self.branch])
 
 
-class GithubRepository(GitRepository):
+class GitMergeRequestBase(GitRepository):
 
-    name = 'GitHub'
-
-    _cmd = 'hub'
+    # Subclasses must override _username.
+    _username = None
 
     _is_supported = None
     _version = None
 
     @classmethod
     def is_supported(cls):
-        if not settings.GITHUB_USERNAME:
+        if cls._username is None:
             return False
-        return super(GithubRepository, cls).is_supported()
-
-    @classmethod
-    def _getenv(cls):
-        """Generate environment for process execution."""
-        env = super(GithubRepository, cls)._getenv()
-        # Add path to config if it exists
-        userconfig = os.path.expanduser('~/.config/hub')
-        if os.path.exists(userconfig):
-            env['HUB_CONFIG'] = userconfig
-
-        return env
+        return super(GitMergeRequestBase, cls).is_supported()
 
     def create_pull_request(self, origin_branch, fork_branch):
         """Create pull request to merge branch in forked repository into
@@ -553,7 +541,7 @@ class GithubRepository(GitRepository):
     def fork(self):
         """Create fork of original repository if one doesn't exist yet."""
         remotes = self.execute(['remote']).splitlines()
-        if settings.GITHUB_USERNAME not in remotes:
+        if self._username not in remotes:
             self.execute(['fork'])
 
     def push(self):
@@ -579,7 +567,42 @@ class GithubRepository(GitRepository):
 
     def configure_remote(self, pull_url, push_url, branch):
         # We don't use push URL at all
-        super(GithubRepository, self).configure_remote(pull_url, None, branch)
+        super(GitMergeRequestBase, self).configure_remote(
+            pull_url, None, branch)
+
+
+class GithubRepository(GitMergeRequestBase):
+
+    name = 'GitHub'
+    _cmd = 'hub'
+
+    @property
+    def _username(self):
+        return settings.GITHUB_USERNAME
+
+    @classmethod
+    def _getenv(cls):
+        """Generate environment for process execution."""
+        env = super(GithubRepository, cls)._getenv()
+        # Add path to config if it exists
+        userconfig = os.path.expanduser('~/.config/hub')
+        if os.path.exists(userconfig):
+            env['HUB_CONFIG'] = userconfig
+
+        return env
+
+    def create_pull_request(self, origin_branch, fork_branch):
+        """Create pull request to merge branch in forked repository into
+        branch of remote repository.
+        """
+        cmd = [
+            'pull-request',
+            '-f',
+            '-h', '{0}:{1}'.format(settings.GITHUB_USERNAME, fork_branch),
+            '-b', origin_branch,
+            '-m', settings.DEFAULT_PULL_MESSAGE,
+        ]
+        self.execute(cmd)
 
 
 class LocalRepository(GitRepository):
@@ -665,3 +688,48 @@ class LocalRepository(GitRepository):
             repo.execute(['add', target])
             if repo.needs_commit():
                 repo.commit('Started tranlation using Weblate')
+
+
+class GitlabRepository(GitMergeRequestBase):
+
+    name = 'Gitlab'
+
+    # docs: https://zaquestion.github.io/lab/
+    _cmd = 'lab'
+
+    @property
+    def _username(self):
+        return settings.GITLAB_USERNAME
+
+    def create_pull_request(self, origin_branch, fork_branch):
+        """Create merge (a.k.a pull) request to merge branch in forked
+        repository into branch of remote repository.
+
+        :param origin_branch: Git branch in the project's repo to create pull
+            request against.
+        :param fork_branch: Git branch in the fork's repo which contains the
+            updates.
+        """
+        # Checkout the branch we want to use as the source for new MR.
+        cmd = [
+            'checkout',
+            '-B',
+            fork_branch,
+            '{}/{}'.format(self._username, fork_branch)
+        ]
+        self.execute(cmd)
+        # Create a new MR against origin/<origin_branch> from the fork.
+        cmd = [
+            'mr',
+            'create',
+            'origin',
+            origin_branch,
+            '-m', settings.DEFAULT_PULL_MESSAGE,
+        ]
+        self.execute(cmd)
+        # Return to the previous checked out branch.
+        cmd = [
+            'checkout',
+            '-'
+        ]
+        self.execute(cmd)

--- a/weblate/vcs/models.py
+++ b/weblate/vcs/models.py
@@ -49,6 +49,7 @@ class VCSConf(AppConf):
         'weblate.vcs.git.GitWithGerritRepository',
         'weblate.vcs.git.SubversionRepository',
         'weblate.vcs.git.GithubRepository',
+        'weblate.vcs.git.GitlabRepository',
         'weblate.vcs.git.LocalRepository',
         'weblate.vcs.mercurial.HgRepository',
     )

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -34,6 +34,7 @@ from weblate.utils.files import remove_readonly
 from weblate.vcs.base import RepositoryException
 from weblate.vcs.git import (
     GithubRepository,
+    GitlabRepository,
     GitRepository,
     GitWithGerritRepository,
     LocalRepository,
@@ -46,6 +47,12 @@ class GithubFakeRepository(GithubRepository):
     _is_supported = None
     _version = None
     _cmd = get_test_file('hub')
+
+
+class GitlabFakeRepository(GitlabRepository):
+    _is_supported = None
+    _version = None
+    _cmd = get_test_file('lab')
 
 
 class GitTestRepository(GitRepository):
@@ -400,6 +407,13 @@ class VCSGerritTest(VCSGitTest):
 @override_settings(GITHUB_USERNAME="test")
 class VCSGithubTest(VCSGitTest):
     _class = GithubFakeRepository
+    _vcs = 'git'
+    _sets_push = False
+
+
+@override_settings(GITLAB_USERNAME="test")
+class VCSGitlabTest(VCSGitTest):
+    _class = GitlabFakeRepository
     _vcs = 'git'
     _sets_push = False
 


### PR DESCRIPTION
This support is based on "lab" CLI, which is inspired by "hub" tool, which is
used for GitHub's pull request support.

"lab" also proxies a lot of commands to "hub", so parts of the Github and
Gitlab's requirements are abstracted out in a mixin class and then only the
basic functionality that is different is implemented via separate classes.

Creating a draft PR for early reviews, will update with test cases soon.