### PR TITLE
WIP: split `.js`, load some asynchronously & on-demand, use ESM

### DIFF
--- a/weblate/static/attach-tribute-to.js
+++ b/weblate/static/attach-tribute-to.js
@@ -1,0 +1,51 @@
+// import $ from "./vendor/jquery.js";
+import Tribute from "./vendor/tribute.js";
+
+console.log(Tribute);
+
+/* Username autocompletion */
+var tribute = new Tribute({
+  trigger: "@",
+  requireLeadingSpace: true,
+  menuShowMinLength: 2,
+  searchOpts: {
+    pre: "​",
+    post: "​",
+  },
+  noMatchTemplate: function () {
+    return "";
+  },
+  menuItemTemplate: function (item) {
+    let link = document.createElement("a");
+    link.innerText = item.string;
+    return link.outerHTML;
+  },
+  values: (text, callback) => {
+    $.ajax({
+      type: "GET",
+      url: `/api/users/?username=${text}`,
+      dataType: "json",
+      success: function (data) {
+        var userMentionList = data.results.map(function (user) {
+          return {
+            value: user.username,
+            key: `${user.full_name} (${user.username})`,
+          };
+        });
+        callback(userMentionList);
+      },
+      error: function (jqXHR, textStatus, errorThrown) {
+        console.error(errorThrown);
+      },
+    });
+  },
+});
+export default function attachTributeTo(elements) {
+  tribute.attach(elements);
+  elements.forEach((editor) => {
+    editor.addEventListener("tribute-active-true", function (e) {
+      $(".tribute-container").addClass("open");
+      $(".tribute-container ul").addClass("dropdown-menu");
+    });
+  });
+}

--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -1,3 +1,7 @@
+import $ from "../vendor/jquery.js";
+import Mousetrap from "./vendor/mousetrap.js";
+import "./vendor/mousetrap-global-bind.js";
+
 var WLT = WLT || {};
 
 WLT.Config = (function () {

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -1,3 +1,10 @@
+import $ from "../vendor/jquery.js";
+import Cookies from "./vendor/js.cookie.js";
+import autosize from "./vendor/autosize.js";
+// TODO perf: import Mousetrap dynamically.
+import Mousetrap from "./vendor/mousetrap.js";
+import "./vendor/mousetrap-global-bind.js";
+
 (function () {
   var EditorBase = WLT.Editor.Base;
 

--- a/weblate/static/editor/zen.js
+++ b/weblate/static/editor/zen.js
@@ -1,3 +1,7 @@
+import $ from "../vendor/jquery.js";
+import Mousetrap from "./vendor/mousetrap.js";
+import "./vendor/mousetrap-global-bind.js";
+
 (function () {
   var EditorBase = WLT.Editor.Base;
 

--- a/weblate/static/init-multi.js
+++ b/weblate/static/init-multi.js
@@ -1,0 +1,12 @@
+import $ from "./vendor/jquery.js";
+import "./vendor/multi.js";
+
+// TODO don't import `multi` if there are no such elements.
+
+/* Override all multiple selects */
+$("select[multiple]").multi({
+  enable_search: true,
+  search_placeholder: gettext("Search…"),
+  non_selected_header: gettext("Available:"),
+  selected_header: gettext("Chosen:"),
+});

--- a/weblate/static/init-shortcuts.js
+++ b/weblate/static/init-shortcuts.js
@@ -1,0 +1,24 @@
+import $ from "./vendor/jquery.js";
+import Mousetrap from "./vendor/mousetrap.js";
+import "./vendor/mousetrap-global-bind.js";
+
+function submitForm(evt) {
+  var $target = $(evt.target);
+  var $form = $target.closest("form");
+
+  if ($form.length === 0) {
+    $form = $(".translation-form");
+  }
+  if ($form.length > 0) {
+    let submits = $form.find('input[type="submit"]');
+
+    if (submits.length === 0) {
+      submits = $form.find('button[type="submit"]');
+    }
+    if (submits.length > 0) {
+      submits[0].click();
+    }
+  }
+  return false;
+}
+Mousetrap.bindGlobal(["alt+enter", "mod+enter"], submitForm);

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1119,7 +1119,7 @@ $(function () {
   var markdownEditors = document.querySelectorAll(".markdown-editor");
   if (markdownEditors.length >= 1) {
     // TODO prefetch `attach-tribute-to`.
-    import('./attach-tribute-to.js').then(attachTributeTo => {
+    import("./attach-tribute-to.js").then((attachTributeTo) => {
       attachTributeTo(markdownEditors);
     });
   }

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1,3 +1,18 @@
+import $ from "./vendor/jquery.js";
+const jQuery = $;
+import autosize from "./vendor/autosize.js";
+import Cookies from "./vendor/js.cookie.js";
+import slugify from "./vendor/slugify.js";
+import Modernizr from "./vendor/modernizr.js";
+// TODO use Prism as described here https://prismjs.com/#basic-usage-bundlers.
+// TODO load Prism asynchronously, and load languages on-demand, see `initHighlight` below.
+// import "./vendor/prism/prism-core.js";
+// import "./vendor/prism/prism-markup.js";
+// import "./vendor/prism/prism-rest.js";
+// import "./vendor/prism/prism-markdown.js";
+// import "./vendor/prism/prism-icu-message-format.js";
+import ClipboardJS from "./vendor/clipboard.js";
+
 var loading = [];
 
 // Remove some weird things from location hash
@@ -92,26 +107,7 @@ jQuery.fn.extend({
   },
 });
 
-function submitForm(evt) {
-  var $target = $(evt.target);
-  var $form = $target.closest("form");
-
-  if ($form.length === 0) {
-    $form = $(".translation-form");
-  }
-  if ($form.length > 0) {
-    let submits = $form.find('input[type="submit"]');
-
-    if (submits.length === 0) {
-      submits = $form.find('button[type="submit"]');
-    }
-    if (submits.length > 0) {
-      submits[0].click();
-    }
-  }
-  return false;
-}
-Mousetrap.bindGlobal(["alt+enter", "mod+enter"], submitForm);
+// TODO run `init-shortcuts.js`.
 
 function screenshotStart() {
   $("#search-results tbody.unit-listing-body").empty();
@@ -337,6 +333,7 @@ function quoteSearch(value) {
   return value;
 }
 
+// TODO do this asynchronously
 function initHighlight(root) {
   if (typeof ResizeObserver === "undefined") {
     return;
@@ -612,6 +609,7 @@ $(function () {
   });
 
   /* Check if browser provides native datepicker */
+  // TODO don't import `bootstrap-datepicker` if this is the case.
   if (Modernizr.inputtypes.date) {
     $(document).off(".datepicker.data-api");
   }
@@ -807,6 +805,7 @@ $(function () {
   });
 
   /* Copy to clipboard */
+  // TODO perf: do this asynchronously?
   var clipboard = new ClipboardJS("[data-clipboard-text]");
   clipboard.on("success", function (e) {
     var text =
@@ -836,15 +835,10 @@ $(function () {
     select_auto_source.trigger("change");
   }
 
-  /* Override all multiple selects */
-  $("select[multiple]").multi({
-    enable_search: true,
-    search_placeholder: gettext("Search…"),
-    non_selected_header: gettext("Available:"),
-    selected_header: gettext("Chosen:"),
-  });
+  // TODO run `init-multi.js`.
 
   /* Slugify name */
+  // TODO perf: do this asynchronously?
   slugify.extend({ ".": "-" });
   $('input[name="slug"]').each(function () {
     var $slug = $(this);
@@ -1122,50 +1116,13 @@ $(function () {
     }
   );
 
-  /* Username autocompletion */
-  var tribute = new Tribute({
-    trigger: "@",
-    requireLeadingSpace: true,
-    menuShowMinLength: 2,
-    searchOpts: {
-      pre: "​",
-      post: "​",
-    },
-    noMatchTemplate: function () {
-      return "";
-    },
-    menuItemTemplate: function (item) {
-      let link = document.createElement("a");
-      link.innerText = item.string;
-      return link.outerHTML;
-    },
-    values: (text, callback) => {
-      $.ajax({
-        type: "GET",
-        url: `/api/users/?username=${text}`,
-        dataType: "json",
-        success: function (data) {
-          var userMentionList = data.results.map(function (user) {
-            return {
-              value: user.username,
-              key: `${user.full_name} (${user.username})`,
-            };
-          });
-          callback(userMentionList);
-        },
-        error: function (jqXHR, textStatus, errorThrown) {
-          console.error(errorThrown);
-        },
-      });
-    },
-  });
-  tribute.attach(document.querySelectorAll(".markdown-editor"));
-  document.querySelectorAll(".markdown-editor").forEach((editor) => {
-    editor.addEventListener("tribute-active-true", function (e) {
-      $(".tribute-container").addClass("open");
-      $(".tribute-container ul").addClass("dropdown-menu");
+  var markdownEditors = document.querySelectorAll(".markdown-editor");
+  if (markdownEditors.length >= 1) {
+    // TODO prefetch `attach-tribute-to`.
+    import('./attach-tribute-to.js').then(attachTributeTo => {
+      attachTributeTo(markdownEditors);
     });
-  });
+  }
 
   /* Textarea highlighting */
   Prism.languages.none = {};

--- a/weblate/static/zammad.js
+++ b/weblate/static/zammad.js
@@ -1,3 +1,5 @@
+import $ from "../vendor/jquery.js";
+
 $(function () {
   $("#support-form").ZammadForm({
     messageTitle: gettext("Weblate feedback"),

--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -48,6 +48,7 @@
   <script src="{% url 'js-catalog' %}" defer></script>
 {% compress js %}
 {% if rollbar_token %}
+<!-- TODO also separate this? But what if `!rollbar_token`? -->
 <script>
 var _rollbarConfig = {
     accessToken: "{{ rollbar_token }}",
@@ -62,24 +63,15 @@ var _rollbarConfig = {
 // End Rollbar Snippet
 </script>
 {% endif %}
-  <script defer data-cfasync="false" src="{% static 'vendor/jquery.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/js.cookie.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/autosize.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/multi.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/mousetrap.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/mousetrap-global-bind.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/clipboard.js' %}{{ cache_param }}"></script>
+  <!-- TODO separate bootstrap? https://getbootstrap.com/docs/5.1/getting-started/javascript/#using-bootstrap-as-a-module -->
   <script defer data-cfasync="false" src="{% static 'vendor/bootstrap/js/bootstrap.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/bootstrap/js/bootstrap-datepicker.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/modernizr.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/slugify.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/tribute.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-core.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-markup.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-rest.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-markdown.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-icu-message-format.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'loader-bootstrap.js' %}{{ cache_param }}"></script>
+  <script type="module" data-cfasync="false" src="{% static 'loader-bootstrap.js' %}{{ cache_param }}"></script>
 {% endcompress %}
 
 {% block extra_script %}


### PR DESCRIPTION
## Proposed changes

This is super WIP, for now look at it as a discussion rather than a full-fledged MR.

In order to improve page loading performance, it would be cool to load some JS asynchronously and on-demand, and tree-shake some of it. Examples: shortcuts, syntax highlighting, username autocompletion.
Here's the audit I ran:

![image](https://user-images.githubusercontent.com/39462442/166430897-de74756a-5480-4d14-8979-59e70bb19670.png)

As you can see, on my PC it takes ~400ms to load a __prefetched__ page (i.e. it's only rendering, not including network download). You can imagine it's a little worse on mobile.

First step to this is rewriting the scripts with imports.

This also makes the code easier to maintain as there's fewer global vars.

TODO:
* [ ] Make sure nothing broke
* [ ] See TODOs in the code
* [ ] Perhaps a transpiler needs to be used as [ESM imports are not supported in old browsers (~92% now)](https://caniuse.com/es6-module-dynamic-import). Which one? Webpack?

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
