### PR TITLE
docker: Add support for Google Translate v3

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -785,15 +785,15 @@ Machine translation settings
 
 .. envvar:: WEBLATE_MT_GOOGLE_CREDENTIALS
 
-    Enables :ref:`google-translate-api-v3-advanced` and sets :setting:`MT_GOOGLE_CREDENTIALS`
+    Enables :ref:`google-translate-api-v3` and sets :setting:`MT_GOOGLE_CREDENTIALS`
 
 .. envvar:: WEBLATE_MT_GOOGLE_PROJECT
 
-    Enables :ref:`google-translate-api-v3-advanced` and sets :setting:`MT_GOOGLE_PROJECT`
+    Enables :ref:`google-translate-api-v3` and sets :setting:`MT_GOOGLE_PROJECT`
 
 .. envvar:: WEBLATE_MT_GOOGLE_LOCATION
 
-    Enables :ref:`google-translate-api-v3-advanced` and sets :setting:`MT_GOOGLE_LOCATION`
+    Enables :ref:`google-translate-api-v3` and sets :setting:`MT_GOOGLE_LOCATION`
 
 .. envvar:: WEBLATE_MT_MICROSOFT_COGNITIVE_KEY
 

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -785,15 +785,15 @@ Machine translation settings
 
 .. envvar:: WEBLATE_MT_GOOGLE_CREDENTIALS
 
-    Enables :ref:`google-translate-api-v3` and sets :setting:`MT_GOOGLE_CREDENTIALS`
+    Enables :ref:`google-translate-api3` and sets :setting:`MT_GOOGLE_CREDENTIALS`
 
 .. envvar:: WEBLATE_MT_GOOGLE_PROJECT
 
-    Enables :ref:`google-translate-api-v3` and sets :setting:`MT_GOOGLE_PROJECT`
+    Enables :ref:`google-translate-api3` and sets :setting:`MT_GOOGLE_PROJECT`
 
 .. envvar:: WEBLATE_MT_GOOGLE_LOCATION
 
-    Enables :ref:`google-translate-api-v3` and sets :setting:`MT_GOOGLE_LOCATION`
+    Enables :ref:`google-translate-api3` and sets :setting:`MT_GOOGLE_LOCATION`
 
 .. envvar:: WEBLATE_MT_MICROSOFT_COGNITIVE_KEY
 

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -783,6 +783,18 @@ Machine translation settings
 
     Enables :ref:`google-translate` and sets :setting:`MT_GOOGLE_KEY`
 
+.. envvar:: WEBLATE_MT_GOOGLE_CREDENTIALS
+
+    Enables :ref:`google-translate-api-v3-advanced` and sets :setting:`MT_GOOGLE_CREDENTIALS`
+
+.. envvar:: WEBLATE_MT_GOOGLE_PROJECT
+
+    Enables :ref:`google-translate-api-v3-advanced` and sets :setting:`MT_GOOGLE_PROJECT`
+
+.. envvar:: WEBLATE_MT_GOOGLE_LOCATION
+
+    Enables :ref:`google-translate-api-v3-advanced` and sets :setting:`MT_GOOGLE_LOCATION`
+
 .. envvar:: WEBLATE_MT_MICROSOFT_COGNITIVE_KEY
 
     Enables :ref:`ms-cognitive-translate` and sets :setting:`MT_MICROSOFT_COGNITIVE_KEY`

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -812,6 +812,14 @@ MT_GOOGLE_KEY = os.environ.get("WEBLATE_MT_GOOGLE_KEY", None)
 if MT_GOOGLE_KEY:
     MT_SERVICES += ("weblate.machinery.google.GoogleTranslation",)
 
+# Google Translate API V3 (Advanced)
+MT_GOOGLE_CREDENTIALS = os.environ.get("WEBLATE_MT_GOOGLE_CREDENTIALS", None)
+MT_GOOGLE_PROJECT = os.environ.get("WEBLATE_MT_GOOGLE_PROJECT", None)
+MT_GOOGLE_LOCATION = os.environ.get("WEBLATE_MT_GOOGLE_LOCATION", None)
+
+if MT_GOOGLE_CREDENTIALS and MT_GOOGLE_PROJECT:
+    MT_SERVICES += ("weblate.machinery.googlev3.GoogleV3Translation",)
+
 # Baidu app key and secret
 MT_BAIDU_ID = None
 MT_BAIDU_SECRET = None


### PR DESCRIPTION
New logic to obtain Google Translation API v3 environment variables from the docker compose environment (see https://github.com/WeblateOrg/docker-compose/pull/109).

## Proposed changes

Set variables defined by proposed change to the docker compose environment.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Trivial change.
