### PR TITLE
skip strings with empty source for "other occurrences"

### DIFF
--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -109,6 +109,7 @@ def get_other_units(unit):
             translation__component__project=translation.component.project,
             translation__language=translation.language,
         )
+        .exclude(source="")
         .filter(query)
     )
 


### PR DESCRIPTION
this happens for translation types where source can be empty like "gettext PO file (monolingual)"

Signed-Off-By: Matthias Blümel <matthias.bluemel@krumedia.com>

Before submitting pull request, please ensure that:

- [X] Every commit has a message which describes it
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with test case

It's probaly better to filter them in the lines above but I don't know how