### PR TITLE
Changed deepl api version to v2.

### DIFF
--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -24,7 +24,7 @@ from django.conf import settings
 
 from weblate.machinery.base import MachineTranslation, MissingConfiguration
 
-DEEPL_API = 'https://api.deepl.com/v1/translate'
+DEEPL_API = 'https://api.deepl.com/v2/translate'
 
 
 class DeepLTranslation(MachineTranslation):


### PR DESCRIPTION
This simply changes the used deepl API version to v2. For the simple translation request that weblate performs the request and response format stayed exactly the same so no further changes are required.
