### PR TITLE
Spelling: Suitable for offline translation

### DIFF
--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -342,7 +342,7 @@
       <tr>
         <th class="number">{{ object.stats.all|intcomma }}</th>
         <td>
-          {% trans "All strings, converted files enriched with comments; suitable for translating offline" %}
+          {% trans "All strings, converted files enriched with comments; suitable for offline translation" %}
         </td>
         {% for exporter in exporters %}
           <td class="formats">
@@ -354,7 +354,7 @@
       <tr>
         <th class="number">{{ object.stats.todo|intcomma }}</th>
         <td>
-          {% trans "Strings needing action, converted files enriched with comments; suitable for translating offline" %}
+          {% trans "Strings needing action, converted files enriched with comments; suitable for offline translation" %}
         </td>
         {% for exporter in exporters %}
           <td class="formats">


### PR DESCRIPTION
Not 100% sure this is better, I think I have seen "offline translation" somewhere else.