### PR TITLE
Set the value of gitreview.username from the gerrit push URL

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -572,21 +572,12 @@ class GitWithGerritRepository(GitRepository):
         self, pull_url: str, push_url: str, branch: str, fast: bool = True
     ) -> tuple[tuple[str, str, str | None], ...]:
         if push_url:
-            return (('remote "gerrit"', "url", push_url),)
+            gerrit_user = self.get_username_from_url(push_url)
+            return (
+                ('remote "gerrit"', "url", push_url),
+                ("gitreview", "username", gerrit_user)
+            )
         return (('remote "gerrit"', "url", None),)
-
-    def configure_remote(
-        self, pull_url: str, push_url: str, branch: str, fast: bool = True
-    ) -> None:
-        """
-        Configure remote repository.
-
-        Gets the gerrit username from push URL and
-        sets it as the value of gitreview.username.
-        """
-        gerrit_user = self.get_username_from_url(push_url)
-        self.config_update(("gitreview", "username", gerrit_user))
-        super().configure_remote(pull_url, push_url, branch, fast)
 
 
 class SubversionRepository(GitRepository):

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -552,12 +552,11 @@ class GitWithGerritRepository(GitRepository):
         if url is not None:
             if url.startswith("git@"):
                 return url.split(":")[-1].split("/")[0]
-            elif url.startswith(("ssh://", "https://")) and '@' in url:
+            if url.startswith(("ssh://", "https://")) and "@" in url:
                 return url.split("//")[-1].split("@")[0]
-            elif url.startswith(("ssh://", "https://")):
+            if url.startswith(("ssh://", "https://")):
                 return url.split("//")[-1].split("/")[1]
-            else:
-                return ""
+            return ""
         return ""
 
     def push(self, branch) -> None:

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -564,6 +564,16 @@ class GitWithGerritRepository(GitRepository):
             return (('remote "gerrit"', "url", push_url),)
         return (('remote "gerrit"', "url", None),)
 
+    def configure_remote(
+        self, pull_url: str, push_url: str, branch: str, fast: bool = True
+    ) -> None:
+        # Gets the gerrit username from push URL and sets it as the value of gitreview.username
+        gerrit_user = push_url.split('@')[0].split('//')[1]
+        self.config_update(
+            ("gitreview", "username", gerrit_user)
+        )
+        super().configure_remote(pull_url, push_url, branch, fast)
+
 
 class SubversionRepository(GitRepository):
     name = "Subversion"

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -567,7 +567,12 @@ class GitWithGerritRepository(GitRepository):
     def configure_remote(
         self, pull_url: str, push_url: str, branch: str, fast: bool = True
     ) -> None:
-        # Gets the gerrit username from push URL and sets it as the value of gitreview.username
+        """
+        Configure remote repository.
+
+        Gets the gerrit username from push URL and
+        sets it as the value of gitreview.username.
+        """
         gerrit_user = push_url.split("@")[0].split("//")[1]
         self.config_update(("gitreview", "username", gerrit_user))
         super().configure_remote(pull_url, push_url, branch, fast)

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -568,10 +568,8 @@ class GitWithGerritRepository(GitRepository):
         self, pull_url: str, push_url: str, branch: str, fast: bool = True
     ) -> None:
         # Gets the gerrit username from push URL and sets it as the value of gitreview.username
-        gerrit_user = push_url.split('@')[0].split('//')[1]
-        self.config_update(
-            ("gitreview", "username", gerrit_user)
-        )
+        gerrit_user = push_url.split("@")[0].split("//")[1]
+        self.config_update(("gitreview", "username", gerrit_user))
         super().configure_remote(pull_url, push_url, branch, fast)
 
 

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -575,7 +575,7 @@ class GitWithGerritRepository(GitRepository):
             gerrit_user = self.get_username_from_url(push_url)
             return (
                 ('remote "gerrit"', "url", push_url),
-                ("gitreview", "username", gerrit_user)
+                ("gitreview", "username", gerrit_user),
             )
         return (('remote "gerrit"', "url", None),)
 

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -1678,6 +1678,26 @@ class VCSGerritTest(VCSGitUpstreamTest):
             handle.write("#!/bin/sh\nexit 0\n")
         os.chmod(hook, 0o755)  # noqa: S103, nosec
 
+    def test_set_gitreview_username_git(self):
+        with self.repo.lock:
+            self.repo.configure_remote("pullurl", "git@domain.com:gituser/repo.git", "branch")
+            self.assertEqual(self.repo.get_config("gitreview.username"), "gituser")
+
+    def test_set_gitreview_username_ssh(self):
+        with self.repo.lock:
+            self.repo.configure_remote("pullurl", "ssh://sshuser@domain.com:29418/repo.git", "branch")
+            self.assertEqual(self.repo.get_config("gitreview.username"), "sshuser")
+
+    def test_set_gitreview_username_https(self):
+        with self.repo.lock:
+            self.repo.configure_remote("pullurl", "https://httpsuser@domain.com/user/repo.git", "branch")
+            self.assertEqual(self.repo.get_config("gitreview.username"), "httpsuser")
+
+    def test_set_gitreview_username_https_pathuser(self):
+        with self.repo.lock:
+            self.repo.configure_remote("pullurl", "https://domain.com/httpspathuser/repo.git", "branch")
+            self.assertEqual(self.repo.get_config("gitreview.username"), "httpspathuser")
+
 
 class VCSSubversionTest(VCSGitTest):
     _class = SubversionRepository

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -1680,23 +1680,33 @@ class VCSGerritTest(VCSGitUpstreamTest):
 
     def test_set_gitreview_username_git(self):
         with self.repo.lock:
-            self.repo.configure_remote("pullurl", "git@domain.com:gituser/repo.git", "branch")
+            self.repo.configure_remote(
+                "pullurl", "git@domain.com:gituser/repo.git", "branch"
+            )
             self.assertEqual(self.repo.get_config("gitreview.username"), "gituser")
 
     def test_set_gitreview_username_ssh(self):
         with self.repo.lock:
-            self.repo.configure_remote("pullurl", "ssh://sshuser@domain.com:29418/repo.git", "branch")
+            self.repo.configure_remote(
+                "pullurl", "ssh://sshuser@domain.com:29418/repo.git", "branch"
+            )
             self.assertEqual(self.repo.get_config("gitreview.username"), "sshuser")
 
     def test_set_gitreview_username_https(self):
         with self.repo.lock:
-            self.repo.configure_remote("pullurl", "https://httpsuser@domain.com/user/repo.git", "branch")
+            self.repo.configure_remote(
+                "pullurl", "https://httpsuser@domain.com/user/repo.git", "branch"
+            )
             self.assertEqual(self.repo.get_config("gitreview.username"), "httpsuser")
 
     def test_set_gitreview_username_https_pathuser(self):
         with self.repo.lock:
-            self.repo.configure_remote("pullurl", "https://domain.com/httpspathuser/repo.git", "branch")
-            self.assertEqual(self.repo.get_config("gitreview.username"), "httpspathuser")
+            self.repo.configure_remote(
+                "pullurl", "https://domain.com/httpspathuser/repo.git", "branch"
+            )
+            self.assertEqual(
+                self.repo.get_config("gitreview.username"), "httpspathuser"
+            )
 
 
 class VCSSubversionTest(VCSGitTest):


### PR DESCRIPTION
## Proposed changes
This will automatically get the username from the push URL when using Gerrit as VCS
This solves issue #10596

## Checklist


- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
