### PR TITLE
Spelling: Created -on x2

### DIFF
--- a/weblate/templates/fonts/font_detail.html
+++ b/weblate/templates/fonts/font_detail.html
@@ -18,7 +18,7 @@
 <tr><th>{% trans "Font family" %}</th><td>{{ object.family }}</td></tr>
 <tr><th>{% trans "Font style" %}</th><td>{{ object.style }}</td></tr>
 <tr><th>{% trans "File size" %}</th><td>{{ object.font.size }}</td></tr>
-<tr><th>{% trans "Created on" %}</th><td>{{ object.timestamp|naturaltime }}</td></tr>
+<tr><th>{% trans "Created" %}</th><td>{{ object.timestamp|naturaltime }}</td></tr>
 <tr><th>{% trans "Uploaded by" %}</th><td>{{ object.get_user_display }}</td></tr>
 <tr><th>{% trans "Used in groups" %}</th><td>
 {% for group in object.get_usage %}

--- a/weblate/templates/screenshots/screenshot_detail.html
+++ b/weblate/templates/screenshots/screenshot_detail.html
@@ -111,7 +111,7 @@
 <div class="panel-heading"><h4 class="panel-title">{% trans "Screenshot details" %}</h4></div>
 
 <table class="table table-condensed table-striped">
-<tr><th>{% trans "Created on" %}</th><td>{{ object.timestamp|naturaltime }}</td></tr>
+<tr><th>{% trans "Created" %}</th><td>{{ object.timestamp|naturaltime }}</td></tr>
 <tr><th>{% trans "Uploaded by" %}</th><td>{{ object.get_user_display }}</td></tr>
 </table>
 


### PR DESCRIPTION
Not 100% sure about the fonts, but this situation is prevented
![bilde](https://user-images.githubusercontent.com/13802408/81463232-64819000-91a7-11ea-9b37-cf5537633b30.png)
Created on  ...................................................................5 months ago
[Created on](https://hosted.weblate.org/translate/weblate/master/en/?checksum=3beb7745147a7faf ) ...................................................................[%(count)s months ago](https://hosted.weblate.org/translate/weblate/master/th/?checksum=d0fd21d070c7bd)

Probably fails in some languages, but alas.