### PR TITLE
perf: js: load username autocompletion asynchronously and on-demand

### DIFF
--- a/weblate/static/attach-tribute-to.js
+++ b/weblate/static/attach-tribute-to.js
@@ -1,0 +1,49 @@
+// import $ from "./vendor/jquery.js";
+import "./vendor/tribute.js"; // It does `window.Tribute =`
+
+/* Username autocompletion */
+var tribute = new Tribute({
+  trigger: "@",
+  requireLeadingSpace: true,
+  menuShowMinLength: 2,
+  searchOpts: {
+    pre: "​",
+    post: "​",
+  },
+  noMatchTemplate: function () {
+    return "";
+  },
+  menuItemTemplate: function (item) {
+    let link = document.createElement("a");
+    link.innerText = item.string;
+    return link.outerHTML;
+  },
+  values: (text, callback) => {
+    $.ajax({
+      type: "GET",
+      url: `/api/users/?username=${text}`,
+      dataType: "json",
+      success: function (data) {
+        var userMentionList = data.results.map(function (user) {
+          return {
+            value: user.username,
+            key: `${user.full_name} (${user.username})`,
+          };
+        });
+        callback(userMentionList);
+      },
+      error: function (jqXHR, textStatus, errorThrown) {
+        console.error(errorThrown);
+      },
+    });
+  },
+});
+export default function attachTributeTo(elements) {
+  tribute.attach(elements);
+  elements.forEach((editor) => {
+    editor.addEventListener("tribute-active-true", function (e) {
+      $(".tribute-container").addClass("open");
+      $(".tribute-container ul").addClass("dropdown-menu");
+    });
+  });
+}

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1125,7 +1125,7 @@ $(function () {
   var markdownEditors = document.querySelectorAll(".markdown-editor");
   if (markdownEditors.length >= 1) {
     // TODO prefetch `attach-tribute-to` and its dependencies?
-    import('./attach-tribute-to.js').then(({ default: attachTributeTo }) => {
+    import("./attach-tribute-to.js").then(({ default: attachTributeTo }) => {
       attachTributeTo(markdownEditors);
     });
   }

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1122,50 +1122,13 @@ $(function () {
     }
   );
 
-  /* Username autocompletion */
-  var tribute = new Tribute({
-    trigger: "@",
-    requireLeadingSpace: true,
-    menuShowMinLength: 2,
-    searchOpts: {
-      pre: "​",
-      post: "​",
-    },
-    noMatchTemplate: function () {
-      return "";
-    },
-    menuItemTemplate: function (item) {
-      let link = document.createElement("a");
-      link.innerText = item.string;
-      return link.outerHTML;
-    },
-    values: (text, callback) => {
-      $.ajax({
-        type: "GET",
-        url: `/api/users/?username=${text}`,
-        dataType: "json",
-        success: function (data) {
-          var userMentionList = data.results.map(function (user) {
-            return {
-              value: user.username,
-              key: `${user.full_name} (${user.username})`,
-            };
-          });
-          callback(userMentionList);
-        },
-        error: function (jqXHR, textStatus, errorThrown) {
-          console.error(errorThrown);
-        },
-      });
-    },
-  });
-  tribute.attach(document.querySelectorAll(".markdown-editor"));
-  document.querySelectorAll(".markdown-editor").forEach((editor) => {
-    editor.addEventListener("tribute-active-true", function (e) {
-      $(".tribute-container").addClass("open");
-      $(".tribute-container ul").addClass("dropdown-menu");
+  var markdownEditors = document.querySelectorAll(".markdown-editor");
+  if (markdownEditors.length >= 1) {
+    // TODO prefetch `attach-tribute-to` and its dependencies?
+    import('./attach-tribute-to.js').then(({ default: attachTributeTo }) => {
+      attachTributeTo(markdownEditors);
     });
-  });
+  }
 
   /* Textarea highlighting */
   Prism.languages.none = {};

--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -73,14 +73,13 @@ var _rollbarConfig = {
   <script defer data-cfasync="false" src="{% static 'vendor/bootstrap/js/bootstrap-datepicker.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/modernizr.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/slugify.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'vendor/tribute.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-core.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-markup.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-rest.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-markdown.js' %}{{ cache_param }}"></script>
   <script defer data-cfasync="false" src="{% static 'vendor/prism/prism-icu-message-format.js' %}{{ cache_param }}"></script>
-  <script defer data-cfasync="false" src="{% static 'loader-bootstrap.js' %}{{ cache_param }}"></script>
 {% endcompress %}
+  <script defer type="module" data-cfasync="false" src="{% static 'loader-bootstrap.js' %}{{ cache_param }}"></script>
 
 {% block extra_script %}
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

This is a subtask of #7586, a proof of concept, if you will.
This appears to be working, but there are two problems:
* `loader-bootstrap.js` and its dependencies don't get compressed by `django-compressor`. Tolerable.
* Even when `cache_param` is not an empty string, dependencies don't get their cache hashes because they're inside JS files, which are not templates, so cache invalidation doesn't work. Not sure how bad is it. Maybe this link can help, idk: https://docs.djangoproject.com/en/4.0/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.

Why don't we put `loader-bootstrap.js` inside a `{% compress %}` block:
* because it removes `type="module"` from the element
* because the output file would get put inside a `CACHE` subdirectory, but its dependencies would remain where they were, so relative import paths would stop working. Even if we were to put it inside a `compress` block, its dependencies would still not get compressed.

Not sure how to get rid of these problems without a transpiler.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
