### PR TITLE
Update translating.rst

### DIFF
--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -116,7 +116,7 @@ languages translators select in the preferences will be shown
 (see :ref:`secondary-languages`) above the source string.
 
 Below the translation, translators will find suggestion made by others, to be
-accepted (✓), accepted with changes (🖉), or deleted (🗑).
+accepted (✓), accepted with changes (✏️), or deleted (🗑).
 
 .. _plurals:
 


### PR DESCRIPTION
## Proposed changes

fix translating documentation to update a broken emoji

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ x] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ x] I have described the changes in the commit messages.

## Other information

On macOS in firefox the emoji displays as a broken textbox. Emojipedia says that the broken emoji is a pencil emoji only visible on LG, so updated it with a pencil one that is widely visible
