### PR TITLE
component: Postpone template validation until it is really needed

### DIFF
--- a/weblate/trans/exceptions.py
+++ b/weblate/trans/exceptions.py
@@ -31,3 +31,11 @@ class FileParseError(WeblateError):
 
 class PluralFormsMismatch(WeblateError):
     """Plural forms do not match the language."""
+
+
+class InvalidTemplate(WeblateError):
+    """Template file can not be parsed."""
+
+    def __init__(self, nested, message=None):
+        super().__init__(message or self.__doc__)
+        self.nested = nested

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -386,6 +386,7 @@ class Translation(
         details["reason"] = self.reason
 
         self.log_info("processing %s, %s", self.filename, self.reason)
+        self.component.check_template_valid()
 
         # List of updated units (used for cleanup and duplicates detection)
         updated = {}


### PR DESCRIPTION


## Proposed changes

Parse the template at the point we will actually need it (once a change
in one of the translations is detected).

Fixes #7383

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
