### PR TITLE
Add database backup setting via env var for docker

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -728,6 +728,17 @@ both Weblate and PostgreSQL containers.
    `SSL Mode Descriptions <https://www.postgresql.org/docs/11/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_
 
 
+Database backup settings
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. seealso::
+    :ref:`backup-dumps`
+
+.. envvar:: WEBLATE_DATABASE_BACKUP
+
+    Configures the daily database dump using :setting:`DATABASE_BACKUP`. Defaults to ``plain``.
+
+
 Caching server setup
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1059,6 +1059,9 @@ CELERY_TASK_ROUTES = {
     "weblate.wladmin.tasks.backup_service": {"queue": "backup"},
 }
 
+# Database backup type
+DATABASE_BACKUP = os.environ.get("WEBLATE_DATABASE_BACKUP", "plain")
+
 # Enable auto updating
 AUTO_UPDATE = get_env_bool("WEBLATE_AUTO_UPDATE", False)
 


### PR DESCRIPTION
Allows configuring or disabling the built-in daily database dump with the environment variable `WEBLATE_DATABASE_BACKUP`.

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
