### PR TITLE
Spelling: Component license

### DIFF
--- a/weblate/templates/mail/component_license_subject.txt
+++ b/weblate/templates/mail/component_license_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Component {{ component }} license changed to {{ target }}{% endblocktrans %}
+{% blocktrans %}The license of the component {{ component }} was changed to {{ target }}{% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
Alternative, The "component" component license changed to.
Would be more in tune with the others?
Edit: Left suggestion.