### PR TITLE
Editor: use delegated events

### DIFF
--- a/weblate/static/editor.js
+++ b/weblate/static/editor.js
@@ -30,6 +30,24 @@ function markTranslated(elm) {
     elm.find('input[name="review"][value="20"]').prop('checked', true);
 }
 
+function Editor() {
+    var translationAreaSelector =  '.translation-editor';
+
+    this.$editor = $('.js-editor');
+    this.$translationArea = $(translationAreaSelector);
+
+    this.$editor.on('change', translationAreaSelector, testChangeHandler);
+    this.$editor.on('keypress', translationAreaSelector, testChangeHandler);
+    this.$editor.on('keydown', translationAreaSelector, testChangeHandler);
+    this.$editor.on('paste', translationAreaSelector, testChangeHandler);
+    this.$editor.on('focusin', translationAreaSelector, function () {
+        lastEditor = $(this);
+    });
+
+    initEditor();
+    this.$translationArea[0].focus();
+}
+
 function initEditor() {
     /* Autosizing */
     autosize($('.translation-editor'));
@@ -615,14 +633,7 @@ $('.bug-comment').click(function () {
 // end TODO: move to non-zen editor
 
 /* Translation editor */
-var translationEditor = $('.translation-editor');
-$document.on('change', '.translation-editor', testChangeHandler);
-$document.on('keypress', '.translation-editor', testChangeHandler);
-$document.on('keydown', '.translation-editor', testChangeHandler);
-$document.on('paste', '.translation-editor', testChangeHandler);
-$document.on('focusin', '.translation-editor', function () { lastEditor = $(this); });
-initEditor();
-translationEditor.get(0).focus();
+new Editor();
 
 // TODO: move to non-zen editor
 if ($('#button-first').length > 0) {

--- a/weblate/static/editor.js
+++ b/weblate/static/editor.js
@@ -44,6 +44,57 @@ function Editor() {
         lastEditor = $(this);
     });
 
+    /* Count characters */
+    this.$editor.on('keyup', translationAreaSelector, function() {
+        var $this = $(this);
+        var counter = $this.parent().find('.length-indicator');
+        var limit = parseInt(counter.data('max'));
+        var length = $this.val().length;
+        counter.text(length);
+        if (length >= limit) {
+            counter.parent().addClass('badge-danger').removeClass('badge-warning');
+        } else if (length + 10 >= limit) {
+            counter.parent().addClass('badge-warning').removeClass('badge-danger');
+        } else {
+            counter.parent().removeClass('badge-warning').removeClass('badge-danger');
+        }
+    });
+
+    /* Copy source text */
+    this.$editor.on('click', '.copy-text', function (e) {
+        var $this = $(this);
+
+        $this.button('loading');
+        $this.closest('.translation-item').find('.translation-editor').val(
+            $.parseJSON($this.data('content'))
+        ).change();
+        autosize.update($('.translation-editor'));
+        markFuzzy($this.closest('form'));
+        $this.button('reset');
+        e.preventDefault();
+    });
+
+    /* Direction toggling */
+    this.$editor.on('change', '.direction-toggle', function () {
+        var $this = $(this);
+
+        $this.closest('.translation-item').find('.translation-editor').attr(
+            'dir',
+            $this.find('input').val()
+        );
+    });
+
+    /* Special characters */
+    this.$editor.on('click', '.specialchar', function (e) {
+        var $this = $(this);
+        var text = $this.data('value');
+
+        $this.closest('.translation-item').find('.translation-editor').insertAtCaret(text).change();
+        autosize.update($('.translation-editor'));
+        e.preventDefault();
+    });
+
+    // TODO: mode-specific initialization
     initEditor();
     this.$translationArea[0].focus();
 }
@@ -66,57 +117,6 @@ function initEditor() {
         /* There is 10px padding */
         $editors.css('min-height', ((tdHeight - (contentHeight - editorHeight - 10)) / $editors.length) + 'px');
     });
-
-    /* Count characters */
-    $(".translation-editor").keyup(function() {
-        var $this = $(this);
-        var counter = $this.parent().find('.length-indicator');
-        var limit = parseInt(counter.data('max'));
-        var length = $this.val().length;
-        counter.text(length);
-        if (length >= limit) {
-            counter.parent().addClass('badge-danger').removeClass('badge-warning');
-        } else if (length + 10 >= limit) {
-            counter.parent().addClass('badge-warning').removeClass('badge-danger');
-        } else {
-            counter.parent().removeClass('badge-warning').removeClass('badge-danger');
-        }
-    });
-
-    /* Copy source text */
-    $('.copy-text').click(function (e) {
-        var $this = $(this);
-
-        $this.button('loading');
-        $this.closest('.translation-item').find('.translation-editor').val(
-            $.parseJSON($this.data('content'))
-        ).change();
-        autosize.update($('.translation-editor'));
-        markFuzzy($this.closest('form'));
-        $this.button('reset');
-        e.preventDefault();
-    });
-
-    /* Direction toggling */
-    $('.direction-toggle').change(function () {
-        var $this = $(this);
-
-        $this.closest('.translation-item').find('.translation-editor').attr(
-            'dir',
-            $this.find('input').val()
-        );
-    });
-
-    /* Special characters */
-    $('.specialchar').click(function (e) {
-        var $this = $(this);
-        var text = $this.data('value');
-
-        $this.closest('.translation-item').find('.translation-editor').insertAtCaret(text).change();
-        autosize.update($('.translation-editor'));
-        e.preventDefault();
-    });
-
 }
 
 function testChangeHandler(e) {

--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -274,7 +274,7 @@ var _rollbarConfig = {
 {% endblock %}
 </header>
 
-<div class="content">
+<div class="content {% block content_class %}{% endblock %}">
 
 {% if messages %}
 {% for message in messages %}

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -27,6 +27,8 @@
 </a>
 {% endblock %}
 
+{% block content_class %}js-editor{% endblock %}
+
 {% block content %}
 
 {% include "show-component-state.html" with object=unit.translation.component %}

--- a/weblate/templates/zen.html
+++ b/weblate/templates/zen.html
@@ -26,6 +26,8 @@
 </a>
 {% endblock %}
 
+{% block content_class %}js-editor{% endblock %}
+
 {% block content %}
 
 {% include "show-component-state.html" with object=object.component %}


### PR DESCRIPTION
* Moves initialization out of the global scope into a function
* Sets up events as delegated, i.e. no need to re-attach handlers when new contents are loaded (e.g. in Zen mode)