### PR TITLE
Fixed #10296: Tolerated interrobang swapping.

### DIFF
--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -132,6 +132,17 @@ class Check:
             return False
 
         return (src in chars) != (tgt in chars)
+    
+    def check_interrobang(self, source, target):
+        """Ckeck whether interrobang is present."""
+        strings = ("!?","?!")
+        try:
+            src = source[-2:]
+            tgt = target[-2:]
+        except IndexError:
+            return False
+
+        return (src in strings) != (tgt in strings)
 
     def get_doc_url(self, user=None):
         """Return link to documentation."""

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -132,10 +132,10 @@ class Check:
             return False
 
         return (src in chars) != (tgt in chars)
-    
+
     def check_interrobang(self, source, target):
         """Ckeck whether interrobang is present."""
-        strings = ("!?","?!")
+        strings = ("!?", "?!")
         try:
             src = source[-2:]
             tgt = target[-2:]

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -133,17 +133,6 @@ class Check:
 
         return (src in chars) != (tgt in chars)
 
-    def check_interrobang(self, source, target):
-        """Ckeck whether interrobang is present."""
-        strings = ("!?", "?!")
-        try:
-            src = source[-2:]
-            tgt = target[-2:]
-        except IndexError:
-            return False
-
-        return (src in strings) != (tgt in strings)
-
     def get_doc_url(self, user=None):
         """Return link to documentation."""
         return get_doc_url("user/checks", self.doc_id, user=user)

--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -248,7 +248,7 @@ class EndQuestionCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
-        if source[-2:]  in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
+        if source[-2:] in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
             return False
         if unit.translation.language.is_base(("jbo",)):
             return False
@@ -276,7 +276,7 @@ class EndExclamationCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
-        if source[-2:]  in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
+        if source[-2:] in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
             return False
         if (
             unit.translation.language.is_base(("eu",))

--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -248,6 +248,8 @@ class EndQuestionCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
+        if source[-2:]  in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
+            return False
         if unit.translation.language.is_base(("jbo",)):
             return False
         if unit.translation.language.is_base(("hy",)):
@@ -274,6 +276,8 @@ class EndExclamationCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
+        if source[-2:]  in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
+            return False
         if (
             unit.translation.language.is_base(("eu",))
             and source[-1] == "!"
@@ -288,6 +292,21 @@ class EndExclamationCheck(TargetCheck):
         if source.endswith("Texy!") or target.endswith("Texy!"):
             return False
         return self.check_chars(source, target, -1, ("!", "！", "՜", "᥄", "႟", "߹"))
+
+
+class EndInterrobangCheck(TargetCheck):
+    """Check for final interrobang expression."""
+
+    check_id = "end_Interrobang"
+    name = gettext_lazy("Mismatched interrobang")
+    description = gettext_lazy(
+        "Source and translation do not both end with an interrobang expression"
+    )
+
+    def check_single(self, source, target, unit):
+        if not source or not target:
+            return False
+        return self.check_interrobang(source, target)
 
 
 class EndEllipsisCheck(TargetCheck):

--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -309,11 +309,10 @@ class EndInterrobangCheck(TargetCheck):
         if not source or not target:
             return False
 
-        interrobang_sets = [("!?", "?!"), ("？！", "！？")]
+        interrobangs = ("!?", "?!", "？！", "！？")
 
-        for sets in interrobang_sets:
-            if (source.endswith(sets)) != (target.endswith(sets)):
-                return True
+        if (source.endswith(interrobangs)) != (target.endswith(interrobangs)):
+            return True
 
         return bool(self.check_chars(source, target, -1, ("⁈", "⁉")))
 

--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -249,10 +249,7 @@ class EndQuestionCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
-        if (
-            source[-2:] in {"?!", "!?", "？！", "！？"}
-            or target[-2:] in {"?!", "!?", "？！", "！？"}
-        ) or (source[-1] in {"⁈", "⁉"} or target[-1] in {"⁈", "⁉"}):
+        if source.endswith(self.interrobangs) or target.endswith(self.interrobangs):
             return False
         if unit.translation.language.is_base(("jbo",)):
             return False
@@ -281,10 +278,7 @@ class EndExclamationCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
-        if (
-            source[-2:] in {"?!", "!?", "？！", "！？"}
-            or target[-2:] in {"?!", "!?", "？！", "！？"}
-        ) or (source[-1] in {"⁈", "⁉"} or target[-1] in {"⁈", "⁉"}):
+        if source.endswith(self.interrobangs) or target.endswith(self.interrobangs):
             return False
         if (
             unit.translation.language.is_base(("eu",))
@@ -318,7 +312,7 @@ class EndInterrobangCheck(TargetCheck):
         interrobang_sets = [("!?", "?!"), ("？！", "！？")]
 
         for sets in interrobang_sets:
-            if (source[-2:] in sets) != (target[-2:] in sets):
+            if (source.endswith(sets)) != (target.endswith(sets)):
                 return True
 
         return bool(self.check_chars(source, target, -1, ("⁈", "⁉")))

--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -231,6 +231,7 @@ class EndQuestionCheck(TargetCheck):
         "Source and translation do not both end with a question mark"
     )
     question_el = ("?", ";", ";")
+    interrobangs = ("?!", "!?", "？！", "！？", "⁈", "⁉")
 
     def _check_hy(self, source, target):
         if source[-1] == "?":
@@ -248,7 +249,10 @@ class EndQuestionCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
-        if source[-2:] in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
+        if (
+            source[-2:] in {"?!", "!?", "？！", "！？"}
+            or target[-2:] in {"?!", "!?", "？！", "！？"}
+        ) or (source[-1] in {"⁈", "⁉"} or target[-1] in {"⁈", "⁉"}):
             return False
         if unit.translation.language.is_base(("jbo",)):
             return False
@@ -272,11 +276,15 @@ class EndExclamationCheck(TargetCheck):
     description = gettext_lazy(
         "Source and translation do not both end with an exclamation mark"
     )
+    interrobangs = ("?!", "!?", "？！", "！？", "⁈", "⁉")
 
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
-        if source[-2:] in {"?!", "!?"} or target[-2:] in {"?!", "!?"}:
+        if (
+            source[-2:] in {"?!", "!?", "？！", "！？"}
+            or target[-2:] in {"?!", "!?", "？！", "！？"}
+        ) or (source[-1] in {"⁈", "⁉"} or target[-1] in {"⁈", "⁉"}):
             return False
         if (
             unit.translation.language.is_base(("eu",))
@@ -306,7 +314,14 @@ class EndInterrobangCheck(TargetCheck):
     def check_single(self, source, target, unit):
         if not source or not target:
             return False
-        return self.check_interrobang(source, target)
+
+        interrobang_sets = [("!?", "?!"), ("？！", "！？")]
+
+        for sets in interrobang_sets:
+            if (source[-2:] in sets) != (target[-2:] in sets):
+                return True
+
+        return bool(self.check_chars(source, target, -1, ("⁈", "⁉")))
 
 
 class EndEllipsisCheck(TargetCheck):

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -39,6 +39,7 @@ class WeblateChecksConf(AppConf):
         "weblate.checks.chars.EndColonCheck",
         "weblate.checks.chars.EndQuestionCheck",
         "weblate.checks.chars.EndExclamationCheck",
+        "weblate.checks.chars.EndInterrobangCheck",
         "weblate.checks.chars.EndEllipsisCheck",
         "weblate.checks.chars.EndSemicolonCheck",
         "weblate.checks.chars.MaxLengthCheck",

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -226,7 +226,7 @@ class EndInterrobangCheckTest(CheckTestCase):
         self.test_good_matching = ("string!?", "string?!", "")
         self.test_failure_1 = ("string!?", "string?", "")
         self.test_failure_2 = ("string!?", "string!", "")
-        self.test_failure_3 = ("string!", "string!?","")
+        self.test_failure_3 = ("string!", "string!?", "")
 
     def test_translate(self):
         self.do_test(False, ("string!?", "string!?", ""))

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -199,6 +199,14 @@ class EndQuestionCheckTest(CheckTestCase):
         self.do_test(False, ("Text?", "ပုံဖျက်မလား။", ""), "my")
         self.do_test(True, ("Te xt", "ပုံဖျက်မလား။", ""), "my")
 
+    def test_interrobang(self) -> None:
+        self.do_test(False, ("string!?", "string?", ""))
+        self.do_test(False, ("string?", "string?!", ""))
+        self.do_test(False, ("string⁈", "string?", ""))
+        self.do_test(False, ("string?", "string⁉", ""))
+        self.do_test(False, ("string？！", "string?", ""))
+        self.do_test(False, ("string?", "string！？", ""))
+
 
 class EndExclamationCheckTest(CheckTestCase):
     check = EndExclamationCheck()
@@ -217,20 +225,36 @@ class EndExclamationCheckTest(CheckTestCase):
     def test_eu(self) -> None:
         self.do_test(False, ("Text!", "¡Texte!", ""), "eu")
 
+    def test_interrobang(self) -> None:
+        self.do_test(False, ("string!?", "string!", ""))
+        self.do_test(False, ("string!", "string?!", ""))
+        self.do_test(False, ("string⁈", "string!", ""))
+        self.do_test(False, ("string!", "string⁉", ""))
+        self.do_test(False, ("string？！", "string!", ""))
+        self.do_test(False, ("string!", "string！？", ""))
+
 
 class EndInterrobangCheckTest(CheckTestCase):
     check = EndInterrobangCheck()
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.test_good_matching = ("string!?", "string?!", "")
         self.test_failure_1 = ("string!?", "string?", "")
         self.test_failure_2 = ("string!?", "string!", "")
         self.test_failure_3 = ("string!", "string!?", "")
 
-    def test_translate(self):
+    def test_translate(self) -> None:
         self.do_test(False, ("string!?", "string!?", ""))
+        self.do_test(False, ("string⁉", "string⁈", ""))
+        self.do_test(False, ("string⁉", "string⁉", ""))
+        self.do_test(False, ("string！？", "string！？", ""))
+        self.do_test(False, ("string！？", "string？！", ""))
         self.do_test(True, ("string?", "string?!", ""))
+        self.do_test(True, ("string⁉", "string!?", ""))
+        self.do_test(True, ("string?!", "string⁈", ""))
+        self.do_test(True, ("string?!", "string？！", ""))
+        self.do_test(True, ("string！？", "string!?", ""))
 
 
 class EndEllipsisCheckTest(CheckTestCase):

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -13,6 +13,7 @@ from weblate.checks.chars import (
     EndColonCheck,
     EndEllipsisCheck,
     EndExclamationCheck,
+    EndInterrobangCheck,
     EndNewlineCheck,
     EndQuestionCheck,
     EndSemicolonCheck,
@@ -215,6 +216,21 @@ class EndExclamationCheckTest(CheckTestCase):
 
     def test_eu(self) -> None:
         self.do_test(False, ("Text!", "¡Texte!", ""), "eu")
+
+
+class EndInterrobangCheckTest(CheckTestCase):
+    check = EndInterrobangCheck()
+
+    def setUp(self):
+        super().setUp()
+        self.test_good_matching = ("string!?", "string?!", "")
+        self.test_failure_1 = ("string!?", "string?", "")
+        self.test_failure_2 = ("string!?", "string!", "")
+        self.test_failure_3 = ("string!", "string!?","")
+
+    def test_translate(self):
+        self.do_test(False, ("string!?", "string!?", ""))
+        self.do_test(True, ("string?", "string?!", ""))
 
 
 class EndEllipsisCheckTest(CheckTestCase):

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -250,11 +250,12 @@ class EndInterrobangCheckTest(CheckTestCase):
         self.do_test(False, ("string⁉", "string⁉", ""))
         self.do_test(False, ("string！？", "string！？", ""))
         self.do_test(False, ("string！？", "string？！", ""))
+        self.do_test(False, ("string?!", "string？！", ""))
+        self.do_test(False, ("string！？", "string!?", ""))
         self.do_test(True, ("string?", "string?!", ""))
         self.do_test(True, ("string⁉", "string!?", ""))
         self.do_test(True, ("string?!", "string⁈", ""))
-        self.do_test(True, ("string?!", "string？！", ""))
-        self.do_test(True, ("string！？", "string!?", ""))
+        self.do_test(True, ("string？！", "string⁈", ""))
 
 
 class EndEllipsisCheckTest(CheckTestCase):

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -980,6 +980,7 @@ CHECK_LIST = [
     "weblate.checks.chars.EndColonCheck",
     "weblate.checks.chars.EndQuestionCheck",
     "weblate.checks.chars.EndExclamationCheck",
+    "weblate.checks.chars.EndInterrobangCheck",
     "weblate.checks.chars.EndEllipsisCheck",
     "weblate.checks.chars.EndSemicolonCheck",
     "weblate.checks.chars.MaxLengthCheck",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -633,6 +633,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 #     "weblate.checks.chars.EndColonCheck",
 #     "weblate.checks.chars.EndQuestionCheck",
 #     "weblate.checks.chars.EndExclamationCheck",
+#     "weblate.checks.chars.EndInterrobangCheck",
 #     "weblate.checks.chars.EndEllipsisCheck",
 #     "weblate.checks.chars.EndSemicolonCheck",
 #     "weblate.checks.chars.MaxLengthCheck",


### PR DESCRIPTION
The updated code now allows for the swapping of "?!/!?" while translating and checks for the presence of interrobangs in both the source and translation. Tests have been implemented to validate the changes made to the code.

## Proposed changes

"EndQuestionCheck" and "EndExclamationCheck" do not produce warnings if an interrobang (?!/!?) is present. I added "EndInterrobangCheck" to verify if there is an interrobang in the original text or the translation (through the check_interrobang function) and generate warnings in case of mismatch. This function also permits the swapping of (?!/!?) without triggering any warnings. Tests have been implemented to validate the modifications made to the code.

Fixes: #10296 

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

