### PR TITLE
translation: Always commit whole component

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1594,7 +1594,7 @@ class Component(models.Model, URLMixin, PathMixin, CacheKeyMixin):
     @perform_on_link
     def commit_pending(self, reason: str, user, skip_push: bool = False):
         """Check whether there is any translation to be committed."""
-        # Get all translation with pending changes
+        # Get all translation with pending changes, source translation first
         translations = sorted(
             Translation.objects.filter(unit__pending=True)
             .filter(Q(component=self) | Q(component__linked_component=self))
@@ -1613,7 +1613,7 @@ class Component(models.Model, URLMixin, PathMixin, CacheKeyMixin):
                     translation.component.linked_component = self
                 if translation.pk == translation.component.source_translation.pk:
                     translation = translation.component.source_translation
-                translation.commit_pending(reason, user, skip_push=True, signals=False)
+                translation._commit_pending(reason, user)
                 components[translation.component.pk] = translation.component
 
         # Fire postponed post commit signals


### PR DESCRIPTION


## Proposed changes

- Avoids additional logic to commit template changes first
- Remove ordering issue when add-on is triggered on partial commits
- Make the code more straightforward as the commit implementation is no longer a generic entry point

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
