### PR TITLE
chore: avoid using QuerySet.first() when None is not handled

### DIFF
--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -690,9 +690,7 @@ class NewAlertNotificaton(Notification):
             fake.project = fake.component.project
             return bool(list(self.get_users(FREQ_INSTANT, fake, users=[user.pk])))
         if change.alert.obj.project_wide:
-            first_component = change.component.project.component_set.order_by(
-                "id"
-            ).first()
+            first_component = change.component.project.component_set.order_by("id")[0]
             # Notify for the first component
             if change.component.id == first_component.id:
                 return True

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -130,7 +130,7 @@ class UserAPITest(APIBaseTest):
     def test_get(self):
         response = self.do_request(
             "api:user-detail",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="get",
             superuser=True,
             code=200,
@@ -184,14 +184,14 @@ class UserAPITest(APIBaseTest):
         group = Group.objects.get(name="Viewers")
         self.do_request(
             "api:user-groups",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="post",
             code=403,
             request={"group_id": group.id},
         )
         self.do_request(
             "api:user-groups",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="post",
             superuser=True,
             code=400,
@@ -199,7 +199,7 @@ class UserAPITest(APIBaseTest):
         )
         self.do_request(
             "api:user-groups",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="post",
             superuser=True,
             code=200,
@@ -208,7 +208,7 @@ class UserAPITest(APIBaseTest):
 
     def test_remove_group(self):
         group = Group.objects.get(name="Viewers")
-        username = User.objects.filter(is_active=True).first().username
+        username = User.objects.filter(is_active=True)[0].username
         self.do_request(
             "api:user-groups",
             kwargs={"username": username},
@@ -246,7 +246,7 @@ class UserAPITest(APIBaseTest):
     def test_list_notifications(self):
         response = self.do_request(
             "api:user-notifications",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="get",
             superuser=True,
             code=200,
@@ -256,13 +256,13 @@ class UserAPITest(APIBaseTest):
     def test_post_notifications(self):
         self.do_request(
             "api:user-notifications",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="post",
             code=403,
         )
         self.do_request(
             "api:user-notifications",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="post",
             superuser=True,
             code=201,
@@ -275,7 +275,7 @@ class UserAPITest(APIBaseTest):
         self.assertEqual(Subscription.objects.count(), 10)
 
     def test_get_notifications(self):
-        user = User.objects.filter(is_active=True).first()
+        user = User.objects.filter(is_active=True)[0]
         self.do_request(
             "api:user-notifications-details",
             kwargs={"username": user.username, "subscription_id": 1000},
@@ -286,23 +286,21 @@ class UserAPITest(APIBaseTest):
             "api:user-notifications-details",
             kwargs={
                 "username": user.username,
-                "subscription_id": Subscription.objects.filter(user=user).first().id,
+                "subscription_id": Subscription.objects.filter(user=user)[0].id,
             },
             method="get",
             code=200,
         )
 
     def test_put_notifications(self):
-        user = User.objects.filter(is_active=True).first()
+        user = User.objects.filter(is_active=True)[0]
         response = self.do_request(
             "api:user-notifications-details",
             kwargs={
                 "username": user.username,
                 "subscription_id": Subscription.objects.filter(
                     user=user, notification="NewAnnouncementNotificaton"
-                )
-                .first()
-                .id,
+                )[0].id,
             },
             method="put",
             superuser=True,
@@ -316,16 +314,14 @@ class UserAPITest(APIBaseTest):
         self.assertEqual(response.data["notification"], "RepositoryNotification")
 
     def test_patch_notifications(self):
-        user = User.objects.filter(is_active=True).first()
+        user = User.objects.filter(is_active=True)[0]
         response = self.do_request(
             "api:user-notifications-details",
             kwargs={
                 "username": user.username,
                 "subscription_id": Subscription.objects.filter(
                     user=user, notification="NewAnnouncementNotificaton"
-                )
-                .first()
-                .id,
+                )[0].id,
             },
             method="patch",
             superuser=True,
@@ -335,12 +331,12 @@ class UserAPITest(APIBaseTest):
         self.assertEqual(response.data["notification"], "RepositoryNotification")
 
     def test_delete_notifications(self):
-        user = User.objects.filter(is_active=True).first()
+        user = User.objects.filter(is_active=True)[0]
         self.do_request(
             "api:user-notifications-details",
             kwargs={
                 "username": user.username,
-                "subscription_id": Subscription.objects.filter(user=user).first().id,
+                "subscription_id": Subscription.objects.filter(user=user)[0].id,
             },
             method="delete",
             superuser=True,
@@ -349,7 +345,7 @@ class UserAPITest(APIBaseTest):
         self.assertEqual(Subscription.objects.count(), 8)
 
     def test_statistics(self):
-        user = User.objects.filter(is_active=True).first()
+        user = User.objects.filter(is_active=True)[0]
         request = self.do_request(
             "api:user-statistics",
             kwargs={"username": user.username},
@@ -360,13 +356,13 @@ class UserAPITest(APIBaseTest):
     def test_put(self):
         self.do_request(
             "api:user-detail",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="put",
             code=403,
         )
         self.do_request(
             "api:user-detail",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="put",
             superuser=True,
             code=200,
@@ -377,24 +373,24 @@ class UserAPITest(APIBaseTest):
                 "is_active": True,
             },
         )
-        self.assertEqual(User.objects.filter(is_active=True).first().full_name, "Name")
+        self.assertEqual(User.objects.filter(is_active=True)[0].full_name, "Name")
 
     def test_patch(self):
         self.do_request(
             "api:user-detail",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="patch",
             code=403,
         )
         self.do_request(
             "api:user-detail",
-            kwargs={"username": User.objects.filter(is_active=True).first().username},
+            kwargs={"username": User.objects.filter(is_active=True)[0].username},
             method="patch",
             superuser=True,
             code=200,
             request={"full_name": "Other"},
         )
-        self.assertEqual(User.objects.filter(is_active=True).first().full_name, "Other")
+        self.assertEqual(User.objects.filter(is_active=True)[0].full_name, "Other")
 
 
 class GroupAPITest(APIBaseTest):
@@ -2258,7 +2254,7 @@ class MemoryAPITest(APIBaseTest):
     def test_delete(self):
         self.do_request(
             "api:memory-detail",
-            kwargs={"pk": Memory.objects.first().pk},
+            kwargs={"pk": Memory.objects.all()[0].pk},
             method="delete",
             superuser=True,
             code=204,
@@ -3682,7 +3678,7 @@ class ChangeAPITest(APIBaseTest):
 
     def test_filter_changes_before(self):
         """Filter changes prior to timestamp."""
-        start = Change.objects.order().first().timestamp - timedelta(seconds=60)
+        start = Change.objects.order()[0].timestamp - timedelta(seconds=60)
         response = self.client.get(
             reverse("api:change-list"), {"timestamp_before": start.isoformat()}
         )
@@ -4112,7 +4108,7 @@ class LabelAPITest(APIBaseTest):
     def test_create_label(self):
         self.do_request(
             "api:project-labels",
-            kwargs={"slug": Project.objects.first().slug},
+            kwargs={"slug": Project.objects.all()[0].slug},
             method="post",
             superuser=True,
             request={
@@ -4124,7 +4120,7 @@ class LabelAPITest(APIBaseTest):
 
         self.do_request(
             "api:project-labels",
-            kwargs={"slug": Project.objects.first().slug},
+            kwargs={"slug": Project.objects.all()[0].slug},
             method="post",
             superuser=False,
             request={

--- a/weblate/lang/management/commands/move_language.py
+++ b/weblate/lang/management/commands/move_language.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from weblate.lang.models import Language, Plural
+from weblate.lang.models import Language
 from weblate.utils.management.base import BaseCommand
 
 
@@ -42,9 +42,11 @@ class Command(BaseCommand):
             group.languages.add(target)
 
         for plural in source.plural_set.iterator():
+            formulas = target.plural_set.filter(formula=plural.formula)
             try:
-                new_plural = target.plural_set.filter(formula=plural.formula).first()
-                plural.translation_set.update(plural=new_plural)
-            except Plural.DoesNotExist:
+                new_plural = formulas[0]
+            except IndexError:
                 plural.language = target
                 plural.save()
+            else:
+                plural.translation_set.update(plural=new_plural)

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -69,7 +69,7 @@ class MemoryModelTest(TransactionsTestMixin, FixtureTestCase):
                     "original_source": "Hello",
                     "text": "Ahoj",
                     "show_quality": True,
-                    "delete_url": f"/api/memory/{Memory.objects.first().pk}/",
+                    "delete_url": f"/api/memory/{Memory.objects.all()[0].pk}/",
                 }
             ],
         )

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -397,8 +397,10 @@ class ProjectBackup:
         source_translation_id = -1
         for item in data["translations"]:
             language = self.import_language(item["language_code"])
-            plural = language.plural_set.filter(**item["plural"]).first()
-            if plural is None:
+            plurals = language.plural_set.filter(**item["plural"])
+            try:
+                plural = plurals[0]
+            except IndexError:
                 if item["plural"]["source"] == Plural.SOURCE_DEFAULT:
                     plural = language.plural
                 elif item["plural"]["source"] in (
@@ -409,7 +411,7 @@ class ProjectBackup:
                 else:
                     plural = language.plural_set.filter(
                         source=item["plural"]["source"]
-                    ).first()
+                    )[0]
             translation = Translation(
                 component=component,
                 filename=item["filename"],

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -31,7 +31,7 @@ class BackupsTest(ViewTestCase):
     def test_create_backup(self):
         # Additional content to test on backups
         label = self.project.label_set.create(name="Label", color="navy")
-        unit = self.component.source_translation.unit_set.first()
+        unit = self.component.source_translation.unit_set.all()[0]
         unit.labels.add(label)
         shot = Screenshot.objects.create(
             name="Obrazek", translation=self.component.source_translation

--- a/weblate/trans/tests/test_changes.py
+++ b/weblate/trans/tests/test_changes.py
@@ -47,7 +47,7 @@ class ChangesTest(ViewTestCase):
 
     def test_string(self):
         response = self.client.get(
-            reverse("changes", kwargs={"path": Unit.objects.first().get_url_path()})
+            reverse("changes", kwargs={"path": Unit.objects.all()[0].get_url_path()})
         )
         self.assertContains(response, "Source string added")
         self.assertContains(response, "Changes of string in")

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -532,7 +532,7 @@ class ComponentDeleteTest(RepoTestCase):
         component = self.create_component()
         # Introduce missing source string check. This can happen when adding new check
         # on upgrade or similar situation.
-        unit = Unit.objects.filter(check__isnull=False).first().source_unit
+        unit = Unit.objects.filter(check__isnull=False)[0].source_unit
         unit.source = "Test..."
         unit.save(update_fields=["source"])
         unit.check_set.filter(name="ellipisis").delete()

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -134,7 +134,7 @@ class ProjectTest(RepoTestCase):
             )
             user = create_test_user()
             translation = component.translation_set.get(language_code="cs")
-            unit = translation.unit_set.first()
+            unit = translation.unit_set.all()[0]
             suggestion = Suggestion.objects.add(unit, ["Test"], None)
             Vote.objects.create(suggestion=suggestion, value=Vote.POSITIVE, user=user)
         component.project.delete()

--- a/weblate/utils/tests/test_db.py
+++ b/weblate/utils/tests/test_db.py
@@ -53,7 +53,7 @@ class SearchSQLOperatorTest(FixtureTestCase):
         # This is essentially what bulk edit does with such search
         from weblate.trans.models import Component, Project, Unit
 
-        obj = Project.objects.first()
+        obj = Project.objects.all()[0]
         unit_set = Unit.objects.filter(translation__component__project=obj).prefetch()
         matching = unit_set.search("10°", project=obj)
         components = Component.objects.filter(


### PR DESCRIPTION
## Proposed changes

The first() might return None when object is not present what is not well handled in some situations. The code should crash on getting instead.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
