### PR TITLE
template: show checkmark for components with 0 strings

### DIFF
--- a/weblate/templates/snippets/list-objects-percent.html
+++ b/weblate/templates/snippets/list-objects-percent.html
@@ -8,6 +8,8 @@
     {% endif %}
     {% if value and value == all %}
         <span class="green" title="{% blocktrans count count=all %}Completed translation with {{ count }} string{% plural %}Completed translation with {{ count }} strings{% endblocktrans %}">{% icon "check.svg" %}</span>
+    {% elif value == 0 and all == 0 %}
+      <span class="green" title="{% blocktrans %}No strings to translate{% endblocktrans %}">{% icon "check.svg" %}</span>
     {% else %}
         {{ percent|percent_format }}
     {% endif %}


### PR DESCRIPTION
## Proposed changes

closes #7778 

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

![Screenshot 2022-07-07 at 16 16 51](https://user-images.githubusercontent.com/24358501/177795802-7d36aba6-a971-4639-86fd-469029a93a14.png)


The checkmark was not shown because `0` is `False` in python so the else statement was executed. 
