### PR TITLE
Remove trailing slash of repo URL if exists

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1451,7 +1451,7 @@ class Component(models.Model, URLMixin, PathMixin):
                 raise ValidationError(
                     {setting: _("Option is not available for linked repositories.")}
                 )
-        self.linked_component = Component.objects.get_linked(self.repo)
+        self.linked_component = Component.objects.get_linked(self.repo).rstrip("/")
 
     def clean_lang_codes(self, matches):
         """Validate that there are no double language codes."""


### PR DESCRIPTION
Webhook detection (at least for GitHub) is broken if the repository URL contains a trailing slash.

This patch uses rstrip to remove a trailing slash if it exists. The validation logic isn't changed by this.

Signed-off-by: Paul Spooren <mail@aparcar.org>