### PR TITLE
db: Fallback to Django operator for some strings

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,7 @@ Weblate 4.16
 Not yet released.
 
 * Format string checks now also detects duplicated formats.
+* Improved search performance for some specially formatted strings.
 
 `All changes in detail <https://github.com/WeblateOrg/weblate/milestone/89?closed=1>`__.
 

--- a/weblate/utils/tests/test_db.py
+++ b/weblate/utils/tests/test_db.py
@@ -2,12 +2,57 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from unittest import TestCase
+from unittest import SkipTest, TestCase
 
-from weblate.utils.db import re_escape
+from weblate.trans.models import Unit
+from weblate.utils.db import re_escape, using_postgresql
+
+BASE_SQL = 'SELECT "trans_unit"."id" FROM "trans_unit" WHERE '
 
 
 class DbTest(TestCase):
     def test_re_escape(self):
         self.assertEqual(re_escape("[a-z]"), "\\[a\\-z\\]")
         self.assertEqual(re_escape("a{1,4}"), "a\\{1,4\\}")
+
+
+class PostgreSQLOperatorTesT(TestCase):
+    def setUp(self):
+        if not using_postgresql():
+            raise SkipTest("PostgreSQL only test.")
+
+    def test_search(self):
+        queryset = Unit.objects.filter(source__search="test").only("id")
+        self.assertEqual(
+            str(queryset.query),
+            BASE_SQL + '"trans_unit"."source" % test = true',
+        )
+        queryset = Unit.objects.filter(source__search="'''").only("id")
+        self.assertEqual(
+            str(queryset.query),
+            BASE_SQL + """UPPER("trans_unit"."source"::text) LIKE UPPER(%'''%)""",
+        )
+
+    def test_ilike(self):
+        queryset = Unit.objects.filter(source__ilike="test").only("id")
+        self.assertEqual(
+            str(queryset.query),
+            BASE_SQL + '"trans_unit"."source" ILIKE test',
+        )
+        queryset = Unit.objects.filter(source__ilike="'''").only("id")
+        self.assertEqual(
+            str(queryset.query),
+            BASE_SQL + """UPPER("trans_unit"."source"::text) = UPPER(''')""",
+        )
+
+    def test_substring(self):
+        queryset = Unit.objects.filter(source__substring="test").only("id")
+        self.assertEqual(
+            str(queryset.query),
+            BASE_SQL + '"trans_unit"."source" ILIKE %test%',
+        )
+        queryset = Unit.objects.filter(source__substring="'''").only("id")
+        self.assertEqual(
+            str(queryset.query),
+            BASE_SQL + """UPPER("trans_unit"."source"::text) LIKE UPPER(%'''%)""",
+        )


### PR DESCRIPTION


## Proposed changes

Use iexact and icontains for strings that pg_trgm doesn't handle well. It looks at alphanumeric characters and in case there are none, all strings match the index causing huge penalty when doing recheck at the next step.

Fixes #8668
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
