### PR TITLE
Feat: Add clipboard paste functionality for screenshots

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,7 @@ Not yet released.
 * :http:get:`/api/components/(string:project)/(string:component)/credits/` and :http:get:`/api/projects/(string:project)/credits/` API endpoints for components and projects.
 * :ref:`glossary-terminology` entries in Glossary can now only be created by users with :guilabel:`Add glossary terminology` permission.
 * :ref:`check-python-brace-format` detects extra curly braces.
+* Screenshots now can be pasted from the clipboard in :ref:`screenshots`.
 
 **Bug fixes**
 

--- a/weblate/screenshots/forms.py
+++ b/weblate/screenshots/forms.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from django import forms
+from django.utils.translation import gettext_lazy
 
 from weblate.screenshots.models import Screenshot
 from weblate.trans.forms import QueryField
@@ -51,6 +52,29 @@ class ScreenshotForm(forms.ModelForm):
         self.fields["translation"].initial = component.source_translation
         self.fields["translation"].empty_label = None
 
+        self.fields["paste_button"] = forms.CharField(
+            widget=PasteButtonWidget(), required=False, label=""
+        )
+
+        self.order_fields(
+            ["name", "repository_filename", "paste_button", "image", "translation"]
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        # Remove the paste_button from cleaned data
+        if "paste_button" in cleaned_data:
+            del cleaned_data["paste_button"]
+        return cleaned_data
+
 
 class SearchForm(forms.Form):
     q = QueryField(required=False)
+
+
+class PasteButtonWidget(forms.Widget):
+    def render(self, name, value, attrs=None, renderer=None):
+        info_label = '<p id="paste-screenshot-info-label" class="text-center"></p>'
+        btn_text = gettext_lazy("Paste from clipboard")
+        btn_template = f'<button id="paste-screenshot-btn" class="btn" type="button">{btn_text}</button>'
+        return info_label + btn_template

--- a/weblate/static/js/screenshots/clipboard-paste.js
+++ b/weblate/static/js/screenshots/clipboard-paste.js
@@ -1,0 +1,70 @@
+// Copyright © Michal Čihař <michal@weblate.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+$(document).ready(() => {
+  // The paste trigger button
+  const $pasteScreenshotBtn = $("#paste-screenshot-btn");
+  // The file input to store the screenshot file
+  const $screenshotFileInput = $("#screenshot-form-container input#id_image");
+
+  $pasteScreenshotBtn.on("click", async (e) => {
+    e.preventDefault();
+    try {
+      // Read clipboard content
+      const clipboardItems = await navigator.clipboard.read();
+      let imageFound = false;
+      for (const clipboardItem of clipboardItems) {
+        // Find the image in the clipboard
+        for (const type of clipboardItem.types) {
+          if (type.startsWith("image/")) {
+            // Convert the image data to a file data
+            const blob = await clipboardItem.getType(type);
+            const reader = new FileReader();
+            reader.onload = (_event) => {
+              if ($screenshotFileInput.length) {
+                // Load the file data into the form input
+                const fileName = `screenshot_${Date.now()}.${type.split("/")[1]}`;
+                const imageFile = new File([blob], fileName, { type: type });
+                const dataTransfer = new DataTransfer();
+                dataTransfer.items.add(imageFile);
+                $screenshotFileInput[0].files = dataTransfer.files;
+                // Inform paste success
+                showInfo("success", gettext("Image Pasted!"));
+              } else {
+                showInfo("danger", gettext("Something went wrong!"));
+              }
+            };
+            reader.readAsDataURL(blob);
+            imageFound = true;
+            break;
+          }
+        }
+        if (imageFound) {
+          break;
+        }
+      }
+      if (!imageFound) {
+        showInfo("warning", gettext("No image found in clipboard"));
+      }
+    } catch (err) {
+      showInfo("danger", gettext("Something went wrong!"));
+      console.error("Failed to read clipboard contents: ", err);
+    }
+  });
+});
+
+/**
+ * Displays an information message on the screenshot form.
+ *
+ * @param {string} type - The type of the message (e.g., "success", "error", "warning").
+ * @param {string} message - The content of the message.
+ */
+function showInfo(type, message) {
+  const $pasteScreenshotInfo = $("#paste-screenshot-info-label");
+  const span = `<span class="text-${type}">${message}</span>`;
+  $pasteScreenshotInfo.html(span);
+  $pasteScreenshotInfo
+    .css("transform", "scale(1)")
+    .removeClass("animate__animated animate__fadeIn");
+}

--- a/weblate/static/js/screenshots/clipboard-paste.js
+++ b/weblate/static/js/screenshots/clipboard-paste.js
@@ -8,6 +8,11 @@ $(document).ready(() => {
   // The file input to store the screenshot file
   const $screenshotFileInput = $("#screenshot-form-container input#id_image");
 
+  // Check if the browser supports the Clipboard API
+  if (!navigator.clipboard || !navigator.clipboard.read) {
+    $pasteScreenshotBtn.remove();
+  }
+
   $pasteScreenshotBtn.on("click", async (e) => {
     e.preventDefault();
     try {

--- a/weblate/templates/screenshots/screenshot_detail.html
+++ b/weblate/templates/screenshots/screenshot_detail.html
@@ -1,9 +1,17 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load permissions %}
+{% load compress %}
 {% load crispy_forms_tags %}
 {% load translations %}
 {% load icons %}
+{% load static %}
+
+{% block extra_script %}
+{% compress js %}
+<script defer data-cfasync="false" src="{% static 'js/screenshots/clipboard-paste.js' %}{{ cache_param }}"></script>
+{% endcompress %}
+{% endblock %}
 
 {% block breadcrumbs %}
 {% path_object_breadcrumbs object.translation.component %}
@@ -61,7 +69,7 @@
 </div>
 
 {% if user_can_edit_screenshot %}
-<form action="{{ object.get_absolute_url }}" method="POST" enctype="multipart/form-data">
+<form action="{{ object.get_absolute_url }}" method="POST" enctype="multipart/form-data" id="screenshot-form-container">
 {% csrf_token %}
 <div class="panel panel-default">
 <div class="panel-heading"><h4 class="panel-title">{% trans "Edit screenshot" %}</h4></div>

--- a/weblate/templates/screenshots/screenshot_list.html
+++ b/weblate/templates/screenshots/screenshot_list.html
@@ -30,11 +30,9 @@
 <div class="panel panel-default">
 <div class="panel-heading"><h4 class="panel-title">{% trans "Add new screenshot" %}</h4></div>
   <div class="panel-body">
-    {% trans "Paste from clipboard" %}
-  </button>
-  <div id="screenshot-form-container">
-    {{ add_form|crispy }}
-  </div>
+    <div id="screenshot-form-container">
+      {{ add_form|crispy }}
+    </div>
   </div>
   <div class="panel-footer">
   <input type="submit" class="btn btn-primary" value="{% trans "Upload" %}" />

--- a/weblate/templates/screenshots/screenshot_list.html
+++ b/weblate/templates/screenshots/screenshot_list.html
@@ -30,8 +30,6 @@
 <div class="panel panel-default">
 <div class="panel-heading"><h4 class="panel-title">{% trans "Add new screenshot" %}</h4></div>
   <div class="panel-body">
-  <p id="paste-screenshot-info-label" class="text-center"></p>
-  <button id="paste-screenshot-btn" class="btn" type="button">
     {% trans "Paste from clipboard" %}
   </button>
   <div id="screenshot-form-container">

--- a/weblate/templates/screenshots/screenshot_list.html
+++ b/weblate/templates/screenshots/screenshot_list.html
@@ -1,10 +1,18 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load permissions %}
+{% load compress %}
 {% load crispy_forms_tags %}
 {% load humanize %}
 {% load icons %}
+{% load static %}
 {% load translations %}
+
+{% block extra_script %}
+{% compress js %}
+<script defer data-cfasync="false" src="{% static 'js/screenshots/clipboard-paste.js' %}{{ cache_param }}"></script>
+{% endcompress %}
+{% endblock %}
 
 {% block breadcrumbs %}
 {% path_object_breadcrumbs object %}
@@ -22,7 +30,13 @@
 <div class="panel panel-default">
 <div class="panel-heading"><h4 class="panel-title">{% trans "Add new screenshot" %}</h4></div>
   <div class="panel-body">
-  {{ add_form|crispy }}
+  <p id="paste-screenshot-info-label" class="text-center"></p>
+  <button id="paste-screenshot-btn" class="btn" type="button">
+    {% trans "Paste from clipboard" %}
+  </button>
+  <div id="screenshot-form-container">
+    {{ add_form|crispy }}
+  </div>
   </div>
   <div class="panel-footer">
   <input type="submit" class="btn btn-primary" value="{% trans "Upload" %}" />

--- a/weblate/templates/screenshots/snippets/paste-button.html
+++ b/weblate/templates/screenshots/snippets/paste-button.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+
+<p id="paste-screenshot-info-label" class="text-center"></p>
+<button id="paste-screenshot-btn" class="btn" type="button">{% trans "Paste from clipboard" %}</button>

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -809,10 +809,6 @@
             <h4 class="panel-title">{% trans "Add new screenshot" %}</h4>
           </div>
           <div class="panel-body">
-            <p id="paste-screenshot-info-label" class="text-center"></p>
-            <button id="paste-screenshot-btn" class="btn" type="button">
-              {% trans "Paste from clipboard" %}
-            </button>
             <div id="screenshot-form-container">
               {{ screenshot_form|crispy }}
             </div>

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -11,6 +11,7 @@
 {% compress js %}
 <script defer data-cfasync="false" src="{% static 'editor/base.js' %}{{ cache_param }}"></script>
 <script defer data-cfasync="false" src="{% static 'editor/full.js' %}{{ cache_param }}"></script>
+<script defer data-cfasync="false" src="{% static 'js/screenshots/clipboard-paste.js' %}{{ cache_param }}"></script>
 {% endcompress %}
 {% endblock %}
 
@@ -807,8 +808,14 @@
             <button type="button" class="close" data-dismiss="modal" aria-label="{% trans "Close" %}"><span aria-hidden="true">&times;</span></button>
             <h4 class="panel-title">{% trans "Add new screenshot" %}</h4>
           </div>
-          <div class="modal-body">
-            {{ screenshot_form|crispy }}
+          <div class="panel-body">
+            <p id="paste-screenshot-info-label" class="text-center"></p>
+            <button id="paste-screenshot-btn" class="btn" type="button">
+              {% trans "Paste from clipboard" %}
+            </button>
+            <div id="screenshot-form-container">
+              {{ screenshot_form|crispy }}
+            </div>
             <input type="hidden" name="source" value="{{ unit.pk }}" />
           </div>
           <div class="modal-footer">


### PR DESCRIPTION

## Proposed changes
**Added:** Paste screenshot from clipboard.

The user clicks paste. Then the clipboard is read if the permesion is given and the context is secure (as required by the clipboard API). Then the image is pasted into the select file input. Otherwise if no image is available we only inform the  user about that.


Closes: #6710

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
