### PR TITLE
Docker: Fix user and group in dev-docker

### DIFF
--- a/dev-docker/Dockerfile
+++ b/dev-docker/Dockerfile
@@ -13,6 +13,9 @@ FROM weblate/weblate:edge
 
 # TODO: put some new dependencies here
 
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
 USER root
 # Following are removed during cleanup of weblate/weblate
 RUN apt-get update && apt-get install -y \
@@ -28,7 +31,14 @@ RUN apt-get update && apt-get install -y \
     g++ \
     libsasl2-dev \
     libldap2-dev \
-    libssl-dev
+    libssl-dev \
+    &&  if ! getent group "${GROUP_ID}"; then \
+            groupadd --gid "${GROUP_ID}" developer; \
+        fi \
+    &&  if ! getent passwd "${USER_ID}"; then \
+            useradd --gid "${GROUP_ID}" --uid "${USER_ID}" --shell /bin/bash developer; \
+        fi
+
 COPY requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt
 # List should match weblate/weblate

--- a/dev-docker/docker-compose.yml
+++ b/dev-docker/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     build:
       context: ../
       dockerfile: dev-docker/Dockerfile
+      args:
+        USER_ID: ${USER_ID}
+        GROUP_ID: ${GROUP_ID}
     ports:
       - ${WEBLATE_HOST}:8080
     user: $USER_ID:$GROUP_ID


### PR DESCRIPTION
Create user and group while building dev-docker image
to fix 'Failed to generate key: b'No user exists for uid ...\r\n''
error when generating ssh keypair via weblate web interface

Signed-off-by: Aleksandr Loktionov <loktionovam@gmail.com>

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
