### PR TITLE
Updated DeepL languages

### DIFF
--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -42,7 +42,7 @@ class DeepLTranslation(MachineTranslation):
 
     def download_languages(self):
         """List of supported languages is currently hardcoded."""
-        return ("en", "de", "fr", "es", "it", "nl", "pl", "pt", "ru")
+        return ("en", "de", "fr", "es", "it", "nl", "pl", "pt", "ru", "ja", "zh", "pt-br")
 
     def download_translations(self, source, language, text, unit, user, search):
         """Download list of possible translations from a service."""


### PR DESCRIPTION
This PR adds languages [supported by DeepL](https://www.deepl.com/docs-api/translating-text/request/) not yet tracked in Weblate.
Not yet tracked:
 - Japanese (ja)
 - Chinese simplified (zh-hans, DeepL has it as zh)
 - Portugues Brazilian (pt-br, only supported as target language)

A potential problem might be that pt-br is only supported as target_lang (for source lang it's just pt) but the logic does not differentiate between supported source and target languages.

Before submitting pull request, please ensure that:
- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
