### PR TITLE
vcs: Avoid locking for getting repository status

### DIFF
--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -289,8 +289,7 @@ class Repository:
 
     def status(self):
         """Return status of the repository."""
-        with self.lock:
-            return self.execute(self._cmd_status)
+        return self.execute(self._cmd_status, needs_lock=False)
 
     def push(self, branch):
         """Push given branch to remote repository."""

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -51,6 +51,7 @@ class GitRepository(Repository):
     _cmd_last_remote_revision = ["log", "-n", "1", "--format=format:%H", "@{upstream}"]
     _cmd_list_changed_files = ["diff", "--name-status"]
     _cmd_push = ["push"]
+    _cmd_status = ["--no-optional-locks", "status"]
 
     name = "Git"
     req_version = "2.12"
@@ -197,7 +198,7 @@ class GitRepository(Repository):
 
     def needs_commit(self, filenames: Optional[List[str]] = None):
         """Check whether repository needs commit."""
-        cmd = ["status", "--porcelain"]
+        cmd = ["--no-optional-locks", "status", "--porcelain"]
         if filenames:
             cmd.extend(["--ignored=matching", "--"])
             cmd.extend(filenames)


### PR DESCRIPTION


## Proposed changes

The git status updating of index is optional, so better to disable it
and avoid locking completely here.

Fixes #6036
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
