### PR TITLE
formats: make "state" attribute literal

### DIFF
--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -267,7 +267,7 @@ Translation states
 
 .. versionchanged:: 3.3
 
-   Weblate ignored the state attribute prior to the 3.3 release.
+   Weblate ignored the ``state`` attribute prior to the 3.3 release.
 
 The ``state`` attribute in the file is partially processed and mapped to the
 "Needs edit" state in Weblate (the following states are used to flag the string as


### PR DESCRIPTION
I believe "state" should not be translated, since it is the name of an attribute. So, marking it as ``` ``literal`` ```.