### PR TITLE
Update documentation on file upload permissions

### DIFF
--- a/docs/user/files.rst
+++ b/docs/user/files.rst
@@ -102,33 +102,43 @@ Add as translation (``translate``)
     the default behavior.
 
     Only translations are used from the uploaded file and no additional content.
+
+    This option is available only if the user has the :ref:`"Edit strings" permission <privileges>`.
 Add as suggestion (``suggest``)
     Imported strings are added as suggestions, do this when you want to have your
     uploaded strings reviewed.
 
     Only translations are used from the uploaded file and no additional content.
+
+    This option is available only if the user has the :ref:`"Add suggestion" permission <privileges>`.
 Add as translation needing edit (``fuzzy``)
     Imported strings are added as translations needing edit. This can be useful
     when you want translations to be used, but also reviewed.
 
     Only translations are used from the uploaded file and no additional content.
+
+    This option is available only if the user has the :ref:`"Edit strings" permission <privileges>`.
 Replace existing translation file (``replace``)
     Existing file is replaced with new content. This can lead to loss of existing
     translations, use with caution.
+
+    This option is available only if the user has the :ref:`"Edit component settings" permission <privileges>`.
 Update source strings (``source``)
     Updates source strings in bilingual translation file. This is similar to
     what :ref:`addon-weblate.gettext.msgmerge` does.
 
-    This option is supported only for some file formats.
+    This option is available only for some file formats and only if the user has the
+    :ref:`"Upload translations" permission <privileges>`.
 Add new strings (``add``)
     Adds new strings to the translation. It skips the one which already exist.
 
     In case you want to both add new strings and update existing translations,
     upload the file second time with :guilabel:`Add as translation`.
 
-    This option is available only with :ref:`component-manage_units` turned on.
-
     Only source, translation and key (context) are used from the uploaded file.
+
+    This option is available only with :ref:`component-manage_units` turned on
+    and only if the user has the :ref:`"Add new string" permission <privileges>`.
 
 .. seealso::
 

--- a/docs/user/files.rst
+++ b/docs/user/files.rst
@@ -105,12 +105,19 @@ Add as translation (``translate``)
 
     This option is available only if the user has the :ref:`"Edit strings" permission <privileges>`.
 Add as suggestion (``suggest``)
-    Imported strings are added as suggestions, do this when you want to have your
+    Imported strings are added as suggestions. Do this when you want to have your
     uploaded strings reviewed.
 
     Only translations are used from the uploaded file and no additional content.
 
     This option is available only if the user has the :ref:`"Add suggestion" permission <privileges>`.
+Add as approved translation (``approve``)
+    Imported strings are added as approved translations. Do this when you already
+    reviewed your translations before uploading them.
+
+    Only translations are used from the uploaded file and no additional content.
+
+    This option is available only if the user has the :ref:`"Review strings" permission <privileges>`.
 Add as translation needing edit (``fuzzy``)
     Imported strings are added as translations needing edit. This can be useful
     when you want translations to be used, but also reviewed.

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -651,7 +651,7 @@ class SimpleUploadForm(forms.Form):
         return ("user/files", f"upload-{field.name}")
 
     def remove_translation_choice(self, value) -> None:
-        """Remove "Add as translation" choice."""
+        """Remove given file upload method from choices."""
         choices = self.fields["method"].choices
         self.fields["method"].choices = [
             choice for choice in choices if choice[0] != value


### PR DESCRIPTION
## Proposed changes

- I updated the documentation with which permissions are required for the individual file upload methods.
- I also added documentation for the `approve` method, which was previously missing. Please confirm that its accurate and actually what this method does as I just assumed that this is what it does, based on what the `suggestion` method does.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added documentation to describe my feature.
- [X] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.

## Other information

I did not build the documentation locally, or tested that the references/links are correct. I'd appreciate if you could do that on your side.