### PR TITLE
Listings: avoid extraneous underline on hover

### DIFF
--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -51,7 +51,7 @@
     <a href="{{ object.component.project.get_absolute_url }}">{{ object.component.project.name }}</a>/<a href="{{ object.component.get_absolute_url }}">{{ object.component.name }}</a>
     — <a class="tail" href="{{ browse_url }}">{{ object.language }}</a>
 {% else %}
-    <a href="{{ browse_url }}">
+    <a href="{{ browse_url }}">{% spaceless %}
     {% if name_source == "language" %}
         {{ object.language }}
     {% elif name_source == "component_name" %}
@@ -63,7 +63,7 @@
     {% else %}
         {{ object }}
     {% endif %}
-    </a>
+    {% endspaceless %}</a>
 {% endif %}
 {% indicate_alerts object %}
 </th>

--- a/weblate/templates/trans/embed-alert.html
+++ b/weblate/templates/trans/embed-alert.html
@@ -1,9 +1,11 @@
 {% load static %}
 
 {% for icon, text, url in icons %}
+{% spaceless %}
 {% if url %}<a href="{{ url }}">{% endif %}
 <img src="{% static icon %}" title="{{ text }}" alt="{{ text }}" class="state-icon" />
 {% if url %}</a>{% endif %}
+{% endspaceless %}
 {% endfor %}
 
 {% if component.license and component.license != "proprietary" %}


### PR DESCRIPTION
Text before:
<img width="197" alt="before_text" src="https://user-images.githubusercontent.com/16768/82996006-a82c2480-a004-11ea-8de3-67f9b23a21de.png">
Text after:
<img width="208" alt="after_text" src="https://user-images.githubusercontent.com/16768/82996059-b417e680-a004-11ea-913f-731ad8b6be9c.png">

Icons before:
<img width="315" alt="before_img" src="https://user-images.githubusercontent.com/16768/82996036-aeba9c00-a004-11ea-8c5f-1cc4658b6ca2.png">
Icons after:
<img width="320" alt="after_img" src="https://user-images.githubusercontent.com/16768/82996076-b7ab6d80-a004-11ea-9adc-e1e6728664dd.png">