### PR TITLE
feat(accounts): add autocomplete hints for password field

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Not yet released.
 **Improvements**
 
 * :ref:`subscriptions` now include strings which need updating.
+* Improved compatibility with password managers.
 
 **Bug fixes**
 

--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -85,11 +85,16 @@ class UniqueEmailMixin(forms.Form):
 class PasswordField(forms.CharField):
     """Password field."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        kwargs["widget"] = forms.PasswordInput(render_value=False)
+    def __init__(self, new_password: bool = False, **kwargs) -> None:
+        kwargs["widget"] = forms.PasswordInput(
+            attrs={
+                "autocomplete": "new-password" if new_password else "current-password"
+            },
+            render_value=False,
+        )
         kwargs["max_length"] = 256
         kwargs["strip"] = False
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
 
 class UniqueUsernameField(UsernameField):
@@ -465,8 +470,12 @@ class SetPasswordForm(DjangoSetPasswordForm):
     new_password1 = PasswordField(
         label=gettext_lazy("New password"),
         help_text=password_validation.password_validators_help_text_html(),
+        new_password=True,
     )
-    new_password2 = PasswordField(label=gettext_lazy("New password confirmation"))
+    new_password2 = PasswordField(
+        label=gettext_lazy("New password confirmation"),
+        new_password=True,
+    )
 
     @transaction.atomic
     def save(self, request, delete_session=False) -> None:


### PR DESCRIPTION


## Proposed changes

This makes it possible to generate new passwords instead of filling in existing one.

Thanks to @spaze for hint on this.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
