### PR TITLE
stats: cache none last change result as well

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -61,10 +61,10 @@ class TranslationManager(models.Manager):
         self, component, lang, code, path, force=False, request=None, change=None
     ):
         """Parse translation meta info and updates translation object."""
-        translation = component.translation_set.get_or_create(
+        translation, created = component.translation_set.get_or_create(
             language=lang,
             defaults={"filename": path, "language_code": code, "plural": lang.plural},
-        )[0]
+        )
         if translation.filename != path or translation.language_code != code:
             force = True
             translation.filename = path
@@ -80,6 +80,8 @@ class TranslationManager(models.Manager):
             translation.check_flags = flags
             translation.save(update_fields=["check_flags"])
         translation.check_sync(force, request=request, change=change)
+        if created:
+            Change.store_last_change(translation, None)
 
         return translation
 

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -515,7 +515,10 @@ class TranslationStats(BaseStats):
 
         cache_key = Change.get_last_change_cache_key(self._object.pk)
         change_pk = cache.get(cache_key)
-        if change_pk:
+        if change_pk == 0:
+            # No change
+            return None
+        if change_pk is not None:
             try:
                 return Change.objects.get(pk=change_pk)
             except Change.DoesNotExist:
@@ -523,6 +526,7 @@ class TranslationStats(BaseStats):
         try:
             last_change = self._object.change_set.content().order()[0]
         except IndexError:
+            Change.store_last_change(self._object, None)
             return None
         last_change.update_cache_last_change()
         return last_change


### PR DESCRIPTION
## Proposed changes

It is actually the most expensive one to get, so it makes sense to cache negative result as well.


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
