### PR TITLE
git: don't assume the last element is the version number

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -214,7 +214,7 @@ class GitRepository(Repository):
     @classmethod
     def _get_version(cls):
         """Return VCS program version."""
-        return cls._popen(['--version']).split()[-1]
+        return cls._popen(['--version']).split()[2]
 
     def commit(self, message, author=None, timestamp=None, files=None):
         """Create new revision."""


### PR DESCRIPTION
Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation

This change makes weblate work with some custom git versions. The current implementation simply takes the last element from the output of `git --version`, which in the case of git on macOS returns:

```
git version 2.20.1 (Apple Git-117)
```

A more robust check might be to always take the 3rd element from the beginning.

The current VCS test infrastructure does not make it possible to mock the git version output, and the whole `VCSGitTest` class depends on a working `git` right from `setUp`...