### PR TITLE
Implement automated cleanup of unused glossary languages

### DIFF
--- a/weblate/glossary/tasks.py
+++ b/weblate/glossary/tasks.py
@@ -31,16 +31,23 @@ def sync_glossary_languages(pk: int, component: Component | None = None):
 
     # Identify unnecessary empty glossary languages
     empty_glossary_languages = set(component.glossary_languages.all()) - set(
-        component.translations.filter(glossary_entries__isnull=False).values_list("language", flat=True))
+        component.translations.filter(glossary_entries__isnull=False).values_list(
+            "language", flat=True
+        )
+    )
 
     # Remove unnecessary empty glossary languages
     for glossary_language in empty_glossary_languages:
         component.remove_language(glossary_language)
 
     # Identify removed translation languages and their associated glossary languages
-    removed_languages = Language.objects.filter(component=component).exclude(pk__in=language_ids)
+    removed_languages = Language.objects.filter(component=component).exclude(
+        pk__in=language_ids
+    )
     for removed_language in removed_languages:
-        removed_glossary_languages = component.glossary_languages.filter(code=removed_language.code)
+        removed_glossary_languages = component.glossary_languages.filter(
+            code=removed_language.code
+        )
         for glossary_language in removed_glossary_languages:
             component.remove_language(glossary_language)
 


### PR DESCRIPTION
## Proposed changes

This commit implements a solution to identify and remove unnecessary empty glossary languages in the translation tool. It calculates a set of empty glossary languages by comparing the set of all glossary languages associated with a component to the set of languages with non-empty glossary entries in its translations. The identified empty glossary languages are then removed from the component.

Additionally, this commit addresses the removal of translation languages and their associated glossary languages. It identifies removed translation languages and iterates through their associated glossary languages, removing them from the component.

These changes streamline the management of glossary languages and ensure that only relevant languages are retained in the system.



## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information


Fixes: #11168

