### PR TITLE
Formats: Add scheme format.

### DIFF
--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -443,6 +443,23 @@ Ruby format
 
     `Ruby Kernel#sprintf <https://ruby-doc.org/core/Kernel.html#method-i-sprintf>`_
 
+Scheme format
+*************
+
+*Scheme format string does not match source*
+
++------------------------+------------------------------------------------------------+
+| Simple format string   | ``There are ~d apples``                                    |
++------------------------+------------------------------------------------------------+
+| Flag to enable         | `scheme-format`                                            |
++------------------------+------------------------------------------------------------+
+
+.. seealso::
+
+    `Srfi 28 <https://srfi.schemers.org/srfi-28/srfi-28.html>`_,
+    `Chicken Scheme format <https://wiki.call-cc.org/eggref/5/format>`_,
+    `Guile Scheme formatted output <https://www.gnu.org/software/guile/manual/html_node/Formatted-Output.html>`_
+
 Vue I18n formatting
 *******************
 

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -71,6 +71,7 @@ class WeblateChecksConf(AppConf):
         "weblate.checks.format.PerlFormatCheck",
         "weblate.checks.format.JavaScriptFormatCheck",
         "weblate.checks.format.LuaFormatCheck",
+        "weblate.checks.format.SchemeFormatCheck",
         "weblate.checks.format.CSharpFormatCheck",
         "weblate.checks.format.JavaFormatCheck",
         "weblate.checks.format.JavaMessageFormatCheck",

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -917,6 +917,7 @@ CHECK_LIST = [
     "weblate.checks.format.PerlFormatCheck",
     "weblate.checks.format.JavaScriptFormatCheck",
     "weblate.checks.format.LuaFormatCheck",
+    "weblate.checks.format.SchemeFormatCheck",
     "weblate.checks.format.CSharpFormatCheck",
     "weblate.checks.format.JavaFormatCheck",
     "weblate.checks.format.JavaMessageFormatCheck",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -692,6 +692,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 #     "weblate.checks.format.PerlFormatCheck",
 #     "weblate.checks.format.JavaScriptFormatCheck",
 #     "weblate.checks.format.LuaFormatCheck",
+#     "weblate.checks.format.SchemeFormatCheck",
 #     "weblate.checks.format.CSharpFormatCheck",
 #     "weblate.checks.format.JavaFormatCheck",
 #     "weblate.checks.format.JavaMessageFormatCheck",


### PR DESCRIPTION
Fixes #5504.

## Proposed changes

This adds scheme format checking.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Lint passes, but I have two failing tests. I have  copied tests from php, and adapted them to scheme syntax, but I might not understand fully what they are testing. The two failing tests are:

```
2021-03-06T21:37:47.5201557Z ----------------------------------------------------------------------
2021-03-06T21:37:47.5203539Z Traceback (most recent call last):
2021-03-06T21:37:47.5206320Z   File "/home/runner/work/weblate/weblate/weblate/checks/tests/test_format_checks.py", line 306, in test_missing_tilde_format
2021-03-06T21:37:47.5208133Z     self.check.check_format("~s~~ ~~", "~s~~ tilde", False, None)
2021-03-06T21:37:47.5210472Z AssertionError: {'missing': ['~'], 'extra': []} is not false
2021-03-06T21:37:47.5211631Z 
2021-03-06T21:37:47.5212506Z ======================================================================
2021-03-06T21:37:47.5214028Z FAIL: test_space_format (weblate.checks.tests.test_format_checks.SchemeFormatCheckTest)
2021-03-06T21:37:47.5216034Z ----------------------------------------------------------------------
2021-03-06T21:37:47.5217256Z Traceback (most recent call last):
2021-03-06T21:37:47.5219118Z   File "/home/runner/work/weblate/weblate/weblate/checks/tests/test_format_checks.py", line 311, in test_space_format
2021-03-06T21:37:47.5220385Z     self.check.check_format("~d ~ string", "~d ~ other", False, None)
2021-03-06T21:37:47.5221167Z AssertionError: False is not true
2021-03-06T21:37:47.5221643Z 
2021-03-06T21:37:47.5222475Z ----------------------------------------------------------------------
```

I think I don't understand the purpose of the second value (c_format_is_position_based). I see it returns a boolean, but I'm not entirely sure what the input is, and what the boolean represents exactly. I tried to define my own `scheme_format_is_position_based`, but I'm not sure this is correct.

I don't really understand how positioning works either, like if the original source has `~a ~d` and the translated versions has `~1@*~d ~0@*~a` (btw formats are 0-based), how can weblate detect this is correct?
