### PR TITLE
chore: add sentry connection keep-alive

### DIFF
--- a/weblate/utils/errors.py
+++ b/weblate/utils/errors.py
@@ -122,6 +122,7 @@ def init_error_collection(celery=False) -> None:
             ],
             attach_stacktrace=True,
             _experiments={"max_spans": 2000},
+            keep_alive=True,
             **settings.SENTRY_EXTRA_ARGS,
         )
         # Ignore Weblate logging, those should trigger proper errors


### PR DESCRIPTION
To avoid spurious missed check-in issues with Sentry Crons for Celery Beat.

## Proposed changes

Since the introduction of Celery Beat monitoring with Sentry Cron in https://github.com/WeblateOrg/weblate/commit/1d1a92ba456646f99143ccc2a1c1074a2d6e0e9d we are getting a lot of spurious missed check-in alerts similar to these here: https://github.com/getsentry/sentry-python/issues/3179

Using [`keep_alive=True`](https://docs.sentry.io/platforms/python/configuration/options/#keep-alive) has fixed it for us.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Using `SENTRY_EXTRA_ARGS` for this configuration is not possible with the docker container.