### PR TITLE
Add Cloudron installation method

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -35,6 +35,7 @@ Depending on your setup and experience, choose an appropriate installation metho
 
 * :doc:`install/openshift`
 * :doc:`install/kubernetes`
+* `Installing on Cloudron <https://www.cloudron.io/store/org.weblate.cloudronapp.html>`_
 
 .. _requirements:
 


### PR DESCRIPTION
Cloudron has a 1-click installation package for Weblate and we make sure all instances are automatically kept up-to-date.
The package is at https://git.cloudron.io/cloudron/weblate-app where we also maintain selenium e2e tests, which have to succeed before we push an update. Usually updates happen withing a few days from upstream release.