### PR TITLE
[IMP] Component name available for searching

### DIFF
--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -51,7 +51,7 @@ Fields
 ``language:TEXT``
    String target language.
 ``component:TEXT``
-   Component slug or Component name case insensitive search, see :ref:`component-slug` and :ref:`component-name`.
+   Component slug or name case insensitive search, see :ref:`component-slug` and :ref:`component-name`.
 ``project:TEXT``
    Project slug, see :ref:`project-slug`.
 ``changed_by:TEXT``

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -51,7 +51,7 @@ Fields
 ``language:TEXT``
    String target language.
 ``component:TEXT``
-   Component slug, see :ref:`component-slug`.
+   Component slug or Component name case insensitive search, see :ref:`component-slug` and :ref:`component-name`.
 ``project:TEXT``
    Project slug, see :ref:`project-slug`.
 ``changed_by:TEXT``

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -278,6 +278,8 @@ class TermExpr:
             return query & Q(check__dismissed=False)
         if field == "dismissed_check":
             return query & Q(check__dismissed=True)
+        if field == "component":
+            return query | Q(translation__component__name__icontains=match)
 
         return query
 

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -248,7 +248,7 @@ class QueryParserTest(TestCase, SearchMixin):
         self.assert_query(
             "component:hello",
             Q(translation__component__slug__iexact="hello")
-            | Q(translation__component__name__icontains="hello")
+            | Q(translation__component__name__icontains="hello"),
         )
 
     def test_project(self):

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -246,7 +246,9 @@ class QueryParserTest(TestCase, SearchMixin):
 
     def test_component(self):
         self.assert_query(
-            "component:hello", Q(translation__component__slug__iexact="hello")
+            "component:hello",
+            Q(translation__component__slug__iexact="hello")
+            | Q(translation__component__name__icontains="hello")
         )
 
     def test_project(self):


### PR DESCRIPTION
## Proposed changes

Component name is available on search now.

Searching by component:`slug` is not useful due to the possible lack of knowledge of Users. 
Users don't need to know what `slug` is, so most of the time, they will search for **component name**, because is the only text inside the weblate page that refers to the component.

So, the new way to search for component names will be: 
`component_name`:_substring of component name_

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
