### PR TITLE
README: Simplify license description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,7 @@ version.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program. If not, see https://www.gnu.org/licenses/.
+PARTICULAR PURPOSE. See the `GNU General Public License`_ for more details.
 
 .. _weblate.org: https://weblate.org/
+.. _GNU General Public License: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
The sentence "You should have received a copy of ..." is not suitable for the README on the GitHub repository.

## Proposed changes

This PR removes the paragraph "You should have received a copy of the GNU General Public License ..." and adds a link to GPLv3 instead.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [X] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.

## Other information
