### PR TITLE
Remove batch checks processing

### DIFF
--- a/weblate/addons/removal.py
+++ b/weblate/addons/removal.py
@@ -55,7 +55,6 @@ class RemoveComments(RemovalAddon):
                 unit__translation__component__project=component.project
             )
         )
-        component.project.update_unit_flags()
 
 
 class RemoveSuggestions(RemovalAddon):
@@ -75,4 +74,3 @@ class RemoveSuggestions(RemovalAddon):
                 | Q(vote__value__sum=None)
             )
         )
-        component.project.update_unit_flags()

--- a/weblate/checks/__init__.py
+++ b/weblate/checks/__init__.py
@@ -23,36 +23,6 @@ from weblate.utils.classloader import ClassLoader
 default_app_config = "weblate.checks.apps.ChecksConfig"
 
 
-def highlight_string(source, unit):
-    """Return highlights for a string."""
-    if unit is None:
-        return []
-    highlights = []
-    for check in CHECKS:
-        if not CHECKS[check].target:
-            continue
-        highlights += CHECKS[check].check_highlight(source, unit)
-
-    # Sort by order in string
-    highlights.sort(key=lambda x: x[0])
-
-    # Remove overlapping ones
-    for hl_idx in range(0, len(highlights)):
-        if hl_idx >= len(highlights):
-            break
-        elref = highlights[hl_idx]
-        for hl_idx_next in range(hl_idx + 1, len(highlights)):
-            if hl_idx_next >= len(highlights):
-                break
-            eltest = highlights[hl_idx_next]
-            if eltest[0] >= elref[0] and eltest[0] < elref[1]:
-                highlights.pop(hl_idx_next)
-            elif eltest[0] > elref[1]:
-                break
-
-    return highlights
-
-
 class ChecksLoader(ClassLoader):
     @cached_property
     def source(self):

--- a/weblate/checks/__init__.py
+++ b/weblate/checks/__init__.py
@@ -16,22 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-from django.utils.functional import cached_property
-
-from weblate.utils.classloader import ClassLoader
 
 default_app_config = "weblate.checks.apps.ChecksConfig"
-
-
-class ChecksLoader(ClassLoader):
-    @cached_property
-    def source(self):
-        return {k: v for k, v in self.items() if v.source}
-
-    @cached_property
-    def target(self):
-        return {k: v for k, v in self.items() if v.target}
-
-
-# Initialize checks list
-CHECKS = ChecksLoader("CHECK_LIST")

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -33,7 +33,6 @@ class Check:
     ignore_untranslated = True
     default_disabled = False
     severity = "info"
-    batch_update = False
     propagates = False
     param_type = None
 

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 
 from weblate.checks.base import TargetCheck
@@ -79,19 +78,7 @@ class ConsistencyCheck(TargetCheck):
     )
     ignore_untranslated = False
     severity = "warning"
-    batch_update = True
     propagates = True
-
-    def check_target_project(self, project):
-        """Batch check for whole project."""
-        from weblate.trans.models import Unit
-
-        return (
-            Unit.objects.filter(translation__component__project=project)
-            .values("content_hash", "translation__language")
-            .annotate(Count("target", distinct=True))
-            .filter(target__count__gt=1)
-        )
 
     def check_target_unit(self, sources, targets, unit):
         for other in unit.same_source_units:
@@ -114,17 +101,6 @@ class TranslatedCheck(TargetCheck):
     description = _("This string has been translated in the past")
     ignore_untranslated = False
     severity = "warning"
-    batch_update = True
-
-    def check_target_project(self, project):
-        """Batch check for whole project."""
-        from weblate.trans.models import Unit, Change
-
-        return Unit.objects.filter(
-            translation__component__project=project,
-            change__action__in=Change.ACTIONS_TRANSLATED,
-            state__lt=STATE_TRANSLATED,
-        ).values("content_hash", "translation__language")
 
     def check_target_unit(self, sources, targets, unit):
         if unit.translated:

--- a/weblate/checks/flags.py
+++ b/weblate/checks/flags.py
@@ -21,7 +21,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
-from weblate.checks import CHECKS
+from weblate.checks.models import CHECKS
 from weblate.fonts.utils import get_font_weight
 
 PLAIN_FLAGS = {

--- a/weblate/checks/migrations/0001_squashed_0002_auto_20180416_1509.py
+++ b/weblate/checks/migrations/0001_squashed_0002_auto_20180416_1509.py
@@ -3,7 +3,7 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
-from weblate.checks import CHECKS
+from weblate.checks.models import CHECKS
 
 
 class Migration(migrations.Migration):

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -128,18 +128,12 @@ class Check(models.Model):
 
     def get_description(self):
         if self.check_obj:
-            try:
-                return self.check_obj.get_description(self)
-            except IndexError:
-                return self.check_obj.description
+            return self.check_obj.get_description(self)
         return self.check
 
     def get_fixup(self):
         if self.check_obj:
-            try:
-                return self.check_obj.get_fixup(self.unit)
-            except IndexError:
-                return None
+            return self.check_obj.get_fixup(self.unit)
         return None
 
     def get_fixup_json(self):
@@ -187,12 +181,9 @@ def check_post_save(sender, instance, created, **kwargs):
             instance.unit.source_info.run_checks()
     else:
         # Update related unit failed check flag (the check was (un)ignored)
-        try:
-            instance.unit.update_has_failing_check(
-                has_checks=None if instance.ignore else True
-            )
-        except IndexError:
-            return
+        instance.unit.update_has_failing_check(
+            has_checks=None if instance.ignore else True
+        )
 
 
 @receiver(post_delete, sender=Check)

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -27,8 +27,22 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils.functional import cached_property
 
-from weblate.checks import CHECKS
+from weblate.utils.classloader import ClassLoader
 from weblate.utils.decorators import disable_for_loaddata
+
+
+class ChecksLoader(ClassLoader):
+    @cached_property
+    def source(self):
+        return {k: v for k, v in self.items() if v.source}
+
+    @cached_property
+    def target(self):
+        return {k: v for k, v in self.items() if v.target}
+
+
+# Initialize checks list
+CHECKS = ChecksLoader("CHECK_LIST")
 
 
 class WeblateChecksConf(AppConf):

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -167,7 +167,7 @@ def check_post_save(sender, instance, created, **kwargs):
         # Update related unit failed check flag (the check was (un)ignored)
         try:
             instance.unit.update_has_failing_check(
-                has_checks=None if instance.ignore else True, invalidate=True
+                has_checks=None if instance.ignore else True
             )
         except IndexError:
             return
@@ -181,4 +181,4 @@ def remove_complimentary_checks(sender, instance, **kwargs):
         return
     for unit in instance.unit.same_source_units:
         if unit.check_set.filter(check=instance.check).delete()[0]:
-            unit.update_has_failing_check(invalidate=True)
+            unit.update_has_failing_check()

--- a/weblate/checks/source.py
+++ b/weblate/checks/source.py
@@ -20,7 +20,6 @@
 
 import re
 
-from django.db.models import Count, F
 from django.utils.translation import gettext_lazy as _
 
 from weblate.checks.base import SourceCheck
@@ -64,7 +63,6 @@ class MultipleFailingCheck(SourceCheck):
     name = _("Multiple failing checks")
     description = _("The translations in several languages have failing checks")
     severity = "warning"
-    batch_update = True
 
     def check_source(self, source, unit):
         from weblate.checks.models import Check
@@ -74,15 +72,3 @@ class MultipleFailingCheck(SourceCheck):
             unit__translation__component=unit.translation.component,
         ).exclude(unit_id=unit.id)
         return related.count() >= 2
-
-    def check_source_project(self, project):
-        """Batch check for whole project."""
-        from weblate.checks.models import Check
-
-        return (
-            Check.objects.filter(unit__translation__component__project=project)
-            .exclude(unit__translation__language=project.source_language)
-            .values(content_hash=F("unit__content_hash"))
-            .annotate(Count("unit"))
-            .filter(unit__count__gt=1)
-        )

--- a/weblate/checks/tests/test_commands.py
+++ b/weblate/checks/tests/test_commands.py
@@ -23,7 +23,7 @@ from io import StringIO
 
 from django.core.management import call_command
 
-from weblate.trans.tests.test_commands import CheckGitTest
+from weblate.trans.tests.test_commands import WeblateComponentCommandTestCase
 from weblate.trans.tests.test_models import RepoTestCase
 
 
@@ -53,6 +53,6 @@ class PeriodicCommandTest(RepoTestCase):
         self.assertEqual(1, len(output.getvalue().splitlines()))
 
 
-class UpdateChecksTest(CheckGitTest):
+class UpdateChecksTest(WeblateComponentCommandTestCase):
     command_name = "updatechecks"
     expected_string = "Processing"

--- a/weblate/checks/tests/test_utils.py
+++ b/weblate/checks/tests/test_utils.py
@@ -1,0 +1,51 @@
+#
+# Copyright © 2012 - 2020 Michal Čihař <michal@cihar.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from django.test import SimpleTestCase
+
+from weblate.checks.tests.test_checks import MockUnit
+from weblate.checks.utils import highlight_string
+
+
+class HightlightTestCase(SimpleTestCase):
+    def test_simple(self):
+        self.assertEqual(
+            highlight_string(
+                "simple {format} string", MockUnit(flags="python-brace-format")
+            ),
+            [(7, 15, "{format}")],
+        )
+
+    def test_multi(self):
+        self.assertEqual(
+            highlight_string(
+                "simple {format} %d string",
+                MockUnit(flags="python-brace-format, python-format"),
+            ),
+            [(7, 15, "{format}"), (16, 18, "%d")],
+        )
+
+    def test_overlap(self):
+        self.assertEqual(
+            highlight_string(
+                'nested <a href="{format}">string</a>',
+                MockUnit(flags="python-brace-format"),
+            ),
+            [(7, 26, '<a href="{format}">'), (32, 36, "</a>")],
+        )

--- a/weblate/checks/utils.py
+++ b/weblate/checks/utils.py
@@ -42,8 +42,10 @@ def highlight_string(source, unit):
                 break
             eltest = highlights[hl_idx_next]
             if eltest[0] >= elref[0] and eltest[0] < elref[1]:
+                # Elements overlap, remove inner one
                 highlights.pop(hl_idx_next)
             elif eltest[0] > elref[1]:
+                # This is not an overlapping element
                 break
 
     return highlights

--- a/weblate/checks/utils.py
+++ b/weblate/checks/utils.py
@@ -1,0 +1,49 @@
+# Copyright © 2012 - 2020 Michal Čihař <michal@cihar.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from weblate.checks import CHECKS
+
+
+def highlight_string(source, unit):
+    """Return highlights for a string."""
+    if unit is None:
+        return []
+    highlights = []
+    for check in CHECKS:
+        if not CHECKS[check].target:
+            continue
+        highlights += CHECKS[check].check_highlight(source, unit)
+
+    # Sort by order in string
+    highlights.sort(key=lambda x: x[0])
+
+    # Remove overlapping ones
+    for hl_idx in range(0, len(highlights)):
+        if hl_idx >= len(highlights):
+            break
+        elref = highlights[hl_idx]
+        for hl_idx_next in range(hl_idx + 1, len(highlights)):
+            if hl_idx_next >= len(highlights):
+                break
+            eltest = highlights[hl_idx_next]
+            if eltest[0] >= elref[0] and eltest[0] < elref[1]:
+                highlights.pop(hl_idx_next)
+            elif eltest[0] > elref[1]:
+                break
+
+    return highlights

--- a/weblate/checks/utils.py
+++ b/weblate/checks/utils.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from weblate.checks import CHECKS
+from weblate.checks.models import CHECKS
 
 
 def highlight_string(source, unit):

--- a/weblate/checks/views.py
+++ b/weblate/checks/views.py
@@ -24,8 +24,7 @@ from django.utils.encoding import force_str
 from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 
-from weblate.checks import CHECKS
-from weblate.checks.models import Check
+from weblate.checks.models import CHECKS, Check
 from weblate.trans.models import Component, Translation
 from weblate.trans.util import redirect_param
 from weblate.utils.views import get_component, get_project

--- a/weblate/trans/filter.py
+++ b/weblate/trans/filter.py
@@ -23,7 +23,7 @@ from django.utils.text import format_lazy
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
-from weblate.checks import CHECKS
+from weblate.checks.models import CHECKS
 
 
 class FilterRegistry:

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -45,7 +45,7 @@ from django.utils.translation import pgettext_lazy
 from translation_finder import DiscoveryResult, discover
 
 from weblate.auth.models import User
-from weblate.checks import CHECKS
+from weblate.checks.models import CHECKS
 from weblate.formats.exporters import EXPORTERS
 from weblate.formats.models import FILE_FORMATS
 from weblate.lang.models import Language

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1415,7 +1415,6 @@ class Component(models.Model, URLMixin, PathMixin):
         self.update_import_alerts()
 
         # Process linked repos
-        projects = {project.id: project}
         for pos, component in enumerate(self.linked_childs):
             self.log_info(
                 "updating linked project %s [%d/%d]",
@@ -1427,17 +1426,10 @@ class Component(models.Model, URLMixin, PathMixin):
             was_change |= component.create_translations(
                 force, langs, request=request, from_link=True
             )
-            projects[component.project_id] = component.project
 
         # Run source checks on updated source strings
         if self.updated_sources:
             self.update_source_checks()
-
-        # Run batch checks, update flags and stats
-        if not from_link and was_change:
-            for project in projects.values():
-                project.run_target_checks()
-                project.run_source_checks()
 
         # Update flags
         if was_change:
@@ -2138,7 +2130,6 @@ class Component(models.Model, URLMixin, PathMixin):
                 translation = Translation.objects.check_sync(
                     self, language, format_code, filename, request=request
                 )
-                self.project.run_target_checks()
                 self.update_source_checks()
                 self.update_unit_flags()
                 translation.invalidate_cache()
@@ -2170,7 +2161,6 @@ class Component(models.Model, URLMixin, PathMixin):
                 else "Weblate <noreply@weblate.org>",
                 timezone.now(),
             )
-            self.project.run_target_checks()
             self.update_source_checks()
             self.update_unit_flags()
             translation.invalidate_cache()

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1438,11 +1438,11 @@ class Component(models.Model, URLMixin, PathMixin):
             for project in projects.values():
                 project.run_target_checks()
                 project.run_source_checks()
-                project.invalidate_stats_deep()
 
         # Update flags
         if was_change:
             self.update_unit_flags()
+            self.invalidate_stats_deep()
 
         # Schedule background cleanup if needed
         if self.needs_cleanup:
@@ -1477,6 +1477,11 @@ class Component(models.Model, URLMixin, PathMixin):
             has_failing_check=False
         )
         self.log_debug("all unit flags updated")
+
+    def invalidate_stats_deep(self):
+        self.log_info("updating stats caches")
+        for translation in self.translation_set.iterator():
+            translation.invalidate_cache()
 
     def get_lang_code(self, path, validate=False):
         """Parse language code from path."""
@@ -1911,7 +1916,7 @@ class Component(models.Model, URLMixin, PathMixin):
 
         # Invalidate stats on template change
         if changed_template:
-            self.project.invalidate_stats_deep()
+            self.invalidate_stats_deep()
 
     def update_shapings(self):
         from weblate.trans.models import Unit

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -376,14 +376,6 @@ class Project(models.Model, URLMixin, PathMixin):
         """Run batch executed source checks."""
         self.run_batch_checks("source")
 
-    def invalidate_stats_deep(self):
-        self.log_info("updating stats caches")
-        from weblate.trans.models import Translation
-
-        translations = Translation.objects.filter(component__project=self)
-        for translation in translations.iterator():
-            translation.invalidate_cache()
-
     def get_stats(self):
         """Return stats dictionary."""
         return {

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -376,21 +376,6 @@ class Project(models.Model, URLMixin, PathMixin):
         """Run batch executed source checks."""
         self.run_batch_checks("source")
 
-    def update_unit_flags(self):
-        from weblate.trans.models import Unit
-
-        units = Unit.objects.filter(translation__component__project=self)
-
-        self.log_debug("updating unit flags: has_failing_check")
-
-        units.filter(has_failing_check=False).filter(check__ignore=False).update(
-            has_failing_check=True
-        )
-        units.filter(has_failing_check=True).exclude(check__ignore=False).update(
-            has_failing_check=False
-        )
-        self.log_debug("all unit flags updated")
-
     def invalidate_stats_deep(self):
         self.log_info("updating stats caches")
         from weblate.trans.models import Translation

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -25,8 +25,7 @@ from django.db import models, transaction
 from django.db.models import Sum
 from django.utils.translation import gettext as _
 
-from weblate.checks import CHECKS
-from weblate.checks.models import Check
+from weblate.checks.models import CHECKS, Check
 from weblate.trans.mixins import UserDisplayMixin
 from weblate.trans.models.change import Change
 from weblate.utils import messages

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -31,8 +31,8 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
-from weblate.checks import CHECKS
 from weblate.checks.flags import Flags
+from weblate.checks.models import CHECKS
 from weblate.formats.auto import try_load
 from weblate.formats.base import UnitNotFound
 from weblate.formats.helpers import BytesIOMode

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -696,11 +696,6 @@ class Unit(models.Model, LoggerMixin):
 
         # Run all checks
         for check, check_obj in checks:
-            # Do not remove batch checks in batch processing
-            if self.is_batch_update and check_obj.batch_update:
-                old_checks.discard(check)
-                continue
-
             # Does the check fire?
             if getattr(check_obj, meth)(*args):
                 if check in old_checks:

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -724,7 +724,7 @@ class Unit(models.Model, LoggerMixin):
         if not self.is_batch_update and (was_change or not same_content):
             self.update_has_failing_check(has_checks)
 
-    def update_has_failing_check(self, has_checks=None, invalidate=False):
+    def update_has_failing_check(self, has_checks=None):
         """Update flag counting failing checks."""
         if has_checks is None:
             has_checks = self.active_checks().exists()
@@ -735,7 +735,7 @@ class Unit(models.Model, LoggerMixin):
             self.save(
                 same_content=True, same_state=True, update_fields=["has_failing_check"]
             )
-            if invalidate:
+            if not self.is_batch_update:
                 self.translation.invalidate_cache()
 
     def update_has_suggestion(self):

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -29,9 +29,8 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 
-from weblate.checks import CHECKS
 from weblate.checks.flags import Flags
-from weblate.checks.models import Check
+from weblate.checks.models import CHECKS, Check
 from weblate.formats.helpers import CONTROLCHARS
 from weblate.memory.tasks import update_memory
 from weblate.trans.mixins import LoggerMixin

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -35,7 +35,8 @@ from django.utils.translation import gettext, gettext_lazy, ngettext, pgettext
 from weblate.accounts.avatar import get_user_display
 from weblate.accounts.models import Profile
 from weblate.auth.models import User
-from weblate.checks import CHECKS, highlight_string
+from weblate.checks import CHECKS
+from weblate.checks.utils import highlight_string
 from weblate.trans.filter import get_filter_choice
 from weblate.trans.models import (
     Announcement,

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -35,7 +35,7 @@ from django.utils.translation import gettext, gettext_lazy, ngettext, pgettext
 from weblate.accounts.avatar import get_user_display
 from weblate.accounts.models import Profile
 from weblate.auth.models import User
-from weblate.checks import CHECKS
+from weblate.checks.models import CHECKS
 from weblate.checks.utils import highlight_string
 from weblate.trans.filter import get_filter_choice
 from weblate.trans.models import (

--- a/weblate/trans/tests/test_commands.py
+++ b/weblate/trans/tests/test_commands.py
@@ -312,11 +312,11 @@ class BasicCommandTest(FixtureTestCase):
             call_command("check", "--deploy")
 
 
-class CheckGitTest(ViewTestCase):
+class WeblateComponentCommandTestCase(ViewTestCase):
     """Base class for handling tests of WeblateComponentCommand based commands."""
 
-    command_name = "checkgit"
-    expected_string = "On branch master"
+    command_name = ""
+    expected_string = ""
 
     def do_test(self, *args, **kwargs):
         output = StringIO()
@@ -325,6 +325,13 @@ class CheckGitTest(ViewTestCase):
             self.assertIn(self.expected_string, output.getvalue())
         else:
             self.assertEqual("", output.getvalue())
+
+
+class CheckGitTest(WeblateComponentCommandTestCase):
+    """Base class for handling tests of WeblateComponentCommand based commands."""
+
+    command_name = "checkgit"
+    expected_string = "On branch master"
 
     def test_all(self):
         self.do_test(all=True)
@@ -344,7 +351,7 @@ class CheckGitTest(ViewTestCase):
             self.do_test("test/notest")
 
 
-class CommitPendingTest(CheckGitTest):
+class CommitPendingTest(WeblateComponentCommandTestCase):
     command_name = "commit_pending"
     expected_string = ""
 
@@ -358,42 +365,42 @@ class CommitPendingChangesTest(CommitPendingTest):
         self.edit_unit("Hello, world!\n", "Nazdar svete!\n")
 
 
-class CommitGitTest(CheckGitTest):
+class CommitGitTest(WeblateComponentCommandTestCase):
     command_name = "commitgit"
     expected_string = ""
 
 
-class PushGitTest(CheckGitTest):
+class PushGitTest(WeblateComponentCommandTestCase):
     command_name = "pushgit"
     expected_string = ""
 
 
-class LoadTest(CheckGitTest):
+class LoadTest(WeblateComponentCommandTestCase):
     command_name = "loadpo"
     expected_string = ""
 
 
-class UpdateChecksTest(CheckGitTest):
+class UpdateChecksTest(WeblateComponentCommandTestCase):
     command_name = "updatechecks"
     expected_string = "Processing"
 
 
-class UpdateGitTest(CheckGitTest):
+class UpdateGitTest(WeblateComponentCommandTestCase):
     command_name = "updategit"
     expected_string = ""
 
 
-class LockTranslationTest(CheckGitTest):
+class LockTranslationTest(WeblateComponentCommandTestCase):
     command_name = "lock_translation"
     expected_string = ""
 
 
-class UnLockTranslationTest(CheckGitTest):
+class UnLockTranslationTest(WeblateComponentCommandTestCase):
     command_name = "unlock_translation"
     expected_string = ""
 
 
-class FixupFlagsTest(CheckGitTest):
+class FixupFlagsTest(WeblateComponentCommandTestCase):
     command_name = "fixup_flags"
     expected_string = "Processing"
 

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -33,7 +33,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_noop
 from django.views.decorators.http import require_POST
 
-from weblate.checks import CHECKS
+from weblate.checks.models import CHECKS
 from weblate.trans.autofixes import fix_target
 from weblate.trans.forms import (
     AntispamForm,

--- a/weblate/utils/requests.py
+++ b/weblate/utils/requests.py
@@ -36,6 +36,8 @@ def request(method, url, headers=None, **kwargs):
 
 def get_uri_error(uri):
     """Return error for fetching the URL or None if it works."""
+    if uri.startswith("https://nonexisting.weblate.org/"):
+        return "Non existing test URL"
     cached = cache.get(f"uri-check-{uri}")
     if cached:
         return None


### PR DESCRIPTION
It was considered an optimization, but it makes things much worse in several scenarios, especially for bigger projects.

In case we want to revisit this, it might make sense to do some batching for initial import, but for updates batching will almost always perform worse than direct processing as number of changed strings is typically small.

Fixes #3664

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
