### PR TITLE
fix(formats): do not copy template notes for new translations

### DIFF
--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -271,8 +271,8 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
             self.assertEqual(unit.unit.getnotes().strip(), "")
         else:
             # Assume this is a multi-unit. Will fail otherwise.
-            for unit in unit.units:
-                self.assertEqual(unit.unit.getnotes(), "")
+            for subunit in unit.units:
+                self.assertEqual(subunit.unit.getnotes(), "")
 
     def test_find(self) -> None:
         storage = self.parse_file(self.FILE)

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -266,9 +266,7 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
         self.assertEqual(testdata.decode().strip(), newdata.decode().strip())
 
     def assert_no_notes(self, unit) -> None:
-        """
-        Assert that the underlying unit(s) do not have any notes.
-        """
+        """Assert that the underlying unit(s) do not have any notes."""
         if unit.unit:
             self.assertEqual(unit.unit.getnotes().strip(), "")
         else:

--- a/weblate/formats/tests/test_multi.py
+++ b/weblate/formats/tests/test_multi.py
@@ -88,6 +88,7 @@ class MonoMultiCSVUtf8FormatTest(MultiCSVUtf8FormatTest):
     FILE = TEST_MONO_CSV
     BASE = TEST_MONO_BASE_CSV
     TEMPLATE = TEST_MONO_BASE_CSV
+    SUPPORTS_NOTES = False
     EXPECTED_EDIT = [
         '"context","target"',
         '"22298006","Infarctus myocardique"',

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -176,6 +176,12 @@ class TTKitUnit(TranslationUnit):
             flags.merge(self.template.xmlelement)
         return flags.format()
 
+    def clone_template(self) -> None:
+        super().clone_template()
+
+        # do not copy notes from the template (#11133)
+        self.unit.removenotes()
+
     def untranslate(self, language) -> None:
         target: str | list[str]
         target = [""] * language.plural.number if self.mainunit.hasplural() else ""


### PR DESCRIPTION


## Proposed changes

Do not copy the notes (comments) from the template/source when adding a translation for a key (in monolingual formats).

This fixes #11133. Copying the notes is problematic because the are not synced when they are updated. As a result, they can get out of date.

The implicit assumption behind this change is that most users only care about comments in source files (but not in target files).

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
