### PR TITLE
docs: Fix automatic suggestions name

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,7 +15,7 @@ Not yet released.
 * Add Vue I18n formatting check.
 * Generic placeholders check now supports regular expressions.
 * Improved look of matrix mode.
-* Machinery is now called automated suggestions.
+* Machinery is now called automatic suggestions.
 
 Weblate 4.2.2
 -------------


### PR DESCRIPTION
Change "automated suggestions" to "automatic suggestions" to match the rename on aea07a13