### PR TITLE
Checks: Reduce need of database queries when rendering unit

### DIFF
--- a/weblate/formats/exporters.py
+++ b/weblate/formats/exporters.py
@@ -151,7 +151,7 @@ class BaseExporter:
         if context:
             output.addnote(note, origin="developer")
         # Comments
-        for comment in unit.get_comments():
+        for comment in unit.all_comments:
             output.addnote(comment.comment, origin="translator")
         # Suggestions
         for suggestion in unit.suggestions:

--- a/weblate/formats/tests/test_exporters.py
+++ b/weblate/formats/tests/test_exporters.py
@@ -42,14 +42,6 @@ from weblate.trans.tests.test_models import BaseTestCase
 from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
 
 
-def fake_get_comments():
-    return [Comment(comment="Weblate translator comment")]
-
-
-def empty_get_comments():
-    return []
-
-
 class PoExporterTest(BaseTestCase):
     _class = PoExporter
     _has_context = True
@@ -105,12 +97,14 @@ class PoExporterTest(BaseTestCase):
         if source_info:
             for key, value in source_info.items():
                 setattr(unit, key, value)
-            unit.get_comments = fake_get_comments
+            unit.__dict__["all_comments"] = [
+                Comment(comment="Weblate translator comment")
+            ]
             unit.__dict__["suggestions"] = [
                 Suggestion(target="Weblate translator suggestion")
             ]
         else:
-            unit.get_comments = empty_get_comments
+            unit.__dict__["all_comments"] = []
         exporter = self.get_exporter(lang, translation=translation)
         exporter.add_unit(unit)
         return self.check_export(exporter)

--- a/weblate/templates/snippets/unit-state.html
+++ b/weblate/templates/snippets/unit-state.html
@@ -9,7 +9,7 @@
 <span title="{% trans "Untranslated" context "String state" %}" class="state-empty">{% icon "empty.svg" %}</span>
 <span
   {% if detail %}
-    title="{% trans "Failed checks:" context "String state" %} {{ unit.check_set.all|join:", "}}"
+    title="{% trans "Failed checks:" context "String state" %} {{ unit.all_checks|join:", "}}"
   {% else %}
     title="{% trans "Failed checks" context "String state" %}"
   {% endif %}

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -407,8 +407,7 @@
 
 <div class="col-sm-3 source-info">
 
-{% with unit.check_set.all as checks %}
-{% if checks or unit.suggestions or shapings %}
+{% if unit.all_checks or unit.suggestions or shapings %}
 <div class="panel panel-danger">
   <div class="panel-heading"><h4 class="panel-title">{% trans "Things to check" %}</h4></div>
 
@@ -427,7 +426,7 @@
     </div>
   {% endif %}
 
-    {% for check in checks %}
+    {% for check in unit.all_checks %}
     <div class="list-group-item check check-item {% if check.ignore %}check-disabled{% endif %}">
         <h5>
             {% documentation_icon 'user/checks' check.check_obj.doc_id right=True %}
@@ -488,7 +487,6 @@
   </div>
 </div>
 {% endif %}
-{% endwith %}
 
 <div class="panel panel-default">
   <div class="panel-heading">

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -43,7 +43,7 @@
 <a href="{% url 'profile' %}#preferences" class="btn btn-link" title="{% trans "Configure editor" %}">{% icon "settings.svg" %}</a>
 </div>
 
-{% with comments=unit.get_comments nearby=unit.nearby nearby_keys=unit.nearby_keys shapings=unit.shapings%}
+{% with nearby=unit.nearby nearby_keys=unit.nearby_keys shapings=unit.shapings %}
 
 <div class="row query-container">
   <div class="col-sm-9">
@@ -230,8 +230,8 @@
 {% if others.total %}
 <li><a href="#others" data-toggle="tab" id="toggle-others">{% trans "Other occurrences" %} <span class="badge">{{ others.total }}</span></a></li>
 {% endif %}
-{% if comments or user_can_add_comment %}
-<li><a href="#comments" data-toggle="tab" id="toggle-comments">{% trans "Comments" %}{% if comments %} <span class="badge">{{ comments|length }}</span>{% endif %}</a></li>
+{% if unit.all_comments or user_can_add_comment %}
+<li><a href="#comments" data-toggle="tab" id="toggle-comments">{% trans "Comments" %}{% if unit.all_comments %} <span class="badge">{{ unit.all_comments|length }}</span>{% endif %}</a></li>
 {% endif %}
 {% if user_can_use_mt %}
 <li><a href="#machine" data-toggle="tab" id="toggle-machine" data-load="mt" title="{% trans "Machine translation suggestions" %}">{% trans "Machine translation" %}</a></li>
@@ -371,12 +371,12 @@
 </div>
 {% endif %}
 
-{% if comments or user_can_add_comment %}
+{% if unit.all_comments or user_can_add_comment %}
 <div class="tab-pane" id="comments">
 
-{% if comments %}
+{% if unit.all_comments %}
   {% with this_unit_url as next_url %}
-    {% include "list-comments.html" with object=unit.translation %}
+    {% include "list-comments.html" with object=unit.translation comments=unit.all_comments %}
   {% endwith %}
 {% endif %}
 
@@ -456,14 +456,14 @@
     </div>
     {% endfor %}
 
-  {% if comments %}
+  {% if unit.all_comments %}
     <div class="list-group-item check">
         <h5 class="list-group-item-heading">
             {% documentation_icon 'user/translating' 'comments' right=True %}
             {% icon "comment.svg" %}
             {% trans "Comments" %}
         </h5>
-        <p class="list-group-item-text">{% blocktrans count count=comments|length %}There is {{ count }} comment for this string.{% plural %}There are {{ count }} comments for this string.{% endblocktrans %}</p>
+        <p class="list-group-item-text">{% blocktrans count count=unit.all_comments|length %}There is {{ count }} comment for this string.{% plural %}There are {{ count }} comments for this string.{% endblocktrans %}</p>
         <p class="list-group-item-text list-buttons">
             <a href="#comments" data-toggle="tab" class="btn btn-warning">{% trans "View" %}</a>
         </p>

--- a/weblate/trans/models/__init__.py
+++ b/weblate/trans/models/__init__.py
@@ -239,4 +239,9 @@ def post_delete_linked(sender, instance, **kwargs):
 @disable_for_loaddata
 def stats_invalidate(sender, instance, created, **kwargs):
     """Invalidate stats on new comment or suggestion."""
+    # Invalidate stats counts
     instance.unit.translation.invalidate_cache()
+    # Invalidate unit cached properties
+    for key in ["all_comments", "suggestions"]:
+        if key in instance.__dict__:
+            del instance.__init__[key]

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -50,7 +50,7 @@ class EditTest(ViewTestCase):
         self.assert_redirects_offset(response, self.translate_url, 2)
         unit = self.get_unit(source=self.source)
         self.assertEqual(unit.target, self.target)
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertEqual(unit.state, STATE_TRANSLATED)
         self.assert_backend(self.already_translated + 1)
 
@@ -60,7 +60,7 @@ class EditTest(ViewTestCase):
         self.assert_redirects_offset(response, self.translate_url, 2)
         unit = self.get_unit(source=self.source)
         self.assertEqual(unit.target, self.target)
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertEqual(unit.state, STATE_TRANSLATED)
         self.assert_backend(self.already_translated + 1)
 
@@ -70,7 +70,7 @@ class EditTest(ViewTestCase):
         self.assert_redirects_offset(response, self.translate_url, 2)
         unit = self.get_unit(source=self.source)
         self.assertEqual(unit.target, self.second_target)
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertEqual(unit.state, STATE_TRANSLATED)
         self.assert_backend(self.already_translated + 1)
 
@@ -204,7 +204,7 @@ class EditResourceSourceTest(ViewTestCase):
         self.assert_redirects_offset(response, translate_url, 2)
         unit = self.get_unit("Nazdar svete!\n", "en")
         self.assertEqual(unit.target, "Nazdar svete!\n")
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertEqual(unit.state, STATE_TRANSLATED)
         self.assert_backend(4, "en")
 
@@ -536,8 +536,8 @@ class EditComplexTest(ViewTestCase):
         unit = self.get_unit()
         self.assertEqual(unit.target, "Nazdar svete!\n")
         self.assertFalse(unit.has_failing_check)
-        self.assertEqual(len(unit.checks()), 0)
-        self.assertEqual(len(unit.active_checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
+        self.assertEqual(len(unit.active_checks), 0)
         self.assertEqual(unit.translation.stats.allchecks, 0)
         self.assert_backend(1)
 
@@ -550,12 +550,12 @@ class EditComplexTest(ViewTestCase):
         self.assertEqual(unit.target, "Hello, world!\n")
         self.assertTrue(unit.has_failing_check)
         self.assertEqual(unit.state, STATE_TRANSLATED)
-        self.assertEqual(len(unit.checks()), 1)
-        self.assertEqual(len(unit.active_checks()), 1)
+        self.assertEqual(len(unit.all_checks), 1)
+        self.assertEqual(len(unit.active_checks), 1)
         self.assertEqual(unit.translation.stats.allchecks, 1)
 
         # Ignore check
-        check_id = unit.active_checks()[0].id
+        check_id = unit.active_checks[0].id
         response = self.client.post(
             reverse("js-ignore-check", kwargs={"check_id": check_id})
         )
@@ -563,8 +563,8 @@ class EditComplexTest(ViewTestCase):
         # Should have one less failing check
         unit = self.get_unit()
         self.assertFalse(unit.has_failing_check)
-        self.assertEqual(len(unit.checks()), 1)
-        self.assertEqual(len(unit.active_checks()), 0)
+        self.assertEqual(len(unit.all_checks), 1)
+        self.assertEqual(len(unit.active_checks), 0)
         self.assertEqual(unit.translation.stats.allchecks, 0)
         # Ignore check for all languages
         ignore_url = reverse("js-ignore-check-source", kwargs={"check_id": check_id})
@@ -577,8 +577,8 @@ class EditComplexTest(ViewTestCase):
         # Should have one less check
         unit = self.get_unit()
         self.assertFalse(unit.has_failing_check)
-        self.assertEqual(len(unit.checks()), 0)
-        self.assertEqual(len(unit.active_checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
+        self.assertEqual(len(unit.active_checks), 0)
         self.assertEqual(unit.translation.stats.allchecks, 0)
 
         # Save with no failing checks
@@ -588,7 +588,7 @@ class EditComplexTest(ViewTestCase):
         unit = self.get_unit()
         self.assertEqual(unit.target, "Nazdar svete!\n")
         self.assertFalse(unit.has_failing_check)
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertEqual(unit.translation.stats.allchecks, 0)
         self.assert_backend(1)
 
@@ -604,8 +604,8 @@ class EditComplexTest(ViewTestCase):
         self.assertEqual(unit.target, "Hello, world!\n")
         self.assertEqual(unit.state, STATE_FUZZY)
         self.assertTrue(unit.has_failing_check)
-        self.assertEqual(len(unit.checks()), 1)
-        self.assertEqual(len(unit.active_checks()), 1)
+        self.assertEqual(len(unit.all_checks), 1)
+        self.assertEqual(len(unit.active_checks), 1)
         self.assertEqual(unit.translation.stats.allchecks, 1)
 
     def test_commit_push(self):

--- a/weblate/trans/tests/test_suggestions.py
+++ b/weblate/trans/tests/test_suggestions.py
@@ -58,7 +58,7 @@ class SuggestionsTest(ViewTestCase):
         self.assert_backend(0)
 
         # Unit should not be translated
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertFalse(unit.translated)
         self.assertFalse(unit.fuzzy)
         self.assertEqual(len(self.get_unit().suggestions), 2)
@@ -83,7 +83,7 @@ class SuggestionsTest(ViewTestCase):
         self.assert_backend(0)
 
         # Unit should not be translated
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertFalse(unit.translated)
         self.assertFalse(unit.fuzzy)
         self.assertEqual(len(self.get_unit().suggestions), 1)
@@ -146,7 +146,7 @@ class SuggestionsTest(ViewTestCase):
         self.assertEqual(translation.stats.suggestions, 1)
 
         # Unit should be translated
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertTrue(unit.translated)
         self.assertFalse(unit.fuzzy)
         self.assertEqual(unit.target, "Ahoj svete!\n")
@@ -222,7 +222,7 @@ class SuggestionsTest(ViewTestCase):
         self.assertEqual(translation.stats.suggestions, 0)
 
         # Unit should be translated
-        self.assertEqual(len(unit.checks()), 0)
+        self.assertEqual(len(unit.all_checks), 0)
         self.assertTrue(unit.translated)
         self.assertFalse(unit.fuzzy)
         self.assertEqual(unit.target, "Nazdar svete!\n")

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -201,7 +201,7 @@ def perform_suggestion(unit, form, request):
 def perform_translation(unit, form, request):
     """Handle translation and stores it to a backend."""
     # Remember old checks
-    oldchecks = set(unit.active_checks().values_list("check", flat=True))
+    oldchecks = unit.all_checks_names
 
     # Run AutoFixes on user input
     if not unit.translation.is_template:
@@ -227,7 +227,7 @@ def perform_translation(unit, form, request):
         )
 
     # Get new set of checks
-    newchecks = set(unit.active_checks().values_list("check", flat=True))
+    newchecks = unit.all_checks_names
 
     # Did we introduce any new failures?
     if saved and newchecks > oldchecks:


### PR DESCRIPTION
Fetch all checks once and then generate needed filters on Python
side. In most cases we are needed all of them anyway, so better
to do the query just once instead of repeating that.

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
