### PR TITLE
Add the ability to switch to Gitlab as a VCS type for a component.

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1485,7 +1485,7 @@ class ComponentSettingsForm(SettingsBaseForm):
                 template='layout/pills.html',
             )
         )
-        vcses = ('git', 'gerrit', 'github', 'local')
+        vcses = ('git', 'gerrit', 'github', 'gitlab', 'local')
         if self.instance.vcs not in vcses:
             vcses = (self.instance.vcs, )
         self.fields['vcs'].choices = [


### PR DESCRIPTION
This change follows a previous PR (#3024 ) and adds the ability to switch translation components to Gitlab as a VCS type.