### PR TITLE
search: Avoid using select_for_update on possibly nullable joins

### DIFF
--- a/weblate/trans/bulk.py
+++ b/weblate/trans/bulk.py
@@ -23,7 +23,7 @@ def bulk_perform(
     project,
     components=None,
 ):
-    matching = unit_set.search(query, distinct=False, project=project).prefetch()
+    matching = unit_set.search(query, project=project)
     if components is None:
         components = Component.objects.filter(
             id__in=matching.values_list("translation__component_id", flat=True)
@@ -52,8 +52,11 @@ def bulk_perform(
             else:
                 update_unit_ids = []
                 source_units = []
+                unit_ids = list(component_units.values_list("id", flat=True))
                 # Generate changes for state change
-                for unit in component_units.select_for_update():
+                for unit in (
+                    Unit.objects.filter(id__in=unit_ids).prefetch().select_for_update()
+                ):
                     source_unit_ids.add(unit.source_unit_id)
 
                     if (

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -128,12 +128,10 @@ class UnitQuerySet(models.QuerySet):
             )
         )
 
-    def search(self, query, distinct: bool = True, **context):
+    def search(self, query, **context):
         """High level wrapper for searching."""
         result = self.filter(parse_query(query, **context))
-        if distinct:
-            result = result.distinct()
-        return result
+        return result.distinct()
 
     def same(self, unit, exclude=True):
         """Unit with same source within same project."""


### PR DESCRIPTION

## Proposed changes
The search() result can contain nullable join in several lookups (for example has:label) and in that case it is not possible to do select_for_update().

Avoids that by doing the search first and then locking only based on primary key.

Fixes #8899

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
