### PR TITLE
fix: add json customize addon's compat

### DIFF
--- a/weblate/addons/json.py
+++ b/weblate/addons/json.py
@@ -21,6 +21,7 @@ class JSONCustomizeAddon(StoreBaseAddon):
             "json-nested",
             "webextension",
             "i18next",
+            'i18nextv4',
             "arb",
             "go-i18n-json",
         }

--- a/weblate/addons/json.py
+++ b/weblate/addons/json.py
@@ -21,7 +21,7 @@ class JSONCustomizeAddon(StoreBaseAddon):
             "json-nested",
             "webextension",
             "i18next",
-            'i18nextv4',
+            "i18nextv4",
             "arb",
             "go-i18n-json",
         }


### PR DESCRIPTION
## Proposed changes

Fix json customize addon not work when using i18nextv4 format

## Checklist

- [x ] Lint and unit tests pass locally with my changes.
- [x ] I have added tests that prove my fix is effective or that my feature works.
- [x ] I have added documentation to describe my feature.
- [x ] I have squashed my commits into logic units.
- [ x] I have described the changes in the commit messages.

