### PR TITLE
Font fixes for bar chart widgets

### DIFF
--- a/weblate/templates/svg/multi-language-badge-horizontal.svg
+++ b/weblate/templates/svg/multi-language-badge-horizontal.svg
@@ -8,7 +8,7 @@
 <a xlink:href="{{ translation.6 }}" xlink:title="{{ translation.0 }}">
 <text
    xml:space="preserve"
-   style="font-style:normal;font-weight:normal;font-size:11px;font-family:'Source Sans 3',Sans;fill:#808080;text-anchor:end;"
+   style="font-style:normal;font-weight:normal;font-size:11px;font-family:'Source Sans 3',sans-serif;fill:#808080;text-anchor:end;"
    x="-170"
    y="{{ translation.2 }}"
    transform="rotate(-90)"

--- a/weblate/templates/svg/multi-language-badge.svg
+++ b/weblate/templates/svg/multi-language-badge.svg
@@ -8,13 +8,13 @@
 <a xlink:href="{{ translation.6 }}" xlink:title="{{ translation.0 }}">
 <text
    xml:space="preserve"
-   style="font-style:normal;font-weight:normal;font-size:11px;font-family:'Source Sans 3',Sans;fill:#808080;text-anchor:end;"
+   style="font-style:normal;font-weight:normal;font-size:11px;font-family:'Source Sans 3',sans-serif;fill:#808080;text-anchor:end;"
    x="{{ language_offset }}"
    y="{{ translation.2 }}"
    id="text{{ translation.2 }}">{{ translation.0 }}</text>
 <text
    xml:space="preserve"
-   style="font-style:normal;font-weight:normal;font-size:11px;font-family:'Source Sans 3',Sans;fill:#808080"
+   style="font-style:normal;font-weight:normal;font-size:11px;font-family:'Source Sans 3',sans-serif;fill:#808080"
    x="{{ text_offset }}"
    y="{{ translation.2 }}"
    id="percent{{ translation.2 }}">{{ translation.1 }}%</text>

--- a/weblate/templates/svg/style.svg
+++ b/weblate/templates/svg/style.svg
@@ -1,6 +1,6 @@
 {% load static %}
 {% if fonts_cdn_url %}
-  <style type="text/css">@import url({{ fonts_cdn_url }}font-source/source-sans-pro.css);</style>
+  <style type="text/css">@import url({{ fonts_cdn_url }}font-source/source-sans-3.css);</style>
 {% else %}
-  <style type="text/css">@import url({{ site_url }}{% static 'font-source/source-sans-pro.css' %});</style>
+  <style type="text/css">@import url({{ site_url }}{% static 'vendor/font-source/source-sans-3.css' %});</style>
 {% endif %}


### PR DESCRIPTION
## Proposed changes

I have noticed some problems with the bar chart widgets generated by Weblate:
- The font "Source Sans Pro" was replaced by "Source Sans 3" and moved to a subdirectory. However, the widgets still try to use the old font from the old path.
- My browser (Firefox) did not recognize the specified fallback ``Sans``. As a result, the serif font "Times New Roman" was used. This seems to be unintentional.

In this PR, I updated the SVG templates. The font CSS should now be imported from the correct path. And I changed the fallback to ``sans-serif`` which is also used in other places.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.