### PR TITLE
accounts: Fix overriding name and image of auth

### DIFF
--- a/weblate/accounts/templatetags/authnames.py
+++ b/weblate/accounts/templatetags/authnames.py
@@ -72,8 +72,8 @@ def get_auth_params(auth: str):
 
     # Settings override
     settings_params = {
-        "name": f"SOCIAL_AUTH_{auth.upper()}_TITLE",
-        "image": f"SOCIAL_AUTH_{auth.upper()}_IMAGE",
+        "name": f"SOCIAL_AUTH_{auth.upper().replace('-','_')}_TITLE",
+        "image": f"SOCIAL_AUTH_{auth.upper().replace('-','_')}_IMAGE",
     }
     for target, source in settings_params.items():
         value = getattr(settings, source, None)


### PR DESCRIPTION
Fixes #6216

## Proposed changes

Fix the issue with overriding title/image for auth providers with dashes ('-') in the name

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

