### PR TITLE
feat: add xml add-on

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -659,6 +659,21 @@ Customize JSON output
 
 Allows adjusting JSON output behavior, for example indentation or sorting.
 
+.. _addon-weblate.xml.customize:
+
+Customize XML output
+---------------------
+
+:Add-on ID: ``weblate.xml.customize``
+:Configuration: +-----------------+-------------------------+-------------------------------------------------------+
+                | ``tags_format`` | XML Closing Tags format | Available choices:                                    |
+                |                 |                         | ``self_closing_tags`` -- Self-closing tags (<note/>)  |
+                |                 |                         | ``closing_tags`` -- Self-closing tags (<note></note>) |
+                +-----------------+-------------------------+-------------------------------------------------------+
+:Triggers: storage post-load
+
+Allows adjusting XML output behavior, for example closing tags.
+
 .. _addon-weblate.properties.sort:
 
 Format the Java properties file

--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -665,11 +665,10 @@ Customize XML output
 ---------------------
 
 :Add-on ID: ``weblate.xml.customize``
-:Configuration: +-----------------+-------------------------+-------------------------------------------------------+
-                | ``tags_format`` | XML Closing Tags format | Available choices:                                    |
-                |                 |                         | ``self_closing_tags`` -- Self-closing tags (<note/>)  |
-                |                 |                         | ``closing_tags`` -- Self-closing tags (<note></note>) |
-                +-----------------+-------------------------+-------------------------------------------------------+
+:Configuration: +-----------------+-------------------------+----------------------------------------------------------------------------------------------------------+
+                | ``tags_format`` | XML Closing Tags format | Available choices:                                                                                       |
+                |                 |                         | ``closing_tags`` -- when true, output xml will force closing tags even when tag is empty (<note></note>) |
+                +-----------------+-------------------------+----------------------------------------------------------------------------------------------------------+
 :Triggers: storage post-load
 
 Allows adjusting XML output behavior, for example closing tags.

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1945,6 +1945,7 @@ example:
         "weblate.addons.flags.BulkEditAddon",
         "weblate.addons.generate.GenerateFileAddon",
         "weblate.addons.json.JSONCustomizeAddon",
+        "weblate.addons.xml.XMLCustomizeAddon",
         "weblate.addons.properties.PropertiesSortAddon",
         "weblate.addons.git.GitSquashAddon",
         "weblate.addons.removal.RemoveComments",

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -204,14 +204,10 @@ class JSONCustomizeForm(BaseAddonForm):
 class XMLCustomizeForm(BaseAddonForm):
     """Class defining user Form to configure XML Formatting AddOn"""
 
-    tags_format = forms.ChoiceField(
-        label=_("XML closing tags format"),
-        choices=[
-            ("self_closing_tags", _("Self-Closing Tags")),
-            ("closing_tags", _("Closing Tags")),
-        ],
-        required=True,
-        initial="self_closing_tags",
+    closing_tags = forms.BooleanField(
+        label=_("Include closing tag for blank XML tags"),
+        required=False,
+        initial=True,
     )
 
 

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -202,6 +202,8 @@ class JSONCustomizeForm(BaseAddonForm):
 
 
 class XMLCustomizeForm(BaseAddonForm):
+    """Class defining user Form to configure XML Formatting AddOn"""
+
     tags_format = forms.ChoiceField(
         label=_("XML closing tags format"),
         choices=[

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -201,6 +201,18 @@ class JSONCustomizeForm(BaseAddonForm):
     )
 
 
+class XMLCustomizeForm(BaseAddonForm):
+    tags_format = forms.ChoiceField(
+        label=_("XML closing tags format"),
+        choices=[
+            ("self_closing_tags", _("Self-Closing Tags")),
+            ("closing_tags", _("Closing Tags")),
+        ],
+        required=True,
+        initial="self_closing_tags",
+    )
+
+
 class YAMLCustomizeForm(BaseAddonForm):
     indent = forms.IntegerField(
         label=_("YAML indentation"), min_value=1, max_value=10, initial=2, required=True

--- a/weblate/addons/models.py
+++ b/weblate/addons/models.py
@@ -205,6 +205,7 @@ class AddonsConf(AppConf):
         "weblate.addons.generate.PseudolocaleAddon",
         "weblate.addons.generate.PrefillAddon",
         "weblate.addons.json.JSONCustomizeAddon",
+        "weblate.addons.xml.XMLCustomizeAddon",
         "weblate.addons.properties.PropertiesSortAddon",
         "weblate.addons.git.GitSquashAddon",
         "weblate.addons.removal.RemoveComments",

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -58,6 +58,7 @@ from weblate.addons.properties import PropertiesSortAddon
 from weblate.addons.removal import RemoveComments, RemoveSuggestions
 from weblate.addons.resx import ResxUpdateAddon
 from weblate.addons.tasks import daily_addons
+from weblate.addons.xml import XMLCustomizeAddon
 from weblate.addons.yaml import YAMLCustomizeAddon
 from weblate.lang.models import Language
 from weblate.trans.models import Comment, Component, Suggestion, Translation, Unit, Vote
@@ -541,6 +542,33 @@ class JsonAddonTest(ViewTestCase):
         self.assertNotEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn('\t\t\t\t\t\t\t\t"try"', commit)
+
+
+class XMLAddonTest(ViewTestCase):
+    def create_component(self):
+        return self.create_xliff("complex")
+
+    def test_customize_self_closing_tags(self):
+        XMLCustomizeAddon.create(self.component, configuration={"closing_tags": False})
+
+        rev = self.component.repository.last_revision
+        self.edit_unit("Thank you for using Weblate", "Děkujeme, že používáte Weblate")
+        self.get_translation().commit_pending("test", None)
+        self.assertNotEqual(rev, self.component.repository.last_revision)
+
+        commit = self.component.repository.show(self.component.repository.last_revision)
+        self.assertIn("<target/>", commit)
+
+    def test_customize_closing_tags(self):
+        XMLCustomizeAddon.create(self.component, configuration={"closing_tags": True})
+
+        rev = self.component.repository.last_revision
+        self.edit_unit("Thank you for using Weblate", "Děkujeme, že používáte Weblate")
+        self.get_translation().commit_pending("test", None)
+        self.assertNotEqual(rev, self.component.repository.last_revision)
+
+        commit = self.component.repository.show(self.component.repository.last_revision)
+        self.assertIn("<target></target>", commit)
 
 
 class YAMLAddonTest(ViewTestCase):

--- a/weblate/addons/xml.py
+++ b/weblate/addons/xml.py
@@ -31,7 +31,7 @@ class XMLCustomizeAddon(StoreBaseAddon):
     name = "weblate.xml.customize"
     verbose = _("Customize XML output")
     description = _(
-        "Allows adjusting XML output behavior, for example indentation or sorting."
+        "Allows adjusting XML output behavior, for example closing tags instead of self-closing tags for empty tags."
     )
     settings_form = XMLCustomizeForm
 
@@ -45,6 +45,4 @@ class XMLCustomizeAddon(StoreBaseAddon):
     def store_post_load(self, translation, store):
         """Hook triggered once component formatter has been loaded."""
         config = self.instance.configuration
-        store.store.XMLSelfClosingTags = (
-            config.get("tags_format", "closing_tags") == "self_closing_tags"
-        )
+        store.store.XMLSelfClosingTags = not config.get("closing_tags", True)

--- a/weblate/addons/xml.py
+++ b/weblate/addons/xml.py
@@ -1,0 +1,39 @@
+#
+# Copyright © 2022–2023 Loïc LEUILLIOT <loic.leuilliot@gmail.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+from django.utils.translation import gettext_lazy as _
+
+from weblate.addons.base import StoreBaseAddon
+from weblate.addons.forms import XMLCustomizeForm
+
+
+class XMLCustomizeAddon(StoreBaseAddon):
+    name = "weblate.xml.customize"
+    verbose = _("Customize XML output")
+    description = _(
+        "Allows adjusting XML output behavior, for example indentation or sorting."
+    )
+    settings_form = XMLCustomizeForm
+
+    def store_post_load(self, translation, store):
+        config = self.instance.configuration
+        store.XMLSelfClosingTags = (
+            config.get("tags_format", "closing_tags") == "self_closing_tags"
+        )

--- a/weblate/addons/xml.py
+++ b/weblate/addons/xml.py
@@ -19,12 +19,15 @@
 
 
 from django.utils.translation import gettext_lazy as _
+from translate.storage.lisa import LISAfile
 
 from weblate.addons.base import StoreBaseAddon
 from weblate.addons.forms import XMLCustomizeForm
 
 
 class XMLCustomizeAddon(StoreBaseAddon):
+    """Class providing XML formatting changes as a component AddOn"""
+
     name = "weblate.xml.customize"
     verbose = _("Customize XML output")
     description = _(
@@ -32,8 +35,16 @@ class XMLCustomizeAddon(StoreBaseAddon):
     )
     settings_form = XMLCustomizeForm
 
+    @classmethod
+    def can_install(cls, component, user):
+        """Hook triggered to determine if add-on is compatible with component."""
+        # component are attached to a file format which is defined by a loader
+        # we want to provide this package only for component using LISAfile as loader
+        return issubclass(component.file_format_cls.loader, LISAfile)
+
     def store_post_load(self, translation, store):
+        """Hook triggered once component formatter has been loaded."""
         config = self.instance.configuration
-        store.XMLSelfClosingTags = (
+        store.store.XMLSelfClosingTags = (
             config.get("tags_format", "closing_tags") == "self_closing_tags"
         )

--- a/weblate/addons/xml.py
+++ b/weblate/addons/xml.py
@@ -31,7 +31,8 @@ class XMLCustomizeAddon(StoreBaseAddon):
     name = "weblate.xml.customize"
     verbose = _("Customize XML output")
     description = _(
-        "Allows adjusting XML output behavior, for example closing tags instead of self-closing tags for empty tags."
+        "Allows adjusting XML output behavior, for example closing tags instead of "
+        "self-closing tags for empty tags."
     )
     settings_form = XMLCustomizeForm
 

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1115,6 +1115,7 @@ WEBLATE_ADDONS = [
     "weblate.addons.generate.PseudolocaleAddon",
     "weblate.addons.generate.PrefillAddon",
     "weblate.addons.json.JSONCustomizeAddon",
+    "weblate.addons.xml.XMLCustomizeAddon",
     "weblate.addons.properties.PropertiesSortAddon",
     "weblate.addons.git.GitSquashAddon",
     "weblate.addons.removal.RemoveComments",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -787,6 +787,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 #     "weblate.addons.generate.PseudolocaleAddon",
 #     "weblate.addons.generate.PrefillAddon",
 #     "weblate.addons.json.JSONCustomizeAddon",
+#     "weblate.addons.xml.XMLCustomizeAddon",
 #     "weblate.addons.properties.PropertiesSortAddon",
 #     "weblate.addons.git.GitSquashAddon",
 #     "weblate.addons.removal.RemoveComments",


### PR DESCRIPTION
## Proposed changes

I'm using Weblate to maintain XLIFF translation files from my Business Central packages.
Compiler is using non self-closing tags format when no data is stored in a node - and as a result, huge diff are currently generated after a unit is translated from Weblate.

The purpose of this changes is to provide an optional way to handle the output formatting of XLIFF files.

It relays on the following pull request which add a flag to the XLIFF storage https://github.com/translate/translate/pull/4751

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
