### PR TITLE
Fix small typos

### DIFF
--- a/weblate/checks/management/commands/list_checks.py
+++ b/weblate/checks/management/commands/list_checks.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             is_format = isinstance(check, BaseFormatCheck)
             if not is_format and lines:
                 self.flush_lines(lines)
-            # Output immediatelly
+            # Output immediately
             self.stdout.write(".. _{}:\n".format(check.doc_id))
             if not lines:
                 lines.append("\n")

--- a/weblate/templates/trans/alert/duplicatelanguage.html
+++ b/weblate/templates/trans/alert/duplicatelanguage.html
@@ -10,7 +10,7 @@
     <ul>
     <li>{% trans "In case the translation to the source language is desired, please change the source language in the component settings." %} {% documentation_icon "admin/projects" "component-source_language" %}</li>
     <li>{% trans "In case the translation file for the source language is not needed, please remove it from the repository." %}</li>
-    <li>{% trans "In case the translation file for the source language is needed, but shoud be ignored by Weblate, please adjust the language filter to exclude it." %} {% documentation_icon "admin/projects" "component-language_regex" %}</li>
+    <li>{% trans "In case the translation file for the source language is needed, but should be ignored by Weblate, please adjust the language filter to exclude it." %} {% documentation_icon "admin/projects" "component-language_regex" %}</li>
 
     </ul>
 

--- a/weblate/utils/django_hacks.py
+++ b/weblate/utils/django_hacks.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 
 def immediate_on_commit(cls):
-    """Wrapper to make transaction.on_commit execute immediatelly.
+    """Wrapper to make transaction.on_commit execute immediately.
 
     TODO: Remove when immediate_on_commit function is actually implemented
     Django Ticket #: 30456, Link: https://code.djangoproject.com/ticket/30457#no1


### PR DESCRIPTION
Fixed two small typos found in the source files:
immediatelly ⇒ immediately
shoud ⇒ should

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
