### PR TITLE
Docker: Fix WEBLATE_ADD_LOGIN_REQUIRED_URLS_EXCEPTIONS crashing weblate

### DIFF
--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1061,7 +1061,7 @@ if REQUIRE_LOGIN:
 # In such case you will want to include some of the exceptions
 LOGIN_REQUIRED_URLS_EXCEPTIONS = get_env_list(
     "WEBLATE_LOGIN_REQUIRED_URLS_EXCEPTIONS",
-    (
+    [
         rf"{URL_PREFIX}/accounts/(.*)$",  # Required for login
         rf"{URL_PREFIX}/admin/login/(.*)$",  # Required for admin login
         rf"{URL_PREFIX}/static/(.*)$",  # Required for development mode
@@ -1073,7 +1073,7 @@ LOGIN_REQUIRED_URLS_EXCEPTIONS = get_env_list(
         rf"{URL_PREFIX}/js/i18n/$",  # Javascript localization
         rf"{URL_PREFIX}/contact/$",  # Optional for contact form
         rf"{URL_PREFIX}/legal/(.*)$",  # Optional for legal app
-    ),
+    ],
 )
 modify_env_list(LOGIN_REQUIRED_URLS_EXCEPTIONS, "LOGIN_REQUIRED_URLS_EXCEPTIONS")
 


### PR DESCRIPTION
Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with test case
- [x] Any new functionality is covered by user documentation

The default value of `LOGIN_REQUIRED_URLS_EXCEPTIONS` is an immutable tuple, which makes it impossible to be changed by `modify_env_list` regarding `WEBLATE_ADD_LOGIN_REQUIRED_URLS_EXCEPTIONS`. Changing it to a mutable list fixes the bug below.

**Describe the bug**
Setting `WEBLATE_ADD_LOGIN_REQUIRED_URLS_EXCEPTIONS` in `docker-compose.override.yml` makes weblate unable to start. 
**To Reproduce**
Follow steps in https://docs.weblate.org/en/latest/admin/install/docker.html
Set `WEBLATE_ADD_LOGIN_REQUIRED_URLS_EXCEPTIONS` to some value in `docker-compose.override.yml`.
Run `docker-compose up`.
**Exception traceback**
```
weblate_1   | Traceback (most recent call last):                                                                                                                              
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/weblate/runner.py", line 32, in main                                                                             
weblate_1   |     execute_from_command_line(argv)                                                                                                                             
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/django/core/management/__init__.py", line 401, in execute_from_command_line                                      
weblate_1   |     utility.execute()                                                                                                                                           
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/django/core/management/__init__.py", line 345, in execute                                                        
weblate_1   |     settings.INSTALLED_APPS                                                                                                                                     
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/django/conf/__init__.py", line 76, in __getattr__                                                                
weblate_1   |     self._setup(name)                                                                                                                                           
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/django/conf/__init__.py", line 63, in _setup                                                                     
weblate_1   |     self._wrapped = Settings(settings_module)                                                                                                                   
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/django/conf/__init__.py", line 142, in __init__                                                                  
weblate_1   |     mod = importlib.import_module(self.SETTINGS_MODULE)                                                                                                         
weblate_1   |   File "/usr/lib/python3.7/importlib/__init__.py", line 127, in import_module                                                                                   
weblate_1   |     return _bootstrap._gcd_import(name[level:], package, level)                                                                                                 
weblate_1   |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import                                                                                               
weblate_1   |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load                                                                                             
weblate_1   |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked                                                                                    
weblate_1   |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked                                                                                             
weblate_1   |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module                                                                                       
weblate_1   |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed                                                                                  
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/weblate/settings_docker.py", line 1056, in <module>                                                              
weblate_1   |     modify_env_list(LOGIN_REQUIRED_URLS_EXCEPTIONS, "LOGIN_REQUIRED_URLS_EXCEPTIONS")                                                                           
weblate_1   |   File "/usr/local/lib/python3.7/dist-packages/weblate/utils/environment.py", line 60, in modify_env_list                                                       
weblate_1   |     current.insert(0, item)                                                                                                                                     
weblate_1   | AttributeError: 'tuple' object has no attribute 'insert'
```
