### PR TITLE
Addition of pa_PK to basic language exceptions

### DIFF
--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -24,7 +24,15 @@ from weblate_language_data.ambiguous import AMBIGUOUS
 
 NO_CODE_LANGUAGES = {lang[0] for lang in languages.LANGUAGES}
 
-UNDERSCORE_EXCEPTIONS = {"nb_NO", "zh_Hant", "zh_Hans", "be_Latn", "ro_MD", "pt_BR", "pa_PK"}
+UNDERSCORE_EXCEPTIONS = {
+    "nb_NO",
+    "zh_Hant",
+    "zh_Hans",
+    "be_Latn",
+    "ro_MD",
+    "pt_BR",
+    "pa_PK",
+}
 AT_EXCEPTIONS = {"ca@valencia"}
 
 

--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -24,7 +24,7 @@ from weblate_language_data.ambiguous import AMBIGUOUS
 
 NO_CODE_LANGUAGES = {lang[0] for lang in languages.LANGUAGES}
 
-UNDERSCORE_EXCEPTIONS = {"nb_NO", "zh_Hant", "zh_Hans", "be_Latn", "ro_MD", "pt_BR"}
+UNDERSCORE_EXCEPTIONS = {"nb_NO", "zh_Hant", "zh_Hans", "be_Latn", "ro_MD", "pt_BR", "pa_PK"}
 AT_EXCEPTIONS = {"ca@valencia"}
 
 


### PR DESCRIPTION
## Proposed changes
This is intended to fix #8223 by adding `pa_PK` to the list of "underscore" codes to include in the basic language list. Like `pt_BR`, the majority of Punjabi speakers live in Pakistan, and like the situations with Chinese, Belarusian, and Norwegian, there are differences in the way the languages are written which mean `pa` and `pa_PK` cannot be readily substituted for eachother.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [X] Lint and unit tests pass locally with my changes.
- [X] I have described the changes in the commit messages.

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
