### PR TITLE
"String translated in the past" warning enhancement

### DIFF
--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -103,8 +103,7 @@ class TranslatedCheck(TargetCheck):
         target = self.check_target_unit(unit.source, unit.target, unit)
         return (
             _(
-                'This string has been translated in the past. \
-                Last Translation was "%s"'
+                'This string has been translated in the past, last translation was "%s"'
             )
             % target
         )

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -95,12 +95,19 @@ class TranslatedCheck(TargetCheck):
 
     check_id = "translated"
     name = _("Has been translated")
-    description = ""
+    description = _("This string has been translated in the past")
     ignore_untranslated = False
 
     def get_description(self, check=None):
         unit = check.unit
-        self.check_target_unit(unit.source, unit.target, unit)
+        target = self.check_target_unit(unit.source, unit.target, unit)
+        self.description = (
+            _(
+                'This string has been translated in the past. \
+                Last Translation was "%s"'
+            )
+            % target
+        )
         return self.description
 
     def check_target_unit(self, sources, targets, unit):
@@ -114,16 +121,9 @@ class TranslatedCheck(TargetCheck):
 
         changes = unit.change_set.filter(action__in=states).order()
 
-        for action in changes.values_list("action", flat=True):
+        for action, target in changes.values_list("action", "target"):
             if action in Change.ACTIONS_CONTENT:
-                self.description = (
-                    _(
-                        'This string has been translated in the past. \
-                                Last Translation was "%s"'
-                    )
-                    % changes.latest("timestamp").target
-                )
-                return True
+                return target
             if action == Change.ACTION_SOURCE_CHANGE:
                 break
 

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -101,14 +101,13 @@ class TranslatedCheck(TargetCheck):
     def get_description(self, check=None):
         unit = check.unit
         target = self.check_target_unit(unit.source, unit.target, unit)
-        description = (
+        return (
             _(
                 'This string has been translated in the past. \
                 Last Translation was "%s"'
             )
             % target
         )
-        return description
 
     def check_target_unit(self, sources, targets, unit):
         if unit.translated:

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -98,7 +98,7 @@ class TranslatedCheck(TargetCheck):
     description = ""
     ignore_untranslated = False
 
-    def get_description(self, check):
+    def get_description(self, check=None):
         unit = check.unit
         self.check_target_unit(unit.source, unit.target, unit)
         return self.description

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -95,7 +95,6 @@ class TranslatedCheck(TargetCheck):
 
     check_id = "translated"
     name = _("Has been translated")
-    description = _("This string has been translated in the past")
     ignore_untranslated = False
 
     def check_target_unit(self, sources, targets, unit):
@@ -111,6 +110,12 @@ class TranslatedCheck(TargetCheck):
 
         for action in changes.values_list("action", flat=True):
             if action in Change.ACTIONS_CONTENT:
+                self.description = (
+                    _(
+                        'This string has been translated in the past. Last Translation was "%s"'
+                    )
+                    % changes.latest("timestamp").target
+                )
                 return True
             if action == Change.ACTION_SOURCE_CHANGE:
                 break

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -101,14 +101,14 @@ class TranslatedCheck(TargetCheck):
     def get_description(self, check=None):
         unit = check.unit
         target = self.check_target_unit(unit.source, unit.target, unit)
-        self.description = (
+        description = (
             _(
                 'This string has been translated in the past. \
                 Last Translation was "%s"'
             )
             % target
         )
-        return self.description
+        return description
 
     def check_target_unit(self, sources, targets, unit):
         if unit.translated:

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -95,7 +95,13 @@ class TranslatedCheck(TargetCheck):
 
     check_id = "translated"
     name = _("Has been translated")
+    description = ""
     ignore_untranslated = False
+
+    def get_description(self, check):
+        unit = check.unit
+        self.check_target_unit(unit.source, unit.target, unit)
+        return self.description
 
     def check_target_unit(self, sources, targets, unit):
         if unit.translated:

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -112,7 +112,8 @@ class TranslatedCheck(TargetCheck):
             if action in Change.ACTIONS_CONTENT:
                 self.description = (
                     _(
-                        'This string has been translated in the past. Last Translation was "%s"'
+                        'This string has been translated in the past. \
+                                Last Translation was "%s"'
                     )
                     % changes.latest("timestamp").target
                 )

--- a/weblate/locale/django.pot
+++ b/weblate/locale/django.pot
@@ -2098,7 +2098,7 @@ msgid "Has been translated"
 msgstr ""
 
 #: weblate/checks/consistency.py:98
-msgid "This string has been translated in the past. Last Translation was \"%s\""
+msgid "This string has been translated in the past"
 msgstr ""
 
 #: weblate/checks/duplicate.py:42

--- a/weblate/locale/django.pot
+++ b/weblate/locale/django.pot
@@ -2098,7 +2098,7 @@ msgid "Has been translated"
 msgstr ""
 
 #: weblate/checks/consistency.py:98
-msgid "This string has been translated in the past"
+msgid "This string has been translated in the past. Last Translation was \"%s\""
 msgstr ""
 
 #: weblate/checks/duplicate.py:42


### PR DESCRIPTION
The string "This string has been translated in the past" changed to "This string has been translated in the past. Last translation was %s".
