### PR TITLE
Add jsonschema #3373

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ Cython==0.29.14; python_version >= '3.0'
 borgbackup>=1.1.0,<1.2.0; python_version >= '3.0'
 misaka>=2.1.0,<2.2.0
 GitPython>=2.1.14,<3.1.0
+jsonschema==3.2.0

--- a/weblate/memory/storage.py
+++ b/weblate/memory/storage.py
@@ -21,7 +21,6 @@
 from __future__ import unicode_literals
 
 import json
-from jsonschema import validate
 import os.path
 
 from django.conf import settings
@@ -35,6 +34,7 @@ from whoosh import qparser, query
 from whoosh.fields import ID, NUMERIC, STORED, TEXT, SchemaClass
 
 from jsonschema.exceptions import ValidationError
+from jsonschema import validate
 from weblate.lang.models import Language
 from weblate.utils.errors import report_error
 from weblate.utils.index import WhooshIndex
@@ -201,11 +201,11 @@ class TranslationMemory(WhooshIndex):
             found += 1
         # Try to validate with the JSON Schema
         try:
-            with open(TEMPLATES_DIR + 'json.schema', "r") as read_it: 
-                jsonschema = json.load(read_it) 
+            with open(TEMPLATES_DIR + 'json.schema', "r") as read_it:
+                jsonschema = json.load(read_it)
             validate(data, jsonschema)
         except ValidationError:
-            raise MemoryImportError(_('Failed to validate JSON file with the JSON Schema!'))
+            raise MemoryImportError(_('JSON Schema Validation failed!'))
         return found
 
     @classmethod

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -20,7 +20,6 @@
 from __future__ import unicode_literals
 
 import json
-from jsonschema import validate
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -30,6 +29,7 @@ from django.urls import reverse
 from six import StringIO
 from django.conf import settings
 
+from jsonschema import validate
 from weblate.checks.tests.test_checks import MockUnit
 from weblate.memory.machine import WeblateMemory
 from weblate.memory.storage import CATEGORY_FILE, TranslationMemory

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -93,20 +93,20 @@ class MemoryTest(SimpleTestCase):
         self.assertEqual(memory.doc_count(), 0)
 
     def test_json_schema_correct(self):
-        with open(get_test_file('memory.json'), "r") as read_it: 
+        with open(get_test_file('memory.json'), "r") as read_it:
             jsonfile = json.load(read_it)
 
-        with open(TEMPLATES_DIR + 'site.jsonschema', "r") as read_it: 
-            jsonschema = json.load(read_it) 
+        with open(TEMPLATES_DIR + 'json.schema', "r") as read_it:
+            jsonschema = json.load(read_it)
 
         validate(instance=jsonfile, schema=jsonschema)
 
     def test_json_schema_invalid(self):
-        with open(get_test_file('memory-invalid.json'), "r") as read_it: 
+        with open(get_test_file('memory-invalid.json'), "r") as read_it:
             jsonfile = json.load(read_it)
 
-        with open(TEMPLATES_DIR + 'site.jsonschema', "r") as read_it: 
-            jsonschema = json.load(read_it) 
+        with open(TEMPLATES_DIR + 'json.schema', "r") as read_it:
+            jsonschema = json.load(read_it)
 
         with self.assertRaises(ValidationError):
             validate(instance=jsonfile, schema=jsonschema)

--- a/weblate/templates/json.schema
+++ b/weblate/templates/json.schema
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://weblate.org/json.schema",
+  "type": "array",
+  "title": "The Weblate Translations Schema",
+  "items": {
+    "type": "object",
+    "title": "The Items Schema",
+    "required": [
+      "source_language",
+      "target_language",
+      "source",
+      "target",
+      "origin",
+      "category"
+    ],
+    "properties": {
+      "source_language": {
+        "type": "string",
+        "description": "The language being translated from",
+        "default": "",
+        "examples": [
+          "en"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "target_language": {
+        "type": "string",
+        "description": "The language being translated to",
+        "examples": [
+          "cs"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "source": {
+        "type": "string",
+        "description": "The payload in the source_language",
+        "examples": [
+          "Hello"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "target": {
+        "type": "string",
+        "description": "The payload in the target_language",
+        "examples": [
+          "Ahoj"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "origin": {
+        "type": "string",
+        "description": "The origin Schema",
+        "examples": [
+          "test"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "category": {
+        "type": "integer",
+        "description": "The Category Schema",
+        "examples": [
+          1
+        ]
+      }
+    }
+  }
+}

--- a/weblate/templates/site.jsonschema
+++ b/weblate/templates/site.jsonschema
@@ -1,0 +1,81 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "array",
+  "title": "The Root Schema",
+  "items": {
+    "$id": "#/items",
+    "type": "object",
+    "title": "The Items Schema",
+    "required": [
+      "source_language",
+      "target_language",
+      "source",
+      "target",
+      "origin",
+      "category"
+    ],
+    "properties": {
+      "source_language": {
+        "$id": "#/items/properties/source_language",
+        "type": "string",
+        "title": "The Source_language Schema",
+        "default": "",
+        "examples": [
+          "en"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "target_language": {
+        "$id": "#/items/properties/target_language",
+        "type": "string",
+        "title": "The Target_language Schema",
+        "default": "",
+        "examples": [
+          "cs"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "source": {
+        "$id": "#/items/properties/source",
+        "type": "string",
+        "title": "The Source Schema",
+        "default": "",
+        "examples": [
+          "Hello"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "target": {
+        "$id": "#/items/properties/target",
+        "type": "string",
+        "title": "The Target Schema",
+        "default": "",
+        "examples": [
+          "Ahoj"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "origin": {
+        "$id": "#/items/properties/origin",
+        "type": "string",
+        "title": "The Origin Schema",
+        "default": "",
+        "examples": [
+          "test"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "category": {
+        "$id": "#/items/properties/category",
+        "type": "integer",
+        "title": "The Category Schema",
+        "default": 0,
+        "examples": [
+          1
+        ]
+      }
+    }
+  }
+}

--- a/weblate/templates/site.jsonschema
+++ b/weblate/templates/site.jsonschema
@@ -1,7 +1,7 @@
 {
   "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
+  "$id": "https://weblate.org/site.jsonschema",
   "type": "array",
   "title": "The Root Schema",
   "items": {

--- a/weblate/trans/tests/data/memory-invalid.json
+++ b/weblate/trans/tests/data/memory-invalid.json
@@ -1,0 +1,10 @@
+[
+    {
+        "source_language": 123,
+        "target_language": 456,
+        "source": 3,
+        "target": "Ahoj",
+        "origin": "test",
+        "category": 1
+    }
+]

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -1171,6 +1171,12 @@ real_patterns = [
             template_name="site.webmanifest", content_type="application/json"
         ),
     ),
+        url(
+        r"^site\.jsonschema$",
+        TemplateView.as_view(
+            template_name="site.jsonschema", content_type="application/json"
+        ),
+    ),
 ]
 
 if "weblate.billing" in settings.INSTALLED_APPS:

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -1171,10 +1171,10 @@ real_patterns = [
             template_name="site.webmanifest", content_type="application/json"
         ),
     ),
-        url(
-        r"^site\.jsonschema$",
+    url(
+        r"^json.schema$",
         TemplateView.as_view(
-            template_name="site.jsonschema", content_type="application/json"
+            template_name="json.schema", content_type="application/schema+json"
         ),
     ),
 ]


### PR DESCRIPTION
Howdy,

I added the schema under the root templates folder and also set up the Django urls to serve it as json. Also wrote test cases for its validation (correct and invalid json is tested).

The schema itself was created with the help of [jsonschema](https://jsonschema.net/).

Not sure if this is the right direction to take, let me know if any changes are needed. We can add it to the docs later on once its fully implemented.