### PR TITLE
tests(formats): test monolingual unit handling in Weblate

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Not yet released.
 * The status widgets are now supported site-wide and language-wide, see :ref:`promotion`.
 * :ref:`reports` are now available for categories.
 * Highlight newlines in the editor.
+* :doc:`/formats/csv` better handle with with two fields only.
 
 **Bug fixes**
 

--- a/weblate/formats/multi.py
+++ b/weblate/formats/multi.py
@@ -32,7 +32,7 @@ class MultiUnit(TranslationUnit):
         unit: TranslationUnit,
         template: TranslationUnit | None = None,
     ) -> None:
-        super().__init__(parent, None, None)
+        super().__init__(parent, None, template)
         self.units = [unit]
 
     def merge(self, unit) -> None:
@@ -138,7 +138,7 @@ class MultiFormatMixin(TranslationFormat):
                 result[id_hash].merge(unit)
             else:
                 if not isinstance(unit, MultiUnit):
-                    unit = MultiUnit(unit.parent, unit)
+                    unit = MultiUnit(unit.parent, unit, template=unit.template)
                 result[id_hash] = unit
         return list(result.values())
 

--- a/weblate/formats/tests/test_multi.py
+++ b/weblate/formats/tests/test_multi.py
@@ -89,14 +89,14 @@ class MonoMultiCSVUtf8FormatTest(MultiCSVUtf8FormatTest):
     BASE = TEST_MONO_BASE_CSV
     TEMPLATE = TEST_MONO_BASE_CSV
     EXPECTED_EDIT = [
-        '"source","target"',
+        '"context","target"',
         '"22298006","Infarctus myocardique"',
         '"22298006","Infarctus du myocarde"',
         '"271681002","douleur à l\'estomac"',
         '"271681002","douleur gastrique"',
     ]
     EXPECTED_ADD = [
-        '"source","target"',
+        '"context","target"',
         '"22298006","Infarctus myocardique"',
         '"22298006","Infarctus du myocarde"',
         '"22298006","Infarctus myocardique"',

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -395,6 +395,8 @@ class TTKitFormat(TranslationFormat):
         # Monolingual translation
         if self.is_template or self.template_store:
             unit.setid(key)
+            if isinstance(unit, csvunit):
+                unit.setcontext(key)
             target = source
             source = self.create_unit_key(key, source)
         # Bilingual translation
@@ -751,7 +753,7 @@ class XliffUnit(TTKitUnit):
 
         # Use source for monolingual base if target is not set
         if self.unit.target is None:
-            if self.parent.is_template:
+            if self.parent.is_template or isinstance(self.unit, csvunit):
                 return get_string(self.unit.source)
             return ""
 
@@ -989,7 +991,23 @@ class CSVUnit(MonolingualSimpleUnit):
 
     @cached_property
     def target(self):
-        return self.unescape_csv(super().target)
+        if (
+            not self.parent.is_template
+            and self.template is not None
+            and self.unit is not None
+            and "target" not in self.parent.store.fieldnames
+        ):
+            # Use source if target is not stored
+            target = get_string(self.unit.source)
+        else:
+            target = super().target
+        return self.unescape_csv(target)
+
+    def set_target(self, target: str | list[str]) -> None:
+        super().set_target(target)
+        if self.template is not None and not self.parent.is_template:
+            # Update source for bilingual as CSV fields can contain just source
+            self.unit.source = self.unit.target
 
     def is_fuzzy(self, fallback=False):
         # Report fuzzy state only if present in the fields
@@ -1613,14 +1631,22 @@ class CSVFormat(TTKitFormat):
         header = next(reader)
         fileobj.close()
 
-        # Check if the file is not two column only
+        # Check if the file is not two column only, in that case translate-toolkit detection
+        # wrongly assumes three column files
         if len(header) != 2:
             return store
 
-        return self.parse_simple_csv(content, filename)
+        return self.parse_simple_csv(content, filename, header=header)
 
-    def parse_simple_csv(self, content, filename):
-        result = self.get_store_instance(fieldnames=["source", "target"])
+    def parse_simple_csv(self, content, filename, header: None | list[str] = None):
+        fieldnames = ["source", "target"]
+        if header and all(
+            field in {"source", "target", "context", "id"} for field in header
+        ):
+            fieldnames = header
+        elif self.is_template or self.template_store:
+            fieldnames = ["context", "target"]
+        result = self.get_store_instance(fieldnames=fieldnames)
         result.parse(content, sample_length=None)
         result.filename = filename
         return result

--- a/weblate/trans/tests/data/fr-multi-mono.csv
+++ b/weblate/trans/tests/data/fr-multi-mono.csv
@@ -1,4 +1,4 @@
-"source","target"
+"context","target"
 "22298006","Infarctus myocardique"
 "22298006","Infarctus du myocarde"
 "22298006","Infarctus cardiaque"


### PR DESCRIPTION
## Proposed changes

* This tests for Translation.update_units does.
* Adds basic pathlib support to translation formats.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
