### PR TITLE
unit: Label automatically translated strings to ease their filtering

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Released on December 16th 2021.
 * Added support for project scoped access tokens for API.
 * Fixed string removal in some cases.
 * Fixed translating newly added strings.
+* Label automatically translated strings to ease their filtering.
 
 `All changes in detail <https://github.com/WeblateOrg/weblate/milestone/74?closed=1>`__.
 

--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -95,6 +95,13 @@ Labels
 Labels are used to categorize strings within a project to further customize the
 localization workflow (for example to define categories of strings).
 
+Following labels are used by Weblate:
+
+Automatically translated
+   Strings was translated using :ref:`auto-translation`.
+Source needs review
+   String marked for review using :ref:`source-reviews`.
+
 .. seealso::
 
     :ref:`labels`
@@ -341,6 +348,9 @@ Useful in several situations like consolidating translation between different
 components (for example the application and its website) or when bootstrapping
 a translation for a new component using existing translations
 (translation memory).
+
+The automatically translated strings are labelled by :guilabel:`Automatically
+translated`.
 
 .. seealso::
 


### PR DESCRIPTION
## Proposed changes

This is similar approach to what we use in source review - the label is
automatically created when needed.

Fixes #6774

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
