### PR TITLE
Adding indent type to choose between integers and strings for JSON addon

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -530,11 +530,13 @@ Customize JSON output
 ---------------------
 
 :Add-on ID: ``weblate.json.customize``
-:Configuration: +---------------+------------------+--+
-                | ``sort_keys`` | Sort JSON keys   |  |
-                +---------------+------------------+--+
-                | ``indent``    | JSON indentation |  |
-                +---------------+------------------+--+
+:Configuration: +-------------------+---------------------------+--+
+                | ``sort_keys``     | Sort JSON keys            |  |
+                +-------------------+---------------------------+--+
+                | ``indent_type``   | JSON indentation Type     |  |
+                +-------------------+---------------------------+--+
+                | ``indent``        | JSON indentation          |  |
+                +-------------------+---------------------------+--+
 
 Allows adjusting JSON output behavior, for example indentation or sorting.
 

--- a/docs/locales/docs.pot
+++ b/docs/locales/docs.pot
@@ -1924,11 +1924,19 @@ msgid "Sort JSON keys"
 msgstr ""
 
 #: ../../admin/addons.rst:536
+msgid "``indent_type``"
+msgstr ""
+
+#: ../../admin/addons.rst:536
+msgid "JSON indentation type"
+msgstr ""
+
+#: ../../admin/addons.rst:538
 #: ../../admin/addons.rst:620
 msgid "``indent``"
 msgstr ""
 
-#: ../../admin/addons.rst:536
+#: ../../admin/addons.rst:538
 msgid "JSON indentation"
 msgstr ""
 

--- a/docs/locales/docs.pot
+++ b/docs/locales/docs.pot
@@ -1924,19 +1924,11 @@ msgid "Sort JSON keys"
 msgstr ""
 
 #: ../../admin/addons.rst:536
-msgid "``indent_type``"
-msgstr ""
-
-#: ../../admin/addons.rst:536
-msgid "JSON indentation type"
-msgstr ""
-
-#: ../../admin/addons.rst:538
 #: ../../admin/addons.rst:620
 msgid "``indent``"
 msgstr ""
 
-#: ../../admin/addons.rst:538
+#: ../../admin/addons.rst:536
 msgid "JSON indentation"
 msgstr ""
 

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -183,8 +183,20 @@ class GitSquashForm(BaseAddonForm):
 
 class JSONCustomizeForm(BaseAddonForm):
     sort_keys = forms.BooleanField(label=_("Sort JSON keys"), required=False)
-    indent = forms.IntegerField(
-        label=_("JSON indentation"), min_value=0, initial=4, required=True
+    indent_type = forms.ChoiceField(
+        label=_("JSON indentation"),
+        widget=forms.RadioSelect,
+        choices=(
+            ("integer", _("Treat Indentation as an integer")),
+            ("string", _("Treat Indentation as a string")),
+        ),
+        initial="integer",
+        required=True,
+    )
+    indent = forms.CharField(
+        label=_("JSON indentation"),
+        required=True,
+        initial="4",
     )
 
 

--- a/weblate/addons/json.py
+++ b/weblate/addons/json.py
@@ -44,5 +44,9 @@ class JSONCustomizeAddon(StoreBaseAddon):
 
     def store_post_load(self, translation, store):
         config = self.instance.configuration
-        store.store.dump_args["indent"] = int(config.get("indent", 4))
+        store.store.dump_args["indent_type"] = config.get("indent_type", "integer")
+        if config.get("indent_type", "integer"):
+            store.store.dump_args["indent"] = int(config.get("indent", "4"))
+        else:
+            store.store.dump_args["indent"] = config.get("indent", "4")
         store.store.dump_args["sort_keys"] = bool(int(config.get("sort_keys", 0)))

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -484,7 +484,7 @@ class JsonAddonTest(ViewTestCase):
 
     def test_customize(self):
         JSONCustomizeAddon.create(
-            self.component, configuration={"indent": 8, "sort": 1}
+            self.component, configuration={"indent_type": 'integer', "indent": 8, "sort": 1}
         )
         rev = self.component.repository.last_revision
         self.edit_unit("Hello, world!\n", "Nazdar svete!\n")


### PR DESCRIPTION
## Proposed changes

This is in response to the issue we was having where we need to indent based on tabs in our files vs spaces.
JSON.dump's indent can be used as integer for spaces or as a string with whatever you want inside of it. That's why in this PR I made an indent_type to parse if the type needs to be treated as an integer

Linked Issue:
https://github.com/WeblateOrg/weblate/issues/5969

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
