### PR TITLE
Allow SOCIAL_AUTH_* _IMAGE and _TITLE customization for Keycloak and SAML

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1178,6 +1178,8 @@ In case you want to use own keys, place the certificate and private key in
 .. envvar:: WEBLATE_SAML_IDP_ENTITY_ID
 .. envvar:: WEBLATE_SAML_IDP_URL
 .. envvar:: WEBLATE_SAML_IDP_X509CERT
+.. envvar:: WEBLATE_SAML_IDP_IMAGE
+.. envvar:: WEBLATE_SAML_IDP_TITLE
 
     SAML Identity Provider settings, see :ref:`saml-auth`.
 

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1142,6 +1142,8 @@ Keycloak
 .. envvar:: WEBLATE_SOCIAL_AUTH_KEYCLOAK_ALGORITHM
 .. envvar:: WEBLATE_SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL
 .. envvar:: WEBLATE_SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL
+.. envvar:: WEBLATE_SOCIAL_AUTH_KEYCLOAK_TITLE
+.. envvar:: WEBLATE_SOCIAL_AUTH_KEYCLOAK_IMAGE
 
     Enables Keycloak authentication, see
     `documentation <https://github.com/python-social-auth/social-core/blob/master/social_core/backends/keycloak.py>`_.

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -391,6 +391,8 @@ if "WEBLATE_SAML_IDP_URL" in os.environ:
             "url": SITE_URL,
         }
     }
+    SOCIAL_AUTH_SAML_IMAGE = os.environ.get("WEBLATE_SAML_IDP_IMAGE", "")
+    SOCIAL_AUTH_SAML_TITLE = os.environ.get("WEBLATE_SAML_IDP_TITLE", "")
 
 # Azure
 if "WEBLATE_SOCIAL_AUTH_AZUREAD_OAUTH2_KEY" in os.environ:
@@ -437,6 +439,12 @@ if "WEBLATE_SOCIAL_AUTH_KEYCLOAK_KEY" in os.environ:
     )
     SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = os.environ.get(
         "WEBLATE_SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL", ""
+    )
+    SOCIAL_AUTH_KEYCLOAK_IMAGE = os.environ.get(
+        "WEBLATE_SOCIAL_AUTH_KEYCLOAK_IMAGE", ""
+    )
+    SOCIAL_AUTH_KEYCLOAK_TITLE = os.environ.get(
+        "WEBLATE_SOCIAL_AUTH_KEYCLOAK_TITLE", ""
     )
     SOCIAL_AUTH_KEYCLOAK_ID_KEY = "email"
 


### PR DESCRIPTION
## Proposed changes

I propose to allow the following variables to be set (according to documentation) when run in docker:
* `SOCIAL_AUTH_KEYCLOAK_IMAGE`
* `SOCIAL_AUTH_KEYCLOAK_TITLE`
* `SOCIAL_AUTH_SAML_IMAGE`
* `SOCIAL_AUTH_SAML_TITLE`

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information