### PR TITLE
Formats: Add support for Fluent

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,8 @@ Weblate 4.8
 
 Not yet released.
 
+* Added support for Fluent files.
+
 Weblate 4.7.1
 -------------
 

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -124,6 +124,8 @@ Capabilities of all supported formats:
 +---------------------+------------------+---------------+----------------+---------------+----------------+----------------+-------------------------+
 | :ref:`txt`          | mono             | no            | no             | no            | no             | no             |                         |
 +---------------------+------------------+---------------+----------------+---------------+----------------+----------------+-------------------------+
+| :ref:`fluent`       | mono             | yes           | yes            | no            | no             | no             |                         |
++---------------------+------------------+---------------+----------------+---------------+----------------+----------------+-------------------------+
 
 .. [#m] See :ref:`bimono`
 .. [#p] Plurals are necessary to properly localize strings with variable count.
@@ -1483,6 +1485,39 @@ TBX is an XML format for the exchange of terminology data.
 
     `TBX on Wikipedia <https://en.wikipedia.org/wiki/TermBase_eXchange>`_,
     :doc:`tt:formats/tbx`,
+    :ref:`glossary`
+
+.. _fluent:
+
+Fluent format
+------------------------
+
+.. versionadded:: 4.8
+
+.. note::
+
+   Support for this format is currently in beta, feedback from testing is welcome.
+
+Fluent is a monolingual text format that focuses on asymmetric localization: a
+simple string in one language can map to a complex multi-variant translation in
+another language.
+
++-------------------------------------------------------------------+
+| Typical Weblate :ref:`component`                                  |
++================================+==================================+
+| Filemask                       | ``i18n/*/component-name.flt``    |
++--------------------------------+----------------------------------+
+| Monolingual base language file | `Empty`                          |
++--------------------------------+----------------------------------+
+| Template for new translations  | `Empty`                          |
++--------------------------------+----------------------------------+
+| File format                    | `Fluent file`                    |
++--------------------------------+----------------------------------+
+
+.. seealso::
+
+    `Project Fluent <https://www.projectfluent.org/>`_,
+    :doc:`tt:formats/fluent`,
     :ref:`glossary`
 
 

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -1507,7 +1507,7 @@ another language.
 +================================+==================================+
 | Filemask                       | ``i18n/*/component-name.flt``    |
 +--------------------------------+----------------------------------+
-| Monolingual base language file | `Empty`                          |
+| Monolingual base language file | ``i18n/en/component-name.flt``   |
 +--------------------------------+----------------------------------+
 | Template for new translations  | `Empty`                          |
 +--------------------------------+----------------------------------+

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -1516,7 +1516,7 @@ another language.
 
 .. seealso::
 
-    `Project Fluent <https://www.projectfluent.org/>`_,
+    `Project Fluent <https://projectfluent.org/>`_,
     :doc:`tt:formats/fluent`,
     :ref:`glossary`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ django-redis>=4.11.0,<6.0.0
 Django[argon2]>=3.2,<3.3
 djangorestframework>=3.11.0,<3.13.0
 filelock>=3.0.0,<3.1.0
+fluent.syntax>=0.18.1,<0.19.0
 GitPython>=2.1.15,<3.2.0
 hiredis>=1.0.1,<2.1.0
 html2text>=2019.8.11,<2020.1.17

--- a/weblate/formats/models.py
+++ b/weblate/formats/models.py
@@ -146,6 +146,7 @@ class FormatsConf(AppConf):
         "weblate.formats.ttkit.XWikiPagePropertiesFormat",
         "weblate.formats.ttkit.XWikiFullPageFormat",
         "weblate.formats.ttkit.TBXFormat",
+        "weblate.formats.ttkit.FluentFormat",
     )
 
     class Meta:

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -35,6 +35,7 @@ from weblate.formats.ttkit import (
     CSVSimpleFormat,
     DTDFormat,
     FlatXMLFormat,
+    FluentFormat,
     GWTFormat,
     INIFormat,
     InnoSetupINIFormat,
@@ -66,6 +67,7 @@ TEST_PO = get_test_file("cs.po")
 TEST_CSV = get_test_file("cs-mono.csv")
 TEST_CSV_NOHEAD = get_test_file("cs.csv")
 TEST_FLATXML = get_test_file("cs-flat.xml")
+TEST_FLUENT = get_test_file("en.flt")
 TEST_JSON = get_test_file("cs.json")
 TEST_NESTED_JSON = get_test_file("cs-nested.json")
 TEST_WEBEXT_JSON = get_test_file("cs-webext.json")
@@ -1133,3 +1135,20 @@ class TBXFormatTest(AutoFormatTest):
     FIND_MATCH = "adresní řádek"
     NEW_UNIT_MATCH = b"<term>Source string</term>"
     EXPECTED_FLAGS = ""
+
+
+class FluentFormatTest(AutoFormatTest):
+    FORMAT = FluentFormat
+    FILE = TEST_FLUENT
+    BASE = ""
+    MIME = ""
+    EXT = "flt"
+    COUNT = 2
+    MATCH = "\n"
+    MASK = "flt/*/component.flt"
+    EXPECTED_PATH = "flt/en-US/component.flt"
+    FIND = "hello-user"
+    FIND_MATCH = "Hello, {$userName}!"
+    NEW_UNIT_MATCH = b"\nnew-unit = Source string\n"
+    EXPECTED_FLAGS = ""
+    MONOLINGUAL = True

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -1786,3 +1786,13 @@ class PropertiesMi18nFormat(PropertiesUtf8Format):
     language_format = "java"
     check_flags = ("es-format",)
     monolingual = True
+
+
+class FluentFormat(TTKitFormat):
+    name = _("Fluent file")
+    format_id = "fluent"
+    monolingual = True
+    unit_class = MonolingualIDUnit
+    autoload = ("*.flt",)
+    new_translation = "\n"
+    loader = ("fluent", "FluentFile")

--- a/weblate/trans/tests/data/en.flt
+++ b/weblate/trans/tests/data/en.flt
@@ -1,0 +1,13 @@
+# Simple things are simple.
+hello-user = Hello, {$userName}!
+
+# Complex things are possible.
+shared-photos =
+    {$userName} {$photoCount ->
+        [one] added a new photo
+       *[other] added {$photoCount} new photos
+    } to {$userGender ->
+        [male] his stream
+        [female] her stream
+       *[other] their stream
+    }.

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -387,6 +387,10 @@ class ComponentTest(RepoTestCase):
         component = self.create_tbx()
         self.verify_component(component, 2, "cs", 4, unit="address bar")
 
+    def test_create_fluent(self):
+        component = self.create_fluent()
+        self.verify_component(component, 2, "en", 4)
+
     def test_link(self):
         component = self.create_link()
         self.verify_component(component, 4, "cs", 4)

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -392,6 +392,9 @@ class RepoTestMixin:
     def create_tbx(self):
         return self._create_component("tbx", "tbx/*.tbx")
 
+    def create_fluent(self):
+        return self._create_component("fluent", "i18n/*/component.flt")
+
     def create_link(self, **kwargs):
         parent = self.create_iphone(*kwargs)
         return Component.objects.create(


### PR DESCRIPTION
## Proposed changes

This PR adds basic support for Fluent files (issue #1926).

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
  - I haven't been able to get the tests to run to completion locally (or if they do, it will take a very long time and looks like it is looping from the log output).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

This PR requires https://github.com/translate/translate/pull/4378. Both PRs require some testing by people who know how `translate-toolkit` and `weblate` work (i.e. not me!) to flush out any edge cases I missed.