### PR TITLE
Billing: fix typo commerial

### DIFF
--- a/weblate/templates/manage/billing.html
+++ b/weblate/templates/manage/billing.html
@@ -12,7 +12,7 @@
 <ul class="nav nav-pills">
   <li role="presentation" class="active"><a href="#trial" role="tab" data-toggle="tab">{% trans "Trial" %} <span class="badge">{{ trial|length|intcomma }}</span></a></li>
   <li role="presentation"><a href="#pending" role="tab" data-toggle="tab">{% trans "Pending approval" %} <span class="badge">{{ pending|length|intcomma }}</span></a></li>
-  <li role="presentation"><a href="#paid" role="tab" data-toggle="tab">{% trans "Commerial" %} <span class="badge">{{ paid|length|intcomma }}</span></a></li>
+  <li role="presentation"><a href="#paid" role="tab" data-toggle="tab">{% trans "Commercial" %} <span class="badge">{{ paid|length|intcomma }}</span></a></li>
   <li role="presentation"><a href="#free" role="tab" data-toggle="tab">{% trans "Libre" %} <span class="badge">{{ free|length|intcomma }}</span></a></li>
   <li role="presentation"><a href="#removal" role="tab" data-toggle="tab">{% trans "Scheduled removal" %} <span class="badge">{{ removal|length|intcomma }}</span></a></li>
   <li role="presentation"><a href="#terminated" role="tab" data-toggle="tab">{% trans "Terminated" %} <span class="badge">{{ terminated|length|intcomma }}</span></a></li>


### PR DESCRIPTION
Page shows "Commerial" but I assume the correct is "Commercial".