### PR TITLE
Fix various typos

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -279,8 +279,8 @@ Matching files:
    - :file:`locale/de/website/de.po`
 
 
-Splitted Android strings
-########################
+Split Android strings
+#####################
 
 Android resource strings, split into several files.
 

--- a/docs/admin/install/openshift.rst
+++ b/docs/admin/install/openshift.rst
@@ -90,7 +90,7 @@ Eliminate
    $ oc delete all -l app=<APPLICATION_NAME>
    $ oc delete configmap -l app= <APPLICATION_NAME>
    $ oc delete secret -l app=<APPLICATION_NAME>
-   # ATTTENTION! The following command is only optional and will permanently delete all of your data.
+   # ATTENTION! The following command is only optional and will permanently delete all of your data.
    $ oc delete pvc -l app=<APPLICATION_NAME>
 
    $ oc delete all -l app=weblate \

--- a/docs/changes/v4.rst
+++ b/docs/changes/v4.rst
@@ -91,7 +91,7 @@ Please follow :ref:`generic-upgrade-instructions` in order to perform update.
   table). To reduce downtime, you can copy
   :file:`weblate/metrics/migrations/*.py` from Weblate 4.17 to 4.16 and start
   the migration in the background. Once it is completed, perform full upgrade
-  as ususal.
+  as usual.
 * Docker container now requires PostgreSQL 12 or newer, please see
   :ref:`docker-postgres-upgrade` for upgrade instructions. Weblate itself
   supports older versions as well, when appropriate Django version is installed.
@@ -254,7 +254,7 @@ Released on November 5th 2022.
 
 * Added support for removing entries from translation memory.
 * Improved analysis on the duplicate language alert.
-* Improved accurancy of the consecutive duplicated-words check.
+* Improved accuracy of the consecutive duplicated-words check.
 * Improved scaling of sending many notifications.
 * Improved string-state handling for subtitle translation.
 * Deprecated insecure configuration of VCS service API keys via _TOKEN/_USERNAME configuration instead of _CREDENTIALS list.

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -174,7 +174,7 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
     @classmethod
     def setUpClass(cls):
         if cls.FORMAT is None:
-            raise SkipTest("Base test class not intented for execution.")
+            raise SkipTest("Base test class not intended for execution.")
         super().setUpClass()
 
     def setUp(self):

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -954,7 +954,7 @@ SESSION_COOKIE_HTTPONLY = True
 # SSL redirect
 SECURE_SSL_REDIRECT = ENABLE_HTTPS
 SECURE_SSL_HOST = SITE_DOMAIN
-# Sent referrrer only for same origin links
+# Sent referrer only for same origin links
 SECURE_REFERRER_POLICY = "same-origin"
 # SSL redirect URL exemption list
 SECURE_REDIRECT_EXEMPT = (r"healthz/$",)  # Allowing HTTP access to health check

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -622,7 +622,7 @@ SESSION_COOKIE_HTTPONLY = True
 # SSL redirect
 SECURE_SSL_REDIRECT = ENABLE_HTTPS
 SECURE_SSL_HOST = SITE_DOMAIN
-# Sent referrrer only for same origin links
+# Sent referrer only for same origin links
 SECURE_REFERRER_POLICY = "same-origin"
 # SSL redirect URL exemption list
 SECURE_REDIRECT_EXEMPT = (r"healthz/$",)  # Allowing HTTP access to health check

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -303,7 +303,7 @@ def perform_translation(unit, form, request):
     project = unit.translation.component.project
     # Remember old checks
     oldchecks = unit.all_checks_names
-    # Alernative translations handling
+    # Alternative translations handling
     add_alternative = "add_alternative" in request.POST
 
     # Update explanation for glossary

--- a/weblate/utils/tests/test_pii.py
+++ b/weblate/utils/tests/test_pii.py
@@ -11,5 +11,5 @@ from weblate.utils.pii import mask_email
 class PIITestCase(SimpleTestCase):
     def test_mask_email(self):
         self.assertEqual(mask_email("michal@cihar.com"), "m****l@*****.**m")
-        self.assertEqual(mask_email("mic@locahost"), "***@*******t")
+        self.assertEqual(mask_email("mic@localhost"), "***@********t")
         self.assertEqual(mask_email("michal@cz"), "m****l@*z")


### PR DESCRIPTION
## Proposed changes

Misc. typo fixes

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.

## Other information

Found another typo in test but didn't include it. Here it is for review:

```diff
diff --git a/weblate/utils/tests/test_pii.py b/weblate/utils/tests/test_pii.py
index fc84e73b0b..21ddf685ed 100644
--- a/weblate/utils/tests/test_pii.py
+++ b/weblate/utils/tests/test_pii.py
@@ -11,5 +11,5 @@ from weblate.utils.pii import mask_email
 class PIITestCase(SimpleTestCase):
     def test_mask_email(self):
         self.assertEqual(mask_email("michal@cihar.com"), "m****l@*****.**m")
-        self.assertEqual(mask_email("mic@locahost"), "***@*******t")
+        self.assertEqual(mask_email("mic@localhost"), "***@********t")
         self.assertEqual(mask_email("michal@cz"), "m****l@*z")
```
**Note:** the `***@********t` contains an extra asterisk to reflect the extra letter added in `localhost`. I didn't add this because I wasn't sure if it would break the test.