### PR TITLE
Contact form language reworked

### DIFF
--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -12,9 +12,9 @@
 
 <div class="alert alert-info">
   <ul>
-    <li>{% blocktrans %}For questions about specific translation project, contact its maintainers directly, not by this form.{% endblocktrans %}</li>
-    <li>{% blocktrans %}You can only contact maintainers of the whole server here.{% endblocktrans %}</li>
-    <li>{% blocktrans %}If you seek support for Weblate, or want to file a bug-report, check its website at {{ weblate_link }}.{% endblocktrans %}</li>
+    <li>{% blocktrans %}Contact maintainers of this Weblate here.{% endblocktrans %}</li>
+    <li>{% blocktrans %}Questions about specific translation projects should instead be directed to their respective maintainers.{% endblocktrans %}</li>
+    <li>{% blocktrans %}Get support for and contribute to Weblate at {{ weblate_link }}.{% endblocktrans %}</li>
   </ul>
 </div>
 

--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -14,7 +14,7 @@
   <ul>
     <li>{% blocktrans %}Contact maintainers of this Weblate here.{% endblocktrans %}</li>
     <li>{% blocktrans %}Questions about specific translation projects should instead be directed to their respective maintainers.{% endblocktrans %}</li>
-    <li>{% blocktrans %}Get support for and contribute to Weblate at {{ weblate_link }}.{% endblocktrans %}</li>
+    <li>{% blocktrans %}Get support for and contribute to Weblate itself at {{ weblate_link }}.{% endblocktrans %}</li>
   </ul>
 </div>
 


### PR DESCRIPTION
@orangesunny "For questions about specific translation project" which I already supplied an idiomatic suggestion for, isn't correct English.  "about ___(a/any) specific" or "projects" is the mistake. It is also a double-clause sentence. It is my name in the "reviewers".

"Bug-report" originally does away with the "bug reports to headquarters" idiosyncrasy, but is avoided here.