### PR TITLE
Spelling: Clarify ambigous language codes in use

### DIFF
--- a/weblate/templates/trans/alert/ambiguouslanguage.html
+++ b/weblate/templates/trans/alert/ambiguouslanguage.html
@@ -2,8 +2,8 @@
 {% load translations %}
 
 <p>
-  {% trans "The component translation files are using ambiguous language code." %}
-  {% trans "These language codes indicate a macrolanguage and it is usually better to use code of individual language instead." %}
+  {% trans "Files for translated languages are using ambiguous language codes." %}
+  {% trans "These language codes indicate a macrolanguage and it is usually better to use the code of the individual language instead." %}
 </p>
 
 <p>{% trans "The following occurrences were found:" %}</p>

--- a/weblate/templates/trans/alert/ambiguouslanguage.html
+++ b/weblate/templates/trans/alert/ambiguouslanguage.html
@@ -3,7 +3,7 @@
 
 <p>
   {% trans "Files for translated languages are using ambiguous language codes." %}
-  {% trans "These language codes indicate a macrolanguage and it is usually better to use the code of the individual language instead." %}
+  {% trans "These language codes indicate a macrolanguage, and it is usually better to use the code of the individual language instead." %}
 </p>
 
 <p>{% trans "The following occurrences were found:" %}</p>


### PR DESCRIPTION
At first I thought this meant

"Different components of the same language are using ambiguous language codes"