### PR TITLE
typo: msgctxt enage -> engage

### DIFF
--- a/docs/locales/et/LC_MESSAGES/docs.po
+++ b/docs/locales/et/LC_MESSAGES/docs.po
@@ -26366,7 +26366,7 @@ msgstr "Sinu keeled"
 
 #: ../../contributing/schemas.rst:19
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "Language"
 #| msgid_plural "Languages"
 msgid "*Language*"
@@ -26544,7 +26544,7 @@ msgstr "Tõlgitud keeled"
 
 #: ../../contributing/schemas.rst:19
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "Language"
 #| msgid_plural "Languages"
 msgid "*Language code*"

--- a/docs/locales/pa/LC_MESSAGES/docs.po
+++ b/docs/locales/pa/LC_MESSAGES/docs.po
@@ -26137,7 +26137,7 @@ msgstr "ਵਰਤੋਂਕਾਰ ਪਰੋਫਾਈਲ"
 
 #: ../../contributing/schemas.rst:19
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "Language"
 #| msgid_plural "Languages"
 msgid "**language**"
@@ -26145,7 +26145,7 @@ msgstr "ਭਾਸ਼ਾ"
 
 #: ../../contributing/schemas.rst:19
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "Language"
 #| msgid_plural "Languages"
 msgid "*Language*"
@@ -26301,7 +26301,7 @@ msgstr "ਆਪਣੇ-ਆਪ ਅਨੁਵਾਦ"
 
 #: ../../contributing/schemas.rst:19
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "Language"
 #| msgid_plural "Languages"
 msgid "*Language code*"
@@ -35558,7 +35558,7 @@ msgstr ""
 #~ msgstr "ਸ਼ਬਦਾਵਲੀ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ"
 
 #, fuzzy
-#~| msgctxt "Label on enage page"
+#~| msgctxt "Label on engage page"
 #~| msgid "Language"
 #~| msgid_plural "Languages"
 #~ msgid "Language of the term"

--- a/docs/locales/tzm/LC_MESSAGES/docs.po
+++ b/docs/locales/tzm/LC_MESSAGES/docs.po
@@ -1884,7 +1884,7 @@ msgstr ""
 
 #: ../../admin/addons.rst:361
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "String"
 #| msgid_plural "Strings"
 msgid "String prefix"
@@ -1896,7 +1896,7 @@ msgstr ""
 
 #: ../../admin/addons.rst:363
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "String"
 #| msgid_plural "Strings"
 msgid "String suffix"
@@ -29056,7 +29056,7 @@ msgstr ""
 
 #: ../../formats.rst:358
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "String"
 #| msgid_plural "Strings"
 msgid "String keys"

--- a/weblate/locale/ar/LC_MESSAGES/django.po
+++ b/weblate/locale/ar/LC_MESSAGES/django.po
@@ -6401,7 +6401,7 @@ msgstr ""
 "الترجمة للمطور والمترجم."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "سلاسل"
@@ -6412,7 +6412,7 @@ msgstr[4] "سلاسل"
 msgstr[5] "سلاسل"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "لغة"

--- a/weblate/locale/ar_LY/LC_MESSAGES/django.po
+++ b/weblate/locale/ar_LY/LC_MESSAGES/django.po
@@ -5731,7 +5731,7 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
@@ -5742,7 +5742,7 @@ msgstr[4] ""
 msgstr[5] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/ars/LC_MESSAGES/django.po
+++ b/weblate/locale/ars/LC_MESSAGES/django.po
@@ -5732,7 +5732,7 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
@@ -5743,7 +5743,7 @@ msgstr[4] ""
 msgstr[5] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/ast/LC_MESSAGES/django.po
+++ b/weblate/locale/ast/LC_MESSAGES/django.po
@@ -6259,7 +6259,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Cadenes"
@@ -6268,7 +6268,7 @@ msgstr[1] "Cadenes"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Llingua"

--- a/weblate/locale/az/LC_MESSAGES/django.po
+++ b/weblate/locale/az/LC_MESSAGES/django.po
@@ -6920,7 +6920,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Sətir"
@@ -6929,7 +6929,7 @@ msgstr[1] "Sətir"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Dil"

--- a/weblate/locale/be/LC_MESSAGES/django.po
+++ b/weblate/locale/be/LC_MESSAGES/django.po
@@ -6225,7 +6225,7 @@ msgstr ""
 "перакладчыкаў."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Радок"
@@ -6233,7 +6233,7 @@ msgstr[1] "Радкі"
 msgstr[2] "Радкоў"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Мова"

--- a/weblate/locale/be@latin/LC_MESSAGES/django.po
+++ b/weblate/locale/be@latin/LC_MESSAGES/django.po
@@ -6846,7 +6846,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Radkі"
@@ -6856,7 +6856,7 @@ msgstr[2] "Radkі"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Mova"

--- a/weblate/locale/ber/LC_MESSAGES/django.po
+++ b/weblate/locale/ber/LC_MESSAGES/django.po
@@ -5697,14 +5697,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/bg/LC_MESSAGES/django.po
+++ b/weblate/locale/bg/LC_MESSAGES/django.po
@@ -6998,7 +6998,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Текстове"
@@ -7007,7 +7007,7 @@ msgstr[1] "Текстове"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Език"

--- a/weblate/locale/bn/LC_MESSAGES/django.po
+++ b/weblate/locale/bn/LC_MESSAGES/django.po
@@ -5721,14 +5721,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/bn_BD/LC_MESSAGES/django.po
+++ b/weblate/locale/bn_BD/LC_MESSAGES/django.po
@@ -5734,14 +5734,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/br/LC_MESSAGES/django.po
+++ b/weblate/locale/br/LC_MESSAGES/django.po
@@ -6886,7 +6886,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Neudennadoù"
@@ -6898,7 +6898,7 @@ msgstr[4] "Neudennadoù"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Yezh"

--- a/weblate/locale/ca/LC_MESSAGES/django.po
+++ b/weblate/locale/ca/LC_MESSAGES/django.po
@@ -6139,14 +6139,14 @@ msgstr ""
 "alhora."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Cadena"
 msgstr[1] "Cadenes"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Llengua"

--- a/weblate/locale/ce/LC_MESSAGES/django.po
+++ b/weblate/locale/ce/LC_MESSAGES/django.po
@@ -5694,14 +5694,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/ckb/LC_MESSAGES/django.po
+++ b/weblate/locale/ckb/LC_MESSAGES/django.po
@@ -6172,7 +6172,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Source words"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "وشەکانی سەرچاوە"
@@ -6181,7 +6181,7 @@ msgstr[1] "وشەکانی سەرچاوە"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "زمان"

--- a/weblate/locale/crh/LC_MESSAGES/django.po
+++ b/weblate/locale/crh/LC_MESSAGES/django.po
@@ -5688,13 +5688,13 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/cs/LC_MESSAGES/django.po
+++ b/weblate/locale/cs/LC_MESSAGES/django.po
@@ -5964,7 +5964,7 @@ msgstr ""
 "nástroje, který usnadňuje překládání jak pro vývojáře tak i pro překladatele."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Řetězec"
@@ -5972,7 +5972,7 @@ msgstr[1] "Řetězce"
 msgstr[2] "Řetězců"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Jazyk"

--- a/weblate/locale/cv/LC_MESSAGES/django.po
+++ b/weblate/locale/cv/LC_MESSAGES/django.po
@@ -5720,14 +5720,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/cy/LC_MESSAGES/django.po
+++ b/weblate/locale/cy/LC_MESSAGES/django.po
@@ -6270,7 +6270,7 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
@@ -6281,7 +6281,7 @@ msgstr[4] ""
 msgstr[5] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/da/LC_MESSAGES/django.po
+++ b/weblate/locale/da/LC_MESSAGES/django.po
@@ -6287,14 +6287,14 @@ msgstr ""
 "udviklet til at gøre oversættelse lettere, både for udviklere og oversættere."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Streng"
 msgstr[1] "Strenge"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Sprog"

--- a/weblate/locale/de/LC_MESSAGES/django.po
+++ b/weblate/locale/de/LC_MESSAGES/django.po
@@ -6150,14 +6150,14 @@ msgstr ""
 "erleichtert."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Zeichenkette"
 msgstr[1] "Zeichenketten"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Sprache"

--- a/weblate/locale/django.pot
+++ b/weblate/locale/django.pot
@@ -5696,14 +5696,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/el/LC_MESSAGES/django.po
+++ b/weblate/locale/el/LC_MESSAGES/django.po
@@ -6139,14 +6139,14 @@ msgstr ""
 "τους προγραμματιστές αλλά και για τους μεταφραστές."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Κείμενο"
 msgstr[1] "Κείμενα"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Γλώσσα"

--- a/weblate/locale/en_GB/LC_MESSAGES/django.po
+++ b/weblate/locale/en_GB/LC_MESSAGES/django.po
@@ -6690,7 +6690,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Strings"
@@ -6699,7 +6699,7 @@ msgstr[1] "Strings"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Language"

--- a/weblate/locale/enm/LC_MESSAGES/django.po
+++ b/weblate/locale/enm/LC_MESSAGES/django.po
@@ -5695,14 +5695,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/eo/LC_MESSAGES/django.po
+++ b/weblate/locale/eo/LC_MESSAGES/django.po
@@ -6241,7 +6241,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Search"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Serĉi"
@@ -6250,7 +6250,7 @@ msgstr[1] "Serĉi"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Lingvo"

--- a/weblate/locale/es/LC_MESSAGES/django.po
+++ b/weblate/locale/es/LC_MESSAGES/django.po
@@ -6080,14 +6080,14 @@ msgstr ""
 "traductores."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Cadena"
 msgstr[1] "Cadenas"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Idioma"

--- a/weblate/locale/et/LC_MESSAGES/django.po
+++ b/weblate/locale/et/LC_MESSAGES/django.po
@@ -6087,14 +6087,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Lausend"
 msgstr[1] "Lausendid"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Keel"

--- a/weblate/locale/eu/LC_MESSAGES/django.po
+++ b/weblate/locale/eu/LC_MESSAGES/django.po
@@ -6249,7 +6249,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings limit"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Kateen muga"
@@ -6258,7 +6258,7 @@ msgstr[1] "Kateen muga"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Your languages"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Zure hizkuntzak"

--- a/weblate/locale/fa/LC_MESSAGES/django.po
+++ b/weblate/locale/fa/LC_MESSAGES/django.po
@@ -6128,7 +6128,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Source strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "رشته های منبع"
@@ -6137,7 +6137,7 @@ msgstr[1] "رشته های منبع"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Interlingua"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "میان‌زبان"

--- a/weblate/locale/fi/LC_MESSAGES/django.po
+++ b/weblate/locale/fi/LC_MESSAGES/django.po
@@ -6069,14 +6069,14 @@ msgstr ""
 "niin kehittäjien kuin kääntäjien kannalta."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Teksti"
 msgstr[1] "Tekstit"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Kieli"

--- a/weblate/locale/fil/LC_MESSAGES/django.po
+++ b/weblate/locale/fil/LC_MESSAGES/django.po
@@ -5708,14 +5708,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/fr/LC_MESSAGES/django.po
+++ b/weblate/locale/fr/LC_MESSAGES/django.po
@@ -6122,14 +6122,14 @@ msgstr ""
 "les traducteurs."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Chaîne"
 msgstr[1] "Chaînes"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Langue"

--- a/weblate/locale/fur/LC_MESSAGES/django.po
+++ b/weblate/locale/fur/LC_MESSAGES/django.po
@@ -5772,14 +5772,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/fy/LC_MESSAGES/django.po
+++ b/weblate/locale/fy/LC_MESSAGES/django.po
@@ -6501,7 +6501,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Source change"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Boarnewiziging"
@@ -6510,7 +6510,7 @@ msgstr[1] "Boarnewiziging"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Taal"

--- a/weblate/locale/gl/LC_MESSAGES/django.po
+++ b/weblate/locale/gl/LC_MESSAGES/django.po
@@ -6745,7 +6745,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Cadeas"
@@ -6754,7 +6754,7 @@ msgstr[1] "Cadeas"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Lingua"

--- a/weblate/locale/he/LC_MESSAGES/django.po
+++ b/weblate/locale/he/LC_MESSAGES/django.po
@@ -5860,7 +5860,7 @@ msgstr ""
 "על מלאכת התרגום הן על מפתחים והן על מתרגמים."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "מחרוזת"
@@ -5869,7 +5869,7 @@ msgstr[2] "מחרוזות"
 msgstr[3] "מחרוזות"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "שפה"

--- a/weblate/locale/hi/LC_MESSAGES/django.po
+++ b/weblate/locale/hi/LC_MESSAGES/django.po
@@ -5742,14 +5742,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/hr/LC_MESSAGES/django.po
+++ b/weblate/locale/hr/LC_MESSAGES/django.po
@@ -5963,7 +5963,7 @@ msgstr ""
 "jednostavno prevođenje, kako za programere tako i za prevodioce."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Izraz"
@@ -5971,7 +5971,7 @@ msgstr[1] "Izraza"
 msgstr[2] "Izraza"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Jezik"

--- a/weblate/locale/hu/LC_MESSAGES/django.po
+++ b/weblate/locale/hu/LC_MESSAGES/django.po
@@ -6233,14 +6233,14 @@ msgstr ""
 "és fejlesztők számára egyaránt."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Szöveg"
 msgstr[1] "Szövegek"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Nyelv"

--- a/weblate/locale/hy/LC_MESSAGES/django.po
+++ b/weblate/locale/hy/LC_MESSAGES/django.po
@@ -6381,7 +6381,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Search"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Որոնում"
@@ -6390,7 +6390,7 @@ msgstr[1] "Որոնում"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Լեզու"

--- a/weblate/locale/ia/LC_MESSAGES/django.po
+++ b/weblate/locale/ia/LC_MESSAGES/django.po
@@ -5706,14 +5706,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/id/LC_MESSAGES/django.po
+++ b/weblate/locale/id/LC_MESSAGES/django.po
@@ -6364,13 +6364,13 @@ msgstr ""
 "dan penerjemah."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "String"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Bahasa"

--- a/weblate/locale/ie/LC_MESSAGES/django.po
+++ b/weblate/locale/ie/LC_MESSAGES/django.po
@@ -5698,14 +5698,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/is/LC_MESSAGES/django.po
+++ b/weblate/locale/is/LC_MESSAGES/django.po
@@ -5885,14 +5885,14 @@ msgstr ""
 "sem hannað er til að auðvelda þýðingar fyrir forritara jafnt sem þýðendur."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Strengur"
 msgstr[1] "Strengir"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Tungumál"

--- a/weblate/locale/it/LC_MESSAGES/django.po
+++ b/weblate/locale/it/LC_MESSAGES/django.po
@@ -6043,14 +6043,14 @@ msgstr ""
 "progettato per facilitare la traduzione a sviluppatori e traduttori."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Stringa"
 msgstr[1] "Stringhe"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Lingua"

--- a/weblate/locale/ja/LC_MESSAGES/django.po
+++ b/weblate/locale/ja/LC_MESSAGES/django.po
@@ -5959,13 +5959,13 @@ msgstr ""
 "ツール %(weblate_name_link)s を使用して翻訳しています。"
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "文字列"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "言語"

--- a/weblate/locale/kab/LC_MESSAGES/django.po
+++ b/weblate/locale/kab/LC_MESSAGES/django.po
@@ -6203,14 +6203,14 @@ msgstr ""
 "yettwafeṣlen i tsuqilt s tifses i yineflayen neɣ imsuqal."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Azrir"
 msgstr[1] "Izriren"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Tutlayt"

--- a/weblate/locale/kk/LC_MESSAGES/django.po
+++ b/weblate/locale/kk/LC_MESSAGES/django.po
@@ -6707,14 +6707,14 @@ msgstr ""
 "tárjimelenedi."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Jol"
 msgstr[1] "Jol sany"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Til"

--- a/weblate/locale/km/LC_MESSAGES/django.po
+++ b/weblate/locale/km/LC_MESSAGES/django.po
@@ -6036,7 +6036,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings limit"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "​តួអក្សរ​មាន​ដែនកំណត់​"
@@ -6044,7 +6044,7 @@ msgstr[0] "​តួអក្សរ​មាន​ដែនកំណត់​"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Languages limit"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "ភាសា​មាន​ដែនកំណត់​"

--- a/weblate/locale/kmr/LC_MESSAGES/django.po
+++ b/weblate/locale/kmr/LC_MESSAGES/django.po
@@ -5900,14 +5900,14 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Translation status"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Rewşa wergerê"
 msgstr[1] "Rewşa wergerê"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/ko/LC_MESSAGES/django.po
+++ b/weblate/locale/ko/LC_MESSAGES/django.po
@@ -6051,13 +6051,13 @@ msgstr ""
 "%(weblate_name_link)s를 이용하여 번역되고 있습니다."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "문자열"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "언어"

--- a/weblate/locale/ksh/LC_MESSAGES/django.po
+++ b/weblate/locale/ksh/LC_MESSAGES/django.po
@@ -6544,7 +6544,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings with any failing checks"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Täxschtöckscher med scheif jejange Pröövonge"
@@ -6554,7 +6554,7 @@ msgstr[2] "Täxschtöckscher med scheif jejange Pröövonge"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Schprohch"

--- a/weblate/locale/ln/LC_MESSAGES/django.po
+++ b/weblate/locale/ln/LC_MESSAGES/django.po
@@ -6237,7 +6237,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings limit"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Ndelo ya masakola"
@@ -6246,7 +6246,7 @@ msgstr[1] "Ndelo ya masakola"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Lokótá"

--- a/weblate/locale/lt/LC_MESSAGES/django.po
+++ b/weblate/locale/lt/LC_MESSAGES/django.po
@@ -6393,7 +6393,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Add new association"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Pridėti naują asociaciją"
@@ -6404,7 +6404,7 @@ msgstr[3] "Pridėti naują asociaciją"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Kalba"

--- a/weblate/locale/mk/LC_MESSAGES/django.po
+++ b/weblate/locale/mk/LC_MESSAGES/django.po
@@ -6114,14 +6114,14 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Translation notifications"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Преведувачки известувања"
 msgstr[1] "Преведувачки известувања"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/ml/LC_MESSAGES/django.po
+++ b/weblate/locale/ml/LC_MESSAGES/django.po
@@ -5725,14 +5725,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/mr/LC_MESSAGES/django.po
+++ b/weblate/locale/mr/LC_MESSAGES/django.po
@@ -5815,14 +5815,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/ms/LC_MESSAGES/django.po
+++ b/weblate/locale/ms/LC_MESSAGES/django.po
@@ -5685,13 +5685,13 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/my/LC_MESSAGES/django.po
+++ b/weblate/locale/my/LC_MESSAGES/django.po
@@ -5705,13 +5705,13 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/nb/LC_MESSAGES/django.po
+++ b/weblate/locale/nb/LC_MESSAGES/django.po
@@ -6000,14 +6000,14 @@ msgstr ""
 "for å lette oversettelsesarbeidet for både utviklere og oversettere."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Streng"
 msgstr[1] "Strenger"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Språk"

--- a/weblate/locale/nl/LC_MESSAGES/django.po
+++ b/weblate/locale/nl/LC_MESSAGES/django.po
@@ -6027,14 +6027,14 @@ msgstr ""
 "als vertalers."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Tekenreeks"
 msgstr[1] "Tekenreeksen"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Taal"

--- a/weblate/locale/oc/LC_MESSAGES/django.po
+++ b/weblate/locale/oc/LC_MESSAGES/django.po
@@ -5712,14 +5712,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/or/LC_MESSAGES/django.po
+++ b/weblate/locale/or/LC_MESSAGES/django.po
@@ -5694,14 +5694,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/pa/LC_MESSAGES/django.po
+++ b/weblate/locale/pa/LC_MESSAGES/django.po
@@ -5906,14 +5906,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "ਭਾਸ਼ਾ"

--- a/weblate/locale/pl/LC_MESSAGES/django.po
+++ b/weblate/locale/pl/LC_MESSAGES/django.po
@@ -6046,7 +6046,7 @@ msgstr ""
 "programistów jak i tłumaczy."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Tekst"
@@ -6054,7 +6054,7 @@ msgstr[1] "Teksty"
 msgstr[2] "Tekstów"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Język"

--- a/weblate/locale/ps/LC_MESSAGES/django.po
+++ b/weblate/locale/ps/LC_MESSAGES/django.po
@@ -5694,14 +5694,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/pt/LC_MESSAGES/django.po
+++ b/weblate/locale/pt/LC_MESSAGES/django.po
@@ -6017,14 +6017,14 @@ msgstr ""
 "como aos tradutores."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Cadeia"
 msgstr[1] "Cadeias"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Idioma"

--- a/weblate/locale/pt_BR/LC_MESSAGES/django.po
+++ b/weblate/locale/pt_BR/LC_MESSAGES/django.po
@@ -6024,14 +6024,14 @@ msgstr ""
 "tradutores."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Texto"
 msgstr[1] "Textos"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Idioma"

--- a/weblate/locale/pt_PT/LC_MESSAGES/django.po
+++ b/weblate/locale/pt_PT/LC_MESSAGES/django.po
@@ -6044,14 +6044,14 @@ msgstr ""
 "como aos tradutores."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Cadeia"
 msgstr[1] "Cadeias"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Idioma"

--- a/weblate/locale/ro/LC_MESSAGES/django.po
+++ b/weblate/locale/ro/LC_MESSAGES/django.po
@@ -6143,7 +6143,7 @@ msgstr ""
 "pentru traducători."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Șir de caractere"
@@ -6151,7 +6151,7 @@ msgstr[1] "Șir de caractere"
 msgstr[2] "Șiruri de caractere"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Limbă"

--- a/weblate/locale/ru/LC_MESSAGES/django.po
+++ b/weblate/locale/ru/LC_MESSAGES/django.po
@@ -6058,7 +6058,7 @@ msgstr ""
 "переводчиков."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Строка"
@@ -6066,7 +6066,7 @@ msgstr[1] "Строки"
 msgstr[2] "Строк"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Язык"

--- a/weblate/locale/sc/LC_MESSAGES/django.po
+++ b/weblate/locale/sc/LC_MESSAGES/django.po
@@ -5695,14 +5695,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/si/LC_MESSAGES/django.po
+++ b/weblate/locale/si/LC_MESSAGES/django.po
@@ -5699,14 +5699,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/sk/LC_MESSAGES/django.po
+++ b/weblate/locale/sk/LC_MESSAGES/django.po
@@ -6885,7 +6885,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Reťazcov"
@@ -6895,7 +6895,7 @@ msgstr[2] "Reťazcov"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Jazyk"

--- a/weblate/locale/sl/LC_MESSAGES/django.po
+++ b/weblate/locale/sl/LC_MESSAGES/django.po
@@ -6646,7 +6646,7 @@ msgstr ""
 "poenostavi prevajanje tako za razvijalce kot za prevajalce."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Niz"
@@ -6655,7 +6655,7 @@ msgstr[2] "Nizi"
 msgstr[3] "Nizov"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Jezik"

--- a/weblate/locale/sq/LC_MESSAGES/django.po
+++ b/weblate/locale/sq/LC_MESSAGES/django.po
@@ -6050,14 +6050,14 @@ msgstr ""
 "përkthyesit."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Varg"
 msgstr[1] "Vargje"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Gjuhë"

--- a/weblate/locale/sr/LC_MESSAGES/django.po
+++ b/weblate/locale/sr/LC_MESSAGES/django.po
@@ -5881,7 +5881,7 @@ msgstr ""
 "да олакша превођење и програмерима и преводиоцима."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "ниска"
@@ -5889,7 +5889,7 @@ msgstr[1] "ниске"
 msgstr[2] "ниски"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "језик"

--- a/weblate/locale/sr_Latn/LC_MESSAGES/django.po
+++ b/weblate/locale/sr_Latn/LC_MESSAGES/django.po
@@ -5889,7 +5889,7 @@ msgstr ""
 "da olakša prevođenje i programerima i prevodiocima."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "niska"
@@ -5897,7 +5897,7 @@ msgstr[1] "niske"
 msgstr[2] "niski"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "jezik"

--- a/weblate/locale/sv/LC_MESSAGES/django.po
+++ b/weblate/locale/sv/LC_MESSAGES/django.po
@@ -5976,14 +5976,14 @@ msgstr ""
 "för att underlätta översättning för både utvecklare och översättare."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Sträng"
 msgstr[1] "Strängar"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Språk"

--- a/weblate/locale/sw/LC_MESSAGES/django.po
+++ b/weblate/locale/sw/LC_MESSAGES/django.po
@@ -5830,7 +5830,7 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
@@ -5839,7 +5839,7 @@ msgstr[1] ""
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Interlingua"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Kiintalingua"

--- a/weblate/locale/ta/LC_MESSAGES/django.po
+++ b/weblate/locale/ta/LC_MESSAGES/django.po
@@ -5795,7 +5795,7 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
@@ -5804,7 +5804,7 @@ msgstr[1] ""
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Interlingua"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "இன்டர்லிங்வா"

--- a/weblate/locale/th/LC_MESSAGES/django.po
+++ b/weblate/locale/th/LC_MESSAGES/django.po
@@ -5997,13 +5997,13 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "สตริง"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "ภาษา"

--- a/weblate/locale/tlh/LC_MESSAGES/django.po
+++ b/weblate/locale/tlh/LC_MESSAGES/django.po
@@ -6094,7 +6094,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Last name"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "pong Qav"
@@ -6102,7 +6102,7 @@ msgstr[0] "pong Qav"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Your name"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "ponglIj'e'"

--- a/weblate/locale/tr/LC_MESSAGES/django.po
+++ b/weblate/locale/tr/LC_MESSAGES/django.po
@@ -5993,14 +5993,14 @@ msgstr ""
 "tasarlanmış bir web aracıdır."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Dizgi"
 msgstr[1] "Dizgi"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Dil"

--- a/weblate/locale/tzm/LC_MESSAGES/django.po
+++ b/weblate/locale/tzm/LC_MESSAGES/django.po
@@ -1351,7 +1351,7 @@ msgstr "Tisuɣal"
 
 #: weblate/addons/forms.py:457
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "String"
 #| msgid_plural "Strings"
 msgid "String prefix"
@@ -1359,7 +1359,7 @@ msgstr "Aseddi"
 
 #: weblate/addons/forms.py:462
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "String"
 #| msgid_plural "Strings"
 msgid "String suffix"
@@ -5726,14 +5726,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Aseddi"
 msgstr[1] "Isedditen"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Tutlayt"
@@ -7622,7 +7622,7 @@ msgstr "Sken tutlayin maṛṛa"
 
 #: weblate/templates/snippets/info.html:268
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "String"
 #| msgid_plural "Strings"
 msgid "String statistics"
@@ -7630,7 +7630,7 @@ msgstr "Aseddi"
 
 #: weblate/templates/snippets/info.html:273
 #, fuzzy
-#| msgctxt "Label on enage page"
+#| msgctxt "Label on engage page"
 #| msgid "String"
 #| msgid_plural "Strings"
 msgid "Strings percent"

--- a/weblate/locale/ug/LC_MESSAGES/django.po
+++ b/weblate/locale/ug/LC_MESSAGES/django.po
@@ -5976,14 +5976,14 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "Translation status"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "تەرجىمە ئەھۋالى"
 msgstr[1] "تەرجىمە ئەھۋالى"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/uk/LC_MESSAGES/django.po
+++ b/weblate/locale/uk/LC_MESSAGES/django.po
@@ -6042,7 +6042,7 @@ msgstr ""
 "перекладачами."
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Рядок"
@@ -6051,7 +6051,7 @@ msgstr[2] "Рядків"
 msgstr[3] "Рядок"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Мова"

--- a/weblate/locale/uz/LC_MESSAGES/django.po
+++ b/weblate/locale/uz/LC_MESSAGES/django.po
@@ -5719,14 +5719,14 @@ msgid ""
 msgstr ""
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] ""

--- a/weblate/locale/vi/LC_MESSAGES/django.po
+++ b/weblate/locale/vi/LC_MESSAGES/django.po
@@ -6374,7 +6374,7 @@ msgstr ""
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
 #, fuzzy
 #| msgid "iOS Strings"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "Chuỗi hệ điều hành iOS"
@@ -6382,7 +6382,7 @@ msgstr[0] "Chuỗi hệ điều hành iOS"
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
 #, fuzzy
 #| msgid "Language"
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "Ngôn ngữ"

--- a/weblate/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/weblate/locale/zh_Hans/LC_MESSAGES/django.po
@@ -5784,13 +5784,13 @@ msgstr ""
 "翻译而设计的在线翻译工具。"
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "字符串"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "语言"

--- a/weblate/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/weblate/locale/zh_Hant/LC_MESSAGES/django.po
@@ -5780,13 +5780,13 @@ msgstr ""
 "者皆能輕鬆處理翻譯為設計目標的網頁介面工具。"
 
 #: weblate/templates/engage.html:25 weblate/trans/widgets.py:255
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "String"
 msgid_plural "Strings"
 msgstr[0] "字串"
 
 #: weblate/templates/engage.html:29 weblate/trans/widgets.py:263
-msgctxt "Label on enage page"
+msgctxt "Label on engage page"
 msgid "Language"
 msgid_plural "Languages"
 msgstr[0] "語言"

--- a/weblate/templates/engage.html
+++ b/weblate/templates/engage.html
@@ -22,11 +22,11 @@
 <div class="row bignumbers">
 <div class="col-md-4">
 <strong>{{ full_stats.source_strings|intcomma }}</strong>
-<p>{% blocktrans count count=full_stats.source_strings context "Label on enage page" %}String{% plural %}Strings{% endblocktrans %}</p>
+<p>{% blocktrans count count=full_stats.source_strings context "Label on engage page" %}String{% plural %}Strings{% endblocktrans %}</p>
 </div>
 <div class="col-md-4">
 <strong>{{ full_stats.languages|intcomma }}</strong>
-<p>{% blocktrans count count=full_stats.languages context "Label on enage page" %}Language{% plural %}Languages{% endblocktrans %}</p>
+<p>{% blocktrans count count=full_stats.languages context "Label on engage page" %}Language{% plural %}Languages{% endblocktrans %}</p>
 </div>
 <div class="col-md-4">
 <strong>{% blocktrans with translated=full_stats.translated_percent|intcomma context "Translated percents" %}{{percent}}%{% endblocktrans %}</strong>

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -252,7 +252,7 @@ class NormalWidget(BitmapWidget):
                 self.head_template.format(number_format(self.total)),
                 self.foot_template.format(
                     npgettext(
-                        "Label on enage page", "String", "Strings", self.total
+                        "Label on engage page", "String", "Strings", self.total
                     ).upper()
                 ),
             ],
@@ -260,7 +260,7 @@ class NormalWidget(BitmapWidget):
                 self.head_template.format(number_format(self.languages)),
                 self.foot_template.format(
                     npgettext(
-                        "Label on enage page", "Language", "Languages", self.languages
+                        "Label on engage page", "Language", "Languages", self.languages
                     ).upper()
                 ),
             ],


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- N/A Lint and unit tests pass locally with my changes.
- N/A I have added tests that prove my fix is effective or that my feature works.
- N/A I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->

This is a minor change that does not add any new logic.

I was looking through the engage page and widget code and noticed a typo.
It doesn't impact the website/backend, just the message context of some i18n strings.

I assume `Label on enage page` was meant to be `Label on engage page`.

![image](https://user-images.githubusercontent.com/22801583/123015495-d5463480-d3c8-11eb-9e1f-b822c4d9452f.png)
