### PR TITLE
Files: Return a filtered component view for zip file download requests

### DIFF
--- a/weblate/trans/views/files.py
+++ b/weblate/trans/views/files.py
@@ -86,11 +86,8 @@ def download_component(request, project, component):
 
 def download_project(request, project):
     obj = get_project(request, project)
+    obj.commit_pending("download", None)
     components = obj.component_set.filter_access(request.user)
-    if not components:
-        raise PermissionDenied()
-    for component in components:
-        component.commit_pending("download", None)
     return download_multi(
         Translation.objects.filter(component__in=components), request.GET.get("format")
     )
@@ -98,12 +95,9 @@ def download_project(request, project):
 
 def download_lang_project(request, lang, project):
     obj = get_project(request, project)
-    components = obj.component_set.filter_access(request.user)
-    if not components:
-        raise PermissionDenied()
-    for component in components:
-        component.commit_pending("download", None)
+    obj.commit_pending("download", None)
     langobj = get_object_or_404(Language, code=lang)
+    components = obj.component_set.filter_access(request.user)
     return download_multi(
         Translation.objects.filter(component__in=components, language=langobj),
         request.GET.get("format"),

--- a/weblate/trans/views/files.py
+++ b/weblate/trans/views/files.py
@@ -86,18 +86,26 @@ def download_component(request, project, component):
 
 def download_project(request, project):
     obj = get_project(request, project)
-    obj.commit_pending("download", None)
+    components = obj.component_set.filter_access(request.user)
+    if not components:
+        raise PermissionDenied()
+    for component in components:
+        component.commit_pending("download", None)
     return download_multi(
-        Translation.objects.filter(component__project=obj), request.GET.get("format")
+        Translation.objects.filter(component__in=components), request.GET.get("format")
     )
 
 
 def download_lang_project(request, lang, project):
     obj = get_project(request, project)
-    obj.commit_pending("download", None)
+    components = obj.component_set.filter_access(request.user)
+    if not components:
+        raise PermissionDenied()
+    for component in components:
+        component.commit_pending("download", None)
     langobj = get_object_or_404(Language, code=lang)
     return download_multi(
-        Translation.objects.filter(component__project=obj, language=langobj),
+        Translation.objects.filter(component__in=components, language=langobj),
         request.GET.get("format"),
     )
 


### PR DESCRIPTION
Fixes https://github.com/WeblateOrg/weblate/issues/4491

In addition to this, we should probably be updating weblate/templates/component-list.html to prevent showing the Download button  if no components are visible. I'm not familiar with this framework as to how to do it, though