### PR TITLE
unit: use enum for string states

### DIFF
--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -31,7 +31,7 @@ from weblate.trans.models import (
 )
 from weblate.trans.util import check_upload_method_permissions, cleanup_repo_url
 from weblate.utils.site import get_site_url
-from weblate.utils.state import STATE_CHOICES, STATE_READONLY
+from weblate.utils.state import STATE_READONLY, StringState
 from weblate.utils.validators import validate_bitmap
 from weblate.utils.views import (
     create_component_from_doc,
@@ -1094,7 +1094,9 @@ class UnitWriteSerializer(serializers.ModelSerializer):
 
 class NewUnitSerializer(serializers.Serializer):
     state = serializers.ChoiceField(
-        choices=[choice for choice in STATE_CHOICES if choice[0] != STATE_READONLY],
+        choices=[
+            choice for choice in StringState.choices if choice[0] != STATE_READONLY
+        ],
         required=False,
     )
 

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -21,7 +21,7 @@ from weblate.trans.mixins import UserDisplayMixin
 from weblate.trans.models.alert import ALERTS
 from weblate.trans.models.project import Project
 from weblate.utils.pii import mask_email
-from weblate.utils.state import STATE_LOOKUP
+from weblate.utils.state import StringState
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -696,9 +696,9 @@ class Change(models.Model, UserDisplayMixin):
 
     def get_state_display(self):
         state = self.details.get("state")
-        if not state:
+        if state is None:
             return ""
-        return STATE_LOOKUP[state]
+        return StringState(state).label
 
     def is_merge_failure(self):
         return self.action in self.ACTIONS_MERGE_FAILURE

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -50,6 +50,7 @@ from weblate.utils.state import (
     STATE_FUZZY,
     STATE_READONLY,
     STATE_TRANSLATED,
+    StringState,
 )
 from weblate.utils.stats import GhostStats, TranslationStats
 
@@ -1372,7 +1373,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
         auto_context: bool = False,
         is_batch_update: bool = False,
         skip_existing: bool = False,
-        state: int | None = None,
+        state: StringState | None = None,
     ):
         if isinstance(source, list):
             source = join_plural(source)
@@ -1466,9 +1467,11 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
             if unit is None:
                 if "read-only" in translation.all_flags:
                     unit_state = STATE_READONLY
-                elif has_translation and (state is None or state == STATE_EMPTY):
+                elif state is None:
+                    unit_state = STATE_TRANSLATED if has_translation else STATE_EMPTY
+                elif has_translation and state == STATE_EMPTY:
                     unit_state = STATE_TRANSLATED
-                elif not has_translation and (state is None or state != STATE_EMPTY):
+                elif not has_translation and state != STATE_EMPTY:
                     unit_state = STATE_EMPTY
                 else:
                     unit_state = state

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -47,11 +47,11 @@ from weblate.utils.hash import calculate_hash, hash_to_checksum
 from weblate.utils.search import parse_query
 from weblate.utils.state import (
     STATE_APPROVED,
-    STATE_CHOICES,
     STATE_EMPTY,
     STATE_FUZZY,
     STATE_READONLY,
     STATE_TRANSLATED,
+    StringState,
 )
 
 if TYPE_CHECKING:
@@ -351,8 +351,10 @@ class Unit(models.Model, LoggerMixin):
     source = models.TextField()
     previous_source = models.TextField(default="", blank=True)
     target = models.TextField(default="", blank=True)
-    state = models.IntegerField(default=STATE_EMPTY, choices=STATE_CHOICES)
-    original_state = models.IntegerField(default=STATE_EMPTY, choices=STATE_CHOICES)
+    state = models.IntegerField(default=STATE_EMPTY, choices=StringState.choices)
+    original_state = models.IntegerField(
+        default=STATE_EMPTY, choices=StringState.choices
+    )
     details = models.JSONField(default=dict)
 
     position = models.IntegerField()

--- a/weblate/utils/state.py
+++ b/weblate/utils/state.py
@@ -2,23 +2,31 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db.models import IntegerChoices
 from django.utils.translation import pgettext_lazy
 
-STATE_EMPTY = 0
-STATE_FUZZY = 10
-STATE_TRANSLATED = 20
-STATE_APPROVED = 30
-STATE_READONLY = 100
+if TYPE_CHECKING:
+    from django_stubs_ext import StrOrPromise
 
-STATE_CHOICES = (
-    (STATE_EMPTY, pgettext_lazy("String state", "Empty")),
-    (STATE_FUZZY, pgettext_lazy("String state", "Needs editing")),
-    (STATE_TRANSLATED, pgettext_lazy("String state", "Translated")),
-    (STATE_APPROVED, pgettext_lazy("String state", "Approved")),
-    (STATE_READONLY, pgettext_lazy("String state", "Read only")),
-)
 
-STATE_LOOKUP = dict(STATE_CHOICES)
+class StringState(IntegerChoices):
+    STATE_EMPTY = 0, pgettext_lazy("String state", "Empty")
+    STATE_FUZZY = 10, pgettext_lazy("String state", "Needs editing")
+    STATE_TRANSLATED = 20, pgettext_lazy("String state", "Translated")
+    STATE_APPROVED = 30, pgettext_lazy("String state", "Approved")
+    STATE_READONLY = 100, pgettext_lazy("String state", "Read only")
+
+
+STATE_EMPTY = StringState.STATE_EMPTY
+STATE_FUZZY = StringState.STATE_FUZZY
+STATE_TRANSLATED = StringState.STATE_TRANSLATED
+STATE_APPROVED = StringState.STATE_APPROVED
+STATE_READONLY = StringState.STATE_READONLY
+
 
 STATE_NAMES = {
     "empty": STATE_EMPTY,
@@ -30,3 +38,11 @@ STATE_NAMES = {
     "readonly": STATE_READONLY,
     "read-only": STATE_READONLY,
 }
+
+
+def get_state_label(
+    state: int, label: StrOrPromise, enable_review: bool
+) -> StrOrPromise:
+    if state == STATE_TRANSLATED and enable_review:
+        return pgettext_lazy("String state", "Waiting for review")
+    return label


### PR DESCRIPTION
## Proposed changes

- introduce StringState enum to track string state
- reuse it's verbose labels for choices instead of doing it again with a different content

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
