### PR TITLE
Store fuzzy flag for monolingual PO files

### DIFF
--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -405,6 +405,7 @@ class Change(models.Model, UserDisplayMixin):
         ACTION_BULK_EDIT,
         ACTION_APPROVE,
         ACTION_MARKED_EDIT,
+        ACTION_SOURCE_CHANGE,
     }
 
     # Actions shown on the repository management page

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -695,7 +695,7 @@ class Unit(models.Model, LoggerMixin):
             and same_target
         ):
             if not same_source and state in (STATE_TRANSLATED, STATE_APPROVED):
-                if self.previous_source == self.source and self.fuzzy:
+                if self.previous_source == source and self.fuzzy:
                     # Source change was reverted
                     previous_source = ""
                     state = STATE_TRANSLATED

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -705,6 +705,7 @@ class Unit(models.Model, LoggerMixin):
                     if previous_source == "":
                         source_change = previous_source = self.source
                     state = STATE_FUZZY
+                self.pending = True
             elif (
                 self.state == STATE_FUZZY
                 and state == STATE_FUZZY


### PR DESCRIPTION
## Proposed changes

The fuzzy state calculated by Weblate was not stored to the file and was kept in the database only. This was caused by lack of support for this in most of the formats, but it makes sense to write it out for formats that do support this.

Fixes #8036
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
