### PR TITLE
[FIX] do not trim the target string when updateing a translation

### DIFF
--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -911,7 +911,7 @@ class UserStatisticsSerializer(ReadOnlySerializer):
 
 
 class PluralField(serializers.ListField):
-    child = serializers.CharField()
+    child = serializers.CharField(trim_whitespace=False)
 
     def get_attribute(self, instance):
         return getattr(instance, f"get_{self.field_name}_plurals")()


### PR DESCRIPTION
## Proposed changes

While updating a Unit via REST API, the translated text (target field) was trimmed. During debugging, I found out that in django's rest_framework module there is a parameter called `trim_whitespace` that is enabled by default, and the value of the submitted target field is automatically trimmed.

I am not sure that i fixed this problem properly, but this quick patch fixed this exact problem.

I used this code to submit the update:

```python
HEADERS = {"Authorization": "Token wlu_yvCobi.........LZ3E4vlQtuRBMR2"}
r = requests.patch("https://weblate.xyz.tld/api/units/199129/", headers=HEADERS,
        json={"target": "\n    - OK", "state": 20},
    )
```

In the [`api/views.py#1253`](https://github.com/WeblateOrg/weblate/blob/main/weblate/api/views.py#L1253) line the `data`:

Before this patch:
```python
data = OrderedDict([('target', ['- OK']), ('state', 20)])
```

After this patch:
```python
data = OrderedDict([('target', ['\n    - OK']), ('state', 20)])
```

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
