### PR TITLE
CI only: Repro write template store

### DIFF
--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 import tempfile
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import TYPE_CHECKING, BinaryIO, NoReturn, TypeAlias
 
 from django.http import HttpResponse

--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 import tempfile
-from copy import copy
+from copy import copy, deepcopy
 from typing import TYPE_CHECKING, BinaryIO, NoReturn, TypeAlias
 
 from django.http import HttpResponse
@@ -276,7 +276,7 @@ class TranslationUnit:
         return self.unit is not None
 
     def clone_template(self) -> None:
-        self.mainunit = self.unit = copy(self.template)
+        self.mainunit = self.unit = deepcopy(self.template)
         self._invalidate_target()
 
     def untranslate(self, language) -> None:

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -362,10 +362,7 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
 
         # Reload the storage to check notes were correctly written.
         template_storage = self.FORMAT(template_file)
-        template_storage.find_unit(
-            self.NEW_UNIT_KEY, self.NEW_UNIT_KEY
-        )
-
+        template_storage.find_unit(self.NEW_UNIT_KEY, self.NEW_UNIT_KEY)
 
     def test_flags(self) -> None:
         """


### PR DESCRIPTION
Debugging PR for https://github.com/WeblateOrg/weblate/pull/11937#discussion_r1679520763

It looks like in the formats that fail, the unit gets *moved* from the template to the target store: After both stores are saved, the key only exists in the target store, but not the template anymore.