### PR TITLE
improvement: `/engage` page: prefetch "Register" and "Translate" URLs

### DIFF
--- a/weblate/templates/engage.html
+++ b/weblate/templates/engage.html
@@ -7,6 +7,14 @@
 {% block breadcrumbs_container %}
 {% endblock %}
 
+{% block extra_meta %}
+{# Both are likely to get visited. #}
+{% if not user.is_authenticated %}
+<link rel="prefetch" href="{% url 'register' %}" />
+{% endif %}
+<link rel="prefetch" href="{{ translate_button_url }}" />
+{% endblock %}
+
 {% block content %}
 
 <div class="engage container">
@@ -60,7 +68,7 @@
 {% if not user.is_authenticated %}
 <a href="{% url 'register' %}" class="btn btn-primary btn-lg">{% trans "Register" %}</a>
 {% endif %}
-<a id="engage-project" href="{{ object.get_absolute_url }}#languages" class="btn btn-primary btn-lg">{% trans "Translate" context "Call to action on engage page" %}</a>
+<a id="engage-project" href="{{ translate_button_url }}" class="btn btn-primary btn-lg">{% trans "Translate" context "Call to action on engage page" %}</a>
 <a href="{{ object.get_absolute_url }}#languages" class="btn btn-primary btn-lg">{% trans "View project languages" %}</a>
 </p>
 

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -122,6 +122,7 @@ def show_engage(request, project, lang=None):
             "project_link": format_html(
                 '<a href="{}">{}</a>', obj.get_absolute_url(), obj.name
             ),
+            "translate_button_url": obj.get_absolute_url() + "#languages",
             "title": _("Get involved in {0}!").format(obj),
         },
     )


### PR DESCRIPTION
Currently doesn't work because these views are decorated with `@never_cache`,
* [ ] https://github.com/WeblateOrg/weblate/issues/7716

This should make navigation faster.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
