### PR TITLE
docs: fix simple typo, uknown -> unknown

### DIFF
--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -77,7 +77,7 @@ def get_plural_type(base_code, plural_formula):
     if base_code in ("ar",):
         return data.PLURAL_ARABIC
 
-    # Log error in case of uknown mapping
+    # Log error in case of unknown mapping
     LOGGER.error("Can not guess type of plural for %s: %s", base_code, plural_formula)
 
     return data.PLURAL_UNKNOWN


### PR DESCRIPTION
There is a small typo in weblate/lang/models.py.

Should read `unknown` rather than `uknown`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md