### PR TITLE
improvement: add `has:screenshot` filters to UI

### DIFF
--- a/weblate/templates/snippets/query-builder.html
+++ b/weblate/templates/snippets/query-builder.html
@@ -43,6 +43,7 @@
                   <li><a href="#" data-field="has:suggestion">{% search_name "has:suggestion" %}</a></li>
                   <li><a href="#" data-field="has:comment">{% search_name "has:comment" %}</a></li>
                   <li><a href="#" data-field="has:check">{% search_name "has:check" %}</a></li>
+                  <li><a href="#" data-field="NOT has:screenshot">{% search_name "NOT has:screenshot" %}</a></li>
                   <li><a href="#" data-field="has:plural">{% search_name "has:plural" %}</a></li>
                   <li><a href="#" data-field="has:context">{% search_name "has:context" %}</a></li>
                 </ul>

--- a/weblate/trans/filter.py
+++ b/weblate/trans/filter.py
@@ -38,6 +38,7 @@ class FilterRegistry:
             ("fuzzy", _("Strings marked for edit"), "state:needs-editing"),
             ("suggestions", _("Strings with suggestions"), "has:suggestion"),
             ("variants", _("Strings with variants"), "has:variant"),
+            ("screenshots", _("Strings with screenshots"), "has:screenshot"),
             ("labels", _("Strings with labels"), "has:label"),
             ("context", _("Strings with context"), "has:context"),
             (
@@ -64,6 +65,7 @@ class FilterRegistry:
                 "state:approved AND has:suggestion",
             ),
             ("unapproved", _("Strings waiting for review"), "state:translated"),
+            ("noscreenshot", _("Strings without screenshots"), "NOT has:screenshot"),
             ("unlabeled", _("Strings without a label"), "NOT has:label"),
             ("pluralized", _("Pluralized string"), "has:plural"),
         ]

--- a/weblate/utils/forms.py
+++ b/weblate/utils/forms.py
@@ -113,6 +113,7 @@ class SearchField(Field):
             "fuzzy",
             "suggestions",
             "variants",
+            "screenshots",
             "labels",
             "context",
             "nosuggestions",


### PR DESCRIPTION
## Proposed changes

Follow-up to b240770f3a9. This should make it easier to translate by first translating strings with screenshots. And, for admins, find strings with no screenshots (#3821).

Did not test. Also I'm not sure if I changed the right places, and that I did not miss to change something else.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
