### PR TITLE
Spelling: Jump to

### DIFF
--- a/weblate/templates/paginator.html
+++ b/weblate/templates/paginator.html
@@ -16,7 +16,7 @@
       {% endfor %}
       <input type="hidden" name="limit" value="{{ page_obj.paginator.per_page }}" aria-label="{{ page_obj.paginator.per_page }}" />
       <div class="input-group">
-        <input type="number" min="1" max="{{ page_obj.paginator.num_pages }}" name="page" class="form-control" value="{{ page_obj.number }}" aria-label="{% trans "Enter position to jump" %}">
+        <input type="number" min="1" max="{{ page_obj.paginator.num_pages }}" name="page" class="form-control" value="{{ page_obj.number }}" aria-label="{% trans "Jump to" %}">
         <span class="input-group-addon">
           {% comment %}Translators: This is partial position indicator shown when editing position{% endcomment %}
           {% blocktrans with page_obj.paginator.num_pages as total %}/ {{ total }}{% endblocktrans %}

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -70,7 +70,7 @@
                 <input type="hidden" name="{{ key }}" value="{{ value }}" aria-label="{{ value }}" />
               {% endfor %}
               <div class="input-group">
-                <input type="number" min="1" max="{{ filter_count }}" name="offset" class="form-control" value="{{ filter_pos }}" aria-label="{% trans "Enter position to jump" %}">
+                <input type="number" min="1" max="{{ filter_count }}" name="offset" class="form-control" value="{{ filter_pos }}" aria-label="{% trans "Jump to" %}">
                 <span class="input-group-addon">{% blocktrans %}/ {{ filter_count }}{% endblocktrans %}</span>
               </div>
             </form>


### PR DESCRIPTION
Otherwise, "Enter position to jump to".