### PR TITLE
Fix: Limit number of components displayed on translations overview page

### DIFF
--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -186,7 +186,7 @@
   <div class="panel-heading"><h4 class="panel-title">{% trans "Other components" %}</h4></div>
 {% include "snippets/list-objects.html" with objects=other_translations name_source="component_name" label=_("Component") in_panel=True %}
   <div class="panel-footer">
-    <a href="{% url 'project-language' lang=object.language.code project=object.component.project.slug %}">See all components</a>
+    <a href="{% url 'project-language' lang=object.language.code project=object.component.project.slug %}">{% trans "Browse all components" %}</a>
   </div>
 </div>
 {% endif %}

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -185,6 +185,9 @@
 <div class="panel panel-default">
   <div class="panel-heading"><h4 class="panel-title">{% trans "Other components" %}</h4></div>
 {% include "snippets/list-objects.html" with objects=other_translations name_source="component_name" label=_("Component") in_panel=True %}
+  <div class="panel-footer">
+    <a href="{% url 'project-language' lang=object.language.code project=object.component.project.slug %}">See all components</a>
+  </div>
 </div>
 {% endif %}
 

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -317,8 +317,7 @@ def show_translation(request, project, component, lang):
 
     # Limit the number of other components displayed to 10, preferring untranslated ones
     other_translations = sorted(
-        other_translations,
-        key=lambda t : t.stats.translated_percent
+        other_translations, key=lambda t: t.stats.translated_percent
     )[:10]
 
     return render(

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -315,6 +315,9 @@ def show_translation(request, project, component, lang):
         if test_component.can_add_new_language(user):
             other_translations.append(GhostTranslation(test_component, obj.language))
 
+    # Limit the number of other components displayed to 10, preferring untranslated ones
+    other_translations = sorted(other_translations, key=lambda t : t.stats.translated_percent)[:10]
+
     return render(
         request,
         "translation.html",

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -306,7 +306,7 @@ def show_translation(request, project, component, lang):
     )
 
     # Include ghost translations for other components, this
-    # adds quick way to create transaltions in other components
+    # adds quick way to create translations in other components
     existing = {translation.component.slug for translation in other_translations}
     existing.add(obj.component.slug)
     for test_component in obj.component.project.component_set.filter_access(

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -316,7 +316,10 @@ def show_translation(request, project, component, lang):
             other_translations.append(GhostTranslation(test_component, obj.language))
 
     # Limit the number of other components displayed to 10, preferring untranslated ones
-    other_translations = sorted(other_translations, key=lambda t : t.stats.translated_percent)[:10]
+    other_translations = sorted(
+        other_translations,
+        key=lambda t : t.stats.translated_percent
+    )[:10]
 
     return render(
         request,


### PR DESCRIPTION
Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation

Here is my fix to #4220, which does the following:
1. Limit the number of "Other components" displayed to 10, preferring untranslated ones
2. Template: Add a link to the full list of components