### PR TITLE
add reference to translate-toolkit

### DIFF
--- a/docs/admin/upgrade.rst
+++ b/docs/admin/upgrade.rst
@@ -39,6 +39,12 @@ work, but is not as well tested as single version upgrades.
 
       pip install -U Weblate
 
+   And make sure **translate-toolkit** is up to date:
+
+   .. code-block:: sh
+
+      pip install -U translate-toolkit[all]
+
    With Git checkout you need to fetch new source code and update your installation:
 
    .. code-block:: sh


### PR DESCRIPTION
While upgrading from weblate 4.7 to 4.8.1, I got some warnings about missing packages and formats such as fluent when issuing `weblate check --deploy`. I was able to get rid of these warnings by updating translate-toolkit.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Add information about updating translate-toolkit to the weblate update page.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
