### PR TITLE
Account_activity language reworked

### DIFF
--- a/weblate/templates/mail/account_activity.html
+++ b/weblate/templates/mail/account_activity.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <p>
-{% blocktrans %}There has been a following change in your account at {{ site_title }}:{% endblocktrans %}
+{% blocktrans %}The following activity has occured on your account at {{ site_title }}:{% endblocktrans %}
 </p>
 
 <p>
@@ -29,9 +29,9 @@
 </table>
 
 <p>
-{% blocktrans %}If you don’t recognize this change, you can report it by clicking the button below.{% endblocktrans %}
-<b>{% blocktrans %}Don’t use this button for support questions. Such questions won’t be answered.{% endblocktrans %}</b>
-{% blocktrans with link_start='<a href="https://github.com/WeblateOrg/weblate/issues/new/choose">' link_end='</a>'  %}If you have an idea or a question, {{ link_start }}this{{ link_end }} is a good place to start.{% endblocktrans %}
+{% blocktrans %}If this was not done by you, report it by clicking the button below.{% endblocktrans %}
+<b>{% blocktrans %}(Request support through other means.){% endblocktrans %}</b>
+{% blocktrans with link_start='<a href="https://github.com/WeblateOrg/weblate/issues/new/choose">' link_end='</a>'  %}Ideas and questions can be sent to the {{ link_start }}Weblate issue tracker{{ link_end }}.{% endblocktrans %}
 </p>
 
 <div class="line buttons">

--- a/weblate/templates/mail/account_activity.html
+++ b/weblate/templates/mail/account_activity.html
@@ -30,7 +30,7 @@
 
 <p>
 {% blocktrans %}If this was not done by you, report it by clicking the button below.{% endblocktrans %}
-<b>{% blocktrans %}(Request support through other means.){% endblocktrans %}</b>
+<b>{% blocktrans %}Please request support through other means.{% endblocktrans %}</b>
 {% blocktrans with link_start='<a href="https://github.com/WeblateOrg/weblate/issues/new/choose">' link_end='</a>'  %}Ideas and questions can be sent to the {{ link_start }}Weblate issue tracker{{ link_end }}.{% endblocktrans %}
 </p>
 


### PR DESCRIPTION
As the last possible means of quality control, despite statements as to how flawed it was, this has been implemented knowingly. The problem isn't so much discarding better alternatives as it is a disregard for all other means of available help beyond pointing out basic errors.

Between the uncalled-for description of me in abolishing the review team and what members of it instrument on their own accord, the process speaks for itself.

Happy to return to fixing problems as they exist, and not deal with problems relating to interpersonal conflicts as they are created, which I still refuse to do.