### PR TITLE
Fix the Changes pagination issue due the unformated period values

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2757,9 +2757,11 @@ class ChangesForm(forms.Form):
             # We don't care about empty values
             if not value:
                 continue
-            if isinstance(value, datetime):
+            if isinstance(value, dict) and "start_date" in value.keys() and "end_date" in value.keys():
                 # Convert date to string
-                items.append((param, value.date().isoformat()))
+                start_date = value["start_date"].strftime("%m/%d/%Y")
+                end_date = value["end_date"].strftime("%m/%d/%Y")
+                items.append((param, f"{start_date} - {end_date}"))
             elif isinstance(value, User):
                 items.append((param, value.username))
             elif isinstance(value, list):

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2757,7 +2757,11 @@ class ChangesForm(forms.Form):
             # We don't care about empty values
             if not value:
                 continue
-            if isinstance(value, dict) and "start_date" in value.keys() and "end_date" in value.keys():
+            if (
+                isinstance(value, dict)
+                and "start_date" in value
+                and "end_date" in value
+            ):
                 # Convert date to string
                 start_date = value["start_date"].strftime("%m/%d/%Y")
                 end_date = value["end_date"].strftime("%m/%d/%Y")

--- a/weblate/trans/tests/test_changes.py
+++ b/weblate/trans/tests/test_changes.py
@@ -5,9 +5,11 @@
 """Tests for changes browsing."""
 
 from datetime import timedelta
+from html import escape
 
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.http import urlencode
 
 from weblate.trans.models import Unit
 from weblate.trans.tests.test_views import ViewTestCase
@@ -67,3 +69,15 @@ class ChangesTest(ViewTestCase):
         period = "{} - {}".format(start.strftime("%m/%d/%Y"), end.strftime("%m/%d/%Y"))
         response = self.client.get(reverse("changes"), {"period": period})
         self.assertContains(response, "Resource update")
+
+    def test_pagination(self) -> None:
+        end = timezone.now()
+        start = end - timedelta(days=1)
+        period = "{} - {}".format(start.strftime("%m/%d/%Y"), end.strftime("%m/%d/%Y"))
+        response = self.client.get(reverse("changes"), {"period": period})
+        query_string = urlencode({"page": 2, "limit": 20, "period": period})
+        self.assertContains(response, escape(query_string))
+        response = self.client.get(
+            reverse("changes"), {"page": 2, "limit": 20, "period": period}
+        )
+        self.assertContains(response, "String added in the upload")


### PR DESCRIPTION
## Proposed changes

This fixes the issue regarding the pagination buttons in Changes. The pagination buttons leads to 404 page when a date range filter is added.
This solves issue #11954.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
