### PR TITLE
fix(machinery): overwrite Django built-in URL field validation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Not yet released.
 
 **Bug fixes**
 
+* Support for using Docker network names in automatic suggestion settings.
+
 **Compatibility**
 
 **Upgrading**

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -8,7 +8,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext, gettext_lazy, pgettext_lazy
 
-from weblate.utils.validators import WeblateServiceURLValidator
+from weblate.utils.forms import WeblateServiceURLField
 
 
 class BaseMachineryForm(forms.Form):
@@ -37,9 +37,8 @@ class KeyMachineryForm(BaseMachineryForm):
 
 
 class URLMachineryForm(BaseMachineryForm):
-    url = forms.URLField(
+    url = WeblateServiceURLField(
         label=pgettext_lazy("Automatic suggestion service configuration", "API URL"),
-        validators=[WeblateServiceURLValidator()],
     )
 
 
@@ -251,18 +250,16 @@ class AlibabaMachineryForm(KeySecretMachineryForm):
 
 
 class ModernMTMachineryForm(KeyURLMachineryForm):
-    url = forms.URLField(
+    url = WeblateServiceURLField(
         label=pgettext_lazy("Automatic suggestion service configuration", "API URL"),
         initial="https://api.modernmt.com/",
-        validators=[WeblateServiceURLValidator()],
     )
 
 
 class DeepLMachineryForm(KeyURLMachineryForm):
-    url = forms.URLField(
+    url = WeblateServiceURLField(
         label=pgettext_lazy("Automatic suggestion service configuration", "API URL"),
         initial="https://api.deepl.com/v2/",
-        validators=[WeblateServiceURLValidator()],
     )
     formality = forms.CharField(
         label=pgettext_lazy("Automatic suggestion service configuration", "Formality"),
@@ -292,7 +289,7 @@ class OpenAIMachineryForm(KeyMachineryForm):
         ("gpt-3.5-turbo", "GPT-3.5 Turbo"),
         ("custom", pgettext_lazy("OpenAI model selection", "Custom model")),
     )
-    base_url = forms.URLField(
+    base_url = WeblateServiceURLField(
         label=pgettext_lazy(
             "Automatic suggestion service configuration",
             "OpenAI API base URL",

--- a/weblate/utils/forms.py
+++ b/weblate/utils/forms.py
@@ -18,7 +18,8 @@ from weblate.trans.filter import FILTERS
 from weblate.trans.util import sort_unicode
 from weblate.utils.errors import report_error
 from weblate.utils.search import parse_query
-from weblate.utils.validators import validate_email, validate_username
+
+from .validators import WeblateServiceURLValidator, validate_email, validate_username
 
 
 class QueryField(forms.CharField):
@@ -234,3 +235,7 @@ class CachedModelMultipleChoiceField(
     CachedModelChoiceField, forms.ModelMultipleChoiceField
 ):
     pass
+
+
+class WeblateServiceURLField(forms.URLField):
+    default_validators = [WeblateServiceURLValidator()]


### PR DESCRIPTION
## Proposed changes

The previous solution applied both Django and Weblate validation to these fields.

Fixes #12291

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
