### PR TITLE
Docs: Fix typo in GET categories

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1140,7 +1140,7 @@ Projects
 
    .. versionadded:: 5.0
 
-    Returns statistics for a project. See :http:get:`/api/categories/(int:id)/` for field definitions.
+    Returns categories for a project. See :http:get:`/api/categories/(int:id)/` for field definitions.
 
     :param project: Project URL slug
     :type project: string


### PR DESCRIPTION
The doc says "Returns statistics for a project." when it should be "Returns categories for a project."