### PR TITLE
Fix the initial values of period in ChangeForm when there is a user input

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1393,8 +1393,10 @@ $(function () {
   $("input[name='period']").daterangepicker(
     {
       autoApply: true,
-      startDate: moment(),
-      endDate: moment(),
+      startDate:
+        $("input[name='period']#id_period").attr("data-start-date") || moment(),
+      endDate:
+        $("input[name='period']#id_period").attr("data-end-date") || moment(),
       alwaysShowCalendars: true,
       opens: "left",
       locale: {

--- a/weblate/trans/views/changes.py
+++ b/weblate/trans/views/changes.py
@@ -92,6 +92,13 @@ class ChangesView(PathViewMixin, ListView):
         if self.changes_form.is_valid():
             context["query_string"] = self.changes_form.urlencode()
             context["search_items"] = self.changes_form.items()
+            if period := self.changes_form.cleaned_data.get("period"):
+                self.changes_form.fields["period"].widget.attrs["data-start-date"] = (
+                    period["start_date"].strftime("%m/%d/%Y")
+                )
+                self.changes_form.fields["period"].widget.attrs["data-end-date"] = (
+                    period["end_date"].strftime("%m/%d/%Y")
+                )
 
         context["form"] = self.changes_form
 


### PR DESCRIPTION
## Proposed changes

When using the date range search filter on the Changes page, the dates just go back to the current date instead of setting the initial date range to the dates that were submitted. To solve this, the form must be able to supply the submitted date range values and be set as initial start and end dates in the form.

## Checklist
- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
