### PR TITLE
Search: Add ``has:context`` search type

### DIFF
--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -40,7 +40,7 @@ Fields
 ``pending:BOOLEAN``
    String pending for flushing to VCS.
 ``has:TEXT``
-   Search for string having attributes (``plural``, ``suggestion``, ``comment``, ``check``, ``ignored-check``, ``translation``, ``shaping``).
+   Search for string having attributes (``plural``, ``context``, ``suggestion``, ``comment``, ``check``, ``ignored-check``, ``translation``, ``shaping``).
 ``is:TEXT``
    Search for string states (``pending``, ``translated``, ``untranslated``).
 ``language:TEXT``

--- a/weblate/templates/snippets/query-builder.html
+++ b/weblate/templates/snippets/query-builder.html
@@ -37,6 +37,7 @@
                   <li><a href="#" data-field="has:comment">{% trans "String has comment" %}</a></li>
                   <li><a href="#" data-field="has:failing_check">{% trans "String has failing check" %}</a></li>
                   <li><a href="#" data-field="has:plural">{% trans "String has plural" %}</a></li>
+                  <li><a href="#" data-field="has:context">{% trans "String has context" %}</a></li>
                 </ul>
               </div><!-- /btn-group -->
               <span class="input-group-btn">

--- a/weblate/trans/filter.py
+++ b/weblate/trans/filter.py
@@ -37,6 +37,7 @@ class FilterRegistry:
             ("suggestions", _("Strings with suggestions"), "has:suggestion"),
             ("shapings", _("Strings with shapings"), "has:shaping"),
             ("labels", _("Strings with labels"), "has:label"),
+            ("context", _("Strings with context"), "has:context"),
             (
                 "nosuggestions",
                 _("Strings needing action without suggestions"),

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -265,6 +265,8 @@ def has_sql(text):
         return Q(shaping__isnull=False)
     if text == "label":
         return Q(labels__isnull=False)
+    if text == "context":
+        return ~Q(context="")
 
     raise ValueError("Unsupported has lookup: {}".format(text))
 

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -209,6 +209,7 @@ class QueryParserTest(TestCase):
         self.assert_query("has:translation", Q(state__gte=STATE_TRANSLATED))
         self.assert_query("has:shaping", Q(shaping__isnull=False))
         self.assert_query("has:label", Q(labels__isnull=False))
+        self.assert_query("has:context", ~Q(context=""))
 
     def test_is(self):
         self.assert_query("is:pending", Q(pending=True))


### PR DESCRIPTION
New search type allows search for strings with settled context
no matter which context really are.

Fixes #3684