### PR TITLE
rewording and bolding access removal message

### DIFF
--- a/weblate/templates/manage-access.html
+++ b/weblate/templates/manage-access.html
@@ -54,10 +54,10 @@
         <h4 class="modal-title">{% trans "Are you absolutely sure?" %}</h4>
       </div>
       <div class="modal-body">
-        {% blocktrans with user=user.username %}This will permanently remove {{ user }} from this project.{% endblocktrans %}
+        {% blocktrans with user=user.username %}This will remove <b>{{ user }}</b> access to this project.{% endblocktrans %}
       </div>
       <div class="modal-footer">
-        <input type="submit" class="btn btn-danger" value="{% trans "Delete" %}" />
+        <input type="submit" class="btn btn-danger" value="{% trans "Remove" %}" />
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->


### PR DESCRIPTION
- username bold to make it more visible
- message clearer to prevent potential guessing if translations of the removed user stay

<!-- This file is maintained in https://github.com/WeblateOrg/meta/ -->
<!-- markdownlint-disable MD041 -->

Before submitting a pull request, please ensure that:

- [x] Every commit has a message which concisely describes it.
- [x] Every commit is needed on its own; if you have just minor fixes to previous commits, you can squash them.

- [ ] Any new functionality is covered by user documentation.
  seems that covering this is not needed, @nijel let me know if you think that something should be modified at https://docs.weblate.org/en/latest/admin/access.html?highlight=access#managing-per-project-access-control