### PR TITLE
7705 suggestion already exists bug

### DIFF
--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -63,7 +63,7 @@ class AutoTranslate:
             len(item) > unit.get_max_length() for item in target
         ):
             suggestion = Suggestion.objects.add(
-                unit, target, request=None, vote=False, user=user
+                unit, target, request=None, vote=False, user=user, raise_exception=False
             )
             if suggestion:
                 self.updated += 1

--- a/weblate/trans/exceptions.py
+++ b/weblate/trans/exceptions.py
@@ -27,3 +27,7 @@ class InvalidTemplateError(WeblateError):
 
 class FailedCommitError(WeblateError):
     """Could not commit file."""
+
+
+class SuggestionSimilarToTranslationError(WeblateError):
+    """Target of the Suggestion is similar to source."""

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1003,7 +1003,9 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
             if isinstance(new_target, str):
                 new_target = [new_target]
             if current_target != new_target and not dbunit.readonly:
-                if Suggestion.objects.add(dbunit, new_target, request):
+                if Suggestion.objects.add(
+                    dbunit, new_target, request, raise_exception=False
+                ):
                     accepted += 1
                 else:
                     skipped += 1

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -32,7 +32,7 @@ from weblate.checks.models import CHECKS, get_display_checks
 from weblate.glossary.forms import TermForm
 from weblate.glossary.models import get_glossary_terms
 from weblate.screenshots.forms import ScreenshotForm
-from weblate.trans.exceptions import FileParseError
+from weblate.trans.exceptions import FileParseError, SuggestionSimilarToTranslationError
 from weblate.trans.forms import (
     AutoForm,
     ChecksumForm,
@@ -303,16 +303,24 @@ def perform_suggestion(unit, form, request):
         return False
 
     # Create the suggestion
-    result = Suggestion.objects.add(
-        unit,
-        form.cleaned_data["target"],
-        request,
-        request.user.has_perm("suggestion.vote", unit),
-    )
-    if not result:
-        messages.error(request, gettext("Your suggestion already exists!"))
-    elif result.fixups:
-        display_fixups(request, result.fixups)
+    try:
+        result = Suggestion.objects.add(
+            unit,
+            form.cleaned_data["target"],
+            request,
+            request.user.has_perm("suggestion.vote", unit),
+            raise_exception=True,
+        )
+    except SuggestionSimilarToTranslationError:
+        messages.error(
+            request, gettext("Your suggestion is similar to the current translation!")
+        )
+        result = False
+    else:
+        if not result:
+            messages.error(request, gettext("Your suggestion already exists!"))
+        elif result.fixups:
+            display_fixups(request, result.fixups)
     return result
 
 


### PR DESCRIPTION
Raise a specific exception when the submitted suggestion is the same as the current translation
Any code calling Suggestion.objects.add is responsible of handling that error

## Checklist
- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

fixes #7705 
