### PR TITLE
Add an exception to handle IntegrityError in the format_unit_source

### DIFF
--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from django import forms, template
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.db import IntegrityError
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
@@ -439,20 +440,35 @@ def format_unit_source(
     wrap: bool = False,
     show_copy: bool = False,
 ):
-    source_translation = unit.translation.component.source_translation
-    return format_translation(
-        plurals=unit.get_source_plurals() if value is None else split_plural(value),
-        language=source_translation.language,
-        plural=source_translation.plural,
-        unit=unit,
-        diff=diff,
-        search_match=search_match,
-        match=match,
-        simple=simple,
-        glossary=glossary,
-        wrap=wrap,
-        show_copy=show_copy,
-    )
+    try:
+        source_translation = unit.translation.component.source_translation
+        return format_translation(
+            plurals=unit.get_source_plurals() if value is None else split_plural(value),
+            language=source_translation.language,
+            plural=source_translation.plural,
+            unit=unit,
+            diff=diff,
+            search_match=search_match,
+            match=match,
+            simple=simple,
+            glossary=glossary,
+            wrap=wrap,
+            show_copy=show_copy,
+        )
+    except IntegrityError:
+        return format_translation(
+            plurals=unit.get_target_plurals() if value is None else split_plural(value),
+            language=unit.translation.language,
+            plural=unit.translation.plural,
+            unit=unit,
+            diff=diff,
+            search_match=search_match,
+            match=match,
+            simple=simple,
+            glossary=glossary,
+            wrap=wrap,
+            show_copy=show_copy,
+        )
 
 
 @register.inclusion_tag("snippets/format-translation.html")


### PR DESCRIPTION
## Proposed changes

This adds an exception to handle `IntegrityError` in the format_unit_source.
This solves issue #12293.

## Checklist
- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
