### PR TITLE
MetrixQuerySet: fix passing secondary argument to filter method call

### DIFF
--- a/weblate/metrics/models.py
+++ b/weblate/metrics/models.py
@@ -94,7 +94,7 @@ class MetricQuerySet(models.QuerySet):
     ) -> MetricQuerySet:
         # Include secondary in the query as it is part of unique index
         # and makes subsequent date filtering more effective.
-        return self.filter(scope=scope, relation=relation, secondary=0)
+        return self.filter(scope=scope, relation=relation, secondary=secondary)
 
     def get_current_metric(
         self, obj, scope: int, relation: int, secondary: int = 0


### PR DESCRIPTION
## Proposed changes

Although all calls have 0 there, let's still make the argument used to prevent confusing behavior in the future. Follow-up from https://github.com/WeblateOrg/weblate/pull/9921.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have added documentation to describe my feature.~~
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
