### PR TITLE
Auth: Improve permissions caching

### DIFF
--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -18,6 +18,7 @@
 #
 
 import re
+from collections import defaultdict
 
 from appconf import AppConf
 from django.conf import settings
@@ -329,7 +330,8 @@ class User(AbstractBaseUser):
 
     def __init__(self, *args, **kwargs):
         self.extra_data = {}
-        self.perm_cache = {}
+        self.cla_cache = {}
+        self._permissions = None
         self.current_subscription = None
         for name in self.DUMMY_FIELDS:
             if name in kwargs:
@@ -340,7 +342,19 @@ class User(AbstractBaseUser):
         return reverse("user_page", kwargs={"user": self.username})
 
     def clear_cache(self):
-        self.perm_cache = {}
+        self.cla_cache = {}
+        self._permissions = None
+        perm_caches = (
+            "project_permissions",
+            "component_permissions",
+            "allowed_projects",
+            "allowed_project_ids",
+            "watched_projects",
+            "owned_projects",
+        )
+        for name in perm_caches:
+            if name in self.__dict__:
+                del self.__dict__[name]
 
     def has_usable_password(self):
         # For some reason Django says that empty string is a valid password
@@ -383,6 +397,7 @@ class User(AbstractBaseUser):
         if not self.email:
             self.email = None
         super().save(*args, **kwargs)
+        self.clear_cache()
 
     def has_module_perms(self, module):
         """Compatibility API for admin interface."""
@@ -441,7 +456,7 @@ class User(AbstractBaseUser):
         """Check access to given project."""
         if self.is_superuser:
             return True
-        return self.groups.filter(projects=project).exists()
+        return project.pk in self.project_permissions
 
     def check_access(self, project):
         """Raise an error if user is not allowed to access this project."""
@@ -453,7 +468,7 @@ class User(AbstractBaseUser):
         """List of allowed projects."""
         if self.is_superuser:
             return Project.objects.order()
-        return Project.objects.filter(group__user=self).distinct().order()
+        return Project.objects.filter(pk__in=self.allowed_project_ids)
 
     @cached_property
     def allowed_project_ids(self):
@@ -462,7 +477,9 @@ class User(AbstractBaseUser):
 
         This is more effective to use in queries than doing complex joins.
         """
-        return {project.pk for project in self.allowed_projects}
+        if self.is_superuser:
+            return set(Project.objects.values_list("id", flat=True))
+        return set(self.project_permissions.keys())
 
     @cached_property
     def watched_projects(self):
@@ -477,6 +494,49 @@ class User(AbstractBaseUser):
     @cached_property
     def owned_projects(self):
         return self.projects_with_perm("project.edit")
+
+    def _fetch_permissions(self):
+        """Fetch all user permissions into a dictionary."""
+        projects = defaultdict(list)
+        components = defaultdict(list)
+        for group in self.groups.iterator():
+            languages = set(
+                Group.languages.through.objects.filter(group=group).values_list(
+                    "language_id", flat=True
+                )
+            )
+            permissions = set(
+                group.roles.values_list("permissions__codename", flat=True)
+            )
+            # Component list specific permissions
+            if group.componentlist:
+                for component, project in group.componentlist.components.values_list(
+                    "id", "project_id"
+                ):
+                    components[component].append((permissions, languages))
+                    # Grant access to the project
+                    projects[project].append(((), languages))
+                continue
+            # Project specific permissions
+            for project in Group.projects.through.objects.filter(
+                group=group
+            ).values_list("project_id", flat=True):
+                projects[project].append((permissions, languages))
+        self._permissions = {"projects": projects, "components": components}
+
+    @cached_property
+    def project_permissions(self):
+        """Dictionary with all project permissions."""
+        if self._permissions is None:
+            self._fetch_permissions()
+        return self._permissions["projects"]
+
+    @cached_property
+    def component_permissions(self):
+        """Dictionary with all project permissions."""
+        if self._permissions is None:
+            self._fetch_permissions()
+        return self._permissions["components"]
 
     def projects_with_perm(self, perm):
         if self.is_superuser:

--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -63,7 +63,7 @@ class ModelTest(FixtureTestCase):
         self.group.save()
 
         # No permissions as component list is empty
-        self.assertTrue(self.user.can_access_project(self.project))
+        self.assertFalse(self.user.can_access_project(self.project))
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         # Permissions should exist after adding to a component list
@@ -81,6 +81,7 @@ class ModelTest(FixtureTestCase):
         self.group.languages.set(Language.objects.filter(code="de"), clear=True)
 
         # Permissions should deny access
+        self.user.clear_cache()
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 

--- a/weblate/trans/models/agreement.py
+++ b/weblate/trans/models/agreement.py
@@ -24,15 +24,15 @@ from django.db import models
 
 class ContributorAgreementManager(models.Manager):
     def has_agreed(self, user, component):
-        cache_key = ("cla", user.pk, component.pk)
-        if cache_key not in user.perm_cache:
-            user.perm_cache[cache_key] = self.filter(
+        cache_key = (user.pk, component.pk)
+        if cache_key not in user.cla_cache:
+            user.cla_cache[cache_key] = self.filter(
                 component=component, user=user
             ).exists()
-        return user.perm_cache[cache_key]
+        return user.cla_cache[cache_key]
 
     def create(self, user, component, **kwargs):
-        user.perm_cache[("cla", user.pk, component.pk)] = True
+        user.cla_cache[(user.pk, component.pk)] = True
         return super().create(user=user, component=component, **kwargs)
 
     def order(self):


### PR DESCRIPTION
Fetch all user permissiosn in single query. We typically check for bunch
of permissions in every request, so it's better to fetch them all at
once and then do cheap lookups in Python.

This replaces per function cache layer on individual permissions as it
is no longer needed as individual lookups are now cheap.

This is also prepartion for extending permission system in future.
Restrictions or component level permissions are now easier to implement.

Issue #3646
Issue #3267

Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation
