### PR TITLE
8969: Bitbucket Fix not throwing error and locking project when PR al…

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -1590,5 +1590,18 @@ class BitbucketServerRepository(GitMergeRequestBase):
             "post", credentials, pr_url, json=request_body
         )
 
+        """
+        Bitbucket Server will return error if PR already exists. The push
+        method in parent class will push changes to the correct fork or
+        branch, and always call this create_pull_request method after. If PR
+        exist already just do nothing because Bitbucket will automatically
+        update the PR if the from ref is updated.
+        """
         if "id" not in response:
+            pr_exist_message = (
+                "Only one pull request may be open "
+                "for a given source and target branch"
+            )
+            if pr_exist_message in error_message:
+                return
             raise RepositoryException(0, f"Pull request failed: {error_message}")

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -1478,7 +1478,16 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         )
 
     def mock_pr_response(self, status):
-        body = {"id": "333"} if status == 201 else self._bb_api_error_stub
+        if status == 201:
+            body = {"id": "333"}
+        elif status == 409:
+            pr_exist_message = (
+                "Only one pull request may be open "
+                "for a given source and target branch"
+            )
+            body = {"errors": [{"context": "<string>", "message": pr_exist_message}]}
+        else:
+            body = self._bb_api_error_stub
 
         responses.add(
             responses.POST,
@@ -1588,6 +1597,45 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         self.mock_reviewer_reponse(200, branch)  # get default reviewers
         self.mock_pr_response(201)  # create pr ok
         super().test_push(branch)
+        mock_push_to_fork.stop()
+
+    @responses.activate
+    def test_push_with_existing_pr(self, branch=""):
+        self.repo.component.repo = f"{self._bbhost}/bb_pk/bb_repo.git"
+
+        # Patch push_to_fork() function because we don't want to actually
+        # make a git push request
+        mock_push_to_fork_patcher = patch(
+            "weblate.vcs.git.GitMergeRequestBase.push_to_fork"
+        )
+        mock_push_to_fork = mock_push_to_fork_patcher.start()
+        mock_push_to_fork.return_value = ""
+
+        self.mock_fork_response(201)  # fork created
+        self.mock_repo_response(200)  # get target repo info
+        self.mock_reviewer_reponse(200, branch)  # get default reviewers
+        self.mock_pr_response(409)  # create pr error, PR already exists
+        super().test_push(branch)
+        mock_push_to_fork.stop()
+
+    @responses.activate
+    def test_push_pr_error_reponse(self, branch=""):
+        self.repo.component.repo = f"{self._bbhost}/bb_pk/bb_repo.git"
+
+        # Patch push_to_fork() function because we don't want to actually
+        # make a git push request
+        mock_push_to_fork_patcher = patch(
+            "weblate.vcs.git.GitMergeRequestBase.push_to_fork"
+        )
+        mock_push_to_fork = mock_push_to_fork_patcher.start()
+        mock_push_to_fork.return_value = ""
+
+        self.mock_fork_response(201)  # fork created
+        self.mock_repo_response(200)  # get target repo info
+        self.mock_reviewer_reponse(200, branch)  # get default reviewers
+        self.mock_pr_response(401)  # create pr error
+        with self.assertRaises(RepositoryException):
+            super().test_push(branch)
         mock_push_to_fork.stop()
 
     @responses.activate


### PR DESCRIPTION
…ready exists

## Proposed changes

Fixed issue described in [8969](https://github.com/WeblateOrg/weblate/issues/8969). Weblate should no longer lock the repo when this happens. 
Bitbucket Server updates PR automatically when PR from ref changes and thus does not need to try and recreate/update a PR. Much like the Gitea implementation just does nothing when a PR already exists.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

