### PR TITLE
fix(permissions): do not deny editing approved strings without reviews

### DIFF
--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -252,8 +252,12 @@ def check_edit_approved(user: User, permission: str, obj: Model):
             if not unit.source_unit.translated:
                 return Denied(gettext("The source string needs review."))
             return Denied(gettext("The string is read only."))
-        if unit.approved and not check_unit_review(
-            user, "unit.review", obj, skip_enabled=True
+        # Ignore approved state if review is not disabled. This might
+        # happen after disabling them.
+        if (
+            unit.approved
+            and obj.enable_review
+            and not check_unit_review(user, "unit.review", obj, skip_enabled=True)
         ):
             return Denied(
                 gettext(


### PR DESCRIPTION
## Proposed changes

This might happen after disabling reviews and having approved strings. On the other side we don't want to wipe out approved states immediatelly in case user is doing some more changes (for example changing per-language workflows).

Fixes #12075
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
