### PR TITLE
Docs: fix shortcut format

### DIFF
--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -204,13 +204,13 @@ The following keyboard shortcuts can be utilized during translation:
 |                                           |                                                                       |
 | :kbd:`Cmd+1` to :kbd:`Cmd+9`              |                                                                       |
 +-------------------------------------------+-----------------------------------------------------------------------+
-| :kbd:`Ctrl+M`+:kbd:`1` to :kbd:`9` or     | Copy the machine translation of given number to current translation.  |
+| :kbd:`Ctrl+M`\+\ :kbd:`1` to :kbd:`9` or  | Copy the machine translation of given number to current translation.  |
 |                                           |                                                                       |
-| :kbd:`Cmd+M`+:kbd:`1` to :kbd:`9`         |                                                                       |
+| :kbd:`Cmd+M`\+\ :kbd:`1` to :kbd:`9`      |                                                                       |
 +-------------------------------------------+-----------------------------------------------------------------------+
-| :kbd:`Ctrl+I`+:kbd:`1` to :kbd:`9` or     | Ignore one item in the list of failing checks.                        |
+| :kbd:`Ctrl+I`\+\ :kbd:`1` to :kbd:`9` or  | Ignore one item in the list of failing checks.                        |
 |                                           |                                                                       |
-| :kbd:`Cmd+I`+:kbd:`1` to :kbd:`9`         |                                                                       |
+| :kbd:`Cmd+I`\+\ :kbd:`1` to :kbd:`9`      |                                                                       |
 +-------------------------------------------+-----------------------------------------------------------------------+
 | :kbd:`Ctrl+J` or                          | Shows the :guilabel:`Nearby strings` tab.                             |
 |                                           |                                                                       |


### PR DESCRIPTION
Before:

![Captura de tela de 2021-03-05 17-01-36](https://user-images.githubusercontent.com/1571783/110167476-8d2ce300-7dd4-11eb-8a95-d4e79557491e.png)

After:

![Captura de tela de 2021-03-05 17-01-24](https://user-images.githubusercontent.com/1571783/110167493-95851e00-7dd4-11eb-9df7-d318f876d94a.png)

See: https://docs.weblate.org/en/latest/user/translating.html#keyboard-shortcuts