### PR TITLE
template: add tooltip for current sort order

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -940,16 +940,13 @@ $(function () {
       })
       .data("sort");
     var sort_value = $("#id_sort_by").val();
+    var $label = $(this).find("span.search-icon");
     if (sort_dropdown_value) {
       if (
         sort_value.replace("-", "") === sort_dropdown_value.replace("-", "") &&
         sort_value !== sort_dropdown_value
       ) {
-        $("#query-sort-toggle .asc").hide();
-        $("#query-sort-toggle .desc").show();
-      } else {
-        $("#query-sort-toggle .desc").hide();
-        $("#query-sort-toggle .asc").show();
+        $label.toggle();
       }
     }
   }
@@ -1028,9 +1025,7 @@ $(function () {
   });
   $(".query-sort-toggle").click(function () {
     var $this = $(this);
-    var $label = $this.find("span.search-icon");
     var $input = $this.closest(".search-group").find("input[name=sort_by]");
-    $label.toggle();
     var sort_params = $input.val().split(",");
     sort_params.forEach(function (param, index) {
       if (param.indexOf("-") !== -1) {

--- a/weblate/templates/snippets/sort-field.html
+++ b/weblate/templates/snippets/sort-field.html
@@ -21,10 +21,10 @@
   </div>
   <div class="btn-group" role="group">
     <button type="button" class="btn btn-default search-field query-sort-toggle">
-      <span class="search-icon asc active">
+      <span title="{% trans 'Ascending' %}" class="search-icon asc active">
         {% icon "sort-ascending.svg" %}
       </span>
-      <span class="search-icon desc">{% icon "sort-descending.svg" %}</span>
+      <span title="{% trans 'Descending' %}" class="search-icon desc">{% icon "sort-descending.svg" %}</span>
     </button>
   </div>
 </div>


### PR DESCRIPTION
## Proposed changes

closes #7830 

## Checklist

- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

![Screenshot 2022-07-01 at 14 46 41](https://user-images.githubusercontent.com/24358501/176898757-42815f6a-665e-48ad-adfa-4a07e0c6418d.png)

https://user-images.githubusercontent.com/24358501/178294980-743cd1fb-9d5d-46ea-bb3a-656141f66b52.mov




I am not sure about the exact reason but the sort order change was happening at two places, one before submitting the form([`toggle`](https://github.com/WeblateOrg/weblate/blob/main/weblate/static/loader-bootstrap.js#L1033)) and another after the response received on the basis of [`sort_by`](https://github.com/WeblateOrg/weblate/blob/main/weblate/static/loader-bootstrap.js#L943-L953) value. Now I made it to happen only once after the response is received and it's looking fine.