### PR TITLE
fix(formats): new_translation = "[]\n" for go-i18n-json

### DIFF
--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -548,6 +548,7 @@ class GoI18NV1JSONFormatTest(JSONFormatTest):
     MASK = "go-i18n-json/*.json"
     EXPECTED_PATH = "go-i18n-json/cs_CZ.json"
     FIND_CONTEXT = "hello"
+    MATCH = "[]\n"
     NEW_UNIT_MATCH = (
         b'{\n        "id": "key",\n        "translation": "Source string"\n    }\n'
     )

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -1496,6 +1496,7 @@ class GoI18JSONFormat(JSONFormat):
     format_id = "go-i18n-json"
     loader = ("jsonl10n", "GoI18NJsonFile")
     autoload: tuple[str, ...] = ()
+    new_translation = "[]\n"
     supports_plural: bool = True
 
 


### PR DESCRIPTION
## Proposed changes

The go-i18n-json v1 format uses an array as top level element (unlike all other JSON formats).

I have manually checked, that the added `parse_file` line in the tests would have caught this.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information


Discovered while working on #11133 / #11937.