### PR TITLE
component: Improve duplication of components

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Not yet released.
 
 * :ref:`subscriptions` now include strings which need updating.
 * Improved compatibility with password managers.
+* :ref:`trans` Clone more settings automatically during duplication of existing component.
 
 **Bug fixes**
 

--- a/weblate/templates/component.html
+++ b/weblate/templates/component.html
@@ -96,6 +96,7 @@
       <li><a href="{% url 'manage-access' project=object.project.slug %}">{% trans "Users" %}</a></li>
       {% endif %}
       {% if user_can_edit_component %}
+      <li><a href="{% url 'create-component' %}?component={{ object.id }}#existing">{% trans "Duplicate Component" %}</li>
       <li><a href="{% url 'guide' path=object.get_url_path %}">{% trans "Community localization checklist" %}</a></li>
       <li><a href="{% url 'addons' path=object.get_url_path %}">{% trans "Add-ons" %}</a></li>
       {% endif %}

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1686,10 +1686,27 @@ class ComponentCreateForm(SettingsBaseForm, ComponentDocsMixin, ComponentAntispa
             "language_regex",
             "source_language",
             "is_glossary",
+            "agreement",
+            "merge_style",
+            "commit_message",
+            "add_message",
+            "delete_message",
+            "merge_message",
+            "addon_message",
+            "pull_message",
         ]
         widgets = {
             "source_language": SortedSelect,
             "language_code_style": SortedSelect,
+            "license": forms.HiddenInput(),
+            "agreement": forms.HiddenInput(),
+            "merge_style": forms.HiddenInput(),
+            "commit_message": forms.HiddenInput(),
+            "add_message": forms.HiddenInput(),
+            "delete_message": forms.HiddenInput(),
+            "merge_message": forms.HiddenInput(),
+            "addon_message": forms.HiddenInput(),
+            "pull_message": forms.HiddenInput(),
         }
 
 

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -24,7 +24,7 @@ from django.utils.functional import cached_property
 from weblate.auth.models import User
 from weblate.configuration.models import Setting
 from weblate.formats.models import FILE_FORMATS
-from weblate.trans.models import Component, Project
+from weblate.trans.models import Category, Component, Project
 from weblate.utils.files import remove_tree
 from weblate.vcs.models import VCS_REGISTRY
 
@@ -167,6 +167,12 @@ class RepoTestMixin:
         self.addCleanup(remove_tree, project.full_path, True)
         return project
 
+    def create_category(self, project, **kwargs):
+        """Create test category."""
+        return Category.objects.create(
+            name="Test", slug="test", project=project, **kwargs
+        )
+
     def format_local_path(self, path):
         """Format path for local access to the repository."""
         if sys.platform != "win32":
@@ -188,6 +194,8 @@ class RepoTestMixin:
             raise SkipTest(f"File format {file_format} is not supported!")
         if "project" not in kwargs:
             kwargs["project"] = self.create_project()
+        if "category" not in kwargs:
+            kwargs["category"] = self.create_category(project=kwargs["project"])
 
         repo = push = self.format_local_path(getattr(self, f"{vcs}_repo_path"))
         if vcs not in VCS_REGISTRY:

--- a/weblate/trans/views/create.py
+++ b/weblate/trans/views/create.py
@@ -432,6 +432,7 @@ class CreateComponentSelection(CreateComponent):
 
     components: ComponentQuerySet
     origin = None
+    duplicate_existing_component = None
 
     @cached_property
     def branch_data(self):
@@ -463,6 +464,16 @@ class CreateComponentSelection(CreateComponent):
             self.components = self.components.filter(project__pk=self.selected_project)
         self.origin = request.POST.get("origin")
 
+        try:
+            self.duplicate_existing_component = int(request.GET.get("component"))
+        except (ValueError, TypeError):
+            self.duplicate_existing_component = None
+        self.initial = {}
+        if self.duplicate_existing_component:
+            self.initial["component"] = Component.objects.get(
+                pk=self.duplicate_existing_component
+            )
+
     def get_context_data(self, **kwargs):
         kwargs = super().get_context_data(**kwargs)
         kwargs["components"] = self.components
@@ -493,6 +504,10 @@ class CreateComponentSelection(CreateComponent):
             ).order_project()
             form.branch_data = self.branch_data
         elif isinstance(form, ComponentSelectForm):
+            if self.duplicate_existing_component:
+                self.components |= Component.objects.filter(
+                    pk=self.duplicate_existing_component
+                )
             form.fields["component"].queryset = self.components
         return form
 
@@ -518,12 +533,22 @@ class CreateComponentSelection(CreateComponent):
         component = form.cleaned_data["component"]
         if self.origin == "existing":
             return self.redirect_create(
-                repo=component.get_repo_link_url(),
+                repo=component.repo or component.get_repo_link_url(),
                 project=component.project.pk,
+                category=component.category.pk if component.category else "",
                 name=form.cleaned_data["name"],
                 slug=form.cleaned_data["slug"],
                 vcs=component.vcs,
                 source_language=component.source_language.pk,
+                license=component.license,
+                agreement=component.agreement,
+                merge_style=component.merge_style,
+                commit_message=component.commit_message,
+                add_message=component.add_message,
+                delete_message=component.delete_message,
+                merge_message=component.merge_message,
+                addon_message=component.addon_message,
+                pull_message=component.pull_message,
             )
         if self.origin == "branch":
             form.instance.save()


### PR DESCRIPTION
## **WIP**

## Proposed changes

closes #10896 



## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have tested that my improvement is effective and works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

**Duplicate Functionality in Dropdown**

<img width="420" alt="Screenshot 2024-05-10 at 11 13 14" src="https://github.com/WeblateOrg/weblate/assets/24358501/0b6c969a-02ce-452b-a995-a25e542b915f">

**Pre-selected Component in dropdown**
<img width="1494" alt="Screenshot 2024-05-29 at 12 27 13" src="https://github.com/WeblateOrg/weblate/assets/24358501/e167eff4-7ec8-4f4f-b337-2febe4fe1e3a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced duplication process for components, allowing automatic cloning of additional settings.
  - Added a direct link for users with edit permissions to duplicate existing components in the management interface.
  
- **Improvements**
  - Updates to the form handling for language translations, improving metadata management.
  - Enhanced component selection during creation, making it easier to duplicate components with relevant attributes retained.

These updates aim to streamline workflows and improve user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->