### PR TITLE
Add clickable list object numbers using search URLs

### DIFF
--- a/weblate/templates/snippets/list-objects-number.html
+++ b/weblate/templates/snippets/list-objects-number.html
@@ -8,6 +8,10 @@
         <a href="{{ translate_url }}?{{ query }}">
             {{ value|intcomma }}
         </a>
+    {% elif search_url %}
+        <a href="{% url 'search' path=search_url %}?{{ query }}">
+            {{ value|intcomma }}
+        </a>
     {% else %}
         {{ value|intcomma }}
     {% endif %}

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -159,13 +159,13 @@
     {% endif %}
     {% include "snippets/list-objects-percent.html" with percent=category.stats.translated_percent value=category.stats.translated query="q=state:>=translated" all=category.stats.all %}
     {% if not hide_details %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo query="q=state:<translated" class="zero-width-640" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo_words query="q=state:<translated" class="zero-width-720" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.todo_chars query="q=state:<translated" class="zero-width-1200" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.nottranslated query="q=state:empty" class="zero-width-1400" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.allchecks query="q=has:check" class="zero-width-768" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-900" %}
-    {% include "snippets/list-objects-number.html" with value=category.stats.comments query="q=has:comment#comments" class="zero-width-1000" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo search_url=category.get_url_path query="q=state:<translated" class="zero-width-640" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo_words search_url=category.get_url_path query="q=state:<translated" class="zero-width-720" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.todo_chars search_url=category.get_url_path query="q=state:<translated" class="zero-width-1200" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.nottranslated search_url=category.get_url_path query="q=state:empty" class="zero-width-1400" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.allchecks search_url=category.get_url_path query="q=has:check" class="zero-width-768" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.suggestions search_url=category.get_url_path query="q=has:suggestion#suggestions" class="zero-width-900" %}
+    {% include "snippets/list-objects-number.html" with value=category.stats.comments search_url=category.get_url_path query="q=has:comment#comments" class="zero-width-1000" %}
     {% endif %}
   </tr>
   <tr data-parent="{{ row_id }}">
@@ -249,18 +249,18 @@
   {% review_percent object.stats %}
 {% endif %}
 {% if is_glossary %}
-  {% include "snippets/list-objects-number.html" with value=object.stats.translated query="q=state:>=translated" show_zero=True %}
+  {% include "snippets/list-objects-number.html" with value=object.stats.translated search_url=object.get_url_path query="q=state:>=translated" show_zero=True %}
 {% else %}
   {% include "snippets/list-objects-percent.html" with percent=object.stats.translated_percent value=object.stats.translated query="q=state:>=translated" all=object.stats.all %}
 {% endif %}
 {% if not hide_details %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo query="q=state:<translated" class="zero-width-640" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo_words query="q=state:<translated" class="zero-width-720" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.todo_chars query="q=state:<translated" class="zero-width-1200" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.nottranslated query="q=state:empty" class="zero-width-1400" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.allchecks query="q=has:check" class="zero-width-768" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.suggestions query="q=has:suggestion#suggestions" class="zero-width-900" %}
-{% include "snippets/list-objects-number.html" with value=object.stats.comments query="q=has:comment#comments" class="zero-width-1000" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo search_url=object.get_url_path query="q=state:<translated" class="zero-width-640" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo_words search_url=object.get_url_path query="q=state:<translated" class="zero-width-720" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.todo_chars search_url=object.get_url_path query="q=state:<translated" class="zero-width-1200" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.nottranslated search_url=object.get_url_path query="q=state:empty" class="zero-width-1400" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.allchecks search_url=object.get_url_path query="q=has:check" class="zero-width-768" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.suggestions search_url=object.get_url_path query="q=has:suggestion#suggestions" class="zero-width-900" %}
+{% include "snippets/list-objects-number.html" with value=object.stats.comments search_url=object.get_url_path query="q=has:comment#comments" class="zero-width-1000" %}
 {% endif %}
 </tr>
 <tr data-parent="{{ row_id }}">


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

~~Added an additional list object component to `list-objects.html` which gets displayed when the project view is open.~~


Updated `list-objects.html` to add a search URL to every list objects number entry. `list-objects-number.html` has also been modified to ensure that the number can be clicked if the search URL is defined. This allows the user to click on all numbers within the table. This also includes comments as described in https://github.com/WeblateOrg/weblate/issues/9089.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Resolves https://github.com/WeblateOrg/weblate/issues/9089.

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->

In the repository I could not find any examples of frontend-related tests for specific UI elements. Since this pull request only includes frontend changes, I did not add any tests for it. Also since the proposed change is a very minor UX update which was previously already available in other views, additional documentation has not been added.

Please let me know if tests and/or documentation changes are needed regardless.
