### PR TITLE
feat: explicitly link `GettextCustomizeForm.width` choices to `xgettext` flags

### DIFF
--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -112,8 +112,8 @@ class GettextCustomizeForm(BaseAddonForm):
     width = forms.ChoiceField(
         label=_("Long lines wrapping"),
         choices=[
-            (77, _("Wrap lines at 77 characters and at newlines")),
-            (65535, _("Only wrap lines at newlines")),
+            (77, _("Wrap lines at 77 characters and at newlines (xgettext default)")),
+            (65535, _("Only wrap lines at newlines (like 'xgettext --no-wrap')")),
             (-1, _("No line wrapping")),
         ],
         required=True,


### PR DESCRIPTION
## Proposed changes

The original `GettextCustomizeForm.width` specified its choices in terms of gettext behavior.  In 54c519d, this specification was removed in favor of help text.  While the help text clarifies gettext's own behavior, highlighting the comparison to `xgettext` and its flags is helpful for choosing the right Weblate option.

Motivating discussion:  #7791


## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [n/a] I have added tests that prove my fix is effective or that my feature works.
- [n/a] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.


## Other information

Feel free to close if you prefer the current text!  In that case, just consider this user feedback.  :-)