### PR TITLE
fix(add-ons): disable discovery add-on on site and project wide

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -49,6 +49,7 @@ class BaseAddon:
     icon = "cog.svg"
     project_scope = False
     repo_scope = False
+    needs_component = False
     has_summary = False
     alert: str = ""
     trigger_update = False

--- a/weblate/addons/discovery.py
+++ b/weblate/addons/discovery.py
@@ -22,6 +22,7 @@ class DiscoveryAddon(BaseAddon):
     multiple = True
     icon = "magnify.svg"
     repo_scope = True
+    needs_component = True
     trigger_update = True
 
     def post_update(

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -1442,6 +1442,10 @@ class AddonSerializer(serializers.ModelSerializer[Addon]):
 
         # Don't allow duplicate add-ons
         addon = addon_class(Addon())
+        if not component and addon_class.needs_component:
+            raise serializers.ValidationError(
+                {"component": "This add-on can only be installed on the component."}
+            )
         if not instance:
             if component:
                 self.check_addon(name, Addon.objects.filter_component(component))

--- a/weblate/templates/addons/addon_head.html
+++ b/weblate/templates/addons/addon_head.html
@@ -3,8 +3,10 @@
 {% load icons %}
 
 <h4>
-{% if addon.repo_scope %}
-<span class="badge pull-right flip" title="{% trans "This add-on is used for all components sharing this repository." %}">{% trans "repository wide" %}</span>
+{% if scope and scope != "component" and addon.needs_component %}
+  <span class="badge badge-danger pull-right flip">{% trans "The add-on can only be installed on the component." %}</span>
+{% elif addon.repo_scope %}
+  <span class="badge pull-right flip" title="{% trans "This add-on is used for all components sharing this repository." %}">{% trans "repository wide" %}</span>
 {% endif %}
 {% icon addon.icon %}
 {{ addon.verbose }}

--- a/weblate/templates/addons/addon_list.html
+++ b/weblate/templates/addons/addon_list.html
@@ -82,7 +82,11 @@
   {% include 'addons/addon_head.html' with addon=addon %}
   </td>
   <td class="bottom-button">
-    <form method="POST" class="inlineform">{% csrf_token %}<input type="hidden" name="name" value="{{ addon.name }}" /><button type="submit" class="btn btn-primary" data-addon="{{ addon.name }}">{% trans "Install" %}</button></form>
+    {% if scope != "component" and addon.needs_component %}
+      <button class="btn btn-primary" disabled title="{% trans "The add-on can only be installed on the component." %}">{% trans "Install" %}</button>
+    {% else %}
+      <form method="POST" class="inlineform">{% csrf_token %}<input type="hidden" name="name" value="{{ addon.name }}" /><button type="submit" class="btn btn-primary" data-addon="{{ addon.name }}">{% trans "Install" %}</button></form>
+    {% endif %}
   </td>
   </tr>
 {% endfor %}


### PR DESCRIPTION
## Proposed changes

It currently shows preview based on the component, so it crashes without it.

While technically there is no reason not to allow it, it is unlikely that a single discovery add-on configuration would work on different repositories.

Fixes #11939
Fixes WEBLATE-QC

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
