### PR TITLE
feat(api): allow project wide translations download

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1811,6 +1811,52 @@ class ProjectAPITest(APIBaseTest):
         component = Component.objects.get(slug="local-project")
         self.assertEqual(component.enforced_checks, ["same"])
 
+    def test_download_project_translations_private(self) -> None:
+        project = self.component.project
+        project.access_control = Project.ACCESS_PRIVATE
+        project.save(update_fields=["access_control"])
+        self.do_request(
+            "api:project-file",
+            self.project_kwargs,
+            method="get",
+            code=404,
+            request={"format": "zip"},
+        )
+
+    def test_download_project_translations_prohibited(self) -> None:
+        self.authenticate()
+        self.user.groups.clear()
+        self.user.clear_cache()
+        self.do_request(
+            "api:project-file",
+            self.project_kwargs,
+            method="get",
+            code=403,
+            request={"format": "zip"},
+        )
+
+    def test_download_project_translations(self) -> None:
+        response = self.do_request(
+            "api:project-file",
+            self.project_kwargs,
+            method="get",
+            code=200,
+            superuser=True,
+            request={"format": "zip"},
+        )
+        self.assertEqual(response.headers["content-type"], "application/zip")
+
+    def test_download_project_translations_converted(self) -> None:
+        response = self.do_request(
+            "api:project-file",
+            self.project_kwargs,
+            method="get",
+            code=200,
+            superuser=True,
+            request={"format": "zip:csv"},
+        )
+        self.assertEqual(response.headers["content-type"], "application/zip")
+
 
 class ComponentAPITest(APIBaseTest):
     def setUp(self) -> None:


### PR DESCRIPTION
## Proposed changes

Allows authenticated and permissioned users to download all translations for a specific project.

This exposes the `{{hosted}}/api/projects/{{project}}/file/` endpoint, accessible via a GET request, as proposed in https://github.com/WeblateOrg/weblate/issues/11239


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Closes https://github.com/WeblateOrg/weblate/issues/11239
