### PR TITLE
feat: hide personal API key on page display

### DIFF
--- a/weblate/templates/accounts/profile.html
+++ b/weblate/templates/accounts/profile.html
@@ -293,9 +293,10 @@
 <tr>
 <th>{% trans "Your personal API key:" %}</th>
 <td>
-    {{ user.auth_token.key }}
+    <button type="button" class="btn btn-link btn-xs" data-toggle="collapse" data-target="#apiKey" title="{% trans "Show/hide API key" %}">{% icon "eye.svg" %}</button>
     <button type="button" class="btn btn-link btn-xs" data-clipboard-text="{{ user.auth_token.key }}" data-clipboard-message="{% trans "API key copied to clipboard." %}" title="{% trans "Copy to clipboard" %}">{% icon "copy.svg" %}</button>
     <a href="" class="pull-right flip btn btn-primary link-post" data-href="{% url 'reset-api-key' %}">{% trans "Regenerate API key" %}</a>
+    <div class="collapse" id="apiKey">{{ user.auth_token.key }}</div>
 </td>
 </tr>
 <tr>

--- a/weblate/templates/trans/project-access.html
+++ b/weblate/templates/trans/project-access.html
@@ -277,8 +277,9 @@
           <tr>
             <th>{% trans "Your personal API key:" %}</th>
             <td>
-                {{ user.auth_token.key }}
-                <button type="button" class="btn btn-link btn-xs" data-clipboard-text="{{ user.auth_token.key }}" data-clipboard-message="{% trans "API key copied to clipboard." %}" title="{% trans "Copy to clipboard" %}">{% icon "copy.svg" %}</button>
+              <button type="button" class="btn btn-link btn-xs" data-toggle="collapse" data-target="#apiKey" title="{% trans "Show/hide API key" %}">{% icon "eye.svg" %}</button>
+              <button type="button" class="btn btn-link btn-xs" data-clipboard-text="{{ user.auth_token.key }}" data-clipboard-message="{% trans "API key copied to clipboard." %}" title="{% trans "Copy to clipboard" %}">{% icon "copy.svg" %}</button>
+              <div class="collapse" id="apiKey">{{ user.auth_token.key }}</div>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
The API key can be shown by clicking on a button. The already implemented feature "Copy to clipboard" stays the same.

Closes #9520

## Proposed changes

This hides the API key per default. If you share your screen (or somebody looks over your shoulder) your API key does not get exposed.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

