### PR TITLE
Use url_has_allowed_host_and_scheme

### DIFF
--- a/weblate/accounts/pipeline.py
+++ b/weblate/accounts/pipeline.py
@@ -26,7 +26,7 @@ from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.encoding import force_str
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from social_core.exceptions import AuthAlreadyAssociated, AuthMissingParameter
 from social_core.pipeline.partial import partial
@@ -204,9 +204,9 @@ def cleanup_next(strategy, **kwargs):
     # This is mostly fix for lack of next validation in Python Social Auth
     # see https://github.com/python-social-auth/social-core/issues/62
     url = strategy.session_get('next')
-    if url and not is_safe_url(url, allowed_hosts=None):
+    if url and not url_has_allowed_host_and_scheme(url, allowed_hosts=None):
         strategy.session_set('next', None)
-    if is_safe_url(kwargs.get('next', ''), allowed_hosts=None):
+    if url_has_allowed_host_and_scheme(kwargs.get('next', ''), allowed_hosts=None):
         return None
     return {'next': None}
 

--- a/weblate/accounts/strategy.py
+++ b/weblate/accounts/strategy.py
@@ -22,7 +22,7 @@ from importlib import import_module
 
 from django.conf import settings
 from django.urls import reverse
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from social_django.strategy import DjangoStrategy
 
 from weblate.utils.site import get_site_url
@@ -53,7 +53,7 @@ class WeblateStrategy(DjangoStrategy):
         # This is mostly fix for lack of next validation in Python Social Auth
         # - https://github.com/python-social-auth/social-core/pull/92
         # - https://github.com/python-social-auth/social-core/issues/62
-        if 'next' in data and not is_safe_url(data['next'], allowed_hosts=None):
+        if 'next' in data and not url_has_allowed_host_and_scheme(data['next'], allowed_hosts=None):
             data['next'] = '{0}#account'.format(reverse('profile'))
         return data
 

--- a/weblate/accounts/strategy.py
+++ b/weblate/accounts/strategy.py
@@ -53,8 +53,9 @@ class WeblateStrategy(DjangoStrategy):
         # This is mostly fix for lack of next validation in Python Social Auth
         # - https://github.com/python-social-auth/social-core/pull/92
         # - https://github.com/python-social-auth/social-core/issues/62
-        if 'next' in data and not url_has_allowed_host_and_scheme(data['next'], allowed_hosts=None):
-            data['next'] = '{0}#account'.format(reverse('profile'))
+        if 'next' in data and not url_has_allowed_host_and_scheme(data['next'],
+            allowed_hosts=None):
+                data['next'] = '{0}#account'.format(reverse('profile'))
         return data
 
     def build_absolute_uri(self, path=None):

--- a/weblate/trans/context_processors.py
+++ b/weblate/trans/context_processors.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.html import escape
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
@@ -112,7 +112,7 @@ def get_bread_image(path):
 
 def weblate_context(request):
     """Context processor to inject various useful variables into context."""
-    if is_safe_url(request.GET.get('next', ''), allowed_hosts=None):
+    if url_has_allowed_host_and_scheme(request.GET.get('next', ''), allowed_hosts=None):
         login_redirect_url = request.GET['next']
     else:
         login_redirect_url = request.get_full_path()

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -33,7 +33,7 @@ from django.shortcuts import render as django_render
 from django.shortcuts import resolve_url
 from django.utils import timezone
 from django.utils.encoding import force_str
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from lxml import etree
@@ -282,7 +282,7 @@ def redirect_next(next_url, fallback):
     """Redirect to next URL from request after validating it."""
     if (
         next_url is None
-        or not is_safe_url(next_url, allowed_hosts=None)
+        or not url_has_allowed_host_and_scheme(next_url, allowed_hosts=None)
         or not next_url.startswith('/')
     ):
         return redirect(fallback)


### PR DESCRIPTION
https://django.readthedocs.io/en/latest/releases/3.0.html 

> To avoid possible confusion as to effective scope, the private internal utility is_safe_url() is renamed to url_has_allowed_host_and_scheme(). That a URL has an allowed host and scheme doesn’t in general imply that it’s “safe”. It may still be quoted incorrectly, for example. Ensure to also use iri_to_uri() on the path component of untrusted URLs.