### PR TITLE
Add new url to CSP request header

### DIFF
--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -128,6 +128,11 @@ class SecurityMiddleware(object):
             style.add(domain)
             font.add(domain)
 
+        # When using external image for Auth0 provider, add it here
+        if "://" in settings.SOCIAL_AUTH_AUTH0_IMAGE:
+            domain = urlparse(settings.SOCIAL_AUTH_AUTH0_IMAGE).hostname
+            image.add(domain)
+
         response["Content-Security-Policy"] = CSP_TEMPLATE.format(
             " ".join(style),
             " ".join(image),


### PR DESCRIPTION
When using Auth0 as authentication provider, admin can set also custom image hosted on some external server. When this occurs, it should be added to `Content-Security-Policy` http header.