### PR TITLE
settings: add support for multiple vcs api host credentials from env var

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -751,6 +751,7 @@ Generic settings
 .. envvar:: WEBLATE_GITHUB_USERNAME
 .. envvar:: WEBLATE_GITHUB_TOKEN
 .. envvar:: WEBLATE_GITHUB_HOST
+.. envvar:: WEBLATE_GITHUB_CREDENTIALS
 
     Configures GitHub pull-requests integration by changing
     :setting:`GITHUB_CREDENTIALS`.
@@ -762,6 +763,7 @@ Generic settings
 .. envvar:: WEBLATE_GITLAB_USERNAME
 .. envvar:: WEBLATE_GITLAB_TOKEN
 .. envvar:: WEBLATE_GITLAB_HOST
+.. envvar:: WEBLATE_GITLAB_CREDENTIALS
 
     Configures GitLab merge-requests integration  by changing
     :setting:`GITLAB_CREDENTIALS`.
@@ -773,6 +775,8 @@ Generic settings
        WEBLATE_GITLAB_USERNAME=weblate
        WEBLATE_GITLAB_HOST=gitlab.com
        WEBLATE_GITLAB_TOKEN=token
+       # or as a Python dictionary
+       WEBLATE_GITLAB_CREDENTIALS='{ "gitlab.com": { "username": "weblate", "token": "token" } }'
 
     .. seealso::
 
@@ -781,6 +785,7 @@ Generic settings
 .. envvar:: WEBLATE_GITEA_USERNAME
 .. envvar:: WEBLATE_GITEA_TOKEN
 .. envvar:: WEBLATE_GITEA_HOST
+.. envvar:: WEBLATE_GITEA_CREDENTIALS
 
     Configures Gitea pull-requests integration by changing
     :setting:`GITEA_CREDENTIALS`.
@@ -793,6 +798,7 @@ Generic settings
 .. envvar:: WEBLATE_PAGURE_USERNAME
 .. envvar:: WEBLATE_PAGURE_TOKEN
 .. envvar:: WEBLATE_PAGURE_HOST
+.. envvar:: WEBLATE_PAGURE_CREDENTIALS
 
     Configures Pagure merge-requests integration  by changing
     :setting:`PAGURE_CREDENTIALS`.
@@ -804,6 +810,7 @@ Generic settings
 .. envvar:: WEBLATE_BITBUCKETSERVER_USERNAME
 .. envvar:: WEBLATE_BITBUCKETSERVER_TOKEN
 .. envvar:: WEBLATE_BITBUCKETSERVER_HOST
+.. envvar:: WEBLATE_BITBUCKETSERVER_CREDENTIALS
 
     Configures Bitbucket Server pull-requests integration by changing
     :setting:`BITBUCKETSERVER_CREDENTIALS`.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,8 @@ Not yet released.
 
 **Improvements**
 
+* Configure VCS API credentials as a Python dict from environment variables.
+
 **Bug fixes**
 
 **Compatibility**

--- a/docs/snippets/vcs-credentials.rst
+++ b/docs/snippets/vcs-credentials.rst
@@ -17,7 +17,7 @@ The following configuration is available for each host:
 
 .. hint::
 
-   In the Docker container, the credentials are configured in three variables
+   In the Docker container, the credentials can be configured in three variables
    and the credentials are built out of that. An example configuration for
    GitHub might look like:
 
@@ -37,3 +37,16 @@ The following configuration is available for each host:
               "token": "api-token",
           }
       }
+
+   Alternatively the Python dictonary can be provided as a string:
+
+   .. code-block:: shell
+
+      WEBLATE_GITHUB_CREDENTIALS='{ "api.github.com": { "username": "api-user", "token": "api-token", } }'
+
+   Or the path to a file containing the Python dictionary:
+
+   .. code-block:: shell
+
+      echo '{ "api.github.com": { "username": "api-user", "token": "api-token", } }' > /path/to/github-credentials
+      WEBLATE_GITHUB_CREDENTIALS_FILE='/path/to/github-credentials'

--- a/weblate/utils/environment.py
+++ b/weblate/utils/environment.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 
 
@@ -90,6 +91,8 @@ def get_env_credentials(
     name: str,
 ) -> dict[str, dict[str, str]]:
     """Parses VCS integration credentials."""
+    if credentials := get_env_str(f"WEBLATE_{name}_CREDENTIALS"):
+        return ast.literal_eval(credentials)
     username = os.environ.get(f"WEBLATE_{name}_USERNAME")
     token = os.environ.get(f"WEBLATE_{name}_TOKEN")
     host = os.environ.get(f"WEBLATE_{name}_HOST")

--- a/weblate/utils/tests/test_environment.py
+++ b/weblate/utils/tests/test_environment.py
@@ -83,6 +83,20 @@ class EnvTest(SimpleTestCase):
         del os.environ["WEBLATE_TEST_TOKEN"]
         del os.environ["WEBLATE_TEST_HOST"]
 
+        os.environ["WEBLATE_TEST_CREDENTIALS"] = "{invalid-syntax}"
+        with self.assertRaises(ValueError):
+            get_env_credentials("TEST")
+
+        os.environ[
+            "WEBLATE_TEST_CREDENTIALS"
+        ] = '{"host": {"username": "user", "token": "token"}}'
+        self.assertEqual(
+            get_env_credentials("TEST"),
+            {"host": {"username": "user", "token": "token"}},
+        )
+
+        del os.environ["WEBLATE_TEST_CREDENTIALS"]
+
     def test_get_env_ratelimit(self):
         os.environ["RATELIMIT_ANON"] = "1/hour"
         self.assertEqual(


### PR DESCRIPTION
## Proposed changes

Resolves #8132

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

The env variable is a "Python dict as a string" because it most closely matches the [docs](https://docs.weblate.org/en/latest/admin/config.html#gitlab-credentials). Could also be JSON or YAML instead.