### PR TITLE
Spelling: Turn on, for the project

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -876,7 +876,7 @@ class AutoForm(forms.Form):
         label=_('Components'),
         required=False,
         help_text=_(
-            "Enable project contribution to shared translation memory on project to "
+            "Turn on contribution to shared translation memory for the project to "
             "get access to additional components."
         ),
         initial=''


### PR DESCRIPTION
I don't understand "to get access to additional components." Should it be something like "to make use of automated translations from more projects"?