### PR TITLE
trans: link filenames when sending parse error mails

### DIFF
--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -472,6 +472,16 @@ class ParseErrorNotification(Notification):
     verbose = _("Parse error")
     template_name = "parse_error"
 
+    def get_context(
+        self, change=None, subscription=None, extracontext=None, changes=None
+    ):
+        context = super().get_context(change, subscription, extracontext, changes)
+        if change:
+            context["details"]["filelink"] = change.component.get_repoweb_link(
+                change.details.get("filename"), "1"
+            )
+        return context
+
 
 @register_notification
 class NewStringNotificaton(Notification):

--- a/weblate/templates/mail/parse_error.html
+++ b/weblate/templates/mail/parse_error.html
@@ -13,7 +13,11 @@
 <h2>{% trans "Failing file" %}</h2>
 
 <p>
-{{ details.filename }}
+{% if details.filelink %}
+    <a href="{{ details.filelink }}">{{ details.filename }}</a>
+{% else %}
+    {{ details.filename }}
+{% endif %}
 </p>
 
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

closes #2106 

- Link Filename if they exist on parsing error mail.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
