### PR TITLE
Adds graphviz package to Read the Docs build image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: '3.11'
+  apt_packages:
+    # Graphviz is needed for sphinx.ext.graphviz
+    - graphviz
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
## Proposed changes

Hi friends! I was looking at your documentation and noticed that the nice diagrams were broken. Example: https://docs.weblate.org/en/latest/workflows.html#quality-gateway-for-the-source-strings

Read the Docs' newer build images stopped bundling a bunch of different packages. You can imagine that it's something that when most projects don't need Graphviz, it's a lot of extra load on the CI platform to bake it into default images. More background here: https://github.com/readthedocs/readthedocs.org/issues/8800

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
