### PR TITLE
Add "nb" locale mapping to Google Translate

### DIFF
--- a/weblate/machinery/google.py
+++ b/weblate/machinery/google.py
@@ -14,6 +14,7 @@ GOOGLE_API_ROOT = "https://translation.googleapis.com/language/translate/v2/"
 class GoogleBaseTranslation(MachineTranslation):
     # Map codes used by Google to the ones used by Weblate
     language_map = {
+        "nb": "no",
         "nb_NO": "no",
         "fil": "tl",
         "zh_Hant": "zh-TW",


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Currently only the "nb_NO" (locale with country code) is mapped to "no", but no mapping exists for just the locale "nb". This "nb" locale doesn't exist in Weblate by default, but can be created through the Django admin interface via the "Languages" section. Because of this, the Google Translate automatic translation provider currently doesn't recognize the "nb" locale. This change will add a mapping for the "nb" locale as well.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
