### PR TITLE
stats: keep stats up-to-date instead of invalidating

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -2510,7 +2510,8 @@ class TranslationAPITest(APIBaseTest):
                 "total": 4,
             },
         )
-        self.assertEqual(self.component.project.stats.suggestions, 1)
+        project = Project.objects.get(id=self.component.project_id)
+        self.assertEqual(project.stats.suggestions, 1)
         with open(TEST_PO, "rb") as handle:
             response = self.client.put(
                 reverse("api:translation-file", kwargs=self.translation_kwargs),

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -2513,12 +2513,9 @@ class Component(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
         self.batched_checks = set()
 
     def _invalidate_triger(self):
-        from weblate.trans.tasks import update_component_stats
-
         self._invalidate_scheduled = False
         self.log_info("updating stats caches")
-        self.stats.invalidate(childs=True)
-        update_component_stats.delay(self.pk)
+        self.stats.update_language_stats()
         self.invalidate_glossary_cache()
 
     def invalidate_cache(self):

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -68,6 +68,8 @@ class SuggestionManager(models.Manager):
         if user is not None:
             user.profile.increase_count("suggested")
 
+        unit.invalidate_related_cache()
+
         return suggestion
 
 
@@ -163,8 +165,9 @@ class Suggestion(models.Model, UserDisplayMixin):
         self.delete()
 
     def delete(self, using=None, keep_parents=False):
+        result = super().delete(using=using, keep_parents=keep_parents)
         self.unit.invalidate_related_cache()
-        return super().delete(using=using, keep_parents=keep_parents)
+        return result
 
     def get_num_votes(self):
         """Return number of votes."""

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1271,7 +1271,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
 
     def _invalidate_triger(self):
         self._invalidate_scheduled = False
-        self.stats.invalidate()
+        self.stats.update_stats()
         self.component.invalidate_glossary_cache()
 
     def invalidate_cache(self):
@@ -1312,8 +1312,8 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
                 self.component.push_if_needed()
 
         # Delete from the database
-        self.stats.invalidate()
         self.delete()
+        transaction.on_commit(self.stats.update_parents)
         transaction.on_commit(self.component.schedule_update_checks)
 
         # Record change

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -87,7 +87,6 @@ class ViewTestCase(RepoTestCase):
         self.project = self.component.project
         self.translation = self.get_translation()
         # Invalidate caches
-        self.project.stats.invalidate()
         cache.clear()
         # Login
         self.client.login(username="testuser", password="testpassword")

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -200,11 +200,12 @@ def perform_rename(form_cls, request, obj, perm: str):
         return redirect_param(obj, "#organize")
 
     # Invalidate old stats
-    obj.stats.invalidate()
+    old_stats = list(obj.stats.get_update_objects())
 
     obj = form.save()
+
     # Invalidate new stats
-    obj.stats.invalidate()
+    obj.stats.update_parents(old_stats)
 
     return redirect(obj)
 

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -4,15 +4,16 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
 from copy import copy
 from datetime import timedelta
 from itertools import chain
 from types import GeneratorType
 
 import sentry_sdk
+from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from django.db.models import Count, Q, Sum
 from django.db.models.functions import Length
 from django.urls import reverse
@@ -202,23 +203,24 @@ class BaseStats:
     def load(self):
         return cache.get(self.cache_key, {})
 
-    def save(self):
+    def save(self, update_parents: bool = True):
         """Save stats to cache."""
         cache.set(self.cache_key, self._data, 30 * 86400)
 
-    def get_invalidate_keys(
-        self,
-        language: Language | None = None,
-        childs: bool = False,
-        parents: bool = True,
-    ):
-        return {self.cache_key, GlobalStats().cache_key}
+    def get_update_objects(self):
+        yield GlobalStats()
 
-    def invalidate(self, language: Language | None = None, childs: bool = False):
-        """Invalidate local and cache data."""
-        self.clear()
-        keys = self.get_invalidate_keys(language, childs)
-        cache.delete_many(keys)
+    def update_parents(self, extra_objects: list[BaseStats] | None = None):
+        # Get unique list of stats to update.
+        # This preserves ordering so that closest ones are updated first.
+        stat_objects = {stat.cache_key: stat for stat in self.get_update_objects()}
+        if extra_objects:
+            for stat in extra_objects:
+                stat_objects[stat.cache_key] = stat
+
+        # Update stats
+        for stat in stat_objects.values():
+            stat.update_stats()
 
     def clear(self):
         """Clear local cache."""
@@ -236,7 +238,7 @@ class BaseStats:
         """Calculate stats for translation."""
         raise NotImplementedError
 
-    def ensure_basic(self, save=True):
+    def ensure_basic(self, save: bool = True):
         """Ensure we have basic stats."""
         # Prefetch basic stats at once
         if self._data is None:
@@ -247,6 +249,11 @@ class BaseStats:
                 self.save()
             return True
         return False
+
+    def update_stats(self, update_parents: bool = True):
+        self._data = {}
+        self.prefetch_basic()
+        self.save(update_parents=update_parents)
 
     def prefetch_basic(self):
         with sentry_sdk.start_span(
@@ -324,7 +331,7 @@ class DummyTranslationStats(BaseStats):
     def cache_key(self):
         return None
 
-    def save(self):
+    def save(self, update_parents: bool = True):
         return
 
     def load(self):
@@ -340,26 +347,31 @@ class DummyTranslationStats(BaseStats):
 class TranslationStats(BaseStats):
     """Per translation stats."""
 
-    def get_invalidate_keys(
-        self,
-        language: Language | None = None,
-        childs: bool = False,
-        parents: bool = True,
-    ):
-        result = super().get_invalidate_keys(language, childs, parents)
-        # Happens when deleting language from the admin interface
-        with suppress(ObjectDoesNotExist):
-            result.update(self._object.language.stats.get_invalidate_keys())
+    def save(self, update_parents: bool = True):
+        from weblate.utils.tasks import update_translation_stats_parents
 
-        if parents:
-            # Happens when deleting language from the admin interface
-            with suppress(ObjectDoesNotExist):
-                result.update(
-                    self._object.component.stats.get_invalidate_keys(
-                        language=self._object.language
-                    )
-                )
-        return result
+        super().save()
+
+        if settings.CELERY_TASK_ALWAYS_EAGER:
+            transaction.on_commit(self.update_parents)
+        else:
+            pk = self._object.pk
+            transaction.on_commit(lambda: update_translation_stats_parents.delay(pk))
+
+    def get_update_objects(self):
+        yield self._object.language.stats
+        yield from self._object.language.stats.get_update_objects()
+
+        yield self._object.component.stats
+        yield from self._object.component.stats.get_update_objects()
+
+        project_language = ProjectLanguage(
+            project=self._object.component.project, language=self._object.language
+        )
+        yield project_language.stats
+        yield from project_language.stats.get_update_objects()
+
+        yield from super().get_update_objects()
 
     @property
     def language(self):
@@ -686,8 +698,8 @@ class ComponentStats(LanguageStats):
     def save_lazy_translated_percent(self):
         cache.set(self.lazy_translated_percent_key, self.translated_percent, 30 * 86400)
 
-    def save(self):
-        super().save()
+    def save(self, update_parents: bool = True):
+        super().save(update_parents=update_parents)
         self.save_lazy_translated_percent()
 
     def calculate_source(self, stats_obj, stats):
@@ -705,23 +717,33 @@ class ComponentStats(LanguageStats):
             self.store("source_words", stats_obj.all_words)
             self.store("source_strings", stats_obj.all)
 
-    def get_invalidate_keys(
-        self,
-        language: Language | None = None,
-        childs: bool = False,
-        parents: bool = True,
-    ):
-        result = super().get_invalidate_keys(language, childs, parents)
-        if parents:
-            result.update(self._object.project.stats.get_invalidate_keys(language))
-            if self._object.category:
-                result.update(self._object.category.stats.get_invalidate_keys(language))
-            for clist in self._object.componentlist_set.iterator():
-                result.update(clist.stats.get_invalidate_keys())
-        if childs:
-            for translation in self.translation_set:
-                result.update(translation.stats.get_invalidate_keys(parents=False))
-        return result
+    def get_update_objects(self):
+        yield self._object.project.stats
+        yield from self._object.project.stats.get_update_objects()
+
+        if self._object.category:
+            yield self._object.category.stats
+            yield from self._object.category.stats.get_update_objects()
+
+        for clist in self._object.componentlist_set.iterator():
+            yield clist.stats
+            yield from clist.stats.get_update_objects()
+
+        yield from super().get_update_objects()
+
+    def update_language_stats(self):
+        extras = []
+
+        # Update languages
+        for translation in self.translation_set:
+            translation.stats.update_stats(update_parents=False)
+            extras.extend(translation.stats.get_update_objects())
+
+        # Update our stats
+        self.update_stats()
+
+        # Update all parents
+        self.update_parents(extras)
 
     def get_language_stats(self):
         yield from (
@@ -1010,27 +1032,15 @@ class CategoryLanguageStats(LanguageStats):
 class CategoryStats(BaseStats):
     basic_keys = SOURCE_KEYS
 
-    def get_invalidate_keys(
-        self,
-        language: Language | None = None,
-        childs: bool = False,
-        parents: bool = True,
-    ):
-        result = super().get_invalidate_keys(language, childs, parents)
-        if parents:
-            result.update(self._object.project.stats.get_invalidate_keys(language))
-            if self._object.category:
-                result.update(self._object.category.stats.get_invalidate_keys(language))
-            if language:
-                result.update(
-                    self.get_single_language_stats(language).get_invalidate_keys()
-                )
-            else:
-                for lang in self._object.languages:
-                    result.update(
-                        self.get_single_language_stats(lang).get_invalidate_keys()
-                    )
-        return result
+    def get_update_objects(self):
+        yield self._object.project.stats
+        yield from self._object.project.stats.get_update_objects()
+
+        if self._object.category:
+            yield self._object.category.stats
+            yield from self._object.category.stats.get_update_objects()
+
+        yield from super().get_update_objects()
 
     @cached_property
     def component_set(self):
@@ -1083,25 +1093,6 @@ class ProjectStats(BaseStats):
     @cached_property
     def has_review(self):
         return self._object.enable_review
-
-    def get_invalidate_keys(
-        self,
-        language: Language | None = None,
-        childs: bool = False,
-        parents: bool = True,
-    ):
-        result = super().get_invalidate_keys(language, childs, parents)
-        if parents:
-            if language:
-                result.update(
-                    self.get_single_language_stats(language).get_invalidate_keys()
-                )
-            else:
-                for lang in self._object.languages:
-                    result.update(
-                        self.get_single_language_stats(lang).get_invalidate_keys()
-                    )
-        return result
 
     @cached_property
     def category_set(self):
@@ -1246,7 +1237,7 @@ class GhostStats(BaseStats):
     def cache_key(self):
         return "stats-zero"
 
-    def save(self):
+    def save(self, update_parents: bool = True):
         return
 
     def load(self):

--- a/weblate/utils/tasks.py
+++ b/weblate/utils/tasks.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML
 import weblate.utils.version
 from weblate.formats.models import FILE_FORMATS
 from weblate.machinery.models import MACHINERY
+from weblate.trans.models import Translation
 from weblate.trans.util import get_clean_env
 from weblate.utils.backup import backup_lock
 from weblate.utils.celery import app
@@ -69,6 +70,12 @@ def settings_backup():
         with open(data_dir("backups", "environment.yml"), "w") as handle:
             yaml = YAML()
             yaml.dump(dict(os.environ), handle)
+
+
+@app.task(trail=False)
+def update_translation_stats_parents(pk: int):
+    translation = Translation.objects.get(pk=pk)
+    translation.stats.update_parents()
 
 
 @app.task(trail=False, autoretry_for=(WeblateLockTimeoutError,))


### PR DESCRIPTION


## Proposed changes

Always calculate up-to-date stats for a translation on a change, parent stats are updated automatically in the background.

There is no explicit cache invalidation anymore to make sure some stats are always present (and thus nearly no request on higher level will force calculating them).

This might cause that parent stats are showing outdated number for very short time, but this should cause no harm.

Fixes #9662

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
