### PR TITLE
Rename `ckb` and `kmr`

### DIFF
--- a/weblate/trans/fixtures/simple-project.json
+++ b/weblate/trans/fixtures/simple-project.json
@@ -1919,7 +1919,7 @@
     "pk": 148,
     "fields": {
       "code": "ckb",
-      "name": "Sorani",
+      "name": "Central Kurdish",
       "direction": "rtl"
     }
   },
@@ -3152,7 +3152,7 @@
     "pk": 289,
     "fields": {
       "code": "kmr",
-      "name": "Kurmanji",
+      "name": "Northern Kurdish",
       "direction": "ltr"
     }
   },


### PR DESCRIPTION
## Proposed changes

Renamed `ckb` and `kmr` to Central Kurdish and Northern Kurdish.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Reasons for the change:

- The current names are not popular, nor standard.
- The renamed entities are not often searched for by Kurm.. or Sora..
- To match with the name of the other dialect, `sdh` (Southern Kurdish).
