### PR TITLE
Extends screenshot API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1906,6 +1906,15 @@ Screenshots
     :>json string file_url: URL to download a file; see :http:get:`/api/screenshots/(int:id)/file/`
     :>json array units: link to associated source string information; see :http:get:`/api/units/(int:id)/`
 
+.. http:delete:: /api/screenshots/(int:id)/units/(int:unit_id)
+
+    Remove source string association with screenshot.
+
+    :param id: Screenshot ID
+    :type id: int
+    :param unit_id: Source string unit ID
+    :type id: int
+
 .. http:post:: /api/screenshots/
 
     Creates a new screenshot.
@@ -1918,6 +1927,35 @@ Screenshots
     :>json string component: URL of a related component object
     :>json string file_url: URL to download a file; see :http:get:`/api/screenshots/(int:id)/file/`
     :>json array units: link to associated source string information; see :http:get:`/api/units/(int:id)/`
+
+.. http:patch:: /api/screenshots/(int:id)/
+
+    Edit partial information about screenshot.
+
+    :param id: Screenshot ID
+    :type id: int
+    :>json string name: name of a screenshot
+    :>json string component: URL of a related component object
+    :>json string file_url: URL to download a file; see :http:get:`/api/screenshots/(int:id)/file/`
+    :>json array units: link to associated source string information; see :http:get:`/api/units/(int:id)/`
+
+.. http:put:: /api/screenshots/(int:id)/
+
+    Edit full information about screenshot.
+
+    :param id: Screenshot ID
+    :type id: int
+    :>json string name: name of a screenshot
+    :>json string component: URL of a related component object
+    :>json string file_url: URL to download a file; see :http:get:`/api/screenshots/(int:id)/file/`
+    :>json array units: link to associated source string information; see :http:get:`/api/units/(int:id)/`
+
+.. http:delete:: /api/screenshots/(int:id)/
+
+    Delete screenshot.
+
+    :param id: Screenshot ID
+    :type id: int
 
 
 Component lists

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1911,6 +1911,13 @@ class ScreenshotAPITest(APIBaseTest):
             "api:screenshot-detail",
             kwargs={"pk": Screenshot.objects.get().pk},
             method="patch",
+            code=403,
+            request={"name": "Test New screenshot"},
+        )
+        self.do_request(
+            "api:screenshot-detail",
+            kwargs={"pk": Screenshot.objects.get().pk},
+            method="patch",
             code=200,
             superuser=True,
             request={"name": "Test New screenshot"},
@@ -1926,7 +1933,14 @@ class ScreenshotAPITest(APIBaseTest):
         self.do_request(
             "api:screenshot-detail",
             kwargs={"pk": Screenshot.objects.get().pk},
-            method="patch",
+            method="put",
+            code=403,
+            request=request,
+        )
+        self.do_request(
+            "api:screenshot-detail",
+            kwargs={"pk": Screenshot.objects.get().pk},
+            method="put",
             code=200,
             superuser=True,
             request=request,
@@ -1934,6 +1948,12 @@ class ScreenshotAPITest(APIBaseTest):
         self.assertEqual(Screenshot.objects.get().name, "Test new screenshot")
 
     def test_delete_screenshot(self):
+        self.do_request(
+            "api:screenshot-detail",
+            kwargs={"pk": Screenshot.objects.get().pk},
+            method="delete",
+            code=403,
+        )
         self.do_request(
             "api:screenshot-detail",
             kwargs={"pk": Screenshot.objects.get().pk},
@@ -1976,6 +1996,13 @@ class ScreenshotAPITest(APIBaseTest):
             reverse("api:screenshot-units", kwargs={"pk": Screenshot.objects.get().pk}),
             {"unit_id": unit.pk},
         )
+        response = self.client.delete(
+            reverse(
+                "api:screenshot-delete-units",
+                kwargs={"pk": Screenshot.objects.get().pk, "unit_id": -1},
+            ),
+        )
+        self.assertEqual(response.status_code, 400)
         response = self.client.delete(
             reverse(
                 "api:screenshot-delete-units",

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1206,14 +1206,12 @@ class ScreenshotViewSet(DownloadViewSet, viewsets.ModelViewSet):
 
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
-        request.user.check_access_component(instance.component)
         if not request.user.has_perm("screenshot.edit", instance.component):
             self.permission_denied(request, message="Can not edit screenshot.")
         return super().update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        request.user.check_access_component(instance.component)
         if not request.user.has_perm("screenshot.delete", instance.component):
             self.permission_denied(request, message="Can not delete screenshot.")
         return super().destroy(request, *args, **kwargs)


### PR DESCRIPTION
Closes #3761 

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
