### PR TITLE
machinery: Remove a parameter that are no longer used

### DIFF
--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -62,7 +62,7 @@ class MachineTranslation:
     force_uncleanup = False
     hightlight_syntax = False
     settings_form = None
-    validate_payload = ("en", "de", "test", None, None, False, 75)
+    validate_payload = ("en", "de", "test", None, None, 75)
     request_timeout = 5
 
     @classmethod


### PR DESCRIPTION
https://github.com/WeblateOrg/weblate/commit/e3595b31c2600a92102b1f8a23e9e5ae14c166db This commit removed a parameter for the fuction `download_translations`, but did not remove the parameter of the test case, which will cause the failure when adding a new api.

<img width="785" alt="image" src="https://user-images.githubusercontent.com/30619816/222905754-7b1cab56-f1e2-43d3-ab57-927b57000aff.png">

## Proposed changes

Fix the problem that failed when adding a new api.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
