### PR TITLE
translation: delay emitting post commit signal

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1968,7 +1968,7 @@ class Component(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
 
         # Fire postponed post commit signals
         for component in components.values():
-            vcs_post_commit.send(sender=self.__class__, component=component)
+            component.send_post_commit_signal()
             component.store_local_revision()
             component.update_import_alerts(delete=False)
 
@@ -2021,7 +2021,7 @@ class Component(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
 
             # Send post commit signal
             if signals:
-                vcs_post_commit.send(sender=self.__class__, component=self)
+                self.send_post_commit_signal()
 
             self.store_local_revision()
 
@@ -2030,6 +2030,9 @@ class Component(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
                 self.push_if_needed()
 
             return True
+
+    def send_post_commit_signal(self):
+        vcs_post_commit.send(sender=self.__class__, component=self)
 
     def get_parse_error_message(self, error) -> str:
         error_message = getattr(error, "strerror", "")

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1088,6 +1088,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
                 files=filenames,
                 author=request.user.get_author_name(),
                 extra_context={"addon_name": "Source update"},
+                signals=False,
             ):
                 self.handle_store_change(
                     request,
@@ -1095,6 +1096,9 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
                     previous_revision,
                     change=Change.ACTION_REPLACE_UPLOAD,
                 )
+                # Emit signals later to avoid cleanup add-on to store translation
+                # revision before parsing
+                component.send_post_commit_signal()
         return (0, 0, self.unit_set.count(), self.unit_set.count())
 
     def handle_replace(self, request, fileobj):
@@ -1125,7 +1129,10 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
             # Commit to VCS
             previous_revision = self.component.repository.last_revision
             if self.git_commit(
-                request.user, request.user.get_author_name(), store_hash=False
+                request.user,
+                request.user.get_author_name(),
+                store_hash=False,
+                signals=False,
             ):
                 # Drop store cache
                 self.handle_store_change(
@@ -1134,6 +1141,9 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
                     previous_revision,
                     change=Change.ACTION_REPLACE_UPLOAD,
                 )
+                # Emit signals later to avoid cleanup add-on to store translation
+                # revision before parsing
+                self.component.send_post_commit_signal()
 
         return (0, 0, self.unit_set.count(), len(store2.content_units))
 


### PR DESCRIPTION


## Proposed changes
With early trigger, the translation files are not yet parsed and the update might be skipped. Emiting signals later avoids cleanup add-on to store translation revision before parsing.

Fixes #10763
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
