### PR TITLE
Add formality parameter to DeepL API integration

### DIFF
--- a/docs/admin/machine.rst
+++ b/docs/admin/machine.rst
@@ -112,11 +112,13 @@ DeepL
 -----
 
 :Service ID: ``deepl``
-:Configuration: +---------+---------+--+
-                | ``url`` | API URL |  |
-                +---------+---------+--+
-                | ``key`` | API key |  |
-                +---------+---------+--+
+:Configuration: +---------------+-----------+--+
+                | ``url``       | API URL   |  |
+                +---------------+-----------+--+
+                | ``key``       | API key   |  |
+                +---------------+-----------+--+
+                | ``formality`` | Formality |  |
+                +---------------+-----------+--+
 
 DeepL is paid service providing good machine translation for a few languages.
 You need to purchase :guilabel:`DeepL API` subscription or you can use legacy

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -254,8 +254,6 @@ class MachineTranslation:
         return False
 
     def translate_cache_key(self, source, language, text, threshold):
-        if not self.cache_translations:
-            return None
         return "mt:{}:{}:{}:{}".format(
             self.mtid,
             calculate_hash(source, language),
@@ -341,13 +339,13 @@ class MachineTranslation:
         raise UnsupportedLanguageError("Not supported")
 
     def get_cached(self, source, language, text, threshold, replacements):
+        if not self.cache_translations:
+            return None, None
         cache_key = self.translate_cache_key(source, language, text, threshold)
-        if cache_key:
-            result = cache.get(cache_key)
-            if result and (replacements or self.force_uncleanup):
-                self.uncleanup_results(replacements, result)
-            return cache_key, result
-        return cache_key, None
+        result = cache.get(cache_key)
+        if result and (replacements or self.force_uncleanup):
+            self.uncleanup_results(replacements, result)
+        return cache_key, result
 
     def search(self, unit, text, user):
         """Search for known translations of `text`."""

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -62,7 +62,9 @@ class DeepLTranslation(MachineTranslation):
 
     # using custom cache key to ensure that formal and informal suggestions are cached separately
     def translate_cache_key(self, source, language, text, threshold):
-        return super().translate_cache_key(source, language, text, threshold) + self.settings.get("formality", "default")
+        return super().translate_cache_key(
+            source, language, text, threshold
+        ) + self.settings.get("formality", "default")
 
     def download_translations(
         self,

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -26,7 +26,8 @@ class DeepLTranslation(MachineTranslation):
 
     def __init__(self, settings: dict[str, str]):
         super().__init__(settings)
-        self.mtid = self.mtid + "_" + settings['formality']
+        self.formality =  self.settings["formality"] if "formality" in self.settings else "default"
+        self.mtid = self.mtid + "_" + self.formality
 
     def map_language_code(self, code):
         """Convert language to service specific code."""
@@ -78,7 +79,7 @@ class DeepLTranslation(MachineTranslation):
             "text": text,
             "source_lang": source,
             "target_lang": language,
-            "formality": self.settings["formality"] if "formality" in self.settings else "default",
+            "formality": self.formality,
             "tag_handling": "xml",
             "ignore_tags": "x",
         }

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -24,13 +24,6 @@ class DeepLTranslation(MachineTranslation):
     hightlight_syntax = True
     settings_form = DeepLMachineryForm
 
-    def __init__(self, settings: dict[str, str]):
-        super().__init__(settings)
-        self.formality = (
-            self.settings["formality"] if "formality" in self.settings else "default"
-        )
-        self.mtid = self.mtid + "_" + self.formality
-
     def map_language_code(self, code):
         """Convert language to service specific code."""
         return super().map_language_code(code).replace("_", "-").upper()
@@ -66,6 +59,10 @@ class DeepLTranslation(MachineTranslation):
     def is_supported(self, source, language):
         """Check whether given language combination is supported."""
         return (source, language) in self.supported_languages
+
+    # using custom cache key to ensure that formal and informal suggestions are cached separately
+    def translate_cache_key(self, source, language, text, threshold):
+        return super().translate_cache_key(source, language, text, threshold) + self.settings.get("formality", "default")
 
     def download_translations(
         self,

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -81,7 +81,7 @@ class DeepLTranslation(MachineTranslation):
             "text": text,
             "source_lang": source,
             "target_lang": language,
-            "formality": self.formality,
+            "formality": self.settings.get("formality", "default"),
             "tag_handling": "xml",
             "ignore_tags": "x",
         }

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -24,6 +24,10 @@ class DeepLTranslation(MachineTranslation):
     hightlight_syntax = True
     settings_form = DeepLMachineryForm
 
+    def __init__(self, settings: dict[str, str]):
+        super().__init__(settings)
+        self.mtid = self.mtid + "_" + settings['formality']
+
     def map_language_code(self, code):
         """Convert language to service specific code."""
         return super().map_language_code(code).replace("_", "-").upper()
@@ -74,6 +78,7 @@ class DeepLTranslation(MachineTranslation):
             "text": text,
             "source_lang": source,
             "target_lang": language,
+            "formality": self.settings["formality"] if "formality" in self.settings else "default",
             "tag_handling": "xml",
             "ignore_tags": "x",
         }

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -62,9 +62,9 @@ class DeepLTranslation(MachineTranslation):
 
     # using custom cache key to ensure that formal and informal suggestions are cached separately
     def translate_cache_key(self, source, language, text, threshold):
-        return super().translate_cache_key(
-            source, language, text, threshold
-        ) + self.settings.get("formality", "default")
+        key = super().translate_cache_key(source, language, text, threshold)
+        formality = self.settings.get("formality", "default")
+        return f"{key}:{formality}"
 
     def download_translations(
         self,

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -26,7 +26,9 @@ class DeepLTranslation(MachineTranslation):
 
     def __init__(self, settings: dict[str, str]):
         super().__init__(settings)
-        self.formality =  self.settings["formality"] if "formality" in self.settings else "default"
+        self.formality = (
+            self.settings["formality"] if "formality" in self.settings else "default"
+        )
         self.mtid = self.mtid + "_" + self.formality
 
     def map_language_code(self, code):

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -219,7 +219,7 @@ class DeepLMachineryForm(KeyURLMachineryForm):
     )
     formality = forms.CharField(
         label=pgettext_lazy(
-            "Automatic suggestion service configuration", "Default formality"
+            "Automatic suggestion service configuration", "Formality"
         ),
         help_text=gettext_lazy(
             "Uses the specified formality if language is not specified as (in)formal"

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -61,7 +61,6 @@ class LibreTranslateMachineryForm(KeyURLMachineryForm):
         required=False,
     )
 
-
 class MyMemoryMachineryForm(BaseMachineryForm):
     email = forms.EmailField(
         label=pgettext_lazy(
@@ -211,9 +210,14 @@ class ModernMTMachineryForm(KeyURLMachineryForm):
         initial="https://api.modernmt.com/",
     )
 
-
 class DeepLMachineryForm(KeyURLMachineryForm):
     url = forms.URLField(
         label=pgettext_lazy("Automatic suggestion service configuration", "API URL"),
         initial="https://api.deepl.com/v2/",
+    )
+    formality = forms.CharField(
+        label=pgettext_lazy("Automatic suggestion service configuration", "Default formality"),
+        help_text=gettext_lazy("Uses the specified formality if language is not specified as (in)formal"),
+        widget=forms.Select(choices=(('default ','Default'),('prefer_more','Formal'),('prefer_less','Informal'))),
+        initial="default",
     )

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -218,9 +218,7 @@ class DeepLMachineryForm(KeyURLMachineryForm):
         initial="https://api.deepl.com/v2/",
     )
     formality = forms.CharField(
-        label=pgettext_lazy(
-            "Automatic suggestion service configuration", "Formality"
-        ),
+        label=pgettext_lazy("Automatic suggestion service configuration", "Formality"),
         help_text=gettext_lazy(
             "Uses the specified formality if language is not specified as (in)formal"
         ),

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -61,6 +61,7 @@ class LibreTranslateMachineryForm(KeyURLMachineryForm):
         required=False,
     )
 
+
 class MyMemoryMachineryForm(BaseMachineryForm):
     email = forms.EmailField(
         label=pgettext_lazy(
@@ -210,14 +211,25 @@ class ModernMTMachineryForm(KeyURLMachineryForm):
         initial="https://api.modernmt.com/",
     )
 
+
 class DeepLMachineryForm(KeyURLMachineryForm):
     url = forms.URLField(
         label=pgettext_lazy("Automatic suggestion service configuration", "API URL"),
         initial="https://api.deepl.com/v2/",
     )
     formality = forms.CharField(
-        label=pgettext_lazy("Automatic suggestion service configuration", "Default formality"),
-        help_text=gettext_lazy("Uses the specified formality if language is not specified as (in)formal"),
-        widget=forms.Select(choices=(('default ','Default'),('prefer_more','Formal'),('prefer_less','Informal'))),
+        label=pgettext_lazy(
+            "Automatic suggestion service configuration", "Default formality"
+        ),
+        help_text=gettext_lazy(
+            "Uses the specified formality if language is not specified as (in)formal"
+        ),
+        widget=forms.Select(
+            choices=(
+                ("default ", "Default"),
+                ("prefer_more", "Formal"),
+                ("prefer_less", "Informal"),
+            )
+        ),
         initial="default",
     )

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -232,4 +232,5 @@ class DeepLMachineryForm(KeyURLMachineryForm):
             )
         ),
         initial="default",
+        required=False,
     )


### PR DESCRIPTION
## Proposed changes

I added an option to the DeepL API integration to specify the formality.
Link to DeepL API: https://www.deepl.com/docs-api/translate-text

This PR adds a dropdown-setting to the configuration screen of the DeepL integration, with 3 options:
Default (which is the default and sets `formality` to `default`)
Informal (this sets `formality` to `prefer_less`)
Formal (this sets `formality` to `prefer_more`)

This PR also adjusts the `mtid` field of the `MachineTranslation` to make sure the caching works correct (informal/formal/default texts of DeepL suggestions are cached separately).

The `@FORMAL` and `@INFORMAL` language id endings have precedence over this new setting.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
I am not very familiar with Python or Django, so I didn't know what the best way is to translate the config options and label/help text for the new `CharField`