### PR TITLE
Generate 4096 bit RSA host key

### DIFF
--- a/weblate/vcs/ssh.py
+++ b/weblate/vcs/ssh.py
@@ -108,6 +108,8 @@ def generate_ssh_key(request):
             [
                 "ssh-keygen",
                 "-q",
+                "-b",
+                "4096",
                 "-N",
                 "",
                 "-C",


### PR DESCRIPTION
Newer GitLab needs a host key with minimun 4096 bit lenth.

