### PR TITLE
Add Cloudron installation method

### DIFF
--- a/docs/admin/deployments.rst
+++ b/docs/admin/deployments.rst
@@ -25,6 +25,17 @@ Bitnami provides a Weblate stack for many platforms at
 installation, see <https://bitnami.com/stack/weblate/README.txt> for more
 documentation.
 
+Weblate Cloudron Package
+------------------------
+
+`Cloudron <https://cloudron.io/>`_ is a platform for self-hosting web applications.
+Weblate installed with Cloudron will be automatically kept up-to-date.
+The package is maintained by the Cloudron team at their `Weblate package repo <https://git.cloudron.io/cloudron/weblate-app>`_.
+
+.. image:: https://cloudron.io/img/button.svg
+             :alt: Install Weblate with Cloudron
+             :target: https://cloudron.io/button.html?app=org.weblate.cloudronapp
+
 Weblate in YunoHost
 -------------------
 


### PR DESCRIPTION
Cloudron has a 1-click installation package for Weblate and we make sure all instances are automatically kept up-to-date.
The package is at https://git.cloudron.io/cloudron/weblate-app where we also maintain selenium e2e tests, which have to succeed before we push an update. Usually updates happen withing a few days from upstream release.

Previous attempt at the wrong page https://github.com/WeblateOrg/weblate/pull/5065