### PR TITLE
basic languages: factor in the default variant of languages without a base form

### DIFF
--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -4,6 +4,7 @@
 
 from django.utils.translation import pgettext_lazy
 from weblate_language_data import languages
+from weblate_language_data.aliases import ALIASES
 from weblate_language_data.ambiguous import AMBIGUOUS
 
 NO_CODE_LANGUAGES = {lang[0] for lang in languages.LANGUAGES}
@@ -20,11 +21,21 @@ UNDERSCORE_EXCEPTIONS = {
 AT_EXCEPTIONS = {"ca@valencia"}
 
 
+def is_default_variant(code):
+    language = code.partition("_")[0]
+    if (
+        language not in NO_CODE_LANGUAGES
+        and language in ALIASES
+    ):
+        return code == ALIASES[language]
+    return False
+
+
 def is_basic(code):
     if code in AMBIGUOUS:
         return False
     if "_" in code:
-        return code in UNDERSCORE_EXCEPTIONS
+        return code in UNDERSCORE_EXCEPTIONS or is_default_variant(code)
     return "@" not in code or code in AT_EXCEPTIONS
 
 

--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -23,10 +23,7 @@ AT_EXCEPTIONS = {"ca@valencia"}
 
 def is_default_variant(code):
     language = code.partition("_")[0]
-    if (
-        language not in NO_CODE_LANGUAGES
-        and language in ALIASES
-    ):
+    if language not in NO_CODE_LANGUAGES and language in ALIASES:
         return code == ALIASES[language]
     return False
 

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -4,6 +4,8 @@
 
 """Test for language manipulations."""
 
+import warnings
+
 from gettext import c2py
 from io import StringIO
 from itertools import chain
@@ -203,36 +205,35 @@ class BasicLanguagesTest(TestCase):
     def check_presence(languages, reference=False):
         result = 0
         base_alias = None
-        for i, l in enumerate(languages):
-            if l is None:
+        for i, lang in enumerate(languages):
+            if lang is None:
                 continue
             if reference:
                 if i == 0:
-                    check = l in data.NO_CODE_LANGUAGES
+                    check = lang in data.NO_CODE_LANGUAGES
                 else:
                     if i == 1:
                         base_language = languages[0]
                         if base_language in ALIASES:
                             base_alias = ALIASES[base_language]
                     check = (
-                        l == base_alias and not result & BASE_FORM
-                    ) or l in data.UNDERSCORE_EXCEPTIONS
+                        lang == base_alias and not result & BASE_FORM
+                    ) or lang in data.UNDERSCORE_EXCEPTIONS
             else:
-                check = l in data.BASIC_LANGUAGES
+                check = lang in data.BASIC_LANGUAGES
             result += check << i
         if reference:
             if base_alias is None or base_alias == languages[1]:
                 return (result,)
-            else:
-                return result, base_alias, base_alias in data.BASIC_LANGUAGES
+            return result, base_alias, base_alias in data.BASIC_LANGUAGES
         return result
 
     @staticmethod
     def list_languages(bitset, languages):
         langs = []
-        for i, l in enumerate(languages):
+        for i, lang in enumerate(languages):
             if bitset & 1 << i:
-                langs.append(l)
+                langs.append(lang)
         return langs if langs else None
 
     @staticmethod
@@ -246,7 +247,7 @@ class BasicLanguagesTest(TestCase):
             base_language = language_forms[0]
             adapted, *base_alias = self.check_presence(language_forms, True)
             if adapted != expected:
-                print(
+                warnings.warn(
                     f"Unexpected results for '{base_language}' language group. Adapting test case to current language-data."
                 )
                 adaptive.append(base_language)
@@ -266,11 +267,11 @@ class BasicLanguagesTest(TestCase):
 
     def test_basic_languages(self):
         heads_up = []
-        for i, l in enumerate(TEST_LANGUAGE_GROUPS):
-            with self.subTest(f"Testing the '{l[0]}' language group", i=i):
-                self.run_test(l, heads_up)
+        for i, lang in enumerate(TEST_LANGUAGE_GROUPS):
+            with self.subTest(f"Testing the '{lang[0]}' language group", i=i):
+                self.run_test(lang, heads_up)
         if heads_up:
-            print(
+            warnings.warn(
                 f"Perhaps the test case needs to catch up with language-data for {heads_up}?"
             )
 

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -169,41 +169,36 @@ TEST_LANGUAGES = (
 # Constants for BasicLanguagesTest
 
 # bit masks
-BASE_FORM    = 1
-BASE_ALIAS   = 1 << 1
+BASE_FORM = 1
+BASE_ALIAS = 1 << 1
 BASE_VARIANT = 1 << 2
 
 # combinations
-BASE_LANGUAGE_ONLY   = BASE_FORM
+BASE_LANGUAGE_ONLY = BASE_FORM
 DEFAULT_VARIANT_ONLY = BASE_ALIAS
-TWO_VARIANTS_ONLY    = BASE_ALIAS | BASE_VARIANT
-BASE_PLUS_VARIANT    = BASE_FORM | BASE_VARIANT
+TWO_VARIANTS_ONLY = BASE_ALIAS | BASE_VARIANT
+BASE_PLUS_VARIANT = BASE_FORM | BASE_VARIANT
 
 TEST_LANGUAGE_GROUPS = (
     # We've got 'en' language and its variants like 'en_US' and 'en_GB' will not be present in the default list of basic languages
     ("en", None, "en_US", "en_GB", BASE_LANGUAGE_ONLY),
-
     # There is no standalone 'zh' language but rather 'zh_Hans' and 'zh_Hant' as UNDERSCORE_EXCEPTIONS
     ("zh", "zh_Hans", "zh_Hant", TWO_VARIANTS_ONLY),
-
     # The base language 'be' stands alongside 'be_Latn' as basic languages
     ("be", None, "be_Latn", BASE_PLUS_VARIANT),
-
     # Both the base language and a variant in UNDERSCORE_EXCEPTIONS as basic languages
     ("pt", None, "pt_BR", BASE_PLUS_VARIANT),
-
     # 'nb' being alias for the 'nb_NO' language instead
     ("nb", "nb_NO", DEFAULT_VARIANT_ONLY),
-
     # We no longer have standalone 'yue' and 'nan' languages, so keep their aliases 'yue_Hant' and 'nan_Hant' in basic languages instead
     ("yue", "yue_Hant", "yue_Hans", DEFAULT_VARIANT_ONLY),
-    ("nan", "nan_Hant", "nan_Latn", DEFAULT_VARIANT_ONLY)
+    ("nan", "nan_Hant", "nan_Latn", DEFAULT_VARIANT_ONLY),
 )
 
 
 class BasicLanguagesTest(TestCase):
     """Test for the default list of basic languages."""
-    
+
     @staticmethod
     def check_presence(languages, reference=False):
         result = 0
@@ -219,13 +214,15 @@ class BasicLanguagesTest(TestCase):
                         base_language = languages[0]
                         if base_language in ALIASES:
                             base_alias = ALIASES[base_language]
-                    check = (l == base_alias and not result & BASE_FORM) or l in data.UNDERSCORE_EXCEPTIONS
+                    check = (
+                        l == base_alias and not result & BASE_FORM
+                    ) or l in data.UNDERSCORE_EXCEPTIONS
             else:
                 check = l in data.BASIC_LANGUAGES
             result += check << i
         if reference:
             if base_alias is None or base_alias == languages[1]:
-                return result,
+                return (result,)
             else:
                 return result, base_alias, base_alias in data.BASIC_LANGUAGES
         return result
@@ -249,22 +246,33 @@ class BasicLanguagesTest(TestCase):
             base_language = language_forms[0]
             adapted, *base_alias = self.check_presence(language_forms, True)
             if adapted != expected:
-                print(f"Unexpected results for '{base_language}' language group. Adapting test case to current language-data.")
+                print(
+                    f"Unexpected results for '{base_language}' language group. Adapting test case to current language-data."
+                )
                 adaptive.append(base_language)
             if adapted == 0:
-                self.skipTest(f"Never mind. '{base_language}' is not present in the list of languages and no alias is found.")
+                self.skipTest(
+                    f"Never mind. '{base_language}' is not present in the list of languages and no alias is found."
+                )
             expected = adapted
             if not expected & BASE_FORM and base_alias:
-                self.assertTrue(base_alias[1], f"There is no standalone '{base_language}' language and its alias '{base_alias[0]}' is not present in basic languages.")
-        self.assertEqual(result, expected, self.get_friendly_result(result, expected, language_forms))
- 
+                self.assertTrue(
+                    base_alias[1],
+                    f"There is no standalone '{base_language}' language and its alias '{base_alias[0]}' is not present in basic languages.",
+                )
+        self.assertEqual(
+            result, expected, self.get_friendly_result(result, expected, language_forms)
+        )
+
     def test_basic_languages(self):
         heads_up = []
         for i, l in enumerate(TEST_LANGUAGE_GROUPS):
             with self.subTest(f"Testing the '{l[0]}' language group", i=i):
                 self.run_test(l, heads_up)
         if heads_up:
-            print(f"Perhaps the test case needs to catch up with language-data for {heads_up}?")
+            print(
+                f"Perhaps the test case needs to catch up with language-data for {heads_up}?"
+            )
 
 
 class TestSequenceMeta(type):

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -247,7 +247,8 @@ class BasicLanguagesTest(TestCase):
             adapted, *base_alias = self.check_presence(language_forms, True)
             if adapted != expected:
                 warnings.warn(
-                    f"Unexpected results for '{base_language}' language group. Adapting test case to current language-data.", stacklevel=1
+                    f"Unexpected results for '{base_language}' language group. Adapting test case to current language-data.",
+                    stacklevel=1,
                 )
                 adaptive.append(base_language)
             if adapted == 0:
@@ -271,7 +272,8 @@ class BasicLanguagesTest(TestCase):
                 self.run_test(lang, heads_up)
         if heads_up:
             warnings.warn(
-                f"Perhaps the test case needs to catch up with language-data for {heads_up}?", stacklevel=1
+                f"Perhaps the test case needs to catch up with language-data for {heads_up}?",
+                stacklevel=1,
             )
 
 

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -247,7 +247,7 @@ class BasicLanguagesTest(TestCase):
             adapted, *base_alias = self.check_presence(language_forms, True)
             if adapted != expected:
                 warnings.warn(
-                    f"Unexpected results for '{base_language}' language group. Adapting test case to current language-data."
+                    f"Unexpected results for '{base_language}' language group. Adapting test case to current language-data.", stacklevel=1
                 )
                 adaptive.append(base_language)
             if adapted == 0:
@@ -271,7 +271,7 @@ class BasicLanguagesTest(TestCase):
                 self.run_test(lang, heads_up)
         if heads_up:
             warnings.warn(
-                f"Perhaps the test case needs to catch up with language-data for {heads_up}?"
+                f"Perhaps the test case needs to catch up with language-data for {heads_up}?", stacklevel=1
             )
 
 

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -5,7 +5,6 @@
 """Test for language manipulations."""
 
 import warnings
-
 from gettext import c2py
 from io import StringIO
 from itertools import chain

--- a/weblate/trans/tests/test_newlang.py
+++ b/weblate/trans/tests/test_newlang.py
@@ -127,19 +127,10 @@ class NewLangTest(ViewTestCase):
         self.reset_rate()
         response = self.client.post(
             reverse("new-language", kwargs=self.kw_component),
-            lang,
+            {"lang": "af"},
             follow=True,
         )
         self.assertContains(response, "Please fix errors in the form")
-
-        # Language without base form
-        self.reset_rate()
-        response = self.client.post(
-            reverse("new-language", kwargs=self.kw_component),
-            {"lang": "yue_Hant"},
-            follow=True,
-        )
-        self.assertNotContains(response, "Please fix errors in the form")
 
     def test_add_owner(self):
         self.component.project.add_user(self.user, "Administration")

--- a/weblate/trans/tests/test_newlang.py
+++ b/weblate/trans/tests/test_newlang.py
@@ -127,10 +127,19 @@ class NewLangTest(ViewTestCase):
         self.reset_rate()
         response = self.client.post(
             reverse("new-language", kwargs=self.kw_component),
-            {"lang": "af"},
+            lang,
             follow=True,
         )
         self.assertContains(response, "Please fix errors in the form")
+
+        # Language without base form
+        self.reset_rate()
+        response = self.client.post(
+            reverse("new-language", kwargs=self.kw_component),
+            {"lang": "yue_Hant"},
+            follow=True,
+        )
+        self.assertNotContains(response, "Please fix errors in the form")
 
     def test_add_owner(self):
         self.component.project.add_user(self.user, "Administration")


### PR DESCRIPTION
A regression was introduced a while back when a couple of languages were split into their respective couple of variants in [language-data](https://github.com/WeblateOrg/language-data/commits/main/weblate_language_data/languages.py?since=2023-04-18&until=2023-04-18) and, thereby, here got filtered out of the default list of basic languages altogether since they no longer present themselves in their base form.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Instead of adding them to `UNDERSCORE_EXCEPTIONS` to resurrect their pre-split position, this PR tries to adopt a more future-proof approach to the default list of basic languages to include the default variant of languages without a base form (when an alias for which is present) such that they would not be filtered out of the default list of basic languages altogether just because, some point in time, they cease to stand alone 'bare feet' in Weblate's list of languages.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->

Subject to manual overrides, the list of basic languages is presented to the user in the "Start new translation" page, which says they would need to contact the project maintainer if they wish to add a language not on that list.
