### PR TITLE
Refactor checks.same to keep feature parity with checks.format.

### DIFF
--- a/weblate/checks/same.py
+++ b/weblate/checks/same.py
@@ -25,12 +25,7 @@ from django.utils.translation import gettext_lazy as _
 
 from weblate.checks.base import TargetCheck
 from weblate.checks.data import IGNORE_WORDS
-from weblate.checks.format import (
-    C_PRINTF_MATCH,
-    PHP_PRINTF_MATCH,
-    PYTHON_BRACE_MATCH,
-    PYTHON_PRINTF_MATCH,
-)
+from weblate.checks.format import FLAG_RULES
 from weblate.checks.languages import LANGUAGES
 from weblate.checks.qt import QT_FORMAT_MATCH, QT_PLURAL_MATCH
 from weblate.checks.ruby import RUBY_FORMAT_MATCH
@@ -80,15 +75,11 @@ def strip_format(msg, flags):
 
     These are quite often not changed by translators.
     """
-    if "python-format" in flags:
-        regex = PYTHON_PRINTF_MATCH
-    elif "python-brace-format" in flags:
-        regex = PYTHON_BRACE_MATCH
-    elif "php-format" in flags:
-        regex = PHP_PRINTF_MATCH
-    elif "c-format" in flags:
-        regex = C_PRINTF_MATCH
-    elif "qt-format" in flags:
+    for format_flag, (regex, _is_position_based) in FLAG_RULES.items():
+        if format_flag in flags:
+            return regex.sub("", msg)
+
+    if "qt-format" in flags:
         regex = QT_FORMAT_MATCH
     elif "qt-plural-format" in flags:
         regex = QT_PLURAL_MATCH


### PR DESCRIPTION
## Proposed changes

Hello,
I'm [trying](https://github.com/WeblateOrg/weblate/pull/5248) to support a new programming language (Lua, flagged as `#, lua-format`), and I noticed weblate.checks.same was aware of several format string flavors in its own right.
To avoid making this worse by making weblate.checks.format better, I propose a simple refactoring so the "same" check automatically picks up enhancements like this.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Either this is a good refactor (and some of the above criteria are inapplicable), or it's problematic and we can take another approach.
Honestly, it's probably not too bad to merge #5248 and leave this alone, but I felt like I had to provide an alternative.

All the best,
Justin