### PR TITLE
docs: add link to dev-docker contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ environment by running:
    ./rundev.sh
 ```
 
+For more, see: https://docs.weblate.org/en/latest/contributing/start.html#dev-docker
+
 ## More info
 
 To be found on the website:


### PR DESCRIPTION
This would have helped me a lot, so hopefully it helps others.