### PR TITLE
Editor: move remaining code to full mode

### DIFF
--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -105,7 +105,7 @@ WLT.Editor = (function () {
 
     EditorBase.prototype.init = function() {
         /* Autosizing */
-        autosize($('.translation-editor'));
+        autosize(this.$translationArea);
     };
 
     EditorBase.prototype.initHighlight = function () {

--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -233,16 +233,6 @@ WLT.Editor = (function () {
         }
     });
 
-    /* Report source bug */
-    $('.bug-comment').click(function () {
-        $('.translation-tabs a[href="#comments"]').tab('show');
-        $("#id_scope").val("report");
-        $([document.documentElement, document.body]).animate({
-            scrollTop: $('#comment-form').offset().top
-        }, 1000);
-        $("#id_comment").focus();
-    });
-
     // end TODO: move to non-zen editor
 
     return {

--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -31,8 +31,6 @@ WLT.Utils = (function () {
 WLT.Editor = (function () {
     var lastEditor = null;
 
-    var $document = $(document);
-
     function EditorBase() {
         var translationAreaSelector =  '.translation-editor';
 

--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -203,38 +203,6 @@ WLT.Editor = (function () {
         autosize.update(editor);
     }
 
-
-    // TODO: move to editor
-
-    /* Translate forms persistence */
-    if ($('.translation-form').length > 0 && window.localStorage && window.localStorage.translation_autosave) {
-        var translationRestore = JSON.parse(window.localStorage.translation_autosave);
-
-        $.each(translationRestore, function () {
-            var target = $('#' + this.id);
-
-            if (target.length > 0) {
-                target.val(this.value);
-                autosize.update(target);
-            }
-        });
-        localStorage.removeItem('translation_autosave');
-    }
-
-    $('.auto-save-translation').on('submit', function () {
-        if (window.localStorage) {
-            let data = $('.translation-editor').map(function () {
-                var $this = $(this);
-
-                return {id: $this.attr('id'), value: $this.val()};
-            });
-
-            window.localStorage.translation_autosave = JSON.stringify(data.get());
-        }
-    });
-
-    // end TODO: move to non-zen editor
-
     return {
         Base: EditorBase,
     };

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -7,6 +7,8 @@
     function FullEditor() {
         EditorBase.call(this);
 
+        var self = this;
+
         // TODO: leverage this.$editor where possible
         this.initTabs();
         this.initChecks();
@@ -25,7 +27,7 @@
         Mousetrap.bindGlobal(
             'mod+e',
             function(e) {
-                $('.translation-editor').get(0).focus();
+                self.$translationArea.get(0).focus();
                 return false;
             }
         );
@@ -139,6 +141,8 @@
             return;
         }
 
+        var self = this;
+
         /* Check ignoring */
         $('.check-dismiss').click(function () {
             var $this = $(this);
@@ -165,7 +169,7 @@
         /* Check fix */
         $('[data-check-fixup]').click(function (e) {
             var fixups = $(this).data('check-fixup');
-            $('.translation-editor').each(function () {
+            self.$translationArea.each(function () {
                 var $this = $(this);
                 $.each(fixups, function (key, value) {
                     var re = new RegExp(value[0], value[2]);
@@ -250,7 +254,7 @@
                         $('#glossary-words').html(data.results);
                         form.find('[name=words]').attr('value', data.words);
                     }
-                    $('.translation-editor:first').focus();
+                    self.$translationArea.first().focus();
                     form.trigger('reset');
                 },
                 error: function (xhr, textStatus, errorThrown) {
@@ -297,6 +301,7 @@
         }
     }
 
+    // TODO: move some logic to the class so that $translationArea can be reused
     function processMachineTranslation(data, scope) {
         decreaseLoading(scope);
         if (data.responseStatus !== 200) {

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -65,6 +65,8 @@
     FullEditor.prototype.constructor = FullEditor;
 
     FullEditor.prototype.initTranslationForm = function () {
+        var self = this;
+
         this.$translationForm = $('.translation-form');
 
         /* Report source bug */
@@ -75,6 +77,37 @@
                 scrollTop: $('#comment-form').offset().top
             }, 1000);
             $("#id_comment").focus();
+        });
+
+
+        /* Form persistence. Restores translation form upon comment submission */
+        if (window.localStorage && window.localStorage.translation_autosave) {
+            var translationRestore = JSON.parse(window.localStorage.translation_autosave);
+
+            $.each(translationRestore, function () {
+                var target = $('#' + this.id);
+
+                if (target.length > 0) {
+                    target.val(this.value);
+                    autosize.update(target);
+                }
+            });
+            localStorage.removeItem('translation_autosave');
+        }
+
+        this.$editor.on('submit', '.auto-save-translation', function () {
+            if (window.localStorage) {
+                var data = self.$translationArea.map(function () {
+                    var $this = $(this);
+
+                    return {
+                        id: $this.attr('id'),
+                        value: $this.val(),
+                    };
+                });
+
+                window.localStorage.translation_autosave = JSON.stringify(data.get());
+            }
         });
     };
 

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -86,11 +86,10 @@
         if (restoreValue !== null) {
             var translationRestore = JSON.parse(restoreValue);
 
-            $.each(translationRestore, function () {
-                var target = $('#' + this.id);
-
-                if (target.length > 0) {
-                    target.val(this.value);
+            translationRestore.forEach(function (restoreArea) {
+                var target = document.getElementById(restoreArea.id);
+                if (target) {
+                    target.value = restoreArea.value;
                     autosize.update(target);
                 }
             });

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -81,8 +81,10 @@
 
 
         /* Form persistence. Restores translation form upon comment submission */
-        if (window.localStorage.translation_autosave) {
-            var translationRestore = JSON.parse(window.localStorage.translation_autosave);
+        var restoreKey = 'translation_autosave';
+        var restoreValue = window.localStorage.getItem(restoreKey);
+        if (restoreValue !== null) {
+            var translationRestore = JSON.parse(restoreValue);
 
             $.each(translationRestore, function () {
                 var target = $('#' + this.id);
@@ -92,7 +94,7 @@
                     autosize.update(target);
                 }
             });
-            localStorage.removeItem('translation_autosave');
+            localStorage.removeItem(restoreKey);
         }
 
         this.$editor.on('submit', '.auto-save-translation', function () {
@@ -105,7 +107,7 @@
                 };
             });
 
-            window.localStorage.translation_autosave = JSON.stringify(data.get());
+            window.localStorage.setItem(restoreKey, JSON.stringify(data.get()));
         });
     };
 

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -8,6 +8,7 @@
 
         var self = this;
 
+        this.initTranslationForm();
         this.initTabs();
         this.initChecks();
         this.initGlossary();
@@ -62,6 +63,20 @@
     }
     FullEditor.prototype = Object.create(EditorBase.prototype);
     FullEditor.prototype.constructor = FullEditor;
+
+    FullEditor.prototype.initTranslationForm = function () {
+        this.$translationForm = $('.translation-form');
+
+        /* Report source bug */
+        this.$translationForm.on('click', '.bug-comment', function () {
+            $('.translation-tabs a[href="#comments"]').tab('show');
+            $("#id_scope").val("report");
+            $([document.documentElement, document.body]).animate({
+                scrollTop: $('#comment-form').offset().top
+            }, 1000);
+            $("#id_comment").focus();
+        });
+    };
 
     FullEditor.prototype.initTabs = function () {
         this.isMTLoaded = false;

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -81,7 +81,7 @@
 
 
         /* Form persistence. Restores translation form upon comment submission */
-        if (window.localStorage && window.localStorage.translation_autosave) {
+        if (window.localStorage.translation_autosave) {
             var translationRestore = JSON.parse(window.localStorage.translation_autosave);
 
             $.each(translationRestore, function () {
@@ -96,18 +96,16 @@
         }
 
         this.$editor.on('submit', '.auto-save-translation', function () {
-            if (window.localStorage) {
-                var data = self.$translationArea.map(function () {
-                    var $this = $(this);
+            var data = self.$translationArea.map(function () {
+                var $this = $(this);
 
-                    return {
-                        id: $this.attr('id'),
-                        value: $this.val(),
-                    };
-                });
+                return {
+                    id: $this.attr('id'),
+                    value: $this.val(),
+                };
+            });
 
-                window.localStorage.translation_autosave = JSON.stringify(data.get());
-            }
+            window.localStorage.translation_autosave = JSON.stringify(data.get());
         });
     };
 

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -1,7 +1,6 @@
 (function () {
     var EditorBase = WLT.Editor.Base;
 
-    var $document = $(document);
     var $window = $(window);
 
     function FullEditor() {
@@ -9,7 +8,6 @@
 
         var self = this;
 
-        // TODO: leverage this.$editor where possible
         this.initTabs();
         this.initChecks();
         this.initGlossary();
@@ -76,7 +74,7 @@
         });
 
         /* Machine translation */
-        $document.on('show.bs.tab', '[data-load="mt"]', function (e) {
+        this.$editor.on('show.bs.tab', '[data-load="mt"]', function (e) {
             if (this.isMTLoaded) {
                 return;
             }
@@ -91,7 +89,7 @@
         });
 
         /* Translation memory */
-        $document.on('show.bs.tab', '[data-load="memory"]', function (e) {
+        this.$editor.on('show.bs.tab', '[data-load="memory"]', function (e) {
             if (this.isTMLoaded) {
                 return;
             }
@@ -218,7 +216,7 @@
         });
 
         /* Clicking links (e.g. comments, suggestions) */
-        $document.on('click', '.check [data-toggle="tab"]', function (e) {
+        this.$editor.on('click', '.check [data-toggle="tab"]', function (e) {
             var href = $(this).attr('href');
 
             e.preventDefault();
@@ -231,7 +229,7 @@
         var self = this;
 
         /* Copy from glossary */
-        $document.on('click', '.glossary-embed', function (e) {
+        this.$editor.on('click', '.glossary-embed', function (e) {
             var text = $(this).find('.target').text();
 
             self.insertIntoTranslation(text);


### PR DESCRIPTION
* Moves all remaining code to full mode (bug reporting, translation area persistence)
* Reuses jQuery objects as much as possible
* Binds events to `$editor` when possible
* `localStorage`-related cleanups