### PR TITLE
fix(checks): improve format string error reporting

### DIFF
--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
 from django.http import Http404
-from django.utils.html import conditional_escape, format_html, format_html_join
+from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext
 from lxml import etree
 from siphashc import siphash
@@ -292,10 +292,13 @@ class TargetCheck(BaseCheck):
         )
 
     def get_values_text(self, message: str, values: Iterable[str]) -> StrOrPromise:
-        return format_html_join(
-            ", ",
-            conditional_escape(message),
-            ((self.format_value(value),) for value in sorted(values)),
+        return format_html(
+            message,
+            format_html_join(
+                ", ",
+                "{}",
+                ((self.format_value(value),) for value in sorted(values)),
+            ),
         )
 
     def get_missing_text(self, values: Iterable[str]) -> StrOrPromise:

--- a/weblate/checks/tests/test_format_checks.py
+++ b/weblate/checks/tests/test_format_checks.py
@@ -609,6 +609,49 @@ class PythonBraceFormatCheckTest(CheckTestCase):
             self.check.check_format("{{ {{ {s} }}", "{{ {{ {s} }}", False, None)
         )
 
+    def test_description(self) -> None:
+        unit = Unit(
+            source="{s} {a}",
+            target="a a",
+            extra_flags="python-brace-format",
+            translation=Translation(
+                component=Component(
+                    file_format="po",
+                    source_language=Language("en"),
+                )
+            ),
+        )
+        check = Check(unit=unit)
+        self.assertHTMLEqual(
+            self.check.get_description(check),
+            """
+            The following format strings are missing:
+            <span class="hlcheck" data-value="{a}">{a}</span>,
+            <span class="hlcheck" data-value="{s}">{s}</span>
+            """,
+        )
+
+    def test_description_braces(self) -> None:
+        unit = Unit(
+            source="{s}",
+            target="{ {s} }",
+            extra_flags="python-brace-format",
+            translation=Translation(
+                component=Component(
+                    file_format="po",
+                    source_language=Language("en"),
+                )
+            ),
+        )
+        check = Check(unit=unit)
+        self.assertHTMLEqual(
+            self.check.get_description(check),
+            """
+            Single <span class="hlcheck" data-value="{">{</span> encountered in the format string.<br>
+            Single <span class="hlcheck" data-value="}">}</span> encountered in the format string.
+            """,
+        )
+
 
 class CSharpFormatCheckTest(CheckTestCase):
     check = CSharpFormatCheck()


### PR DESCRIPTION
## Proposed changes

Since f2f333fd275 the errors are not longer shown with a single messsage, but the message is shown for each missing/extra format.

This also introduces specific error message for single braces in python brace format.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
