### PR TITLE
Shortcuts: fix `mod+i <N>`

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,7 @@ Not yet released.
 * Added support for new file formats: :ref:`html`, :ref:`odf`, :ref:`idml`, :ref:`winrc`.
 * Consistently use dismissed as state of dismissed checks.
 * Add support for configuring default addons to enable.
+* Fixed editor keyboard shortcut to dismiss checks.
 
 Weblate 4.0.4
 -------------

--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -151,29 +151,29 @@ The following keyboard shortcuts can be utilized during translation:
     Navigates to previous translation in current search.
 :kbd:`Alt+PageDown`
     Navigates to next translation in current search.
-:kbd:`Ctrl+Enter` or :kbd:`Option+Enter`
+:kbd:`Ctrl+Enter` or :kbd:`Cmd+Enter`
     Saves current translation.
-:kbd:`Ctrl+Shift+Enter` or :kbd:`Option+Shift+Enter`
+:kbd:`Ctrl+Shift+Enter` or :kbd:`Cmd+Shift+Enter`
     Unmarks translation as fuzzy and submits it.
-:kbd:`Ctrl+E` or :kbd:`Option+E`
+:kbd:`Ctrl+E` or :kbd:`Cmd+E`
     Focus translation editor.
-:kbd:`Ctrl+U` or :kbd:`Option+U`
+:kbd:`Ctrl+U` or :kbd:`Cmd+U`
     Focus comment editor.
-:kbd:`Ctrl+M` or :kbd:`Option+M`
+:kbd:`Ctrl+M` or :kbd:`Cmd+M`
     Shows machine translation tab.
-:kbd:`Ctrl+<NUMBER>` or :kbd:`Option+<NUMBER>`
+:kbd:`Ctrl+<NUMBER>` or :kbd:`Cmd+<NUMBER>`
     Copies placeable of given number from source string.
-:kbd:`Ctrl+M <NUMBER>` or :kbd:`Option+M <NUMBER>`
+:kbd:`Ctrl+M <NUMBER>` or :kbd:`Cmd+M <NUMBER>`
     Copy machine translation of given number to current translation.
-:kbd:`Ctrl+I <NUMBER>` or :kbd:`Option+I <NUMBER>`
+:kbd:`Ctrl+I <NUMBER>` or :kbd:`Cmd+I <NUMBER>`
     Ignore failing check of given number.
-:kbd:`Ctrl+J` or :kbd:`Option+J`
+:kbd:`Ctrl+J` or :kbd:`Cmd+J`
     Shows nearby strings tab.
-:kbd:`Ctrl+S` or :kbd:`Option+S`
+:kbd:`Ctrl+S` or :kbd:`Cmd+S`
     Shows search tab.
-:kbd:`Ctrl+O` or :kbd:`Option+O`
+:kbd:`Ctrl+O` or :kbd:`Cmd+O`
     Copies source string.
-:kbd:`Ctrl+T` or :kbd:`Option+T`
+:kbd:`Ctrl+T` or :kbd:`Cmd+T`
     Toggles "Needs editing" flag.
 
 .. _visual-keyboard:

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1211,15 +1211,17 @@ $(function () {
         titleFormat: 'MM yyyy'
     };
 
-    /* Check dismiss shortcuts */
-    Mousetrap.bindGlobal('mod+i', function(e) {});
-    for (var i = 1; i < 10; i++) {
-        Mousetrap.bindGlobal(
-            'mod+i ' + i,
-            function(e) {
-                return false;
+    if (document.querySelectorAll('.check-item').length > 0) {
+        // Cancel out browser's `meta+i` and let Mousetrap handle the rest
+        document.addEventListener('keydown', function (e) {
+            var isMod = /Mac|iPod|iPhone|iPad/.test(navigator.platform) ?
+                e.metaKey :
+                e.ctrlKey;
+            if (isMod && e.key.toLowerCase() === 'i') {
+                e.preventDefault();
+                e.stopPropagation();
             }
-        );
+        });
     }
 
     $('.check-item').each(function(idx) {

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -4,6 +4,8 @@ var translationMemoryLoaded = false;
 var activityDataLoaded = false;
 var lastEditor = null;
 
+var IS_MAC = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
 // Remove some weird things from location hash
 if (window.location.hash && (window.location.hash.indexOf('"') > -1 || window.location.hash.indexOf('=') > -1)) {
     window.location.hash = '';
@@ -400,12 +402,14 @@ function processMachineTranslation(data, scope) {
             if (idx < 10) {
                 var key = getNumericKey(idx);
 
+                var title;
+                if (IS_MAC) {
+                    title = interpolate(gettext('Cmd+M then %s'), [key]);
+                } else {
+                    title = interpolate(gettext('Ctrl+M then %s'), [key]);
+                }
                 $(this).find('.mt-number').html(
-                    ' <kbd title="' +
-                    interpolate(gettext('Ctrl+M then %s'), [key]) +
-                    '">' +
-                    key +
-                    '</kbd>'
+                    ' <kbd title="' + title + '">' + key + '</kbd>'
                 );
                 Mousetrap.bindGlobal(
                     'mod+m ' + key,
@@ -1010,7 +1014,13 @@ $(function () {
             if (idx < 10) {
                 let key = getNumericKey(idx);
 
-                $(this).attr('title', interpolate(gettext('Ctrl/Command+%s'), [key]));
+                var title;
+                if (IS_MAC) {
+                    title = interpolate(gettext('Cmd+%s'), [key]);
+                } else {
+                    title = interpolate(gettext('Ctrl+%s'), [key]);
+                }
+                $(this).attr('title', title);
                 $(this).find('.highlight-number').html('<kbd>' + key + '</kbd>');
 
                 Mousetrap.bindGlobal(
@@ -1214,9 +1224,7 @@ $(function () {
     if (document.querySelectorAll('.check-item').length > 0) {
         // Cancel out browser's `meta+i` and let Mousetrap handle the rest
         document.addEventListener('keydown', function (e) {
-            var isMod = /Mac|iPod|iPhone|iPad/.test(navigator.platform) ?
-                e.metaKey :
-                e.ctrlKey;
+            var isMod = IS_MAC ? e.metaKey : e.ctrlKey;
             if (isMod && e.key.toLowerCase() === 'i') {
                 e.preventDefault();
                 e.stopPropagation();
@@ -1230,12 +1238,14 @@ $(function () {
         if (idx < 10) {
             let key = getNumericKey(idx);
 
+            var title;
+            if (IS_MAC) {
+                title = interpolate(gettext('Press Cmd+I then %s to dismiss this.'), [key]);
+            } else {
+                title = interpolate(gettext('Press Ctrl+I then %s to dismiss this.'), [key]);
+            }
             $(this).find('.check-number').html(
-                ' <kbd title="' +
-                interpolate(gettext('Press Ctrl+I then %s to dismiss this.'), [key]) +
-                '">' +
-                key +
-                '</kbd>'
+                ' <kbd title="' + title + '">' + key + '</kbd>'
             );
 
             Mousetrap.bindGlobal(


### PR DESCRIPTION
* Brings back to life "dismiss check" shortcut
* Adjusts shortcut tooltip help based on the platform
* Fixes docs on Mac shortcuts.

Fixes #2034.