### PR TITLE
stats: drop ensure_* helpers

### DIFF
--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -343,7 +343,6 @@ def show_category_language(request, obj):
 
 
 def show_project(request, obj):
-    obj.stats.ensure_basic()
     user = request.user
 
     all_changes = obj.change_set.prefetch().order()
@@ -425,7 +424,6 @@ def show_project(request, obj):
 
 
 def show_category(request, obj):
-    obj.stats.ensure_basic()
     user = request.user
 
     all_changes = Change.objects.for_category(obj).prefetch().order()
@@ -509,7 +507,6 @@ def show_category(request, obj):
 
 
 def show_component(request, obj):
-    obj.stats.ensure_basic()
     user = request.user
 
     last_changes = obj.change_set.prefetch().order()[:10].preload("component")
@@ -576,7 +573,6 @@ def show_component(request, obj):
 def show_translation(request, obj):
     component = obj.component
     project = component.project
-    obj.stats.ensure_all()
     last_changes = obj.change_set.prefetch().order()[:10].preload("translation")
     user = request.user
 

--- a/weblate/utils/management/commands/ensure_stats.py
+++ b/weblate/utils/management/commands/ensure_stats.py
@@ -15,7 +15,8 @@ class Command(BaseCommand):
     help = "ensures that stats are present"
 
     def handle(self, *args, **options):
-        GlobalStats().ensure_basic()
+        all_strings = GlobalStats().all
+        self.stdout.write(f"found {all_strings} strings")
         if not Metric.objects.filter(
             date=timezone.now().date(), scope=Metric.SCOPE_GLOBAL
         ).exists():

--- a/weblate/utils/render.py
+++ b/weblate/utils/render.py
@@ -57,7 +57,6 @@ def render_template(template, **kwargs):
         kwargs["hook_name"] = kwargs["addon_name"]
 
     if isinstance(translation, Translation):
-        translation.stats.ensure_basic()
         kwargs["language_code"] = translation.language_code
         kwargs["language_name"] = translation.language.get_name()
         kwargs["stats"] = translation.stats.get_data()

--- a/weblate/utils/tests/test_commands.py
+++ b/weblate/utils/tests/test_commands.py
@@ -21,4 +21,4 @@ class DBCommandTests(TestCase):
     def test_stats(self):
         output = StringIO()
         call_command("ensure_stats", stdout=output)
-        self.assertEqual("", output.getvalue())
+        self.assertEqual("found 0 strings\n", output.getvalue())


### PR DESCRIPTION
## Proposed changes

Since https://github.com/WeblateOrg/weblate/pull/10269 there should be no performance difference in prefetch and getting individual values as both are calculated same. This makes the ensure_* helpers useless as lazy fetching produces same result with less code.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
