### PR TITLE
Feature/api/download translations

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1322,6 +1322,9 @@ Components
 
 .. http:get:: /api/components/(string:project)/(string:component)/file/
 
+
+    .. versionadded:: 4.9
+
     Downloads all available translations associated with the component as an archive file using the requested format.
 
     :param project: Project URL slug

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1320,6 +1320,17 @@ Components
     :type component: string
     :>json array results: array of component objects; see :http:get:`/api/changes/(int:id)/`
 
+.. http:get:: /api/components/(string:project)/(string:component)/file/
+
+    Downloads all available translations associated with the component as an archive file using the requested format.
+
+    :param project: Project URL slug
+    :type project: string
+    :param component: Component URL slug
+    :type component: string
+
+    :query string format: The archive format to use; If not specified, defaults to ``zip``; Supported formats: ``zip``
+
 .. http:get::  /api/components/(string:project)/(string:component)/screenshots/
 
     Returns a list of component screenshots.

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1839,6 +1839,17 @@ class ComponentAPITest(APIBaseTest):
         )
         self.assertEqual(response.headers["content-type"], "application/zip")
 
+    def test_download_translation_zip_prohibited(self):
+        project = self.component.project
+        project.access_control = Project.ACCESS_PROTECTED
+        project.save(update_fields=["access_control"])
+        response = self.do_request(
+            "api:component-download-archive",
+            self.component_kwargs,
+            method="get",
+            code=403,
+        )          
+
     def test_links(self):
         self.do_request(
             "api:component-links",

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1843,7 +1843,7 @@ class ComponentAPITest(APIBaseTest):
         project = self.component.project
         project.access_control = Project.ACCESS_PROTECTED
         project.save(update_fields=["access_control"])
-        response = self.do_request(
+        self.do_request(
             "api:component-download-archive",
             self.component_kwargs,
             method="get",

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1848,7 +1848,7 @@ class ComponentAPITest(APIBaseTest):
             self.component_kwargs,
             method="get",
             code=403,
-        )          
+        )
 
     def test_links(self):
         self.do_request(

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1829,6 +1829,16 @@ class ComponentAPITest(APIBaseTest):
             request={"language_code": "cs"},
         )
 
+    def test_download_translation_zip_ok(self):
+        response = self.do_request(
+            "api:component-download-archive",
+            self.component_kwargs,
+            method="get",
+            code=200,
+            superuser=True,
+        )
+        self.assertEqual(response.headers["content-type"], "application/zip")
+
     def test_links(self):
         self.do_request(
             "api:component-links",

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -91,6 +91,7 @@ from weblate.trans.models import (
 )
 from weblate.trans.stats import get_project_stats
 from weblate.trans.tasks import auto_translate, component_removal, project_removal
+from weblate.trans.views.files import download_multi
 from weblate.utils.celery import get_queue_stats, get_task_progress, is_task_ready
 from weblate.utils.docs import get_doc_url
 from weblate.utils.errors import report_error
@@ -950,6 +951,24 @@ class ComponentViewSet(
             raise Http404("Project not found")
         instance.links.remove(project)
         return Response(status=HTTP_204_NO_CONTENT)
+
+    @action(detail=True, methods=["get"], url_path="file")
+    def download_archive(self, request, **kwargs):
+        # Implementation is analogous to files#download_component, but we can't reuse
+        #  that here because the lookup for the component is different
+        instance = self.get_object()
+        if not request.user.has_perm("translation.download", instance):
+            self.permission_denied(
+                request, "Can not download all translations for the component"
+            )
+
+        requested_format = request.query_params.get("format", "zip")
+        return download_multi(
+            instance.translation_set.all(),
+            [ instance ],
+            requested_format,
+            name=instance.full_slug.replace("/", "-"),
+        )
 
 
 class TranslationViewSet(MultipleFieldMixin, WeblateViewSet, DestroyModelMixin):

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -965,7 +965,7 @@ class ComponentViewSet(
         requested_format = request.query_params.get("format", "zip")
         return download_multi(
             instance.translation_set.all(),
-            [ instance ],
+            [instance],
             requested_format,
             name=instance.full_slug.replace("/", "-"),
         )


### PR DESCRIPTION
## Proposed changes

Introduces a new endpoint on components API's translations to allow downloading a component's translations as a ZIP file as requested by #5957

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
