### PR TITLE
Update the Squash addon

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -244,6 +244,13 @@ Squash Git commits prior to pushing changes. You can choose one of following mod
 Original commit messages are kept, but authorship is lost unless "Per author" is selected, or
 the commit message is customized to include it.
 
+.. versionadded:: 4.1
+
+The original commit messages can optionally be overridden with a custom commit message.
+
+Trailers (commit lines like ``Co-authored-by: ...``) can optionally be removed from the
+original commit messages and appended to the end of the squashed commit message.
+
 .. _addon-weblate.json.customize:
 
 Customize JSON output

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -146,12 +146,33 @@ class GitSquashForm(BaseAddonForm):
         initial="all",
         required=True,
     )
+    append_trailers = forms.BooleanField(
+        label=_("Append trailers to squashed commit message"),
+        required=False,
+        initial=False,
+        help_text=_(
+            "Trailer lines are lines that look similar to RFC 822 e-mail "
+            "headers, at the end of the otherwise free-form part of a commit "
+            "message, such as 'Co-authored-by: ...'."
+        ),
+    )
+    commit_message = forms.CharField(
+        widget=forms.Textarea(),
+        required=False,
+        help_text=_(
+            "This commit message will be used instead of the combined commit "
+            "messages from the squashed commits."
+        ),
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
-            Field("squash"), Div(template="addons/squash_help.html")
+            Field("squash"),
+            Field("append_trailers"),
+            Field("commit_message"),
+            Div(template="addons/squash_help.html"),
         )
 
 

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -77,7 +77,7 @@ class GitSquashAddon(BaseAddon):
         if self.instance.configuration.get("append_trailers"):
             command = [
                 "log",
-                "--format={}".format("%(trailers:separator)"),
+                "--format=%(trailers:separator)",
                 "{}..HEAD".format(remote),
             ]
             if filenames:

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -91,7 +91,16 @@ class GitSquashAddon(BaseAddon):
                 ]
             )
 
-            commit_message = "\n\n".join([commit_message, "\n".join(trailer_lines)])
+            commit_message_lines_with_trailers_removed = [
+                line for line in commit_message.split("\n") if line not in trailer_lines
+            ]
+
+            commit_message = "\n\n".join(
+                [
+                    "\n".join(commit_message_lines_with_trailers_removed),
+                    "\n".join(trailer_lines),
+                ]
+            )
 
         return commit_message
 

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -77,7 +77,7 @@ class GitSquashAddon(BaseAddon):
         if self.instance.configuration.get("append_trailers"):
             command = [
                 "log",
-                "--format=%(trailers:separator)",
+                "--format=%(trailers)",
                 "{}..HEAD".format(remote),
             ]
             if filenames:

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -19,7 +19,7 @@
 
 
 import os.path
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 from django.utils.translation import gettext_lazy as _
 
@@ -83,14 +83,15 @@ class GitSquashAddon(BaseAddon):
             if filenames:
                 command += ["--"] + filenames
 
-            trailers = "\n".join(
+            trailer_lines = OrderedDict.fromkeys(
                 [
                     trailer
                     for trailer in repository.execute(command).split("\n")
                     if trailer.strip()
                 ]
             )
-            commit_message = "\n\n".join([commit_message, trailers])
+
+            commit_message = "\n\n".join([commit_message, "\n".join(trailer_lines)])
 
         return commit_message
 

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -83,7 +83,13 @@ class GitSquashAddon(BaseAddon):
             if filenames:
                 command += ["--"] + filenames
 
-            trailers = repository.execute(command)
+            trailers = "\n".join(
+                [
+                    trailer
+                    for trailer in repository.execute(command).split("\n")
+                    if trailer.strip()
+                ]
+            )
             commit_message = "\n\n".join([commit_message, trailers])
 
         return commit_message

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -800,6 +800,36 @@ class GitSquashAddonTest(ViewTestCase):
         self.component.commit_pending("test", None)
         self.assertEqual(self.component.repository.count_outgoing(), 3)
 
+    def test_commit_message(self):
+        commit_message = "Squashed commit message"
+        GitSquashAddon.create(
+            self.component,
+            configuration={"squash": "all", "commit_message": commit_message},
+        )
+
+        self.edit()
+
+        commit = self.component.repository.show(self.component.repository.last_revision)
+        self.assertIn(commit_message, commit)
+        self.assertEqual(self.component.repository.count_outgoing(), 1)
+
+    def test_append_trailers(self):
+        GitSquashAddon.create(
+            self.component, configuration={"squash": "all", "append_trailers": True}
+        )
+
+        self.edit()
+
+        commit = self.component.repository.show(self.component.repository.last_revision)
+
+        expected_trailers = (
+            "    Translation: Test/Test\n"
+            "    Translate-URL: http://example.com/projects/test/test/de/\n"
+            "    Translate-URL: http://example.com/projects/test/test/cs/\n"
+        )
+        self.assertIn(expected_trailers, commit)
+        self.assertEqual(self.component.repository.count_outgoing(), 1)
+
 
 class TestRemoval(FixtureTestCase):
     def setUp(self):

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -42,7 +42,7 @@ class GitRepository(Repository):
     _cmd_list_changed_files = ["diff", "--name-status"]
 
     name = "Git"
-    req_version = "1.6"
+    req_version = "2.12"
     default_branch = "master"
     ref_to_remote = "..{0}"
     ref_from_remote = "{0}.."
@@ -395,7 +395,7 @@ class GitWithGerritRepository(GitRepository):
 class SubversionRepository(GitRepository):
 
     name = "Subversion"
-    req_version = "1.6"
+    req_version = "2.12"
 
     _version = None
 


### PR DESCRIPTION
Fixes #3709. Support appending trailers and overriding the commit message.

Draft PR because I'm not sure how to approach adding tests for this, the existing tests are only counting the number of commits that are produced, not the commit messages produced. Some pointers to what you'd like to see here would be helpful.

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
