### PR TITLE
docker: add WEBLATE_IP_PROXY_OFFSET

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -680,6 +680,12 @@ Generic settings
         environment:
           WEBLATE_IP_PROXY_HEADER: HTTP_X_FORWARDED_FOR
 
+.. envvar:: WEBLATE_IP_PROXY_OFFSET
+
+    .. versionadded:: 5.0.1
+
+    Configures :setting:`IP_PROXY_OFFSET`.
+
 .. envvar:: WEBLATE_USE_X_FORWARDED_PORT
 
     .. versionadded:: 5.0.1

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1001,7 +1001,7 @@ ANONYMOUS_USER_NAME = "anonymous"
 # Reverse proxy settings
 IP_PROXY_HEADER = get_env_str("WEBLATE_IP_PROXY_HEADER")
 IP_BEHIND_REVERSE_PROXY = bool(IP_PROXY_HEADER)
-IP_PROXY_OFFSET = -1
+IP_PROXY_OFFSET = get_env_int("WEBLATE_IP_PROXY_OFFSET", -1)
 
 # Sending HTML in mails
 EMAIL_SEND_HTML = True


### PR DESCRIPTION
Resolves #9854

## Proposed changes

Support [IP_PROXY_OFFSET](https://docs.weblate.org/en/latest/admin/config.html#std-setting-IP_PROXY_OFFSET) configuration in the docker image.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
