### PR TITLE
Fix typo in documentation ("conflict" form parameter)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1847,7 +1847,7 @@ Translations
     :type component: string
     :param language: Translation language code
     :type language: string
-    :form string conflicts: How to deal with conflicts (``ignore``, ``replace-translated`` or ``replace-approved``)
+    :form string conflict: How to deal with conflicts (``ignore``, ``replace-translated`` or ``replace-approved``)
     :form file file: Uploaded file
     :form string email: Author e-mail
     :form string author: Author name


### PR DESCRIPTION
The form parameter for how to handle a conflict when uploading a file is called "conflict", not "conflicts". I have figured this out through trial and error, but not verified in code.

POSTing with "conflicts" returns a "bad request (400)" error.

## Proposed changes

I propose to fix the typo in the documentation.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
