### PR TITLE
deepl: Switch to API version 2

### DIFF
--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -679,7 +679,7 @@ class MachineTranslationTest(TestCase):
     def test_deepl(self):
         machine = self.get_machine(DeepLTranslation)
         httpretty.register_uri(
-            httpretty.POST, 'https://api.deepl.com/v1/translate', body=DEEPL_RESPONSE
+            httpretty.POST, 'https://api.deepl.com/v2/translate', body=DEEPL_RESPONSE
         )
         self.assert_translate(machine, lang='de', word='Hello')
 
@@ -688,7 +688,7 @@ class MachineTranslationTest(TestCase):
     def test_cache(self):
         machine = self.get_machine(DeepLTranslation, True)
         httpretty.register_uri(
-            httpretty.POST, 'https://api.deepl.com/v1/translate', body=DEEPL_RESPONSE
+            httpretty.POST, 'https://api.deepl.com/v2/translate', body=DEEPL_RESPONSE
         )
         # Fetch from service
         self.assert_translate(machine, lang='de', word='Hello')


### PR DESCRIPTION
Since October 2018, the DeepL API version 1 doesn't seem to be supported anymore and in fact when trying to send requests to their API via curl, we now subsequently get an `HTTP 403` error.

This is also noted in their upstream documentation:

https://www.deepl.com/en/docs-api.html?part=accessing

Fortunately the changes between API version 1 and 2 seem to be not very substantial and while in theory we could just change the URL and be done, I decided to improve the implementation a bit.

So first of all, there seems to now be an API endpoint, which will respond with the list of languages, which we now use instead of the hardcoded list.

Additionally, the response for the `/translate` endpoint not only returns the translation(s) but also the "detected source language". It looks something like this:

```json
{"translations": [
   {
     "detected_source_language": "DE",
     "text": "Hello world!"
   }
]}
```

When testing against the API I found that the detected source language seems to always match the source language we provide via the `source_lang` parameter, but to be absolutely sure things don't go wrong I added an additional check to make sure that the detected_source_language is equal
to the source language we provided.