### PR TITLE
Fix problems when saving XWiki properties.

### DIFF
--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -869,7 +869,7 @@ class XWikiPropertiesFormatTest(PropertiesFormatTest):
         with open(TEST_XWIKI_PROPERTIES_NEW_LANGUAGE) as handle:
             expected = handle.read()
 
-        self.assertEqual(expected + '\n', newdata)
+        self.assertEqual(expected + "\n", newdata)
 
 
 class XWikiPagePropertiesFormatTest(PropertiesFormatTest):

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -852,9 +852,10 @@ class XWikiPropertiesFormatTest(PropertiesFormatTest):
     def test_new_language(self):
         self.maxDiff = None
         out = os.path.join(self.tempdir, f"test_new_language.{self.EXT}")
-        self.FORMAT.add_language(out, Language.objects.get(code="cs"), self.BASE)
+        language = Language.objects.get(code="cs")
+        self.FORMAT.add_language(out, language, self.BASE)
         template_storage = self.parse_file(self.FILE)
-        new_language = self.FORMAT(out, template_storage, Language.objects.get(code="cs"))
+        new_language = self.FORMAT(out, template_storage, language.code)
         unit, add = new_language.find_unit("job.status.success")
         self.assertTrue(add)
         unit.set_target("Fait")

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -869,7 +869,7 @@ class XWikiPropertiesFormatTest(PropertiesFormatTest):
         with open(TEST_XWIKI_PROPERTIES_NEW_LANGUAGE) as handle:
             expected = handle.read()
 
-        self.assertEqual(expected, newdata)
+        self.assertEqual(expected + '\n', newdata)
 
 
 class XWikiPagePropertiesFormatTest(PropertiesFormatTest):

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -89,6 +89,7 @@ TEST_HE_CUSTOM = get_test_file("he-custom.po")
 TEST_HE_SIMPLE = get_test_file("he-simple.po")
 TEST_HE_THREE = get_test_file("he-three.po")
 TEST_XWIKI_PROPERTIES = get_test_file("xwiki.properties")
+TEST_XWIKI_PROPERTIES_NEW_LANGUAGE = get_test_file("xwiki_new_language.properties")
 TEST_XWIKI_PAGE_PROPERTIES = get_test_file("XWikiPageProperties.xml")
 TEST_XWIKI_PAGE_PROPERTIES_SOURCE = get_test_file("XWikiPagePropertiesSource.xml")
 TEST_XWIKI_FULL_PAGE = get_test_file("XWikiFullPage.xml")
@@ -847,6 +848,27 @@ class XWikiPropertiesFormatTest(PropertiesFormatTest):
     NEW_UNIT_MATCH = b"\nkey=Source string\n"
     EXPECTED_FLAGS = ""
     EDIT_TARGET = "[{0}] تىپتىكى خىزمەتنى باشلاش"
+
+    def test_new_language(self):
+        self.maxDiff = None
+        out = os.path.join(self.tempdir, f"test_new_language.{self.EXT}")
+        self.FORMAT.add_language(out, Language.objects.get(code="cs"), self.BASE)
+        template_storage = self.parse_file(self.FILE)
+        new_language = self.FORMAT(out, template_storage, Language.objects.get(code="cs"))
+        unit, add = new_language.find_unit("job.status.success")
+        self.assertTrue(add)
+        unit.set_target("Fait")
+        new_language.add_unit(unit.unit)
+        new_language.save()
+
+        # Read new content
+        with open(out) as handle:
+            newdata = handle.read()
+
+        with open(TEST_XWIKI_PROPERTIES_NEW_LANGUAGE) as handle:
+            expected = handle.read()
+
+        self.assertEqual(expected, newdata)
 
 
 class XWikiPagePropertiesFormatTest(PropertiesFormatTest):

--- a/weblate/trans/tests/data/xwiki_new_language.properties
+++ b/weblate/trans/tests/data/xwiki_new_language.properties
@@ -67,7 +67,8 @@
 ## until 10.1
 #######################################
 
-job.status.success=Fait.
+job.status.success=Fait
 ### Missing: job.status.canceled=Canceled.
 ### Missing: job.status.error=Failed.
 #@deprecatedend
+

--- a/weblate/trans/tests/data/xwiki_new_language.properties
+++ b/weblate/trans/tests/data/xwiki_new_language.properties
@@ -71,4 +71,3 @@ job.status.success=Fait
 ### Missing: job.status.canceled=Canceled.
 ### Missing: job.status.error=Failed.
 #@deprecatedend
-

--- a/weblate/trans/tests/data/xwiki_new_language.properties
+++ b/weblate/trans/tests/data/xwiki_new_language.properties
@@ -1,0 +1,73 @@
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
+
+###############################################################################
+# XWiki Core localization
+#
+# This contains the translations of the module in the default language
+# (generally English).
+#
+# Translation key syntax:
+#   <short top level project name>.<short module name>.<propertyName>
+#   where:
+#   * <short top level project name> = top level project name without the "xwiki-" prefix,
+#                                     for example: commons, rendering, platform, enterprise, manager, etc
+#   * <short module name> = the name of the Maven module without the <short top level project name> prefix,
+#                           for example: oldcore, scheduler, activitystream, etc
+#   * <propertyName> = the name of the property using camel case,
+#                      for example updateJobClassCommitComment
+#
+# Comments: it's possible to add some detail about a key to make easier to
+#   translate it by adding a comment before it. To make sure a comment is not
+#   assigned to the following key use at least three sharps (###) for the comment
+#   or after it.
+#
+# Deprecated keys:
+#   * when deleting a key it should be moved to deprecated section at the end
+#     of the file (between #@deprecatedstart and #@deprecatedend) and associated to the
+#     first version in which it started to be deprecated
+#   * when renaming a key, it should be moved to the same deprecated section
+#     and a comment should be added with the following syntax:
+#     #@deprecated new.key.name
+#     old.key.name=Some translation
+###############################################################################
+
+### Missing: job.question.button.confirm=Confirm the operation {0}
+### Missing: job.question.button.cancel=Cancel
+### Missing: job.question.notification.canceling=Canceling with ''
+### Missing: job.question.notification.answering=Answering to test '' {3}
+### Missing: job.question.\ escapedSpace.answering=Property with escaped space
+###############################################################################
+## Deprecated
+## Note: each element should be removed when the last branch using it is no longer supported
+###############################################################################
+
+## Used to indicate where deprecated keys start
+
+#@deprecatedstart
+
+#######################################
+## until 10.1
+#######################################
+
+job.status.success=Fait.
+### Missing: job.status.canceled=Canceled.
+### Missing: job.status.error=Failed.
+#@deprecatedend


### PR DESCRIPTION
## Proposed changes

Those changes aims at fixing #5040.
Basically the idea is to ensure that in case of a new language the unit is properly retrieved and not marked as missing. 

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages
