### PR TITLE
Add port 60000 to an scripts/test-database.sh

### DIFF
--- a/scripts/test-database.sh
+++ b/scripts/test-database.sh
@@ -13,6 +13,7 @@ export CI_DATABASE="${1:-postgresql}"
 export CI_DB_USER=weblate
 export CI_DB_PASSWORD=weblate
 export CI_DB_HOST=127.0.0.1
+export CI_DB_PORT=60000
 
 # Django settings module to use
 export DJANGO_SETTINGS_MODULE=weblate.settings_test


### PR DESCRIPTION
docker-compose-postgresql.yml exposes db on host on port 60000. Small improvement for development setup docs. The content of the bash script is inlined in `contributing/tests.rst`.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- ~[ ] I have added tests that prove my fix is effective or that my feature works.~
- ~[ ] I have added documentation to describe my feature.~
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
