### PR TITLE
Fix PunctuationSpacingCheck for repeated punctation

### DIFF
--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -415,7 +415,10 @@ class PunctuationSpacingCheck(TargetCheck):
             if char in FRENCH_PUNCTUATION:
                 if i + 1 < total and not target[i + 1].isspace():
                     continue
-                if i == 0 or target[i - 1] not in whitespace:
+                if i == 0 or (
+                    target[i - 1] not in whitespace
+                    and target[i - 1] not in FRENCH_PUNCTUATION
+                ):
                     return True
         return False
 

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -351,8 +351,8 @@ class PunctuationSpacingCheckTest(CheckTestCase):
     def setUp(self):
         super().setUp()
         self.test_good_matching = (
-            "string? string! string: string;",
-            "string ? string\u202F! string&nbsp;; string\u00A0:",
+            "string? string?! string! string: string;",
+            "string ? string ?! string\u202F! string&nbsp;; string\u00A0:",
             "",
         )
         self.test_good_none = (


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
There's a rule for French that ensures there's whitespace before certain punctuation characters: https://docs.weblate.org/en/latest/user/checks.html#punctuation-spacing

However there are some strings where you have doubled characters such as `!!`, `?!`, `::`. The lack of space between them was flagged by this check, which I think is wrong.

Some examples of what would be flagged before this PR:
- `%s1  ::  %s2`
- `État collecteur : dommages lourds !!`
- `BT, t'as abandonné l'Arche ! Pourquoi ?!`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [X] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
I didn't run tests/lint, but I hope the change is simple enough for that to be fine.
