### PR TITLE
Fix creating repository forks on gitea

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -1099,7 +1099,9 @@ class GiteaRepository(GitMergeRequestBase):
     def create_fork(self, credentials: Dict):
         fork_url = "{}/forks".format(credentials["url"])
 
-        response, error = self.request("post", credentials, fork_url)
+        # Empty json body is required here, otherwise we'll get an
+        # "Empty Content-Type" error from gitea.
+        response, error = self.request("post", credentials, fork_url, json={})
         if "message" in response and "repository is already forked by user" in error:
             # we have to get the repository again if it is already forked
             response, error = self.request("get", credentials, credentials["url"])

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -545,7 +545,7 @@ class VCSGiteaTest(VCSGitUpstreamTest):
             match=[matchers.header_matcher({"Content-Type": "application/json"})],
         )
 
-    def test_api_url_github_com(self):
+    def test_api_url_try_gitea(self):
         self.repo.component.repo = "https://try.gitea.io/WeblateOrg/test.git"
         self.assertEqual(
             self.repo.get_api_url()[0],

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -14,6 +14,7 @@ import responses
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
+from responses import matchers
 
 from weblate.trans.models import Component, Project
 from weblate.trans.tests.utils import RepoTestMixin, TempDirMixin
@@ -534,12 +535,14 @@ class VCSGiteaTest(VCSGitUpstreamTest):
             responses.POST,
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks",
             json={"ssh_url": "git@github.com:test/test.git"},
+            match=[matchers.header_matcher({"Content-Type": "application/json"})],
         )
         responses.add(
             responses.POST,
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/pulls",
             json=pr_response,
             status=pr_status,
+            match=[matchers.header_matcher({"Content-Type": "application/json"})],
         )
 
     def test_api_url_github_com(self):


### PR DESCRIPTION
## Proposed changes

https://github.com/WeblateOrg/weblate/commit/38008c51e6a12630348ed36f34d0370e1fb10c9c changed the request being send to gitea for creating a project
fork from sensing an empty json body with the correct Content-Type
header to sending just an empty body and no Content-Type header.

Gitea doesn't accept these requests and returns an "Empty Content-Type"
error instead.

Fix that by adding back the json body via requests `json` parameter
which also adds the correct content type header again.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
