### PR TITLE
make md-text link checks order-independent

### DIFF
--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -186,6 +186,36 @@ class MarkdownLinkCheckTest(CheckTestCase):
         )
 
 
+class MarkdownLinkCheckMultipleOrderIndependentLinksTest(CheckTestCase):
+    check = MarkdownLinkCheck()
+
+    def setUp(self):
+        super(MarkdownLinkCheckMultipleOrderIndependentLinksTest, self).setUp()
+
+        self.test_good_matching = (
+            "[Weblate](#weblate) has an [example]({{example}}) "
+            "for illustrating the useage of [Weblate](#weblate)",
+            "Ein [Beispiel]({{example}}) in [Webspät](#weblate) "
+            "illustriert die Verwendung von [Webspät](#weblate)",
+            "md-text",
+        )
+
+        self.test_failure_1 = (
+            "[Weblate](#weblate) has an [example]({{example}}) "
+            "for illustrating the useage of [Weblate](#weblate)",
+            "Ein [Beispiel]({{example}}) in [Webspät](#weblate) "
+            "illustriert die Verwendung von [Webspät](#Webspät)",
+            "md-text",
+        )
+        self.test_failure_2 = (
+            "[Weblate](#weblate) has an [example]({{example}}) "
+            "for illustrating the useage of [Weblate](#weblate)",
+            "Ein [Beispiel]({{example}}) in [Webspät](#weblate) "
+            "illustriert die Verwendung von Webspät",
+            "md-text",
+        )
+
+
 class MarkdownSyntaxCheckTest(CheckTestCase):
     check = MarkdownSyntaxCheck()
 


### PR DESCRIPTION
- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation

---

This PR makes markdown links for `md-link` checker order independent.

This closes https://github.com/WeblateOrg/weblate/issues/3651