### PR TITLE
Add case-sensitive key sorting setting in Properties add-on

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -785,7 +785,9 @@ Format the Java properties file
 -------------------------------
 
 :Add-on ID: ``weblate.properties.sort``
-:Configuration: `This add-on has no configuration.`
+:Configuration: +--------------------+--------------------------------------------+--+
+                | ``case_sensitive`` | Enable case-sensitive key sorting          |  |
+                +--------------------+--------------------------------------------+--+
 :Triggers: repository pre-commit
 
 Formats and sorts the Java properties file.

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -630,3 +630,11 @@ class PseudolocaleAddonForm(BaseAddonForm):
         result["source"] = result["source"].pk
         result["target"] = result["target"].pk
         return result
+
+
+class PropertiesSortAddonForm(BaseAddonForm):
+    case_sensitive = forms.BooleanField(
+        label=gettext_lazy("Enable case-sensitive key sorting"),
+        required=False,
+        initial=False,
+    )

--- a/weblate/addons/properties.py
+++ b/weblate/addons/properties.py
@@ -18,6 +18,7 @@ from django.utils.translation import gettext_lazy
 
 from weblate.addons.base import BaseAddon
 from weblate.addons.events import AddonEvent
+from weblate.addons.forms import PropertiesSortAddonForm
 
 SPLITTER = re.compile(r"\s*=\s*")
 UNICODE = re.compile(r"\\[uU][0-9a-fA-F]{4}")
@@ -113,12 +114,12 @@ def filter_lines(lines):
     return result
 
 
-def format_file(filename) -> None:
+def format_file(filename, case_sensitive) -> None:
     """Format single properties file."""
     with open(filename) as handle:
         lines = handle.readlines()
 
-    result = sorted(lines, key=sort_key)
+    result = sorted(lines) if case_sensitive else sorted(lines, key=sort_key)
 
     fix_newlines(result)
     format_unicode(result)
@@ -136,6 +137,8 @@ class PropertiesSortAddon(BaseAddon):
     description = gettext_lazy("Formats and sorts the Java properties file.")
     compat = {"file_format": {"properties-utf8", "properties", "gwt"}}
     icon = "sort-alphabetical.svg"
+    settings_form = PropertiesSortAddonForm
 
     def pre_commit(self, translation, author) -> None:
-        format_file(translation.get_filename())
+        case_sensitive = self.instance.configuration["case_sensitive"]
+        format_file(translation.get_filename(), case_sensitive)

--- a/weblate/addons/properties.py
+++ b/weblate/addons/properties.py
@@ -24,9 +24,11 @@ SPLITTER = re.compile(r"\s*=\s*")
 UNICODE = re.compile(r"\\[uU][0-9a-fA-F]{4}")
 
 
-def sort_key(line):
+def sort_key(line, case_sensitive):
     """Sort key for properties."""
     prefix = SPLITTER.split(line, 1)[0]
+    if case_sensitive:
+        return prefix
     return prefix.lower()
 
 
@@ -119,7 +121,7 @@ def format_file(filename, case_sensitive) -> None:
     with open(filename) as handle:
         lines = handle.readlines()
 
-    result = sorted(lines) if case_sensitive else sorted(lines, key=sort_key)
+    result = sorted(lines, key=lambda line: sort_key(line, case_sensitive))
 
     fix_newlines(result)
     format_unicode(result)

--- a/weblate/addons/properties.py
+++ b/weblate/addons/properties.py
@@ -24,7 +24,7 @@ SPLITTER = re.compile(r"\s*=\s*")
 UNICODE = re.compile(r"\\[uU][0-9a-fA-F]{4}")
 
 
-def sort_key(line, case_sensitive):
+def sort_key(line: str, case_sensitive: bool) -> str:
     """Sort key for properties."""
     prefix = SPLITTER.split(line, 1)[0]
     if case_sensitive:
@@ -116,7 +116,7 @@ def filter_lines(lines):
     return result
 
 
-def format_file(filename, case_sensitive) -> None:
+def format_file(filename: str, case_sensitive: bool) -> None:
     """Format single properties file."""
     with open(filename) as handle:
         lines = handle.readlines()
@@ -142,5 +142,5 @@ class PropertiesSortAddon(BaseAddon):
     settings_form = PropertiesSortAddonForm
 
     def pre_commit(self, translation, author) -> None:
-        case_sensitive = self.instance.configuration["case_sensitive"]
+        case_sensitive = self.instance.configuration.get("case_sensitive", False)
         format_file(translation.get_filename(), case_sensitive)

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -849,6 +849,16 @@ class PropertiesAddonTest(ViewTestCase):
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("java/swing_messages_cs.properties", commit)
 
+    def test_sort_case_sensitive(self) -> None:
+        self.edit_unit("Hello, world!\n", "Nazdar svete!\n")
+        self.assertTrue(PropertiesSortAddon.can_install(self.component, None))
+        PropertiesSortAddon.create(
+            component=self.component, configuration={"case_sensitive": True}
+        )
+        self.get_translation().commit_pending("test", None)
+        commit = self.component.repository.show(self.component.repository.last_revision)
+        self.assertIn("java/swing_messages_cs.properties", commit)
+
     def test_cleanup(self) -> None:
         self.assertTrue(CleanupAddon.can_install(self.component, None))
         init_rev = self.component.repository.last_revision


### PR DESCRIPTION
## Proposed changes

This adds a configuration to toggle case-sensitive key sorting to the `weblate.properties.sort` add-on.
This solves issue #11714.

Example images:

![Screenshot 2024-06-25 at 16-27-23 Freeplane_Test Component @ Devel Weblate](https://github.com/WeblateOrg/weblate/assets/20557045/d681c09c-1fa7-462f-9cd9-6c04d66f520a)

![Screenshot 2024-06-25 at 16-23-01 Freeplane_Test Component @ Devel Weblate](https://github.com/WeblateOrg/weblate/assets/20557045/14d85303-1d61-4797-99d2-caef6f5cb90c)


## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

