### PR TITLE
Add missing WEBLATE_AUTO_UPDATE option to docs

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1248,6 +1248,16 @@ Example SSL configuration:
         :ref:`production-email`,
         :setting:`django:EMAIL_BACKEND`
 
+.. envvar:: WEBLATE_AUTO_UPDATE
+
+    Configures if and how Weblate should update repositories.
+
+    .. seealso::
+
+        :setting:`AUTO_UPDATE`
+
+    .. note:: This is a Boolean setting (use ``"true"`` or ``"false"``).
+
 Site integration
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This section also hints to the setting type which will help administrators understanding the scope.

## Proposed changes

The docker part of the documentation is missing the `WEBLATE_AUTO_UPDATE` setting which can be quite useful.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe ~~my~~a feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Things to consider in terms of documentation quality:
I had to learn the hard and manual fiddling fiddling way that a lot of settings work different or not to their full extend as the source installation versions. As example: `full` is not a valid setting in docker context because the setting is evaluated by a function that looks for boolean kind of strings.

Right now this forces administrators to dig through the code which can slow down deployment processes. 
Possibly the documentation could point out the setting type. Don't know.

