### PR TITLE
fix: wrong time hint in chinese

### DIFF
--- a/weblate/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/weblate/locale/zh_Hans/LC_MESSAGES/django.po
@@ -5155,7 +5155,7 @@ msgstr "请登录以开始新翻译"
 #: weblate/templates/component.html:156
 #, python-format
 msgid "Appeared %(first)s, last seen %(last)s"
-msgstr "%(first)s天前出现，最后露面%(last)s天前"
+msgstr "%(first)s出现，最后露面%(last)s"
 
 #: weblate/templates/component.html:160
 #: weblate/templates/manage/performance.html:42


### PR DESCRIPTION
The time hit in english is `Appeared %(first)s, last seen %(last)s`, it's right.

But the wrong translate appear in chinese, what seems like 

>14 小时前天前出现，最后露面12 小时前天前

It's so funny