### PR TITLE
Neutral colors for progress bars and translation unit states

### DIFF
--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -1795,11 +1795,14 @@ a.language:hover {
 .unit-state-translated {
   background-color: #2eccaa;
 }
-.unit-state-todo {
+.unit-state-bad {
   background-color: #f6664c;
 }
+.unit-state-todo {
+  background-color: #e9eaec;
+}
 .unit-state-approved {
-  background-color: #1378d0;
+  background-color: #144d3f;
 }
 .unit-state-saving {
   animation: morph-state 2s infinite;

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -1802,7 +1802,7 @@ a.language:hover {
   background-color: #e9eaec;
 }
 .unit-state-approved {
-  background-color: #144d3f;
+  background-color: #1fa385;
 }
 .unit-state-saving {
   animation: morph-state 2s infinite;

--- a/weblate/static/style-dark.css
+++ b/weblate/static/style-dark.css
@@ -2639,11 +2639,14 @@ a.language:hover {
 .unit-state-translated {
   background-color: rgb(41, 179, 150);
 }
-.unit-state-todo {
+.unit-state-bad {
   background-color: rgb(172, 33, 9);
 }
+.unit-state-todo {
+  background-color: rgb(40, 43, 44);
+}
 .unit-state-approved {
-  background-color: rgb(17, 106, 183);
+  background-color: rgb(18, 68, 55);
 }
 .sticky-header {
   background-color: rgb(26, 29, 30);

--- a/weblate/static/style-dark.css
+++ b/weblate/static/style-dark.css
@@ -2646,7 +2646,7 @@ a.language:hover {
   background-color: rgb(40, 43, 44);
 }
 .unit-state-approved {
-  background-color: rgb(18, 68, 55);
+  background-color: rgb(28, 143, 117);
 }
 .sticky-header {
   background-color: rgb(26, 29, 30);

--- a/weblate/templates/snippets/progress.html
+++ b/weblate/templates/snippets/progress.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="progress">
+<div class="progress" title="{% trans "Needs attention" %}">
   {% if approved %}
   <div class="progress-bar" role="progressbar" aria-valuenow="{{ approved }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ approved }}%;" title="{% trans "Approved" %}"></div>
   {% endif %}

--- a/weblate/templates/snippets/progress.html
+++ b/weblate/templates/snippets/progress.html
@@ -7,7 +7,4 @@
   {% if good %}
   <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{ good }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ good }}%;" title="{% trans "Translated without any problems" %}"></div>
   {% endif %}
-  {% if bad %}
-  <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{ bad }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ bad }}%;" title="{% trans "Needs attention" %}"></div>
-  {% endif %}
 </div>

--- a/weblate/templates/snippets/progress.html
+++ b/weblate/templates/snippets/progress.html
@@ -2,7 +2,7 @@
 
 <div class="progress">
   {% if approved %}
-  <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="{{ approved }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ approved }}%;" title="{% trans "Approved" %}"></div>
+  <div class="progress-bar" role="progressbar" aria-valuenow="{{ approved }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ approved }}%;" title="{% trans "Approved" %}"></div>
   {% endif %}
   {% if good %}
   <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{ good }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ good }}%;" title="{% trans "Translated without any problems" %}"></div>

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -175,11 +175,13 @@
 <tr data-href="{{ translate_url }}?q={{ query }}" class="clickable-row">
 <th class="number">{{ count|intcomma }}</th>
 <td class="legend">
+    {% if name != "all" %}
     <div class="progress">
       {% if color %}
         <div class="progress-bar{% if color != "primary" %} progress-bar-{{ color }}{% endif %}" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%;"></div>
       {% endif %}
     </div>
+    {% endif %}
 </td>
 <td class="full-cell">
     <a href="{{ translate_url }}?q={{ query }}">

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -177,7 +177,7 @@
 <td class="legend">
     <div class="progress">
       {% if color %}
-        <div class="progress-bar progress-bar-{{ color }}" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%;"></div>
+        <div class="progress-bar{% if color != "primary" %} progress-bar-{{ color }}{% endif %}" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%;"></div>
       {% endif %}
     </div>
 </td>

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -830,12 +830,12 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
         result.add(self.stats, "all", "")
 
         result.add_if(
-            self.stats, "readonly", "info" if self.enable_review else "success"
+            self.stats, "readonly", "primary" if self.enable_review else "success"
         )
 
         if not self.is_readonly:
             if self.enable_review:
-                result.add_if(self.stats, "approved", "info")
+                result.add_if(self.stats, "approved", "primary")
 
             # Count of translated strings
             result.add_if(self.stats, "translated", "success")
@@ -845,35 +845,35 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
                 result.add_if(self.stats, "unapproved", "success")
 
                 # Approved with suggestions
-                result.add_if(self.stats, "approved_suggestions", "info")
+                result.add_if(self.stats, "approved_suggestions", "primary")
 
             # Unfinished strings
-            result.add_if(self.stats, "todo", "danger")
+            result.add_if(self.stats, "todo", "")
 
             # Untranslated strings
-            result.add_if(self.stats, "nottranslated", "danger")
+            result.add_if(self.stats, "nottranslated", "")
 
             # Fuzzy strings
-            result.add_if(self.stats, "fuzzy", "danger")
+            result.add_if(self.stats, "fuzzy", "")
 
             # Translations with suggestions
-            result.add_if(self.stats, "suggestions", "danger")
-            result.add_if(self.stats, "nosuggestions", "danger")
+            result.add_if(self.stats, "suggestions", "")
+            result.add_if(self.stats, "nosuggestions", "")
 
         # All checks
-        result.add_if(self.stats, "allchecks", "danger")
+        result.add_if(self.stats, "allchecks", "")
 
         # Translated strings with checks
         if not self.is_source:
-            result.add_if(self.stats, "translated_checks", "danger")
+            result.add_if(self.stats, "translated_checks", "")
 
         # Dismissed checks
-        result.add_if(self.stats, "dismissed_checks", "danger")
+        result.add_if(self.stats, "dismissed_checks", "")
 
         # Process specific checks
         for check in CHECKS:
             check_obj = CHECKS[check]
-            result.add_if(self.stats, check_obj.url_id, "danger")
+            result.add_if(self.stats, check_obj.url_id, "")
 
         # Grab comments
         result.add_if(self.stats, "comments", "")

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -700,7 +700,9 @@ def words_progress(obj):
 @register.simple_tag
 def unit_state_class(unit) -> str:
     """Return state flags."""
-    if unit.has_failing_check or not unit.translated:
+    if unit.has_failing_check:
+        return "unit-state-bad"
+    if not unit.translated:
         return "unit-state-todo"
     if unit.approved or (unit.readonly and unit.translation.enable_review):
         return "unit-state-approved"

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -667,11 +667,9 @@ def translation_progress_data(
         approved += readonly
         translated -= readonly
 
-    bad = total - approved - translated
     return {
         "approved": f"{translation_percent(approved, total, False):.1f}",
         "good": f"{translation_percent(translated, total):.1f}",
-        "bad": f"{translation_percent(bad, total, False):.1f}",
     }
 
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Make progress bars use neutral colors (primary and neutral instead of info and danger). Updated also legend and unit states colors. Introduced new class for unit states, `.unit-state-bad` to differ units with problems from `.unit-state-todo`.

For me personally currently high amount of "danger" color for in progress translations causes an "UI anxiety".

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have added documentation to describe my feature.~~
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->

<details>
  <summary>Light before</summary>
  
![hosted weblate org_projects_accrescent_ (1)](https://github.com/WeblateOrg/weblate/assets/9288014/70e33146-d963-4a03-bf85-90f105a87b3b)

</details>

<details>
  <summary>Light after</summary>
  
![hosted weblate org_projects_accrescent_](https://github.com/WeblateOrg/weblate/assets/9288014/0c1e90e0-8eb8-43a9-9d27-3d833cdd8eca)

</details>
<details>
  <summary>Dark before</summary>
  
![hosted weblate org_projects_accrescent_ (3)](https://github.com/WeblateOrg/weblate/assets/9288014/a9e8fd89-3cd4-4754-961b-c59c964a55fa)


</details>
<details>
  <summary>Dark after</summary>
  
![hosted weblate org_projects_accrescent_ (2)](https://github.com/WeblateOrg/weblate/assets/9288014/e4a59b99-f3c0-4673-8440-3dd48bd4e841)
</details>

Legend in translation view:

<details>
  <summary>Light before</summary>
  
![hosted weblate org_projects_accrescent_client_pl_ (2)](https://github.com/WeblateOrg/weblate/assets/9288014/8cbb4463-f6a5-42dc-bed2-2c233ca515b1)

</details>

<details>
  <summary>Light after</summary>
  
![hosted weblate org_projects_accrescent_client_pl_ (3)](https://github.com/WeblateOrg/weblate/assets/9288014/1bc5a1b5-7415-4be1-a787-c0f324abca7f)

</details>
<details>
  <summary>Dark before</summary>
  
![hosted weblate org_projects_accrescent_client_pl_ (1)](https://github.com/WeblateOrg/weblate/assets/9288014/a353d230-25e1-4fce-8fe2-ee7f255f5572)

</details>
<details>
  <summary>Dark after</summary>
  
![hosted weblate org_projects_accrescent_client_pl_](https://github.com/WeblateOrg/weblate/assets/9288014/5c07845f-237b-46af-a994-94f7d842f227)
</details>

Units view:


<details>
  <summary>Light before</summary>
  
![hosted weblate org_browse_antennapod_website-general_fr__sort_by=labels offset=4 (3)](https://github.com/WeblateOrg/weblate/assets/9288014/04252bd7-0d20-4f74-9dd4-7094be311598)

</details>
<details>
  <summary>Light after</summary>
  
![hosted weblate org_browse_antennapod_website-general_fr__sort_by=labels offset=4 (5)](https://github.com/WeblateOrg/weblate/assets/9288014/39327dd9-7cf4-41aa-ab3d-a0925a986374)

</details>
<details>
  <summary>Dark before</summary>
  
![hosted weblate org_browse_antennapod_website-general_fr__sort_by=labels offset=4](https://github.com/WeblateOrg/weblate/assets/9288014/4a520d82-6f5b-479a-892a-554377660608)

</details>
<details>
  <summary>Dark after</summary>
  
![hosted weblate org_browse_antennapod_website-general_fr__sort_by=labels offset=4 (4)](https://github.com/WeblateOrg/weblate/assets/9288014/b373cb23-4168-463e-b9b8-3d166672c7cb)

</details>
