### PR TITLE
checks: Support for Perl brace format (#10626)

### DIFF
--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -707,6 +707,24 @@ Percent placeholders
 
    :ref:`check-formats`,
 
+.. _check-perl-brace-format:
+
+Perl brace format
+*****************
+
+:Summary: Perl brace format string does not match source
+:Scope: translated strings
+:Check class: ``weblate.checks.format.PerlBraceFormatCheck``
+:Check identifier: ``perl_brace_format``
+:Flag to enable: ``perl-brace-format``
+:Flag to ignore: ``ignore-perl-brace-format``
+:Named format string example: ``There are {number} apples``
+
+.. seealso::
+
+   :ref:`check-formats`,
+   `Perl Format Strings <https://www.gnu.org/software/gettext/manual/html_node/perl_002dformat.html>`_
+
 .. _check-perl-format:
 
 Perl format

--- a/weblate/checks/format.py
+++ b/weblate/checks/format.py
@@ -128,6 +128,8 @@ PYTHON_BRACE_MATCH = re.compile(
     re.VERBOSE,
 )
 
+PERL_BRACE_MATCH = re.compile(r"({([a-zA-Z0-9_]+)})")
+
 C_SHARP_MATCH = re.compile(
     r"""
         {                               # initial {
@@ -247,6 +249,7 @@ FLAG_RULES = {
     "c-format": (C_PRINTF_MATCH, c_format_is_position_based),
     "object-pascal-format": (PASCAL_FORMAT_MATCH, pascal_format_is_position_based),
     "perl-format": (C_PRINTF_MATCH, c_format_is_position_based),
+    "perl-brace-format": (PERL_BRACE_MATCH, name_format_is_position_based),
     "javascript-format": (C_PRINTF_MATCH, c_format_is_position_based),
     "lua-format": (C_PRINTF_MATCH, c_format_is_position_based),
     "python-brace-format": (PYTHON_BRACE_MATCH, name_format_is_position_based),
@@ -498,6 +501,19 @@ class CFormatCheck(BasePrintfCheck):
     check_id = "c_format"
     name = gettext_lazy("C format")
     description = gettext_lazy("C format string does not match source")
+
+
+class PerlBraceFormatCheck(BaseFormatCheck):
+    """Check for Perl brace format string."""
+
+    check_id = "perl_brace_format"
+    name = gettext_lazy("Perl brace format")
+    description = gettext_lazy("Perl brace format string does not match source")
+    regexp = PERL_BRACE_MATCH
+    plural_parameter_regexp = re.compile(r"\{(?:count|number|num|n)\}")
+
+    def is_position_based(self, string):
+        return name_format_is_position_based(string)
 
 
 class PerlFormatCheck(CFormatCheck):

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -49,6 +49,7 @@ class WeblateChecksConf(AppConf):
         "weblate.checks.format.PHPFormatCheck",
         "weblate.checks.format.CFormatCheck",
         "weblate.checks.format.PerlFormatCheck",
+        "weblate.checks.format.PerlBraceFormatCheck",
         "weblate.checks.format.JavaScriptFormatCheck",
         "weblate.checks.format.LuaFormatCheck",
         "weblate.checks.format.ObjectPascalFormatCheck",

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -981,6 +981,7 @@ CHECK_LIST = [
     "weblate.checks.format.PHPFormatCheck",
     "weblate.checks.format.CFormatCheck",
     "weblate.checks.format.PerlFormatCheck",
+    "weblate.checks.format.PerlBraceFormatCheck",
     "weblate.checks.format.JavaScriptFormatCheck",
     "weblate.checks.format.LuaFormatCheck",
     "weblate.checks.format.ObjectPascalFormatCheck",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -636,6 +636,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 #     "weblate.checks.format.PHPFormatCheck",
 #     "weblate.checks.format.CFormatCheck",
 #     "weblate.checks.format.PerlFormatCheck",
+#     "weblate.checks.format.PerlBraceFormatCheck",
 #     "weblate.checks.format.JavaScriptFormatCheck",
 #     "weblate.checks.format.LuaFormatCheck",
 #     "weblate.checks.format.ObjectPascalFormatCheck",


### PR DESCRIPTION
perl-format and perl-brace-format are distinct
https://www.gnu.org/software/gettext/manual/html_node/perl_002dformat.html

This patch adds support for perl-brace-format:
  "There are {number} apples"

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
