### PR TITLE
Make the cached Loader check more robust.

### DIFF
--- a/weblate/utils/checks.py
+++ b/weblate/utils/checks.py
@@ -233,7 +233,6 @@ def check_settings(app_configs, **kwargs):
 
 def check_templates(app_configs, **kwargs):
     """Check for cached DjangoTemplates Loader."""
-
     if settings.DEBUG:
         return []
 


### PR DESCRIPTION
The check should be applied to the engine instances, not their (unprocessed) configuration. This fixes false positives such as when no `loaders` are defined (cached is added automatically in this case) and/or when `APP_DIRS` is enabled.

Don't encourage cached loader with `DEBUG`.

Get rid of the legacy TEMPLATE_LOADERS.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
