### PR TITLE
Fixes exact checkbox alignment and backend logic

### DIFF
--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -86,7 +86,9 @@ Exact operators
 ---------------
 
 You can do an exact match query on different string fields using ``=`` operator. For example, to
-source for all source strings exactly matching ``hello world``, use: ``source:="hello world"``
+search for all source strings exactly matching ``hello world``, use: ``source:="hello world"``. 
+For searching single word expressions, you can skip quotes. For example, to search for all source strings
+matching ``hello``, you can use: ``source:=hello``.
 
 
 Regular expressions

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -86,7 +86,7 @@ Exact operators
 ---------------
 
 You can do an exact match query on different string fields using ``=`` operator. For example, to
-search for all source strings exactly matching ``hello world``, use: ``source:="hello world"``. 
+search for all source strings exactly matching ``hello world``, use: ``source:="hello world"``.
 For searching single word expressions, you can skip quotes. For example, to search for all source strings
 matching ``hello``, you can use: ``source:=hello``.
 

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -441,16 +441,6 @@ legend {
 .search-group {
     margin: 0 15px 15px 0;
 }
-#is-exact {
-    position: absolute;
-    right: 5.25rem;
-    top: 0.05rem;
-    z-index: 4;
-    padding: 0.35rem 0.65rem;
-    background-color: #e9eaec;
-    display: flex;
-    align-items: center;
-}
 #is-exact span {
     margin: 4px 4px 0 4px;
 }

--- a/weblate/templates/snippets/query-builder.html
+++ b/weblate/templates/snippets/query-builder.html
@@ -21,7 +21,7 @@
                 </ul>
               </div><!-- /btn-group -->
               <input type="text" class="form-control" placeholder="{% trans "Search for…" %}">
-              <span id="is-exact"><input type="checkbox" > <span>{% trans "Exact" context "Exact search toggle" %}</span> </span>
+              <span id="is-exact" class="input-group-addon"><input type="checkbox" > <span>{% trans "Exact" context "Exact search toggle" %}</span> </span>
               <span class="input-group-btn">
                 <button class="btn btn-default search-add" type="button">{% trans "Add" %}</button>
               </span>

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -69,8 +69,8 @@ class Exact(whoosh.query.Term):
     pass
 
 
-class ExactPlugin(QuotePlugin):
-    """Exact match plugin with quotes to specify an exact term."""
+class ExactPlugin(whoosh.qparser.TaggingPlugin):
+    """Exact match plugin to specify an exact term."""
 
     class ExactNode(whoosh.qparser.syntax.TextNode):
         qclass = Exact
@@ -78,7 +78,7 @@ class ExactPlugin(QuotePlugin):
         def r(self):
             return "Exact %r" % self.text
 
-    expr = r"\=(^|(?<=\W))['\"](?P<text>.*?)['\"](?=\s|\]|[)}]|$)"
+    expr = r"\=(^|(?<=\W))(['\"]?)(?P<text>.*?)\2(?=\s|\]|[)}]|$)"
     nodetype = ExactNode
 
 

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -94,7 +94,7 @@ class QueryParserTest(TestCase):
         self.assert_query("source:='hello'", Q(source__iexact="hello"))
         self.assert_query('source:="hello world"', Q(source__iexact="hello world"))
         self.assert_query("source:='hello world'", Q(source__iexact="hello world"))
-        self.assert_query("source:=hello", Q(source__substring="=hello"))
+        self.assert_query("source:=hello", Q(source__iexact="hello"))
 
     def test_regex(self):
         self.assert_query('source:r"^hello"', Q(source__regex="^hello"))


### PR DESCRIPTION
Before submitting pull request, please ensure that:

- [x] Every commit has message which describes it
- [x] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with testcase
- [x] Any new functionality is covered by user documentation

Fixes #3675 

- Used `.input-group-addon` for the exact checkbox instead of an absolute label.
- Fixed the regex expression to match quotes for multi-word expression and without(or with) quotes for single word.
- Added documentation for the same.