### PR TITLE
Add tmx as an accepted file format to download a translation file.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1917,7 +1917,7 @@ Translations
         parameter differs and without such parameter you get translation file
         as stored in VCS.
 
-    :query format: File format to use; if not specified no format conversion happens; supported file formats: ``po``, ``mo``, ``xliff``, ``xliff11``, ``tbx``, ``csv``, ``xlsx``, ``json``, ``aresource``, ``strings``
+    :query format: File format to use; if not specified no format conversion happens; supported file formats: ``po``, ``mo``, ``xliff``, ``xliff11``, ``tbx``, ``tmx``, ``csv``, ``xlsx``, ``json``, ``aresource``, ``strings``
     :query string q: Filter downloaded strings, see :ref:`search`, only applicable when conversion is in place (``format`` is specified).
 
     :param project: Project URL slug


### PR DESCRIPTION
## Proposed changes

Update docs adding `tmx` as a valid file format when using `GET /api/translations/(string: project)/(string: component)/(string: language)/file/` endpoint.

## Checklist

It's an fix to API documentation that I checked works correctly in version 4.15.2

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

