### PR TITLE
Adds check for duplicate words.

### DIFF
--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -214,6 +214,15 @@ This only checks for the length of translation characters.
 Unlike the other checks, the flag should be set as a ``key:value`` pair like
 ``max-length:100``.
 
+.. _check-duplicate:
+
+Consecutive duplicated tokens
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Checks that no duplicate tokens occur in translation.
+
+Check is false if any token occurs more than once consecutively.
+
 .. _check-python-format:
 .. _check-python-brace-format:
 .. _check-php-format:

--- a/weblate/checks/duplicate.py
+++ b/weblate/checks/duplicate.py
@@ -1,0 +1,39 @@
+#
+# Copyright © 2012 - 2020 Michal Čihař <michal@cihar.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+import re
+
+from django.utils.translation import gettext_lazy as _
+
+from weblate.checks.base import TargetCheck
+
+
+class DuplicateCheck(TargetCheck):
+    """Check for duplicated tokens."""
+
+    check_id = "duplicate"
+    name = _("Consecutive duplicated tokens")
+    description = _("Text contains the same token twice in a row")
+    severity = "warning"
+
+    def check_single(self, source, target, unit):
+        if re.search(r"\b(\w+)(?:\s+\1)+\b", target):
+            return True
+        return False

--- a/weblate/checks/tests/test_duplicate_checks.py
+++ b/weblate/checks/tests/test_duplicate_checks.py
@@ -1,0 +1,51 @@
+#
+# Copyright © 2012 - 2020 Michal Čihař <michal@cihar.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for duplicate checks."""
+
+
+from weblate.checks.duplicate import DuplicateCheck
+from weblate.checks.tests.test_checks import CheckTestCase, MockUnit
+
+
+class DuplicateCheckTest(CheckTestCase):
+
+    check = DuplicateCheck()
+
+    _MOCK_UNIT = MockUnit(code="cs", note="")
+
+    def _run_check(self, target):
+        return self.check.check_single("", target, self._MOCK_UNIT)
+
+    def test_no_duplicated_token(self):
+        self.assertFalse(self._run_check("I have two lemons"))
+
+    def test_check_respects_boundaries_suffix(self):
+        """'lemon lemon' is a false duplicate."""
+        self.assertFalse(self._run_check("I have two lemon lemons"))
+
+    def test_check_respects_boundaries_prefix(self):
+        """'melon on' is a false duplicate."""
+        self.assertFalse(self._run_check("I have a melon on my back"))
+
+    def test_check_single_duplicated_token(self):
+        self.assertTrue(self._run_check("I have two two lemons"))
+
+    def test_check_multiple_duplicated_tokens(self):
+        self.assertTrue(self._run_check("I have two two lemons lemons"))


### PR DESCRIPTION
Fixes #3702

This check mostly just looks for consecutive tokens that consist entirely of word characters (crucially excluding things like punctuation).

In order to eliminate some false positives, I've added a blacklist of tokens and patterns that are likely to be repeated. I generated this list in the simplest way possible: counting reduplicated terms in a large text corpus and selecting the top terms by frequency. We could do something much smarter (e.g. by using PMI or a classifier), but this is quick and scalable.

Happy to generate similar blacklists for other languages here or in a follow-up PR.