### PR TITLE
stats: avoid fetching last change from database when doing it

### DIFF
--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -579,6 +579,9 @@ class Change(models.Model, UserDisplayMixin):
         super().save(*args, **kwargs)
         transaction.on_commit(lambda: notify_change.delay(self.pk))
         if self.is_last_content_change_storable():
+            # Update cache for stats so that it does not have to hit
+            # the database again
+            self.translation.stats.last_change_cache = self
             transaction.on_commit(self.update_cache_last_change)
 
     def get_absolute_url(self):

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -115,6 +115,7 @@ class BaseStats:
         self._object = obj
         self._data = None
         self._pending_save = False
+        self.last_change_cache = None
 
     @property
     def pk(self):
@@ -484,6 +485,10 @@ class TranslationStats(BaseStats):
 
     def get_last_change_obj(self):
         from weblate.trans.models import Change
+
+        # This is set in Change.save
+        if self.last_change_cache is not None:
+            return self.last_change_cache
 
         cache_key = Change.get_last_change_cache_key(self._object.pk)
         change_pk = cache.get(cache_key)


### PR DESCRIPTION
## Proposed changes

Improve logic to store the last change object locally as well so that update_stats() does not have to fetch it again. This needs to be done immediately to be available right after creating the change (contrary to what update_cache_last_change() does – it updates the cache for other processes).

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
