### PR TITLE
Tune-up of VCS documentation

### DIFF
--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -131,8 +131,8 @@ Weblate internal URLs
 +++++++++++++++++++++
 
 Share one repository setup between different components by referring to
-its placement as ``weblate://project/component`` in other components. This way other components
-use the VCS repository configuration of the referenced component.
+its placement as ``weblate://project/component`` in other(linked) components. This way linked components
+use the VCS repository configuration of the main(referenced) component.
 
 .. hint::
 

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -5,7 +5,7 @@ Version control integration
 
 Weblate currently supports :ref:`vcs-git` (with extended support for
 :ref:`vcs-github`, :ref:`vcs-gerrit` and :ref:`vcs-git-svn`) and
-:ref:`vcs-mercurial` as version control backends.
+:ref:`vcs-mercurial` as version control back-ends.
 
 .. _vcs-repos:
 
@@ -26,16 +26,16 @@ Accessing repositories from Hosted Weblate
 For Hosted Weblate there is a dedicated push user registered on GitHub,
 Bitbucket, Codeberg and GitLab (with username :guilabel:`weblate` named
 :guilabel:`Weblate push user`). You need to add this user as a collaborator and
-give it appropriate permission to your repository (read only is okay for
+give it appropriate permission to your repository (read-only is okay for
 cloning, write is required for pushing). Depending on service and your
-organization settings, this happens immediately or requires confirmation from
+organization settings, this happens immediately, or requires confirmation on
 Weblate side.
 
-The invitations on GitHub are accepted automatically within five minutes, on
-other services manual processing might be needed, so please be patient.
+Added users are accepted within five minutes GitHub, on other services
+manual processing might be needed, so please be patient.
 
 Once the :guilabel:`weblate` user is added, you can configure
-:ref:`component-repo` and :ref:`component-push` using SSH protocol (for example
+:ref:`component-repo` and :ref:`component-push` using the SSH protocol (for example
 ``git@github.com:WeblateOrg/weblate.git``).
 
 .. _ssh-repos:
@@ -49,7 +49,7 @@ repository this way.
 
 .. warning::
 
-    On GitHub, each key can be use only once, see :ref:`vcs-repos-github` and
+    On GitHub, each key can only be used once, see :ref:`vcs-repos-github` and
     :ref:`hosted-push`.
 
 Weblate also stores the host key fingerprint upon first connection, and fails to
@@ -130,14 +130,17 @@ approach is also used for Hosted Weblate, there is dedicated
 Weblate internal URLs
 +++++++++++++++++++++
 
-To share one repository between different components you can use a special URL
-like ``weblate://project/component``. This way, the component will share the
-VCS repository configuration with the referenced component
-(``project/component`` in the example).
+Share one repository setup between different components by reffering to
+its placement as ``weblate://project/component``. This way other components
+use the VCS repository configuration of the referenced component.
 
-Weblate automatically adjusts repository URL when creating component when it
-finds component with matching repository setup. You can override this in last
-step of component configuration.
+.. hint::
+
+   Make sure not to delete components others point to for their setup.
+
+Weblate automatically adjusts the repository URL when creating a component when it
+finds a component with a matching repository setup. You can override this in
+the last step of the component configuration.
 
 Reasons to use this:
 
@@ -431,8 +434,8 @@ users to maintain a full clone of the internal repository and commit locally.
 Subversion credentials
 ++++++++++++++++++++++
 
-Weblate expects you to have accepted the certificate up-front and if needed,
-your credentials. It will look to insert them into the :setting:`DATA_DIR`
+Weblate expects you to have accepted the certificate up-front (and your
+credentials if needed). It will look to insert them into the :setting:`DATA_DIR`
 directory. Accept the certificate by using `svn` once with the `$HOME`
 environment variable set to the :setting:`DATA_DIR`:
 

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -130,7 +130,7 @@ approach is also used for Hosted Weblate, there is dedicated
 Weblate internal URLs
 +++++++++++++++++++++
 
-Share one repository setup between different components by reffering to
+Share one repository setup between different components by referring to
 its placement as ``weblate://project/component`` in other components. This way other components
 use the VCS repository configuration of the referenced component.
 

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -52,7 +52,7 @@ repository this way.
     On GitHub, each key can only be used once, see :ref:`vcs-repos-github` and
     :ref:`hosted-push`.
 
-Weblate also stores the fingerprint for the host key upon first connection, and fails to
+Weblate also stores the fingerprint of the host key upon first connection, and fails to
 connect to the host should it be changed later (see :ref:`verify-ssh`).
 
 In case adjustment is needed, do so from the Weblate admin interface:

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -28,7 +28,7 @@ Bitbucket, Codeberg and GitLab (with username :guilabel:`weblate` named
 :guilabel:`Weblate push user`). You need to add this user as a collaborator and
 give it appropriate permission to your repository (read-only is okay for
 cloning, write is required for pushing). Depending on service and your
-organization settings, this happens immediately, or requires confirmation on
+organization settings, this happens immediately, or requires confirmation on the
 Weblate side.
 
 Added users are accepted within five minutes GitHub, on other services

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -31,8 +31,8 @@ cloning, write is required for pushing). Depending on service and your
 organization settings, this happens immediately, or requires confirmation on the
 Weblate side.
 
-Added users are accepted within five minutes GitHub, on other services
-manual processing might be needed, so please be patient.
+The :guilabel:`weblate` user on GitHub accepts invitations automatically within five minutes. 
+Manual processing might be needed on the other services, so please be patient.
 
 Once the :guilabel:`weblate` user is added, you can configure
 :ref:`component-repo` and :ref:`component-push` using the SSH protocol (for example

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -52,7 +52,7 @@ repository this way.
     On GitHub, each key can only be used once, see :ref:`vcs-repos-github` and
     :ref:`hosted-push`.
 
-Weblate also stores the fingerprint of the host key upon first connection, and fails to
+Weblate also stores the host key fingerprint upon first connection, and fails to
 connect to the host should it be changed later (see :ref:`verify-ssh`).
 
 In case adjustment is needed, do so from the Weblate admin interface:

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -24,7 +24,7 @@ Accessing repositories from Hosted Weblate
 ++++++++++++++++++++++++++++++++++++++++++
 
 For Hosted Weblate there is a dedicated push user registered on GitHub,
-Bitbucket, Codeberg and GitLab (with username :guilabel:`weblate` named
+Bitbucket, Codeberg and GitLab (with the username :guilabel:`weblate` named
 :guilabel:`Weblate push user`). You need to add this user as a collaborator and
 give it appropriate permission to your repository (read-only is okay for
 cloning, write is required for pushing). Depending on service and your
@@ -147,7 +147,7 @@ Reasons to use this:
 * Saves disk space on the server, the repository is stored just once.
 * Makes the updates faster, only one repository is updated.
 * There is just single exported repository with Weblate translations (see :ref:`git-exporter`).
-* Some addons can operate on more components sharing single repository, for example :ref:`addon-weblate.git.squash`.
+* Some addons can operate on multiple components sharing one repository, for example :ref:`addon-weblate.git.squash`.
 
 
 HTTPS repositories
@@ -425,7 +425,7 @@ users to maintain a full clone of the internal repository and commit locally.
 
 .. versionchanged:: 2.19
 
-    Before this, there was only support for standard layout repositories.
+    Before this, only repositories using the standard layout were supported.
 
 .. _git-svn: https://git-scm.com/docs/git-svn
 

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -131,7 +131,7 @@ Weblate internal URLs
 +++++++++++++++++++++
 
 Share one repository setup between different components by reffering to
-its placement as ``weblate://project/component``. This way other components
+its placement as ``weblate://project/component`` in other components. This way other components
 use the VCS repository configuration of the referenced component.
 
 .. hint::

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -134,11 +134,11 @@ Share one repository setup between different components by referring to
 its placement as ``weblate://project/component`` in other(linked) components. This way linked components
 use the VCS repository configuration of the main(referenced) component.
 
-.. hint::
+.. warning::
 
-   Make sure not to delete components others point to for their setup.
+   Removing main component also removes linked components.
 
-Weblate automatically adjusts the repository URL when creating a component when it
+Weblate automatically adjusts the repository URL when creating a component if it
 finds a component with a matching repository setup. You can override this in
 the last step of the component configuration.
 

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -52,7 +52,7 @@ repository this way.
     On GitHub, each key can only be used once, see :ref:`vcs-repos-github` and
     :ref:`hosted-push`.
 
-Weblate also stores the host key fingerprint upon first connection, and fails to
+Weblate also stores the fingerprint for the host key upon first connection, and fails to
 connect to the host should it be changed later (see :ref:`verify-ssh`).
 
 In case adjustment is needed, do so from the Weblate admin interface:


### PR DESCRIPTION
Should it be "SVN co" instead of "svn co"? Not sure what that is.