### PR TITLE
Fix Docker paths (python3.7 -> 3.9)

### DIFF
--- a/dev-docker/docker-compose.yml
+++ b/dev-docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       # Local data directory
       - $PWD/data:/app/data
       # Override Weblate with local dir
-      - $PWD/../weblate:/usr/local/lib/python3.7/dist-packages/weblate
+      - $PWD/../weblate:/usr/local/lib/python3.9/dist-packages/weblate
     restart: always
     depends_on:
       - database

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -576,7 +576,7 @@ if "ROLLBAR_KEY" in os.environ:
         "access_token": os.environ["ROLLBAR_KEY"],
         "environment": os.environ.get("ROLLBAR_ENVIRONMENT", "production"),
         "branch": "main",
-        "root": "/usr/local/lib/python3.7/dist-packages/weblate/",
+        "root": "/usr/local/lib/python3.9/dist-packages/weblate/",
         "exception_level_filters": [
             (PermissionDenied, "ignored"),
             (Http404, "ignored"),


### PR DESCRIPTION
## Proposed changes

The Docker image for weblate was recently updated to use a newer version of Debian, and a newer version of Python (https://github.com/WeblateOrg/docker/commit/a86df5b527e20cd86df4596d6d4a59ce79da62bb). There are still docker files in the main repository assuming the use of Python 3.7, however.

This PR updates the paths directly related to docker to use `/python3.9/` rather than `/python3.7/`. Without these changes, trying to run a local development Docker image with `rundev.sh` will not actually use your local version of weblate.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

There are also some strings in the documentation that refer people to Python 3.7, but as those aren't directly related to Docker I've left them as they are.