### PR TITLE
Fix various typos

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1758,7 +1758,7 @@ Read-only root filesystem
 
 .. versionadded:: 4.18
 
-When running the container with a read-only root filesytem, two additional
+When running the container with a read-only root filesystem, two additional
 `tmpfs` volumes are required - :file:`/tmp` and :file:`/run`.
 
 

--- a/docs/admin/translating.rst
+++ b/docs/admin/translating.rst
@@ -104,7 +104,7 @@ Explanation
 
 .. versionchanged:: 4.18
 
-   Support for synching explanation with a file was introduced.
+   Support for syncing explanation with a file was introduced.
 
 Use the explanation to clarify scope or usage of the translation. You can use
 Markdown to include links and other markup.

--- a/docs/admin/upgrade.rst
+++ b/docs/admin/upgrade.rst
@@ -391,7 +391,7 @@ Please follow :ref:`generic-upgrade-instructions` in order to perform update.
   table). To reduce downtime, you can copy
   :file:`weblate/metrics/migrations/*.py` from Weblate 4.17 to 4.16 and start
   the migration in the background. Once it is completed, perform full upgrade
-  as ususal.
+  as usual.
 * Docker container now requires PostgreSQL 12 or newer, please see
   :ref:`docker-postgres-upgrade` for upgrade instructions. Weblate itself
   supports older versions as well, when appropriate Django version is installed.

--- a/weblate/auth/admin.py
+++ b/weblate/auth/admin.py
@@ -20,7 +20,7 @@ BUILT_IN_ROLES = {role[0] for role in ROLES}
 
 
 def block_group_edit(obj):
-    """Whether to allo user editing of an group."""
+    """Whether to allow user editing of a group."""
     return obj and obj.internal
 
 

--- a/weblate/auth/tests/test_commands.py
+++ b/weblate/auth/tests/test_commands.py
@@ -32,7 +32,7 @@ class CommandTest(TestCase, TempDirMixin):
         user = User.objects.get(username="admin")
         self.assertEqual(user.full_name, "Weblate Admin")
         self.assertTrue(user.check_password("admin"))
-        # Ensure the passord is not changed when not needed
+        # Ensure the password is not changed when not needed
         old = user.password
         call_command("createadmin", password="admin", update=True)
         user = User.objects.get(username="admin")

--- a/weblate/glossary/views.py
+++ b/weblate/glossary/views.py
@@ -41,7 +41,7 @@ def add_glossary_term(request, unit_id):
                 "snippets/glossary.html",
                 {
                     "glossary": (
-                        # distinct is needed as get_glossary_terms is distict
+                        # distinct is needed as get_glossary_terms is distinct
                         # and mixed queries can not be combined
                         get_glossary_terms(unit)
                         | translation.unit_set.filter(pk__in=terms).distinct()

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -277,7 +277,7 @@ class MachineTranslation:
 
     def make_re_placeholder(self, text: str):
         """Convert placeholder into a regular expression."""
-        # Allow addditional space before ]
+        # Allow additional space before ]
         return re.escape(text[:-1]) + " *" + re.escape(text[-1:])
 
     def format_replacement(self, h_start: int, h_end: int, h_text: str):

--- a/weblate/metrics/models.py
+++ b/weblate/metrics/models.py
@@ -142,7 +142,7 @@ class MetricManager(models.Manager):
         if data:
             db_data = [data.pop(name, 0) for name in METRIC_ORDER]
             if data:
-                raise ValueError(f"Usupported data: {data}")
+                raise ValueError(f"Unsupported data: {data}")
 
         metric, created = self.get_or_create(
             scope=scope,

--- a/weblate/trans/management/commands/cleanuptrans.py
+++ b/weblate/trans/management/commands/cleanuptrans.py
@@ -18,7 +18,7 @@ from weblate.utils.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    help = "clenups orphaned checks and suggestions"
+    help = "cleanups orphaned checks and suggestions"
 
     def handle(self, *args, **options):
         """Perform cleanup of Weblate database."""

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1035,7 +1035,7 @@ class Unit(models.Model, LoggerMixin):
             # Update user stats
             change.author.profile.increase_count("translated")
 
-            # Force commiting on completing translation
+            # Force committing on completing translation
             translated = self.translation.stats.translated
             if old_translated < translated and translated == self.translation.stats.all:
                 Change.objects.create(

--- a/weblate/trans/tests/data/XWikiFullPageSource.xml
+++ b/weblate/trans/tests/data/XWikiFullPageSource.xml
@@ -162,7 +162,7 @@ XWiki allows you to create links to other pages in your wiki or on the web:
 * [[Sandbox Home&gt;&gt;WebHome]] -&gt; links can have labels
 * [[Wiki Home&gt;&gt;Main.WebHome]] -&gt; a link can use the SpaceName.PageName format to link to a page located in another space
 * [[http://www.xwiki.org]] -&gt; you can link to wiki pages or to external websites
-* [[XWiki.org Website&gt;&gt;http://www.xwiki.org]] -&gt; link labels work for exernal links too
+* [[XWiki.org Website&gt;&gt;http://www.xwiki.org]] -&gt; link labels work for external links too
 
 You can also create links to attachments:
 

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -796,7 +796,7 @@ class GitMergeRequestBase(GitForcePushRepository):
                 0, f"{self.name} API access for {hostname} is not configured"
             )
 
-        # Scheme overide
+        # Scheme override
         if "scheme" in credentials:
             scheme = credentials["scheme"]
         # Fallback to https


### PR DESCRIPTION
## Proposed changes

Fix several user-facing and non-user-facing typos.

Found via `codespell -q 3 -S ./weblate/static/vendor -L childs`

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

n/a