### PR TITLE
stats: last_changed now reflects changes outside Weblate as well

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,8 @@ Not yet released.
 
 **Compatibility**
 
+* Last changed timestamp now reflects changes outside Weblate as well. This affects both :ref:`api` and user interface.
+
 **Upgrading**
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -605,6 +605,10 @@ class Change(models.Model, UserDisplayMixin):
             # Update cache for stats so that it does not have to hit
             # the database again
             self.translation.stats.last_change_cache = self
+            if self.translation.stats.is_loaded:
+                self.translation.stats.fetch_last_change()
+            self.translation.invalidate_cache()
+
             transaction.on_commit(self.update_cache_last_change)
 
     def get_absolute_url(self):
@@ -654,7 +658,7 @@ class Change(models.Model, UserDisplayMixin):
         cache.set(cache_key, change.pk if change else 0, 180 * 86400)
 
     def is_last_content_change_storable(self):
-        return self.translation_id and self.action in self.ACTIONS_CONTENT
+        return self.translation_id
 
     def update_cache_last_change(self):
         self.store_last_change(self.translation, self)

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -81,9 +81,6 @@ class TranslationManager(models.Manager):
             translation.check_flags = flags
             translation.save(update_fields=["check_flags"])
         translation.check_sync(force, request=request, change=change)
-        if created:
-            Change.store_last_change(translation, None)
-
         return translation
 
 

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -172,6 +172,7 @@ class BaseStats:
 
         Used in stats endpoints.
         """
+        self.ensure_loaded()
         percents = [
             "translated_percent",
             "approved_percent",
@@ -688,7 +689,7 @@ class TranslationStats(BaseStats):
             except Change.DoesNotExist:
                 pass
         try:
-            last_change = self._object.change_set.content().order()[0]
+            last_change = self._object.change_set.order()[0]
         except IndexError:
             Change.store_last_change(self._object, None)
             return None


### PR DESCRIPTION
## Proposed changes

It used to track only changes by users inside Weblate, now it reflects all changes to the translation - including repository updates, comments or commits.

Fixes #6548
See #10512


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
