### PR TITLE
Extend API:  Add more api views related to screenshots

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -553,6 +553,20 @@ Components
 
         Additional common headers, parameters and status codes are documented at :ref:`api-generic`.
 
+.. http:get::  /api/components/(string:project)/(string:component)/screenshots/
+
+    Returns a list of component screenshots.
+
+    :param project: Project URL slug
+    :type project: string
+    :param component: Component URL slug
+    :type component: string
+    :>json array results: array of component screenshots; see :http:get:`/api/screenshots/(int:pk)/`
+
+    .. seealso::
+
+        Additional common headers, parameters and status codes are documented at :ref:`api-generic`.
+
 
 .. http:get:: /api/components/(string:project)/(string:component)/lock/
 
@@ -1113,6 +1127,41 @@ Screenshots
             -F image=@image.png \
             -H "Authorization: Token TOKEN" \
             http://example.com/api/screenshots/1/file/
+
+.. http:post:: /api/screenshots/(int:pk)/units/
+
+    Associate source string with screenshot.
+
+    :param pk: Screenshot ID
+    :type pk: int
+    :form string pk: Unit ID
+    :>json string name: name of a screenshot
+    :>json string component: URL of a related component object
+    :>json string file_url: URL to download a file; see :http:get:`/api/screenshots/(int:pk)/file/`
+    :>json array units: link to associated source string information; see :http:get:`/api/units/(int:pk)/`
+
+    .. seealso::
+
+        Additional common headers, parameters and status codes are documented at :ref:`api-generic`.
+
+.. http:post:: /api/screenshots/
+
+    Creates a new screenshot.
+
+    :form file image: Uploaded file
+    :form string name: Screenshot name
+    :form string project_slug: Project Slug
+    :form string component_slug: Component Slug
+    :>json string name: name of a screenshot
+    :>json string component: URL of a related component object
+    :>json string file_url: URL to download a file; see :http:get:`/api/screenshots/(int:pk)/file/`
+    :>json array units: link to associated source string information; see :http:get:`/api/units/(int:pk)/`
+
+
+    .. seealso::
+
+        Additional common headers, parameters and status codes are documented at :ref:`api-generic`.
+
 
 
 .. _hooks:


### PR DESCRIPTION
Resolving: #3076 
## Description

Work toward Extending API functionality to allow for the following:
- Getting a list screenshots per component.
- Adding new screenshots.
- Associating strings with screenshots.

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
