### PR TITLE
Allow 50 characters for app store title

### DIFF
--- a/weblate/formats/txt.py
+++ b/weblate/formats/txt.py
@@ -106,7 +106,7 @@ class MultiParser:
 
 class AppStoreParser(MultiParser):
     filenames = (
-        ("title.txt", "max-length:30"),
+        ("title.txt", "max-length:50"),
         ("short[_-]description.txt", "max-length:80"),
         ("full[_-]description.txt", "max-length:4000"),
         ("subtitle.txt", "max-length:80"),


### PR DESCRIPTION
Google Play allows up to 50 characters for the title

## Proposed changes

Allows title.txt for Fastlane to be up to 50 characters instead of up to 30 as Google Play allows up to 50:

![image](https://user-images.githubusercontent.com/1885159/101060463-bba9e080-358f-11eb-8e4c-c91d15572e8b.png)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.

## Other information

I'm using this option to ping @eighthave to ensure F-Droid is also aware of the 50 character limit of Google Play.
