### PR TITLE
Fix #9979: Add left and right arrows for browsing project strings

### DIFF
--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -255,6 +255,10 @@ The following keyboard shortcuts can be utilized during translation:
 |                                           |                                                                       |
 | :kbd:`Cmd+Y`                              |                                                                       |
 +-------------------------------------------+-----------------------------------------------------------------------+
+| :kbd:`→` and                              | Browse the next translation strings.                                  |
+|                                           |                                                                       |
+| :kbd:`←`                                  | Browse the previous translation strings.                              |
++-------------------------------------------+-----------------------------------------------------------------------+
 
 .. _visual-keyboard:
 

--- a/weblate/static/editor/browse.js
+++ b/weblate/static/editor/browse.js
@@ -1,10 +1,14 @@
+// Copyright © Michal Čihař <michal@weblate.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 (() => {
   function ProjectStringsBrowser() {
     Mousetrap.bindGlobal("right", (e) => {
       const nextButton = $("#button-next");
       const nextLocation = nextButton.attr("href");
       if (nextButton.length && !nextButton.hasClass("disabled")) {
-        if (nextLocation != undefined) {
+        if (nextLocation !== undefined) {
           window.location.href = nextLocation;
         }
       }
@@ -14,7 +18,7 @@
       const prevButton = $("#button-prev");
       const prevLocation = prevButton.attr("href");
       if (prevButton.length && !prevButton.hasClass("disabled")) {
-        if (prevLocation != undefined) {
+        if (prevLocation !== undefined) {
           window.location.href = prevLocation;
         }
       }

--- a/weblate/static/editor/browse.js
+++ b/weblate/static/editor/browse.js
@@ -1,0 +1,29 @@
+(() => {
+    function ProjectStringsBrowser() {
+        Mousetrap.bindGlobal("right", (e) => {
+            const nextButton = $('#button-next');
+            const nextLocation = nextButton.attr('href');
+            if (nextButton.length && !nextButton.hasClass('disabled')) {
+                if (nextLocation != undefined) {
+                    window.location.href = nextLocation;
+                }
+            }
+            return false;
+        });
+        Mousetrap.bindGlobal("left", (e) => {
+            const prevButton = $('#button-prev');
+            const prevLocation = prevButton.attr('href')
+            if (prevButton.length && !prevButton.hasClass('disabled')) {
+                if (prevLocation != undefined) {
+                    window.location.href = prevLocation;
+                }
+            }
+            return false;
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+        new ProjectStringsBrowser();
+    });
+})();
+

--- a/weblate/static/editor/browse.js
+++ b/weblate/static/editor/browse.js
@@ -1,29 +1,28 @@
 (() => {
-    function ProjectStringsBrowser() {
-        Mousetrap.bindGlobal("right", (e) => {
-            const nextButton = $('#button-next');
-            const nextLocation = nextButton.attr('href');
-            if (nextButton.length && !nextButton.hasClass('disabled')) {
-                if (nextLocation != undefined) {
-                    window.location.href = nextLocation;
-                }
-            }
-            return false;
-        });
-        Mousetrap.bindGlobal("left", (e) => {
-            const prevButton = $('#button-prev');
-            const prevLocation = prevButton.attr('href')
-            if (prevButton.length && !prevButton.hasClass('disabled')) {
-                if (prevLocation != undefined) {
-                    window.location.href = prevLocation;
-                }
-            }
-            return false;
-        });
-    }
-
-    document.addEventListener("DOMContentLoaded", () => {
-        new ProjectStringsBrowser();
+  function ProjectStringsBrowser() {
+    Mousetrap.bindGlobal("right", (e) => {
+      const nextButton = $("#button-next");
+      const nextLocation = nextButton.attr("href");
+      if (nextButton.length && !nextButton.hasClass("disabled")) {
+        if (nextLocation != undefined) {
+          window.location.href = nextLocation;
+        }
+      }
+      return false;
     });
-})();
+    Mousetrap.bindGlobal("left", (e) => {
+      const prevButton = $("#button-prev");
+      const prevLocation = prevButton.attr("href");
+      if (prevButton.length && !prevButton.hasClass("disabled")) {
+        if (prevLocation != undefined) {
+          window.location.href = prevLocation;
+        }
+      }
+      return false;
+    });
+  }
 
+  document.addEventListener("DOMContentLoaded", () => {
+    new ProjectStringsBrowser();
+  });
+})();

--- a/weblate/templates/browse.html
+++ b/weblate/templates/browse.html
@@ -11,6 +11,7 @@
 {% compress js %}
 <script defer data-cfasync="false" src="{% static 'editor/base.js' %}{{ cache_param }}"></script>
 <script defer data-cfasync="false" src="{% static 'editor/zen.js' %}{{ cache_param }}"></script>
+<script defer data-cfasync="false" src="{% static 'editor/browse.js' %}{{ cache_param }}"></script>
 {% endcompress %}
 {% endblock %}
 


### PR DESCRIPTION
## Proposed changes
Adds 2 keyboard shortcuts (left and right arrows) for navigating back and forth while browsing translation strings of a project.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
