### PR TITLE
glossary: Reuse match logic while rendering

### DIFF
--- a/weblate/glossary/models.py
+++ b/weblate/glossary/models.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
+from collections import defaultdict
 from itertools import chain
 
 import ahocorasick_rs
@@ -80,9 +81,9 @@ def get_glossary_terms(unit):
     uses_ngram = source_language.uses_ngram()
 
     automaton = project.glossary_automaton
+    positions = defaultdict(list)
     # Extract terms present in the source
     with sentry_sdk.start_span(op="glossary.match", description=project.slug):
-        terms = set()
         for _termno, start, end in automaton.find_matches_as_indexes(
             source, overlapping=True
         ):
@@ -90,10 +91,13 @@ def get_glossary_terms(unit):
                 (start == 0 or NON_WORD_RE.match(source[start - 1]))
                 and (end >= len(source) or NON_WORD_RE.match(source[end]))
             ):
-                terms.add(source[start:end].lower())
+                term = source[start:end].lower()
+                positions[term].append((start, end))
 
         units = list(
-            units.filter(Q(source__lower__md5__in=[MD5(Value(term)) for term in terms]))
+            units.filter(
+                Q(source__lower__md5__in=[MD5(Value(term)) for term in positions])
+            )
         )
 
         # Add variants manually. This could be done by adding filtering on
@@ -115,6 +119,9 @@ def get_glossary_terms(unit):
 
         # Order results, this is Python reimplementation of:
         units.sort(key=lambda x: x.glossary_sort_key)
+
+        for unit in units:
+            unit.glossary_positions = tuple(positions[unit.source.lower()])
 
     # Store in a unit cache
     unit.glossary_terms = units

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -484,6 +484,7 @@ class Unit(models.Model, LoggerMixin):
         self.machinery = None
         # Data for glossary integration
         self.glossary_terms = None
+        self.glossary_positions = None
         # Store original attributes for change tracking
         self.old_unit = None
         if "state" in self.__dict__:

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -4,6 +4,8 @@
 
 """Testing of template tags."""
 
+from __future__ import annotations
+
 import datetime
 
 from django.test import SimpleTestCase, TestCase
@@ -225,6 +227,11 @@ class TranslationFormatTestCase(FixtureTestCase):
         super().setUp()
         self.translation = self.get_translation()
 
+    def build_glossary(self, source: str, target: str, positions=list[tuple[int, int]]):
+        unit = Unit(source=source, target=target, translation=self.translation)
+        unit.glossary_positions = positions
+        return unit
+
     def test_basic(self):
         self.assertEqual(
             format_translation(
@@ -386,9 +393,7 @@ class TranslationFormatTestCase(FixtureTestCase):
             format_translation(
                 ["Hello world"],
                 self.component.source_language,
-                glossary=[
-                    Unit(source="hello", target="ahoj", translation=self.translation)
-                ],
+                glossary=[self.build_glossary("hello", "ahoj", [(0, 5)])],
             )["items"][0]["content"],
             """
             <span class="glossary-term"
@@ -404,12 +409,8 @@ class TranslationFormatTestCase(FixtureTestCase):
                 ["Hello world"],
                 self.component.source_language,
                 glossary=[
-                    Unit(
-                        source="hello world",
-                        target="ahoj svete",
-                        translation=self.translation,
-                    ),
-                    Unit(source="hello", target="ahoj", translation=self.translation),
+                    self.build_glossary("hello world", "ahoj svete", [(0, 11)]),
+                    self.build_glossary("hello", "ahoj", [(0, 5)]),
                 ],
             )["items"][0]["content"],
             """
@@ -427,9 +428,7 @@ class TranslationFormatTestCase(FixtureTestCase):
             format_translation(
                 ["[Hello] world"],
                 self.component.source_language,
-                glossary=[
-                    Unit(source="[hello]", target="ahoj", translation=self.translation)
-                ],
+                glossary=[self.build_glossary("[hello]", "ahoj", [(0, 7)])],
             )["items"][0]["content"],
             """
             <span class="glossary-term"
@@ -443,9 +442,7 @@ class TranslationFormatTestCase(FixtureTestCase):
             format_translation(
                 ["text  Hello world"],
                 self.component.source_language,
-                glossary=[
-                    Unit(source="hello", target="ahoj", translation=self.translation)
-                ],
+                glossary=[self.build_glossary("hello", "ahoj", [(6, 11)])],
             )["items"][0]["content"],
             """
             text
@@ -466,11 +463,7 @@ class TranslationFormatTestCase(FixtureTestCase):
             format_translation(
                 ["Hello world"],
                 self.component.source_language,
-                glossary=[
-                    Unit(
-                        source="hello", target='<b>ahoj"', translation=self.translation
-                    )
-                ],
+                glossary=[self.build_glossary("hello", '<b>ahoj"', [(0, 5)])],
             )["items"][0]["content"],
             """
             <span class="glossary-term"
@@ -485,10 +478,8 @@ class TranslationFormatTestCase(FixtureTestCase):
                 ["Hello glossary"],
                 self.component.source_language,
                 glossary=[
-                    Unit(source="hello", target="ahoj", translation=self.translation),
-                    Unit(
-                        source="glossary", target="glosář", translation=self.translation
-                    ),
+                    self.build_glossary("hello", "ahoj", [(0, 5)]),
+                    self.build_glossary("glossary", "glosář", [(6, 14)]),
                 ],
             )["items"][0]["content"],
             """
@@ -507,9 +498,7 @@ class TranslationFormatTestCase(FixtureTestCase):
                 ["%3$sHow"],
                 self.component.source_language,
                 glossary=[
-                    Unit(
-                        source="show", target="zobrazit", translation=self.translation
-                    ),
+                    self.build_glossary("show", "zobrazit", [(3, 7)]),
                 ],
                 unit=unit,
             )["items"][0]["content"],


### PR DESCRIPTION


## Proposed changes

We already have positions of the glossary terms inside a string, so reuse these instead of doing second matching.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
