### PR TITLE
Allow extending instead of replacing LOGIN_REQUIRED_URLS_EXCEPTIONS

### DIFF
--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -999,6 +999,7 @@ if get_env_bool("WEBLATE_REQUIRE_LOGIN", False):
             rf"{URL_PREFIX}/legal/(.*)$",  # Optional for legal app
         ),
     )
+    LOGIN_REQUIRE_URLS_EXCEPTIONS.extend(get_env_list("WEBLATE_EXTEND_LOGIN_REQUIRED_URLS_EXCEPTIONS"))
 
 # Email server
 EMAIL_USE_TLS = get_env_bool("WEBLATE_EMAIL_USE_TLS", True)


### PR DESCRIPTION
Quite a few of the URLs included in `LOGIN_REQUIRED_URLS_EXCEPTIONS` by default are needed for Weblate to function properly. When using the Weblate docker container, if you need to add a single path as exception then you suddenly need to replace them all, which may cause issues if they change during an update.

By allowing the extension next to the replacement it's trivial to add a single URL while still allowing Weblate to work as normal.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation
