### PR TITLE
ui: Add approved percentage to the object listing (v2)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Not yet released.
 **New features**
 
 **Improvements**
+* :ref:`project-translation_review` also shows the approval percentage in object listings.
 
 **Bug fixes**
 

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -1555,6 +1555,13 @@ input.color_edit:checked + label {
   }
 }
 
+@media (max-width: 540px) {
+  .zero-width-540 {
+    display: none;
+    width: 0;
+  }
+}
+
 .editor-footer {
   z-index: 999;
   position: relative;

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -44,6 +44,18 @@
             </a>
           {% endif %}
         </th>
+        {% if project and project.enable_review %}
+          <th title="{% trans "Sort this column" %}" class="number zero-width-540 sort-cell">
+            {% if objects.paginator.num_pages > 1 %}
+              <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "approved" %}-{% endif %}approved">
+            {% endif %}
+            {% trans "Approved" %}
+            <span class="sort-icon {% if objects.paginator.sort_by == "approved" %}sort-down{% elif objects.paginator.sort_by == "-approved" %}sort-up{% endif %}" />
+            {% if objects.paginator.num_pages > 1 %}
+              </a>
+            {% endif %}
+          </th>
+        {% endif %}
         <th title="{% trans "Sort this column" %}" class="number sort-cell">
           {% if objects.paginator.num_pages > 1 %}
             <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "translated" %}-{% endif %}translated">
@@ -140,6 +152,9 @@
     <th class="object-link">
       <a href="{{ category.get_absolute_url }}">{{ category.name }}</a>
     </th>
+    {% if project and project.enable_review %}
+      {% include "snippets/list-objects-percent.html" with percent=category.stats.approved_percent value=category.stats.approved query="q=state:>=approved" all=category.stats.all class="zero-width-540" %}
+    {% endif %}
     {% include "snippets/list-objects-percent.html" with percent=category.stats.translated_percent value=category.stats.translated query="q=state:>=translated" all=category.stats.all %}
     {% if not hide_details %}
     {% include "snippets/list-objects-number.html" with value=category.stats.todo query="q=state:<translated" class="zero-width-640" %}
@@ -225,6 +240,9 @@
 {% endif %}
 {% indicate_alerts object %}
 </th>
+{% if project and project.enable_review %}
+  {% include "snippets/list-objects-percent.html" with percent=object.stats.approved_percent value=object.stats.approved query="q=state:>=approved" all=object.stats.all class="zero-width-540" %}
+{% endif %}
 {% if is_glossary %}
   {% include "snippets/list-objects-number.html" with value=object.stats.translated query="q=state:>=translated" show_zero=True %}
 {% else %}


### PR DESCRIPTION
## Proposed changes

Show approved percentage in the object listing to have a number corresponding to the left most bar when reviews are enabled.

Only shows the column if reviews are enabled in the project.

A simpler implementation compared to MR #9864.

Resolves WeblateOrg#9855

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
