### PR TITLE
Machinery: Upgrade Google Translate to google-cloud-translate 3.0.0

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -12,7 +12,7 @@ django-auth-ldap>=1.3.0,<2.3.0
 # Gerrit
 git-review>=1.27.0
 # Google
-google-cloud-translate>=2.0.1,<2.1.0
+google-cloud-translate>=3.0.0,<3.1.0
 # INI
 iniparse==0.5
 # Mercurial


### PR DESCRIPTION
The Python module API has changed in a not compatible way, see
https://googleapis.dev/python/translation/latest/UPGRADING.html

Fixes #4358
Fixes #4281
Fixes WEBLATE-4X8
Fixes WEBLATE-4XA
Fixes WEBLATE-4X9

Before submitting pull request, please ensure that:

- [x] Every commit has a message which describes it
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them
- [x] Any code changes come with test case
- [x] Any new functionality is covered by user documentation
