### PR TITLE
fix hexlify()

### DIFF
--- a/weblate/accounts/utils.py
+++ b/weblate/accounts/utils.py
@@ -21,6 +21,7 @@
 
 import binascii
 import os
+import six
 
 from social_django.models import Code
 
@@ -40,16 +41,21 @@ def remove_user(user, request):
     # Remove any email validation codes
     invalidate_reset_codes(user)
 
+    def gen_random_suff():
+        if six.PY3:
+            return os.urandom(5).hex()
+        return binascii.hexlify(os.urandom(5))
+
     # Change username
     user.username = 'deleted-{0}'.format(user.pk)
     user.email = 'noreply+{}@weblate.org'.format(user.pk)
     while User.objects.filter(username=user.username).exists():
         user.username = 'deleted-{0}-{1}'.format(
-            user.pk, binascii.b2a_hex(os.urandom(5))
+            user.pk, gen_random_suff()
         )
     while User.objects.filter(email=user.email).exists():
         user.email = 'noreply+{0}-{1}@weblate.org'.format(
-            user.pk, binascii.b2a_hex(os.urandom(5))
+            user.pk, gen_random_suff()
         )
 
     # Remove user information

--- a/weblate/accounts/utils.py
+++ b/weblate/accounts/utils.py
@@ -19,9 +19,7 @@
 #
 
 
-import binascii
 import os
-import six
 
 from social_django.models import Code
 
@@ -41,21 +39,16 @@ def remove_user(user, request):
     # Remove any email validation codes
     invalidate_reset_codes(user)
 
-    def gen_random_suff():
-        if six.PY3:
-            return os.urandom(5).hex()
-        return binascii.hexlify(os.urandom(5))
-
     # Change username
     user.username = 'deleted-{0}'.format(user.pk)
     user.email = 'noreply+{}@weblate.org'.format(user.pk)
     while User.objects.filter(username=user.username).exists():
         user.username = 'deleted-{0}-{1}'.format(
-            user.pk, gen_random_suff()
+            user.pk, os.urandom(5).hex()
         )
     while User.objects.filter(email=user.email).exists():
         user.email = 'noreply+{0}-{1}@weblate.org'.format(
-            user.pk, gen_random_suff()
+            user.pk, os.urandom(5).hex()
         )
 
     # Remove user information


### PR DESCRIPTION
`hexlify()` returns `b''` in py3, resulting in usernames like `deleted-2-b'614b67018f'`

This is probably not the most elegant fix, but i dont use python2 anymore, so...

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
