### PR TITLE
Show string/word numbers on search results

### DIFF
--- a/weblate/templates/search.html
+++ b/weblate/templates/search.html
@@ -19,7 +19,7 @@
         {% crispy search_form  %}
     </form>
     {% if page_obj.object_list %}
-        <div><p>{{ total_strings }} strings / {{ total_words }} words</p></div>
+      <div><p>{{ total_strings }} {% trans "strings" %} / {{ total_words }} {% trans "words" %}</p></div>
         {% include "snippets/embed-units.html" with units=page_obj.object_list hide_context=True include_search=True force_source=True show_translation=True %}
         {% include "paginator.html" %}
     {% else %}

--- a/weblate/templates/search.html
+++ b/weblate/templates/search.html
@@ -19,6 +19,10 @@
         {% crispy search_form  %}
     </form>
     {% if page_obj.object_list %}
+        <!-- Display total number of strings and words -->
+        <div>
+            <p>{{ total_strings }} strings / {{ total_words }} words</p>
+        </div>
         {% include "snippets/embed-units.html" with units=page_obj.object_list hide_context=True include_search=True force_source=True show_translation=True %}
         {% include "paginator.html" %}
     {% else %}

--- a/weblate/templates/search.html
+++ b/weblate/templates/search.html
@@ -19,10 +19,7 @@
         {% crispy search_form  %}
     </form>
     {% if page_obj.object_list %}
-        <!-- Display total number of strings and words -->
-        <div>
-            <p>{{ total_strings }} strings / {{ total_words }} words</p>
-        </div>
+        <div><p>{{ total_strings }} strings / {{ total_words }} words</p></div>
         {% include "snippets/embed-units.html" with units=page_obj.object_list hide_context=True include_search=True force_source=True show_translation=True %}
         {% include "paginator.html" %}
     {% else %}

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -154,6 +154,11 @@ def search(request, path=None):
         units = get_paginator(
             request, units.order_by_request(search_form.cleaned_data, obj)
         )
+
+        # Calculate total number of strings and words
+        total_strings = units.paginator.count
+        total_words = sum(unit.num_words for unit in units.object_list)
+
         # Rebuild context from scratch here to get new form
         context.update(
             {
@@ -168,6 +173,8 @@ def search(request, path=None):
                 "search_items": search_form.items(),
                 "sort_name": sort["name"],
                 "sort_query": sort["query"],
+                "total_strings": total_strings,
+                "total_words": total_words,
             }
         )
     elif is_ratelimited:

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -157,7 +157,7 @@ def search(request, path=None):
 
         # Calculate total number of strings and words
         total_strings = units.paginator.count
-        total_words = sum(unit.num_words for unit in units.object_list)
+        total_words = sum(unit.num_words for unit in unit_set.all())
 
         # Rebuild context from scratch here to get new form
         context.update(


### PR DESCRIPTION
# Summary:
This pull request adds the display of total strings and words in search results. Issue: #11853

# Changes Introduced:
- Updated the search view to calculate total_strings and total_words from the search results.
- Modified search.html to show total_strings and total_words at the top of the search results.
