### PR TITLE
fix(machinery): avoid mixing translations with different replacements

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,7 @@ Released on June 19th 2024.
 * Fixed behavior of some site-wide :ref:`addons`.
 * Saving strings needing editing to :doc:`/formats/winrc`.
 * :ref:`check-xml-tags` better handle XML entities.
+* Automatic suggestions could mix up replacements between translated strings.
 
 **Compatibility**
 

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -527,13 +527,16 @@ class BatchMachineTranslation:
             # Postprocess translations
             for text, result in translations.items():
                 for _unit, original_source, replacements in pending[text]:
-                    for item in result:
+                    # Always operate on copy of the dictionaries
+                    partial = [x.copy() for x in result]
+
+                    for item in partial:
                         item["original_source"] = original_source
                     if cache_key:
-                        cache.set(cache_key, result, 30 * 86400)
+                        cache.set(cache_key, partial, 30 * 86400)
                     if replacements or self.force_uncleanup:
-                        self.uncleanup_results(replacements, result)
-                    output[original_source] = result
+                        self.uncleanup_results(replacements, partial)
+                    output[original_source] = partial
         return output
 
     def get_error_message(self, exc: Exception) -> str:

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -373,6 +373,16 @@ class MachineTranslationTest(BaseMachineTranslationTest):
             ],
         )
 
+    def test_batch(self):
+        machine_translation = self.get_machine()
+        units = [
+            MockUnit(code="cs", source="Hello, %s!", flags="c-format"),
+            MockUnit(code="cs", source="Hello, %d!", flags="c-format"),
+        ]
+        machine_translation.batch_translate(units)
+        self.assertEqual(units[0].machinery["translation"], ["Nazdar %s!"])
+        self.assertEqual(units[1].machinery["translation"], ["Nazdar %d!"])
+
     def test_key(self) -> None:
         machine_translation = self.get_machine()
         self.assertEqual(


### PR DESCRIPTION
## Proposed changes

The same text and different replacements would use first replacements only because the text is replaced in the translations dictionary.

Fixes #11179


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
