### PR TITLE
fix: `/credits` escaping HTML chars when outputting in `text/plain` mode

### DIFF
--- a/weblate/trans/tests/test_reports.py
+++ b/weblate/trans/tests/test_reports.py
@@ -141,15 +141,14 @@ class ReportsComponentTest(BaseReportsTest):
     def test_credits_view_rst(self):
         response = self.get_credits("rst")
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "text/plain; charset=utf-8")
         self.assertEqual(
-            response.content.decode(),
+            response.content.decode().strip(),
             """
-
 * Czech
 
-    * Weblate &lt;b&gt;Test&lt;/b&gt; <weblate@example.org> (1)
-
-""",
+    * Weblate <b>Test</b> <weblate@example.org> (1)
+""".strip(),
         )
 
     def test_credits_view_html(self):
@@ -157,11 +156,11 @@ class ReportsComponentTest(BaseReportsTest):
         self.assertEqual(response.status_code, 200)
         self.assertHTMLEqual(
             response.content.decode(),
-            "<table>\n"
+            "<table><tbody>\n"
             "<tr>\n<th>Czech</th>\n"
             '<td><ul><li><a href="mailto:weblate@example.org">'
             "Weblate &lt;b&gt;Test&lt;/b&gt;</a> (1)</li></ul></td>\n</tr>\n"
-            "</table>",
+            "</tbody></table>",
         )
 
     def get_counts(self, style, **kwargs):

--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -1,5 +1,6 @@
 #
 # Copyright © 2012–2022 Michal Čihař <michal@cihar.com>
+# Copyright © 2022 WofWca <wofwca@protonmail.com>
 #
 # This file is part of Weblate <https://weblate.org/>
 #
@@ -19,7 +20,7 @@
 
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
-from django.utils.html import escape
+from django.utils.html import conditional_escape, escape, format_html, format_html_join
 from django.views.decorators.http import require_POST
 
 from weblate.lang.models import Language
@@ -32,6 +33,15 @@ from weblate.utils.views import get_component, get_project, show_form_errors
 RST_HEADING = " ".join(["=" * 40] * 2 + ["=" * 24] * 20)
 
 HTML_HEADING = "<table>\n<tr>{0}</tr>"
+
+def format_plaintext(format_string, *args, **kwargs):
+    """Same as `format_html` in syntax, but performs no escaping."""
+    return format_string.format(*args, **kwargs)
+def format_plaintext_join(sep, format_string, args_generator):
+    """Same as `format_html_join` in syntax, but performs no escaping."""
+    return sep.join(
+        format_plaintext(format_string, *args) for args in args_generator
+    )
 
 
 def generate_credits(user, start_date, end_date, **kwargs):
@@ -84,45 +94,49 @@ def get_credits(request, project=None, component=None):
         return JsonResponse(data=data, safe=False)
 
     if form.cleaned_data["style"] == "html":
-        start = "<table>"
-        row_start = "<tr>"
-        language_format = "<th>{0}</th>"
-        translator_start = "<td><ul>"
+        wrap_format = "<table><tbody>{}</tbody></table>"
+        language_format = """
+        <tr>
+            <th>{language}</th>
+            <td><ul>{translators}</ul></td>
+        </tr>
+        """
         translator_format = '<li><a href="mailto:{0}">{1}</a> ({2})</li>'
-        translator_end = "</ul></td>"
-        row_end = "</tr>"
         mime = "text/html"
-        end = "</table>"
+        format_html_or_plain = format_html
+        format_html_or_plain_join = format_html_join
     else:
-        start = ""
-        row_start = ""
-        language_format = "* {0}\n"
-        translator_start = ""
+        wrap_format = "{}"
+        language_format = "* {language}\n\n{translators}\n"
         translator_format = "    * {1} <{0}> ({2})"
-        translator_end = ""
-        row_end = ""
         mime = "text/plain"
-        end = ""
+        format_html_or_plain = format_plaintext
+        format_html_or_plain_join = format_plaintext_join
 
-    result = [start]
-
+    language_outputs = []
     for language in data:
         name, translators = language.popitem()
-        result.append(row_start)
-        result.append(language_format.format(escape(name)))
-        result.append(
-            translator_start
-            + "\n".join(
-                translator_format.format(escape(t[0]), escape(t[1]), t[2])
-                for t in translators
+        language_outputs.append(
+            format_html_or_plain(
+                language_format,
+                language=name,
+                translators=format_html_or_plain_join(
+                    "\n",
+                    translator_format,
+                    ((t[0], t[1], t[2]) for t in translators),
+                ),
             )
-            + translator_end
         )
-        result.append(row_end)
 
-    result.append(end)
-
-    return HttpResponse("\n".join(result), content_type=f"{mime}; charset=utf-8")
+    body = format_html_or_plain(
+        wrap_format,
+        format_html_or_plain_join("\n\n", "{}", ((v,) for v in language_outputs)),
+    )
+    # Just in case someone messes something up.
+    # Also consider simply using `html.unescape` instead.
+    if mime != "text/plain":
+        body = conditional_escape(body)
+    return HttpResponse(body, content_type=f"{mime}; charset=utf-8")
 
 
 COUNT_DEFAULTS = {

--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -34,14 +34,15 @@ RST_HEADING = " ".join(["=" * 40] * 2 + ["=" * 24] * 20)
 
 HTML_HEADING = "<table>\n<tr>{0}</tr>"
 
+
 def format_plaintext(format_string, *args, **kwargs):
     """Same as `format_html` in syntax, but performs no escaping."""
     return format_string.format(*args, **kwargs)
+
+
 def format_plaintext_join(sep, format_string, args_generator):
     """Same as `format_html_join` in syntax, but performs no escaping."""
-    return sep.join(
-        format_plaintext(format_string, *args) for args in args_generator
-    )
+    return sep.join(format_plaintext(format_string, *args) for args in args_generator)
 
 
 def generate_credits(user, start_date, end_date, **kwargs):


### PR DESCRIPTION
Also rewrite with `format_html` instead of `escape`
This also makes it not output leading and trailing newlines
as I think it was an error.

Same issue still exists for `/counts`, need to do the same

Before:

![image](https://user-images.githubusercontent.com/39462442/170829945-ba556665-4c7a-4cb5-bebc-1de951eba551.png)


After:

![image](https://user-images.githubusercontent.com/39462442/170829916-1b0ac161-fb45-4248-b35f-5d9234f9051d.png)


## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
