### PR TITLE
Fix typo in "Add to Glossary" button: cloneEelement

### DIFF
--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -421,7 +421,7 @@
         ".source-language-group [data-clone-text]"
       );
       if (cloneElement !== null) {
-        let source = cloneEelement.getAttribute("data-clone-text");
+        let source = cloneElement.getAttribute("data-clone-text");
         if (source.length < 200) {
           document.getElementById("id_source").value = source;
           document.getElementById("id_target").value = document.querySelector(


### PR DESCRIPTION
## Proposed changes

Fix the typo introduced here https://github.com/WeblateOrg/weblate/commit/06178d91d7588b17b910f0784e94e6b876392ef6#diff-7d2b251c36ee02709692973a783a76ceba6675131719de4a782401f967c25410R424


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

"Add to glossary" button does nothing in UI, but gives this exception in Console

![image](https://user-images.githubusercontent.com/1448666/131147934-789c6471-b3e3-4dc7-9261-46d989986861.png)


<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
