### PR TITLE
glossary: add terminology entries directly

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Not yet released.
 * Rendering strings with plurals, placeholders or alternative translations.
 * User API now includes last sign in date.
 * User API token is now hidden for privacy reasons by default.
+* Faster adding terms to glossary.
 * Better preserve translation on source file change in :doc:`/formats/html` and :doc:`/formats/txt`.
 
 **Bug fixes**


### PR DESCRIPTION


## Proposed changes

- avoids expensive sync_terminology call on adding every glossary entry
- makes added entries credited to the adding user

Fixes #9661

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
