### PR TITLE
Fix links to Liberapay profiles

### DIFF
--- a/weblate/templates/accounts/user.html
+++ b/weblate/templates/accounts/user.html
@@ -96,7 +96,7 @@
         {% endif %}
         {% if page_profile.liberapay %}
           <span class="middle-dot-divider">
-            <span class="profile-icon">{% icon "liberapay.svg" %}</span> <a href="https://liberapay.org/{{ page_profile.liberapay }}" rel="ugc">{{ page_profile.liberapay }}</a>
+            <span class="profile-icon">{% icon "liberapay.svg" %}</span> <a href="https://liberapay.com/{{ page_profile.liberapay }}" rel="ugc">{{ page_profile.liberapay }}</a>
           </span>
         {% endif %}
         {% if page_profile.fediverse %}


### PR DESCRIPTION
A while ago the configuration of the `liberapay.org` domain was changed to redirect all requests to the home page of the `liberapay.com` domain, so the links that Weblate generates no longer lead to the intended pages.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
