### PR TITLE
change: Show the source text of the source string as the content of t…

### DIFF
--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -592,6 +592,9 @@ class Change(models.Model, UserDisplayMixin):
     def get_action_display(self):
         if self.action in self.PLURAL_ACTIONS:
             return self.PLURAL_ACTIONS[self.action] % self.plural_count
+        if self.action == self.ACTION_NEW_SOURCE:
+            return self.get_source()
+
         return str(self.ACTIONS_DICT.get(self.action, self.action))
 
     def get_state_display(self):


### PR DESCRIPTION
Directly show the source text of the source string as the content of the New source string event in the history.
Issue: https://github.com/WeblateOrg/weblate/issues/8350

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
