### PR TITLE
Improve accuracy of checks on plural messages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,9 +7,11 @@ Not yet released.
 * :ref:`mt-yandex-v2` machine translation service.
 
 **Improvements**
+
 * :ref:`project-translation_review` also shows the approval percentage in object listings.
 * Project is added to watched upon accepting an invitation.
 * Configure VCS API credentials as a Python dict from environment variables.
+* Improved accuracy of checks on plural messages.
 
 **Bug fixes**
 

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -95,15 +95,19 @@ class Check:
 
     def check_target_unit(self, sources, targets, unit):
         """Check single unit, handling plurals."""
-        source = unit.source_string
-        # Check singular
-        if self.check_single(source, targets[0], unit):
-            return True
-        # Do we have more to check?
-        if len(sources) > 1:
-            source = sources[-1]
-        # Check plurals against plural from source
-        return any(self.check_single(source, target, unit) for target in targets[1:])
+        from weblate.lang.models import PluralMapper
+
+        source_plural = unit.translation.component.source_language.plural
+        target_plural = unit.translation.plural
+        if len(sources) != source_plural.number or len(targets) != target_plural.number:
+            return any(
+                self.check_single(sources[-1], target, unit) for target in targets
+            )
+        plural_mapper = PluralMapper(source_plural, target_plural)
+        return any(
+            self.check_single(source, target, unit)
+            for source, target in plural_mapper.zip(sources, targets, unit)
+        )
 
     def check_single(self, source, target, unit):
         """Check for single phrase, not dealing with plurals."""

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -93,9 +93,39 @@ class EndStopCheckTest(CheckTestCase):
         self.test_failure_1 = ("string.", "string", "")
         self.test_failure_2 = ("string", "string.", "")
 
+    def test_arabic(self):
+        self.assertTrue(
+            self.check.check_target(
+                ["<unusued singular (hash=…)>", "Lorem ipsum dolor sit amet."],
+                ["zero", "one", "two", "few", "many", "other"],
+                MockUnit(code="ar"),
+            )
+        )
+        self.assertFalse(
+            self.check.check_target(
+                ["<unusued singular (hash=…)>", "Lorem ipsum dolor sit amet."],
+                ["zero.", "one", "two.", "few.", "many.", "other."],
+                MockUnit(code="ar"),
+            )
+        )
+
     def test_japanese(self):
         self.do_test(False, ("Text:", "Text。", ""), "ja")
         self.do_test(True, ("Text:", "Text", ""), "ja")
+        self.assertTrue(
+            self.check.check_target(
+                ["<unusued singular (hash=…)>", "English."],
+                ["Japanese…"],
+                MockUnit(code="ja"),
+            )
+        )
+        self.assertFalse(
+            self.check.check_target(
+                ["<unusued singular (hash=…)>", "English."],
+                ["Japanese。"],
+                MockUnit(code="ja"),
+            )
+        )
 
     def test_hindi(self):
         self.do_test(False, ("Text.", "Text।", ""), "hi")

--- a/weblate/checks/tests/test_checks.py
+++ b/weblate/checks/tests/test_checks.py
@@ -7,6 +7,7 @@
 import random
 
 from django.test import SimpleTestCase
+from translate.lang.data import languages
 
 from weblate.checks.flags import Flags
 from weblate.lang.models import Language, Plural
@@ -20,7 +21,12 @@ class MockLanguage(Language):
 
     def __init__(self, code="cs"):
         super().__init__(code=code)
-        self.plural = Plural(language=self)
+        try:
+            _, number, formula = languages[code]
+        except KeyError:
+            self.plural = Plural(language=self)
+        else:
+            self.plural = Plural(language=self, number=number, formula=formula)
 
 
 class MockProject:

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -972,6 +972,22 @@ class PluralMapper:
                 strings_to_translate.append(s)
         return strings_to_translate
 
+    def zip(self, sources, targets, unit):
+        if len(sources) != self.source_plural.number:
+            raise ValueError(
+                "length of `sources` does't match the number of source plurals"
+            )
+        if len(targets) != self.target_plural.number:
+            raise ValueError(
+                "length of `targets` does't match the number of target plurals"
+            )
+        if self.same_plurals:
+            return zip(sources, targets)
+        return [
+            (sources[-1 if i is None else i], targets[j])
+            for (i, _), j in zip(self._target_map, range(len(targets)))
+        ]
+
 
 class WeblateLanguagesConf(AppConf):
     """Languages settings."""


### PR DESCRIPTION
## Proposed changes

This commit modifies the `Check.check_target_unit()` method to improve how source and target strings are paired for comparison, which should reduce both false positives and false negatives. It fixes <https://github.com/liberapay/salon/issues/581>.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
