### PR TITLE
Implement pluralized add new translation string on web UI

### DIFF
--- a/docs/devel/integration.rst
+++ b/docs/devel/integration.rst
@@ -73,8 +73,9 @@ Any way of adding strings will be picked up, but consider using
 When translation files are separated from the code, the following ways can
 introduce new strings into Weblate.
 
-* Manually, using :guilabel:`Add new translation string` from :guilabel:`Tools`
-  menu in the source language.
+* Manually, using :guilabel:`Add new translation string` menu in the source language.
+  You can choose between :guilabel:`Singular` and :guilabel:`Plural` in the dropdown menu
+  depending on the form of the new translation string to be added.
 * Programmatically, using the API :http:post:`/api/translations/(string:project)/(string:component)/(string:language)/units/`.
 * By uploading source file as :guilabel:`Replace existing translation file`
   (this overwrites existing strings, so please ensure the file includes both

--- a/docs/devel/integration.rst
+++ b/docs/devel/integration.rst
@@ -73,9 +73,10 @@ Any way of adding strings will be picked up, but consider using
 When translation files are separated from the code, the following ways can
 introduce new strings into Weblate.
 
-* Manually, using :guilabel:`Add new translation string` menu in the source language.
-  You can choose between :guilabel:`Singular` and :guilabel:`Plural` in the dropdown menu
-  depending on the form of the new translation string to be added.
+* Manually, using :guilabel:`Add new translation string` from :guilabel:`Tools`
+  menu in the source language. You can choose between the radio buttons
+  :guilabel:`Singular` and :guilabel:`Plural` inside the form. Select the
+  appropriate form of the new translation string to be added.
 * Programmatically, using the API :http:post:`/api/translations/(string:project)/(string:component)/(string:language)/units/`.
 * By uploading source file as :guilabel:`Replace existing translation file`
   (this overwrites existing strings, so please ensure the file includes both

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -665,7 +665,7 @@ class Language(models.Model, CacheKeyMixin):
 
     def get_source_plurals(self):
         """Return blank source fields for pluralized new string."""
-        return ["" for _ in range(self.plural.number)]
+        return [""] * self.plural.number
 
 
 class PluralQuerySet(models.QuerySet):

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -664,7 +664,7 @@ class Language(models.Model, CacheKeyMixin):
         return self.base_code in vals
 
     def get_source_plurals(self):
-        """Returns initial number of source fields for pluralized new string."""
+        """Return blank source fields for pluralized new string."""
         values = ["" for _ in range(self.plural.number)]
         return values
 

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -665,8 +665,7 @@ class Language(models.Model, CacheKeyMixin):
 
     def get_source_plurals(self):
         """Return blank source fields for pluralized new string."""
-        values = ["" for _ in range(self.plural.number)]
-        return values
+        return ["" for _ in range(self.plural.number)]
 
 
 class PluralQuerySet(models.QuerySet):

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -664,9 +664,7 @@ class Language(models.Model, CacheKeyMixin):
         return self.base_code in vals
 
     def get_source_plurals(self):
-        """
-        Returns initial number of source fields for pluralized new string.
-        """
+        """Returns initial number of source fields for pluralized new string."""
         values = ["" for _ in range(self.plural.number)]
         return values
 

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -663,10 +663,6 @@ class Language(models.Model, CacheKeyMixin):
         """Detect whether language is in given list, ignores variants."""
         return self.base_code in vals
 
-    def get_source_plurals(self):
-        """Return blank source fields for pluralized new string."""
-        return [""] * self.plural.number
-
 
 class PluralQuerySet(models.QuerySet):
     def order(self):

--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -663,6 +663,13 @@ class Language(models.Model, CacheKeyMixin):
         """Detect whether language is in given list, ignores variants."""
         return self.base_code in vals
 
+    def get_source_plurals(self):
+        """
+        Returns initial number of source fields for pluralized new string.
+        """
+        values = ["" for _ in range(self.plural.number)]
+        return values
+
 
 class PluralQuerySet(models.QuerySet):
     def order(self):

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1451,15 +1451,36 @@ $(function () {
 
   /* Singular or plural new unit switcher */
   $("input[name='new-unit-form-type']").on("change", function () {
+    const refreshInput = (el, value) => {
+      el.value = value;
+      el.dispatchEvent(new CustomEvent("input"));
+    };
+    const transferTextareaInputs = (fromId, toId) => {
+      $(`${toId} textarea`).each((toIdx, toTextArea) => {
+        $(`${fromId} textarea`).each((fromIdx, fromTextArea) => {
+          if (fromTextArea.name === toTextArea.name) {
+            refreshInput(toTextArea, fromTextArea.value);
+          }
+        });
+      });
+    };
     const selected = $(this).val();
     if (selected === "singular") {
       $("input[name='new-unit-form-type']").removeAttr("checked");
       $("#new-singular #show-singular").prop("checked", true);
+      $("#new-singular input[name='context']").val(
+        $("#new-plural input[name='context']").val(),
+      );
+      transferTextareaInputs("#new-plural", "#new-singular");
       $("#new-plural").addClass("hidden");
       $("#new-singular").removeClass("hidden");
     } else if (selected === "plural") {
       $("input[name='new-unit-form-type']").removeAttr("checked");
       $("#new-plural #show-plural").prop("checked", true);
+      $("#new-plural input[name='context']").val(
+        $("#new-singular input[name='context']").val(),
+      );
+      transferTextareaInputs("#new-singular", "#new-plural");
       $("#new-singular").addClass("hidden");
       $("#new-plural").removeClass("hidden");
     }

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1449,6 +1449,22 @@ $(function () {
     (start, end, label) => {},
   );
 
+  /* Singular or plural new unit switcher */
+  $("input[name='new-unit-form-type']").on("change", function () {
+    const selected = $(this).val();
+    if (selected === "singular") {
+      $("input[name='new-unit-form-type']").removeAttr("checked");
+      $("#new-singular #show-singular").prop("checked", true);
+      $("#new-plural").addClass("hidden");
+      $("#new-singular").removeClass("hidden");
+    } else if (selected === "plural") {
+      $("input[name='new-unit-form-type']").removeAttr("checked");
+      $("#new-plural #show-plural").prop("checked", true);
+      $("#new-singular").addClass("hidden");
+      $("#new-plural").removeClass("hidden");
+    }
+  });
+
   /* Warn users that they do not want to use developer console in most cases */
   console.log(
     "%c%s",

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -311,7 +311,7 @@
           </label>
           <label class="radio-inline">
             <input type="radio" name="new-unit-form-type" id="show-plural" value="plural"
-              {% if object.language.plural.number < 2 %} disabled{% endif %}> {% trans "Plural" %}
+              {% if object.plural.number < 2 %} disabled{% endif %}> {% trans "Plural" %}
           </label>
         </div>
         <div class="panel-footer">
@@ -320,7 +320,7 @@
       </div>
     </form>
     </div>
-    {% if object.language.plural.number > 1 %}
+    {% if object.plural.number > 1 %}
     <div id="new-plural" class="hidden">
       <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
         <div class="panel panel-default">

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -74,9 +74,6 @@
       {% endif %}
       <li><a href="{% url 'data_project' project=object.component.project.slug  %}">{% trans "Data exports" %}</a></li>
       <li><a href="{% url 'checks' path=object.get_url_path %}">{% trans "Failing checks" %}</a></li>
-      {% if user_can_add_unit %}
-      <li><a href="#new" data-toggle="tab">{{ object.component.get_add_label }}</a></li>
-      {% endif %}
     </ul>
   </li>
   {% if user_can_see_repository_status %}
@@ -98,6 +95,17 @@
       {% endif %}
     </ul>
   </li>
+  {% endif %}
+  {% if user_can_add_unit %}
+    <li class="dropdown">
+    <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+      {{ object.component.get_add_label }} <span class="caret"></span>
+    </a>
+    <ul class="dropdown-menu">
+      <li><a href="#new-singular" data-toggle="tab">{% trans "Singular" %}</a></li>
+      <li><a href="#new-plural" data-toggle="tab">{% trans "Plural" %}</a></li>
+    </ul>
+    </li>
   {% endif %}
   {% include "snippets/share-menu.html" with object=object %}
 </ul>
@@ -295,23 +303,42 @@
 {% endif %}
 
 {% if user_can_add_unit %}
-<div class="tab-pane" id="new">
-<form action="{% url 'new-unit' path=object.get_url_path  %}" method="post">
-<div class="panel panel-default">
-<div class="panel-heading"><h4 class="panel-title">{{ object.component.get_add_label }}</h4></div>
-<div class="panel-body">
-{% if obj.is_source %}
-<p>{% trans "You can add a new translation string here, it will automatically appear in all translations." %}</p>
-{% endif %}
-{% csrf_token %}
-{{ new_unit_form|crispy }}
-</div>
-<div class="panel-footer">
-<input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
-</div>
-</div>
-</form>
-</div>
+  <div class="tab-pane" id="new-singular">
+    <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
+      <div class="panel panel-default">
+        <div class="panel-heading"><h4 class="panel-title">{{ object.component.get_add_label }}</h4></div>
+        <div class="panel-body">
+          {% if obj.is_source %}
+            <p>{% trans "You can add a new translation string here, it will automatically appear in all translations." %}</p>
+          {% endif %}
+          {% csrf_token %}
+          {{ new_unit_form|crispy }}
+        </div>
+        <div class="panel-footer">
+          <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
+          <a class="btn btn-warning btn-spaced" href="#new-plural">{% trans "Change to Plural" %}</a>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="tab-pane" id="new-plural">
+    <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
+      <div class="panel panel-default">
+        <div class="panel-heading"><h4 class="panel-title">{{ object.component.get_add_label }}</h4></div>
+        <div class="panel-body">
+          {% if obj.is_source %}
+            <p>{% trans "You can add a new translation string here, it will automatically appear in all translations." %}</p>
+          {% endif %}
+          {% csrf_token %}
+          {{ new_unit_plural_form|crispy }}
+        </div>
+        <div class="panel-footer">
+          <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
+          <a class="btn btn-warning btn-spaced" href="#new-singular">{% trans "Change to Singular" %}</a>
+        </div>
+      </div>
+    </form>
+  </div>
 {% endif %}
 
 <div class="tab-pane" id="download">

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -103,7 +103,9 @@
     </a>
     <ul class="dropdown-menu">
       <li><a href="#new-singular" data-toggle="tab">{% trans "Singular" %}</a></li>
-      <li><a href="#new-plural" data-toggle="tab">{% trans "Plural" %}</a></li>
+      {% if object.language.plural.number > 1 %}
+        <li><a href="#new-plural" data-toggle="tab">{% trans "Plural" %}</a></li>
+      {% endif %}
     </ul>
     </li>
   {% endif %}
@@ -316,29 +318,33 @@
         </div>
         <div class="panel-footer">
           <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
-          <a class="btn btn-warning btn-spaced" href="#new-plural">{% trans "Change to Plural" %}</a>
-        </div>
-      </div>
-    </form>
-  </div>
-  <div class="tab-pane" id="new-plural">
-    <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
-      <div class="panel panel-default">
-        <div class="panel-heading"><h4 class="panel-title">{{ object.component.get_add_label }}</h4></div>
-        <div class="panel-body">
-          {% if obj.is_source %}
-            <p>{% trans "You can add a new translation string here, it will automatically appear in all translations." %}</p>
+          {% if object.language.plural.number > 1 %}
+            <a class="btn btn-warning btn-spaced" href="#new-plural">{% trans "Change to Plural" %}</a>
           {% endif %}
-          {% csrf_token %}
-          {{ new_unit_plural_form|crispy }}
-        </div>
-        <div class="panel-footer">
-          <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
-          <a class="btn btn-warning btn-spaced" href="#new-singular">{% trans "Change to Singular" %}</a>
         </div>
       </div>
     </form>
   </div>
+  {% if object.language.plural.number > 1 %}
+    <div class="tab-pane" id="new-plural">
+      <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
+        <div class="panel panel-default">
+          <div class="panel-heading"><h4 class="panel-title">{{ object.component.get_add_label }}</h4></div>
+          <div class="panel-body">
+            {% if obj.is_source %}
+              <p>{% trans "You can add a new translation string here, it will automatically appear in all translations." %}</p>
+            {% endif %}
+            {% csrf_token %}
+            {{ new_unit_plural_form|crispy }}
+          </div>
+          <div class="panel-footer">
+            <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
+            <a class="btn btn-warning btn-spaced" href="#new-singular">{% trans "Change to Singular" %}</a>
+          </div>
+        </div>
+      </form>
+    </div>
+  {% endif %}
 {% endif %}
 
 <div class="tab-pane" id="download">

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -74,6 +74,9 @@
       {% endif %}
       <li><a href="{% url 'data_project' project=object.component.project.slug  %}">{% trans "Data exports" %}</a></li>
       <li><a href="{% url 'checks' path=object.get_url_path %}">{% trans "Failing checks" %}</a></li>
+      {% if user_can_add_unit %}
+        <li><a href="#new" data-toggle="tab">{{ object.component.get_add_label }}</a></li>
+      {% endif %}
     </ul>
   </li>
   {% if user_can_see_repository_status %}
@@ -95,19 +98,6 @@
       {% endif %}
     </ul>
   </li>
-  {% endif %}
-  {% if user_can_add_unit %}
-    <li class="dropdown">
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-      {{ object.component.get_add_label }} <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu">
-      <li><a href="#new-singular" data-toggle="tab">{% trans "Singular" %}</a></li>
-      {% if object.language.plural.number > 1 %}
-        <li><a href="#new-plural" data-toggle="tab">{% trans "Plural" %}</a></li>
-      {% endif %}
-    </ul>
-    </li>
   {% endif %}
   {% include "snippets/share-menu.html" with object=object %}
 </ul>
@@ -305,8 +295,9 @@
 {% endif %}
 
 {% if user_can_add_unit %}
-  <div class="tab-pane" id="new-singular">
-    <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
+  <div class="tab-pane" id="new">
+    <div id="new-singular">
+      <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
       <div class="panel panel-default">
         <div class="panel-heading"><h4 class="panel-title">{{ object.component.get_add_label }}</h4></div>
         <div class="panel-body">
@@ -315,18 +306,22 @@
           {% endif %}
           {% csrf_token %}
           {{ new_unit_form|crispy }}
+          <label class="radio-inline">
+            <input type="radio" name="new-unit-form-type" id="show-singular" value="singular" checked> {% trans "Singular" %}
+          </label>
+          <label class="radio-inline">
+            <input type="radio" name="new-unit-form-type" id="show-plural" value="plural"
+              {% if object.language.plural.number < 2 %} disabled{% endif %}> {% trans "Plural" %}
+          </label>
         </div>
         <div class="panel-footer">
           <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
-          {% if object.language.plural.number > 1 %}
-            <a class="btn btn-warning btn-spaced" href="#new-plural">{% trans "Change to Plural" %}</a>
-          {% endif %}
         </div>
       </div>
     </form>
-  </div>
-  {% if object.language.plural.number > 1 %}
-    <div class="tab-pane" id="new-plural">
+    </div>
+    {% if object.language.plural.number > 1 %}
+    <div id="new-plural" class="hidden">
       <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
         <div class="panel panel-default">
           <div class="panel-heading"><h4 class="panel-title">{{ object.component.get_add_label }}</h4></div>
@@ -336,15 +331,21 @@
             {% endif %}
             {% csrf_token %}
             {{ new_unit_plural_form|crispy }}
+            <label class="radio-inline">
+              <input type="radio" name="new-unit-form-type" id="show-singular" value="singular"> {% trans "Singular" %}
+            </label>
+            <label class="radio-inline">
+              <input type="radio" name="new-unit-form-type" id="show-plural" value="plural"> {% trans "Plural" %}
+            </label>
           </div>
           <div class="panel-footer">
             <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
-            <a class="btn btn-warning btn-spaced" href="#new-singular">{% trans "Change to Singular" %}</a>
           </div>
         </div>
       </form>
     </div>
   {% endif %}
+  </div>
 {% endif %}
 
 <div class="tab-pane" id="download">

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -186,6 +186,7 @@ class PluralTextarea(forms.Textarea):
 
     def __init__(self, *args, **kwargs) -> None:
         self.profile = None
+        self.is_source_plural = None
         super().__init__(*args, **kwargs)
 
     def get_rtl_toolbar(self, fieldname):
@@ -299,9 +300,14 @@ class PluralTextarea(forms.Textarea):
     def render(self, name, value, attrs=None, renderer=None, **kwargs):
         """Render all textareas with correct plural labels."""
         unit = value
-        values = unit.get_target_plurals()
         translation = unit.translation
         lang_label = lang = translation.language
+        if self.is_source_plural:
+            plurals = ['' for _ in range(lang.plural.number)]
+            values = plurals
+        else:
+            plurals = unit.get_source_plurals()
+            values = unit.get_target_plurals()
         if "zen-mode" in self.attrs:
             lang_label = format_html(
                 '<a class="language" href="{}">{}</a>',
@@ -310,7 +316,6 @@ class PluralTextarea(forms.Textarea):
             )
         plural = translation.plural
         tabindex = self.attrs["tabindex"]
-        plurals = unit.get_source_plurals()
         placeables = set()
         for text in plurals:
             placeables.update(hl[2] for hl in highlight_string(text, unit))
@@ -2406,13 +2411,15 @@ class NewBilingualSourceUnitForm(NewUnitBaseForm):
     )
 
     def __init__(
-        self, translation, user, tabindex: int | None = None, *args, **kwargs
+        self, translation, user, tabindex: int | None = None,
+        is_source_plural: bool | None = None, *args, **kwargs
     ) -> None:
         super().__init__(translation, user, tabindex, *args, **kwargs)
         self.fields["context"].widget.attrs["tabindex"] = self.tabindex
         self.fields["context"].label = translation.component.context_label
         self.fields["source"].widget.attrs["tabindex"] = self.tabindex + 1
         self.fields["source"].widget.profile = user.profile
+        self.fields["source"].widget.is_source_plural = is_source_plural
         self.fields["source"].initial = Unit(
             translation=translation.component.source_translation, id_hash=0
         )
@@ -2476,7 +2483,7 @@ class NewBilingualGlossaryUnitForm(GlossaryAddMixin, NewBilingualUnitForm):
     pass
 
 
-def get_new_unit_form(translation, user, data=None, initial=None):
+def get_new_unit_form(translation, user, data=None, initial=None, is_source_plural=None):
     if translation.component.has_template():
         return NewMonolingualUnitForm(translation, user, data=data, initial=initial)
     if translation.component.is_glossary:
@@ -2488,7 +2495,10 @@ def get_new_unit_form(translation, user, data=None, initial=None):
             translation, user, data=data, initial=initial
         )
     if translation.is_source:
-        return NewBilingualSourceUnitForm(translation, user, data=data, initial=initial)
+        return NewBilingualSourceUnitForm(
+            translation, user, data=data, initial=initial,
+            is_source_plural=is_source_plural
+        )
     return NewBilingualUnitForm(translation, user, data=data, initial=initial)
 
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -303,7 +303,7 @@ class PluralTextarea(forms.Textarea):
         translation = unit.translation
         lang_label = lang = translation.language
         if self.is_source_plural:
-            plurals = lang.get_source_plurals()
+            plurals = translation.get_source_plurals()
             values = plurals
         else:
             plurals = unit.get_source_plurals()

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -303,7 +303,7 @@ class PluralTextarea(forms.Textarea):
         translation = unit.translation
         lang_label = lang = translation.language
         if self.is_source_plural:
-            plurals = ['' for _ in range(lang.plural.number)]
+            plurals = ["" for _ in range(lang.plural.number)]
             values = plurals
         else:
             plurals = unit.get_source_plurals()
@@ -2411,8 +2411,13 @@ class NewBilingualSourceUnitForm(NewUnitBaseForm):
     )
 
     def __init__(
-        self, translation, user, tabindex: int | None = None,
-        is_source_plural: bool | None = None, *args, **kwargs
+        self,
+        translation,
+        user,
+        tabindex: int | None = None,
+        is_source_plural: bool | None = None,
+        *args,
+        **kwargs,
     ) -> None:
         super().__init__(translation, user, tabindex, *args, **kwargs)
         self.fields["context"].widget.attrs["tabindex"] = self.tabindex
@@ -2483,7 +2488,9 @@ class NewBilingualGlossaryUnitForm(GlossaryAddMixin, NewBilingualUnitForm):
     pass
 
 
-def get_new_unit_form(translation, user, data=None, initial=None, is_source_plural=None):
+def get_new_unit_form(
+    translation, user, data=None, initial=None, is_source_plural=None
+):
     if translation.component.has_template():
         return NewMonolingualUnitForm(translation, user, data=data, initial=initial)
     if translation.component.is_glossary:
@@ -2496,8 +2503,11 @@ def get_new_unit_form(translation, user, data=None, initial=None, is_source_plur
         )
     if translation.is_source:
         return NewBilingualSourceUnitForm(
-            translation, user, data=data, initial=initial,
-            is_source_plural=is_source_plural
+            translation,
+            user,
+            data=data,
+            initial=initial,
+            is_source_plural=is_source_plural,
         )
     return NewBilingualUnitForm(translation, user, data=data, initial=initial)
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -303,7 +303,7 @@ class PluralTextarea(forms.Textarea):
         translation = unit.translation
         lang_label = lang = translation.language
         if self.is_source_plural:
-            plurals = ["" for _ in range(lang.plural.number)]
+            plurals = lang.get_source_plurals()
             values = plurals
         else:
             plurals = unit.get_source_plurals()

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2383,12 +2383,19 @@ class NewMonolingualUnitForm(NewUnitBaseForm):
     )
 
     def __init__(
-        self, translation, user, tabindex: int | None = None, *args, **kwargs
+        self,
+        translation,
+        user,
+        tabindex: int | None = None,
+        is_source_plural: bool | None = None,
+        *args,
+        **kwargs,
     ) -> None:
         super().__init__(translation, user, tabindex, *args, **kwargs)
         self.fields["context"].widget.attrs["tabindex"] = self.tabindex
         self.fields["source"].widget.attrs["tabindex"] = self.tabindex + 1
         self.fields["source"].widget.profile = user.profile
+        self.fields["source"].widget.is_source_plural = is_source_plural
         self.fields["source"].initial = Unit(translation=translation, id_hash=0)
 
 
@@ -2492,7 +2499,13 @@ def get_new_unit_form(
     translation, user, data=None, initial=None, is_source_plural=None
 ):
     if translation.component.has_template():
-        return NewMonolingualUnitForm(translation, user, data=data, initial=initial)
+        return NewMonolingualUnitForm(
+            translation,
+            user,
+            data=data,
+            initial=initial,
+            is_source_plural=is_source_plural,
+        )
     if translation.component.is_glossary:
         if translation.is_source:
             return NewBilingualGlossarySourceUnitForm(

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2447,11 +2447,18 @@ class NewBilingualUnitForm(NewBilingualSourceUnitForm):
     )
 
     def __init__(
-        self, translation, user, tabindex: int | None = None, *args, **kwargs
+        self,
+        translation,
+        user,
+        tabindex: int | None = None,
+        is_source_plural: bool | None = None,
+        *args,
+        **kwargs,
     ) -> None:
-        super().__init__(translation, user, tabindex, *args, **kwargs)
+        super().__init__(translation, user, tabindex, is_source_plural, *args, **kwargs)
         self.fields["target"].widget.attrs["tabindex"] = self.tabindex + 2
         self.fields["target"].widget.profile = user.profile
+        self.fields["target"].widget.is_source_plural = is_source_plural
         self.fields["target"].initial = Unit(translation=translation, id_hash=0)
 
 
@@ -2522,7 +2529,9 @@ def get_new_unit_form(
             initial=initial,
             is_source_plural=is_source_plural,
         )
-    return NewBilingualUnitForm(translation, user, data=data, initial=initial)
+    return NewBilingualUnitForm(
+        translation, user, data=data, initial=initial, is_source_plural=is_source_plural
+    )
 
 
 class BulkEditForm(forms.Form):

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1681,6 +1681,10 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
     def all_repo_components(self):
         return self.component.all_repo_components
 
+    def get_source_plurals(self):
+        """Return blank source fields for pluralized new string."""
+        return [""] * self.plural.number
+
 
 class GhostTranslation:
     """Ghost translation object used to show missing translations."""

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -216,6 +216,9 @@ class EditTest(ViewTestCase):
         if not self.component.file_format_cls.can_add_unit:
             self.assertEqual(response.status_code, 403)
             return
+        if not self.component.file_format_cls.supports_plural:
+            self.assertContains(response, "Plurals are not supported by the file format")
+            return
         self.assertContains(response, "New string has been added")
 
         # Duplicate string

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -220,7 +220,6 @@ class EditTest(ViewTestCase):
 
         # Duplicate string
         response = self.add_plural_unit("test-plural")
-        print(f"[TEST] response: {response.content}")
         self.assertContains(response, "This string seems to already exist.")
 
         self.component.commit_pending("test", None)

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -217,7 +217,9 @@ class EditTest(ViewTestCase):
             self.assertEqual(response.status_code, 403)
             return
         if not self.component.file_format_cls.supports_plural:
-            self.assertContains(response, "Plurals are not supported by the file format")
+            self.assertContains(
+                response, "Plurals are not supported by the file format"
+            )
             return
         self.assertContains(response, "New string has been added")
 

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -230,16 +230,23 @@ class EditTest(ViewTestCase):
         self.component.commit_pending("test", None)
 
     def test_bilingual_new_plural_unit(self):
-        args = {
-            "context": "new-bilingual-plural-unit",
-            "source_0": "%(count)s word",
-            "source_1": "%(count)s words",
-            "target_0": "%(count)s slovo",
-            "target_1": "%(count)s slova",
-            "target_2": "%(count)s slov",
-        }
+        """Test the implementation of adding a bilingual new plural unit."""
+        if (
+            not self.component.has_template()
+            and self.component.file_format_cls.can_add_unit
+        ):
+            args = {
+                "context": "new-bilingual-plural-unit",
+                "source_0": "%(count)s word",
+                "source_1": "%(count)s words",
+                "target_0": "%(count)s slovo",
+                "target_1": "%(count)s slova",
+                "target_2": "%(count)s slov",
+            }
 
-        self.test_new_plural_unit(args, "cs")
+            self.test_new_plural_unit(args, language="cs")
+        else:
+            raise SkipTest("Not supported")
 
 
 class EditValidationTest(ViewTestCase):

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -180,7 +180,11 @@ class EditTest(ViewTestCase):
         self.component.commit_pending("test", None)
 
     def add_plural_unit(self, key):
-        args = {"context": key, "source_0": "%(count)s test", "source_1": "%(count)s tests"}
+        args = {
+            "context": key,
+            "source_0": "%(count)s test",
+            "source_1": "%(count)s tests",
+        }
         language = "en"
 
         return self.client.post(
@@ -216,7 +220,7 @@ class EditTest(ViewTestCase):
 
         # Duplicate string
         response = self.add_plural_unit("test-plural")
-        print('[TEST] response: {}'.format(response.content))
+        print(f"[TEST] response: {response.content}")
         self.assertContains(response, "This string seems to already exist.")
 
         self.component.commit_pending("test", None)

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -664,6 +664,7 @@ def show_translation(request, obj):
                 project=project,
             ),
             "new_unit_form": get_new_unit_form(obj, user),
+            "new_unit_plural_form": get_new_unit_form(obj, user, is_source_plural=True),
             "announcement_form": optional_form(
                 AnnouncementForm, user, "component.edit", obj
             ),


### PR DESCRIPTION
## Proposed changes
This changes the way how the adding of new translation string done in the web UI.
This adds an option to add pluralized translation string.
This solves issue #7663.

Example image:
![Screenshot 2024-06-18 at 23-38-58 Test Project_Test Component — English @ Devel Weblate](https://github.com/WeblateOrg/weblate/assets/20557045/58866bd7-049a-44a2-ad96-309bacbf3249)


## Checklist
- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
