### PR TITLE
addons: Use last Change-Id instead of first one

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Not yet released.
 * Fixed false positives from :ref:`check-icu-message-format-syntax`.
 * Indicate lock and contributor agreement on other occurrences listing.
 * Fixed updating PO files with obsolete strings or missing plurals.
+* Improved squash add-on compatibility with Gerrit.
 
 Weblate 4.10.1
 --------------

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -92,20 +92,22 @@ class GitSquashAddon(BaseAddon):
                 command += ["--"] + filenames
 
             trailer_lines = set()
-            seen_change_id = False
+            change_id_line = None
             for trailer in repository.execute(command).split("\n"):
                 # Skip blank lines
                 if not trailer.strip():
                     continue
 
-                # Pick only first Change-Id, there suppose to be only one in the
+                # Pick only last Change-Id, there suppose to be only one in the
                 # commit (used by Gerrit)
                 if trailer.startswith("Change-Id:"):
-                    if seen_change_id:
-                        continue
-                    seen_change_id = True
+                    change_id_line = trailer
+                    continue
 
                 trailer_lines.add(trailer)
+
+            if change_id_line is not None:
+                trailer_lines.add(change_id_line)
 
             if commit_message:
                 # Predefined commit message


### PR DESCRIPTION
## Proposed changes

Picking the first ends up duplicating commits, every time it gets squashed it gets a new Change-Id.

Pick the last instead to hopefully try and avoid that.

Fixes: 2f93229
See #7067


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
