### PR TITLE
Expose PostgreSQL when using the development Docker setup

### DIFF
--- a/dev-docker/docker-compose.yml
+++ b/dev-docker/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     - postgres-data:/var/lib/postgresql/data
     - ./postgres-init:/docker-entrypoint-initdb.d
     restart: always
+    ports:
+      - "5433:5432"
   cache:
     image: redis:7-alpine
     restart: always

--- a/dev-docker/docker-compose.yml
+++ b/dev-docker/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     - ./postgres-init:/docker-entrypoint-initdb.d
     restart: always
     ports:
-      - "5433:5432"
+    - 5433:5432
   cache:
     image: redis:7-alpine
     restart: always

--- a/docs/contributing/start.rst
+++ b/docs/contributing/start.rst
@@ -82,7 +82,8 @@ as the password. The new installation is empty, so you might want to continue wi
 :ref:`adding-projects`.
 
 The :file:`Dockerfile` and :file:`docker-compose.yml` for this are located in the
-:file:`dev-docker` directory.
+:file:`dev-docker` directory. For easier access to the database during development,
+the container running PostgreSQL is exposed on port ``5433``.
 
 The script also accepts some parameters, to execute tests, run it with the
 ``test`` parameter and then specify any :djadmin:`django:test` parameters,


### PR DESCRIPTION
## Proposed changes

Exposing the port of the PostgreSQL container would help a lot in the development especially when dealing with the records inside the database. This database is exposed to port 5433 only when using the development docker-compose of weblate.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
