### PR TITLE
Document translation removal

### DIFF
--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -17,10 +17,32 @@ This can be done using :guilabel:`Start new translation` in :ref:`component`.
 
 .. note::
 
-    Project admins can always start translation within Weblate directly.
+    Project admins can always start translations within Weblate directly.
 
 Language files added manually to the VCS are added to the component when Weblate updates
-the repository. About repository update settings, see :ref:`update-vcs`.
+the repository. ref:`update-vcs` has info on updating repository settings.
+
+.. _removing-translation:
+
+Removing existing translations
+------------------------------
+
+Components or the projects they are in can be removed in their entirety
+from :guilabel:`Removal` found in the administration tab shown to administrators
+of each project or component.
+A list of components to remove is shown, and typing in either the respective
+project or component slated for removal will confirm its deletion.
+
+If you want to remove single strings, removing them in the source file also
+removes them from translations.
+
+.. note::
+
+    Project admins can always remove translations within Weblate directly.
+
+Language files deleted manually from the VCS are removed from the component when Weblate updates
+the repository. ref:`update-vcs` has info on updating repository settings.
+
 
 .. _variants:
 

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -27,17 +27,17 @@ the repository. ref:`update-vcs` has info on updating repository settings.
 Removing existing translations
 ------------------------------
 
-Components or the projects they are in can be removed in their entirety
-from :guilabel:`Removal` found in the administration tab shown to administrators
-of each project or component. Languages can be removed by navigating to the
-one to delete and finding the menu under Tools > Removal.
+Languages, components, or the projects they are in, can be removed (deleted from Weblate 
+and remote repository if used) from the menu :guilabel:`Manage` ↓ :guilabel:`Removal` 
+of each project, component, or language.
 
 A list of components to remove is shown, and typing in the entire name of
-the respective project, component or language slated for removal will
+the respective project, component, or language selected for removal will
 confirm its deletion.
 
 If you want to remove single strings, removing them in the source file also
 removes them from translations.
+
 
 .. note::
 

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -46,11 +46,11 @@ translation project as well upon Weblate's repository update.
 
 
 .. note::
-
-    Project admins can always remove translations within Weblate directly.
-
-Language files deleted manually from the VCS are removed from the component when Weblate updates
-the repository. ref:`update-vcs` has info on updating repository settings.
+     
+     If you delete a language file in connected remote repository, respective 
+     translation will be removed from the component when Weblate updates local repository.
+     
+     More info on the repository update settings can be found on the :ref:`update-vcs`.
 
 
 .. _variants:

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -35,7 +35,14 @@ Initiating the :guilabel:`Removal` action shows the list of components to be rem
 You have to enter the object's `slug` to confirm the removal. The `slug` is the
 project's, language's, or component's pathname as it can be seen in the URL.
 
-Removing single strings in the source file also removes them from Weblate translations.
+If you want to remove just some specific strings, there are following ways:
+
+.. versionadded:: 4.5
+- In Weblate’s UI via button :guilabel:`Tools` ↓ :guilabel:`Remove` while editing the string.
+This has differences between file formats, see: :ref:`component-manage_units`
+
+- Manually in the source file. They will be removed from the 
+translation project as well upon Weblate's repository update.
 
 
 .. note::

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -17,10 +17,10 @@ This can be done using :guilabel:`Start new translation` in :ref:`component`.
 
 .. note::
 
-    Project admins can always start translations within Weblate directly.
-
-Language files added manually to the VCS are added to the component when Weblate updates
-the repository. ref:`update-vcs` has info on updating repository settings.
+    If you add a language file in connected remote repository, respective 
+    translation will be added to the component when Weblate updates local repository.
+     
+    More info on the repository update settings can be found on the :ref:`update-vcs`.
 
 .. _removing-translation:
 

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -17,7 +17,7 @@ This can be done using :guilabel:`Start new translation` in :ref:`component`.
 
 .. note::
 
-    If you add a language file in connected remote repository, respective 
+    If you add a language file in connected remote repository, respective
     translation will be added to the component when Weblate updates local repository.
      
     More info on the repository update settings can be found on the :ref:`update-vcs`.
@@ -27,27 +27,28 @@ This can be done using :guilabel:`Start new translation` in :ref:`component`.
 Removing existing translations
 ------------------------------
 
-Languages, components, or the projects they are in, can be removed (deleted from Weblate 
-and remote repository if used) from the menu :guilabel:`Manage` ↓ :guilabel:`Removal` 
+Languages, components, or the projects they are in, can be removed (deleted from Weblate
+and remote repository if used) from the menu :guilabel:`Manage` ↓ :guilabel:`Removal`
 of each project, component, or language.
 
-Initiating the :guilabel:`Removal` action shows the list of components to be removed. 
+Initiating the :guilabel:`Removal` action shows the list of components to be removed.
 You have to enter the object's `slug` to confirm the removal. The `slug` is the
 project's, language's, or component's pathname as it can be seen in the URL.
 
 If you want to remove just some specific strings, there are following ways:
 
 .. versionadded:: 4.5
-- In Weblate’s UI via button :guilabel:`Tools` ↓ :guilabel:`Remove` while editing the string.
-This has differences between file formats, see: :ref:`component-manage_units`
 
-- Manually in the source file. They will be removed from the 
-translation project as well upon Weblate's repository update.
+- In Weblate’s UI via button :guilabel:`Tools` ↓ :guilabel:`Remove` while editing the string.
+  This has differences between file formats, see: :ref:`component-manage_units`
+
+- Manually in the source file. They will be removed from the
+  translation project as well upon Weblate's repository update.
 
 
 .. note::
      
-     If you delete a language file in connected remote repository, respective 
+     If you delete a language file in connected remote repository, respective
      translation will be removed from the component when Weblate updates local repository.
      
      More info on the repository update settings can be found on the :ref:`update-vcs`.

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -29,9 +29,12 @@ Removing existing translations
 
 Components or the projects they are in can be removed in their entirety
 from :guilabel:`Removal` found in the administration tab shown to administrators
-of each project or component.
-A list of components to remove is shown, and typing in either the respective
-project or component slated for removal will confirm its deletion.
+of each project or component. Languages can be removed by navigating to the
+one to delete and finding the menu under Tools > Removal.
+
+A list of components to remove is shown, and typing in the entire name of
+the respective project, component or language slated for removal will
+confirm its deletion.
 
 If you want to remove single strings, removing them in the source file also
 removes them from translations.

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -35,7 +35,7 @@ Initiating the :guilabel:`Removal` action shows the list of components to be rem
 You have to enter the object's `slug` to confirm the removal. The `slug` is the
 project's, language's, or component's pathname as it can be seen in the URL.
 
-Remove single strings in the source file also removes them from translations in Weblate.
+Removing single strings in the source file also removes them from Weblate translations.
 
 
 .. note::

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -31,12 +31,11 @@ Languages, components, or the projects they are in, can be removed (deleted from
 and remote repository if used) from the menu :guilabel:`Manage` ↓ :guilabel:`Removal` 
 of each project, component, or language.
 
-A list of components to remove is shown, and typing in the entire name of
-the respective project, component, or language selected for removal will
-confirm its deletion.
+Initiating the :guilabel:`Removal` action shows the list of components to be removed. 
+You have to enter the object's `slug` to confirm the removal. The `slug` is the
+project's, language's, or component's pathname as it can be seen in the URL.
 
-If you want to remove single strings, removing them in the source file also
-removes them from translations.
+Remove single strings in the source file also removes them from translations in Weblate.
 
 
 .. note::


### PR DESCRIPTION
Fixes #5235
Check English label names.
Needs something about how it works for different formats, mono-/bilingual files.
Screenshots, formatting?

Edit: It doesn't make any sense that removal of languages is "Tools > Removal" while project and component removal is in "Administrate" > "Removal" (?)