### PR TITLE
ui: Add approved percentage to the object listing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Not yet released.
 
 * Related glossary terms lookup is now faster.
 * Logging of failures when creating pull requests.
+* Additional approval percentage column in object listings.
 
 **Bug fixes**
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,7 +9,7 @@ Not yet released.
 
 * Related glossary terms lookup is now faster.
 * Logging of failures when creating pull requests.
-* Additional approval percentage column in object listings.
+* :ref:`project-translation_review` also shows the approval percentage in object listings.
 
 **Bug fixes**
 

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -1502,8 +1502,27 @@ input.color_edit:checked + label {
   border: 2px solid black;
 }
 
-@media (max-width: 868px) {
-  .zero-width-868 {
+@media (max-width: 640px) {
+  table:not(.approved-col) .list-unfinished {
+    display: none;
+    width: 0;
+  }
+
+  table.approved-col .list-approved {
+    display: none;
+    width: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  table:not(.approved-col) .list-unfinished-words {
+    display: none;
+    width: 0;
+  }
+}
+
+@media (max-width: 786px) {
+  table:not(.approved-col) .list-checks {
     display: none;
     width: 0;
   }
@@ -1513,50 +1532,62 @@ input.color_edit:checked + label {
   }
 }
 
-@media (max-width: 1000px) {
-  .zero-width-1000 {
+@media (max-width: 900px) {
+  table:not(.approved-col) .list-suggestions {
     display: none;
     width: 0;
   }
 }
 
-@media (max-width: 1400px) {
-  .zero-width-1400 {
+@media (max-width: 1000px) {
+  table:not(.approved-col) .list-comments {
+    display: none;
+    width: 0;
+  }
+
+  table.approved-col .list-suggestions {
     display: none;
     width: 0;
   }
 }
 
 @media (max-width: 1200px) {
-  .zero-width-1200 {
+  table .list-unfinished-chars {
     display: none;
     width: 0;
   }
 }
 
-@media (max-width: 1100px) {
-  .zero-width-1100 {
-    display: none;
-    width: 0;
-  }
-}
-
-@media (max-width: 820px) {
-  .zero-width-820 {
+@media (max-width: 1400px) {
+  table .list-untranslated {
     display: none;
     width: 0;
   }
 }
 
 @media (max-width: 740px) {
-  .zero-width-740 {
+  table.approved-col .list-unfinished {
     display: none;
     width: 0;
   }
 }
 
-@media (max-width: 640px) {
-  .zero-width-640 {
+@media (max-width: 820px) {
+  table.approved-col .list-unfinished-words {
+    display: none;
+    width: 0;
+  }
+}
+
+@media (max-width: 868px) {
+  table.approved-col .list-checks {
+    display: none;
+    width: 0;
+  }
+}
+
+@media (max-width: 1100px) {
+  table.approved-col .list-comments {
     display: none;
     width: 0;
   }

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -1502,8 +1502,8 @@ input.color_edit:checked + label {
   border: 2px solid black;
 }
 
-@media (max-width: 768px) {
-  .zero-width-768 {
+@media (max-width: 868px) {
+  .zero-width-868 {
     display: none;
     width: 0;
   }
@@ -1513,8 +1513,8 @@ input.color_edit:checked + label {
   }
 }
 
-@media (max-width: 900px) {
-  .zero-width-900 {
+@media (max-width: 1000px) {
+  .zero-width-1000 {
     display: none;
     width: 0;
   }
@@ -1534,15 +1534,22 @@ input.color_edit:checked + label {
   }
 }
 
-@media (max-width: 1000px) {
-  .zero-width-1000 {
+@media (max-width: 1100px) {
+  .zero-width-1100 {
     display: none;
     width: 0;
   }
 }
 
-@media (max-width: 720px) {
-  .zero-width-720 {
+@media (max-width: 820px) {
+  .zero-width-820 {
+    display: none;
+    width: 0;
+  }
+}
+
+@media (max-width: 740px) {
+  .zero-width-740 {
     display: none;
     width: 0;
   }

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -46,6 +46,16 @@
             </a>
           {% endif %}
         </th>
+        <th title="{% trans "Sort this column" %}" class="number zero-width-640 sort-cell">
+          {% if objects.paginator.num_pages > 1 %}
+            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "approved" %}-{% endif %}approved">
+          {% endif %}
+          {% trans "Approved" %}
+          <span class="sort-icon {% if objects.paginator.sort_by == "approved" %}sort-down{% elif objects.paginator.sort_by == "-approved" %}sort-up{% endif %}" />
+          {% if objects.paginator.num_pages > 1 %}
+            </a>
+          {% endif %}
+        </th>
         <th title="{% trans "Sort this column" %}" class="number sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "translated" %}-{% endif %}translated">
@@ -56,7 +66,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-640 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number zero-width-740 sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated" %}-{% endif %}untranslated">
           {% endif %}
@@ -66,7 +76,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-720 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number zero-width-820 sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated_words" %}-{% endif %}untranslated_words">
           {% endif %}
@@ -96,7 +106,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-768 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number zero-width-868 sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "checks" %}-{% endif %}checks">
           {% endif %}
@@ -106,7 +116,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-900 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number zero-width-1000 sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "suggestions" %}-{% endif %}suggestions">
           {% endif %}
@@ -116,7 +126,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-1000 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number zero-width-1100 sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "comments" %}-{% endif %}comments">
           {% endif %}
@@ -141,15 +151,16 @@
     <th class="object-link">
       <a href="{{ category.get_absolute_url }}">{{ category.name }}</a>
     </th>
+    {% include "snippets/list-objects-percent.html" with percent=category.stats.approved_percent value=category.stats.approved query="q=state:>=approved" all=category.stats.all class="zero-width-640" %}
     {% include "snippets/list-objects-percent.html" with percent=category.stats.translated_percent value=category.stats.translated query="q=state:>=translated" all=category.stats.all %}
     {% if not hide_details %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo query="q=state:<translated" class="zero-width-640" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo_words query="q=state:<translated" class="zero-width-720" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo query="q=state:<translated" class="zero-width-740" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo_words query="q=state:<translated" class="zero-width-820" %}
     {% include "snippets/list-objects-number.html" with value=category.stats.todo_chars query="q=state:<translated" class="zero-width-1200" %}
     {% include "snippets/list-objects-number.html" with value=category.stats.nottranslated query="q=state:empty" class="zero-width-1400" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.allchecks query="q=has:check" class="zero-width-768" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-900" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.comments query="q=has:comment#comments" class="zero-width-1000" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.allchecks query="q=has:check" class="zero-width-868" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-1000" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.comments query="q=has:comment#comments" class="zero-width-1100" %}
     {% endif %}
   </tr>
   <tr data-parent="{{ row_id }}">
@@ -225,19 +236,20 @@
 {% endif %}
 {% indicate_alerts object %}
 </th>
+{% include "snippets/list-objects-percent.html" with percent=object.stats.approved_percent value=object.stats.approved query="q=state:>=approved" all=object.stats.all class="zero-width-640" %}
 {% if is_glossary %}
   {% include "snippets/list-objects-number.html" with value=object.stats.translated query="q=state:>=translated" show_zero=True %}
 {% else %}
   {% include "snippets/list-objects-percent.html" with percent=object.stats.translated_percent value=object.stats.translated query="q=state:>=translated" all=object.stats.all %}
 {% endif %}
 {% if not hide_details %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo query="q=state:<translated" class="zero-width-640" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo_words query="q=state:<translated" class="zero-width-720" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo query="q=state:<translated" class="zero-width-740" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo_words query="q=state:<translated" class="zero-width-820" %}
 {% include "snippets/list-objects-number.html" with value=object.stats.todo_chars query="q=state:<translated" class="zero-width-1200" %}
 {% include "snippets/list-objects-number.html" with value=object.stats.nottranslated query="q=state:empty" class="zero-width-1400" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.allchecks query="q=has:check" class="zero-width-768" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-900" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.comments query="q=has:comment#comments" class="zero-width-1000" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.allchecks query="q=has:check" class="zero-width-868" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-1000" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.comments query="q=has:comment#comments" class="zero-width-1100" %}
 {% endif %}
 </tr>
 <tr data-parent="{{ row_id }}">

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -46,16 +46,18 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-640 sort-cell">
-          {% if objects.paginator.num_pages > 1 %}
-            <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "approved" %}-{% endif %}approved">
-          {% endif %}
-          {% trans "Approved" %}
-          <span class="sort-icon {% if objects.paginator.sort_by == "approved" %}sort-down{% elif objects.paginator.sort_by == "-approved" %}sort-up{% endif %}" />
-          {% if objects.paginator.num_pages > 1 %}
-            </a>
-          {% endif %}
-        </th>
+        {% if project and project.enable_review %}
+          <th title="{% trans "Sort this column" %}" class="number zero-width-640 sort-cell">
+            {% if objects.paginator.num_pages > 1 %}
+              <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "approved" %}-{% endif %}approved">
+            {% endif %}
+            {% trans "Approved" %}
+            <span class="sort-icon {% if objects.paginator.sort_by == "approved" %}sort-down{% elif objects.paginator.sort_by == "-approved" %}sort-up{% endif %}" />
+            {% if objects.paginator.num_pages > 1 %}
+              </a>
+            {% endif %}
+          </th>
+        {% endif %}
         <th title="{% trans "Sort this column" %}" class="number sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "translated" %}-{% endif %}translated">
@@ -151,7 +153,9 @@
     <th class="object-link">
       <a href="{{ category.get_absolute_url }}">{{ category.name }}</a>
     </th>
-    {% include "snippets/list-objects-percent.html" with percent=category.stats.approved_percent value=category.stats.approved query="q=state:>=approved" all=category.stats.all class="zero-width-640" %}
+    {% if project and project.enable_review %}
+      {% include "snippets/list-objects-percent.html" with percent=category.stats.approved_percent value=category.stats.approved query="q=state:>=approved" all=category.stats.all class="zero-width-640" %}
+    {% endif %}
     {% include "snippets/list-objects-percent.html" with percent=category.stats.translated_percent value=category.stats.translated query="q=state:>=translated" all=category.stats.all %}
     {% if not hide_details %}
     {% include "snippets/list-objects-number.html" with value=category.stats.todo query="q=state:<translated" class="zero-width-740" %}
@@ -236,7 +240,9 @@
 {% endif %}
 {% indicate_alerts object %}
 </th>
-{% include "snippets/list-objects-percent.html" with percent=object.stats.approved_percent value=object.stats.approved query="q=state:>=approved" all=object.stats.all class="zero-width-640" %}
+{% if project and project.enable_review %}
+  {% include "snippets/list-objects-percent.html" with percent=object.stats.approved_percent value=object.stats.approved query="q=state:>=approved" all=object.stats.all class="zero-width-640" %}
+{% endif %}
 {% if is_glossary %}
   {% include "snippets/list-objects-number.html" with value=object.stats.translated query="q=state:>=translated" show_zero=True %}
 {% else %}

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -7,11 +7,14 @@
 {% init_unique_row_id %}
 
 {% if objects or list_categories %}
-  {% if objects.paginator.num_pages > 1 %}
-    <table class="table progress-table autocolspan table-listing">
-  {% else %}
-    <table class="sort table progress-table autocolspan table-listing">
-  {% endif %}
+  <table class="table progress-table autocolspan table-listing
+    {% if not objects.paginator.num_pages > 1 %}
+      sort
+    {% endif %}
+    {% if project and project.enable_review %}
+      approved-col
+    {% endif %}
+  ">
   {% if not hide_details and not hide_header %}
     <thead class="sticky-header">
       <tr>
@@ -47,7 +50,7 @@
           {% endif %}
         </th>
         {% if project and project.enable_review %}
-          <th title="{% trans "Sort this column" %}" class="number zero-width-640 sort-cell">
+          <th title="{% trans "Sort this column" %}" class="number list-approved sort-cell">
             {% if objects.paginator.num_pages > 1 %}
               <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "approved" %}-{% endif %}approved">
             {% endif %}
@@ -68,7 +71,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-740 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number list-unfinished sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated" %}-{% endif %}untranslated">
           {% endif %}
@@ -78,7 +81,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-820 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number list-unfinished-words sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated_words" %}-{% endif %}untranslated_words">
           {% endif %}
@@ -88,7 +91,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-1200 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number list-unfinished-chars sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated_chars" %}-{% endif %}untranslated_chars">
           {% endif %}
@@ -98,7 +101,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-1400 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number list-untranslated sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "nottranslated" %}-{% endif %}nottranslated">
           {% endif %}
@@ -108,7 +111,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-868 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number list-checks sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "checks" %}-{% endif %}checks">
           {% endif %}
@@ -118,7 +121,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-1000 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number list-suggestions sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "suggestions" %}-{% endif %}suggestions">
           {% endif %}
@@ -128,7 +131,7 @@
             </a>
           {% endif %}
         </th>
-        <th title="{% trans "Sort this column" %}" class="number zero-width-1100 sort-cell">
+        <th title="{% trans "Sort this column" %}" class="number list-comments sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "comments" %}-{% endif %}comments">
           {% endif %}
@@ -154,17 +157,17 @@
       <a href="{{ category.get_absolute_url }}">{{ category.name }}</a>
     </th>
     {% if project and project.enable_review %}
-      {% include "snippets/list-objects-percent.html" with percent=category.stats.approved_percent value=category.stats.approved query="q=state:>=approved" all=category.stats.all class="zero-width-640" %}
+      {% include "snippets/list-objects-percent.html" with percent=category.stats.approved_percent value=category.stats.approved query="q=state:>=approved" all=category.stats.all class="list-approved" %}
     {% endif %}
     {% include "snippets/list-objects-percent.html" with percent=category.stats.translated_percent value=category.stats.translated query="q=state:>=translated" all=category.stats.all %}
     {% if not hide_details %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo query="q=state:<translated" class="zero-width-740" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo_words query="q=state:<translated" class="zero-width-820" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo_chars query="q=state:<translated" class="zero-width-1200" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.nottranslated query="q=state:empty" class="zero-width-1400" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.allchecks query="q=has:check" class="zero-width-868" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-1000" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.comments query="q=has:comment#comments" class="zero-width-1100" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo query="q=state:<translated" class="list-unfinished" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo_words query="q=state:<translated" class="list-unfinished-words" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo_chars query="q=state:<translated" class="list-unfinished-chars" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.nottranslated query="q=state:empty" class="list-untranslated" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.allchecks query="q=has:check" class="list-checks" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.suggestions query="q=has:suggestion#suggestions" class="list-suggestions" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.comments query="q=has:comment#comments" class="list-comments" %}
     {% endif %}
   </tr>
   <tr data-parent="{{ row_id }}">
@@ -241,7 +244,7 @@
 {% indicate_alerts object %}
 </th>
 {% if project and project.enable_review %}
-  {% include "snippets/list-objects-percent.html" with percent=object.stats.approved_percent value=object.stats.approved query="q=state:>=approved" all=object.stats.all class="zero-width-640" %}
+  {% include "snippets/list-objects-percent.html" with percent=object.stats.approved_percent value=object.stats.approved query="q=state:>=approved" all=object.stats.all class="list-approved" %}
 {% endif %}
 {% if is_glossary %}
   {% include "snippets/list-objects-number.html" with value=object.stats.translated query="q=state:>=translated" show_zero=True %}
@@ -249,13 +252,13 @@
   {% include "snippets/list-objects-percent.html" with percent=object.stats.translated_percent value=object.stats.translated query="q=state:>=translated" all=object.stats.all %}
 {% endif %}
 {% if not hide_details %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo query="q=state:<translated" class="zero-width-740" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo_words query="q=state:<translated" class="zero-width-820" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo_chars query="q=state:<translated" class="zero-width-1200" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.nottranslated query="q=state:empty" class="zero-width-1400" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.allchecks query="q=has:check" class="zero-width-868" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-1000" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.comments query="q=has:comment#comments" class="zero-width-1100" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo query="q=state:<translated" class="list-unfinished" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo_words query="q=state:<translated" class="list-unfinished-words" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo_chars query="q=state:<translated" class="list-unfinished-chars" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.nottranslated query="q=state:empty" class="list-untranslated" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.allchecks query="q=has:check" class="list-checks" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.suggestions query="q=has:suggestion#suggestions" class="list-suggestions" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.comments query="q=has:comment#comments" class="list-comments" %}
 {% endif %}
 </tr>
 <tr data-parent="{{ row_id }}">


### PR DESCRIPTION
## Proposed changes

Show approved percentage in the object listing to have a number corresponding to the blue bar.

Fixes #9855

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

The new column is displayed in front of the translation percentage because when approvals are active they probably become the main progress criteria.

On a smaller display resolution it will be shown in third priority after the name and 'Translated' column.
The other columns appear 100px later than before, except 'Unfinished Characters' which appears after 'Comments' at an additional 100px instead of 200px. This allows 'Untranslated' to show at the usual 1400px, so on common 1440px wide screens no information is lost.