### PR TITLE
improvement: don't stretch screenshot modal if image is narrow

### DIFF
--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -651,7 +651,10 @@ kbd {
 }
 
 .fullmodal .modal-dialog {
-  width: auto;
+  width: max-content;
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 legend {


### PR DESCRIPTION
## Proposed changes

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/39462442/207921027-516b3675-e3b0-4970-8ba9-f2ab1d559049.png) | ![image](https://user-images.githubusercontent.com/39462442/207920531-9be98579-6e02-4ad2-84c4-ec348d08252c.png) |


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->

I also tested it with a narrower screen - it doesn't overflow it (although touches the edge, as it is now on wide screens)
