### PR TITLE
replace other incorrect uses of `unit.source_string`

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -2526,7 +2526,7 @@ class TranslationAPITest(APIBaseTest):
                 "translate_url": "http://example.com/translate/test/test/cs/",
                 "failing_percent": 0.0,
                 "translated_percent": 0.0,
-                "total_words": 15,
+                "total_words": 19,
                 "failing": 0,
                 "translated_words": 0,
                 "fuzzy_percent": 0.0,

--- a/weblate/checks/placeholders.py
+++ b/weblate/checks/placeholders.py
@@ -75,7 +75,7 @@ class PlaceholderCheck(TargetCheckParametrized):
     def check_target_params(self, sources, targets, unit, value):
         expected = set(self.get_matches(value, sources[0]))
         if not expected and len(sources) > 1:
-            expected = set(self.get_matches(value, sources[1]))
+            expected = set(self.get_matches(value, sources[-1]))
         plural_examples = SimpleLazyObject(lambda: unit.translation.plural.examples)
 
         if "case-insensitive" in unit.all_flags:

--- a/weblate/trans/autofixes/base.py
+++ b/weblate/trans/autofixes/base.py
@@ -32,5 +32,19 @@ class AutoFix:
 
     def fix_target(self, target, unit):
         """Return a target translation array with a single fix applied."""
-        results = [self.fix_single_target(t, unit.source_string, unit) for t in target]
+        source_strings = unit.get_source_plurals()
+        if len(source_strings) == 1 and len(target) == 1:
+            results = [self.fix_single_target(target[0], source_strings[0], unit)]
+        else:
+            source_plural = unit.translation.component.source_language.plural
+            target_plural = unit.translation.plural
+            source_examples = {tuple(l): i for i, l in source_plural.examples.items()}
+            plurals_map = [
+                source_examples.get(tuple(target_plural.examples.get(target_index)), -1)
+                for target_index in range(target_plural.number)
+            ]
+            results = [
+                self.fix_single_target(text, source_strings[plurals_map[i]], unit)
+                for i, text in enumerate(target)
+            ]
         return [r[0] for r in results], max(r[1] for r in results)

--- a/weblate/trans/fixtures/simple-project.json
+++ b/weblate/trans/fixtures/simple-project.json
@@ -208,7 +208,7 @@
       "target": "\u001e\u001e\u001e\u001e",
       "state": 0,
       "position": 2,
-      "num_words": 4,
+      "num_words": 8,
       "priority": 100
     }
   },
@@ -292,7 +292,7 @@
       "target": "\u001e\u001e",
       "state": 0,
       "position": 2,
-      "num_words": 4,
+      "num_words": 8,
       "priority": 100
     }
   },
@@ -376,7 +376,7 @@
       "target": "\u001e\u001e",
       "state": 0,
       "position": 2,
-      "num_words": 4,
+      "num_words": 8,
       "priority": 100
     }
   },
@@ -460,7 +460,7 @@
       "previous_source": "",
       "state": 100,
       "position": 2,
-      "num_words": 4,
+      "num_words": 8,
       "priority": 100
     }
   },

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -305,7 +305,11 @@ class PluralTextarea(forms.Textarea):
         lang = translation.language
         plural = translation.plural
         tabindex = self.attrs["tabindex"]
-        placeables = [hl[2] for hl in highlight_string(unit.source_string, unit)]
+        plurals = unit.get_source_plurals()
+        placeables = set()
+        for text in plurals:
+            placeables.update(hl[2] for hl in highlight_string(text, unit))
+        placeables = list(placeables)
         show_plural_labels = len(values) > 1 and not translation.component.is_multivalue
 
         # Need to add extra class
@@ -322,7 +326,6 @@ class PluralTextarea(forms.Textarea):
 
         # Okay we have more strings
         ret = []
-        plurals = unit.get_source_plurals()
         base_id = f"id_{unit.checksum}"
         for idx, val in enumerate(values):
             # Generate ID

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -376,7 +376,11 @@ class Unit(models.Model, LoggerMixin):
         """Wrapper around save to run checks or update fulltext."""
         # Store number of words
         if not same_content or not self.num_words:
-            self.num_words = len(self.source_string.split())
+            self.num_words = sum(
+                len(s.split())
+                for s in self.get_source_plurals()
+                if not s.startswith("<unused singular")
+            )
             if update_fields and "num_words" not in update_fields:
                 update_fields.append("num_words")
 
@@ -862,7 +866,7 @@ class Unit(models.Model, LoggerMixin):
         """
         plurals = self.get_source_plurals()
         singular = plurals[0]
-        if len(plurals) == 1 or "<unused singular" not in singular:
+        if len(plurals) == 1 or not singular.startswith("<unused singular"):
             return singular
         return plurals[1]
 

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -195,13 +195,13 @@ class TranslationTest(RepoTestCase):
         self.assertEqual(translation.stats.translated, 4)
         self.assertEqual(translation.stats.all, 4)
         self.assertEqual(translation.stats.fuzzy, 0)
-        self.assertEqual(translation.stats.all_words, 15)
+        self.assertEqual(translation.stats.all_words, 19)
         # Verify target translation
         translation = component.translation_set.get(language_code="cs")
         self.assertEqual(translation.stats.translated, 0)
         self.assertEqual(translation.stats.all, 4)
         self.assertEqual(translation.stats.fuzzy, 0)
-        self.assertEqual(translation.stats.all_words, 15)
+        self.assertEqual(translation.stats.all_words, 19)
 
     def test_validation(self):
         """Translation validation."""
@@ -214,7 +214,7 @@ class TranslationTest(RepoTestCase):
         component = self.create_component()
         translation = component.translation_set.get(language_code="cs")
         self.assertEqual(translation.stats.all, 4)
-        self.assertEqual(translation.stats.all_words, 15)
+        self.assertEqual(translation.stats.all_words, 19)
         translation.unit_set.all().delete()
         translation.invalidate_cache()
         self.assertEqual(translation.stats.all, 0)


### PR DESCRIPTION


## Proposed changes

Use correctly plurals for counting words or fixing.

Taken out of https://github.com/WeblateOrg/weblate/pull/8323 by @Changaco to merge it separately.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
