### PR TITLE
Update venv-debian.rst

### DIFF
--- a/docs/admin/install/venv-debian.rst
+++ b/docs/admin/install/venv-debian.rst
@@ -28,8 +28,8 @@ Installing on Debian and Ubuntu
     # Web server option 2: Apache with ``mod_wsgi``
     apt install apache2 libapache2-mod-wsgi
 
-    # Caching backend: Redis
-    apt install redis-server
+    # Caching backend: Redis and Rabbitmq
+    apt install redis-server rabbitmq-server
 
     # Database server: PostgreSQL
     apt install postgresql postgresql-contrib


### PR DESCRIPTION
rabbitmq  was  missing, leading to many memory logs, celery defaulted  to 
amqp://guest:**@127.0.0.1:5672//
instead of using redis

Before submitting pull request, please ensure that:

- [ ] Every commit has a message which describes it
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with test case
- [ ] Any new functionality is covered by user documentation
