### PR TITLE
Add supports plural condition for the plural form

### DIFF
--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -309,10 +309,11 @@
           <label class="radio-inline">
             <input type="radio" name="new-unit-form-type" id="show-singular" value="singular" checked> {% trans "Singular" %}
           </label>
-          <label class="radio-inline">
-            <input type="radio" name="new-unit-form-type" id="show-plural" value="plural"
-              {% if object.plural.number < 2 %} disabled{% endif %}> {% trans "Plural" %}
-          </label>
+          {% if supports_plural and object.plural.number > 1 %}
+            <label class="radio-inline">
+              <input type="radio" name="new-unit-form-type" id="show-plural" value="plural"> {% trans "Plural" %}
+            </label>
+          {% endif %}
         </div>
         <div class="panel-footer">
           <input type="submit" value="{% trans "Add" %}" class="btn btn-primary" />
@@ -320,7 +321,7 @@
       </div>
     </form>
     </div>
-    {% if object.plural.number > 1 %}
+    {% if supports_plural and object.plural.number > 1 %}
     <div id="new-plural" class="hidden">
       <form action="{% url 'new-unit' path=object.get_url_path %}" method="post">
         <div class="panel panel-default">

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -651,6 +651,7 @@ def show_translation(request, obj):
             "object": obj,
             "project": project,
             "component": obj.component,
+            "supports_plural": component.file_format_cls.supports_plural,
             "form": form,
             "download_form": DownloadForm(obj, auto_id="id_dl_%s"),
             "autoform": optional_form(


### PR DESCRIPTION
## Proposed changes

The plural form currently is displayed if  `plural.number > 1` and forgot to check if the format supports plurals. This will add another condition to see if the format set in the component supports plurals.
This solves issue #12044.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
