### PR TITLE
screenshots: fix screenshot alerts removal

### DIFF
--- a/weblate/screenshots/models.py
+++ b/weblate/screenshots/models.py
@@ -14,7 +14,7 @@ from django.core.files import File
 from django.core.files.storage import default_storage
 from django.db import models
 from django.db.models import Q
-from django.db.models.signals import m2m_changed
+from django.db.models.signals import m2m_changed, post_delete
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy
@@ -24,8 +24,8 @@ from weblate.checks.flags import Flags
 from weblate.screenshots.fields import ScreenshotField
 from weblate.trans.mixins import UserDisplayMixin
 from weblate.trans.models import Translation, Unit
+from weblate.trans.models.alert import update_alerts
 from weblate.trans.signals import vcs_post_update
-from weblate.trans.tasks import component_alerts
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.errors import report_error
 from weblate.utils.validators import validate_bitmap
@@ -105,7 +105,16 @@ def change_screenshot_assignment(sender, instance, action, **kwargs):
     if instance.translation.component.alert_set.filter(
         name="UnusedScreenshot"
     ).exists():
-        component_alerts.delay([instance.pk])
+        update_alerts(instance.translation.component, alerts={"UnusedScreenshot"})
+
+
+@receiver(post_delete, sender=Screenshot)
+def update_alerts_on_screenshot_delete(sender, instance, **kwargs):
+    # Update the unused screenshot alert if screenshot is deleted
+    if instance.translation.component.alert_set.filter(
+        name="UnusedScreenshot"
+    ).exists():
+        update_alerts(instance.translation.component, alerts={"UnusedScreenshot"})
 
 
 def validate_screenshot_image(component, filename):


### PR DESCRIPTION
Remove Unused Screenshot alerts on deletion and string reassignment

## Proposed changes

Update the screenshots alerts in the component class on string reassignment and on screenshot deletion, so it removes instantly after these actions.

Fixes: #11141 

## Checklist

- [ x ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ x ] I have squashed my commits into logic units.
- [ x ] I have described the changes in the commit messages.

## Other information