### PR TITLE
Editor: separate full & zen modes

### DIFF
--- a/weblate/static/editor.js
+++ b/weblate/static/editor.js
@@ -99,6 +99,141 @@ function Editor() {
     this.$translationArea[0].focus();
 }
 
+function FullEditor() {
+    Editor.call(this);
+
+    Mousetrap.bindGlobal('alt+end', function(e) {window.location = $('#button-end').attr('href'); return false;});
+    Mousetrap.bindGlobal('alt+pagedown', function(e) {window.location = $('#button-next').attr('href'); return false;});
+    Mousetrap.bindGlobal('alt+pageup', function(e) {window.location = $('#button-prev').attr('href'); return false;});
+    Mousetrap.bindGlobal('alt+home', function(e) {window.location = $('#button-first').attr('href'); return false;});
+    Mousetrap.bindGlobal('mod+o', function(e) {$('.translation-item .copy-text').click(); return false;});
+    Mousetrap.bindGlobal('mod+y', function(e) {$('input[name="fuzzy"]').click(); return false;});
+    Mousetrap.bindGlobal(
+        'mod+shift+enter',
+        function(e) {$('input[name="fuzzy"]').prop('checked', false); return submitForm(e);}
+    );
+    Mousetrap.bindGlobal(
+        'mod+e',
+        function(e) {
+            $('.translation-editor').get(0).focus();
+            return false;
+        }
+    );
+    Mousetrap.bindGlobal(
+        'mod+s',
+        function(e) {
+            $('#search-dropdown').click();
+            $('input[name="q"]').focus();
+            return false;
+        }
+    );
+    Mousetrap.bindGlobal(
+        'mod+u',
+        function(e) {
+            $('.nav [href="#comments"]').click();
+            $('textarea[name="comment"]').focus();
+            return false;
+        }
+    );
+    Mousetrap.bindGlobal(
+        'mod+j',
+        function(e) {
+            $('.nav [href="#nearby"]').click();
+            return false;
+        }
+    );
+    Mousetrap.bindGlobal(
+        'mod+m',
+        function(e) {
+            $('.nav [href="#machine"]').click();
+            return false;
+        }
+    );
+}
+
+function ZenEditor() {
+    Editor.call(this);
+
+    $window.scroll(function() {
+        var $loadingNext = $('#loading-next');
+        var loader = $('#zen-load');
+
+        if ($window.scrollTop() >= $document.height() - (2 * $window.height())) {
+            if ($('#last-section').length > 0 || $loadingNext.css('display') !== 'none') {
+                return;
+            }
+            $loadingNext.show();
+
+            loader.data('offset', 20 + parseInt(loader.data('offset'), 10));
+
+            $.get(
+                loader.attr('href') + '&offset=' + loader.data('offset'),
+                function (data) {
+                    $loadingNext.hide();
+
+                    $('.zen tfoot').before(data);
+
+                    initEditor();
+                }
+            );
+        }
+    });
+
+    /*
+        * Ensure current editor is reasonably located in the window
+        * - show whole element if moving back
+        * - scroll down if in bottom half of the window
+        */
+    $document.on('focus', '.zen .translation-editor', function() {
+        var current = $window.scrollTop();
+        var rowOffset = $(this).closest('tbody').offset().top;
+        if (rowOffset < current || rowOffset - current > $window.height() / 2) {
+            $([document.documentElement, document.body]).animate({
+                scrollTop: rowOffset
+            }, 100);
+        }
+    });
+
+    $document.on('change', '.translation-editor', zenEditor);
+    $document.on('change', '.fuzzy_checkbox', zenEditor);
+    $document.on('change', '.review_radio', zenEditor);
+
+    Mousetrap.bindGlobal('mod+end', function(e) {
+        $('.zen-unit:last').find('.translation-editor:first').focus();
+        return false;
+    });
+    Mousetrap.bindGlobal('mod+home', function(e) {
+        $('.zen-unit:first').find('.translation-editor:first').focus();
+        return false;
+    });
+    Mousetrap.bindGlobal('mod+pagedown', function(e) {
+        var focus = $(':focus');
+
+        if (focus.length === 0) {
+            $('.zen-unit:first').find('.translation-editor:first').focus();
+        } else {
+            focus.closest('.zen-unit').next().find('.translation-editor:first').focus();
+        }
+        return false;
+    });
+    Mousetrap.bindGlobal('mod+pageup', function(e) {
+        var focus = $(':focus');
+
+        if (focus.length === 0) {
+            $('.zen-unit:last').find('.translation-editor:first').focus();
+        } else {
+            focus.closest('.zen-unit').prev().find('.translation-editor:first').focus();
+        }
+        return false;
+    });
+
+    $window.on('beforeunload', function() {
+        if ($('.translation-modified').length > 0) {
+            return gettext('There are some unsaved changes, are you sure you want to leave?');
+        }
+    });
+}
+
 function initEditor() {
     /* Autosizing */
     autosize($('.translation-editor'));
@@ -631,141 +766,3 @@ $('.bug-comment').click(function () {
 });
 
 // end TODO: move to non-zen editor
-
-/* Translation editor */
-new Editor();
-
-// TODO: move to non-zen editor
-if ($('#button-first').length > 0) {
-    Mousetrap.bindGlobal('alt+end', function(e) {window.location = $('#button-end').attr('href'); return false;});
-    Mousetrap.bindGlobal('alt+pagedown', function(e) {window.location = $('#button-next').attr('href'); return false;});
-    Mousetrap.bindGlobal('alt+pageup', function(e) {window.location = $('#button-prev').attr('href'); return false;});
-    Mousetrap.bindGlobal('alt+home', function(e) {window.location = $('#button-first').attr('href'); return false;});
-    Mousetrap.bindGlobal('mod+o', function(e) {$('.translation-item .copy-text').click(); return false;});
-    Mousetrap.bindGlobal('mod+y', function(e) {$('input[name="fuzzy"]').click(); return false;});
-    Mousetrap.bindGlobal(
-        'mod+shift+enter',
-        function(e) {$('input[name="fuzzy"]').prop('checked', false); return submitForm(e);}
-    );
-    Mousetrap.bindGlobal(
-        'mod+e',
-        function(e) {
-            $('.translation-editor').get(0).focus();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+s',
-        function(e) {
-            $('#search-dropdown').click();
-            $('input[name="q"]').focus();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+u',
-        function(e) {
-            $('.nav [href="#comments"]').click();
-            $('textarea[name="comment"]').focus();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+j',
-        function(e) {
-            $('.nav [href="#nearby"]').click();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+m',
-        function(e) {
-            $('.nav [href="#machine"]').click();
-            return false;
-        }
-    );
-}
-
-// TODO: move to zen mode
-
-/* Zen mode handling */
-if ($('.zen').length > 0) {
-    $window.scroll(function() {
-        var $loadingNext = $('#loading-next');
-        var loader = $('#zen-load');
-
-        if ($window.scrollTop() >= $document.height() - (2 * $window.height())) {
-            if ($('#last-section').length > 0 || $loadingNext.css('display') !== 'none') {
-                return;
-            }
-            $loadingNext.show();
-
-            loader.data('offset', 20 + parseInt(loader.data('offset'), 10));
-
-            $.get(
-                loader.attr('href') + '&offset=' + loader.data('offset'),
-                function (data) {
-                    $loadingNext.hide();
-
-                    $('.zen tfoot').before(data);
-
-                    initEditor();
-                }
-            );
-        }
-    });
-
-    /*
-        * Ensure current editor is reasonably located in the window
-        * - show whole element if moving back
-        * - scroll down if in bottom half of the window
-        */
-    $document.on('focus', '.zen .translation-editor', function() {
-        var current = $window.scrollTop();
-        var rowOffset = $(this).closest('tbody').offset().top;
-        if (rowOffset < current || rowOffset - current > $window.height() / 2) {
-            $([document.documentElement, document.body]).animate({
-                scrollTop: rowOffset
-            }, 100);
-        }
-    });
-
-    $document.on('change', '.translation-editor', zenEditor);
-    $document.on('change', '.fuzzy_checkbox', zenEditor);
-    $document.on('change', '.review_radio', zenEditor);
-
-    Mousetrap.bindGlobal('mod+end', function(e) {
-        $('.zen-unit:last').find('.translation-editor:first').focus();
-        return false;
-    });
-    Mousetrap.bindGlobal('mod+home', function(e) {
-        $('.zen-unit:first').find('.translation-editor:first').focus();
-        return false;
-    });
-    Mousetrap.bindGlobal('mod+pagedown', function(e) {
-        var focus = $(':focus');
-
-        if (focus.length === 0) {
-            $('.zen-unit:first').find('.translation-editor:first').focus();
-        } else {
-            focus.closest('.zen-unit').next().find('.translation-editor:first').focus();
-        }
-        return false;
-    });
-    Mousetrap.bindGlobal('mod+pageup', function(e) {
-        var focus = $(':focus');
-
-        if (focus.length === 0) {
-            $('.zen-unit:last').find('.translation-editor:first').focus();
-        } else {
-            focus.closest('.zen-unit').prev().find('.translation-editor:first').focus();
-        }
-        return false;
-    });
-
-    $window.on('beforeunload', function() {
-        if ($('.translation-modified').length > 0) {
-            return gettext('There are some unsaved changes, are you sure you want to leave?');
-        }
-    });
-};

--- a/weblate/static/editor.js
+++ b/weblate/static/editor.js
@@ -97,10 +97,16 @@ WLT.editor = (function () {
             e.preventDefault();
         });
 
-        // TODO: mode-specific initialization
-        initEditor();
+        this.init();
+
         this.$translationArea[0].focus();
     }
+
+    Editor.prototype.init = function() {
+        /* Autosizing */
+        autosize($('.translation-editor'));
+    };
+
 
     function FullEditor() {
         Editor.call(this);
@@ -153,10 +159,14 @@ WLT.editor = (function () {
             }
         );
     }
+    FullEditor.prototype = Object.create(Editor.prototype);
+    FullEditor.prototype.constructor = FullEditor;
+
 
     function ZenEditor() {
         Editor.call(this);
 
+        var self = this;
         $window.scroll(function() {
             var $loadingNext = $('#loading-next');
             var loader = $('#zen-load');
@@ -176,7 +186,7 @@ WLT.editor = (function () {
 
                         $('.zen tfoot').before(data);
 
-                        initEditor();
+                        self.init();
                     }
                 );
             }
@@ -236,12 +246,13 @@ WLT.editor = (function () {
             }
         });
     }
+    ZenEditor.prototype = Object.create(Editor.prototype);
+    ZenEditor.prototype.constructor = ZenEditor;
 
-    function initEditor() {
-        /* Autosizing */
-        autosize($('.translation-editor'));
+    ZenEditor.prototype.init = function() {
+        Editor.prototype.init.call(this);
 
-        /* Minimal height for editor */
+        /* Minimal height for side-by-side editor */
         $('.zen-horizontal .translator').each(function () {
             var $this = $(this);
             var tdHeight = $this.height();

--- a/weblate/static/editor.js
+++ b/weblate/static/editor.js
@@ -742,8 +742,7 @@ WLT.editor = (function () {
     });
 
     /* Translate forms persistence */
-    $forms = $('.translation-form');
-    if ($forms.length > 0 && window.localStorage && window.localStorage.translation_autosave) {
+    if ($('.translation-form').length > 0 && window.localStorage && window.localStorage.translation_autosave) {
         var translationRestore = JSON.parse(window.localStorage.translation_autosave);
 
         $.each(translationRestore, function () {

--- a/weblate/static/editor.js
+++ b/weblate/static/editor.js
@@ -1,423 +1,528 @@
-var machineTranslationLoaded = false;
-var translationMemoryLoaded = false;
-var lastEditor = null;
+var WLT = WLT || {};
 
-var IS_MAC = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+WLT.editor = (function () {
+    var machineTranslationLoaded = false;
+    var translationMemoryLoaded = false;
+    var lastEditor = null;
 
-var $window = $(window);
-var $document = $(document);
+    var IS_MAC = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
-function getNumericKey(idx) {
-    var ret = idx + 1;
+    var $window = $(window);
+    var $document = $(document);
 
-    if (ret === 10) {
-        return '0';
+    function getNumericKey(idx) {
+        var ret = idx + 1;
+
+        if (ret === 10) {
+            return '0';
+        }
+        return ret;
     }
-    return ret;
-}
 
-function markFuzzy(elm) {
-    /* Standard worflow */
-    elm.find('input[name="fuzzy"]').prop('checked', true);
-    /* Review workflow */
-    elm.find('input[name="review"][value="10"]').prop('checked', true);
-}
+    function markFuzzy(elm) {
+        /* Standard worflow */
+        elm.find('input[name="fuzzy"]').prop('checked', true);
+        /* Review workflow */
+        elm.find('input[name="review"][value="10"]').prop('checked', true);
+    }
 
-function markTranslated(elm) {
-    /* Standard worflow */
-    elm.find('input[name="fuzzy"]').prop('checked', false);
-    /* Review workflow */
-    elm.find('input[name="review"][value="20"]').prop('checked', true);
-}
+    function markTranslated(elm) {
+        /* Standard worflow */
+        elm.find('input[name="fuzzy"]').prop('checked', false);
+        /* Review workflow */
+        elm.find('input[name="review"][value="20"]').prop('checked', true);
+    }
 
-function Editor() {
-    var translationAreaSelector =  '.translation-editor';
+    function Editor() {
+        var translationAreaSelector =  '.translation-editor';
 
-    this.$editor = $('.js-editor');
-    this.$translationArea = $(translationAreaSelector);
+        this.$editor = $('.js-editor');
+        this.$translationArea = $(translationAreaSelector);
 
-    this.$editor.on('change', translationAreaSelector, testChangeHandler);
-    this.$editor.on('keypress', translationAreaSelector, testChangeHandler);
-    this.$editor.on('keydown', translationAreaSelector, testChangeHandler);
-    this.$editor.on('paste', translationAreaSelector, testChangeHandler);
-    this.$editor.on('focusin', translationAreaSelector, function () {
-        lastEditor = $(this);
-    });
-
-    /* Count characters */
-    this.$editor.on('keyup', translationAreaSelector, function() {
-        var $this = $(this);
-        var counter = $this.parent().find('.length-indicator');
-        var limit = parseInt(counter.data('max'));
-        var length = $this.val().length;
-        counter.text(length);
-        if (length >= limit) {
-            counter.parent().addClass('badge-danger').removeClass('badge-warning');
-        } else if (length + 10 >= limit) {
-            counter.parent().addClass('badge-warning').removeClass('badge-danger');
-        } else {
-            counter.parent().removeClass('badge-warning').removeClass('badge-danger');
-        }
-    });
-
-    /* Copy source text */
-    this.$editor.on('click', '.copy-text', function (e) {
-        var $this = $(this);
-
-        $this.button('loading');
-        $this.closest('.translation-item').find('.translation-editor').val(
-            $.parseJSON($this.data('content'))
-        ).change();
-        autosize.update($('.translation-editor'));
-        markFuzzy($this.closest('form'));
-        $this.button('reset');
-        e.preventDefault();
-    });
-
-    /* Direction toggling */
-    this.$editor.on('change', '.direction-toggle', function () {
-        var $this = $(this);
-
-        $this.closest('.translation-item').find('.translation-editor').attr(
-            'dir',
-            $this.find('input').val()
-        );
-    });
-
-    /* Special characters */
-    this.$editor.on('click', '.specialchar', function (e) {
-        var $this = $(this);
-        var text = $this.data('value');
-
-        $this.closest('.translation-item').find('.translation-editor').insertAtCaret(text).change();
-        autosize.update($('.translation-editor'));
-        e.preventDefault();
-    });
-
-    // TODO: mode-specific initialization
-    initEditor();
-    this.$translationArea[0].focus();
-}
-
-function FullEditor() {
-    Editor.call(this);
-
-    Mousetrap.bindGlobal('alt+end', function(e) {window.location = $('#button-end').attr('href'); return false;});
-    Mousetrap.bindGlobal('alt+pagedown', function(e) {window.location = $('#button-next').attr('href'); return false;});
-    Mousetrap.bindGlobal('alt+pageup', function(e) {window.location = $('#button-prev').attr('href'); return false;});
-    Mousetrap.bindGlobal('alt+home', function(e) {window.location = $('#button-first').attr('href'); return false;});
-    Mousetrap.bindGlobal('mod+o', function(e) {$('.translation-item .copy-text').click(); return false;});
-    Mousetrap.bindGlobal('mod+y', function(e) {$('input[name="fuzzy"]').click(); return false;});
-    Mousetrap.bindGlobal(
-        'mod+shift+enter',
-        function(e) {$('input[name="fuzzy"]').prop('checked', false); return submitForm(e);}
-    );
-    Mousetrap.bindGlobal(
-        'mod+e',
-        function(e) {
-            $('.translation-editor').get(0).focus();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+s',
-        function(e) {
-            $('#search-dropdown').click();
-            $('input[name="q"]').focus();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+u',
-        function(e) {
-            $('.nav [href="#comments"]').click();
-            $('textarea[name="comment"]').focus();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+j',
-        function(e) {
-            $('.nav [href="#nearby"]').click();
-            return false;
-        }
-    );
-    Mousetrap.bindGlobal(
-        'mod+m',
-        function(e) {
-            $('.nav [href="#machine"]').click();
-            return false;
-        }
-    );
-}
-
-function ZenEditor() {
-    Editor.call(this);
-
-    $window.scroll(function() {
-        var $loadingNext = $('#loading-next');
-        var loader = $('#zen-load');
-
-        if ($window.scrollTop() >= $document.height() - (2 * $window.height())) {
-            if ($('#last-section').length > 0 || $loadingNext.css('display') !== 'none') {
-                return;
-            }
-            $loadingNext.show();
-
-            loader.data('offset', 20 + parseInt(loader.data('offset'), 10));
-
-            $.get(
-                loader.attr('href') + '&offset=' + loader.data('offset'),
-                function (data) {
-                    $loadingNext.hide();
-
-                    $('.zen tfoot').before(data);
-
-                    initEditor();
-                }
-            );
-        }
-    });
-
-    /*
-        * Ensure current editor is reasonably located in the window
-        * - show whole element if moving back
-        * - scroll down if in bottom half of the window
-        */
-    $document.on('focus', '.zen .translation-editor', function() {
-        var current = $window.scrollTop();
-        var rowOffset = $(this).closest('tbody').offset().top;
-        if (rowOffset < current || rowOffset - current > $window.height() / 2) {
-            $([document.documentElement, document.body]).animate({
-                scrollTop: rowOffset
-            }, 100);
-        }
-    });
-
-    $document.on('change', '.translation-editor', zenEditor);
-    $document.on('change', '.fuzzy_checkbox', zenEditor);
-    $document.on('change', '.review_radio', zenEditor);
-
-    Mousetrap.bindGlobal('mod+end', function(e) {
-        $('.zen-unit:last').find('.translation-editor:first').focus();
-        return false;
-    });
-    Mousetrap.bindGlobal('mod+home', function(e) {
-        $('.zen-unit:first').find('.translation-editor:first').focus();
-        return false;
-    });
-    Mousetrap.bindGlobal('mod+pagedown', function(e) {
-        var focus = $(':focus');
-
-        if (focus.length === 0) {
-            $('.zen-unit:first').find('.translation-editor:first').focus();
-        } else {
-            focus.closest('.zen-unit').next().find('.translation-editor:first').focus();
-        }
-        return false;
-    });
-    Mousetrap.bindGlobal('mod+pageup', function(e) {
-        var focus = $(':focus');
-
-        if (focus.length === 0) {
-            $('.zen-unit:last').find('.translation-editor:first').focus();
-        } else {
-            focus.closest('.zen-unit').prev().find('.translation-editor:first').focus();
-        }
-        return false;
-    });
-
-    $window.on('beforeunload', function() {
-        if ($('.translation-modified').length > 0) {
-            return gettext('There are some unsaved changes, are you sure you want to leave?');
-        }
-    });
-}
-
-function initEditor() {
-    /* Autosizing */
-    autosize($('.translation-editor'));
-
-    /* Minimal height for editor */
-    $('.zen-horizontal .translator').each(function () {
-        var $this = $(this);
-        var tdHeight = $this.height();
-        var editorHeight = 0;
-        var contentHeight = $this.find('form').height();
-        var $editors = $this.find('.translation-editor');
-        $editors.each(function () {
-            var $editor = $(this);
-            editorHeight += $editor.height();
+        this.$editor.on('change', translationAreaSelector, testChangeHandler);
+        this.$editor.on('keypress', translationAreaSelector, testChangeHandler);
+        this.$editor.on('keydown', translationAreaSelector, testChangeHandler);
+        this.$editor.on('paste', translationAreaSelector, testChangeHandler);
+        this.$editor.on('focusin', translationAreaSelector, function () {
+            lastEditor = $(this);
         });
-        /* There is 10px padding */
-        $editors.css('min-height', ((tdHeight - (contentHeight - editorHeight - 10)) / $editors.length) + 'px');
-    });
-}
 
-function testChangeHandler(e) {
-    if (e.key && e.key === 'Tab') {
-        return;
-    }
-    markTranslated($(this).closest('form'));
-}
-
-function processMachineTranslation(data, scope) {
-    decreaseLoading(scope);
-    if (data.responseStatus === 200) {
-        data.translations.forEach(function (el, idx) {
-            var newRow = $('<tr/>').data('raw', el);
-            var done = false;
-            var $machineTranslations = $('#' + scope + '-translations');
-            var service;
-
-            newRow.append($('<td/>').attr('class', 'target mt-text').attr('lang', data.lang).attr('dir', data.dir).text(el.text));
-            newRow.append($('<td/>').attr('class', 'mt-text').text(el.source));
-            if (scope === "mt") {
-                service = $('<td/>').text(el.service);
-                if (typeof el.origin !== 'undefined') {
-                    service.append(' (');
-                    var origin;
-                    if (typeof el.origin_detail !== 'undefined') {
-                        origin = $('<abbr/>').text(el.origin).attr('title', el.origin_detail);
-                    } else if (typeof el.origin_url !== 'undefined') {
-                        origin = $('<a/>').text(el.origin).attr('href', el.origin_url);
-                    } else {
-                        origin = el.origin;
-                    }
-                    service.append(origin);
-                    service.append(')');
-                    // newRow.append($('<td/>').text(interpolate('%s (%s)', [el.service, ])));
-                }
+        /* Count characters */
+        this.$editor.on('keyup', translationAreaSelector, function() {
+            var $this = $(this);
+            var counter = $this.parent().find('.length-indicator');
+            var limit = parseInt(counter.data('max'));
+            var length = $this.val().length;
+            counter.text(length);
+            if (length >= limit) {
+                counter.parent().addClass('badge-danger').removeClass('badge-warning');
+            } else if (length + 10 >= limit) {
+                counter.parent().addClass('badge-warning').removeClass('badge-danger');
             } else {
-                service = $('<td/>').text(el.origin);
+                counter.parent().removeClass('badge-warning').removeClass('badge-danger');
             }
-            newRow.append(service);
-            /* Quality score as bar with the text */
-            newRow.append($(
-                '<td>' +
-                '<div class="progress" title="' + el.quality + ' / 100">' +
-                '<div class="progress-bar ' +
-                ( el.quality >= 70 ? 'progress-bar-success' : el.quality >= 50 ? 'progress-bar-warning' : 'progress-bar-danger' ) + '"' +
-                ' role="progressbar" aria-valuenow="' + el.quality + '"' +
-                ' aria-valuemin="0" aria-valuemax="100" style="width: ' + el.quality + '%;"></div>' +
-                '</div>' +
-                '</td>'
-            ));
-            /* Translators: Verb for copy operation */
-            newRow.append($(
-                '<td>' +
-                '<a class="copymt btn btn-warning">' +
-                gettext('Copy') +
-                '<span class="mt-number text-info"></span>' +
-                '</a>' +
-                '</td>' +
-                '<td>' +
-                '<a class="copymt-save btn btn-primary">' +
-                gettext('Copy and save') +
-                '</a>' +
-                '</td>'
-            ));
-            $machineTranslations.children('tr').each(function (idx) {
-                var $this = $(this);
-                var base = $this.data('raw');
-                if (base.text == el.text && base.source == el.source) {
-                    // Add origin to current ones
-                    var current = $this.children('td:nth-child(3)');
-                    current.append($("<br/>"));
-                    current.append(service.html());
-                    done = true;
-                    return false;
-                } else if (base.quality <= el.quality) {
-                    // Insert match before lower quality one
-                    $this.before(newRow);
-                    done = true;
-                    return false;
+        });
+
+        /* Copy source text */
+        this.$editor.on('click', '.copy-text', function (e) {
+            var $this = $(this);
+
+            $this.button('loading');
+            $this.closest('.translation-item').find('.translation-editor').val(
+                $.parseJSON($this.data('content'))
+            ).change();
+            autosize.update($('.translation-editor'));
+            markFuzzy($this.closest('form'));
+            $this.button('reset');
+            e.preventDefault();
+        });
+
+        /* Direction toggling */
+        this.$editor.on('change', '.direction-toggle', function () {
+            var $this = $(this);
+
+            $this.closest('.translation-item').find('.translation-editor').attr(
+                'dir',
+                $this.find('input').val()
+            );
+        });
+
+        /* Special characters */
+        this.$editor.on('click', '.specialchar', function (e) {
+            var $this = $(this);
+            var text = $this.data('value');
+
+            $this.closest('.translation-item').find('.translation-editor').insertAtCaret(text).change();
+            autosize.update($('.translation-editor'));
+            e.preventDefault();
+        });
+
+        // TODO: mode-specific initialization
+        initEditor();
+        this.$translationArea[0].focus();
+    }
+
+    function FullEditor() {
+        Editor.call(this);
+
+        Mousetrap.bindGlobal('alt+end', function(e) {window.location = $('#button-end').attr('href'); return false;});
+        Mousetrap.bindGlobal('alt+pagedown', function(e) {window.location = $('#button-next').attr('href'); return false;});
+        Mousetrap.bindGlobal('alt+pageup', function(e) {window.location = $('#button-prev').attr('href'); return false;});
+        Mousetrap.bindGlobal('alt+home', function(e) {window.location = $('#button-first').attr('href'); return false;});
+        Mousetrap.bindGlobal('mod+o', function(e) {$('.translation-item .copy-text').click(); return false;});
+        Mousetrap.bindGlobal('mod+y', function(e) {$('input[name="fuzzy"]').click(); return false;});
+        Mousetrap.bindGlobal(
+            'mod+shift+enter',
+            function(e) {$('input[name="fuzzy"]').prop('checked', false); return submitForm(e);}
+        );
+        Mousetrap.bindGlobal(
+            'mod+e',
+            function(e) {
+                $('.translation-editor').get(0).focus();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+s',
+            function(e) {
+                $('#search-dropdown').click();
+                $('input[name="q"]').focus();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+u',
+            function(e) {
+                $('.nav [href="#comments"]').click();
+                $('textarea[name="comment"]').focus();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+j',
+            function(e) {
+                $('.nav [href="#nearby"]').click();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+m',
+            function(e) {
+                $('.nav [href="#machine"]').click();
+                return false;
+            }
+        );
+    }
+
+    function ZenEditor() {
+        Editor.call(this);
+
+        $window.scroll(function() {
+            var $loadingNext = $('#loading-next');
+            var loader = $('#zen-load');
+
+            if ($window.scrollTop() >= $document.height() - (2 * $window.height())) {
+                if ($('#last-section').length > 0 || $loadingNext.css('display') !== 'none') {
+                    return;
+                }
+                $loadingNext.show();
+
+                loader.data('offset', 20 + parseInt(loader.data('offset'), 10));
+
+                $.get(
+                    loader.attr('href') + '&offset=' + loader.data('offset'),
+                    function (data) {
+                        $loadingNext.hide();
+
+                        $('.zen tfoot').before(data);
+
+                        initEditor();
+                    }
+                );
+            }
+        });
+
+        /*
+            * Ensure current editor is reasonably located in the window
+            * - show whole element if moving back
+            * - scroll down if in bottom half of the window
+            */
+        $document.on('focus', '.zen .translation-editor', function() {
+            var current = $window.scrollTop();
+            var rowOffset = $(this).closest('tbody').offset().top;
+            if (rowOffset < current || rowOffset - current > $window.height() / 2) {
+                $([document.documentElement, document.body]).animate({
+                    scrollTop: rowOffset
+                }, 100);
+            }
+        });
+
+        $document.on('change', '.translation-editor', zenEditor);
+        $document.on('change', '.fuzzy_checkbox', zenEditor);
+        $document.on('change', '.review_radio', zenEditor);
+
+        Mousetrap.bindGlobal('mod+end', function(e) {
+            $('.zen-unit:last').find('.translation-editor:first').focus();
+            return false;
+        });
+        Mousetrap.bindGlobal('mod+home', function(e) {
+            $('.zen-unit:first').find('.translation-editor:first').focus();
+            return false;
+        });
+        Mousetrap.bindGlobal('mod+pagedown', function(e) {
+            var focus = $(':focus');
+
+            if (focus.length === 0) {
+                $('.zen-unit:first').find('.translation-editor:first').focus();
+            } else {
+                focus.closest('.zen-unit').next().find('.translation-editor:first').focus();
+            }
+            return false;
+        });
+        Mousetrap.bindGlobal('mod+pageup', function(e) {
+            var focus = $(':focus');
+
+            if (focus.length === 0) {
+                $('.zen-unit:last').find('.translation-editor:first').focus();
+            } else {
+                focus.closest('.zen-unit').prev().find('.translation-editor:first').focus();
+            }
+            return false;
+        });
+
+        $window.on('beforeunload', function() {
+            if ($('.translation-modified').length > 0) {
+                return gettext('There are some unsaved changes, are you sure you want to leave?');
+            }
+        });
+    }
+
+    function initEditor() {
+        /* Autosizing */
+        autosize($('.translation-editor'));
+
+        /* Minimal height for editor */
+        $('.zen-horizontal .translator').each(function () {
+            var $this = $(this);
+            var tdHeight = $this.height();
+            var editorHeight = 0;
+            var contentHeight = $this.find('form').height();
+            var $editors = $this.find('.translation-editor');
+            $editors.each(function () {
+                var $editor = $(this);
+                editorHeight += $editor.height();
+            });
+            /* There is 10px padding */
+            $editors.css('min-height', ((tdHeight - (contentHeight - editorHeight - 10)) / $editors.length) + 'px');
+        });
+    }
+
+    function testChangeHandler(e) {
+        if (e.key && e.key === 'Tab') {
+            return;
+        }
+        markTranslated($(this).closest('form'));
+    }
+
+    function processMachineTranslation(data, scope) {
+        decreaseLoading(scope);
+        if (data.responseStatus === 200) {
+            data.translations.forEach(function (el, idx) {
+                var newRow = $('<tr/>').data('raw', el);
+                var done = false;
+                var $machineTranslations = $('#' + scope + '-translations');
+                var service;
+
+                newRow.append($('<td/>').attr('class', 'target mt-text').attr('lang', data.lang).attr('dir', data.dir).text(el.text));
+                newRow.append($('<td/>').attr('class', 'mt-text').text(el.source));
+                if (scope === "mt") {
+                    service = $('<td/>').text(el.service);
+                    if (typeof el.origin !== 'undefined') {
+                        service.append(' (');
+                        var origin;
+                        if (typeof el.origin_detail !== 'undefined') {
+                            origin = $('<abbr/>').text(el.origin).attr('title', el.origin_detail);
+                        } else if (typeof el.origin_url !== 'undefined') {
+                            origin = $('<a/>').text(el.origin).attr('href', el.origin_url);
+                        } else {
+                            origin = el.origin;
+                        }
+                        service.append(origin);
+                        service.append(')');
+                        // newRow.append($('<td/>').text(interpolate('%s (%s)', [el.service, ])));
+                    }
+                } else {
+                    service = $('<td/>').text(el.origin);
+                }
+                newRow.append(service);
+                /* Quality score as bar with the text */
+                newRow.append($(
+                    '<td>' +
+                    '<div class="progress" title="' + el.quality + ' / 100">' +
+                    '<div class="progress-bar ' +
+                    ( el.quality >= 70 ? 'progress-bar-success' : el.quality >= 50 ? 'progress-bar-warning' : 'progress-bar-danger' ) + '"' +
+                    ' role="progressbar" aria-valuenow="' + el.quality + '"' +
+                    ' aria-valuemin="0" aria-valuemax="100" style="width: ' + el.quality + '%;"></div>' +
+                    '</div>' +
+                    '</td>'
+                ));
+                /* Translators: Verb for copy operation */
+                newRow.append($(
+                    '<td>' +
+                    '<a class="copymt btn btn-warning">' +
+                    gettext('Copy') +
+                    '<span class="mt-number text-info"></span>' +
+                    '</a>' +
+                    '</td>' +
+                    '<td>' +
+                    '<a class="copymt-save btn btn-primary">' +
+                    gettext('Copy and save') +
+                    '</a>' +
+                    '</td>'
+                ));
+                $machineTranslations.children('tr').each(function (idx) {
+                    var $this = $(this);
+                    var base = $this.data('raw');
+                    if (base.text == el.text && base.source == el.source) {
+                        // Add origin to current ones
+                        var current = $this.children('td:nth-child(3)');
+                        current.append($("<br/>"));
+                        current.append(service.html());
+                        done = true;
+                        return false;
+                    } else if (base.quality <= el.quality) {
+                        // Insert match before lower quality one
+                        $this.before(newRow);
+                        done = true;
+                        return false;
+                    }
+                });
+                if (! done) {
+                    $machineTranslations.append(newRow);
                 }
             });
-            if (! done) {
-                $machineTranslations.append(newRow);
-            }
-        });
-        $('a.copymt').click(function () {
-            var text = $(this).parent().parent().find('.target').text();
+            $('a.copymt').click(function () {
+                var text = $(this).parent().parent().find('.target').text();
 
-            $('.translation-editor').val(text).change();
-            autosize.update($('.translation-editor'));
-            markFuzzy($('.translation-form'));
-        });
-        $('a.copymt-save').click(function () {
-            var text = $(this).parent().parent().find('.target').text();
+                $('.translation-editor').val(text).change();
+                autosize.update($('.translation-editor'));
+                markFuzzy($('.translation-form'));
+            });
+            $('a.copymt-save').click(function () {
+                var text = $(this).parent().parent().find('.target').text();
 
-            $('.translation-editor').val(text).change();
-            autosize.update($('.translation-editor'));
-            markTranslated($('.translation-form'));
-            submitForm({target:$('.translation-editor')});
-        });
+                $('.translation-editor').val(text).change();
+                autosize.update($('.translation-editor'));
+                markTranslated($('.translation-form'));
+                submitForm({target:$('.translation-editor')});
+            });
 
-        for (var i = 1; i < 10; i++) {
-            Mousetrap.bindGlobal(
-                'mod+m ' + i,
-                function() {
-                    return false;
-                }
-            );
-        }
-
-        var $machineTranslations = $('#' + scope + '-translations');
-
-        $machineTranslations.children('tr').each(function (idx) {
-            if (idx < 10) {
-                var key = getNumericKey(idx);
-
-                var title;
-                if (IS_MAC) {
-                    title = interpolate(gettext('Cmd+M then %s'), [key]);
-                } else {
-                    title = interpolate(gettext('Ctrl+M then %s'), [key]);
-                }
-                $(this).find('.mt-number').html(
-                    ' <kbd title="' + title + '">' + key + '</kbd>'
-                );
+            for (var i = 1; i < 10; i++) {
                 Mousetrap.bindGlobal(
-                    'mod+m ' + key,
+                    'mod+m ' + i,
                     function() {
-                        $($('#' + scope + '-translations').children('tr')[idx]).find('a.copymt').click();
                         return false;
                     }
                 );
-            } else {
-                $(this).find('.mt-number').html('');
             }
+
+            var $machineTranslations = $('#' + scope + '-translations');
+
+            $machineTranslations.children('tr').each(function (idx) {
+                if (idx < 10) {
+                    var key = getNumericKey(idx);
+
+                    var title;
+                    if (IS_MAC) {
+                        title = interpolate(gettext('Cmd+M then %s'), [key]);
+                    } else {
+                        title = interpolate(gettext('Ctrl+M then %s'), [key]);
+                    }
+                    $(this).find('.mt-number').html(
+                        ' <kbd title="' + title + '">' + key + '</kbd>'
+                    );
+                    Mousetrap.bindGlobal(
+                        'mod+m ' + key,
+                        function() {
+                            $($('#' + scope + '-translations').children('tr')[idx]).find('a.copymt').click();
+                            return false;
+                        }
+                    );
+                } else {
+                    $(this).find('.mt-number').html('');
+                }
+            });
+
+        } else {
+            var msg = interpolate(
+                gettext('The request for machine translation using %s has failed:'),
+                [data.service]
+            );
+
+            addAlert(msg + ' ' + data.responseDetails);
+        }
+    }
+
+    function failedMachineTranslation(jqXHR, textStatus, errorThrown, scope) {
+        decreaseLoading(scope);
+        if (jqXHR.state() !== 'rejected') {
+            addAlert(gettext('The request for machine translation has failed:') + ' ' + textStatus + ': ' + errorThrown);
+        }
+    }
+
+    function loadMachineTranslations(data, textStatus) {
+        var $form = $('#link-post');
+        decreaseLoading('mt');
+        data.forEach(function (el, idx) {
+            increaseLoading('mt');
+            $.ajax({
+                type: 'POST',
+                url: $('#js-translate').attr('href').replace('__service__', el),
+                success: function (data) {processMachineTranslation(data, 'mt');},
+                error: function (jqXHR, textStatus, errorThrown) {
+                    failedMachineTranslation(jqXHR, textStatus, errorThrown, 'mt');
+                },
+                dataType: 'json',
+                data: {
+                    csrfmiddlewaretoken: $form.find('input').val(),
+                },
+            });
         });
-
-    } else {
-        var msg = interpolate(
-            gettext('The request for machine translation using %s has failed:'),
-            [data.service]
-        );
-
-        addAlert(msg + ' ' + data.responseDetails);
     }
-}
 
-function failedMachineTranslation(jqXHR, textStatus, errorThrown, scope) {
-    decreaseLoading(scope);
-    if (jqXHR.state() !== 'rejected') {
-        addAlert(gettext('The request for machine translation has failed:') + ' ' + textStatus + ': ' + errorThrown);
-    }
-}
+    function zenEditor() {
+        var $this = $(this);
+        var $row = $this.closest('tr');
+        var checksum = $row.find('[name=checksum]').val();
 
-function loadMachineTranslations(data, textStatus) {
-    var $form = $('#link-post');
-    decreaseLoading('mt');
-    data.forEach(function (el, idx) {
-        increaseLoading('mt');
+        $row.addClass('translation-modified');
+
+        var form = $row.find('form');
+        var statusdiv = $('#status-' + checksum).hide();
+        var loadingdiv = $('#loading-' + checksum).show();
         $.ajax({
             type: 'POST',
-            url: $('#js-translate').attr('href').replace('__service__', el),
-            success: function (data) {processMachineTranslation(data, 'mt');},
+            url: form.attr('action'),
+            data: form.serialize(),
+            dataType: 'json',
             error: function (jqXHR, textStatus, errorThrown) {
-                failedMachineTranslation(jqXHR, textStatus, errorThrown, 'mt');
+                addAlert(errorThrown);
+            },
+            success: function (data) {
+                loadingdiv.hide();
+                statusdiv.show();
+                if (data.unit_flags.length > 0) {
+                    $(statusdiv.children()[0]).attr('class', 'state-icon ' + data.unit_flags.join(' '));
+                }
+                $.each(data.messages, function (i, val) {
+                    addAlert(val.text);
+                });
+                $row.removeClass('translation-modified').addClass('translation-saved');
+                if (data.translationsum !== '') {
+                    $row.find('input[name=translationsum]').val(data.translationsum);
+                }
+            }
+        });
+    }
+
+    function insertEditor(text, element)
+    {
+        var root;
+
+        /* Find withing root element */
+        if (typeof element !== 'undefined') {
+            root = element.closest('.zen-unit');
+            if (root.length === 0) {
+                root = element.closest('.translation-form');
+            }
+        } else {
+            root = $(document);
+        }
+
+        var editor = root.find('.translation-editor:focus');
+        if (editor.length === 0) {
+            editor = root.find(lastEditor);
+            if (editor.length === 0) {
+                editor = root.find('.translation-editor:first');
+            }
+        }
+
+        editor.insertAtCaret($.trim(text)).change();
+        autosize.update(editor);
+    }
+
+
+    // TODO: move to editor
+
+    /* Machine translation */
+    $document.on('show.bs.tab', '[data-load="mt"]', function (e) {
+        if (machineTranslationLoaded) {
+            return;
+        }
+        machineTranslationLoaded = true;
+        increaseLoading('mt');
+        $.ajax({
+            url: $('#js-mt-services').attr('href'),
+            success: loadMachineTranslations,
+            error: failedMachineTranslation,
+            dataType: 'json'
+        });
+    });
+
+    /* Translation memory */
+    $document.on('show.bs.tab', '[data-load="memory"]', function (e) {
+        if (translationMemoryLoaded) {
+            return;
+        }
+        translationMemoryLoaded = true;
+        increaseLoading('memory');
+        var $form = $('#link-post');
+        $.ajax({
+            type: 'POST',
+            url: $('#js-translate').attr('href').replace('__service__', 'weblate-translation-memory'),
+            success: function (data) {processMachineTranslation(data, 'memory');},
+            error: function (jqXHR, textStatus, errorThrown) {
+                failedMachineTranslation(jqXHR, textStatus, errorThrown, 'memory');
             },
             dataType: 'json',
             data: {
@@ -425,207 +530,151 @@ function loadMachineTranslations(data, textStatus) {
             },
         });
     });
-}
 
-function zenEditor() {
-    var $this = $(this);
-    var $row = $this.closest('tr');
-    var checksum = $row.find('[name=checksum]').val();
+    $('#memory-search').submit(function () {
+        var form = $(this);
 
-    $row.addClass('translation-modified');
-
-    var form = $row.find('form');
-    var statusdiv = $('#status-' + checksum).hide();
-    var loadingdiv = $('#loading-' + checksum).show();
-    $.ajax({
-        type: 'POST',
-        url: form.attr('action'),
-        data: form.serialize(),
-        dataType: 'json',
-        error: function (jqXHR, textStatus, errorThrown) {
-            addAlert(errorThrown);
-        },
-        success: function (data) {
-            loadingdiv.hide();
-            statusdiv.show();
-            if (data.unit_flags.length > 0) {
-                $(statusdiv.children()[0]).attr('class', 'state-icon ' + data.unit_flags.join(' '));
-            }
-            $.each(data.messages, function (i, val) {
-                addAlert(val.text);
-            });
-            $row.removeClass('translation-modified').addClass('translation-saved');
-            if (data.translationsum !== '') {
-                $row.find('input[name=translationsum]').val(data.translationsum);
-            }
-        }
-    });
-}
-
-function insertEditor(text, element)
-{
-    var root;
-
-    /* Find withing root element */
-    if (typeof element !== 'undefined') {
-        root = element.closest('.zen-unit');
-        if (root.length === 0) {
-            root = element.closest('.translation-form');
-        }
-    } else {
-        root = $(document);
-    }
-
-    var editor = root.find('.translation-editor:focus');
-    if (editor.length === 0) {
-        editor = root.find(lastEditor);
-        if (editor.length === 0) {
-            editor = root.find('.translation-editor:first');
-        }
-    }
-
-    editor.insertAtCaret($.trim(text)).change();
-    autosize.update(editor);
-}
-
-
-// TODO: move to editor
-
-/* Machine translation */
-$document.on('show.bs.tab', '[data-load="mt"]', function (e) {
-    if (machineTranslationLoaded) {
-        return;
-    }
-    machineTranslationLoaded = true;
-    increaseLoading('mt');
-    $.ajax({
-        url: $('#js-mt-services').attr('href'),
-        success: loadMachineTranslations,
-        error: failedMachineTranslation,
-        dataType: 'json'
-    });
-});
-
-/* Translation memory */
-$document.on('show.bs.tab', '[data-load="memory"]', function (e) {
-    if (translationMemoryLoaded) {
-        return;
-    }
-    translationMemoryLoaded = true;
-    increaseLoading('memory');
-    var $form = $('#link-post');
-    $.ajax({
-        type: 'POST',
-        url: $('#js-translate').attr('href').replace('__service__', 'weblate-translation-memory'),
-        success: function (data) {processMachineTranslation(data, 'memory');},
-        error: function (jqXHR, textStatus, errorThrown) {
-            failedMachineTranslation(jqXHR, textStatus, errorThrown, 'memory');
-        },
-        dataType: 'json',
-        data: {
-            csrfmiddlewaretoken: $form.find('input').val(),
-        },
-    });
-});
-
-$('#memory-search').submit(function () {
-    var form = $(this);
-
-    increaseLoading('memory');
-    $('#memory-translations').empty();
-    $.ajax({
-        type: 'POST',
-        url: form.attr('action'),
-        data: form.serialize(),
-        dataType: 'json',
-        success: function (data) {processMachineTranslation(data, 'memory');},
-        error: function (jqXHR, textStatus, errorThrown) {
-            failedMachineTranslation(jqXHR, textStatus, errorThrown, 'memory');
-        },
-    });
-    return false;
-});
-
-/* Store active translation tab in cookie */
-$('.translation-tabs a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
-    Cookies.remove('translate-tab', { path: '' });
-    Cookies.set('translate-tab', $(this).attr('href'), { path: '/', expires: 365 });
-});
-
-/* Check ignoring */
-$('.check-dismiss').click(function () {
-    var $this = $(this);
-    var $form = $('#link-post');
-
-    $.ajax({
-        type: 'POST',
-        url: $this.attr('href'),
-        data: {
-            csrfmiddlewaretoken: $form.find('input').val(),
-        },
-        error: function (jqXHR, textStatus, errorThrown) {
-            addAlert(errorThrown);
-        },
-    });
-    if ($this.hasClass("check-dismiss-all")) {
-        $this.closest('.check').remove();
-    } else {
-        $this.closest('.check').toggleClass("check-dismissed");
-    }
-    return false;
-});
-
-/* Check fix */
-$('[data-check-fixup]').click(function (e) {
-    var fixups = $(this).data('check-fixup');
-    $('.translation-editor').each(function () {
-        var $this = $(this);
-        $.each(fixups, function (key, value) {
-            var re = new RegExp(value[0], value[2]);
-            $this.val($this.val().replace(re, value[1]));
+        increaseLoading('memory');
+        $('#memory-translations').empty();
+        $.ajax({
+            type: 'POST',
+            url: form.attr('action'),
+            data: form.serialize(),
+            dataType: 'json',
+            success: function (data) {processMachineTranslation(data, 'memory');},
+            error: function (jqXHR, textStatus, errorThrown) {
+                failedMachineTranslation(jqXHR, textStatus, errorThrown, 'memory');
+            },
         });
+        return false;
     });
-    return false;
-});
 
-/* Check link clicking */
-$document.on('click', '.check [data-toggle="tab"]', function (e) {
-    var href = $(this).attr('href');
+    /* Store active translation tab in cookie */
+    $('.translation-tabs a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+        Cookies.remove('translate-tab', { path: '' });
+        Cookies.set('translate-tab', $(this).attr('href'), { path: '/', expires: 365 });
+    });
 
-    e.preventDefault();
-    $('.nav [href="' + href + '"]').click();
-    $window.scrollTop($(href).offset().top);
-});
+    /* Check ignoring */
+    $('.check-dismiss').click(function () {
+        var $this = $(this);
+        var $form = $('#link-post');
 
-/* Copy from dictionary */
-$document.on('click', '.glossary-embed', function (e) {
-    var text = $(this).find('.target').text();
-
-    insertEditor(text);
-    e.preventDefault();
-});
-
-/* Copy from source text highlight check */
-$document.on('click', '.hlcheck', function (e) {
-    var text = $(this).clone();
-
-    text.find('.highlight-number').remove();
-    text=text.text();
-    insertEditor(text, $(this));
-    e.preventDefault();
-});
-/* and shortcuts */
-for (var i = 1; i < 10; i++) {
-    Mousetrap.bindGlobal(
-        'mod+' + i,
-        function(e) {
-            return false;
+        $.ajax({
+            type: 'POST',
+            url: $this.attr('href'),
+            data: {
+                csrfmiddlewaretoken: $form.find('input').val(),
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                addAlert(errorThrown);
+            },
+        });
+        if ($this.hasClass("check-dismiss-all")) {
+            $this.closest('.check').remove();
+        } else {
+            $this.closest('.check').toggleClass("check-dismissed");
         }
-    );
-}
+        return false;
+    });
 
-if ($('.hlcheck').length>0) {
-    $('.hlcheck').each(function(idx) {
+    /* Check fix */
+    $('[data-check-fixup]').click(function (e) {
+        var fixups = $(this).data('check-fixup');
+        $('.translation-editor').each(function () {
+            var $this = $(this);
+            $.each(fixups, function (key, value) {
+                var re = new RegExp(value[0], value[2]);
+                $this.val($this.val().replace(re, value[1]));
+            });
+        });
+        return false;
+    });
+
+    /* Check link clicking */
+    $document.on('click', '.check [data-toggle="tab"]', function (e) {
+        var href = $(this).attr('href');
+
+        e.preventDefault();
+        $('.nav [href="' + href + '"]').click();
+        $window.scrollTop($(href).offset().top);
+    });
+
+    /* Copy from dictionary */
+    $document.on('click', '.glossary-embed', function (e) {
+        var text = $(this).find('.target').text();
+
+        insertEditor(text);
+        e.preventDefault();
+    });
+
+    /* Copy from source text highlight check */
+    $document.on('click', '.hlcheck', function (e) {
+        var text = $(this).clone();
+
+        text.find('.highlight-number').remove();
+        text=text.text();
+        insertEditor(text, $(this));
+        e.preventDefault();
+    });
+    /* and shortcuts */
+    for (var i = 1; i < 10; i++) {
+        Mousetrap.bindGlobal(
+            'mod+' + i,
+            function(e) {
+                return false;
+            }
+        );
+    }
+
+    if ($('.hlcheck').length>0) {
+        $('.hlcheck').each(function(idx) {
+            var $this = $(this);
+
+            if (idx < 10) {
+                let key = getNumericKey(idx);
+
+                var title;
+                if (IS_MAC) {
+                    title = interpolate(gettext('Cmd+%s'), [key]);
+                } else {
+                    title = interpolate(gettext('Ctrl+%s'), [key]);
+                }
+                $(this).attr('title', title);
+                $(this).find('.highlight-number').html('<kbd>' + key + '</kbd>');
+
+                Mousetrap.bindGlobal(
+                    'mod+' + key,
+                    function(e) {
+                        $this.click();
+                        return false;
+                    }
+                );
+            } else {
+                $this.find('.highlight-number').html('');
+            }
+        });
+        $('.highlight-number').hide();
+    }
+    Mousetrap.bindGlobal('mod', function (e) {
+        $('.highlight-number').show();
+    }, 'keydown');
+    Mousetrap.bindGlobal('mod', function (e) {
+        $('.highlight-number').hide();
+    }, 'keyup');
+
+    if (document.querySelectorAll('.check-item').length > 0) {
+        // Cancel out browser's `meta+i` and let Mousetrap handle the rest
+        document.addEventListener('keydown', function (e) {
+            var isMod = IS_MAC ? e.metaKey : e.ctrlKey;
+            if (isMod && e.key.toLowerCase() === 'i') {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        });
+    }
+
+    $('.check-item').each(function(idx) {
         var $this = $(this);
 
         if (idx < 10) {
@@ -633,136 +682,97 @@ if ($('.hlcheck').length>0) {
 
             var title;
             if (IS_MAC) {
-                title = interpolate(gettext('Cmd+%s'), [key]);
+                title = interpolate(gettext('Press Cmd+I then %s to dismiss this.'), [key]);
             } else {
-                title = interpolate(gettext('Ctrl+%s'), [key]);
+                title = interpolate(gettext('Press Ctrl+I then %s to dismiss this.'), [key]);
             }
-            $(this).attr('title', title);
-            $(this).find('.highlight-number').html('<kbd>' + key + '</kbd>');
+            $(this).find('.check-number').html(
+                ' <kbd title="' + title + '">' + key + '</kbd>'
+            );
 
             Mousetrap.bindGlobal(
-                'mod+' + key,
+                'mod+i ' + key,
                 function(e) {
-                    $this.click();
+                    $this.find('.check-dismiss-single').click();
                     return false;
                 }
             );
         } else {
-            $this.find('.highlight-number').html('');
+            $(this).find('.check-number').html('');
         }
     });
-    $('.highlight-number').hide();
-}
-Mousetrap.bindGlobal('mod', function (e) {
-    $('.highlight-number').show();
-}, 'keydown');
-Mousetrap.bindGlobal('mod', function (e) {
-    $('.highlight-number').hide();
-}, 'keyup');
 
-if (document.querySelectorAll('.check-item').length > 0) {
-    // Cancel out browser's `meta+i` and let Mousetrap handle the rest
-    document.addEventListener('keydown', function (e) {
-        var isMod = IS_MAC ? e.metaKey : e.ctrlKey;
-        if (isMod && e.key.toLowerCase() === 'i') {
-            e.preventDefault();
-            e.stopPropagation();
-        }
-    });
-}
+    /* Inline dictionary adding */
+    $('.add-dict-inline').submit(function () {
+        var form = $(this);
 
-$('.check-item').each(function(idx) {
-    var $this = $(this);
-
-    if (idx < 10) {
-        let key = getNumericKey(idx);
-
-        var title;
-        if (IS_MAC) {
-            title = interpolate(gettext('Press Cmd+I then %s to dismiss this.'), [key]);
-        } else {
-            title = interpolate(gettext('Press Ctrl+I then %s to dismiss this.'), [key]);
-        }
-        $(this).find('.check-number').html(
-            ' <kbd title="' + title + '">' + key + '</kbd>'
-        );
-
-        Mousetrap.bindGlobal(
-            'mod+i ' + key,
-            function(e) {
-                $this.find('.check-dismiss-single').click();
-                return false;
+        increaseLoading('glossary-add');
+        $.ajax({
+            type: 'POST',
+            url: form.attr('action'),
+            data: form.serialize(),
+            dataType: 'json',
+            success: function (data) {
+                decreaseLoading('glossary-add');
+                if (data.responseCode === 200) {
+                    $('#glossary-words').html(data.results);
+                    form.find('[name=words]').attr('value', data.words);
+                }
+                $('.translation-editor:first').focus();
+                form.trigger('reset');
+            },
+            error: function (xhr, textStatus, errorThrown) {
+                addAlert(errorThrown);
+                decreaseLoading('glossary-add');
             }
-        );
-    } else {
-        $(this).find('.check-number').html('');
-    }
-});
-
-/* Inline dictionary adding */
-$('.add-dict-inline').submit(function () {
-    var form = $(this);
-
-    increaseLoading('glossary-add');
-    $.ajax({
-        type: 'POST',
-        url: form.attr('action'),
-        data: form.serialize(),
-        dataType: 'json',
-        success: function (data) {
-            decreaseLoading('glossary-add');
-            if (data.responseCode === 200) {
-                $('#glossary-words').html(data.results);
-                form.find('[name=words]').attr('value', data.words);
-            }
-            $('.translation-editor:first').focus();
-            form.trigger('reset');
-        },
-        error: function (xhr, textStatus, errorThrown) {
-            addAlert(errorThrown);
-            decreaseLoading('glossary-add');
-        }
-    });
-    $('#add-glossary-form').modal('hide');
-    return false;
-});
-
-/* Translate forms persistence */
-$forms = $('.translation-form');
-if ($forms.length > 0 && window.localStorage && window.localStorage.translation_autosave) {
-    var translationRestore = JSON.parse(window.localStorage.translation_autosave);
-
-    $.each(translation_restore, function () {
-        var target = $('#' + this.id);
-
-        if (target.length > 0) {
-            target.val(this.value);
-            autosize.update(target);
-        }
-    });
-    localStorage.removeItem('translation_autosave');
-}
-
-$('.auto-save-translation').on('submit', function () {
-    if (window.localStorage) {
-        let data = $('.translation-editor').map(function () {
-            var $this = $(this);
-
-            return {id: $this.attr('id'), value: $this.val()};
         });
+        $('#add-glossary-form').modal('hide');
+        return false;
+    });
 
-        window.localStorage.translation_autosave = JSON.stringify(data.get());
+    /* Translate forms persistence */
+    $forms = $('.translation-form');
+    if ($forms.length > 0 && window.localStorage && window.localStorage.translation_autosave) {
+        var translationRestore = JSON.parse(window.localStorage.translation_autosave);
+
+        $.each(translation_restore, function () {
+            var target = $('#' + this.id);
+
+            if (target.length > 0) {
+                target.val(this.value);
+                autosize.update(target);
+            }
+        });
+        localStorage.removeItem('translation_autosave');
     }
-});
 
-/* Report source bug */
-$('.bug-comment').click(function () {
-    $('.translation-tabs a[href="#comments"]').tab('show');
-    $("#id_scope").val("report");
-    $([document.documentElement, document.body]).animate({
-        scrollTop: $('#comment-form').offset().top
-    }, 1000);
-    $("#id_comment").focus();
-});
+    $('.auto-save-translation').on('submit', function () {
+        if (window.localStorage) {
+            let data = $('.translation-editor').map(function () {
+                var $this = $(this);
 
-// end TODO: move to non-zen editor
+                return {id: $this.attr('id'), value: $this.val()};
+            });
+
+            window.localStorage.translation_autosave = JSON.stringify(data.get());
+        }
+    });
+
+    /* Report source bug */
+    $('.bug-comment').click(function () {
+        $('.translation-tabs a[href="#comments"]').tab('show');
+        $("#id_scope").val("report");
+        $([document.documentElement, document.body]).animate({
+            scrollTop: $('#comment-form').offset().top
+        }, 1000);
+        $("#id_comment").focus();
+    });
+
+    // end TODO: move to non-zen editor
+
+    return {
+        Full: FullEditor,
+        Zen: ZenEditor,
+    };
+
+})();

--- a/weblate/static/editor.js
+++ b/weblate/static/editor.js
@@ -746,7 +746,7 @@ WLT.editor = (function () {
     if ($forms.length > 0 && window.localStorage && window.localStorage.translation_autosave) {
         var translationRestore = JSON.parse(window.localStorage.translation_autosave);
 
-        $.each(translation_restore, function () {
+        $.each(translationRestore, function () {
             var target = $('#' + this.id);
 
             if (target.length > 0) {

--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -1,6 +1,6 @@
 var WLT = WLT || {};
 
-WLT.editor = (function () {
+WLT.Editor = (function () {
     var machineTranslationLoaded = false;
     var translationMemoryLoaded = false;
     var lastEditor = null;
@@ -33,7 +33,7 @@ WLT.editor = (function () {
         elm.find('input[name="review"][value="20"]').prop('checked', true);
     }
 
-    function Editor() {
+    function EditorBase() {
         var translationAreaSelector =  '.translation-editor';
 
         this.$editor = $('.js-editor');
@@ -102,171 +102,11 @@ WLT.editor = (function () {
         this.$translationArea[0].focus();
     }
 
-    Editor.prototype.init = function() {
+    EditorBase.prototype.init = function() {
         /* Autosizing */
         autosize($('.translation-editor'));
     };
 
-
-    function FullEditor() {
-        Editor.call(this);
-
-        Mousetrap.bindGlobal('alt+end', function(e) {window.location = $('#button-end').attr('href'); return false;});
-        Mousetrap.bindGlobal('alt+pagedown', function(e) {window.location = $('#button-next').attr('href'); return false;});
-        Mousetrap.bindGlobal('alt+pageup', function(e) {window.location = $('#button-prev').attr('href'); return false;});
-        Mousetrap.bindGlobal('alt+home', function(e) {window.location = $('#button-first').attr('href'); return false;});
-        Mousetrap.bindGlobal('mod+o', function(e) {$('.translation-item .copy-text').click(); return false;});
-        Mousetrap.bindGlobal('mod+y', function(e) {$('input[name="fuzzy"]').click(); return false;});
-        Mousetrap.bindGlobal(
-            'mod+shift+enter',
-            function(e) {$('input[name="fuzzy"]').prop('checked', false); return submitForm(e);}
-        );
-        Mousetrap.bindGlobal(
-            'mod+e',
-            function(e) {
-                $('.translation-editor').get(0).focus();
-                return false;
-            }
-        );
-        Mousetrap.bindGlobal(
-            'mod+s',
-            function(e) {
-                $('#search-dropdown').click();
-                $('input[name="q"]').focus();
-                return false;
-            }
-        );
-        Mousetrap.bindGlobal(
-            'mod+u',
-            function(e) {
-                $('.nav [href="#comments"]').click();
-                $('textarea[name="comment"]').focus();
-                return false;
-            }
-        );
-        Mousetrap.bindGlobal(
-            'mod+j',
-            function(e) {
-                $('.nav [href="#nearby"]').click();
-                return false;
-            }
-        );
-        Mousetrap.bindGlobal(
-            'mod+m',
-            function(e) {
-                $('.nav [href="#machine"]').click();
-                return false;
-            }
-        );
-    }
-    FullEditor.prototype = Object.create(Editor.prototype);
-    FullEditor.prototype.constructor = FullEditor;
-
-
-    function ZenEditor() {
-        Editor.call(this);
-
-        var self = this;
-        $window.scroll(function() {
-            var $loadingNext = $('#loading-next');
-            var loader = $('#zen-load');
-
-            if ($window.scrollTop() >= $document.height() - (2 * $window.height())) {
-                if ($('#last-section').length > 0 || $loadingNext.css('display') !== 'none') {
-                    return;
-                }
-                $loadingNext.show();
-
-                loader.data('offset', 20 + parseInt(loader.data('offset'), 10));
-
-                $.get(
-                    loader.attr('href') + '&offset=' + loader.data('offset'),
-                    function (data) {
-                        $loadingNext.hide();
-
-                        $('.zen tfoot').before(data);
-
-                        self.init();
-                    }
-                );
-            }
-        });
-
-        /*
-            * Ensure current editor is reasonably located in the window
-            * - show whole element if moving back
-            * - scroll down if in bottom half of the window
-            */
-        $document.on('focus', '.zen .translation-editor', function() {
-            var current = $window.scrollTop();
-            var rowOffset = $(this).closest('tbody').offset().top;
-            if (rowOffset < current || rowOffset - current > $window.height() / 2) {
-                $([document.documentElement, document.body]).animate({
-                    scrollTop: rowOffset
-                }, 100);
-            }
-        });
-
-        $document.on('change', '.translation-editor', zenEditor);
-        $document.on('change', '.fuzzy_checkbox', zenEditor);
-        $document.on('change', '.review_radio', zenEditor);
-
-        Mousetrap.bindGlobal('mod+end', function(e) {
-            $('.zen-unit:last').find('.translation-editor:first').focus();
-            return false;
-        });
-        Mousetrap.bindGlobal('mod+home', function(e) {
-            $('.zen-unit:first').find('.translation-editor:first').focus();
-            return false;
-        });
-        Mousetrap.bindGlobal('mod+pagedown', function(e) {
-            var focus = $(':focus');
-
-            if (focus.length === 0) {
-                $('.zen-unit:first').find('.translation-editor:first').focus();
-            } else {
-                focus.closest('.zen-unit').next().find('.translation-editor:first').focus();
-            }
-            return false;
-        });
-        Mousetrap.bindGlobal('mod+pageup', function(e) {
-            var focus = $(':focus');
-
-            if (focus.length === 0) {
-                $('.zen-unit:last').find('.translation-editor:first').focus();
-            } else {
-                focus.closest('.zen-unit').prev().find('.translation-editor:first').focus();
-            }
-            return false;
-        });
-
-        $window.on('beforeunload', function() {
-            if ($('.translation-modified').length > 0) {
-                return gettext('There are some unsaved changes, are you sure you want to leave?');
-            }
-        });
-    }
-    ZenEditor.prototype = Object.create(Editor.prototype);
-    ZenEditor.prototype.constructor = ZenEditor;
-
-    ZenEditor.prototype.init = function() {
-        Editor.prototype.init.call(this);
-
-        /* Minimal height for side-by-side editor */
-        $('.zen-horizontal .translator').each(function () {
-            var $this = $(this);
-            var tdHeight = $this.height();
-            var editorHeight = 0;
-            var contentHeight = $this.find('form').height();
-            var $editors = $this.find('.translation-editor');
-            $editors.each(function () {
-                var $editor = $(this);
-                editorHeight += $editor.height();
-            });
-            /* There is 10px padding */
-            $editors.css('min-height', ((tdHeight - (contentHeight - editorHeight - 10)) / $editors.length) + 'px');
-        });
-    }
 
     function testChangeHandler(e) {
         if (e.key && e.key === 'Tab') {
@@ -438,41 +278,6 @@ WLT.editor = (function () {
                     csrfmiddlewaretoken: $form.find('input').val(),
                 },
             });
-        });
-    }
-
-    function zenEditor() {
-        var $this = $(this);
-        var $row = $this.closest('tr');
-        var checksum = $row.find('[name=checksum]').val();
-
-        $row.addClass('translation-modified');
-
-        var form = $row.find('form');
-        var statusdiv = $('#status-' + checksum).hide();
-        var loadingdiv = $('#loading-' + checksum).show();
-        $.ajax({
-            type: 'POST',
-            url: form.attr('action'),
-            data: form.serialize(),
-            dataType: 'json',
-            error: function (jqXHR, textStatus, errorThrown) {
-                addAlert(errorThrown);
-            },
-            success: function (data) {
-                loadingdiv.hide();
-                statusdiv.show();
-                if (data.unit_flags.length > 0) {
-                    $(statusdiv.children()[0]).attr('class', 'state-icon ' + data.unit_flags.join(' '));
-                }
-                $.each(data.messages, function (i, val) {
-                    addAlert(val.text);
-                });
-                $row.removeClass('translation-modified').addClass('translation-saved');
-                if (data.translationsum !== '') {
-                    $row.find('input[name=translationsum]').val(data.translationsum);
-                }
-            }
         });
     }
 
@@ -781,8 +586,7 @@ WLT.editor = (function () {
     // end TODO: move to non-zen editor
 
     return {
-        Full: FullEditor,
-        Zen: ZenEditor,
+        Base: EditorBase,
     };
 
 })();

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -1,0 +1,62 @@
+(function () {
+    var EditorBase = WLT.Editor.Base;
+
+    function FullEditor() {
+        EditorBase.call(this);
+
+        Mousetrap.bindGlobal('alt+end', function(e) {window.location = $('#button-end').attr('href'); return false;});
+        Mousetrap.bindGlobal('alt+pagedown', function(e) {window.location = $('#button-next').attr('href'); return false;});
+        Mousetrap.bindGlobal('alt+pageup', function(e) {window.location = $('#button-prev').attr('href'); return false;});
+        Mousetrap.bindGlobal('alt+home', function(e) {window.location = $('#button-first').attr('href'); return false;});
+        Mousetrap.bindGlobal('mod+o', function(e) {$('.translation-item .copy-text').click(); return false;});
+        Mousetrap.bindGlobal('mod+y', function(e) {$('input[name="fuzzy"]').click(); return false;});
+        Mousetrap.bindGlobal(
+            'mod+shift+enter',
+            function(e) {$('input[name="fuzzy"]').prop('checked', false); return submitForm(e);}
+        );
+        Mousetrap.bindGlobal(
+            'mod+e',
+            function(e) {
+                $('.translation-editor').get(0).focus();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+s',
+            function(e) {
+                $('#search-dropdown').click();
+                $('input[name="q"]').focus();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+u',
+            function(e) {
+                $('.nav [href="#comments"]').click();
+                $('textarea[name="comment"]').focus();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+j',
+            function(e) {
+                $('.nav [href="#nearby"]').click();
+                return false;
+            }
+        );
+        Mousetrap.bindGlobal(
+            'mod+m',
+            function(e) {
+                $('.nav [href="#machine"]').click();
+                return false;
+            }
+        );
+    }
+    FullEditor.prototype = Object.create(EditorBase.prototype);
+    FullEditor.prototype.constructor = FullEditor;
+
+    document.addEventListener('DOMContentLoaded', function () {
+        new FullEditor();
+    });
+
+})();

--- a/weblate/static/editor/zen.js
+++ b/weblate/static/editor/zen.js
@@ -1,0 +1,154 @@
+(function () {
+    var EditorBase = WLT.Editor.Base;
+
+    var $window = $(window);
+    var $document = $(document);
+
+    function ZenEditor() {
+        EditorBase.call(this);
+
+        var self = this;
+        $window.scroll(function() {
+            var $loadingNext = $('#loading-next');
+            var loader = $('#zen-load');
+
+            if ($window.scrollTop() >= $document.height() - (2 * $window.height())) {
+                if ($('#last-section').length > 0 || $loadingNext.css('display') !== 'none') {
+                    return;
+                }
+                $loadingNext.show();
+
+                loader.data('offset', 20 + parseInt(loader.data('offset'), 10));
+
+                $.get(
+                    loader.attr('href') + '&offset=' + loader.data('offset'),
+                    function (data) {
+                        $loadingNext.hide();
+
+                        $('.zen tfoot').before(data);
+
+                        self.init();
+                    }
+                );
+            }
+        });
+
+        /*
+            * Ensure current editor is reasonably located in the window
+            * - show whole element if moving back
+            * - scroll down if in bottom half of the window
+            */
+        $document.on('focus', '.zen .translation-editor', function() {
+            var current = $window.scrollTop();
+            var rowOffset = $(this).closest('tbody').offset().top;
+            if (rowOffset < current || rowOffset - current > $window.height() / 2) {
+                $([document.documentElement, document.body]).animate({
+                    scrollTop: rowOffset
+                }, 100);
+            }
+        });
+
+        $document.on('change', '.translation-editor', handleTranslationChange);
+        $document.on('change', '.fuzzy_checkbox', handleTranslationChange);
+        $document.on('change', '.review_radio', handleTranslationChange);
+
+        Mousetrap.bindGlobal('mod+end', function(e) {
+            $('.zen-unit:last').find('.translation-editor:first').focus();
+            return false;
+        });
+        Mousetrap.bindGlobal('mod+home', function(e) {
+            $('.zen-unit:first').find('.translation-editor:first').focus();
+            return false;
+        });
+        Mousetrap.bindGlobal('mod+pagedown', function(e) {
+            var focus = $(':focus');
+
+            if (focus.length === 0) {
+                $('.zen-unit:first').find('.translation-editor:first').focus();
+            } else {
+                focus.closest('.zen-unit').next().find('.translation-editor:first').focus();
+            }
+            return false;
+        });
+        Mousetrap.bindGlobal('mod+pageup', function(e) {
+            var focus = $(':focus');
+
+            if (focus.length === 0) {
+                $('.zen-unit:last').find('.translation-editor:first').focus();
+            } else {
+                focus.closest('.zen-unit').prev().find('.translation-editor:first').focus();
+            }
+            return false;
+        });
+
+        $window.on('beforeunload', function() {
+            if ($('.translation-modified').length > 0) {
+                return gettext('There are some unsaved changes, are you sure you want to leave?');
+            }
+        });
+    }
+    ZenEditor.prototype = Object.create(EditorBase.prototype);
+    ZenEditor.prototype.constructor = ZenEditor;
+
+    ZenEditor.prototype.init = function() {
+        EditorBase.prototype.init.call(this);
+
+        /* Minimal height for side-by-side editor */
+        $('.zen-horizontal .translator').each(function () {
+            var $this = $(this);
+            var tdHeight = $this.height();
+            var editorHeight = 0;
+            var contentHeight = $this.find('form').height();
+            var $editors = $this.find('.translation-editor');
+            $editors.each(function () {
+                var $editor = $(this);
+                editorHeight += $editor.height();
+            });
+            /* There is 10px padding */
+            $editors.css('min-height', ((tdHeight - (contentHeight - editorHeight - 10)) / $editors.length) + 'px');
+        });
+    };
+
+    /* Handlers */
+
+    function handleTranslationChange() {
+        var $this = $(this);
+        var $row = $this.closest('tr');
+        var checksum = $row.find('[name=checksum]').val();
+
+        $row.addClass('translation-modified');
+
+        var form = $row.find('form');
+        var statusdiv = $('#status-' + checksum).hide();
+        var loadingdiv = $('#loading-' + checksum).show();
+        $.ajax({
+            type: 'POST',
+            url: form.attr('action'),
+            data: form.serialize(),
+            dataType: 'json',
+            error: function (jqXHR, textStatus, errorThrown) {
+                addAlert(errorThrown);
+            },
+            success: function (data) {
+                loadingdiv.hide();
+                statusdiv.show();
+                if (data.unit_flags.length > 0) {
+                    $(statusdiv.children()[0]).attr('class', 'state-icon ' + data.unit_flags.join(' '));
+                }
+                $.each(data.messages, function (i, val) {
+                    addAlert(val.text);
+                });
+                $row.removeClass('translation-modified').addClass('translation-saved');
+                if (data.translationsum !== '') {
+                    $row.find('input[name=translationsum]').val(data.translationsum);
+                }
+            }
+        });
+    }
+
+
+    document.addEventListener('DOMContentLoaded', function () {
+        new ZenEditor();
+    });
+
+})();

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -9,12 +9,8 @@
 
 {% block extra_script %}
 {% compress js %}
-<script defer data-cfasync="false" src="{% static 'editor.js' %}{{ cache_param }}"></script>
-<script type="text/javascript">
-document.addEventListener('DOMContentLoaded', function() {
-    new WLT.editor.Full();
-});
-</script>
+<script defer data-cfasync="false" src="{% static 'editor/base.js' %}{{ cache_param }}"></script>
+<script defer data-cfasync="false" src="{% static 'editor/full.js' %}{{ cache_param }}"></script>
 {% endcompress %}
 {% endblock %}
 

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -10,6 +10,11 @@
 {% block extra_script %}
 {% compress js %}
 <script defer data-cfasync="false" src="{% static 'editor.js' %}{{ cache_param }}"></script>
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+    new FullEditor();
+});
+</script>
 {% endcompress %}
 {% endblock %}
 

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -12,7 +12,7 @@
 <script defer data-cfasync="false" src="{% static 'editor.js' %}{{ cache_param }}"></script>
 <script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function() {
-    new FullEditor();
+    new WLT.editor.Full();
 });
 </script>
 {% endcompress %}

--- a/weblate/templates/zen.html
+++ b/weblate/templates/zen.html
@@ -8,12 +8,8 @@
 
 {% block extra_script %}
 {% compress js %}
-<script defer data-cfasync="false" src="{% static 'editor.js' %}{{ cache_param }}"></script>
-<script type="text/javascript">
-document.addEventListener('DOMContentLoaded', function() {
-    new WLT.editor.Zen();
-});
-</script>
+<script defer data-cfasync="false" src="{% static 'editor/base.js' %}{{ cache_param }}"></script>
+<script defer data-cfasync="false" src="{% static 'editor/zen.js' %}{{ cache_param }}"></script>
 {% endcompress %}
 {% endblock %}
 

--- a/weblate/templates/zen.html
+++ b/weblate/templates/zen.html
@@ -9,6 +9,11 @@
 {% block extra_script %}
 {% compress js %}
 <script defer data-cfasync="false" src="{% static 'editor.js' %}{{ cache_param }}"></script>
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+    new ZenEditor();
+});
+</script>
 {% endcompress %}
 {% endblock %}
 

--- a/weblate/templates/zen.html
+++ b/weblate/templates/zen.html
@@ -11,7 +11,7 @@
 <script defer data-cfasync="false" src="{% static 'editor.js' %}{{ cache_param }}"></script>
 <script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function() {
-    new ZenEditor();
+    new WLT.editor.Zen();
 });
 </script>
 {% endcompress %}


### PR DESCRIPTION
* Avoids polluting the global namespace
* Makes the distinction between full & zen modes more explicit (more to come)

@nijel I ignore what's the set of browsers Weblate is meant to support, so I kept on using ES5 language features.