### PR TITLE
Fix icon file handling.

### DIFF
--- a/weblate/utils/templatetags/icons.py
+++ b/weblate/utils/templatetags/icons.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 
 from weblate.logger import LOGGER
+from weblate.utils.errors import report_error
 
 register = template.Library()
 
@@ -41,6 +42,7 @@ def icon(name, fallback=None):
         name = fallback
 
     if not name:
+        LOGGER.error("Empty icon name")
         return ""
 
     if name not in CACHE:
@@ -48,8 +50,8 @@ def icon(name, fallback=None):
         try:
             with open(icon_file, "r") as handle:
                 CACHE[name] = mark_safe(handle.read())
-        except OSError as e:
-            LOGGER.error(str(e))
+        except OSError as error:
+            report_error(error, prefix="Failed to load icon")
             return ""
 
     return CACHE[name]

--- a/weblate/utils/templatetags/icons.py
+++ b/weblate/utils/templatetags/icons.py
@@ -28,7 +28,6 @@ from django.utils.safestring import mark_safe
 
 from weblate.logger import LOGGER
 
-
 register = template.Library()
 
 CACHE = {}
@@ -50,7 +49,7 @@ def icon(name, fallback=None):
             with open(icon_file, "r") as handle:
                 CACHE[name] = mark_safe(handle.read())
         except OSError as e:
-            LOGGER.error(e)
+            LOGGER.error(str(e))
             return ""
 
     return CACHE[name]


### PR DESCRIPTION
There are 2 issues with the current code:

1. `DATA_DIR` being ignored for icons (use `settings.STATIC_ROOT`)

2. in case of an exception `icon()` was called with an empty `name`. I could not track where this happens yet, but regardless file reading should handle errors (python2 might need `IOError`, but sorry I don't use python2 anymore, cannot test).

For example:
```
...
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'xxx.xxx.xxx.xxx'. You may need to add 'xxx.xxx.xxx.xxx' to ALLOWED_HOSTS.

During handling of the above exception, another exception occurred:

...
  File "/export/apps/weblate/venv/lib64/python3.6/site-packages/weblate/utils/templatetags/icons.py", line 42, in icon
    with open(os.path.join(PATH, name), "r") as handle:
IsADirectoryError: [Errno 21] Is a directory: '/export/apps/weblate/venv/lib64/python3.6/site-packages/weblate/static/icons/'

During handling of the above exception, another exception occurred:

...
```


Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [ ] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
