### PR TITLE
Translation: Support for adding/removing units on bilingual source

### DIFF
--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -205,13 +205,13 @@ def check_edit_approved(user, permission, obj):
 
 
 def check_manage_units(translation: Translation, component: Component) -> bool:
-    # Check if adding is generally allowed
-    if not component.manage_units or translation.is_readonly:
-        return False
     source = translation.is_source
     template = component.has_template()
-    # Add to source in monolingual and to translations in bilingual
-    if (source and not template) or (not source and template):
+    # Add only to source in monolingual
+    if not source and template:
+        return False
+    # Check if adding is generally allowed
+    if not component.manage_units or (template and not component.edit_template):
         return False
     return True
 


### PR DESCRIPTION


## Proposed changes

This adds/removes units on all translations. Both bilingual and
monolingual formats behave consistently regardless there is difference
in how the units are stored.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
