### PR TITLE
Migrations: Fix for old Django

### DIFF
--- a/ci/run-migrate
+++ b/ci/run-migrate
@@ -37,6 +37,9 @@ for tag in $TAGS ; do
     pip install -r requirements-optional.txt -r requirements-test.txt -r docs/requirements.txt
     run_coverage ./manage.py migrate
     check
+    # Check migrated vote exists
+    ./manage.py shell -c 'from weblate.trans.models import Vote; Vote.objects.get(value=1)'
+    check
 done
 
 ./manage.py makemigrations

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Not yet released.
 * Fixed CSS bug caused flicker in some browsers.
 * Fixed searching on systems with non English locales.
 * Improved GitHub and Bitbucket hooks repositories matching.
+* Fixed data migration on some Python 2.7 installations.
 
 Weblate 3.10.1
 --------------


### PR DESCRIPTION
This affects Python 2.7 installations. The problem is that dict(Model)
returns more attributes than just fields there, so better to construct
list manually.

Fixes #3342

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
