### PR TITLE
Fix for incorrect language being chosen #4966

### DIFF
--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -183,7 +183,9 @@ class LanguageQuerySet(models.QuerySet):
         expanded_code = None
 
         lookups = [
-            # First try getting language as is
+            # First try getting language as is (case-sensitive)
+            Q(code=code),
+            # Then try getting language as is (case-insensitive)
             Q(code__iexact=code),
             # Replace dash with underscore (for things as zh_Hant)
             Q(code__iexact=code.replace("-", "_")),

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -22,7 +22,9 @@
 import gettext
 from io import StringIO
 from itertools import chain
+from unittest import SkipTest
 
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
@@ -247,6 +249,39 @@ class LanguagesTest(BaseTestCase, metaclass=TestSequenceMeta):
             source=Plural.SOURCE_DEFAULT,
         )
         self.run_create("zh-rCN", "zh_CN", "ltr", "0", "Chinese (zh_CN)", False)
+
+    def test_case_sensitive_fuzzy_get(self):
+        """Test handling of manually created zh-TW, zh-TW and zh_TW languages."""
+        if settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
+            raise SkipTest("Not supported on MySQL")
+
+        language = Language.objects.create(
+            code="zh_TW", name="Chinese (Taiwan)"
+        )
+        language.plural_set.create(
+            number=0,
+            formula="0",
+            source=Plural.SOURCE_DEFAULT,
+        )
+        self.run_create("zh_TW", "zh_TW", "ltr", "0", "Chinese (Taiwan) (zh_TW)", False)
+        language = Language.objects.create(code="zh-TW", name="Chinese Taiwan")
+        language.plural_set.create(
+            number=0,
+            formula="0",
+            source=Plural.SOURCE_DEFAULT,
+        )
+        self.run_create("zh-TW", "zh-TW", "ltr", "0", "Chinese Taiwan (zh-TW)", False)
+        language = Language.objects.create(
+            code="zh-tw", name="Traditional Chinese"
+        )
+        language.plural_set.create(
+            number=0,
+            formula="0",
+            source=Plural.SOURCE_DEFAULT,
+        )
+        self.run_create(
+            "zh-tw", "zh-tw", "ltr", "0", "Traditional Chinese (zh-tw)", False
+        )
 
 
 class CommandTest(BaseTestCase):

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -269,9 +269,7 @@ class LanguagesTest(BaseTestCase, metaclass=TestSequenceMeta):
             source=Plural.SOURCE_DEFAULT,
         )
         self.run_create("zh-TW", "zh-TW", "ltr", "0", "Chinese Taiwan (zh-TW)", False)
-        language = Language.objects.create(
-            code="zh-tw", name="Traditional Chinese"
-        )
+        language = Language.objects.create(code="zh-tw", name="Traditional Chinese")
         language.plural_set.create(
             number=0,
             formula="0",

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -255,9 +255,7 @@ class LanguagesTest(BaseTestCase, metaclass=TestSequenceMeta):
         if settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
             raise SkipTest("Not supported on MySQL")
 
-        language = Language.objects.create(
-            code="zh_TW", name="Chinese (Taiwan)"
-        )
+        language = Language.objects.create(code="zh_TW", name="Chinese (Taiwan)")
         language.plural_set.create(
             number=0,
             formula="0",


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
This change fixes issue with incorrect language code being used for creating translations. https://github.com/WeblateOrg/weblate/issues/4966

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
