### PR TITLE
Added 'protocol' setting to Git credentials

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -753,12 +753,12 @@ List for credentials for Gitea servers.
         "try.gitea.io": {
             "username": "weblate",
             "token": "your-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
         "gitea.example.com": {
             "username": "weblate",
             "token": "another-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
     }
 
@@ -784,12 +784,12 @@ List for credentials for GitLab servers.
         "gitlab.com": {
             "username": "weblate",
             "token": "your-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
         "gitlab.example.com": {
             "username": "weblate",
             "token": "another-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
     }
 
@@ -813,12 +813,12 @@ List for credentials for GitHub servers.
         "api.github.com": {
             "username": "weblate",
             "token": "your-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
         "github.example.com": {
             "username": "weblate",
             "token": "another-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
     }
 
@@ -844,7 +844,7 @@ List for credentials for Bitbucket servers.
         "git.self-hosted.com": {
             "username": "weblate",
             "token": "http-access-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
     }
 
@@ -1248,12 +1248,12 @@ List for credentials for Pagure servers.
         "pagure.io": {
             "username": "weblate",
             "token": "your-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
         "pagure.example.com": {
             "username": "weblate",
             "token": "another-api-token",
-            "protocol": "protocol",
+            "protocol": "https",
         },
     }
 

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -753,10 +753,12 @@ List for credentials for Gitea servers.
         "try.gitea.io": {
             "username": "weblate",
             "token": "your-api-token",
+            "protocol": "protocol",
         },
         "gitea.example.com": {
             "username": "weblate",
             "token": "another-api-token",
+            "protocol": "protocol",
         },
     }
 
@@ -782,10 +784,12 @@ List for credentials for GitLab servers.
         "gitlab.com": {
             "username": "weblate",
             "token": "your-api-token",
+            "protocol": "protocol",
         },
         "gitlab.example.com": {
             "username": "weblate",
             "token": "another-api-token",
+            "protocol": "protocol",
         },
     }
 
@@ -809,10 +813,12 @@ List for credentials for GitHub servers.
         "api.github.com": {
             "username": "weblate",
             "token": "your-api-token",
+            "protocol": "protocol",
         },
         "github.example.com": {
             "username": "weblate",
             "token": "another-api-token",
+            "protocol": "protocol",
         },
     }
 
@@ -838,6 +844,7 @@ List for credentials for Bitbucket servers.
         "git.self-hosted.com": {
             "username": "weblate",
             "token": "http-access-token",
+            "protocol": "protocol",
         },
     }
 
@@ -1241,10 +1248,12 @@ List for credentials for Pagure servers.
         "pagure.io": {
             "username": "weblate",
             "token": "your-api-token",
+            "protocol": "protocol",
         },
         "pagure.example.com": {
             "username": "weblate",
             "token": "another-api-token",
+            "protocol": "protocol",
         },
     }
 

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -747,10 +747,14 @@ class GitMergeRequestBase(GitForcePushRepository):
         repo = self.component.repo
         parsed = urllib.parse.urlparse(repo)
         host = parsed.hostname
+        protocol = parsed.scheme
+        if not protocol:
+            protocol = "https"
         if not host:
             # Assume SSH URL
             host, path = repo.split(":")
             host = host.split("@")[-1]
+            protocol = "https"
         else:
             path = parsed.path
         parts = path.split(":")[-1].rstrip("/").split("/")
@@ -774,6 +778,7 @@ class GitMergeRequestBase(GitForcePushRepository):
                 slug=slug,
                 owner_url=urllib.parse.quote_plus(owner),
                 slug_url=urllib.parse.quote_plus(slug),
+                protocol=protocol,
             ),
             owner,
             slug,
@@ -1025,7 +1030,7 @@ class GithubRepository(GitMergeRequestBase):
     name = gettext_lazy("GitHub pull request")
     identifier = "github"
     _version = None
-    API_TEMPLATE = "https://{host}/repos/{owner}/{slug}"
+    API_TEMPLATE = "{protocol}://{host}/repos/{owner}/{slug}"
     push_label = gettext_lazy("This will push changes and create GitHub pull request.")
 
     def format_api_host(self, host):
@@ -1129,7 +1134,7 @@ class GiteaRepository(GitMergeRequestBase):
     name = gettext_lazy("Gitea pull request")
     identifier = "gitea"
     _version = None
-    API_TEMPLATE = "https://{host}/api/v1/repos/{owner}/{slug}"
+    API_TEMPLATE = "{protocol}://{host}/api/v1/repos/{owner}/{slug}"
     push_label = gettext_lazy("This will push changes and create Gitea pull request.")
 
     def create_fork(self, credentials: Dict):
@@ -1306,7 +1311,7 @@ class GitLabRepository(GitMergeRequestBase):
     name = gettext_lazy("GitLab merge request")
     identifier = "gitlab"
     _version = None
-    API_TEMPLATE = "https://{host}/api/v4/projects/{owner_url}%2F{slug_url}"
+    API_TEMPLATE = "{protocol}://{host}/api/v4/projects/{owner_url}%2F{slug_url}"
     push_label = gettext_lazy("This will push changes and create GitLab merge request.")
 
     def get_forked_url(self, credentials: Dict) -> str:
@@ -1446,7 +1451,7 @@ class PagureRepository(GitMergeRequestBase):
     name = gettext_lazy("Pagure merge request")
     identifier = "pagure"
     _version = None
-    API_TEMPLATE = "https://{host}/api/0"
+    API_TEMPLATE = "{protocol}://{host}/api/0"
     push_label = gettext_lazy("This will push changes and create Pagure merge request.")
 
     def create_fork(self, credentials: Dict):
@@ -1536,7 +1541,7 @@ class BitbucketServerRepository(GitMergeRequestBase):
     name = gettext_lazy("Bitbucket Server pull request")
     identifier = "bitbucketserver"
     _version = None
-    API_TEMPLATE = "https://{host}/rest/api/1.0/projects/{owner}/repos/{slug}"
+    API_TEMPLATE = "{protocol}://{host}/rest/api/1.0/projects/{owner}/repos/{slug}"
     bb_fork: Dict = {}
     push_label = gettext_lazy(
         "This will push changes and create Bitbucket Server pull request."

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -547,6 +547,11 @@ class VCSGiteaTest(VCSGitUpstreamTest):
             self.repo.get_api_url()[0],
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test",
         )
+        self.repo.component.repo = "http://try.gitea.io/WeblateOrg/test.git"
+        self.assertEqual(
+            self.repo.get_api_url()[0],
+            "http://try.gitea.io/api/v1/repos/WeblateOrg/test",
+        )
         self.repo.component.repo = "https://try.gitea.io/WeblateOrg/test"
         self.assertEqual(
             self.repo.get_api_url()[0],
@@ -662,6 +667,10 @@ class VCSGitHubTest(VCSGitUpstreamTest):
         self.repo.component.repo = "https://github.com/WeblateOrg/test.git"
         self.assertEqual(
             self.repo.get_api_url()[0], "https://api.github.com/repos/WeblateOrg/test"
+        )
+        self.repo.component.repo = "http://github.com/WeblateOrg/test.git"
+        self.assertEqual(
+            self.repo.get_api_url()[0], "http://api.github.com/repos/WeblateOrg/test"
         )
         self.repo.component.repo = "https://github.com/WeblateOrg/test"
         self.assertEqual(
@@ -904,6 +913,11 @@ class VCSGitLabTest(VCSGitUpstreamTest):
         self.assertEqual(
             self.repo.get_api_url()[0],
             "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest",
+        )
+        self.repo.component.repo = "http://gitlab.com/WeblateOrg/test.git"
+        self.assertEqual(
+            self.repo.get_api_url()[0],
+            "http://gitlab.com/api/v4/projects/WeblateOrg%2Ftest",
         )
         self.repo.component.repo = "https://user:pass@gitlab.com/WeblateOrg/test.git"
         self.assertEqual(


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

These changes allow for users to use protocols other than `https` when connecting to VCS. This change was made because Weblate originally forced `https` connections, which made it impossible for users to connect to VCS using `http`. This pull request also updates the Configuration page of the documentation to reflect these changes. Unit tests have also been added to test `http` connections.

Issue that these changes resolve: #9179 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

