### PR TITLE
Project: Bring back pagination to component listing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Not yet released.
 * Improved alerts behavior with glossaries.
 * Improved Markdown link checks.
 * Indicate glossary and source language in breadcrumbs.
+* Paginate component listing on huge projects.
 
 Weblate 4.5
 -----------

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -238,15 +238,19 @@ function loadTableSorting() {
         // skip empty cells and cells with icon (probably already processed)
         if (
           th.text() !== "" &&
-          !th.hasClass("sort-cell") &&
+          !th.hasClass("sort-init") &&
           !th.hasClass("sort-skip")
         ) {
           // Store index copy
           let myIndex = thIndex;
           // Add icon, title and class
-          th.attr("title", gettext("Sort this column"))
-            .addClass("sort-cell")
-            .append('<span class="sort-icon" />');
+          th.addClass("sort-init");
+          if (!th.hasClass("sort-cell")) {
+            // Skip statically initialized parts (when server side ordering is supported)
+            attr("title", gettext("Sort this column"))
+              .addClass("sort-cell")
+              .append('<span class="sort-icon" />');
+          }
 
           // Click handler
           th.click(function () {

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -288,12 +288,16 @@ td .list-group {
   height: auto;
 }
 
-.sort-cell {
+.sort-cell,
+.sort-cell a {
   cursor: pointer;
+  color: #2a3744;
 }
 
-.sort-cell:hover {
+.sort-cell:hover,
+.sort-cell:hover a {
   color: #1fa385;
+  text-decoration: none;
 }
 
 .sort-icon {

--- a/weblate/templates/dashboard/user.html
+++ b/weblate/templates/dashboard/user.html
@@ -17,7 +17,7 @@
 
 <ul class="nav nav-pills">
 {% if user.is_authenticated %}
-<li {% active_link "your-subscriptions" %}><a href="#your-subscriptions" data-toggle="tab">{% trans "Watched translations" %} <span class="badge">{{ usersubscriptions|length }}</span></a></li>
+<li {% active_link "your-subscriptions" %}><a href="#your-subscriptions" data-toggle="tab">{% trans "Watched translations" %} <span class="badge">{{ usersubscriptions.paginator.count }}</span></a></li>
 {% endif %}
 {% if all_componentlists %}
 <li {% active_link "componentlists" %}><a href="#componentlists" data-toggle="tab">{% trans "Component lists" %} <span class="badge">{{ all_componentlists|length }}</span></a></li>
@@ -49,6 +49,8 @@
 {% if watched_projects %}
     {% if usersubscriptions %}
         {% include "snippets/list-objects.html" with objects=usersubscriptions label=_("Component") hide_completed=user.profile.hide_completed name_source="translation" %}
+
+        {% include "paginator.html" with page_obj=usersubscriptions %}
     {% else %}
         {% include "list-projects.html" with projects=watched_projects %}
     {% endif %}

--- a/weblate/templates/paginator.html
+++ b/weblate/templates/paginator.html
@@ -3,8 +3,8 @@
 
 {% if page_obj.paginator.num_pages > 1 %}
 <ul class="pagination">
-<li {% if page_obj.number == 1 %}class="disabled"{% endif %}><a href="?page=1&amp;limit={{ page_obj.paginator.per_page }}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}" class="green">{% if LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a></li>
-<li {% if not page_obj.has_previous %}class="disabled"{% endif %}><a {% if page_obj.has_previous %}href="?page={{ page_obj.previous_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"{% endif %} class="green">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a></li>
+<li {% if page_obj.number == 1 %}class="disabled"{% endif %}><a href="?page=1&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}" class="green">{% if LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a></li>
+<li {% if not page_obj.has_previous %}class="disabled"{% endif %}><a {% if page_obj.has_previous %}href="?page={{ page_obj.previous_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"{% endif %} class="green">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a></li>
 <li>
   <a id="position-input" title="{% trans "Click to edit position" %}" >
     {% blocktrans with page_obj.number as position and page_obj.paginator.num_pages as total %}{{ position }} / {{ total }}{% endblocktrans %}
@@ -25,7 +25,7 @@
     </form>
   </a>
 </li>
-<li {% if not page_obj.has_next %}class="disabled"{% endif %}><a {% if page_obj.has_next %}href="?page={{ page_obj.next_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"{% endif %} class="green">{% if not LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a></li>
-<li {% if page_obj.paginator.num_pages == page_obj.number %}class="disabled"{% endif %}><a href="?page={{ page_obj.paginator.num_pages }}&amp;limit={{ page_obj.paginator.per_page }}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}" class="green">{% if not LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a></li>
+<li {% if not page_obj.has_next %}class="disabled"{% endif %}><a {% if page_obj.has_next %}href="?page={{ page_obj.next_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"{% endif %} class="green">{% if not LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a></li>
+<li {% if page_obj.paginator.num_pages == page_obj.number %}class="disabled"{% endif %}><a href="?page={{ page_obj.paginator.num_pages }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}" class="green">{% if not LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a></li>
 </ul>
 {% endif %}

--- a/weblate/templates/project.html
+++ b/weblate/templates/project.html
@@ -137,6 +137,8 @@
 
 {% include "snippets/list-objects.html" with objects=components name_source="name" label=_("Component") %}
 
+{% include "paginator.html" with page_obj=components %}
+
 {% if user_can_edit_project %}
 <p>
   <a class="btn btn-primary project-add-component" href="{% url 'create-component' %}?project={{ object.pk }}">{% trans "Add new translation component" %}</a>

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -7,21 +7,88 @@
 {% init_unique_row_id %}
 
 {% if objects %}
-<table class="sort table progress-table autocolspan table-listing">
-{% if not hide_details %}
-<thead>
-<tr>
-<th class="sort-skip"></th>
-<th>{{ label|default:_("Project") }}</th>
-<th class="number">{% trans "Translated" %}</th>
-<th class="number zero-width-640">{% trans "Untranslated" %}</th>
-<th class="number zero-width-720">{% trans "Untranslated words" %}</th>
-<th class="number zero-width-768">{% trans "Checks" %}</th>
-<th class="number zero-width-900">{% trans "Suggestions" %}</th>
-<th class="number zero-width-1000">{% trans "Comments" %}</th>
-</tr>
-</thead>
-{% endif %}
+  {% if objects.paginator.num_pages > 1 %}
+    <table class="table progress-table autocolspan table-listing">
+  {% else %}
+    <table class="sort table progress-table autocolspan table-listing">
+  {% endif %}
+  {% if not hide_details %}
+    <thead>
+      <tr>
+        <th class="sort-skip"></th>
+        <th title="{% trans "Sort this column" %}" class="sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "name" %}-{% endif %}name">
+          {% endif %}
+          {{ label|default:_("Project") }}
+          <span class="sort-icon {% if objects.paginator.sort_by == "name" %}sort-down{% elif objects.paginator.sort_by == "-name" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
+        <th title="{% trans "Sort this column" %}" class="number sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "translated" %}-{% endif %}translated">
+          {% endif %}
+          {% trans "Translated" %}
+          <span class="sort-icon {% if objects.paginator.sort_by == "translated" %}sort-down{% elif objects.paginator.sort_by == "-translated" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
+        <th title="{% trans "Sort this column" %}" class="number zero-width-640 sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated" %}-{% endif %}untranslated">
+          {% endif %}
+          {% trans "Untranslated" %}
+          <span class="sort-icon {% if objects.paginator.sort_by == "untranslated" %}sort-down{% elif objects.paginator.sort_by == "-untranslated" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
+        <th title="{% trans "Sort this column" %}" class="number zero-width-720 sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated_words" %}-{% endif %}untranslated_words">
+          {% endif %}
+          {% trans "Untranslated words" %}
+          <span class="sort-icon {% if objects.paginator.sort_by == "untranslated_words" %}sort-down{% elif objects.paginator.sort_by == "-untranslated_words" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
+        <th title="{% trans "Sort this column" %}" class="number zero-width-768 sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "checks" %}-{% endif %}checks">
+          {% endif %}
+          {% trans "Checks" %}
+          <span class="sort-icon {% if objects.paginator.sort_by == "checks" %}sort-down{% elif objects.paginator.sort_by == "-checks" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
+        <th title="{% trans "Sort this column" %}" class="number zero-width-900 sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "suggestions" %}-{% endif %}suggestions">
+          {% endif %}
+          {% trans "Suggestions" %}
+          <span class="sort-icon {% if objects.paginator.sort_by == "suggestions" %}sort-down{% elif objects.paginator.sort_by == "-suggestions" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
+        <th title="{% trans "Sort this column" %}" class="number zero-width-1000 sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "comments" %}-{% endif %}comments">
+          {% endif %}
+          {% trans "Comments" %}
+          <span class="sort-icon {% if objects.paginator.sort_by == "comments" %}sort-down{% elif objects.paginator.sort_by == "-comments" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
+      </tr>
+    </thead>
+  {% endif %}
 
 
 <tbody>

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -56,6 +56,7 @@ from weblate.utils.ratelimit import session_ratelimit_post
 from weblate.utils.stats import GhostProjectLanguageStats, prefetch_stats
 from weblate.utils.views import (
     get_component,
+    get_paginator,
     get_project,
     get_translation,
     optional_form,
@@ -138,7 +139,10 @@ def show_project(request, project):
         obj.change_set.prefetch().order().filter(action=Change.ACTION_ANNOUNCEMENT)[:10]
     )
 
-    all_components = obj.child_components.filter_access(user).prefetch().order()
+    all_components = prefetch_stats(
+        obj.child_components.filter_access(user).prefetch().order()
+    )
+    all_components = get_paginator(request, all_components)
     for component in all_components:
         component.is_shared = None if component.project == obj else component.project
 
@@ -164,7 +168,7 @@ def show_project(request, project):
         ),
     )
 
-    components = prefetch_tasks(prefetch_stats(all_components))
+    components = prefetch_tasks(all_components)
 
     return render(
         request,

--- a/weblate/trans/views/dashboard.py
+++ b/weblate/trans/views/dashboard.py
@@ -41,6 +41,7 @@ from weblate.trans.models.translation import GhostTranslation
 from weblate.trans.util import render
 from weblate.utils import messages
 from weblate.utils.stats import prefetch_stats
+from weblate.utils.views import get_paginator
 
 
 def translation_prefetch_tasks(translations):
@@ -274,6 +275,7 @@ def dashboard_user(request):
                 component__project__in=user.watched_projects
             )
         )
+        usersubscriptions = get_paginator(request, usersubscriptions)
 
         if user.profile.hide_completed:
             usersubscriptions = get_untranslated(usersubscriptions)


### PR DESCRIPTION
## Proposed changes

In case there is 1k+ components in a projects, the generated page is
huge and takes long to load and render.

This partially reverts 2cddd81be2b8e8cc38d5bfce4aa687fd921897bb from
pull request #4349, ordering as requested by #3011 is still to be
addressed.

Fixes #5513


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
