### PR TITLE
Docs: fix typos and update internal modules list

### DIFF
--- a/docs/admin/customize.rst
+++ b/docs/admin/customize.rst
@@ -68,7 +68,7 @@ Your module structure should look like this:
         ├── addons.py
         └── checks.py
 
-You can find an example of custimizing Weblate at
+You can find an example of customizing Weblate at
 <https://github.com/WeblateOrg/customize-example>, it covers all the topics
 described below.
 

--- a/docs/contributing/internals.rst
+++ b/docs/contributing/internals.rst
@@ -14,7 +14,7 @@ Directory structure
 
 Quick overview of directory structure of Weblate main repository:
 
-``doc``
+``docs``
    Source code for this documentation, built using `Sphinx <https://www.sphinx-doc.org/>`_.
 ``dev-docker``
    Docker code to run development server, see :ref:`dev-docker`.

--- a/docs/contributing/internals.rst
+++ b/docs/contributing/internals.rst
@@ -49,6 +49,14 @@ Weblate consists of several Django applications (some optional, see
 
     The optional :ref:`billing` module.
 
+``checks``
+
+    Translation string :ref:`checks` module.
+
+``fonts``
+
+    Font rendering checks module.
+
 ``formats``
 
     File format abstraction layer based on translate-toolkit.
@@ -76,10 +84,6 @@ Weblate consists of several Django applications (some optional, see
 ``memory``
 
     Built in translation memory, see :ref:`translation-memory`.
-
-``permissions``
-
-    Obsolete.
 
 ``screenshots``
 


### PR DESCRIPTION
Came across these while reading through docs.