### PR TITLE
Add reference to Projects > Template markup

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -572,7 +572,7 @@ Squash Git commits
                 +---------------------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 :Triggers: repository post-commit
 
-Squash Git commits prior to pushing changes.
+Squash Git commits prior to pushing changes. See :ref:`markup` for for the message options.
 
 Git commits can be squashed prior to pushing changes
 in one of the following modes:


### PR DESCRIPTION
Small change to add reference to commit message template options in the Squash commit add-on documentation.