### PR TITLE
improvement: add `prefetch` for `<link rel="next`

### DIFF
--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image" />
 
   {% if next_unit_url %}
-  <link rel="next" href="{{ next_unit_url }}" />
+  <link rel="next prefetch" href="{{ next_unit_url }}" />
   {% endif %}
   {% if prev_unit_url %}
   <link rel="prev" href="{{ prev_unit_url }}" />


### PR DESCRIPTION
## Proposed changes

Although browsers may prefetch the next link just based on `rel="next"`,
they are still entitled to doubt whether it is likely that the user will
want to visit it. Let's tell them that it is indeed highly likely.

This is a follow-up to 2340bf6b25 (#7558)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
