### PR TITLE
ui: add option to hide linked repositories in admin repo status page

### DIFF
--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -1922,3 +1922,7 @@ h5.list-group-item-heading {
     background-color: rgba(255, 165, 0, 0);
   }
 }
+
+#show-linked-repo-toggle:not(:checked) ~ .repo-linked {
+  display: none;
+}

--- a/weblate/templates/manage/repos.html
+++ b/weblate/templates/manage/repos.html
@@ -7,7 +7,10 @@
 {% endblock %}
 
 {% block content %}
+<input type="checkbox" id="show-linked-repo-toggle" checked />
+<label for="show-linked-repo-toggle">{% trans "Show components with linked repositories" %}</label>
 {% for sp in components %}
+<div class="repo{% if sp.is_repo_link %}-linked{% endif %}">
 <h3 id="component-{{ sp.pk }}"><a href="{{ sp.get_absolute_url }}">{{ sp }}</a></h3>
 {% if sp.is_repo_link %}
 <p>
@@ -18,5 +21,6 @@
 {{ sp.repository.status }}
 </pre>
 {% endif %}
+</div>
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
When there are a lot of linked repositories it can become difficult to get a overview of the status of the real repos.

## Proposed changes

Adds a basic checkbox that toggles the display of linked repositories in pure CSS.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Input needs to be on same level as components to make the CSS selector work. Because there is no way in CSS to select a parent element.
