### PR TITLE
stats: remove additional queries needed to figure out source language

### DIFF
--- a/weblate/trans/models/category.py
+++ b/weblate/trans/models/category.py
@@ -136,16 +136,18 @@ class Category(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
         )
 
     @cached_property
-    def all_component_ids(self):
+    def all_components(self):
         from weblate.trans.models import Component
 
-        return set(
-            Component.objects.filter(
-                Q(category=self)
-                | Q(category__category=self)
-                | Q(category__category__category=self)
-            ).values_list("pk", flat=True)
+        return Component.objects.filter(
+            Q(category=self)
+            | Q(category__category=self)
+            | Q(category__category__category=self)
         )
+
+    @cached_property
+    def all_component_ids(self):
+        return set(self.all_components.values_list("pk", flat=True))
 
     def generate_changes(self, old):
         def getvalue(base, attribute):
@@ -172,3 +174,9 @@ class Category(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
                     project=self.project,
                     user=self.acting_user,
                 )
+
+    @cached_property
+    def source_language_ids(self):
+        return set(
+            self.all_components.values_list("source_language_id", flat=True).distinct()
+        )

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -465,6 +465,14 @@ class Project(models.Model, PathMixin, CacheKeyMixin):
     def child_components(self):
         return self.get_child_components_filter(lambda qs: qs)
 
+    @cached_property
+    def source_language_ids(self):
+        return set(
+            self.get_child_components_filter(
+                lambda qs: qs.values_list("source_language_id", flat=True).distinct()
+            )
+        )
+
     def scratch_create_component(
         self,
         name: str,

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -810,9 +810,7 @@ class ProjectLanguage(BaseURLMixin):
 
     @cached_property
     def is_source(self):
-        return not self.project.get_child_components_filter(
-            lambda qs: qs.exclude(source_language=self.language)
-        ).exists()
+        return self.language.id in self.project.source_language_ids
 
     @cached_property
     def change_set(self):
@@ -936,9 +934,7 @@ class CategoryLanguage(BaseURLMixin):
 
     @cached_property
     def is_source(self):
-        return not self.category.component_set.exclude(
-            source_language=self.language
-        ).exists()
+        return self.language.id in self.category.source_language_ids
 
     @cached_property
     def change_set(self):


### PR DESCRIPTION


## Proposed changes

This affects both CategoryLanguage and ProjectLanguage - the parent objects not cache list of source languages to make the individual decisions cheap instead of doing a database query for each language.

Fixes WEBLATE-4F5

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
