### PR TITLE
Added clarification for state:TEXT and is:TEXT

### DIFF
--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -40,14 +40,14 @@ Fields
 ``added:DATETIME``
    Timestamp for when the string was added to Weblate.
 ``state:TEXT``
-   Search for string states (``approved``, ``translated``, ``untranslated``, ``needs-editing``, ``empty``, ``read-only``), supports :ref:`search-operators`.
+   Search for string states (``approved``, ``translated``, ``needs-editing``, ``empty``, ``read-only``), supports :ref:`search-operators`.
 ``pending:BOOLEAN``
    String pending for flushing to VCS.
 ``has:TEXT``
    Search for string having attributes - ``plural``, ``context``, ``suggestion``, ``comment``, ``check``, ``dismissed-check``, ``translation``, ``variant``, ``screenshot``, ``flags``, ``explanation``, ``glossary``, ``note``, ``label``.
 ``is:TEXT``
    Search for pending translations (``pending``).
-   Can also search for all string states except for ``empty`` (``approved``, ``translated``, ``untranslated``, ``needs-editing``, ``read-only``).
+   Can also search for all string states (``approved``, ``translated``, ``untranslated``, ``needs-editing``, ``read-only``).
 ``language:TEXT``
    String target language.
 ``component:TEXT``

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -40,13 +40,14 @@ Fields
 ``added:DATETIME``
    Timestamp for when the string was added to Weblate.
 ``state:TEXT``
-   State search (``approved``, ``translated``, ``needs-editing``, ``empty``, ``read-only``), supports :ref:`search-operators`.
+   Search for string states (``approved``, ``translated``, ``untranslated``, ``needs-editing``, ``empty``, ``read-only``), supports :ref:`search-operators`.
 ``pending:BOOLEAN``
    String pending for flushing to VCS.
 ``has:TEXT``
    Search for string having attributes - ``plural``, ``context``, ``suggestion``, ``comment``, ``check``, ``dismissed-check``, ``translation``, ``variant``, ``screenshot``, ``flags``, ``explanation``, ``glossary``, ``note``, ``label``.
 ``is:TEXT``
-   Search for string states (``pending``, ``translated``, ``untranslated``).
+   Search for pending translations (``pending``).
+   Can also search for all string states except for ``empty`` (``approved``, ``translated``, ``untranslated``, ``needs-editing``, ``read-only``).
 ``language:TEXT``
    String target language.
 ``component:TEXT``


### PR DESCRIPTION
## Proposed changes

Stated that  state:TEXT can only handle searching for string states while  is:TEXT  can search for string states and search for pending translations.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
