### PR TITLE
backups: use static files to download project backup

### DIFF
--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -44,6 +44,8 @@ from weblate.utils.validators import validate_filename
 from weblate.utils.version import VERSION
 from weblate.vcs.models import VCS_REGISTRY
 
+PROJECTBACKUP_PREFIX = "projectbackups"
+
 
 class BackupListDict(TypedDict):
     name: str
@@ -143,7 +145,7 @@ class ProjectBackup:
             handle.write(json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8"))
 
     def generate_filename(self, project):
-        backup_dir = data_dir("projectbackups", f"{project.pk}")
+        backup_dir = data_dir(PROJECTBACKUP_PREFIX, f"{project.pk}")
         backup_info = os.path.join(backup_dir, "README.txt")
         timestamp = int(self.timestamp.timestamp())
         if not os.path.exists(backup_dir):
@@ -612,7 +614,7 @@ class ProjectBackup:
         return self.project
 
     def store_for_import(self):
-        backup_dir = data_dir("projectbackups", "import")
+        backup_dir = data_dir(PROJECTBACKUP_PREFIX, "import")
         if not os.path.exists(backup_dir):
             os.makedirs(backup_dir)
         timestamp = int(timezone.now().timestamp())

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -612,7 +612,9 @@ class Project(models.Model, PathMixin, CacheKeyMixin):
         return settings
 
     def list_backups(self) -> list[BackupListDict]:
-        backup_dir = data_dir("projectbackups", f"{self.pk}")
+        from weblate.trans.backups import PROJECTBACKUP_PREFIX
+
+        backup_dir = data_dir(PROJECTBACKUP_PREFIX, f"{self.pk}")
         result = []
         if not os.path.exists(backup_dir):
             return result

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -2,10 +2,15 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
+import os
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
-from django.http import FileResponse, Http404, JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -14,6 +19,7 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView, View
 
+from weblate.trans.backups import PROJECTBACKUP_PREFIX
 from weblate.trans.forms import (
     AddCategoryForm,
     AnnouncementForm,
@@ -38,9 +44,11 @@ from weblate.trans.tasks import (
     component_removal,
     create_project_backup,
     project_removal,
+    remove_project_backup_download,
 )
 from weblate.trans.util import redirect_param, render
 from weblate.utils import messages
+from weblate.utils.random import get_random_identifier
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.utils.views import parse_path, show_form_errors
 
@@ -368,10 +376,18 @@ class BackupsView(BackupsMixin, TemplateView):
 class BackupsDownloadView(BackupsMixin, View):
     def get(self, request, *args, **kwargs):
         for backup in self.obj.list_backups():
-            if backup["name"] == kwargs["backup"]:
-                return FileResponse(
-                    open(backup["path"], "rb"),  # noqa: SIM115
-                    as_attachment=True,
-                    filename=backup["name"],
-                )
+            if backup["name"] != kwargs["backup"]:
+                continue
+            # Generate random name for download
+            name = os.path.join(
+                PROJECTBACKUP_PREFIX, f"{get_random_identifier(32)}.zip"
+            )
+            # Copy to static files
+            with open(backup["path"], "rb") as handle:
+                name = staticfiles_storage.save(name, handle)
+            # Schedule removal
+            if not settings.CELERY_TASK_ALWAYS_EAGER:
+                remove_project_backup_download.apply_async(args=(name,), countdown=3600)
+            # Redirect to static
+            return redirect(staticfiles_storage.url(name))
         raise Http404


### PR DESCRIPTION
## Proposed changes

These can be huge and would block wsgi for long. Instead, we copy the file temporarily to the static storage and redirect to it. This way the download is handled directly by the web server, which can handle it more effectively than wsgi and can also support resuming of interrupted download. As a side effect, it can be donwloaded via command line tools as the randomly generated temporary URL doesn't require authentication.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
