### PR TITLE
Adds support to create components using docfile and zipfile via API

### DIFF
--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -24,7 +24,6 @@ from rest_framework import serializers
 
 from weblate.accounts.models import Subscription
 from weblate.auth.models import Group, Permission, Role, User
-from weblate.formats.models import FILE_FORMATS
 from weblate.glossary.models import Glossary, Term
 from weblate.lang.models import Language, Plural
 from weblate.screenshots.models import Screenshot
@@ -42,7 +41,6 @@ from weblate.trans.util import check_upload_method_permissions, cleanup_repo_url
 from weblate.utils.site import get_site_url
 from weblate.utils.validators import validate_bitmap
 from weblate.utils.views import create_component_from_doc, create_component_from_zip
-from weblate.vcs.git import LocalRepository
 
 
 class MultiFieldHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
@@ -488,11 +486,11 @@ class ComponentSerializer(RemovableSerializer):
                 code=result["source_language"]["code"]
             )
         if "docfile" in result:
-            fake = create_component_from_doc(result)
+            create_component_from_doc(result)
             result.pop("docfile")
         if "zipfile" in result:
             try:
-                fake = create_component_from_zip(result)
+                create_component_from_zip(result)
             except BadZipfile:
                 raise serializers.ValidationError("Failed to parse uploaded ZIP file.")
             result.pop("zipfile")

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -489,20 +489,10 @@ class ComponentSerializer(RemovableSerializer):
             )
         if "docfile" in result:
             fake = create_component_from_doc(result)
-            format_cls = FILE_FORMATS[result["file_format"]]
-            LocalRepository.from_files(
-                fake.full_path,
-                {result["template"]: format_cls.get_new_file_content()},
-            )
             result.pop("docfile")
         if "zipfile" in result:
             try:
                 fake = create_component_from_zip(result)
-                format_cls = FILE_FORMATS[result["file_format"]]
-                LocalRepository.from_files(
-                    fake.full_path,
-                    {result["template"]: format_cls.get_new_file_content()},
-                )
             except BadZipfile:
                 raise serializers.ValidationError("Failed to parse uploaded ZIP file.")
             result.pop("zipfile")

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+import os
+from zipfile import BadZipfile
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
@@ -23,6 +25,7 @@ from rest_framework import serializers
 
 from weblate.accounts.models import Subscription
 from weblate.auth.models import Group, Permission, Role, User
+from weblate.formats.models import FILE_FORMATS
 from weblate.glossary.models import Glossary, Term
 from weblate.lang.models import Language, Plural
 from weblate.screenshots.models import Screenshot
@@ -39,6 +42,7 @@ from weblate.trans.models import (
 from weblate.trans.util import check_upload_method_permissions, cleanup_repo_url
 from weblate.utils.site import get_site_url
 from weblate.utils.validators import validate_bitmap
+from weblate.vcs.git import LocalRepository
 
 
 class MultiFieldHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
@@ -397,6 +401,9 @@ class ComponentSerializer(RemovableSerializer):
 
     serializer_url_field = MultiFieldHyperlinkedIdentityField
 
+    zipfile = serializers.FileField(required=False)
+    docfile = serializers.FileField(required=False)
+
     class Meta:
         model = Component
         fields = (
@@ -450,6 +457,8 @@ class ComponentSerializer(RemovableSerializer):
             "auto_lock_error",
             "language_regex",
             "variant_regex",
+            "zipfile",
+            "docfile",
         )
         extra_kwargs = {
             "url": {
@@ -478,6 +487,52 @@ class ComponentSerializer(RemovableSerializer):
             result["source_language"] = Language.objects.get(
                 code=result["source_language"]["code"]
             )
+        if "docfile" in result:
+            # Create fake component (needed to calculate path)
+            fake = Component(
+                project=result["project"],
+                slug=result["slug"],
+                name=result["name"],
+            )
+
+            # Create repository
+            uploaded = result["docfile"]
+            ext = os.path.splitext(os.path.basename(uploaded.name))[1]
+            format_cls = FILE_FORMATS[result["file_format"]]
+            filename = "{}/{}{}".format(
+                result["slug"],
+                result["source_language"]["code"]
+                if "source_language" in result
+                else "en",
+                ext,
+            )
+            LocalRepository.from_files(
+                fake.full_path,
+                {
+                    filename: uploaded.read(),
+                    result["template"]: format_cls.get_new_file_content(),
+                },
+            )
+            result.pop("docfile")
+        if "zipfile" in result:
+            # Create fake component (needed to calculate path)
+            fake = Component(
+                project=result["project"],
+                slug=result["slug"],
+                name=result["name"],
+            )
+            format_cls = FILE_FORMATS[result["file_format"]]
+
+            # Create repository
+            try:
+                LocalRepository.from_zip(fake.full_path, result["zipfile"])
+                LocalRepository.from_files(
+                    fake.full_path,
+                    {result["template"]: format_cls.get_new_file_content()},
+                )
+            except BadZipfile:
+                raise serializers.ValidationError("Failed to parse uploaded ZIP file.")
+            result.pop("zipfile")
         return result
 
     def validate(self, attrs):

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -46,6 +46,8 @@ from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
 
 TEST_PO = get_test_file("cs.po")
 TEST_POT = get_test_file("hello-charset.pot")
+TEST_DOC = get_test_file("short_description.txt")
+TEST_ZIP = get_test_file("translations.zip")
 TEST_BADPLURALS = get_test_file("cs-badplurals.po")
 TEST_SCREENSHOT = get_test_file("screenshot.png")
 
@@ -1234,6 +1236,54 @@ class ProjectAPITest(APIBaseTest):
             request={"slug": "new-slug"},
         )
         self.assertEqual(response.data["slug"], "new-slug")
+
+    def test_create_component_docfile(self):
+        with open(TEST_DOC, "rb") as handle:
+            response = self.do_request(
+                "api:project-components",
+                self.project_kwargs,
+                method="post",
+                code=201,
+                superuser=True,
+                request={
+                    "docfile": handle,
+                    "name": "Local project",
+                    "slug": "local-project",
+                    "repo": "local:",
+                    "vcs": "local",
+                    "filemask": "*.strings",
+                    "template": "en.strings",
+                    "file_format": "strings-utf8",
+                    "push": "https://username:password@github.com/example/push.git",
+                    "new_lang": "none",
+                },
+            )
+        self.assertEqual(response.data["repo"], "local:")
+        self.assertEqual(Component.objects.count(), 2)
+
+    def test_create_component_zipfile(self):
+        with open(TEST_ZIP, "rb") as handle:
+            response = self.do_request(
+                "api:project-components",
+                self.project_kwargs,
+                method="post",
+                code=201,
+                superuser=True,
+                request={
+                    "zipfile": handle,
+                    "name": "Local project",
+                    "slug": "local-project",
+                    "repo": "local:",
+                    "vcs": "local",
+                    "filemask": "*.strings",
+                    "template": "en.strings",
+                    "file_format": "strings-utf8",
+                    "push": "https://username:password@github.com/example/push.git",
+                    "new_lang": "none",
+                },
+            )
+        self.assertEqual(response.data["repo"], "local:")
+        self.assertEqual(Component.objects.count(), 2)
 
 
 class GlossaryAPITest(APIBaseTest):

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -46,7 +46,7 @@ from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
 
 TEST_PO = get_test_file("cs.po")
 TEST_POT = get_test_file("hello-charset.pot")
-TEST_DOC = get_test_file("short_description.txt")
+TEST_DOC = get_test_file("cs.html")
 TEST_ZIP = get_test_file("translations.zip")
 TEST_BADPLURALS = get_test_file("cs-badplurals.po")
 TEST_SCREENSHOT = get_test_file("screenshot.png")
@@ -1251,11 +1251,11 @@ class ProjectAPITest(APIBaseTest):
                     "slug": "local-project",
                     "repo": "local:",
                     "vcs": "local",
-                    "filemask": "*.strings",
-                    "template": "en.strings",
-                    "file_format": "strings-utf8",
+                    "filemask": "*.html",
+                    "template": "en.html",
+                    "file_format": "html",
                     "push": "https://username:password@github.com/example/push.git",
-                    "new_lang": "none",
+                    "new_lang": "add",
                 },
             )
         self.assertEqual(response.data["repo"], "local:")
@@ -1275,9 +1275,9 @@ class ProjectAPITest(APIBaseTest):
                     "slug": "local-project",
                     "repo": "local:",
                     "vcs": "local",
-                    "filemask": "*.strings",
-                    "template": "en.strings",
-                    "file_format": "strings-utf8",
+                    "filemask": "*.po",
+                    "new_base": "project.pot",
+                    "file_format": "po",
                     "push": "https://username:password@github.com/example/push.git",
                     "new_lang": "none",
                 },

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -639,7 +639,17 @@ class ProjectViewSet(
     def get_queryset(self):
         return self.request.user.allowed_projects.order_by("id")
 
-    @action(detail=True, methods=["get", "post"], serializer_class=ComponentSerializer)
+    @action(
+        detail=True,
+        methods=["get", "post"],
+        parser_classes=(
+            parsers.JSONParser,
+            parsers.MultiPartParser,
+            parsers.FormParser,
+            parsers.FileUploadParser,
+        ),
+        serializer_class=ComponentSerializer,
+    )
     def components(self, request, **kwargs):
         obj = self.get_object()
         if request.method == "POST":

--- a/weblate/trans/views/create.py
+++ b/weblate/trans/views/create.py
@@ -18,7 +18,6 @@
 #
 
 import json
-import os
 import subprocess
 from zipfile import BadZipfile
 
@@ -51,7 +50,7 @@ from weblate.trans.util import get_clean_env
 from weblate.utils import messages
 from weblate.utils.errors import report_error
 from weblate.utils.licenses import LICENSE_URLS
-from weblate.vcs.git import LocalRepository
+from weblate.utils.views import create_component_from_doc, create_component_from_zip
 from weblate.vcs.models import VCS_REGISTRY
 
 
@@ -321,16 +320,8 @@ class CreateFromZip(CreateComponent):
         if self.stage != "init":
             return super().form_valid(form)
 
-        # Create fake component (needed to calculate path)
-        fake = Component(
-            project=form.cleaned_data["project"],
-            slug=form.cleaned_data["slug"],
-            name=form.cleaned_data["name"],
-        )
-
-        # Create repository
         try:
-            LocalRepository.from_zip(fake.full_path, form.cleaned_data["zipfile"])
+            create_component_from_zip(form.cleaned_data)
         except BadZipfile:
             form.add_error("zipfile", _("Failed to parse uploaded ZIP file."))
             return self.form_invalid(form)
@@ -352,22 +343,7 @@ class CreateFromDoc(CreateComponent):
         if self.stage != "init":
             return super().form_valid(form)
 
-        # Create fake component (needed to calculate path)
-        fake = Component(
-            project=form.cleaned_data["project"],
-            slug=form.cleaned_data["slug"],
-            name=form.cleaned_data["name"],
-        )
-
-        # Create repository
-        uploaded = form.cleaned_data["docfile"]
-        ext = os.path.splitext(os.path.basename(uploaded.name))[1]
-        filename = "{}/{}{}".format(
-            form.cleaned_data["slug"],
-            form.cleaned_data["source_language"].code,
-            ext,
-        )
-        LocalRepository.from_files(fake.full_path, {filename: uploaded.read()})
+        create_component_from_doc(form.cleaned_data)
 
         # Move to discover phase
         self.stage = "discover"


### PR DESCRIPTION
Refs #4156 

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
