### PR TITLE
Fix next param still not working when single social auth is enabled

### DIFF
--- a/weblate/templates/accounts/redirect.html
+++ b/weblate/templates/accounts/redirect.html
@@ -15,7 +15,7 @@
 {% show_message "info" msg %}
 
 <div class="col-sm-6 col-xs-12 btn-auth">
-    <a href="" class="btn btn-link link-auto link-post" data-href="{% url 'social:begin' backend %}{% if next %}?next={{ next }}{% endif %}">{% auth_name backend " " %}</a>
+    <a href="" class="btn btn-link link-auto link-post" data-href="{% url 'social:begin' backend %}" {% if next %}data-params='{"next": "{{ next|escapejs }}"}'{% endif %}>{% auth_name backend " " %}</a>
 </div>
 
 </div>


### PR DESCRIPTION
## Proposed changes

With this change, the POST login request should be set correctly as a form parameter instead of query url
<img width="645" alt="image" src="https://user-images.githubusercontent.com/91042553/224731028-ea6a7195-8c1c-456b-b051-efb540a85bbb.png">

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

n/a
