### PR TITLE
feat(machinery): allow base_url of OpenAI to be customized

### DIFF
--- a/docs/admin/machine.rst
+++ b/docs/admin/machine.rst
@@ -447,23 +447,33 @@ OpenAI
 .. versionadded:: 5.3
 
 :Service ID: ``openai``
-:Configuration: +-------------+--------------------+---------------------------------------------------------------------------------------------------------------------------+
-                | ``key``     | API key            |                                                                                                                           |
-                +-------------+--------------------+---------------------------------------------------------------------------------------------------------------------------+
-                | ``model``   | OpenAI model       | Available choices:                                                                                                        |
-                |             |                    |                                                                                                                           |
-                |             |                    | ``auto`` -- Automatic selection                                                                                           |
-                |             |                    |                                                                                                                           |
-                |             |                    | ``gpt-4-1106-preview`` -- GPT-4 Turbo                                                                                     |
-                |             |                    |                                                                                                                           |
-                |             |                    | ``gpt-4`` -- GPT-4                                                                                                        |
-                |             |                    |                                                                                                                           |
-                |             |                    | ``gpt-3.5-turbo`` -- GPT-3.5 Turbo                                                                                        |
-                +-------------+--------------------+---------------------------------------------------------------------------------------------------------------------------+
-                | ``persona`` | Translator persona | Describe the persona of translator to improve the accuracy of the translation. For example: “You are a squirrel breeder.” |
-                +-------------+--------------------+---------------------------------------------------------------------------------------------------------------------------+
-                | ``style``   | Translator style   | Describe the style of translation. For example: “Use informal language.”                                                  |
-                +-------------+--------------------+---------------------------------------------------------------------------------------------------------------------------+
+:Configuration: +------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+                | ``key``          | API key             |                                                                                                                           |
+                +------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+                | ``base_url``     | OpenAI API base URL | Base URL of the OpenAI API, if it differs from the OpenAI default URL                                                     |
+                +------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+                | ``model``        | OpenAI model        | Available choices:                                                                                                        |
+                |                  |                     |                                                                                                                           |
+                |                  |                     | ``auto`` -- Automatic selection                                                                                           |
+                |                  |                     |                                                                                                                           |
+                |                  |                     | ``gpt-4o`` -- GPT-4o                                                                                                      |
+                |                  |                     |                                                                                                                           |
+                |                  |                     | ``gpt-4-1106-preview`` -- GPT-4 Turbo                                                                                     |
+                |                  |                     |                                                                                                                           |
+                |                  |                     | ``gpt-4`` -- GPT-4                                                                                                        |
+                |                  |                     |                                                                                                                           |
+                |                  |                     | ``gpt-3.5-turbo-1106`` -- Updated GPT 3.5 Turbo                                                                           |
+                |                  |                     |                                                                                                                           |
+                |                  |                     | ``gpt-3.5-turbo`` -- GPT-3.5 Turbo                                                                                        |
+                |                  |                     |                                                                                                                           |
+                |                  |                     | ``custom`` -- Custom model                                                                                                |
+                +------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+                | ``custom_model`` | Custom model name   | Only needed when model is set to 'Custom model'                                                                           |
+                +------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+                | ``persona``      | Translator persona  | Describe the persona of translator to improve the accuracy of the translation. For example: “You are a squirrel breeder.” |
+                +------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+                | ``style``        | Translator style    | Describe the style of translation. For example: “Use informal language.”                                                  |
+                +------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
 
 Performs translation using `OpenAI`_.
 
@@ -476,6 +486,10 @@ used in a prompt for OpenAI and allow you to change the style of the
 translations.
 
 The service automatically uses :ref:`glossary`, see :ref:`glossary-mt`.
+
+.. versionchanged:: 5.7
+
+   Support for custom model and base URL was added.
 
 .. seealso::
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Not yet released.
 * :ref:`adding-new-strings` can now create plural strings in the user interface.
 * :ref:`labels` now include description to explain them.
 * New :ref:`subscriptions` for completed translation and component.
+* :ref:`mt-openai` now supports custom models and URLs.
 
 **Improvements**
 

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -288,7 +288,7 @@ class OpenAIMachineryForm(KeyMachineryForm):
         ("gpt-4", "GPT-4"),
         ("gpt-3.5-turbo-1106", "Updated GPT 3.5 Turbo"),
         ("gpt-3.5-turbo", "GPT-3.5 Turbo"),
-        ("custom", "Custom model"),
+        ("custom", pettext_lazy("OpenAI model selection", "Custom model")),
     )
     base_url = forms.URLField(
         label=pgettext_lazy(
@@ -311,7 +311,7 @@ class OpenAIMachineryForm(KeyMachineryForm):
     )
     custom_model = forms.CharField(
         label=pgettext_lazy(
-            "Custom model name",
+            "OpenAI model selection",
             "Custom model name",
         ),
         help_text=gettext_lazy("Only needed when model is set to 'Custom model'"),

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -293,7 +293,7 @@ class OpenAIMachineryForm(KeyMachineryForm):
     base_url = forms.URLField(
         label=pgettext_lazy(
             "Automatic suggestion service configuration",
-            "Translator Base URL",
+            "OpenAI API base URL",
         ),
         widget=forms.TextInput,
         help_text=gettext_lazy(

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -288,8 +288,17 @@ class OpenAIMachineryForm(KeyMachineryForm):
         ("gpt-4", "GPT-4"),
         ("gpt-3.5-turbo-1106", "Updated GPT 3.5 Turbo"),
         ("gpt-3.5-turbo", "GPT-3.5 Turbo"),
+        ("custom", "Custom model")
     )
-
+    base_url = forms.URLField(
+        label=pgettext_lazy(
+            "Automatic suggestion service configuration",
+            "Translator Base URL",
+        ),
+        widget=forms.TextInput,
+        help_text=gettext_lazy("Base URL of the OpenAI API, if it differs from the OpenAI default URL"),
+        required=False,
+    )
     model = forms.ChoiceField(
         label=pgettext_lazy(
             "Automatic suggestion service configuration",
@@ -297,6 +306,14 @@ class OpenAIMachineryForm(KeyMachineryForm):
         ),
         initial="auto",
         choices=MODEL_CHOICES,
+    )
+    custom_model = forms.CharField(
+        label=pgettext_lazy(
+            "Custom model name",
+            "Custom model name",
+        ),
+        help_text=gettext_lazy("Only needed when model is set to 'Custom model'"),
+        required=False,
     )
     persona = forms.CharField(
         label=pgettext_lazy(

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -288,7 +288,7 @@ class OpenAIMachineryForm(KeyMachineryForm):
         ("gpt-4", "GPT-4"),
         ("gpt-3.5-turbo-1106", "Updated GPT 3.5 Turbo"),
         ("gpt-3.5-turbo", "GPT-3.5 Turbo"),
-        ("custom", "Custom model")
+        ("custom", "Custom model"),
     )
     base_url = forms.URLField(
         label=pgettext_lazy(
@@ -296,7 +296,9 @@ class OpenAIMachineryForm(KeyMachineryForm):
             "Translator Base URL",
         ),
         widget=forms.TextInput,
-        help_text=gettext_lazy("Base URL of the OpenAI API, if it differs from the OpenAI default URL"),
+        help_text=gettext_lazy(
+            "Base URL of the OpenAI API, if it differs from the OpenAI default URL"
+        ),
         required=False,
     )
     model = forms.ChoiceField(

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -288,7 +288,7 @@ class OpenAIMachineryForm(KeyMachineryForm):
         ("gpt-4", "GPT-4"),
         ("gpt-3.5-turbo-1106", "Updated GPT 3.5 Turbo"),
         ("gpt-3.5-turbo", "GPT-3.5 Turbo"),
-        ("custom", pettext_lazy("OpenAI model selection", "Custom model")),
+        ("custom", pgettext_lazy("OpenAI model selection", "Custom model")),
     )
     base_url = forms.URLField(
         label=pgettext_lazy(

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -339,3 +339,16 @@ class OpenAIMachineryForm(KeyMachineryForm):
         ),
         required=False,
     )
+
+    def clean(self) -> None:
+        has_custom_model = bool(self.cleaned_data.get("custom_model"))
+        model = self.cleaned_data.get("model")
+        if model == "custom" and not has_custom_model:
+            raise ValidationError(
+                {"custom_model": gettext("Missing custom model name.")}
+            )
+        if model != "custom" and has_custom_model:
+            raise ValidationError(
+                {"model": gettext("Choose custom model here to enable it.")}
+            )
+        super().clean()

--- a/weblate/machinery/openai.py
+++ b/weblate/machinery/openai.py
@@ -61,7 +61,7 @@ class OpenAITranslation(BatchMachineTranslation):
 
         super().__init__(settings)
         self.client = OpenAI(
-            api_key=self.settings["key"], 
+            api_key=self.settings["key"],
             timeout=self.request_timeout,
             base_url=self.settings.get("base_url") or None,
         )

--- a/weblate/machinery/openai.py
+++ b/weblate/machinery/openai.py
@@ -60,7 +60,13 @@ class OpenAITranslation(BatchMachineTranslation):
         from openai import OpenAI
 
         super().__init__(settings)
-        self.client = OpenAI(api_key=self.settings["key"], timeout=self.request_timeout)
+        kwargs = {
+            "api_key": self.settings["key"],
+            "timeout": self.request_timeout,
+        }
+        if base_url := self.settings.get("base_url"):
+            kwargs["base_url"] = base_url
+        self.client = OpenAI(**kwargs)
         self._models: None | set[str] = None
 
     def is_supported(self, source, language) -> bool:
@@ -82,6 +88,8 @@ class OpenAITranslation(BatchMachineTranslation):
                     continue
                 if model in self._models:
                     return model
+        if self.settings["model"] == "custom":
+            return self.settings["custom_model"]
 
         raise MachineTranslationError(f"Unsupported model: {self.settings['model']}")
 

--- a/weblate/machinery/openai.py
+++ b/weblate/machinery/openai.py
@@ -60,13 +60,11 @@ class OpenAITranslation(BatchMachineTranslation):
         from openai import OpenAI
 
         super().__init__(settings)
-        kwargs = {
-            "api_key": self.settings["key"],
-            "timeout": self.request_timeout,
-        }
-        if base_url := self.settings.get("base_url"):
-            kwargs["base_url"] = base_url
-        self.client = OpenAI(**kwargs)
+        self.client = OpenAI(
+            api_key=self.settings["key"], 
+            timeout=self.request_timeout,
+            base_url=self.settings.get("base_url") or None,
+        )
         self._models: None | set[str] = None
 
     def is_supported(self, source, language) -> bool:

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -1646,6 +1646,27 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
             )
         )
 
+    @responses.activate
+    @respx.mock
+    def test_clean_custom(self):
+        self.mock_response()
+        settings = self.CONFIGURATION.copy()
+        machine = self.MACHINE_CLS
+        form = self.MACHINE_CLS.settings_form(machine, settings)
+        self.assertTrue(form.is_valid())
+
+        settings["model"] = "custom"
+        form = self.MACHINE_CLS.settings_form(machine, settings)
+        self.assertFalse(form.is_valid())
+
+        settings["custom_model"] = "custom"
+        form = self.MACHINE_CLS.settings_form(machine, settings)
+        self.assertTrue(form.is_valid())
+
+        settings["model"] = "auto"
+        form = self.MACHINE_CLS.settings_form(machine, settings)
+        self.assertFalse(form.is_valid())
+
 
 class WeblateTranslationTest(TransactionsTestMixin, FixtureTestCase):
     def test_empty(self) -> None:

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -1590,6 +1590,63 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         )
 
 
+class OpenAICustomTranslationTest(OpenAITranslationTest):
+    CONFIGURATION = {
+        "key": "x",
+        "model": "auto",
+        "persona": "",
+        "style": "",
+        "base_url": "https://custom.example.com/",
+    }
+
+    def mock_response(self) -> None:
+        respx.get("https://custom.example.com/models").mock(
+            httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "gpt-3.5-turbo",
+                            "object": "model",
+                            "created": 1686935002,
+                            "owned_by": "openai",
+                        }
+                    ],
+                },
+            )
+        )
+        respx.post(
+            "https://custom.example.com/chat/completions",
+        ).mock(
+            httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-123",
+                    "object": "chat.completion",
+                    "created": 1677652288,
+                    "model": "gpt-3.5-turbo",
+                    "system_fingerprint": "fp_44709d6fcb",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "Ahoj světe",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 9,
+                        "completion_tokens": 12,
+                        "total_tokens": 21,
+                    },
+                },
+            )
+        )
+
+
 class WeblateTranslationTest(TransactionsTestMixin, FixtureTestCase):
     def test_empty(self) -> None:
         machine = WeblateTranslation({})

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -1534,6 +1534,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         "model": "auto",
         "persona": "",
         "style": "",
+        "base_url": "https://api.openai.com/v1",
     }
 
     def mock_empty(self) -> NoReturn:

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -1534,7 +1534,6 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         "model": "auto",
         "persona": "",
         "style": "",
-        "base_url": "https://api.openai.com/v1",
     }
 
     def mock_empty(self) -> NoReturn:


### PR DESCRIPTION
Allows usage of local LLMs or other providers

![image](https://github.com/WeblateOrg/weblate/assets/6639323/c8e4cdf0-9af1-402f-9836-6091bc78b3ac)

## Proposed changes

Adds a new field when setting up the OpenAI integration to allow the user to add a custom base_url

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
