### PR TITLE
Fix typo: double space

### DIFF
--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -285,7 +285,7 @@ Weblate supports XLIFF in several variants:
 `XLIFF with placeables support`
    Standard XLIFF supporting placeables and other XML elements.
 `XLIFF with gettext extensions`
-   XLIFF enriched  by `XLIFF 1.2 Representation Guide for Gettext PO`_ to support plurals.
+   XLIFF enriched by `XLIFF 1.2 Representation Guide for Gettext PO`_ to support plurals.
 
 
 .. seealso::

--- a/docs/locales/docs.pot
+++ b/docs/locales/docs.pot
@@ -27368,7 +27368,7 @@ msgid "`XLIFF with gettext extensions`"
 msgstr ""
 
 #: ../../formats.rst:288
-msgid "XLIFF enriched  by `XLIFF 1.2 Representation Guide for Gettext PO`_ to support plurals."
+msgid "XLIFF enriched by `XLIFF 1.2 Representation Guide for Gettext PO`_ to support plurals."
 msgstr ""
 
 #: ../../formats.rst:293


### PR DESCRIPTION
I tried to execute update-po to update the `.po` files as well (I don't know if that's necessary for this to get accepted), but I got the following error:

 `ImportError: cannot import name 'environmentfilter' from 'jinja2' (/usr/local/lib/python3.9/dist-packages/jinja2/__init__.py)`
