### PR TITLE
category: preserve the category id when creating a new component

### DIFF
--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -24,7 +24,7 @@
             {% endif %}
           {% elif add_link == "component-category" %}
             {% if user_can_edit_project %}
-              <a class="btn btn-link btn-sm" id="list-add-button" href="{% url 'create-component' %}?project={{ object.project.pk}}&amp;categry={{ object.pk }}" title="{% trans "Add new translation component" %}">{% icon "plus.svg" %}</a>
+              <a class="btn btn-link btn-sm" id="list-add-button" href="{% url 'create-component' %}?project={{ object.project.pk}}&amp;category={{ object.pk }}" title="{% trans "Add new translation component" %}">{% icon "plus.svg" %}</a>
             {% endif %}
           {% elif add_link == "language" %}
             {% if user_can_add_language %}


### PR DESCRIPTION
When you are inside a category and want to create a new component, you can either click "Manage > Add new translation component", or "+" (Add new translation component link)

This + link is on the left of the table's headers of the component list

There is a typo "categry" vs "category" which leads to an empty value on the second screen of the creation form (ie. the category is not pre-selected)