### PR TITLE
improvement: add `<link rel="(next|prev)"` when `page_obj.has_(next|previous)`

### DIFF
--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -21,9 +21,15 @@
 
   {% if next_unit_url %}
   <link rel="next prefetch" href="{{ next_unit_url }}" />
+  {% elif page_obj.has_next %}
+  <!-- TODO refactor: the `page_obj` links' hrefs are copy-pasted from 'paginator.html'. Need to DRY. -->
+  <link rel="next prefetch" href=href="?page={{ page_obj.next_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}">
   {% endif %}
+
   {% if prev_unit_url %}
   <link rel="prev" href="{{ prev_unit_url }}" />
+  {% elif page_obj.has_previous %}
+  <link rel="prev" href="?page={{ page_obj.previous_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}">
   {% endif %}
 
   {% if object.slug and object.project.slug %}


### PR DESCRIPTION
## Proposed changes

Follow-up to 2340bf6b25 (#7558)

TODO:
* [ ] refactor: the `page_obj` links' hrefs are copy-pasted from 'paginator.html'. Need to DRY. Not sure how. Or simply cover with tests?
* [x] also consider adding `prefetch`, as in https://github.com/WeblateOrg/weblate/pull/7565
* [ ] Make sure it's a good way to go about it.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Regarding DRY: I we could add `<link>` directly into `paginator.html`, but only if its `rel` doesn't contain `next` or `prev`, because it's not body-ok.