### PR TITLE
improvement: add `<link rel="(next|prev)"` to `<head>`

### DIFF
--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -19,6 +19,13 @@
   <meta name="description" content="{{ description }}" />
   <meta name="twitter:card" content="summary_large_image" />
 
+  {% if next_unit_url %}
+  <link rel="next" href="{{ next_unit_url }}" />
+  {% endif %}
+  {% if prev_unit_url %}
+  <link rel="prev" href="{{ prev_unit_url }}" />
+  {% endif %}
+
   {% if object.slug and object.project.slug %}
   <meta property="og:image" content="{{ site_url }}{% url 'widget-image' project=object.project.slug widget='open' color='graph' extension='png' %}" />
   <link rel="alternate" type="application/rss+xml" title="RSS feed" href="{% url 'rss-component' project=object.project.slug component=object.slug %}" />

--- a/weblate/templates/snippets/position-field.html
+++ b/weblate/templates/snippets/position-field.html
@@ -6,7 +6,7 @@
   {% if not is_zen %}
     {% if prev_unit_url %}
       <a id="button-first" class="btn btn-default green" href="{{ first_unit_url }}" title="{% trans "First" %}">{% if LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a>
-      <a id="button-prev" class="btn btn-default green" href="{{ prev_unit_url }}" title="{% trans "Previous" %}">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
+      <a id="button-prev" class="btn btn-default green" href="{{ prev_unit_url }}" title="{% trans "Previous" %}" rel="prev">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
     {% else %}
       <a id="button-first" class="btn btn-default green disabled" title="{% trans "First" %}">{% if LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a>
       <a id="button-prev" class="btn btn-default green disabled" title="{% trans "Previous" %}">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
@@ -27,7 +27,7 @@
     </div>
   {% if not is_zen %}
     {% if next_unit_url %}
-      <a id="button-next" class="btn btn-default green" href="{{ next_unit_url }}" title="{% trans "Next" %}">{% if not LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
+      <a id="button-next" class="btn btn-default green" href="{{ next_unit_url }}" title="{% trans "Next" %}" rel="next">{% if not LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
       <a id="button-end" class="btn btn-default green" href="{{ last_unit_url }}" title="{% trans "Last" %}">{% if not LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a>
     {% else %}
       <a id="button-next" class="btn btn-default green disabled" title="{% trans "Next" %}">{% if not LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>


### PR DESCRIPTION
## Proposed changes

This should hint the browser to consider prefetching the next page,
which is especially beneficial on `/translate`.
https://html.spec.whatwg.org/multipage/links.html#link-type-next
https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Possible drawback: e.g. if you edit a string and it is referenced on the next page (e.g. in "Nearby keys"), then if the next page gets prefetched, that referenced string will appear unchanged.
But then, in a perfect world, to negate this, I'd say it would be good to load "Nearby keys" separately from the page SPA-style so they get loaded after the next page loads, which would also benefit performance.

Did not test this since setting up a local copy is going quite rough for now. Gecko browsers currently should be doing prefetching based on these hints (see the links above), not sure about Chromium. Either way I think it's good practice.
Don't think it makes sense to add tests or docs for this.

I have also considered adding `prefetch` keyword for the `next` link, but I suppose let's let the browser decide. Maybe later.

Also I'm not sure if it's very good to use the `next_unit_url` and `prev_unit_url` in `base.html` as these variables MAY have different names in other files in the future, but currently it's just `edit.py` as far as I can tell.