### PR TITLE
Spelling: in {{ component }}

### DIFF
--- a/weblate/templates/mail/repository_error.html
+++ b/weblate/templates/mail/repository_error.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <p>
-{% blocktrans %}There has been a repository failure on {{ component }} at {{ site_title }}.{% endblocktrans %}
+{% blocktrans %}There has been a repository failure in {{ component }} at {{ site_title }}.{% endblocktrans %}
 <p>
 
 

--- a/weblate/templates/mail/repository_operation.html
+++ b/weblate/templates/mail/repository_operation.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <p>
-{% blocktrans %}There has been a repository operation on {{ component }} at {{ site_title }}.{% endblocktrans %}
+{% blocktrans %}There has been a repository operation in {{ component }} at {{ site_title }}.{% endblocktrans %}
 <p>
 
 {% endblock %}


### PR DESCRIPTION
Consistent with https://github.com/WeblateOrg/weblate/blob/master/weblate/templates/mail/repository_error_subject.txt#L3