### PR TITLE
unit: use generate_change for source string change

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,8 @@ Not yet released.
 
 **Improvements**
 
+* Display more details on source string change in history.
+
 **Bug fixes**
 
 * Fixed skipped component update with some add-ons enabled.

--- a/weblate/templates/last-changes-content.html
+++ b/weblate/templates/last-changes-content.html
@@ -71,6 +71,14 @@
                 </label>
                 {% format_unit_target change.unit value=change.target diff=change.old %}
             {% elif change.show_source %}
+              <label>
+                {{ change.unit.translation.component.source_language }}
+                {% comment %}Translators: Number of edits on a change in Damerau–Levenshtein distance{% endcomment %}
+                <span class="badge">{% blocktrans count count=change.get_distance %}{{ count }} character edited{% plural %}{{ count }} characters edited{% endblocktrans %}</span>
+                {% if change.show_unit_state %}
+                  <span class="badge">{{ change.get_state_display }}</span>
+                {% endif %}
+              </label>
               {% if change.target %}
                 {% format_unit_target change.unit value=change.target diff=change.old %}
               {% else %}


### PR DESCRIPTION
## Proposed changes

This stores full unit info and makes changes tracking complete (including state).

See #11446

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
