### PR TITLE
ui: include readonly in approved percentage listing to match with progress bars

### DIFF
--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -151,7 +151,7 @@
       <a href="{{ category.get_absolute_url }}">{{ category.name }}</a>
     </th>
     {% if project and project.enable_review %}
-      {% include "snippets/list-objects-percent.html" with percent=category.stats.approved_percent value=category.stats.approved query="q=state:>=approved" all=category.stats.all class="zero-width-540" %}
+      {% review_percent category.stats %}
     {% endif %}
     {% include "snippets/list-objects-percent.html" with percent=category.stats.translated_percent value=category.stats.translated query="q=state:>=translated" all=category.stats.all %}
     {% if not hide_details %}
@@ -242,7 +242,7 @@
 {% endif %}
 </th>
 {% if project and project.enable_review %}
-  {% include "snippets/list-objects-percent.html" with percent=object.stats.approved_percent value=object.stats.approved query="q=state:>=approved" all=object.stats.all class="zero-width-540" %}
+  {% review_percent object.stats %}
 {% endif %}
 {% if is_glossary %}
   {% include "snippets/list-objects-number.html" with value=object.stats.translated query="q=state:>=translated" show_zero=True %}

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -711,6 +711,19 @@ def get_stats(obj):
     return obj.stats
 
 
+@register.inclusion_tag("snippets/list-objects-percent.html")
+def review_percent(obj):
+    stats = get_stats(obj)
+
+    return {
+        "value": stats.approved + stats.readonly,
+        "percent": stats.approved_percent + stats.readonly_percent,
+        "query": "q=state:>=approved",
+        "all": stats.all,
+        "class": "zero-width-540",
+    }
+
+
 def translation_progress_data(
     total: int, readonly: int, approved: int, translated: int, has_review: bool
 ):


### PR DESCRIPTION
## Proposed changes

Count read-only strings to the approved percentage number shown in object listings.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

The progress bars display both approved and read-only strings as "Approved".
Also in the string status page both read-only strings and approved strings have the same colour.

Since #9936 the percentage of approved strings is shown as a number in the object listing, but without considering read-only strings.

This leads to a visual mis-match between the progress bars and the number:

![image](https://github.com/WeblateOrg/weblate/assets/139211597/31c0b359-aaf1-4d70-b8a5-ae18907db5aa)
