### PR TITLE
Fix `conflicts` parameter in API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1937,7 +1937,7 @@ Translations
     :type component: string
     :param language: Translation language code
     :type language: string
-    :form string conflict: How to deal with conflicts (``ignore``, ``replace-translated`` or ``replace-approved``)
+    :form string conflicts: How to deal with conflicts (``ignore``, ``replace-translated`` or ``replace-approved``)
     :form file file: Uploaded file
     :form string email: Author e-mail
     :form string author: Author name


### PR DESCRIPTION
The parameter was lacking a trailing `s`.