### PR TITLE
fix(add-ons): execute repository scoped add-ons only once

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -192,7 +192,7 @@ class BaseAddon:
         if AddonEvent.EVENT_POST_UPDATE in self.events:
             component.log_debug("running post_update add-on: %s", self.name)
             component.commit_pending("add-on", None)
-            self.post_update(component, "", False, False)
+            self.post_update(component, "", False)
         if AddonEvent.EVENT_COMPONENT_UPDATE in self.events:
             component.log_debug("running component_update add-on: %s", self.name)
             self.component_update(component)
@@ -238,7 +238,7 @@ class BaseAddon:
         # To be implemented in a subclass
 
     def post_update(
-        self, component: Component, previous_head: str, skip_push: bool, child: bool
+        self, component: Component, previous_head: str, skip_push: bool
     ) -> None:
         """
         Event handler after repository is updated from upstream.
@@ -434,7 +434,7 @@ class UpdateBaseAddon(BaseAddon):
         raise NotImplementedError
 
     def post_update(
-        self, component: Component, previous_head: str, skip_push: bool, child: bool
+        self, component: Component, previous_head: str, skip_push: bool
     ) -> None:
         # Ignore file parse error, it will be properly tracked as an alert
         with suppress(FileParseError):

--- a/weblate/addons/cdn.py
+++ b/weblate/addons/cdn.py
@@ -132,7 +132,5 @@ class CDNJSAddon(BaseAddon):
             component.id,
         )
 
-    def post_update(
-        self, component, previous_head: str, skip_push: bool, child: bool
-    ) -> None:
+    def post_update(self, component, previous_head: str, skip_push: bool) -> None:
         self.daily(component)

--- a/weblate/addons/cleanup.py
+++ b/weblate/addons/cleanup.py
@@ -94,5 +94,4 @@ class RemoveBlankAddon(BaseCleanupAddon):
             component,
             "weblate:post-commit" if store_hash else "weblate:post-commit-no-store",
             skip_push=True,
-            child=False,
         )

--- a/weblate/addons/discovery.py
+++ b/weblate/addons/discovery.py
@@ -32,11 +32,7 @@ class DiscoveryAddon(BaseAddon):
     needs_component = True
     trigger_update = True
 
-    def post_update(
-        self, component, previous_head: str, skip_push: bool, child: bool
-    ) -> None:
-        if child:
-            return
+    def post_update(self, component, previous_head: str, skip_push: bool) -> None:
         discovery = self.get_discovery(component)
         discovery.perform(
             remove=self.instance.configuration.get("remove"), background=True

--- a/weblate/addons/models.py
+++ b/weblate/addons/models.py
@@ -273,6 +273,10 @@ def execute_addon_event(
     method: str | Callable,
     args: tuple | None = None,
 ) -> None:
+    # Trigger repository scoped add-ons only on the main component
+    if addon.repo_scope and component.linked_component:
+        return
+
     # Log logging result and error flag for add-on activity log
     log_result = None
     error_occurred = False

--- a/weblate/addons/models.py
+++ b/weblate/addons/models.py
@@ -437,14 +437,13 @@ def post_update(
     sender,
     component: Component,
     previous_head: str,
-    child: bool = False,
     skip_push: bool = False,
     **kwargs,
 ) -> None:
     handle_addon_event(
         AddonEvent.EVENT_POST_UPDATE,
         "post_update",
-        (component, previous_head, skip_push, child),
+        (component, previous_head, skip_push),
         component=component,
     )
 

--- a/weblate/addons/scripts.py
+++ b/weblate/addons/scripts.py
@@ -55,9 +55,7 @@ class BaseScriptAddon(BaseAddon):
     def post_push(self, component) -> None:
         self.run_script(component)
 
-    def post_update(
-        self, component, previous_head: str, skip_push: bool, child: bool
-    ) -> None:
+    def post_update(self, component, previous_head: str, skip_push: bool) -> None:
         self.run_script(component, env={"WL_PREVIOUS_HEAD": previous_head})
 
     def post_commit(self, component: Component, store_hash: bool) -> None:

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -231,7 +231,7 @@ class IntegrationTest(TestAddonMixin, ViewTestCase):
         ADDONS[TestCrashAddon.get_identifier()] = TestCrashAddon
 
         with self.assertRaises(TestError):
-            addon.post_update(self.component, "head", False, False)
+            addon.post_update(self.component, "head", False)
 
         # The crash should be handled here and addon uninstalled
         self.component.trigger_post_update(
@@ -327,9 +327,9 @@ class GettextAddonTest(ViewTestCase):
         addon = MsgmergeAddon.create(component=self.component)
         self.assertNotEqual(rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
-        addon.post_update(self.component, rev, False, False)
+        addon.post_update(self.component, rev, False)
         self.assertEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("po/cs.po", commit)
@@ -460,9 +460,9 @@ class AppStoreAddonTest(ViewTestCase):
         addon = CleanupAddon.create(component=self.component)
         self.assertNotEqual(rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("cs/changelogs/100000.txt", commit)
 
@@ -477,9 +477,9 @@ class AndroidAddonTest(ViewTestCase):
         addon = CleanupAddon.create(component=self.component)
         self.assertNotEqual(rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("android-not-synced/values-cs/strings.xml", commit)
         self.assertIn('\n-    <string name="hello">Ahoj svete</string>', commit)
@@ -495,9 +495,9 @@ class WindowsRCAddonTest(ViewTestCase):
         addon = CleanupAddon.create(component=self.component)
         self.assertNotEqual(rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("winrc/cs-CZ.rc", commit)
         self.assertIn("\n-IDS_MSG5", commit)
@@ -513,9 +513,9 @@ class IntermediateAddonTest(ViewTestCase):
         addon = CleanupAddon.create(component=self.component)
         self.assertNotEqual(rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         commit = self.component.repository.show(self.component.repository.last_revision)
         # It should remove string not present in the English file
         self.assertIn("intermediate/cs.json", commit)
@@ -534,7 +534,7 @@ class ResxAddonTest(ViewTestCase):
         with self.component.repository.lock:
             self.component.repository.execute(["fetch", "--unshallow", "origin"])
         addon.post_update(
-            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False, False
+            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False
         )
         self.assertNotEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
@@ -548,7 +548,7 @@ class ResxAddonTest(ViewTestCase):
         with self.component.repository.lock:
             self.component.repository.execute(["fetch", "--unshallow", "origin"])
         addon.post_update(
-            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False, False
+            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False
         )
         self.assertNotEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
@@ -564,7 +564,7 @@ class CSVAddonTest(ViewTestCase):
         rev = self.component.repository.last_revision
         addon = CleanupAddon.create(component=self.component)
         addon.post_update(
-            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False, False
+            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False
         )
         self.assertNotEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
@@ -575,7 +575,7 @@ class CSVAddonTest(ViewTestCase):
         rev = self.component.repository.last_revision
         addon = RemoveBlankAddon.create(component=self.component)
         addon.post_update(
-            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False, False
+            self.component, "da07dc0dc7052dc44eadfa8f3a2f2609ec634303", False
         )
         self.assertNotEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
@@ -592,7 +592,7 @@ class JsonAddonTest(ViewTestCase):
         addon = CleanupAddon.create(component=self.component)
         self.assertNotEqual(rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("json-mono-sync/cs.json", commit)
@@ -603,7 +603,7 @@ class JsonAddonTest(ViewTestCase):
         addon = RemoveBlankAddon.create(component=self.component)
         self.assertNotEqual(rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("json-mono-sync/cs.json", commit)
@@ -902,9 +902,9 @@ class PropertiesAddonTest(ViewTestCase):
         addon = CleanupAddon.create(component=self.component)
         self.assertNotEqual(init_rev, self.component.repository.last_revision)
         rev = self.component.repository.last_revision
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(rev, self.component.repository.last_revision)
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         commit = self.component.repository.show(self.component.repository.last_revision)
         self.assertIn("java/swing_messages_cs.properties", commit)
         self.component.do_reset()
@@ -1085,7 +1085,7 @@ class DiscoveryTest(ViewTestCase):
             )
         self.assertEqual(Component.objects.filter(repo=link).count(), 3)
         with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
-            addon.post_update(self.component, "", False, False)
+            addon.post_update(self.component, "", False)
         self.assertEqual(Component.objects.filter(repo=link).count(), 3)
 
     def test_form(self) -> None:
@@ -1205,7 +1205,7 @@ class LanguageConsistencyTest(ViewTestCase):
         )
 
         # Trigger post update signal, should do nothing
-        addon.post_update(self.component, "", False, False)
+        addon.post_update(self.component, "", False)
         self.assertEqual(Translation.objects.count(), 15)
 
 

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -2244,7 +2244,6 @@ class Component(models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin):
                 sender=component.__class__,
                 component=component,
                 previous_head=previous_head,
-                child=True,
                 skip_push=skip_push,
             )
 


### PR DESCRIPTION
## Proposed changes

    
    
These should not be executed on linked components, but only on the main    one. This is generic solution to the problem replacing previous specific    solution to single event and add-on.
    
Fixes #12232
Fixes #10892


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
