### PR TITLE
Add 'approved' flag to Units API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1193,6 +1193,7 @@ Units
     :>json string flags: translation unit flags
     :>json boolean fuzzy: whether unit is fuzzy or marked for review
     :>json boolean translated: whether unit is translated
+    :>json boolean approved: whether translation is approved
     :>json int position: unit position in translation file
     :>json boolean has_suggestion: whether unit has suggestions
     :>json boolean has_comment: whether unit has comments

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -546,6 +546,7 @@ class UnitSerializer(RemovableSerializer):
             "flags",
             "fuzzy",
             "translated",
+            "approved",
             "position",
             "has_suggestion",
             "has_comment",


### PR DESCRIPTION
I'm currently wrestling with identifying approved translations from the API for a translation report. This PR adds an 'approved' flag to the Units API. As far as I can tell there's no test coverage changes required.

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
