### PR TITLE
Component: Consolidate commit code

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -239,15 +239,6 @@ class BaseAddon:
         else:
             component.delete_alert(self.alert)
 
-    def get_commit_message(self, component):
-        return render_template(
-            component.addon_message,
-            # Compatibility with older
-            hook_name=self.verbose,
-            addon_name=self.verbose,
-            component=component,
-        )
-
     def commit_and_push(self, component, files=None):
         if files is None:
             files = list(
@@ -259,9 +250,11 @@ class BaseAddon:
             files += self.extra_files
         repository = component.repository
         with repository.lock:
-            if repository.needs_commit():
-                repository.commit(self.get_commit_message(component), files=files)
-                component.push_if_needed(None)
+            component.commit_files(
+                template=component.addon_message,
+                extra_context={"addon_name": self.verbose},
+                files=files,
+            )
 
     def render_repo_filename(self, template, translation):
         component = translation.component

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -216,5 +216,8 @@ class GitSquashAddon(BaseAddon):
             method(component, repository)
             # Commit any left files, those were most likely generated
             # by addon and do not exactly match patterns above
-            if repository.needs_commit():
-                repository.commit(self.get_commit_message(component))
+            component.commit_files(
+                template=component.addon_message,
+                extra_context={"addon_name": self.verbose},
+                signals=False,
+            )

--- a/weblate/trans/tests/test_remote.py
+++ b/weblate/trans/tests/test_remote.py
@@ -23,7 +23,6 @@ import shutil
 from unittest import SkipTest
 
 from django.db import transaction
-from django.utils import timezone
 
 from weblate.trans.models import Component
 from weblate.trans.tests.test_views import ViewTestCase
@@ -111,9 +110,7 @@ class MultiRepoTest(ViewTestCase):
 
         # Do changes in first repo
         with transaction.atomic():
-            translation.git_commit(
-                self.request.user, "TEST <test@example.net>", timezone.now()
-            )
+            translation.git_commit(self.request.user, "TEST <test@example.net>")
         self.assertFalse(translation.needs_commit())
         translation.component.do_push(self.request)
 


### PR DESCRIPTION
Reuse the same commit code in component, translation and addons. This
makes the commit behave consistently (for example it properly pushes and
sends signals).

Fixes #3708
Fixes #3707

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
