### PR TITLE
fix: fix widget image 404 bug

### DIFF
--- a/weblate/templates/snippets/project-nav.html
+++ b/weblate/templates/snippets/project-nav.html
@@ -136,11 +136,11 @@
         {% trans "Share" %} <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
-    {% with object.get_share_url as share_url and object.get_widgets_url as widgets_url %}
+    {% with object.get_share_url as share_url %}
         <li><a href="https://www.facebook.com/sharer.php?u={{ share_url }}">{% trans "Share on Facebook" %}</a></li>
         <li><a href="https://twitter.com/share?text={% blocktrans %}Translate {{ object }} using %23Weblate at {{ share_url }}!{% endblocktrans %}">{% trans "Tweet this translation" %}</a></li>
         <li><a href="{% url 'engage' project=object.slug %}">{% trans "Engage page" %}</a></li>
-        <li><a href="{{ widgets_url }}">{% trans "Status widgets" %}</a></li>
+        <li><a href="{% url 'widgets' project=object.slug %}">{% trans "Status widgets" %}</a></li>
     {% endwith %}
         </ul>
     </li>

--- a/weblate/trans/views/widgets.py
+++ b/weblate/trans/views/widgets.py
@@ -81,7 +81,9 @@ def widgets(request, project):
             if component is not None:
                 kwargs["component"] = component
             color_url = reverse("widget-image", kwargs=kwargs)
-            color_list.append({"name": color, "url": request.build_absolute_uri(color_url)})
+            color_list.append(
+                {"name": color, "url": request.build_absolute_uri(color_url)}
+            )
         widget_list.append(
             {"name": widget_name, "colors": color_list, "verbose": widget_class.verbose}
         )

--- a/weblate/trans/views/widgets.py
+++ b/weblate/trans/views/widgets.py
@@ -57,7 +57,7 @@ def widgets(request, project):
     kwargs = {"project": obj.slug}
     if lang is not None:
         kwargs["lang"] = lang
-    engage_url = get_site_url(reverse("engage", kwargs=kwargs))
+    engage_url = request.build_absolute_uri(reverse("engage", kwargs=kwargs))
     engage_url_track = "{0}?utm_source=widget".format(engage_url)
     engage_link = mark_safe(
         '<a href="{0}" id="engage-link">{0}</a>'.format(escape(engage_url))
@@ -81,7 +81,7 @@ def widgets(request, project):
             if component is not None:
                 kwargs["component"] = component
             color_url = reverse("widget-image", kwargs=kwargs)
-            color_list.append({"name": color, "url": get_site_url(color_url)})
+            color_list.append({"name": color, "url": request.build_absolute_uri(color_url)})
         widget_list.append(
             {"name": widget_name, "colors": color_list, "verbose": widget_class.verbose}
         )


### PR DESCRIPTION
When starting with `localhost:8080`, the widget image is not found, this may be because the `get_site_url` function cannot get the port number, in `widgets.py`, i think should use `request.build_absolute_uri` function, so why use `get_site_url` function?
![Screenshot from 2020-05-29 22-42-13](https://user-images.githubusercontent.com/16129206/83272492-c9a43080-a1fd-11ea-9d84-7bf846d59abb.png)
