### PR TITLE
Allow for multiple downloads in Customize download

### DIFF
--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -394,7 +394,7 @@
     </table>
   </div>
 
-  <form action="{% url 'download' path=object.get_url_path %}" method="get" data-persist="download-translation">
+  <form class="double-submission" action="{% url 'download' path=object.get_url_path %}" method="get" data-persist="download-translation">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4 class="panel-title">


### PR DESCRIPTION
## Proposed changes
Allow multiple downloads in custom download form.

There was an onSubmit event listener blocking the resumbit of the downlaod form. Which can be removed by adding the .double-submission to the desired form.

Closes: #12236

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
