### PR TITLE
Allows exact match in search

### DIFF
--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -86,7 +86,7 @@ Exact operators
 ---------------
 
 You can do an exact match query on different string fields using ``=`` operator. For example, to
-source for all source strings exactly matching ``hello``, use: ``source:=hello``
+source for all source strings exactly matching ``hello world``, use: ``source:="hello world"``
 
 
 Regular expressions

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -82,6 +82,12 @@ You can specify operators, ranges or partial lookups for date or numeric searche
 ``changed:[2019-03-01 to 2019-04-01]``
    Changed between two given dates.
 
+Exact operators
+---------------
+
+You can do an exact match query on different string fields using ``=`` operator. For example, to
+source for all source strings exactly matching ``hello``, use: ``source:=hello``
+
 
 Regular expressions
 -------------------

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1538,9 +1538,13 @@ $(function () {
     $('#is-exact').on('click', function() {
         var input = $(this).closest('.input-group').find('input[type=text]');
         if ($('#is-exact input[type=checkbox]').is(':checked')) {
-            input.val('=' + input.val());
+            if (input.val().indexOf('"') == -1) {
+                input.val('="' + input.val() + '"');
+            } else {
+                input.val('=' + input.val());
+            }
         } else {
-            input.val(input.val().substring(1))
+            input.val(input.val().substring(1));
         }
     })
     $('.search-add').click(function () {

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1535,6 +1535,14 @@ $(function () {
             return false;
         }
     });
+    $('#is-exact').on('click', function() {
+        var input = $(this).closest('.input-group').find('input[type=text]');
+        if ($('#is-exact input[type=checkbox]').is(':checked')) {
+            input.val('=' + input.val());
+        } else {
+            input.val(input.val().substring(1))
+        }
+    })
     $('.search-add').click(function () {
         var group = $(this).closest('.input-group');
         var button = group.find('button');

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -441,6 +441,19 @@ legend {
 .search-group {
     margin: 0 15px 15px 0;
 }
+#is-exact {
+    position: absolute;
+    right: 5.25rem;
+    top: 0.05rem;
+    z-index: 2;
+    padding: 0.35rem 0.65rem;
+    background-color: #e9eaec;
+    display: flex;
+    align-items: center;
+}
+#is-exact span {
+    margin: 4px 4px 0 4px;
+}
 .dir-rtl .search-group {
     margin: 0 0 15px 15px;
 }

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -445,7 +445,7 @@ legend {
     position: absolute;
     right: 5.25rem;
     top: 0.05rem;
-    z-index: 2;
+    z-index: 4;
     padding: 0.35rem 0.65rem;
     background-color: #e9eaec;
     display: flex;

--- a/weblate/templates/snippets/query-builder.html
+++ b/weblate/templates/snippets/query-builder.html
@@ -21,6 +21,7 @@
                 </ul>
               </div><!-- /btn-group -->
               <input type="text" class="form-control" placeholder="{% trans "Search for…" %}">
+              <span id="is-exact"><input type="checkbox" > <span>Exact</span> </span>
               <span class="input-group-btn">
                 <button class="btn btn-default search-add" type="button">{% trans "Add" %}</button>
               </span>

--- a/weblate/templates/snippets/query-builder.html
+++ b/weblate/templates/snippets/query-builder.html
@@ -21,7 +21,7 @@
                 </ul>
               </div><!-- /btn-group -->
               <input type="text" class="form-control" placeholder="{% trans "Search for…" %}">
-              <span id="is-exact"><input type="checkbox" > <span>Exact</span> </span>
+              <span id="is-exact"><input type="checkbox" > <span>{% trans "Exact" %}</span> </span>
               <span class="input-group-btn">
                 <button class="btn btn-default search-add" type="button">{% trans "Add" %}</button>
               </span>

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -264,6 +264,10 @@ def is_sql(text):
     raise ValueError("Unsupported is lookup: {}".format(text))
 
 
+def exact_sql(field, text):
+    return Q(**{field_name(field, "iexact"): text[1:]})
+
+
 def query_sql(obj):
     if isinstance(obj, whoosh.query.And):
         return reduce(
@@ -282,6 +286,8 @@ def query_sql(obj):
             return has_sql(obj.text)
         if obj.fieldname == "is":
             return is_sql(obj.text)
+        if obj.text.startswith("="):
+            return exact_sql(obj.fieldname, obj.text)
         return field_extra(obj.fieldname, Q(**{field_name(obj.fieldname): obj.text}))
     if isinstance(obj, whoosh.query.DateRange):
         return field_extra(

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -91,7 +91,10 @@ class QueryParserTest(TestCase):
         self.assert_query("location:hello.c", Q(location__substring="hello.c"))
 
     def test_exact(self):
-        self.assert_query("source:=hello", Q(source__iexact="hello"))
+        self.assert_query("source:='hello'", Q(source__iexact="hello"))
+        self.assert_query('source:="hello world"', Q(source__iexact="hello world"))
+        self.assert_query("source:='hello world'", Q(source__iexact="hello world"))
+        self.assert_query("source:=hello", Q(source__substring="=hello"))
 
     def test_regex(self):
         self.assert_query('source:r"^hello"', Q(source__regex="^hello"))

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -90,6 +90,9 @@ class QueryParserTest(TestCase):
         )
         self.assert_query("location:hello.c", Q(location__substring="hello.c"))
 
+    def test_exact(self):
+        self.assert_query("source:=hello", Q(source__iexact="hello"))
+
     def test_regex(self):
         self.assert_query('source:r"^hello"', Q(source__regex="^hello"))
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation

Refs #3409 

I have added the code for allowing exact matches with a term `exact:true`. I haven't added tests or documentation yet. If this method looks good way to proceed with, I will add the corresponding tests and documentation updates.

cc: @nijel 
