### PR TITLE
auto_translate management command: Add translation mode support

### DIFF
--- a/docs/admin/management.rst
+++ b/docs/admin/management.rst
@@ -105,6 +105,10 @@ auto_translate
 
 .. versionadded:: 2.5
 
+.. versionchanged:: 4.6
+
+    Added parameter for translation mode.
+
 Performs automatic translation based on other component translations.
 
 .. django-admin-option:: --source PROJECT/COMPONENT
@@ -137,6 +141,11 @@ Performs automatic translation based on other component translations.
 .. django-admin-option:: --threshold THRESHOLD
 
     Similarity threshold for machine translation, defaults to 80.
+
+.. django-admin-option:: --mode MODE
+
+    Specify translation mode, default is "translate" but "fuzzy" or "suggest"
+    can be used.
 
 Example:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,7 @@ Weblate 4.6
 
 Not yet released.
 
+* The auto_translate management command has now a parameter for specifying translation mode.
 * Added support for :ref:`txt`.
 
 Weblate 4.5.2

--- a/weblate/trans/management/commands/auto_translate.py
+++ b/weblate/trans/management/commands/auto_translate.py
@@ -104,8 +104,7 @@ class Command(WeblateTranslationCommand):
 
         if options["mode"] not in ("translate", "fuzzy", "suggest"):
             raise CommandError("Invalid translation mode specified!")
-        else:
-            mode = options["mode"]
+        mode = options["mode"]
 
         if options["inconsistent"]:
             filter_type = "check:inconsistent"

--- a/weblate/trans/management/commands/auto_translate.py
+++ b/weblate/trans/management/commands/auto_translate.py
@@ -67,6 +67,11 @@ class Command(WeblateTranslationCommand):
             type=int,
             help=("Set machine translation threshold"),
         )
+        parser.add_argument(
+            "--mode",
+            default="translate",
+            help=("Translation mode; translate, fuzzy or suggest")
+        )
 
     def handle(self, *args, **options):
         # Get translation object
@@ -97,13 +102,18 @@ class Command(WeblateTranslationCommand):
                         f"Machine translation {translator} is not available"
                     )
 
+        if options["mode"] not in ("translate", "fuzzy", "suggest"):
+            raise CommandError("Invalid translation mode specified!")
+        else:
+            mode = options["mode"]
+
         if options["inconsistent"]:
             filter_type = "check:inconsistent"
         elif options["overwrite"]:
             filter_type = "all"
         else:
             filter_type = "todo"
-        auto = AutoTranslate(user, translation, filter_type, "translate")
+        auto = AutoTranslate(user, translation, filter_type, mode)
         if options["mt"]:
             auto.process_mt(options["mt"], options["threshold"])
         else:

--- a/weblate/trans/management/commands/auto_translate.py
+++ b/weblate/trans/management/commands/auto_translate.py
@@ -70,7 +70,7 @@ class Command(WeblateTranslationCommand):
         parser.add_argument(
             "--mode",
             default="translate",
-            help=("Translation mode; translate, fuzzy or suggest")
+            help=("Translation mode; translate, fuzzy or suggest"),
         )
 
     def handle(self, *args, **options):


### PR DESCRIPTION
## Proposed changes

Add translation mode support to `auto_translate` management command following that it already exists in the [Web Interface](https://docs.weblate.org/en/latest/user/translating.html?highlight=automatic%20translation#automatic-translation).

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

```shell
$ docker-compose exec weblate weblate auto_translate -h
usage: weblate auto_translate [-h] [--user USER] [--source SOURCE] [--add]
                              [--overwrite] [--inconsistent] [--mt MT]
                              [--threshold THRESHOLD] [--mode MODE]
                              [--version] [-v {0,1,2,3}] [--settings SETTINGS]
                              [--pythonpath PYTHONPATH] [--traceback]
                              [--no-color] [--force-color]
                              project component language

performs automatic translation based on other components

positional arguments:
  project               Slug of project
  component             Slug of component
  language              Slug of language

optional arguments:
  -h, --help            show this help message and exit
  --user USER           User performing the change
  --source SOURCE       Source component <project/component>
  --add                 Add translations if they do not exist
  --overwrite           Overwrite existing translations in target component
  --inconsistent        Process only inconsistent translations
  --mt MT               Add machine translation source
  --threshold THRESHOLD
                        Set machine translation threshold
  --mode MODE           Translation mode; translate, fuzzy or suggest
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --force-color         Force colorization of the command output.
```

```shell
$ docker-compose exec weblate weblate auto_translate --source teste2/componenteb1 --mode fuzzy --mt weblate teste2 componenteb1 pt_BR
    [2021-03-29 03:33:51,435: INFO/1839] teste2/componenteb1: running source checks for 3 strings
    Updated 4 units
```

```shell
$  docker-compose exec weblate weblate auto_translate --source teste2/componenteb1 --mode fuzzyXXX --mt weblate teste2 componenteb1 pt_BR
    CommandError: Invalid translation mode specified!
    ERROR: 1
```

```shell
$ docker-compose exec weblate weblate auto_translate --source teste2/componenteb1 --threshold 100 --mt weblate teste2 componenteb1 pt_BR
    [2021-03-29 03:31:22,099: INFO/1733] teste2/componenteb1: running source checks for 0 strings
    Updated 8 units
```
