### PR TITLE
docker.rst: fix typo

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1822,7 +1822,7 @@ it as separate volume to the Docker container, for example:
 Configuring PostgreSQL server
 -----------------------------
 
-The PostgtreSQL container uses default PostgreSQL configuration and it won't
+The PostgreSQL container uses default PostgreSQL configuration and it won't
 effectively utilize your CPU cores or memory. It is recommended to customize
 the configuration to improve the performance.
 

--- a/docs/locales/ab/LC_MESSAGES/docs.po
+++ b/docs/locales/ab/LC_MESSAGES/docs.po
@@ -12166,7 +12166,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/afh/LC_MESSAGES/docs.po
+++ b/docs/locales/afh/LC_MESSAGES/docs.po
@@ -12166,7 +12166,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ang/LC_MESSAGES/docs.po
+++ b/docs/locales/ang/LC_MESSAGES/docs.po
@@ -12166,7 +12166,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ar/LC_MESSAGES/docs.po
+++ b/docs/locales/ar/LC_MESSAGES/docs.po
@@ -12994,7 +12994,7 @@ msgstr "ضبط الإضافات"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ar_LY/LC_MESSAGES/docs.po
+++ b/docs/locales/ar_LY/LC_MESSAGES/docs.po
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ars/LC_MESSAGES/docs.po
+++ b/docs/locales/ars/LC_MESSAGES/docs.po
@@ -12166,7 +12166,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ast/LC_MESSAGES/docs.po
+++ b/docs/locales/ast/LC_MESSAGES/docs.po
@@ -12818,7 +12818,7 @@ msgstr "Contraseña actual"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/az/LC_MESSAGES/docs.po
+++ b/docs/locales/az/LC_MESSAGES/docs.po
@@ -13019,7 +13019,7 @@ msgstr "Konfiqurasiya xətaları"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/be/LC_MESSAGES/docs.po
+++ b/docs/locales/be/LC_MESSAGES/docs.po
@@ -12923,7 +12923,7 @@ msgstr "Наладзіць рэдактар"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/be_Latn/LC_MESSAGES/docs.po
+++ b/docs/locales/be_Latn/LC_MESSAGES/docs.po
@@ -13049,7 +13049,7 @@ msgstr "Naladzić dadatak"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ber/LC_MESSAGES/docs.po
+++ b/docs/locales/ber/LC_MESSAGES/docs.po
@@ -12168,7 +12168,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/bg/LC_MESSAGES/docs.po
+++ b/docs/locales/bg/LC_MESSAGES/docs.po
@@ -12879,7 +12879,7 @@ msgstr "Настройка на добавката"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/bn/LC_MESSAGES/docs.po
+++ b/docs/locales/bn/LC_MESSAGES/docs.po
@@ -12232,7 +12232,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/bn_BD/LC_MESSAGES/docs.po
+++ b/docs/locales/bn_BD/LC_MESSAGES/docs.po
@@ -12232,7 +12232,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/bo/LC_MESSAGES/docs.po
+++ b/docs/locales/bo/LC_MESSAGES/docs.po
@@ -12168,7 +12168,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/br/LC_MESSAGES/docs.po
+++ b/docs/locales/br/LC_MESSAGES/docs.po
@@ -12985,7 +12985,7 @@ msgstr "Ger-tremen en implij"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ca/LC_MESSAGES/docs.po
+++ b/docs/locales/ca/LC_MESSAGES/docs.po
@@ -12916,7 +12916,7 @@ msgstr "Configura l'editor"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ce/LC_MESSAGES/docs.po
+++ b/docs/locales/ce/LC_MESSAGES/docs.po
@@ -12172,7 +12172,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ckb/LC_MESSAGES/docs.po
+++ b/docs/locales/ckb/LC_MESSAGES/docs.po
@@ -12997,7 +12997,7 @@ msgstr "تێپەڕەوشەی ئێستا"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/crh/LC_MESSAGES/docs.po
+++ b/docs/locales/crh/LC_MESSAGES/docs.po
@@ -12172,7 +12172,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/cs/LC_MESSAGES/docs.po
+++ b/docs/locales/cs/LC_MESSAGES/docs.po
@@ -12903,7 +12903,7 @@ msgstr "Nastavit editor"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/cv/LC_MESSAGES/docs.po
+++ b/docs/locales/cv/LC_MESSAGES/docs.po
@@ -12248,7 +12248,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/cy/LC_MESSAGES/docs.po
+++ b/docs/locales/cy/LC_MESSAGES/docs.po
@@ -12827,7 +12827,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/da/LC_MESSAGES/docs.po
+++ b/docs/locales/da/LC_MESSAGES/docs.po
@@ -12943,7 +12943,7 @@ msgstr "Konfigurer editor"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/de/LC_MESSAGES/docs.po
+++ b/docs/locales/de/LC_MESSAGES/docs.po
@@ -15038,7 +15038,7 @@ msgstr "Konfigurieren des PostgreSQL-Servers"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/docs.pot
+++ b/docs/locales/docs.pot
@@ -10270,7 +10270,7 @@ msgid "Configuring PostgreSQL server"
 msgstr ""
 
 #: ../../admin/install/docker.rst:1814
-msgid "The PostgtreSQL container uses default PostgreSQL configuration and it won't effectively utilize your CPU cores or memory. It is recommended to customize the configuration to improve the performance."
+msgid "The PostgreSQL container uses default PostgreSQL configuration and it won't effectively utilize your CPU cores or memory. It is recommended to customize the configuration to improve the performance."
 msgstr ""
 
 #: ../../admin/install/docker.rst:1818

--- a/docs/locales/dv/LC_MESSAGES/docs.po
+++ b/docs/locales/dv/LC_MESSAGES/docs.po
@@ -12166,7 +12166,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/el/LC_MESSAGES/docs.po
+++ b/docs/locales/el/LC_MESSAGES/docs.po
@@ -12902,7 +12902,7 @@ msgstr "Ρύθμιση προγράμματος επεξεργασίας"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/en_GB/LC_MESSAGES/docs.po
+++ b/docs/locales/en_GB/LC_MESSAGES/docs.po
@@ -13015,7 +13015,7 @@ msgstr "Configure addon"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/enm/LC_MESSAGES/docs.po
+++ b/docs/locales/enm/LC_MESSAGES/docs.po
@@ -12169,7 +12169,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/eo/LC_MESSAGES/docs.po
+++ b/docs/locales/eo/LC_MESSAGES/docs.po
@@ -12847,7 +12847,7 @@ msgstr "Agordi kromprogramon"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/es/LC_MESSAGES/docs.po
+++ b/docs/locales/es/LC_MESSAGES/docs.po
@@ -13855,7 +13855,7 @@ msgstr "Configuración del servidor PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/et/LC_MESSAGES/docs.po
+++ b/docs/locales/et/LC_MESSAGES/docs.po
@@ -12776,7 +12776,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/eu/LC_MESSAGES/docs.po
+++ b/docs/locales/eu/LC_MESSAGES/docs.po
@@ -12829,7 +12829,7 @@ msgstr "Oraingo pasahitza"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/fa/LC_MESSAGES/docs.po
+++ b/docs/locales/fa/LC_MESSAGES/docs.po
@@ -12716,7 +12716,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/fi/LC_MESSAGES/docs.po
+++ b/docs/locales/fi/LC_MESSAGES/docs.po
@@ -12617,7 +12617,7 @@ msgstr "Muuta muokkaimen asetuksia"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/fil/LC_MESSAGES/docs.po
+++ b/docs/locales/fil/LC_MESSAGES/docs.po
@@ -12197,7 +12197,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/fr/LC_MESSAGES/docs.po
+++ b/docs/locales/fr/LC_MESSAGES/docs.po
@@ -14005,7 +14005,7 @@ msgstr "Nom du serveur configuré"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/fur/LC_MESSAGES/docs.po
+++ b/docs/locales/fur/LC_MESSAGES/docs.po
@@ -12381,7 +12381,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/fy/LC_MESSAGES/docs.po
+++ b/docs/locales/fy/LC_MESSAGES/docs.po
@@ -12926,7 +12926,7 @@ msgstr "Wachtwurd wizigjen"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/gl/LC_MESSAGES/docs.po
+++ b/docs/locales/gl/LC_MESSAGES/docs.po
@@ -13026,7 +13026,7 @@ msgstr "Confirmación do novo contrasinal"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/he/LC_MESSAGES/docs.po
+++ b/docs/locales/he/LC_MESSAGES/docs.po
@@ -12857,7 +12857,7 @@ msgstr "הגדרת עורך"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/hi/LC_MESSAGES/docs.po
+++ b/docs/locales/hi/LC_MESSAGES/docs.po
@@ -12263,7 +12263,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/hr/LC_MESSAGES/docs.po
+++ b/docs/locales/hr/LC_MESSAGES/docs.po
@@ -12811,7 +12811,7 @@ msgstr "Podesi uređivača"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/hu/LC_MESSAGES/docs.po
+++ b/docs/locales/hu/LC_MESSAGES/docs.po
@@ -12906,7 +12906,7 @@ msgstr "Szerkesztő beállítása"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/hy/LC_MESSAGES/docs.po
+++ b/docs/locales/hy/LC_MESSAGES/docs.po
@@ -12884,7 +12884,7 @@ msgstr "Փոխել գաղտնաբառը"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ia/LC_MESSAGES/docs.po
+++ b/docs/locales/ia/LC_MESSAGES/docs.po
@@ -12228,7 +12228,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/id/LC_MESSAGES/docs.po
+++ b/docs/locales/id/LC_MESSAGES/docs.po
@@ -13555,7 +13555,7 @@ msgstr "Mengonfigurasi server PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ie/LC_MESSAGES/docs.po
+++ b/docs/locales/ie/LC_MESSAGES/docs.po
@@ -12213,7 +12213,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/is/LC_MESSAGES/docs.po
+++ b/docs/locales/is/LC_MESSAGES/docs.po
@@ -12827,7 +12827,7 @@ msgstr "Stilla þýðingaritil"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/it/LC_MESSAGES/docs.po
+++ b/docs/locales/it/LC_MESSAGES/docs.po
@@ -12949,7 +12949,7 @@ msgstr "Configura editor"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ja/LC_MESSAGES/docs.po
+++ b/docs/locales/ja/LC_MESSAGES/docs.po
@@ -14461,11 +14461,11 @@ msgstr "PostgreSQL サーバーの設定"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"PostgtreSQL コンテナは、デフォルトの PostgreSQL 設定を使用するため、CPU コア"
+"PostgreSQL コンテナは、デフォルトの PostgreSQL 設定を使用するため、CPU コア"
 "やメモリを効果的に使用できません。性能を向上させるために設定を変更してくださ"
 "い。"
 

--- a/docs/locales/ka/LC_MESSAGES/docs.po
+++ b/docs/locales/ka/LC_MESSAGES/docs.po
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/kab/LC_MESSAGES/docs.po
+++ b/docs/locales/kab/LC_MESSAGES/docs.po
@@ -12951,7 +12951,7 @@ msgstr "Sbadu amaẓrag"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/kk/LC_MESSAGES/docs.po
+++ b/docs/locales/kk/LC_MESSAGES/docs.po
@@ -13029,7 +13029,7 @@ msgstr "Óńdegishti retteý"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/km/LC_MESSAGES/docs.po
+++ b/docs/locales/km/LC_MESSAGES/docs.po
@@ -12788,7 +12788,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/kmr/LC_MESSAGES/docs.po
+++ b/docs/locales/kmr/LC_MESSAGES/docs.po
@@ -12600,7 +12600,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ko/LC_MESSAGES/docs.po
+++ b/docs/locales/ko/LC_MESSAGES/docs.po
@@ -12805,7 +12805,7 @@ msgstr "편집기 설정"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ksh/LC_MESSAGES/docs.po
+++ b/docs/locales/ksh/LC_MESSAGES/docs.po
@@ -12917,7 +12917,7 @@ msgstr "Et jäzeje Jeheimwoot"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ln/LC_MESSAGES/docs.po
+++ b/docs/locales/ln/LC_MESSAGES/docs.po
@@ -12818,7 +12818,7 @@ msgstr "Loloba lwa bolekisi la sikáwa"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/lt/LC_MESSAGES/docs.po
+++ b/docs/locales/lt/LC_MESSAGES/docs.po
@@ -12890,7 +12890,7 @@ msgstr "Dabartinis slaptažodis"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/lv/LC_MESSAGES/docs.po
+++ b/docs/locales/lv/LC_MESSAGES/docs.po
@@ -12258,7 +12258,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/lzh/LC_MESSAGES/docs.po
+++ b/docs/locales/lzh/LC_MESSAGES/docs.po
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/mk/LC_MESSAGES/docs.po
+++ b/docs/locales/mk/LC_MESSAGES/docs.po
@@ -12656,7 +12656,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ml/LC_MESSAGES/docs.po
+++ b/docs/locales/ml/LC_MESSAGES/docs.po
@@ -12287,7 +12287,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/mr/LC_MESSAGES/docs.po
+++ b/docs/locales/mr/LC_MESSAGES/docs.po
@@ -12530,7 +12530,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ms/LC_MESSAGES/docs.po
+++ b/docs/locales/ms/LC_MESSAGES/docs.po
@@ -12324,7 +12324,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/my/LC_MESSAGES/docs.po
+++ b/docs/locales/my/LC_MESSAGES/docs.po
@@ -12213,7 +12213,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/nb/LC_MESSAGES/docs.po
+++ b/docs/locales/nb/LC_MESSAGES/docs.po
@@ -13164,7 +13164,7 @@ msgstr "Oppgradering av Docker-beholderen"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/nl/LC_MESSAGES/docs.po
+++ b/docs/locales/nl/LC_MESSAGES/docs.po
@@ -12943,7 +12943,7 @@ msgstr "Bewerker instellen"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/nn/LC_MESSAGES/docs.po
+++ b/docs/locales/nn/LC_MESSAGES/docs.po
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/oc/LC_MESSAGES/docs.po
+++ b/docs/locales/oc/LC_MESSAGES/docs.po
@@ -12273,7 +12273,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/or/LC_MESSAGES/docs.po
+++ b/docs/locales/or/LC_MESSAGES/docs.po
@@ -12172,7 +12172,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/pa/LC_MESSAGES/docs.po
+++ b/docs/locales/pa/LC_MESSAGES/docs.po
@@ -12650,7 +12650,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/pa_PK/LC_MESSAGES/docs.po
+++ b/docs/locales/pa_PK/LC_MESSAGES/docs.po
@@ -12175,7 +12175,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/peo/LC_MESSAGES/docs.po
+++ b/docs/locales/peo/LC_MESSAGES/docs.po
@@ -12170,7 +12170,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/pl/LC_MESSAGES/docs.po
+++ b/docs/locales/pl/LC_MESSAGES/docs.po
@@ -12996,7 +12996,7 @@ msgstr "Konfigurowanie serwera PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ps/LC_MESSAGES/docs.po
+++ b/docs/locales/ps/LC_MESSAGES/docs.po
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/pt/LC_MESSAGES/docs.po
+++ b/docs/locales/pt/LC_MESSAGES/docs.po
@@ -14841,11 +14841,11 @@ msgstr "Configurando o servidor PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"O contentor PostgtreSQL usa a configuração padrão do PostgreSQL e não "
+"O contentor PostgreSQL usa a configuração padrão do PostgreSQL e não "
 "utilizará efetivamente os núcleos de CPU ou memória dele. Recomenda-se "
 "personalizar a configuração para melhorar o desempenho."
 

--- a/docs/locales/pt_BR/LC_MESSAGES/docs.po
+++ b/docs/locales/pt_BR/LC_MESSAGES/docs.po
@@ -14872,11 +14872,11 @@ msgstr "Configurando o servidor PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"O contêiner PostgtreSQL usa a configuração padrão do PostgreSQL e não "
+"O contêiner PostgreSQL usa a configuração padrão do PostgreSQL e não "
 "utilizará efetivamente seus núcleos de CPU ou memória. Recomenda-se "
 "personalizar a configuração para melhorar o desempenho."
 

--- a/docs/locales/pt_PT/LC_MESSAGES/docs.po
+++ b/docs/locales/pt_PT/LC_MESSAGES/docs.po
@@ -14837,11 +14837,11 @@ msgstr "Configurando o servidor PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"O contentor PostgtreSQL usa a configuração padrão do PostgreSQL e não "
+"O contentor PostgreSQL usa a configuração padrão do PostgreSQL e não "
 "utilizará efetivamente os núcleos de CPU ou memória dele. Recomenda-se "
 "personalizar a configuração para melhorar o desempenho."
 

--- a/docs/locales/ro/LC_MESSAGES/docs.po
+++ b/docs/locales/ro/LC_MESSAGES/docs.po
@@ -15070,11 +15070,11 @@ msgstr "Configurarea serverului PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"Containerul PostgtreSQL utilizează configurația PostgreSQL implicită și nu "
+"Containerul PostgreSQL utilizează configurația PostgreSQL implicită și nu "
 "va utiliza eficient nucleele CPU sau memoria. Se recomandă personalizarea "
 "configurației pentru a îmbunătăți performanța."
 

--- a/docs/locales/ro_MD/LC_MESSAGES/docs.po
+++ b/docs/locales/ro_MD/LC_MESSAGES/docs.po
@@ -12169,7 +12169,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ru/LC_MESSAGES/docs.po
+++ b/docs/locales/ru/LC_MESSAGES/docs.po
@@ -15123,11 +15123,11 @@ msgstr "Настройка сервера PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"Контейнер PostgtreSQL использует конфигурацию PostgreSQL по умолчанию, "
+"Контейнер PostgreSQL использует конфигурацию PostgreSQL по умолчанию, "
 "которая неэффективно использует ядра процессора или память. Рекомендуется "
 "настроить конфигурацию для повышения производительности."
 

--- a/docs/locales/sc/LC_MESSAGES/docs.po
+++ b/docs/locales/sc/LC_MESSAGES/docs.po
@@ -12172,7 +12172,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/si/LC_MESSAGES/docs.po
+++ b/docs/locales/si/LC_MESSAGES/docs.po
@@ -12184,7 +12184,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/sk/LC_MESSAGES/docs.po
+++ b/docs/locales/sk/LC_MESSAGES/docs.po
@@ -13054,7 +13054,7 @@ msgstr "Nastaviť stĺpce"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/skr/LC_MESSAGES/docs.po
+++ b/docs/locales/skr/LC_MESSAGES/docs.po
@@ -12168,7 +12168,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/sl/LC_MESSAGES/docs.po
+++ b/docs/locales/sl/LC_MESSAGES/docs.po
@@ -12985,7 +12985,7 @@ msgstr "Nastavi stolpce"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/sq/LC_MESSAGES/docs.po
+++ b/docs/locales/sq/LC_MESSAGES/docs.po
@@ -13093,7 +13093,7 @@ msgstr "Formësim i Weblate-it që të përdorë PostgreSQL-in"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/sr/LC_MESSAGES/docs.po
+++ b/docs/locales/sr/LC_MESSAGES/docs.po
@@ -12714,7 +12714,7 @@ msgstr "Подеси уређивач"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/sr_Latn/LC_MESSAGES/docs.po
+++ b/docs/locales/sr_Latn/LC_MESSAGES/docs.po
@@ -12713,7 +12713,7 @@ msgstr "Podesi uređivač"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/sv/LC_MESSAGES/docs.po
+++ b/docs/locales/sv/LC_MESSAGES/docs.po
@@ -12909,7 +12909,7 @@ msgstr "Konfigurera editor"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/sw/LC_MESSAGES/docs.po
+++ b/docs/locales/sw/LC_MESSAGES/docs.po
@@ -12409,7 +12409,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ta/LC_MESSAGES/docs.po
+++ b/docs/locales/ta/LC_MESSAGES/docs.po
@@ -12461,7 +12461,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/te/LC_MESSAGES/docs.po
+++ b/docs/locales/te/LC_MESSAGES/docs.po
@@ -12166,7 +12166,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/th/LC_MESSAGES/docs.po
+++ b/docs/locales/th/LC_MESSAGES/docs.po
@@ -12850,7 +12850,7 @@ msgstr "เปลี่ยนรหัสผ่าน"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/tlh/LC_MESSAGES/docs.po
+++ b/docs/locales/tlh/LC_MESSAGES/docs.po
@@ -12728,7 +12728,7 @@ msgstr "mu'wIj HIjmeH"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/tok/LC_MESSAGES/docs.po
+++ b/docs/locales/tok/LC_MESSAGES/docs.po
@@ -12169,7 +12169,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/tr/LC_MESSAGES/docs.po
+++ b/docs/locales/tr/LC_MESSAGES/docs.po
@@ -14811,11 +14811,11 @@ msgstr "PostgreSQL sunucusunu yapılandırmak"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"PostgtreSQL kapsayıcısı varsayılan PostgreSQL yapılandırmasını kullanır ve "
+"PostgreSQL kapsayıcısı varsayılan PostgreSQL yapılandırmasını kullanır ve "
 "işlemci çekirdeklerini ya da belleği etkili bir şekilde kullanmaz. Başarımı "
 "artırmak için yapılandırmanın özelleştirilmesi önerilir."
 

--- a/docs/locales/tt/LC_MESSAGES/docs.po
+++ b/docs/locales/tt/LC_MESSAGES/docs.po
@@ -12166,7 +12166,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/tzm/LC_MESSAGES/docs.po
+++ b/docs/locales/tzm/LC_MESSAGES/docs.po
@@ -12377,7 +12377,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/ug/LC_MESSAGES/docs.po
+++ b/docs/locales/ug/LC_MESSAGES/docs.po
@@ -12626,7 +12626,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/uk/LC_MESSAGES/docs.po
+++ b/docs/locales/uk/LC_MESSAGES/docs.po
@@ -14939,11 +14939,11 @@ msgstr "Налаштування сервера PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"У контейнері для PostgtreSQL використано типові налаштування PostgreSQL, він "
+"У контейнері для PostgreSQL використано типові налаштування PostgreSQL, він "
 "не зможе ефективно використати ваші ядра процесора або пам'ять. Для "
 "підвищення швидкодії рекомендуємо додатково налаштувати контейнер."
 

--- a/docs/locales/uz/LC_MESSAGES/docs.po
+++ b/docs/locales/uz/LC_MESSAGES/docs.po
@@ -12209,7 +12209,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/vi/LC_MESSAGES/docs.po
+++ b/docs/locales/vi/LC_MESSAGES/docs.po
@@ -12907,7 +12907,7 @@ msgstr "Thay đổi mật khẩu"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/yue_Hant/LC_MESSAGES/docs.po
+++ b/docs/locales/yue_Hant/LC_MESSAGES/docs.po
@@ -12172,7 +12172,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/zgh/LC_MESSAGES/docs.po
+++ b/docs/locales/zgh/LC_MESSAGES/docs.po
@@ -12168,7 +12168,7 @@ msgstr ""
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""

--- a/docs/locales/zh_Hans/LC_MESSAGES/docs.po
+++ b/docs/locales/zh_Hans/LC_MESSAGES/docs.po
@@ -13713,11 +13713,11 @@ msgstr "配置 PostgreSQL 服务器"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""
-"PostgtreSQL容器使用默认的PostgreSQL配置，它不会有效地利用你的CPU核心或内存。"
+"PostgreSQL容器使用默认的PostgreSQL配置，它不会有效地利用你的CPU核心或内存。"
 "建议自定义配置以提高性能。"
 
 #: ../../admin/install/docker.rst:1818

--- a/docs/locales/zh_Hant/LC_MESSAGES/docs.po
+++ b/docs/locales/zh_Hant/LC_MESSAGES/docs.po
@@ -14297,7 +14297,7 @@ msgstr "配置 Weblate 來使用 PostgreSQL"
 
 #: ../../admin/install/docker.rst:1814
 msgid ""
-"The PostgtreSQL container uses default PostgreSQL configuration and it won't "
+"The PostgreSQL container uses default PostgreSQL configuration and it won't "
 "effectively utilize your CPU cores or memory. It is recommended to customize "
 "the configuration to improve the performance."
 msgstr ""


### PR DESCRIPTION
Fixes a small typo in the docs.