### PR TITLE
add alias markdown-text for md-text flag

### DIFF
--- a/weblate/checks/flags.py
+++ b/weblate/checks/flags.py
@@ -60,6 +60,8 @@ TYPED_FLAGS_ARGS["max-length"] = int
 
 IGNORE_CHECK_FLAGS = {CHECKS[x].ignore_string for x in CHECKS}
 
+FLAG_ALIASES = {"markdown-text": "md-text"}
+
 
 class Flags:
     def __init__(self, *args):
@@ -99,6 +101,9 @@ class Flags:
         for flag in flags.split(","):
             value = flag.strip()
             if not value or value in ("fuzzy", "#"):
+                continue
+            if value in FLAG_ALIASES.keys():
+                yield FLAG_ALIASES[value]
                 continue
             yield value
 

--- a/weblate/checks/tests/test_flags.py
+++ b/weblate/checks/tests/test_flags.py
@@ -30,6 +30,11 @@ class FlagTest(SimpleTestCase):
     def test_parse_blank(self):
         self.assertEqual(Flags("foo, bar, ").items(), {"foo", "bar"})
 
+    def test_parse_alias(self):
+        self.assertEqual(
+            Flags("foo, md-text, bar, markdown-text").items(), {"foo", "bar", "md-text"}
+        )
+
     def test_iter(self):
         self.assertEqual(sorted(Flags("foo, bar")), ["bar", "foo"])
 


### PR DESCRIPTION
Add `markdown-text` as alias for the `md-text` flag.

closes https://github.com/WeblateOrg/weblate/issues/3648


Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [ ] Any new functionality is covered by user documentation
