### PR TITLE
utils: Fixed generating query with aliased tables

### DIFF
--- a/weblate/utils/db.py
+++ b/weblate/utils/db.py
@@ -6,7 +6,7 @@
 
 from django.db import connections, models
 from django.db.models import Case, IntegerField, Sum, When
-from django.db.models.lookups import Contains, Exact, PatternLookup, Regex
+from django.db.models.lookups import PatternLookup, Regex
 
 from .inv_regex import invert_re
 
@@ -75,71 +75,40 @@ def count_alnum(string):
     return sum(map(str.isalnum, string))
 
 
-class PostgreSQLFallbackLookup(PatternLookup):
-    def __init__(self, lhs, rhs):
-        self.orig_lhs = lhs
-        self.orig_rhs = rhs
-        super().__init__(lhs, rhs)
-
-    def needs_fallback(self):
-        return isinstance(self.orig_rhs, str) and count_alnum(self.orig_rhs) <= 3
-
-
-class FallbackStringMixin:
-    """Avoid using index for lhs by concatenating to a string."""
-
+class PostgreSQLFallbackLookupMixin:
     def process_lhs(self, compiler, connection, lhs=None):
-        lhs_sql, params = super().process_lhs(compiler, connection, lhs)
-        return f"{lhs_sql} || ''", params
+        if self._needs_fallback:
+            lhs_sql, params = super().process_lhs(compiler, connection, lhs)
+            return f"{lhs_sql} || ''", params
+        return super().process_lhs(compiler, connection, lhs)
 
 
-class PostgreSQLRegexFallbackLookup(FallbackStringMixin, Regex):
-    pass
-
-
-class PostgreContainsFallbackLookup(FallbackStringMixin, Contains):
-    pass
-
-
-class PostgreExactFallbackLookup(FallbackStringMixin, Exact):
-    pass
-
-
-class PostgreSQLRegexLookup(Regex):
+class PostgreSQLFallbackLookup(PostgreSQLFallbackLookupMixin, PatternLookup):
     def __init__(self, lhs, rhs):
-        self.orig_lhs = lhs
-        self.orig_rhs = rhs
+        self._needs_fallback = isinstance(rhs, str) and count_alnum(rhs) <= 3
         super().__init__(lhs, rhs)
 
-    def needs_fallback(self):
-        if not isinstance(self.orig_rhs, str):
-            return False
-        return (
-            min((count_alnum(match) for match in invert_re(self.orig_rhs)), default=0)
-            < 3
-        )
 
-    def as_sql(self, compiler, connection):
-        if self.needs_fallback():
-            return PostgreSQLRegexFallbackLookup(self.orig_lhs, self.orig_rhs).as_sql(
-                compiler, connection
-            )
-        return super().as_sql(compiler, connection)
+class PostgreSQLRegexLookup(PostgreSQLFallbackLookupMixin, Regex):
+    def __init__(self, lhs, rhs):
+        self._needs_fallback = isinstance(rhs, str) and (
+            min((count_alnum(match) for match in invert_re(rhs)), default=0) < 3
+        )
+        super().__init__(lhs, rhs)
 
 
 class PostgreSQLSearchLookup(PostgreSQLFallbackLookup):
     lookup_name = "search"
-    param_pattern = "%s"
 
-    def as_sql(self, compiler, connection):
-        if self.needs_fallback():
-            return PostgreContainsFallbackLookup(self.orig_lhs, self.orig_rhs).as_sql(
-                compiler, connection
-            )
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return f"{lhs} %% {rhs} = true", params
+    def process_rhs(self, qn, connection):
+        if not self._needs_fallback:
+            self.param_pattern = "%s"
+        return super().process_rhs(qn, connection)
+
+    def get_rhs_op(self, connection, rhs):
+        if self._needs_fallback:
+            return connection.operators["contains"] % rhs
+        return "%%%% %s = true" % rhs
 
 
 class MySQLSearchLookup(models.Lookup):
@@ -162,15 +131,10 @@ class PostgreSQLSubstringLookup(PostgreSQLFallbackLookup):
 
     lookup_name = "substring"
 
-    def as_sql(self, compiler, connection):
-        if self.needs_fallback():
-            return PostgreContainsFallbackLookup(self.orig_lhs, self.orig_rhs).as_sql(
-                compiler, connection
-            )
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return f"{lhs} ILIKE {rhs}", params
+    def get_rhs_op(self, connection, rhs):
+        if self._needs_fallback:
+            return connection.operators["contains"] % rhs
+        return "ILIKE %s" % rhs
 
 
 def re_escape(pattern):


### PR DESCRIPTION
## Proposed changes

Generate SQL directly instead of doing intermediate objects for fallback. These would not get proper table aliases causing wrong SQL being generated (ProgrammingError).

Fixes WEBLATE-65M
Fixes #10620


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
