### PR TITLE
translate: Show plural form examples more prominently

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@ Not yet released.
 * Enage page better shows stats.
 * Strings which can not be saved to a file no longer block other strings to be written.
 * Fixed some API URLs for categorized components.
+* Show plural form examples more prominently.
 
 **Bug fixes**
 

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -33,14 +33,13 @@ from weblate.logger import LOGGER
 from weblate.trans.defines import LANGUAGE_CODE_LENGTH, LANGUAGE_NAME_LENGTH
 from weblate.trans.mixins import CacheKeyMixin
 from weblate.trans.util import sort_objects, sort_unicode
-from weblate.utils.templatetags.icons import icon
 from weblate.utils.validators import validate_plural_formula
 
 PLURAL_RE = re.compile(
     r"\s*nplurals\s*=\s*([0-9]+)\s*;\s*plural\s*=\s*([()n0-9!=|&<>+*/%\s?:-]+)"
 )
 PLURAL_TITLE = """
-{name} <span title="{examples}">{icon}</span>
+{name} <span class="text-muted" title="{title}">({examples})</span>
 """
 COPY_RE = re.compile(r"\([0-9]+\)")
 KNOWN_SUFFIXES = {"hant", "hans", "latn", "cyrl", "shaw"}
@@ -830,6 +829,9 @@ class Plural(models.Model):
             if len(result[ret]) >= 10:
                 continue
             result[ret].append(str(i))
+        for example in result.values():
+            if len(example) >= 10:
+                example.append("…")
         return result
 
     @staticmethod
@@ -873,11 +875,8 @@ class Plural(models.Model):
         return format_html(
             PLURAL_TITLE,
             name=self.get_plural_name(idx),
-            icon=icon("info.svg"),
-            # Translators: Label for plurals with example counts
-            examples=gettext("For example: {0}").format(
-                ", ".join(self.examples.get(idx, []))
-            ),
+            examples=", ".join(self.examples.get(idx, [])),
+            title=gettext("Example counts for this plural form."),
         )
 
     def get_plural_name(self, idx):

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -474,7 +474,7 @@ class PluralTest(BaseTestCase):
         plural = Plural(number=2, formula="n!=1")
         self.assertEqual(
             plural.examples,
-            {0: ["1"], 1: ["0", "2", "3", "4", "5", "6", "7", "8", "9", "10"]},
+            {0: ["1"], 1: ["0", "2", "3", "4", "5", "6", "7", "8", "9", "10", "…"]},
         )
 
     def test_plurals(self):

--- a/weblate/static/style-bootstrap.css
+++ b/weblate/static/style-bootstrap.css
@@ -565,6 +565,7 @@ form + .login-label {
 .history-data .text-muted {
   font-size: 14px;
 }
+
 .history-data {
   padding-bottom: 4px;
 }
@@ -1935,4 +1936,7 @@ h5.list-group-item-heading {
 
 #show-linked-repo-toggle:not(:checked) ~ .repo-linked {
   display: none;
+}
+label .text-muted {
+  font-weight: normal;
 }


### PR DESCRIPTION
## Proposed changes

Instead of the tooltip, the text is rendered in the page now:

![image](https://github.com/WeblateOrg/weblate/assets/212189/258422f1-57e4-425c-ad56-253acf6ea5b4)


Fixes #9675
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
