### PR TITLE
Fix the dropdown positions in the pagination tabs

### DIFF
--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -417,6 +417,12 @@ kbd {
 .unit-navi {
     min-width: 25em;
 }
+.unit-navi li {
+    float: left;
+}
+.unit-navi .dropdown-menu {
+    margin-top: 0;
+}
 .fullmodal .modal-dialog {
     width: auto;
 }

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -49,7 +49,7 @@
 <ul class="pagination unit-navi">
 <li><a id="button-first" class="green" href="{{ first_unit_url }}" title="{% trans "First" %}">{% if LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a></li>
 <li><a id="button-prev" class="green" href="{{ prev_unit_url }}" title="{% trans "Previous" %}">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a></li>
-<li>
+<li class="dropdown">
 <a class="dropdown-toggle green" data-toggle="dropdown" href="#" title="{% trans "Edit search parameters" %}" id="search-dropdown">
 {% icon "magnify.svg" %}
 {{ filter_name }}
@@ -66,7 +66,7 @@
 
 </div>
 </li>
-<li>
+<li class="dropdown">
 <a class="dropdown-toggle" data-toggle="dropdown" href="#" title="{% trans "Go to position" %}" id="goto-dropdown">
 {% blocktrans %}{{ filter_pos }} / {{ filter_count }}{% endblocktrans %}
 <span class="caret"></span>


### PR DESCRIPTION
Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them

Refs: #3308 

I have fixed the position for the dropdowns in this PR.

For making it inline editing, I think we need to make some design decisions. For example after clicking on the query field, do we show the applied filter (such as `all queries`) also or just replace that part by an input field? If we show the filter, I guess it needs to expand horizontally. Similarly for position, do we show an input field for the page number while still showing the total (I would prefer this)? or just an input box, with a max and min limit.

I also think it will advantageous to move to bootstrap 4 because that gives us the scope to use flexbox directly. Flexbox really helps in designing grid-based UI.

cc: @nijel 
