### PR TITLE
Add WEBLATE_PRIVACY_URL to docker settings

### DIFF
--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1271,6 +1271,7 @@ LOCALIZE_CDN_PATH = os.environ.get("WEBLATE_LOCALIZE_CDN_PATH", None)
 GET_HELP_URL = os.environ.get("WEBLATE_GET_HELP_URL", None)
 STATUS_URL = os.environ.get("WEBLATE_STATUS_URL", None)
 LEGAL_URL = os.environ.get("WEBLATE_LEGAL_URL", None)
+PRIVACY_URL = os.environ.get("WEBLATE_PRIVACY_URL", None)
 
 # Third party services integration
 MATOMO_SITE_ID = os.environ.get("WEBLATE_MATOMO_SITE_ID", None)


### PR DESCRIPTION
## Proposed changes

As per documentation: 
https://docs.weblate.org/en/weblate-4.8.1/admin/install/docker.html#envvar-WEBLATE_PRIVACY_URL

should be available to docker installations but is not working (nor available) as per 4.8.1.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

`.py` files throw `EXE002` errors on flake8 check, by the sheer number I'm guessing this is supposed to be correct.

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
