### PR TITLE
specialchars: add soft hyphen (U+00AD) button

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -405,7 +405,7 @@ function initHighlight(root) {
       let whitespace_regex = new RegExp(
         [
           "  +|(^) +| +(?=$)| +\n|\n +|\t|",
-          "\u00A0|\u1680|\u2000|\u2001|",
+          "\u00A0|\u00AD|\u1680|\u2000|\u2001|",
           "\u2002|\u2003|\u2004|\u2005|",
           "\u2006|\u2007|\u2008|\u2009|",
           "\u200A|\u202F|\u205F|\u3000",

--- a/weblate/trans/specialchars.py
+++ b/weblate/trans/specialchars.py
@@ -273,6 +273,7 @@ def get_special_chars(language, additional="", source=""):  # noqa: C901
     yield get_quote(code, ALT_CLOSE, gettext("Alternative closing quote"))
 
     if code in HYPHEN_LANGS:
+        yield format_char("\u00AD")
         yield gettext("Hyphen"), "‐", "‐"
 
     if code in EN_DASH_LANGS:

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -67,7 +67,7 @@ GLOSSARY_TEMPLATE = """<span class="glossary-term" title="{}">"""
 
 # This should match whitespace_regex in weblate/static/loader-bootstrap.js
 WHITESPACE_REGEX = (
-    r"(\t|\u00A0|\u1680|\u2000|\u2001|\u2002|\u2003|"
+    r"(\t|\u00A0|\u00AD|\u1680|\u2000|\u2001|\u2002|\u2003|"
     r"\u2004|\u2005|\u2006|\u2007|\u2008|\u2009|\u200A|"
     r"\u202F|\u205F|\u3000)"
 )

--- a/weblate/trans/tests/test_specialchars.py
+++ b/weblate/trans/tests/test_specialchars.py
@@ -23,11 +23,11 @@ class SpecialCharsTest(TestCase):
 
     def test_af(self):
         chars = list(get_special_chars(Language(code="af")))
-        self.assertEqual(len(chars), 11)
+        self.assertEqual(len(chars), 12)
 
     def test_cs(self):
         chars = list(get_special_chars(Language(code="cs")))
-        self.assertEqual(len(chars), 10)
+        self.assertEqual(len(chars), 11)
 
     def test_brx(self):
         chars = list(get_special_chars(Language(code="brx")))
@@ -40,17 +40,17 @@ class SpecialCharsTest(TestCase):
     @override_settings(SPECIAL_CHARS=[chr(x) for x in range(256)])
     def test_settings(self):
         chars = list(get_special_chars(Language(code="cs")))
-        self.assertEqual(len(chars), 262)
+        self.assertEqual(len(chars), 263)
 
     def test_additional(self):
         self.check_chars(
-            Language(code="cs"), 14, ["a", "h", "o", "j"], additional="ahoj"
+            Language(code="cs"), 15, ["a", "h", "o", "j"], additional="ahoj"
         )
 
     def test_arrows(self):
-        self.check_chars(Language(code="cs"), 12, ["→", "⇒"], source="→⇒→⇒")
+        self.check_chars(Language(code="cs"), 13, ["→", "⇒"], source="→⇒→⇒")
 
     def test_arrows_rtl(self):
         self.check_chars(
-            Language(code="ar", direction="rtl"), 13, ["←", "⇐"], source="→⇒→⇒"
+            Language(code="ar", direction="rtl"), 14, ["←", "⇐"], source="→⇒→⇒"
         )


### PR DESCRIPTION
Related to #3006

## Proposed changes

When a languge has hyphens then show a button in the visual keyboard to insert a [soft hyphen](https://en.wikipedia.org/wiki/Soft_hyphen). 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Using `WHITESPACE_REGEX` to get a red highlight in the editor where there are soft hyphens.
