### PR TITLE
Spelling: Screenshot assigned

### DIFF
--- a/weblate/templates/trans/alert/unusedscreenshot.html
+++ b/weblate/templates/trans/alert/unusedscreenshot.html
@@ -1,4 +1,4 @@
 {% load i18n %}
-<p>{% trans "There is at least one screenshot which is not assigned to any strings." %}</p>
+<p>{% trans "At least one string has no screenshot assiged to it." %}</p>
 
 <a class="btn btn-primary" href="{% url 'screenshots' project=component.project.slug component=component.slug %}">{% trans "Manage screenshots" %}</a>


### PR DESCRIPTION
This is what I think it does, as https://hosted.weblate.org/projects/scrutin/app/#alerts doesn't have any screenshots not assigned to anything…