### PR TITLE
fix: wrong Puctuation class name to Punctuation

### DIFF
--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -385,7 +385,7 @@ class KashidaCheck(TargetCheck):
         return [("[{}]".format("".join(KASHIDA_CHARS)), "", "gu")]
 
 
-class PuctuationSpacingCheck(TargetCheck):
+class PunctuationSpacingCheck(TargetCheck):
     check_id = "punctuation_spacing"
     name = _("Punctuation spacing")
     description = _("Missing non breakable space before double punctuation sign")

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -63,7 +63,7 @@ class WeblateChecksConf(AppConf):
         "weblate.checks.chars.EndSemicolonCheck",
         "weblate.checks.chars.MaxLengthCheck",
         "weblate.checks.chars.KashidaCheck",
-        "weblate.checks.chars.PuctuationSpacingCheck",
+        "weblate.checks.chars.PunctuationSpacingCheck",
         "weblate.checks.format.PythonFormatCheck",
         "weblate.checks.format.PythonBraceFormatCheck",
         "weblate.checks.format.PHPFormatCheck",

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -38,7 +38,7 @@ from weblate.checks.chars import (
     KashidaCheck,
     MaxLengthCheck,
     NewLineCountCheck,
-    PuctuationSpacingCheck,
+    PunctuationSpacingCheck,
     ZeroWidthSpaceCheck,
 )
 from weblate.checks.tests.test_checks import CheckTestCase, MockUnit
@@ -314,8 +314,8 @@ class KashidaCheckTest(CheckTestCase):
         self.test_failure_3 = ("string", "string\uFE7F", "")
 
 
-class PuctuationSpacingCheckTest(CheckTestCase):
-    check = PuctuationSpacingCheck()
+class PunctuationSpacingCheckTest(CheckTestCase):
+    check = PunctuationSpacingCheck()
     default_lang = "fr"
 
     def setUp(self):

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -886,7 +886,7 @@ CHECK_LIST = [
     "weblate.checks.chars.EndSemicolonCheck",
     "weblate.checks.chars.MaxLengthCheck",
     "weblate.checks.chars.KashidaCheck",
-    "weblate.checks.chars.PuctuationSpacingCheck",
+    "weblate.checks.chars.PunctuationSpacingCheck",
     "weblate.checks.format.PythonFormatCheck",
     "weblate.checks.format.PythonBraceFormatCheck",
     "weblate.checks.format.PHPFormatCheck",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -674,7 +674,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 #     "weblate.checks.chars.EndSemicolonCheck",
 #     "weblate.checks.chars.MaxLengthCheck",
 #     "weblate.checks.chars.KashidaCheck",
-#     "weblate.checks.chars.PuctuationSpacingCheck",
+#     "weblate.checks.chars.PunctuationSpacingCheck",
 #     "weblate.checks.format.PythonFormatCheck",
 #     "weblate.checks.format.PythonBraceFormatCheck",
 #     "weblate.checks.format.PHPFormatCheck",


### PR DESCRIPTION
A little spell bug, the right spell `Punctuation`  has occurred [here](https://github.com/em0t/weblate/blob/2b99426d55bac2387809e88fc56aaf178c5fd836/weblate/checks/chars.py#L389)