### PR TITLE
Fix: Wrap comment text and make comment textarea automatically resize itself

### DIFF
--- a/weblate/static/loader-codemirror.js
+++ b/weblate/static/loader-codemirror.js
@@ -62,6 +62,7 @@
       theme: "weblate",
       lineNumbers: false,
       lineWrapping: true,
+      viewportMargin: Infinity,
     });
 
     codemirror.on("change", function (cm, event) {

--- a/weblate/static/loader-codemirror.js
+++ b/weblate/static/loader-codemirror.js
@@ -61,6 +61,7 @@
       mode: "text/x-markdown",
       theme: "weblate",
       lineNumbers: false,
+      lineWrapping: true,
     });
 
     codemirror.on("change", function (cm, event) {

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -225,7 +225,8 @@ textarea#id_comment {
   height: 4em;
 }
 div.CodeMirror.cm-s-weblate {
-  height: 5em;
+  min-height: 5em;
+  height: auto;
   color: #555555;
   font-family: inherit;
 }

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -225,7 +225,6 @@ textarea#id_comment {
   height: 4em;
 }
 div.CodeMirror.cm-s-weblate {
-  min-height: 5em;
   height: auto;
   color: #555555;
   font-family: inherit;

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -508,6 +508,7 @@ form + .login-label {
   border-radius: 0 5px 5px 5px;
   background-color: #e5f0f2;
   padding: 8px 10px;
+  word-wrap: break-word;
 }
 
 .comment-source {


### PR DESCRIPTION
Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation

This fixes #4442 and the following changes were made:
1. Wrap comment-area so that long comments without space does not overflow horizontally.
2. Wrap comment textarea using [`lineWrapping`](https://codemirror.net/doc/manual.html#option_lineWrapping) option from CodeEditor. This prevents comment text from having a horizontal scroll.
3. Make comment textarea automatically resize to fit its text