### PR TITLE
Docs: Fix install wlc phrase

### DIFF
--- a/docs/wlc.rst
+++ b/docs/wlc.rst
@@ -64,7 +64,7 @@ Description
 
 Weblate Client is a Python library and command-line utility to manage Weblate remotely
 using :ref:`api`. The command-line utility can be invoked as :command:`wlc` and is
-built on :mod:`wlc`.
+built-in on :mod:`wlc`.
 
 Site wide options
 -----------------

--- a/docs/wlc.rst
+++ b/docs/wlc.rst
@@ -18,7 +18,7 @@ Installation
 ++++++++++++
 
 The Weblate Client is shipped separately and includes the Python module.
-You need to install :mod:`wlc`:, wlc to use these.
+To use the commands below, you need to install :mod:`wlc`:
 
 .. code-block:: sh
 


### PR DESCRIPTION
This proposal changes the rendered text from

> You need to install `wlc`:, wlc to use these.

to

> To use the commands below, you need to install `wlc`:

Notice the ":" misplaced in the currently publish doc.

Before submitting pull request, please ensure that:

- [X] Every commit has a message which describes it
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [X] Any code changes come with test case *(not applicable)*
- [X] Any new functionality is covered by user documentation *(not applicable)*
