### PR TITLE
[IMP] Default Pagination on Environment Variable

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1578,7 +1578,7 @@ How many strings to show around the currently translated string. This is just a 
 DEFAULT_PAGE_LIMIT
 ------------------
 
-.. versionadded:: 4.7.1
+.. versionadded:: 4.7
 
 Default number of elements to display when pagination is active.
 

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1573,6 +1573,15 @@ NEARBY_MESSAGES
 
 How many strings to show around the currently translated string. This is just a default value, users can adjust this in :ref:`user-profile`.
 
+.. setting:: DEFAULT_PAGE_LIMIT
+
+DEFAULT_PAGE_LIMIT
+------------------
+
+.. versionadded:: 4.7.1
+
+Default number of elements to display when pagination is active.
+
 .. setting:: PAGURE_CREDENTIALS
 
 PAGURE_CREDENTIALS

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -927,6 +927,9 @@ LIMIT_TRANSLATION_LENGTH_BY_SOURCE_LENGTH = True
 # Use simple language codes for default language/country combinations
 SIMPLIFY_LANGUAGES = get_env_bool("WEBLATE_SIMPLIFY_LANGUAGES", True)
 
+# Default number of elements to display when pagination is active
+DEFAULT_PAGE_LIMIT = get_env_int("WEBLATE_DEFAULT_PAGE_LIMIT", 100)
+
 # Render forms using bootstrap
 CRISPY_TEMPLATE_PACK = "bootstrap3"
 

--- a/weblate/trans/models/_conf.py
+++ b/weblate/trans/models/_conf.py
@@ -47,6 +47,9 @@ class WeblateConf(AppConf):
     # Enable sharing
     ENABLE_SHARING = True
 
+    # Default number of elements to display when pagination is active
+    DEFAULT_PAGE_LIMIT = 100
+
     # Number of nearby messages to show in each direction
     NEARBY_MESSAGES = 15
 

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -94,9 +94,9 @@ def sort_objects(object_list, sort_by: str):
     return sorted(object_list, key=key, reverse=reverse), sort_by
 
 
-def get_paginator(request, object_list, default_page_limit=100):
+def get_paginator(request, object_list, page_limit=None):
     """Return paginator and current page."""
-    page, limit = get_page_limit(request, default_page_limit)
+    page, limit = get_page_limit(request, page_limit or settings.DEFAULT_PAGE_LIMIT)
     sort_by = request.GET.get("sort_by")
     if sort_by:
         object_list, sort_by = sort_objects(object_list, sort_by)


### PR DESCRIPTION
## Proposed changes

Component pagination is great, but it's better to be able to tune in each different project (with a default option of 100, like now).

For a project with 500 components, 100 components per page it's ok (only 5 pages).
But for a project with 5000 components, 100 components is very low (50 pages are a lot of pages). So let the admin decide which size is better for his users.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
Improves #5513 and references #6034 