### PR TITLE
fix: Fix wrong call to find_unit in XWikiPropertiesFormat

### DIFF
--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -1676,7 +1676,7 @@ class XWikiPropertiesFormat(PropertiesBaseFormat):
                     unit.unit = found_store_unit
                 # else it's a missing unit: we need to mark it as missing.
                 else:
-                    missingunit = self.find_unit(unit.context, unit.source)[0]
+                    missingunit = self.unit_class(self, unit.mainunit, unit.template)
                     unit.unit = missingunit.unit
                     unit.unit.missing = True
             # if the unit was only a comment, we take back the original source file unit


### PR DESCRIPTION
  * 

## Proposed changes

Rely on the creation of a new unit instead of relying on find_unit in XWikiPropertiesFormat which is resource consuming because of the creation of all copies.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
