### PR TITLE
Improved plurals handling in machine translation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,8 @@ Weblate 5.0
 
 Not yet released.
 
+* Improved plurals handling in machine translation.
+
 `All changes in detail <https://github.com/WeblateOrg/weblate/milestone/99?closed=1>`__.
 
 Weblate 4.18.1

--- a/weblate/checks/format.py
+++ b/weblate/checks/format.py
@@ -437,16 +437,15 @@ class BaseFormatCheck(TargetCheck):
         """
         if not self.plural_parameter_regexp:
             # Interpolation isn't available for this format.
-            return ""
+            raise ValueError("Unsupported interpolation!")
         it = self.plural_parameter_regexp.finditer(text)
         match = next(it, None)
-        if match:
-            if next(it, None):
-                # We've found two matching placeholders. We have no way to
-                # determine which one we should replace, so we give up.
-                return ""
-        else:
-            return ""
+        if not match:
+            return text
+        if next(it, None):
+            # We've found two matching placeholders. We have no way to
+            # determine which one we should replace, so we give up.
+            return text
         return text[: match.start()] + str(number) + text[match.end() :]
 
 

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -916,11 +916,15 @@ class PluralMapper:
 
     @cached_property
     def _target_map(self):
-        source_map = {
-            examples[0]: i
-            for i, examples in self.source_plural.examples.items()
-            if len(examples) == 1
-        }
+        exact_source_map = {}
+        all_source_map = {}
+        for i, examples in self.source_plural.examples.items():
+            if len(examples) == 1:
+                exact_source_map[examples[0]] = i
+            else:
+                for example in examples:
+                    all_source_map[example] = i
+
         target_plural = self.target_plural
         target_map = []
         last = target_plural.number - 1
@@ -928,8 +932,10 @@ class PluralMapper:
             examples = target_plural.examples.get(i, ())
             if len(examples) == 1:
                 number = examples[0]
-                if number in source_map:
-                    target_map.append((source_map[number], None))
+                if number in exact_source_map:
+                    target_map.append((exact_source_map[number], None))
+                elif number in all_source_map:
+                    target_map.append((all_source_map[number], number))
                 else:
                     target_map.append((-1, number))
             elif i == last:

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -17,7 +17,8 @@ from weblate_language_data.languages import LANGUAGES
 from weblate_language_data.plurals import CLDRPLURALS, EXTRAPLURALS
 
 from weblate.lang import data
-from weblate.lang.models import Language, Plural, get_plural_type
+from weblate.lang.models import Language, Plural, PluralMapper, get_plural_type
+from weblate.trans.models import Unit
 from weblate.trans.tests.test_models import BaseTestCase
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.utils.db import using_postgresql
@@ -520,3 +521,48 @@ class PluralTest(BaseTestCase):
         for plural in plurals:
             self.assertIn(plural, choices)
             self.assertIn(plural, data.PLURAL_NAMES)
+
+
+class PluralMapperTestCase(FixtureTestCase):
+    def test_english_czech(self):
+        english = Language.objects.get(code="en")
+        czech = Language.objects.get(code="cs")
+        mapper = PluralMapper(english.plural, czech.plural)
+        self.assertEqual(mapper._target_map, ((0, None), (None, None), (-1, None)))
+        unit = Unit.objects.get(
+            translation__language=english, id_hash=2097404709965985808
+        )
+        self.assertEqual(
+            mapper.map(unit),
+            ["Orangutan has %d banana.\n", "", "Orangutan has %d bananas.\n"],
+        )
+
+    def test_russian_english(self):
+        russian = Language.objects.get(code="ru")
+        english = Language.objects.get(code="en")
+        mapper = PluralMapper(russian.plural, english.plural)
+        self.assertEqual(mapper._target_map, ((0, "1"), (-1, None)))
+        # Use English here to test incomplete plural set in the source string
+        unit = Unit.objects.get(
+            translation__language=english, id_hash=2097404709965985808
+        )
+        self.assertEqual(
+            mapper.map(unit),
+            ["Orangutan has %d banana.\n", "Orangutan has %d bananas.\n"],
+        )
+
+    def test_russian_english_interpolate(self):
+        russian = Language.objects.get(code="ru")
+        english = Language.objects.get(code="en")
+        mapper = PluralMapper(russian.plural, english.plural)
+        self.assertEqual(mapper._target_map, ((0, "1"), (-1, None)))
+        # Use English here to test incomplete plural set in the source string
+        unit = Unit.objects.get(
+            translation__language=english, id_hash=2097404709965985808
+        )
+        unit.extra_flags = "python-brace-format"
+        unit.source = unit.source.replace("%d", "{count}")
+        self.assertEqual(
+            mapper.map(unit),
+            ["Orangutan has 1 banana.\n", "Orangutan has {count} bananas.\n"],
+        )

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -472,15 +472,15 @@ class MachineTranslation:
                 self._translate(source, language, text, unit, user, threshold=threshold)
                 for text in plural_mapper.map(unit)
             ]
-            n = len(translation_lists)
-            translation = result.setdefault("translation", [""] * n)
-            quality = result.setdefault("quality", [0] * n)
-            for i, possible_translations in enumerate(translation_lists):
+            plural_count = len(translation_lists)
+            translation = result.setdefault("translation", [""] * plural_count)
+            quality = result.setdefault("quality", [0] * plural_count)
+            for plural, possible_translations in enumerate(translation_lists):
                 for item in possible_translations:
-                    if quality[i] > item["quality"]:
+                    if quality[plural] > item["quality"]:
                         continue
-                    quality[i] = item["quality"]
-                    translation[i] = item["text"]
+                    quality[plural] = item["quality"]
+                    translation[plural] = item["text"]
 
 
 class InternalMachineTranslation(MachineTranslation):

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -24,7 +24,9 @@
       var $el = $(e.target);
       var raw = $el.parent().parent().data("raw");
 
-      $(this.$translationArea.get(raw.plural_form)).replaceValue(raw.text);
+      raw.plural_forms.forEach((plural_form) => {
+        $(this.$translationArea.get(plural_form)).replaceValue(raw.text);
+      });
       autosize.update(this.$translationArea);
       WLT.Utils.markFuzzy(this.$translationForm);
     });
@@ -34,7 +36,9 @@
       var $el = $(e.target);
       var raw = $el.parent().parent().data("raw");
 
-      $(this.$translationArea.get(raw.plural_form)).replaceValue(raw.text);
+      raw.plural_forms.forEach((plural_form) => {
+        $(this.$translationArea.get(plural_form)).replaceValue(raw.text);
+      });
       autosize.update(this.$translationArea);
       WLT.Utils.markTranslated(this.$translationForm);
       submitForm({ target: this.$translationArea });
@@ -565,6 +569,7 @@
     }
 
     renderTranslation(el, service) {
+      el.plural_forms = [];
       var row = $("<tr/>").data("raw", el);
       row.append(
         $("<td/>")
@@ -682,6 +687,10 @@
             base.text == translation.text &&
             base.source == translation.source
           ) {
+            // Add plural
+            if (!base.plural_forms.includes(translation.plural_form)) {
+              base.plural_forms.push(translation.plural_form);
+            }
             // Add origin to current ones
             var current = $this.children("td:nth-child(4)");
             if (base.quality < translation.quality) {


### PR DESCRIPTION
## Proposed changes

This covers some situations that were missed in https://github.com/WeblateOrg/weblate/pull/8323 by @Changaco:

- blank translations when interpolation is supported by the check but not possible
- improved mapping when translating from language with more complex plural rules
- fixed plurals merging in UI when more plurals are translated with a same string
- added tests for `PluralMapper`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
