### PR TITLE
Mark string as translatable

### DIFF
--- a/weblate/templates/mail/base.html
+++ b/weblate/templates/mail/base.html
@@ -311,7 +311,7 @@ img {
             {% endif %}
         </div>
         {% comment %}This avoids Gmail hiding the footer, as it finds unique content here{% endcomment %}
-        <p style="opacity: 0" class="text-muted">Generated on {% now "DATETIME_FORMAT" %}</p>
+        <p style="opacity: 0" class="text-muted">{% trans "Generated on %s", now "DATETIME_FORMAT" %}</p>
     </div>
     </div>
 {% endfilter %}


### PR DESCRIPTION
I found a string that are not marked as translatable. I tried to fix this, but if the fix does not work, feel free to modify it.
