### PR TITLE
specialchars: use iso symbol as soft hyphen button for better clarity

### DIFF
--- a/weblate/trans/specialchars.py
+++ b/weblate/trans/specialchars.py
@@ -17,7 +17,7 @@ CHAR_NAMES = {
     "…": gettext_lazy("Insert horizontal ellipsis"),
     "\u00AD": gettext_lazy("Insert a soft hyphen"),
 }
-DISPLAY_CHARS = {"\t": "↹", "\n": "↵", "\u00AD": "SHY"}
+DISPLAY_CHARS = {"\t": "↹", "\n": "↵", "\u00AD": "﹙-﹚"}
 
 
 HYPHEN_LANGS = {


### PR DESCRIPTION
## Proposed changes

A button with the text "SHY" might not be that clear for non-technical people. Replace it with something that looks similar to the ISO symbol for the soft hypen.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Icon from [Wikipedia](https://en.wikipedia.org/wiki/Soft_hyphen) and [this proposal to Unicode](https://www.unicode.org/L2/L2017/17072-symbols-9995.pdf#page=5). U+2433 never got included in the [Control Pictures Unicode block](https://en.wikipedia.org/wiki/Control_Pictures), so no font has a representation for this.

### Comparison:

Before:
![image](https://github.com/WeblateOrg/weblate/assets/139211597/10507e7f-32bf-4b02-abb2-7ab19d88fadf)

After:
![image](https://github.com/WeblateOrg/weblate/assets/139211597/dd4e9396-77f2-45ca-8c9e-2bc106084284)

