### PR TITLE
docker: allow changing `DEFAULT_PULL_MESSAGE`

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -648,11 +648,12 @@ Default setting for translation propagation, defaults to ``True``.
 
 .. setting:: DEFAULT_PULL_MESSAGE
 
+.. _config-pull-message:
+
 DEFAULT_PULL_MESSAGE
 --------------------
 
-Title for new pull requests,
-defaulting to ``'Update from Weblate'``.
+Configures the default title and message for pull requests.
 
 .. setting:: ENABLE_AVATARS
 

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -693,6 +693,15 @@ Generic settings
 
        :ref:`vcs-pagure`
 
+.. envvar:: WEBLATE_DEFAULT_PULL_MESSAGE
+
+    Configures the default title and message for pull requests via API by changing
+    :setting:`DEFAULT_PULL_MESSAGE`
+
+    .. seealso::
+
+       :ref:`config-pull-message`
+
 .. envvar:: WEBLATE_SIMPLIFY_LANGUAGES
 
     Configures the language simplification policy, see :setting:`SIMPLIFY_LANGUAGES`.

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -241,6 +241,10 @@ GITLAB_TOKEN = os.environ.get("WEBLATE_GITLAB_TOKEN")
 PAGURE_USERNAME = os.environ.get("WEBLATE_PAGURE_USERNAME")
 PAGURE_TOKEN = os.environ.get("WEBLATE_PAGURE_TOKEN")
 
+# Default pull request message.
+# Please see the documentation for more details.
+DEFAULT_PULL_MESSAGE = os.environ.get("WEBLATE_DEFAULT_PULL_MESSAGE")
+
 # Authentication configuration
 AUTHENTICATION_BACKENDS = ()
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Allow changing `DEFAULT_PULL_MESSAGE` in a docker compose environment using the environment variable `WEBLATE_DEFAULT_PULL_MESSAGE`. Document behaviour in `docker.rst` and `config.rst`.

Closes #7204

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes (see below).
- [ ] I have added tests that prove my fix is effective or that my feature work (not relevant).
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
I've not yet come around to test this, as `./rundev.sh test` fails with `panic: handle is invalid` for me, presumably as I'm on windows. It would be really kind, if someone else would be able to lint and run unit tests as well as trying the feature. Otherwise I will try to get back to this as soon as I find some time to test :)
<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
