### PR TITLE
Migrations: Fix multi database scenario

### DIFF
--- a/weblate/accounts/migrations/0004_create_profile.py
+++ b/weblate/accounts/migrations/0004_create_profile.py
@@ -8,12 +8,17 @@ from django.db import migrations
 def create_profiles(apps, schema_editor):
     Profile = apps.get_model("accounts", "Profile")
     User = apps.get_model("weblate_auth", "User")
-    for user in User.objects.iterator():
-        Profile.objects.get_or_create(user=user)
+    db_alias = schema_editor.connection.alias
+    for user in User.objects.using(db_alias).iterator():
+        Profile.objects.using(db_alias).get_or_create(user=user)
 
 
 class Migration(migrations.Migration):
 
     dependencies = [("accounts", "0003_profile_translate_mode")]
 
-    operations = [migrations.RunPython(create_profiles, reverse_code=create_profiles)]
+    operations = [
+        migrations.RunPython(
+            create_profiles, reverse_code=create_profiles, elidable=True
+        )
+    ]

--- a/weblate/accounts/migrations/0006_subscriptions.py
+++ b/weblate/accounts/migrations/0006_subscriptions.py
@@ -21,7 +21,8 @@ MAPPING = [
 
 def migrate_subscriptions(apps, schema_editor):
     Profile = apps.get_model("accounts", "Profile")
-    profiles = Profile.objects.all().select_related("user")
+    db_alias = schema_editor.connection.alias
+    profiles = Profile.objects.using(db_alias).all().select_related("user")
     profiles = profiles.exclude(user__username=settings.ANONYMOUS_USER_NAME)
     for profile in profiles:
         user = profile.user
@@ -41,5 +42,7 @@ class Migration(migrations.Migration):
     dependencies = [("accounts", "0005_auto_20190331_2126")]
 
     operations = [
-        migrations.RunPython(migrate_subscriptions, migrations.RunPython.noop)
+        migrations.RunPython(
+            migrate_subscriptions, migrations.RunPython.noop, elidable=True
+        )
     ]

--- a/weblate/accounts/migrations/0008_auto_20190426_0941.py
+++ b/weblate/accounts/migrations/0008_auto_20190426_0941.py
@@ -7,7 +7,8 @@ import weblate.utils.render
 
 def migrate_editor(apps, schema_editor):
     Profile = apps.get_model("accounts", "Profile")
-    for profile in Profile.objects.exclude(editor_link=""):
+    db_alias = schema_editor.connection.alias
+    for profile in Profile.objects.using(db_alias).exclude(editor_link=""):
         profile.editor_link = weblate.utils.render.migrate_repoweb(profile.editor_link)
         profile.save()
 
@@ -29,5 +30,5 @@ class Migration(migrations.Migration):
                 verbose_name="Editor link",
             ),
         ),
-        migrations.RunPython(migrate_editor, migrations.RunPython.noop),
+        migrations.RunPython(migrate_editor, migrations.RunPython.noop, elidable=True),
     ]

--- a/weblate/accounts/migrations/0015_auto_20190922_1948.py
+++ b/weblate/accounts/migrations/0015_auto_20190922_1948.py
@@ -5,11 +5,16 @@ from django.db import migrations
 
 def migrate_dashboard(apps, schema_editor):
     Profile = apps.get_model("accounts", "Profile")
-    Profile.objects.filter(dashboard_view=2).update(dashboard_view=1)
+    db_alias = schema_editor.connection.alias
+    Profile.objects.using(db_alias).filter(dashboard_view=2).update(dashboard_view=1)
 
 
 class Migration(migrations.Migration):
 
     dependencies = [("accounts", "0014_auto_20190922_1947")]
 
-    operations = [migrations.RunPython(migrate_dashboard, migrations.RunPython.noop)]
+    operations = [
+        migrations.RunPython(
+            migrate_dashboard, migrations.RunPython.noop, elidable=True
+        )
+    ]

--- a/weblate/addons/migrations/0011_squash_addon.py
+++ b/weblate/addons/migrations/0011_squash_addon.py
@@ -11,8 +11,11 @@ def update_squash_addon(apps, schema_editor):
     """Update events setup for weblate.git.squash addon."""
     Addon = apps.get_model("addons", "Addon")
     Event = apps.get_model("addons", "Event")
-    for addon in Addon.objects.filter(name="weblate.git.squash"):
-        Event.objects.get_or_create(addon=addon, event=EVENT_POST_COMMIT)
+    db_alias = schema_editor.connection.alias
+    for addon in Addon.objects.using(db_alias).filter(name="weblate.git.squash"):
+        Event.objects.using(db_alias).get_or_create(
+            addon=addon, event=EVENT_POST_COMMIT
+        )
         addon.event_set.filter(event=EVENT_PRE_PUSH).delete()
 
 
@@ -20,4 +23,4 @@ class Migration(migrations.Migration):
 
     dependencies = [("addons", "0010_auto_20181214_1232")]
 
-    operations = [migrations.RunPython(update_squash_addon)]
+    operations = [migrations.RunPython(update_squash_addon, elidable=True)]

--- a/weblate/addons/migrations/0012_addon_repo_scope.py
+++ b/weblate/addons/migrations/0012_addon_repo_scope.py
@@ -8,7 +8,10 @@ from django.db import migrations, models
 def update_repo_scope(apps, schema_editor):
     """Update the repo_scope flag."""
     Addon = apps.get_model("addons", "Addon")
-    Addon.objects.filter(name="weblate.git.squash").update(repo_scope=True)
+    db_alias = schema_editor.connection.alias
+    Addon.objects.using(db_alias).filter(name="weblate.git.squash").update(
+        repo_scope=True
+    )
 
 
 class Migration(migrations.Migration):
@@ -21,5 +24,7 @@ class Migration(migrations.Migration):
             name="repo_scope",
             field=models.BooleanField(db_index=True, default=False),
         ),
-        migrations.RunPython(update_repo_scope, reverse_code=update_repo_scope),
+        migrations.RunPython(
+            update_repo_scope, reverse_code=update_repo_scope, elidable=True
+        ),
     ]

--- a/weblate/addons/migrations/0013_fix_repo_scope.py
+++ b/weblate/addons/migrations/0013_fix_repo_scope.py
@@ -7,11 +7,14 @@ from django.db import migrations
 
 def fix_repo_scope(apps, schema_editor):
     Addon = apps.get_model("addons", "Addon")
-    Addon.objects.filter(name="weblate.git.squash").update(repo_scope=True)
+    db_alias = schema_editor.connection.alias
+    Addon.objects.using(db_alias).filter(name="weblate.git.squash").update(
+        repo_scope=True
+    )
 
 
 class Migration(migrations.Migration):
 
     dependencies = [("addons", "0012_addon_repo_scope")]
 
-    operations = [migrations.RunPython(fix_repo_scope)]
+    operations = [migrations.RunPython(fix_repo_scope, elidable=True)]

--- a/weblate/addons/migrations/0015_flags.py
+++ b/weblate/addons/migrations/0015_flags.py
@@ -6,10 +6,11 @@ from django.db import migrations
 def migrate_flags(apps, schema_editor):
     """Update the repo_scope flag."""
     Addon = apps.get_model("addons", "Addon")
-    Addon.objects.filter(
+    db_alias = schema_editor.connection.alias
+    Addon.objects.using(db_alias).filter(
         name__in=("weblate.discovery.discovery", "weblate.git.squash")
     ).update(repo_scope=True)
-    Addon.objects.filter(
+    Addon.objects.using(db_alias).filter(
         name__in=("weblate.removal.comments", "weblate.removal.suggestions")
     ).update(project_scope=True)
 
@@ -18,4 +19,6 @@ class Migration(migrations.Migration):
 
     dependencies = [("addons", "0014_auto_20190510_1325")]
 
-    operations = [migrations.RunPython(migrate_flags, migrations.RunPython.noop)]
+    operations = [
+        migrations.RunPython(migrate_flags, migrations.RunPython.noop, elidable=True)
+    ]

--- a/weblate/addons/migrations/0017_auto_format_fixup.py
+++ b/weblate/addons/migrations/0017_auto_format_fixup.py
@@ -7,7 +7,10 @@ from weblate.formats.auto import detect_filename
 
 def resolve_auto_format(apps, schema_editor):
     Addon = apps.get_model("addons", "Addon")
-    for addon in Addon.objects.filter(name="weblate.discovery.discovery"):
+    db_alias = schema_editor.connection.alias
+    for addon in Addon.objects.using(db_alias).filter(
+        name="weblate.discovery.discovery"
+    ):
         if addon.configuration["file_format"] == "auto":
             detect = detect_filename(addon.configuration["match"].replace("\\.", "."))
             if detect is None:

--- a/weblate/addons/migrations/0018_resx.py
+++ b/weblate/addons/migrations/0018_resx.py
@@ -5,7 +5,8 @@ from django.db import migrations
 
 def update_resx_addon(apps, schema_editor):
     Addon = apps.get_model("addons", "Addon")
-    Addon.objects.filter(
+    db_alias = schema_editor.connection.alias
+    Addon.objects.using(db_alias).filter(
         component__file_format="resx", name="weblate.cleanup.generic"
     ).update(name="weblate.resx.update")
 

--- a/weblate/gitexport/migrations/0001_squashed_0002_fill_in_url.py
+++ b/weblate/gitexport/migrations/0001_squashed_0002_fill_in_url.py
@@ -9,8 +9,11 @@ from weblate.gitexport.models import SUPPORTED_VCS, get_export_url
 
 def set_export_url(apps, schema_editor):
     Component = apps.get_model("trans", "Component")
-    matching = Component.objects.filter(vcs__in=SUPPORTED_VCS).exclude(
-        repo__startswith="weblate:/"
+    db_alias = schema_editor.connection.alias
+    matching = (
+        Component.objects.using(db_alias)
+        .filter(vcs__in=SUPPORTED_VCS)
+        .exclude(repo__startswith="weblate:/")
     )
     for component in matching:
         new_url = get_export_url(component)

--- a/weblate/trans/migrations/0015_linked_component_branch.py
+++ b/weblate/trans/migrations/0015_linked_component_branch.py
@@ -8,7 +8,8 @@ from django.db import migrations
 def update_linked(apps, schema_editor):
     """Clean branch for linked components."""
     Component = apps.get_model("trans", "Component")
-    linked = Component.objects.filter(repo__startswith="weblate:")
+    db_alias = schema_editor.connection.alias
+    linked = Component.objects.using(db_alias).filter(repo__startswith="weblate:")
     linked.update(branch="")
 
 
@@ -16,4 +17,6 @@ class Migration(migrations.Migration):
 
     dependencies = [("trans", "0014_auto_20190203_1923")]
 
-    operations = [migrations.RunPython(update_linked, reverse_code=update_linked)]
+    operations = [
+        migrations.RunPython(update_linked, reverse_code=update_linked, elidable=True)
+    ]

--- a/weblate/trans/migrations/0016_fix_alert_occurrence.py
+++ b/weblate/trans/migrations/0016_fix_alert_occurrence.py
@@ -8,7 +8,8 @@ from django.db.models import F, Func, Value
 
 def fix_alert_occurence(apps, schema_editor):
     Alert = apps.get_model("trans", "Alert")
-    Alert.objects.filter(details__contains='"occurences"').update(
+    db_alias = schema_editor.connection.alias
+    Alert.objects.using(db_alias).filter(details__contains='"occurences"').update(
         details=Func(
             F("details"),
             Value('"occurences"'),
@@ -20,7 +21,8 @@ def fix_alert_occurence(apps, schema_editor):
 
 def unfix_alert_occurence(apps, schema_editor):
     Alert = apps.get_model("trans", "Alert")
-    Alert.objects.filter(details__contains='"occurrences"').update(
+    db_alias = schema_editor.connection.alias
+    Alert.objects.using(db_alias).filter(details__contains='"occurrences"').update(
         details=Func(
             F("details"),
             Value('"occurrences"'),
@@ -35,5 +37,7 @@ class Migration(migrations.Migration):
     dependencies = [("trans", "0015_linked_component_branch")]
 
     operations = [
-        migrations.RunPython(fix_alert_occurence, reverse_code=unfix_alert_occurence)
+        migrations.RunPython(
+            fix_alert_occurence, reverse_code=unfix_alert_occurence, elidable=True
+        )
     ]

--- a/weblate/trans/migrations/0018_remove_unusednewbase_alert.py
+++ b/weblate/trans/migrations/0018_remove_unusednewbase_alert.py
@@ -7,11 +7,12 @@ from django.db import migrations
 
 def remove_unusednewbase_alert(apps, schema_editor):
     Alert = apps.get_model("trans", "Alert")
-    Alert.objects.filter(name="UnusedNewBase").delete()
+    db_alias = schema_editor.connection.alias
+    Alert.objects.using(db_alias).filter(name="UnusedNewBase").delete()
 
 
 class Migration(migrations.Migration):
 
     dependencies = [("trans", "0017_component_language_code_style")]
 
-    operations = [migrations.RunPython(remove_unusednewbase_alert)]
+    operations = [migrations.RunPython(remove_unusednewbase_alert, elidable=True)]

--- a/weblate/trans/migrations/0024_resolve_auto_format.py
+++ b/weblate/trans/migrations/0024_resolve_auto_format.py
@@ -25,7 +25,8 @@ def update_format(component, store):
 
 def resolve_auto_format(apps, schema_editor):
     Component = apps.get_model("trans", "Component")
-    for component in Component.objects.filter(file_format="auto"):
+    db_alias = schema_editor.connection.alias
+    for component in Component.objects.using(db_alias).filter(file_format="auto"):
         path = get_path(component)
         template = None
         if component.template:

--- a/weblate/trans/migrations/0025_auto_20190426_0941.py
+++ b/weblate/trans/migrations/0025_auto_20190426_0941.py
@@ -7,7 +7,8 @@ import weblate.utils.render
 
 def migrate_repoweb(apps, schema_editor):
     Component = apps.get_model("trans", "Component")
-    for component in Component.objects.exclude(repoweb=""):
+    db_alias = schema_editor.connection.alias
+    for component in Component.objects.using(db_alias).exclude(repoweb=""):
         component.repoweb = weblate.utils.render.migrate_repoweb(component.repoweb)
         component.save()
 
@@ -27,5 +28,5 @@ class Migration(migrations.Migration):
                 verbose_name="Repository browser",
             ),
         ),
-        migrations.RunPython(migrate_repoweb, migrations.RunPython.noop),
+        migrations.RunPython(migrate_repoweb, migrations.RunPython.noop, elidable=True),
     ]

--- a/weblate/trans/migrations/0026_alert_change.py
+++ b/weblate/trans/migrations/0026_alert_change.py
@@ -5,7 +5,8 @@ from django.db import migrations
 
 def migrate_alert_change(apps, schema_editor):
     Change = apps.get_model("trans", "Change")
-    for change in Change.objects.filter(action=47).exclude(target=""):
+    db_alias = schema_editor.connection.alias
+    for change in Change.objects.using(db_alias).filter(action=47).exclude(target=""):
         change.details = {"alert": change.target}
         change.target = ""
         change.save()
@@ -15,4 +16,8 @@ class Migration(migrations.Migration):
 
     dependencies = [("trans", "0025_auto_20190426_0941")]
 
-    operations = [migrations.RunPython(migrate_alert_change, migrations.RunPython.noop)]
+    operations = [
+        migrations.RunPython(
+            migrate_alert_change, migrations.RunPython.noop, elidable=True
+        )
+    ]

--- a/weblate/trans/migrations/0029_vote_value.py
+++ b/weblate/trans/migrations/0029_vote_value.py
@@ -9,12 +9,13 @@ def migrate_votes(apps, schema_editor):
     if not table_has_row(schema_editor.connection, "trans_vote", "positive"):
         return
     Vote = apps.get_model("trans", "Vote")
-    Vote.objects.filter(positive=True).update(value=1)
-    Vote.objects.filter(positive=False).update(value=-1)
+    db_alias = schema_editor.connection.alias
+    Vote.objects.using(db_alias).filter(positive=True).update(value=1)
+    Vote.objects.using(db_alias).filter(positive=False).update(value=-1)
 
 
 class Migration(migrations.Migration):
 
     dependencies = [("trans", "0028_vote_value")]
 
-    operations = [migrations.RunPython(migrate_votes)]
+    operations = [migrations.RunPython(migrate_votes, elidable=True)]

--- a/weblate/trans/migrations/0034_priority.py
+++ b/weblate/trans/migrations/0034_priority.py
@@ -5,7 +5,8 @@ from django.db import migrations
 
 def migrate_priority(apps, schema_editor):
     Source = apps.get_model("trans", "Source")
-    for source in Source.objects.exclude(priority=100).iterator():
+    db_alias = schema_editor.connection.alias
+    for source in Source.objects.using(db_alias).exclude(priority=100).iterator():
         if source.check_flags:
             source.check_flags += ", "
         source.check_flags += "priority:{}".format(200 - source.priority)
@@ -17,4 +18,4 @@ class Migration(migrations.Migration):
     dependencies = [("trans", "0033_auto_20190802_1427")]
 
     operations = []
-    operations = [migrations.RunPython(migrate_priority)]
+    operations = [migrations.RunPython(migrate_priority, elidable=True)]

--- a/weblate/trans/migrations/0038_contribute_tm.py
+++ b/weblate/trans/migrations/0038_contribute_tm.py
@@ -5,7 +5,8 @@ from django.db.models import F
 
 
 def migrate_tm(apps, schema_editor):
-    apps.get_model("trans", "Project").objects.all().update(
+    db_alias = schema_editor.connection.alias
+    apps.get_model("trans", "Project").objects.using(db_alias).all().update(
         contribute_shared_tm=F("use_shared_tm")
     )
 
@@ -14,4 +15,6 @@ class Migration(migrations.Migration):
 
     dependencies = [("trans", "0037_auto_20190906_1526")]
 
-    operations = [migrations.RunPython(migrate_tm, migrations.RunPython.noop)]
+    operations = [
+        migrations.RunPython(migrate_tm, migrations.RunPython.noop, elidable=True)
+    ]


### PR DESCRIPTION
Adjust RunPython migation steps to use correct database connection and
mark them as elidable for future migrations squashing.

Fixes #3129

Signed-off-by: Michal Čihař <michal@cihar.com>
