### PR TITLE
[docs]: request-timeout is no longer a valid option for WSGIScriptAlias

### DIFF
--- a/weblate/examples/apache-path.conf
+++ b/weblate/examples/apache-path.conf
@@ -28,7 +28,7 @@
     WSGIProcessGroup weblate
     WSGIApplicationGroup %{GLOBAL}
 
-    WSGIScriptAlias /weblate /home/weblate/weblate-env/lib/python3.7/site-packages/weblate/wsgi.py process-group=weblate request-timeout=600
+    WSGIScriptAlias /weblate /home/weblate/weblate-env/lib/python3.7/site-packages/weblate/wsgi.py process-group=weblate
     WSGIPassAuthorization On
 
     <Directory /home/weblate/weblate-env/lib/python3.7/site-packages/weblate/>

--- a/weblate/examples/apache.conf
+++ b/weblate/examples/apache.conf
@@ -28,7 +28,7 @@
     WSGIProcessGroup weblate
     WSGIApplicationGroup %{GLOBAL}
 
-    WSGIScriptAlias / /home/weblate/weblate-env/lib/python3.7/site-packages/weblate/wsgi.py process-group=weblate request-timeout=600
+    WSGIScriptAlias / /home/weblate/weblate-env/lib/python3.7/site-packages/weblate/wsgi.py process-group=weblate
     WSGIPassAuthorization On
 
     <Directory /home/weblate/weblate-env/lib/python3.7/site-packages/weblate/>


### PR DESCRIPTION
## Proposed changes

In `mod_wsgi` 4.9.0 **request-timeout** is no longer a valid option for `WSGIScriptAlias`. [source](https://modwsgi.readthedocs.io/en/master/configuration-directives/WSGIScriptAlias.html)

This patch removes the option from the example configurations in the documentation

## Checklist

- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
