### PR TITLE
utils: provide lock name in timeout error message for better debugging

### DIFF
--- a/weblate/utils/lock.py
+++ b/weblate/utils/lock.py
@@ -68,7 +68,7 @@ class WeblateLock:
 
         if not lock_result:
             raise WeblateLockTimeoutError(
-                f"Lock could not be acquired in {self._timeout}s"
+                f"Lock on {self._name} could not be acquired in {self._timeout}s"
             )
 
     def _enter_file(self):


### PR DESCRIPTION
## Proposed changes

Include the lock's name in the `WeblateLockTimeoutError` message to help with pinpointing which lock is affected.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

This is only for redis locks.
