### PR TITLE
Docs: Remove duplicate quality word

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -241,7 +241,7 @@ List of quality checks to perform on a translation.
 
 Adjust the list of checks to include ones relevant to you.
 
-All built-in quality :ref:`checks` are turned on by default, from
+All built-in :ref:`checks` are turned on by default, from
 where you can change these settings. By default they are commented out in :ref:`sample-configuration`
 so that default values are used. New checks then carried out for each new Weblate version.
 


### PR DESCRIPTION
'checks' link already is rendered as 'Quality checks', so having 'quality' in the paragraph results in having duplicate quality in the resulting string.

How is the documentation currently:
> All built-in quality [Quality checks](https://docs.weblate.org/pt_BR/latest/user/checks.html#checks) are turned on by default (...)