### PR TITLE
Ensure the "Replaced file by upload" fedora message is sent

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1924,12 +1924,13 @@ class Component(models.Model, URLMixin, PathMixin, CacheKeyMixin):
         request=None,
         changed_template: bool = False,
         from_link: bool = False,
+        change: Optional[int] = None,
     ):
         """Load translations from VCS."""
         try:
             with self.lock:
                 return self._create_translations(
-                    force, langs, request, changed_template, from_link
+                    force, langs, request, changed_template, from_link, change
                 )
         except WeblateLockTimeout:
             if settings.CELERY_TASK_ALWAYS_EAGER:
@@ -1971,6 +1972,7 @@ class Component(models.Model, URLMixin, PathMixin, CacheKeyMixin):
         request=None,
         changed_template: bool = False,
         from_link: bool = False,
+        change: Optional[int] = None,
     ):
         """Load translations from VCS."""
         self.store_background_task()
@@ -2054,7 +2056,13 @@ class Component(models.Model, URLMixin, PathMixin, CacheKeyMixin):
                     continue
                 try:
                     translation = Translation.objects.check_sync(
-                        self, lang, code, path, force, request=request
+                        self,
+                        lang,
+                        code,
+                        path,
+                        force,
+                        request=request,
+                        change=change,
                     )
                 except InvalidTemplate as error:
                     self.log_warning(

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -66,7 +66,9 @@ from weblate.utils.stats import GhostStats, TranslationStats
 
 
 class TranslationManager(models.Manager):
-    def check_sync(self, component, lang, code, path, force=False, request=None):
+    def check_sync(
+        self, component, lang, code, path, force=False, request=None, change=None
+    ):
         """Parse translation meta info and updates translation object."""
         translation = component.translation_set.get_or_create(
             language=lang,
@@ -86,7 +88,7 @@ class TranslationManager(models.Manager):
             force = True
             translation.check_flags = flags
             translation.save(update_fields=["check_flags"])
-        translation.check_sync(force, request=request)
+        translation.check_sync(force, request=request, change=change)
 
         return translation
 
@@ -1307,7 +1309,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
         # delete_unit might do changes in the database only and not touch the files
         # for pending new units
         if self.is_source:
-            self.component.create_translations(request=request)
+            self.component.create_translations(request=request, change=change)
             self.component.invalidate_cache()
         else:
             self.check_sync(request=request, change=change)


### PR DESCRIPTION
In handle_store_change we explicitly parse the change no. for the aforementioned message when the translation is not source. However, we never parse this when it is source.

This results in the aforementioned message never being sent when replacing source string via an upload.

Fixes: https://github.com/WeblateOrg/weblate/issues/8285

## Proposed changes

To resolve this by ensuring we can parse this via the create_translation method in the component which will then eventually parse it to check_sync downstream thereby ensuring the message is pushed to the exchange.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
