### PR TITLE
Fix 'Rescan' not enforcing rescan of source translation files.

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1907,7 +1907,7 @@ class Component(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
     def do_file_scan(self, request=None):
         self.commit_pending("file-scan", request.user if request else None)
         try:
-            return self.create_translations(request=request)
+            return self.create_translations(request=request, force=True)
         except FileParseError:
             return False
 


### PR DESCRIPTION
## Proposed changes

Set the `force` option to `True` when calling `create_translations` in the `do_file_scan` handler, as already done by the `do_reset` one.

Currently, 'Reset' will (after resetting the weblate repository) enforce a complete rescan of all source translation files (e.g. all PO files).

The 'Rescan' option however, does not. As a consequence, translations sources are only re-scanned in case the source files are actually detected as changed since last update.

This behavior does not seem consistent with the description of this command (`Loads translations from the files into Weblate. Use when Weblate missed some of the strings after updating the repository`).

And it does not indeed actually update translations when e.g. the regular 'Update' command failed to finish properly (due to reaching the request timeout delay of the WSGI server e.g.).

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Found out this unexpected behavior while investigating 'missed updates' issues for some of our translations at translate.blender.org