### PR TITLE
Component: Lock for updating translations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Not yet released.
 * Added support for seaching source strings with screenshot.
 * Extended information available in the stats insights.
 * Improved search editing on translate pages.
+* Improve handling of concurrent repository updates.
 
 Weblate 4.0.3
 --------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ Pillow>=6.0.0,<7.2.0
 pycairo>=1.15.3
 pygobject>=3.27.0
 python-dateutil>=2.8.1
+python-redis-lock>=3.4.0,<3.6.0
 requests>=2.20.0,<2.24.0
 sentry_sdk>=0.13.0,<0.15.0
 setuptools>=36.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,4 @@ force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
 project = weblate
-known_third_party = django,translate,translation_finder,zeep,boto3,selenium,botocore,social_core,cairo,gi,PIL,social_django,html2text,celery,crispy_forms,requests,openpyxl,whoosh,rest_framework,filelock,defusedxml,lxml,appconf,dateutil,user_agents,numba,sentry_sdk,misaka,git,jellyfish,pytz,responses,bleach,icu,weblate_schemas,diff_match_patch,jsonschema
+known_third_party = django,translate,translation_finder,zeep,boto3,selenium,botocore,social_core,cairo,gi,PIL,social_django,html2text,celery,crispy_forms,requests,openpyxl,whoosh,rest_framework,filelock,defusedxml,lxml,appconf,dateutil,user_agents,numba,sentry_sdk,misaka,git,jellyfish,pytz,responses,bleach,icu,weblate_schemas,diff_match_patch,jsonschema,django_redis,redis_lock


### PR DESCRIPTION
This avoids several race conditions when running concurrent updates. In
case the lock can not be obtained, the update is scheduled in background
and retried until the lock can be obtained.

Fixes #25
Fixes WEBLATE-3RA
Fixes WEBLATE-3JC
Fixes WEBLATE-3QQ
Fixes WEBLATE-3QH
Fixes WEBLATE-3QG
Fixes WEBLATE-3NP
Fixes WEBLATE-3QD
Fixes WEBLATE-3QC
Fixes WEBLATE-3Q4
Fixes WEBLATE-3Q3
Fixes WEBLATE-3NM