### PR TITLE
api: add api to list and delete memory entries

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2009,6 +2009,24 @@ Translations
     :>json string url: URL to access the translation (engagement URL)
     :>json string url_translate: URL to access the translation (real translation URL)
 
+
+Memory
+++++++
+
+.. versionadded:: 4.14
+
+.. http:get:: /api/memory/
+
+    Returns a list of memory results.
+
+.. http:delete:: /api/memory/(int:memory_object_id)/
+
+    Deletes a memory object
+
+    :param memory_object_id: Memory Object ID
+    :type project: int
+
+
 Units
 +++++
 

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -27,6 +27,7 @@ from weblate.addons.models import ADDONS, Addon
 from weblate.auth.models import Group, Permission, Role, User
 from weblate.checks.models import CHECKS
 from weblate.lang.models import Language, Plural
+from weblate.memory.models import Memory
 from weblate.screenshots.models import Screenshot
 from weblate.trans.defines import LANGUAGE_NAME_LENGTH, REPO_LENGTH
 from weblate.trans.models import (
@@ -904,6 +905,22 @@ class PluralField(serializers.ListField):
 
     def get_attribute(self, instance):
         return getattr(instance, f"get_{self.field_name}_plurals")()
+
+
+class MemorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Memory
+        fields = (
+            "id",
+            "source",
+            "target",
+            "source_language",
+            "target_language",
+            "origin",
+            "project",
+            "from_file",
+            "shared",
+        )
 
 
 class UnitSerializer(serializers.ModelSerializer):

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -31,6 +31,7 @@ from weblate_language_data.languages import LANGUAGES
 from weblate.accounts.models import Subscription
 from weblate.auth.models import Group, Role, User
 from weblate.lang.models import Language
+from weblate.memory.models import Memory
 from weblate.screenshots.models import Screenshot
 from weblate.trans.models import (
     Change,
@@ -2181,6 +2182,32 @@ class LanguageAPITest(APIBaseTest):
             request={"name": "New Language"},
         )
         self.assertEqual(Language.objects.get(code="cs").name, "New Language")
+
+
+class MemoryAPITest(APIBaseTest):
+    def test_get(self):
+        self.do_request(
+            "api:memory-list",
+            method="get",
+            superuser=True,
+            code=200,
+        )
+
+        self.do_request(
+            "api:memory-list",
+            method="get",
+            superuser=False,
+            code=403,
+        )
+
+    def test_delete(self):
+        self.do_request(
+            "api:memory-detail",
+            kwargs={"pk": Memory.objects.first().pk},
+            method="delete",
+            superuser=True,
+            code=204,
+        )
 
 
 class TranslationAPITest(APIBaseTest):

--- a/weblate/api/urls.py
+++ b/weblate/api/urls.py
@@ -28,6 +28,7 @@ from weblate.api.views import (
     ComponentViewSet,
     GroupViewSet,
     LanguageViewSet,
+    MemoryViewSet,
     Metrics,
     ProjectViewSet,
     RoleViewSet,
@@ -46,6 +47,7 @@ router.register("roles", RoleViewSet)
 router.register("projects", ProjectViewSet)
 router.register("components", ComponentViewSet)
 router.register("translations", TranslationViewSet)
+router.register("memory", MemoryViewSet)
 router.register("languages", LanguageViewSet)
 router.register("component-lists", ComponentListViewSet)
 router.register("changes", ChangeViewSet)


### PR DESCRIPTION
## Proposed changes

Ref: https://github.com/WeblateOrg/weblate/issues/6440

- Add API for listing and deleting memory entries

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<img width="1083" alt="Screenshot 2022-08-04 at 12 37 46" src="https://user-images.githubusercontent.com/24358501/182827622-f50f8813-19e9-4df4-a326-ef841fc369e1.png">

<img width="1125" alt="Screenshot 2022-08-04 at 14 27 57" src="https://user-images.githubusercontent.com/24358501/182846907-75d31ecf-6ce9-4be6-8c9a-603cf43c8d96.png">

![Screenshot 2022-08-04 at 12 38 04](https://user-images.githubusercontent.com/24358501/182827635-d3d994b3-04a8-4890-bf24-e3e30dd2cfac.png)


@nijel  Please let me know what else I can add in the documentation and for the API test. Thanks