### PR TITLE
CREATE EXTENSION ... IF NOT EXISTS still requires superuser

### DIFF
--- a/weblate/trans/migrations/0064_fulltext_index.py
+++ b/weblate/trans/migrations/0064_fulltext_index.py
@@ -24,7 +24,10 @@ def create_index(apps, schema_editor):
     vendor = schema_editor.connection.vendor
     if vendor == "postgresql":
         # Install pg_trgm for trigram search and index
-        schema_editor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        cur = schema_editor.connection.cursor()
+        cur.execute("SELECT * FROM pg_extension WHERE extname = 'pg_trgm'")
+        if not cur.fetchone():
+            schema_editor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
 
         # Create GIN trigram index on searched fields
         for table, field in FIELDS:


### PR DESCRIPTION
Use a local check to run CREATE EXTENSION only if extension is not installed already.

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with test case
- [ ] Any new functionality is covered by user documentation


`0064_fulltext_index.py` tries to install `pg_trgm` with `IF NOT EXISTS`. Unfortunately that still requires superuser privileges. The manual mentions, that it's possible to install the extension manually but that is not supported by the migration in it's current form.

This is a bigger issue with django itself as well.  It already defines a migration operation `TrigramExtension` to help with the installation of this extension.  I guess it's not easy to use it in this case because of the Mariadb/Mysql/Pgsql 🍝  :D

But in the same way the django docs mention the possibility to install extensions manually, but would fail in the same way on these Operations if the db user is not a superuser...