### PR TITLE
Added changes to document for SECURE_HSTS_SECONDS

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -654,12 +654,16 @@ After enabling it, you should set :setting:`ENABLE_HTTPS` in the settings:
 Set properly SECURE_HSTS_SECONDS
 ++++++++++++++++++++++++++++++++
 
-Set this value to 0 so as to make sure that everything works as expected,
-otherwise you could prevent the client from visiting the site.
+If your site is served over SSL, you have to consider setting a value for :setting:`SECURE_HSTS_SECONDS`
+in the settings.py and enabling HTTP Strict Transport Security.
+By default its set to 0 as shown below.
 
 .. code-block:: python
 
    SECURE_HSTS_SECONDS = 0
+
+If set to a non-zero integer value, the `weblate.middleware.SecurityMiddleware`
+sets the :ref:`django:http-strict-transport-security` header on all responses that do not already have it.
 
 .. warning::
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -655,14 +655,15 @@ Set properly SECURE_HSTS_SECONDS
 ++++++++++++++++++++++++++++++++
 
 If your site is served over SSL, you have to consider setting a value for :setting:`SECURE_HSTS_SECONDS`
-in the settings.py and enabling HTTP Strict Transport Security.
+in the settings.py to enable HTTP Strict Transport Security.
 By default its set to 0 as shown below.
 
 .. code-block:: python
 
    SECURE_HSTS_SECONDS = 0
 
-If set to a non-zero integer value, the `weblate.middleware.SecurityMiddleware`
+If set to a non-zero integer value, the `SecurityMiddleware
+<https://docs.djangoproject.com/en/3.0/ref/middleware/#django.middleware.security.SecurityMiddleware>`_
 sets the :ref:`django:http-strict-transport-security` header on all responses that do not already have it.
 
 .. warning::

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -650,6 +650,23 @@ After enabling it, you should set :setting:`ENABLE_HTTPS` in the settings:
    :setting:`ENABLE_HTTPS`,
    :ref:`production-site`
 
+
+Set properly SECURE_HSTS_SECONDS
+++++++++++++++++++++++++++++++++
+
+Set this value to 0 so as to make sure that everything works as expected,
+otherwise you could prevent the client from visiting the site.
+
+.. code-block:: python
+
+   SECURE_HSTS_SECONDS = 0
+
+.. warning::
+
+    Setting this incorrectly can irreversibly (for some time) break your site. Read the
+    :ref:`django:http-strict-transport-security` documentation first.
+
+
 .. _production-database:
 
 Use a powerful database engine
@@ -1260,3 +1277,4 @@ Other notes
 
 Don't forget to move other services Weblate might have been using like
 Redis, Cron jobs or custom authentication backends.
+

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -662,8 +662,7 @@ By default its set to 0 as shown below.
 
    SECURE_HSTS_SECONDS = 0
 
-If set to a non-zero integer value, the `SecurityMiddleware
-<https://docs.djangoproject.com/en/3.0/ref/middleware/#django.middleware.security.SecurityMiddleware>`_
+If set to a non-zero integer value, the :class:`django:django.middleware.security.SecurityMiddleware`
 sets the :ref:`django:http-strict-transport-security` header on all responses that do not already have it.
 
 .. warning::

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -1277,4 +1277,3 @@ Other notes
 
 Don't forget to move other services Weblate might have been using like
 Redis, Cron jobs or custom authentication backends.
-


### PR DESCRIPTION
Clarify  SECURE_HSTS_SECONDS setting documentation
- Explicitly mention how and why to enable it.
- Link to relevant Django docs.

Fixes [ #3784 ](https://github.com/WeblateOrg/weblate/issues/3784)

I have tested this on my local machine with Sphinx. As its a change in the documentation, please let me know if the sentences are clear and as per standards.

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
