### PR TITLE
API: Allow to use vcs push url during component creation via API.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -487,6 +487,7 @@ Components
     :>json string translations_url: URL to translations list; see :http:get:`/api/components/(string:project)/(string:component)/translations/`
     :>json string lock_url: URL to lock status; see :http:get:`/api/components/(string:project)/(string:component)/lock/`
     :>json string changes_list_url: URL to changes list; see :http:get:`/api/components/(string:project)/(string:component)/changes/`
+    :>json string push: URL of a push repository
 
     .. seealso::
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,7 @@ Weblate 3.11
 
 Not yet released.
 
+* Allow to use vcs push url during component creation via API.
 * Rendered width check now shows image with the render.
 * Fixed links in notifications mails.
 * Improved look of plain text mails.

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -141,6 +141,11 @@ class RepoURLField(serializers.CharField):
         return instance.get_repo_url()
 
 
+class RepoPushField(serializers.CharField):
+    def get_attribute(self, instance):
+        return instance.get_push_url()
+
+
 class ComponentSerializer(RemovableSerializer):
     web_url = AbsoluteURLField(source='get_absolute_url', read_only=True)
     project = ProjectSerializer(read_only=True)
@@ -168,6 +173,8 @@ class ComponentSerializer(RemovableSerializer):
 
     repo = RepoURLField()
 
+    push = RepoPushField()
+
     serializer_url_field = MultiFieldHyperlinkedIdentityField
 
     class Meta(object):
@@ -177,7 +184,7 @@ class ComponentSerializer(RemovableSerializer):
             'branch', 'filemask', 'template', 'new_base', 'file_format',
             'license', 'license_url', 'web_url', 'url',
             'repository_url', 'translations_url', 'statistics_url',
-            'lock_url', 'changes_list_url', 'new_lang',
+            'lock_url', 'changes_list_url', 'new_lang', 'push',
         )
         extra_kwargs = {
             'url': {
@@ -195,6 +202,7 @@ class ComponentSerializer(RemovableSerializer):
             result['repo'] = None
             result['branch'] = None
             result['filemask'] = None
+            result['push'] = None
         return result
 
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -280,7 +280,7 @@ class ProjectAPITest(APIBaseTest):
                 'web': 'https://weblate.org/',
             },
         )
-        self.do_request(
+        response = self.do_request(
             'api:project-components',
             self.project_kwargs,
             method="post",
@@ -292,9 +292,21 @@ class ProjectAPITest(APIBaseTest):
                 'repo': self.format_local_path(self.git_repo_path),
                 'filemask': 'po/*.po',
                 'file_format': 'po',
+                'push': 'https://username:password@github.com/example/push.git',
             },
         )
         self.assertEqual(Component.objects.count(), 2)
+        self.assertEqual(
+            Component.objects.get(
+                slug='api-project',
+                project__slug='test'
+            ).push,
+            'https://username:password@github.com/example/push.git'
+        )
+        self.assertEqual(
+            response.data['push'],
+            'https://github.com/example/push.git'
+        )
 
 
 class ComponentAPITest(APIBaseTest):

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -712,6 +712,13 @@ class Component(models.Model, URLMixin, PathMixin):
         """Return URL of exported VCS repository."""
         return self.git_export
 
+    @perform_on_link
+    def get_push_url(self):
+        """Return URL of a push repository."""
+        if not settings.HIDE_REPO_CREDENTIALS:
+            return self.push
+        return cleanup_repo_url(self.push)
+
     def get_repoweb_link(self, filename, line, template=None):
         """Generate link to source code browser for given file and line.
 


### PR DESCRIPTION
**Problem**: when a new translation component is created via API `Repository push URL` field became empty (pushing is turned off if this field is empty), so translated strings don't send back to the main VCS.

**Solution**: allow to setup a VCS push URL via API request during component creation.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
