### PR TITLE
Bots should avoid using site commit email

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -823,7 +823,11 @@ class Profile(models.Model):
 
     def get_commit_email(self) -> str:
         email = self.commit_email
-        if not email and not settings.PRIVATE_COMMIT_EMAIL_OPT_IN and not self.user.is_bot:
+        if (
+            not email
+            and not settings.PRIVATE_COMMIT_EMAIL_OPT_IN
+            and not self.user.is_bot
+        ):
             email = self.get_site_commit_email()
         if not email:
             email = self.user.email

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -823,7 +823,7 @@ class Profile(models.Model):
 
     def get_commit_email(self) -> str:
         email = self.commit_email
-        if not email and not settings.PRIVATE_COMMIT_EMAIL_OPT_IN:
+        if not email and not settings.PRIVATE_COMMIT_EMAIL_OPT_IN and not self.user.is_bot:
             email = self.get_site_commit_email()
         if not email:
             email = self.user.email


### PR DESCRIPTION
## Proposed changes

This fix prevents bot users to commit using the email based on their username especially when `PRIVATE_COMMIT_EMAIL_OPT_IN = False`
Because bot users have a colon in their username, this results in invalid emails and 500 errors when committing and sending notifications.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
