### PR TITLE
feature: Added url parameter to capitalize widget text

### DIFF
--- a/weblate/templates/widgets.html
+++ b/weblate/templates/widgets.html
@@ -44,7 +44,7 @@
 {% for widget in widget_list %}
 <div class="tab-pane {% if forloop.first %}active{% endif %}" id="{{ widget.name }}">
 
-  
+
 <div>
   <h3>{% trans "Customizing Badge Text Capitalization" %}</h3>
 
@@ -59,7 +59,7 @@
   </ul>
 
 </div>
-  
+
 <p>{% trans "Color variants:" %}</p>
 
 <p>

--- a/weblate/templates/widgets.html
+++ b/weblate/templates/widgets.html
@@ -44,6 +44,22 @@
 {% for widget in widget_list %}
 <div class="tab-pane {% if forloop.first %}active{% endif %}" id="{{ widget.name }}">
 
+  
+<div>
+  <h3>{% trans "Customizing Badge Text Capitalization" %}</h3>
+
+  <p>
+    {% trans "You can customize the capitalization of the translation badge text by using the 'badge_case' URL parameter. This parameter allows you to control the capitalization format of the badge text." %}
+  </p>
+
+  <p>{% trans "Available Options:" %}</p>
+  <ul>
+    <li><strong>lower:</strong> {% trans "Keep all letters in lowercase." %}</li>
+    <li><strong>capitalize:</strong> {% trans "Capitalize the first letter while keeping the rest of the letters in lowercase." %}</li>
+  </ul>
+
+</div>
+  
 <p>{% trans "Color variants:" %}</p>
 
 <p>

--- a/weblate/trans/tests/test_widgets.py
+++ b/weblate/trans/tests/test_widgets.py
@@ -83,6 +83,41 @@ class WidgetsRenderTest(FixtureTestCase, metaclass=WidgetsMeta):
 
         self.assert_widget(widget, response)
 
+   def test_widget_badge_case(self, widget, color):
+        # Test badge text capitalization customization
+        badge_case_lower = "lower"
+        badge_case_capitalize = "capitalize"
+
+        # Test with lowercase badge text (default)
+        response_lower = self.client.get(
+            reverse(
+                "widget-image",
+                kwargs={
+                    "path": self.project.get_url_path(),
+                    "widget": widget,
+                    "color": color,
+                    "extension": WIDGETS[widget].extension,
+                    "badge_case": badge_case_lower,
+                },
+            )
+        )
+        self.assert_widget(widget, response_lower)
+
+        # Test with capitalized badge text
+        response_capitalize = self.client.get(
+            reverse(
+                "widget-image",
+                kwargs={
+                    "path": self.project.get_url_path(),
+                    "widget": widget,
+                    "color": color,
+                    "extension": WIDGETS[widget].extension,
+                    "badge_case": badge_case_capitalize,
+                },
+            )
+        )
+        self.assert_widget(widget, response_capitalize)
+
 
 class WidgetsPercentRenderTest(WidgetsRenderTest):
     def perform_test(self, widget, color):

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -349,6 +349,15 @@ class SVGBadgeWidget(SVGWidget):
             "Kurinto Sans", Pango.Weight.NORMAL, 11, 0, f"  {percent_text}  "
         )[0].width
 
+        # Check for the 'badge_case' URL parameter and customize capitalization accordingly
+        badge_case = response.request.GET.get(
+            "badge_case", "lower"
+        )  # Default to lowercase
+
+        if badge_case == "capitalize":
+            translated_text = translated_text.capitalize()
+            percent_text = percent_text.capitalize()
+
         if self.percent >= 90:
             color = "#4c1"
         elif self.percent >= 75:


### PR DESCRIPTION
WIP

closes #9850 

## Proposed changes

I have added a url parameter as said by @nijel . 
By using ?badge_case="capitalize" , we can capitalize text in tanslate widget.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x ] Lint and unit tests pass locally with my changes.
- [ x] I have added tests that prove my fix is effective or that my feature works.
- [ x] I have added documentation to describe my feature.
- [x ] I have squashed my commits into logic units.
- [x ] I have described the changes in the commit messages.

## Other information


