### PR TITLE
Support Lua format strings. Fixes #4289.

### DIFF
--- a/docs/admin/checks.rst
+++ b/docs/admin/checks.rst
@@ -79,13 +79,13 @@ Here is a list of flags currently accepted:
     Mark this string as a variant of string with matching source. See :ref:`variants`.
 ``regex:REGEX``
     Regular expression to match translation, see :ref:`check-regex`.
-``python-format``, ``c-format``, ``php-format``, ``python-brace-format``, ``javascript-format``, ``c-sharp-format``, ``java-format``, ``java-messageformat``, ``auto-java-messageformat``, ``qt-format``, ``qt-plural-format``, ``ruby-format``, ``vue-format``
+``python-format``, ``c-format``, ``php-format``, ``python-brace-format``, ``javascript-format``, ``c-sharp-format``, ``java-format``, ``java-messageformat``, ``lua-format``, ``auto-java-messageformat``, ``qt-format``, ``qt-plural-format``, ``ruby-format``, ``vue-format``
     Treats all strings like format strings, affects :ref:`check-python-format`,
     :ref:`check-c-format`, :ref:`check-php-format`,
     :ref:`check-qt-format`, :ref:`check-qt-plural-format`, :ref:`check-ruby-format`, :ref:`check-vue-format`,
     :ref:`check-python-brace-format`, :ref:`check-javascript-format`,
     :ref:`check-c-sharp-format`, :ref:`check-java-format`,
-    :ref:`check-java-messageformat`, :ref:`check-same`.
+    :ref:`check-java-messageformat`, :ref:`check-lua-format`, :ref:`check-same`.
 ``strict-same``
     Make "Unchanged translation" avoid using built-in words blacklist, see :ref:`check-same`.
 ``ignore-bbcode``
@@ -110,6 +110,8 @@ Here is a list of flags currently accepted:
     Skip the "Java MessageFormat" quality check.
 ``ignore-javascript-format``
     Skip the "JavaScript format" quality check.
+``ignore-lua-format``
+    Skip the "Lua format" quality check.
 ``ignore-percent-placeholders``
     Skip the "Percent placeholders" quality check.
 ``ignore-perl-format``

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,7 @@ Weblate 4.5
 
 Not yet released.
 
+* Added support for ``lua-format`` used in gettext PO.
 * Added support for sharing a component between projects.
 * Fixed multiple unnamed variables check behavior with multiple format flags.
 * Dropped mailing list field on project in favor of generic instructions for translators.

--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -97,6 +97,7 @@ Check is false when double space is found in source meaning double space is inte
 .. _check-java-format:
 .. _check-java-messageformat:
 .. _check-javascript-format:
+.. _check-lua-format:
 .. _check-percent-placeholders:
 .. _check-perl-format:
 .. _check-php-format:
@@ -268,6 +269,21 @@ JavaScript format
 .. seealso::
 
     `JavaScript formatting strings <https://www.gnu.org/software/gettext/manual/html_node/javascript_002dformat.html>`_
+
+Lua format
+*****************
+
+*Lua format string does not match source*
+
++------------------------+------------------------------------------------------------+
+| Simple format string   | ``There are %d apples``                                    |
++------------------------+------------------------------------------------------------+
+| Flag to enable         | `lua-format`                                               |
++------------------------+------------------------------------------------------------+
+
+.. seealso::
+
+    `Lua formatting strings <https://www.gnu.org/software/gettext/manual/html_node/lua_002dformat.html#lua_002dformat>`_
 
 Percent placeholders
 ********************

--- a/weblate/checks/format.py
+++ b/weblate/checks/format.py
@@ -211,6 +211,7 @@ FLAG_RULES = {
     "c-format": (C_PRINTF_MATCH, c_format_is_position_based),
     "perl-format": (C_PRINTF_MATCH, c_format_is_position_based),
     "javascript-format": (C_PRINTF_MATCH, c_format_is_position_based),
+    "lua-format": (C_PRINTF_MATCH, c_format_is_position_based),
     "python-brace-format": (PYTHON_BRACE_MATCH, name_format_is_position_based),
     "c-sharp-format": (C_SHARP_MATCH, name_format_is_position_based),
     "java-format": (JAVA_MATCH, c_format_is_position_based),
@@ -218,7 +219,7 @@ FLAG_RULES = {
 
 
 class BaseFormatCheck(TargetCheck):
-    """Base class for fomat string checks."""
+    """Base class for format string checks."""
 
     regexp: Optional[Pattern[str]] = None
     default_disabled = True
@@ -233,7 +234,7 @@ class BaseFormatCheck(TargetCheck):
             yield self.check_format(sources[1], targets[0], False)
             return
 
-        # Use plural as source in case singlular misses format string and plural has it
+        # Use plural as source in case singular misses format string and plural has it
         if (
             len(sources) > 1
             and not self.extract_matches(sources[0])
@@ -427,6 +428,14 @@ class JavaScriptFormatCheck(CFormatCheck):
     check_id = "javascript_format"
     name = _("JavaScript format")
     description = _("JavaScript format string does not match source")
+
+
+class LuaFormatCheck(BasePrintfCheck):
+    """Check for Lua format string."""
+
+    check_id = "lua_format"
+    name = _("Lua format")
+    description = _("Lua format string does not match source")
 
 
 class PythonBraceFormatCheck(BaseFormatCheck):

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -70,6 +70,7 @@ class WeblateChecksConf(AppConf):
         "weblate.checks.format.CFormatCheck",
         "weblate.checks.format.PerlFormatCheck",
         "weblate.checks.format.JavaScriptFormatCheck",
+        "weblate.checks.format.LuaFormatCheck",
         "weblate.checks.format.CSharpFormatCheck",
         "weblate.checks.format.JavaFormatCheck",
         "weblate.checks.format.JavaMessageFormatCheck",

--- a/weblate/checks/tests/test_format_checks.py
+++ b/weblate/checks/tests/test_format_checks.py
@@ -29,6 +29,7 @@ from weblate.checks.format import (
     I18NextInterpolationCheck,
     JavaFormatCheck,
     JavaMessageFormatCheck,
+    LuaFormatCheck,
     MultipleUnnamedFormatsCheck,
     PercentPlaceholdersCheck,
     PerlFormatCheck,
@@ -265,6 +266,11 @@ class CFormatCheckTest(CheckTestCase):
 
     def test_parenthesis(self):
         self.assertFalse(self.check.check_format("(%.0lf%%)", "(%%%.0lf)", False))
+
+
+class LuaFormatCheckTest(CFormatCheckTest):
+    check = LuaFormatCheck()
+    flag = "lua-format"
 
 
 class PerlFormatCheckTest(CFormatCheckTest):

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -915,6 +915,7 @@ CHECK_LIST = [
     "weblate.checks.format.CFormatCheck",
     "weblate.checks.format.PerlFormatCheck",
     "weblate.checks.format.JavaScriptFormatCheck",
+    "weblate.checks.format.LuaFormatCheck",
     "weblate.checks.format.CSharpFormatCheck",
     "weblate.checks.format.JavaFormatCheck",
     "weblate.checks.format.JavaMessageFormatCheck",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -686,6 +686,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 #     "weblate.checks.format.CFormatCheck",
 #     "weblate.checks.format.PerlFormatCheck",
 #     "weblate.checks.format.JavaScriptFormatCheck",
+#     "weblate.checks.format.LuaFormatCheck",
 #     "weblate.checks.format.CSharpFormatCheck",
 #     "weblate.checks.format.JavaFormatCheck",
 #     "weblate.checks.format.JavaMessageFormatCheck",


### PR DESCRIPTION
## Proposed changes

Hello, I'd like to fix issue #4289 (Support Lua format) as my first contribution.
For Weblate's purposes, a Lua format string is a C format string. (The differences are that some features supported by `printf()` in C are errors in Lua, and the allowed type codes -- which Weblate does not police in any case -- include 'q'.)

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Because of the close relationship between Lua and C format strings, I believe we can be content with a very simple unit test (same as the corresponding feature for Perl, for instance).

As a new contributor who'd previously only used hosted Weblate, I may have missed a step in the end-to-end delivery of this feature. (Hopefully not.)

Because weblate.checks.same makes an apparent effort to maintain parity with weblate.checks.format, I'm opening a separate PR to ensure it stays caught up.

All the best,
Justin