### PR TITLE
WIP: Import ABCs with collections.abc

### DIFF
--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from collections import defaultdict
+from collections.abc import defaultdict
 from copy import copy
 from email.utils import formataddr
 

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -20,7 +20,7 @@
 
 
 import re
-from collections import defaultdict
+from collections.abc import defaultdict
 
 import social_django.utils
 from django.conf import settings

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -20,7 +20,7 @@
 
 
 import os.path
-from collections import defaultdict
+from collections.abc import defaultdict
 
 from django.utils.translation import gettext_lazy as _
 

--- a/weblate/addons/models.py
+++ b/weblate/addons/models.py
@@ -19,7 +19,7 @@
 #
 
 
-from collections import defaultdict
+from collections.abc import defaultdict
 
 from appconf import AppConf
 from django.db import models

--- a/weblate/formats/txt.py
+++ b/weblate/formats/txt.py
@@ -21,7 +21,7 @@
 
 
 import os
-from collections import OrderedDict
+from collections.abc import OrderedDict
 from glob import glob
 from itertools import chain
 

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -23,7 +23,7 @@ import fnmatch
 import os
 import re
 import time
-from collections import Counter
+from collections.abc import Counter
 from copy import copy
 from glob import glob
 from urllib.parse import urlparse

--- a/weblate/trans/search.py
+++ b/weblate/trans/search.py
@@ -23,7 +23,7 @@
 
 import functools
 import logging
-from collections import defaultdict
+from collections.abc import defaultdict
 from time import sleep
 
 from celery_batches import Batches

--- a/weblate/utils/html.py
+++ b/weblate/utils/html.py
@@ -19,7 +19,7 @@
 #
 
 
-from collections import defaultdict
+from collections.abc import defaultdict
 from html.parser import HTMLParser
 
 

--- a/weblate/utils/version.py
+++ b/weblate/utils/version.py
@@ -19,7 +19,7 @@
 #
 
 
-from collections import namedtuple
+from collections.abc import namedtuple
 from datetime import datetime, timedelta
 from distutils.version import LooseVersion
 


### PR DESCRIPTION
https://docs.python.org/3/library/collections.html#collections.Counter

> Deprecated since version 3.3, will be removed in version 3.9: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.8.

It isn't there in 2.7, but WL has deprecated that in WL 4.0?