### PR TITLE
Trans: Disable key locking in select_for_update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ celery[redis]>=4.4.5,<5.1,!=5.0.0,!=5.0.1,!=5.0.2
 cssselect>=1.0.0,<1.2.0
 Cython>=0.29.14,<0.30
 diff-match-patch==20200713
-Django>=3.1,<3.2
+Django>=3.1,<3.3
 django-appconf>=1.0.3,<1.1
 django-compressor>=2.4,<2.5
 django-crispy-forms>=1.9.0,<1.11.0

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -139,6 +139,9 @@ USE_L10N = True
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True
 
+# Type of automatic primary key, introduced in Django 3.2
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 # URL prefix to use, please see documentation for more details
 URL_PREFIX = ""
 

--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -23,6 +23,7 @@ from django.db import transaction
 
 from weblate.machinery import MACHINE_TRANSLATION_SERVICES
 from weblate.trans.models import Change, Component, Suggestion, Unit
+from weblate.utils.db import get_nokey_args
 from weblate.utils.state import STATE_FUZZY, STATE_TRANSLATED
 
 
@@ -105,7 +106,7 @@ class AutoTranslate:
         units = (
             self.get_units(False)
             .filter(source__in=translations.keys())
-            .select_for_update()
+            .select_for_update(**get_nokey_args())
         )
         self.progress_steps = len(units)
 
@@ -167,7 +168,7 @@ class AutoTranslate:
             for pos, unit in enumerate(
                 Unit.objects.filter(id__in=translations.keys())
                 .prefetch()
-                .select_for_update()
+                .select_for_update(**get_nokey_args())
             ):
                 # Copy translation
                 self.update(unit, self.target_state, translations[unit.pk])

--- a/weblate/trans/bulk.py
+++ b/weblate/trans/bulk.py
@@ -22,6 +22,7 @@ from django.db import transaction
 
 from weblate.checks.flags import Flags
 from weblate.trans.models import Change, Component, Unit
+from weblate.utils.db import get_nokey_args
 from weblate.utils.state import STATE_APPROVED, STATE_FUZZY, STATE_TRANSLATED
 
 EDITABLE_STATES = STATE_FUZZY, STATE_TRANSLATED, STATE_APPROVED
@@ -53,7 +54,7 @@ def bulk_perform(
             component.commit_pending("bulk edit", user)
             component_units = matching.filter(
                 translation__component=component
-            ).select_for_update()
+            ).select_for_update(**get_nokey_args())
 
             can_edit_source = user is None or user.has_perm("source.edit", component)
 

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -53,7 +53,11 @@ from weblate.trans.models.unit import (
 from weblate.trans.signals import store_post_load, vcs_pre_commit
 from weblate.trans.util import split_plural
 from weblate.trans.validators import validate_check_flags
-from weblate.utils.db import FastDeleteModelMixin, FastDeleteQuerySetMixin
+from weblate.utils.db import (
+    FastDeleteModelMixin,
+    FastDeleteQuerySetMixin,
+    get_nokey_args,
+)
 from weblate.utils.errors import report_error
 from weblate.utils.render import render_template
 from weblate.utils.site import get_site_url
@@ -363,7 +367,10 @@ class Translation(
             self.was_new = 0
 
             # Select all current units for update
-            dbunits = {unit.id_hash: unit for unit in self.unit_set.select_for_update()}
+            dbunits = {
+                unit.id_hash: unit
+                for unit in self.unit_set.select_for_update(**get_nokey_args())
+            }
 
             # Process based on intermediate store if available
             if self.component.intermediate:

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -47,7 +47,11 @@ from weblate.trans.util import (
     split_plural,
 )
 from weblate.trans.validators import validate_check_flags
-from weblate.utils.db import FastDeleteModelMixin, FastDeleteQuerySetMixin
+from weblate.utils.db import (
+    FastDeleteModelMixin,
+    FastDeleteQuerySetMixin,
+    get_nokey_args,
+)
 from weblate.utils.errors import report_error
 from weblate.utils.hash import calculate_hash, hash_to_checksum
 from weblate.utils.search import parse_query
@@ -1119,7 +1123,9 @@ class Unit(FastDeleteModelMixin, models.Model, LoggerMixin):
         Propagation is currently disabled on import.
         """
         # Fetch current copy from database and lock it for update
-        self.old_unit = Unit.objects.select_for_update().get(pk=self.pk)
+        self.old_unit = Unit.objects.select_for_update(**get_nokey_args()).get(
+            pk=self.pk
+        )
 
         # Handle simple string units
         if isinstance(new_target, str):

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
@@ -39,6 +38,7 @@ from weblate.trans.forms import (
 from weblate.trans.models import Change, Unit
 from weblate.trans.util import render
 from weblate.utils import messages
+from weblate.utils.db import get_nokey_args
 from weblate.utils.ratelimit import check_rate_limit
 from weblate.utils.views import (
     get_component,
@@ -119,7 +119,7 @@ def search_replace(request, project, component=None, lang=None):
         matching = confirm.cleaned_data["units"]
 
         with transaction.atomic():
-            for unit in matching.select_for_update():
+            for unit in matching.select_for_update(**get_nokey_args()):
                 if not request.user.has_perm("unit.edit", unit):
                     continue
                 unit.translate(

--- a/weblate/utils/db.py
+++ b/weblate/utils/db.py
@@ -18,6 +18,7 @@
 #
 """Database specific code to extend Django."""
 
+import django
 from django.db import connection, models, router
 from django.db.models import Case, IntegerField, Sum, When
 from django.db.models.deletion import Collector
@@ -35,6 +36,17 @@ MY_DROP = "ALTER TABLE trans_{0} DROP INDEX {0}_{1}_fulltext"
 def conditional_sum(value=1, **cond):
     """Wrapper to generate SUM on boolean/enum values."""
     return Sum(Case(When(then=value, **cond), default=0, output_field=IntegerField()))
+
+
+def get_nokey_args():
+    """
+    Returns key locking disable arg for select_for_update.
+
+    This can be inlined once we support Django 3.2 only.
+    """
+    if django.VERSION < (3, 2, 0):
+        return {}
+    return {"no_key": True}
 
 
 def adjust_similarity_threshold(value: float):


### PR DESCRIPTION


## Proposed changes

This reduces locking congestion on doing updates as it holds only row
level locks and not table level ones for primary key.

Needs Django 3.2 (not yet released), see https://code.djangoproject.com/ticket/30375 and https://github.com/django/django/commit/a4e6030904df63b3f10aa0729b86dc6942b0458e

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
