### PR TITLE
Docs: fix reference to own checks

### DIFF
--- a/docs/admin/customize.rst
+++ b/docs/admin/customize.rst
@@ -142,4 +142,4 @@ To install your code for :ref:`custom-autofix`, :ref:`own-checks` or
 
 .. seealso::
 
-    :ref:`custom-autofix`:, ref:`own-checks`, :ref:`own-addon`, :ref:`addon-script`
+    :ref:`custom-autofix`:, :ref:`own-checks`, :ref:`own-addon`, :ref:`addon-script`


### PR DESCRIPTION
The reference wouldn't be linked otherwise.