### PR TITLE
Small doc fixes

### DIFF
--- a/docs/admin/admin.rst
+++ b/docs/admin/admin.rst
@@ -28,7 +28,7 @@ and other settings:
 In the :guilabel:`Reports` section, you can check the status of your site, tweak
 it for :ref:`production`, or manage SSH keys used to access :ref:`vcs-repos`.
 
-Manage database objects in any of the sections below.
+Manage database objects under any of the sections.
 The most interesting one is probably :guilabel:`Weblate translations`,
 where you can manage translatable projects, see :ref:`project` and :ref:`component`.
 

--- a/docs/admin/auth.rst
+++ b/docs/admin/auth.rst
@@ -17,10 +17,10 @@ The authentication attempts are subject to :ref:`rate-limit`.
 Authentication backends
 -----------------------
 
-The inbuilt solution of Django is used for authentication,
+The built-in solution of Django is used for authentication,
 including various social options to do so.
-Using it means you can import the user database of other Django based projects (see
-:ref:`pootle-migration`).
+Using it means you can import the user database of other Django-based projects
+(see :ref:`pootle-migration`).
 
 Django can additionally be set up to authenticate against other means too.
 
@@ -64,7 +64,7 @@ to properly credit contributions users make.
 OpenID authentication
 ~~~~~~~~~~~~~~~~~~~~~
 
-For OpenID based services it's usually just a matter of enabling them. The following
+For OpenID-based services it's usually just a matter of enabling them. The following
 section enables OpenID authentication for OpenSUSE, Fedora and Ubuntu:
 
 .. code-block:: python
@@ -242,7 +242,7 @@ Weblate can be configured to use common or specific tenants for authentication.
 
 The redirect URL is ``https://WEBLATE SERVER/accounts/complete/azuread-oauth2/``
 for common and ``https://WEBLATE SERVER/accounts/complete/azuread-tenant-oauth2/``
-for tenant specific authentication.
+for tenant-specific authentication.
 
 .. code-block:: python
 


### PR DESCRIPTION
* `admin/admin.rst`: sections below -> sections above, see commit message:
> The paragraph uses 'sections below', using as an example
    'Weblate translations'.  However, this and other sections
    are found only in one of this page's screenshots which can
    be found ABOVE, not BELOW, this paragraph.
    Therefore, use 'above' to fix the reference's direction.

* `admin/auth.rst`: spelling fixes:
> 'inbuilt' -> 'built-in'
    'Django based project' -> 'Django-based project'
    'OpenID based services' -> 'OpenID-based services'
    'tenant specific' -> tenant-specific'
