### PR TITLE
chore: use tempfile as context manager even when not deleting it

### DIFF
--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -477,10 +477,11 @@ class TranslationFormat:
         dirname, basename = os.path.split(filename)
         if dirname and not os.path.exists(dirname):
             os.makedirs(dirname)
-        temp = tempfile.NamedTemporaryFile(prefix=basename, dir=dirname, delete=False)
         try:
-            callback(temp)
-            temp.close()
+            with tempfile.NamedTemporaryFile(
+                prefix=basename, dir=dirname, delete=False
+            ) as temp:
+                callback(temp)
             os.replace(temp.name, filename)
         finally:
             if os.path.exists(temp.name):
@@ -853,10 +854,11 @@ class BilingualUpdateMixin:
 
     @classmethod
     def update_bilingual(cls, filename: str, template: str, **kwargs) -> None:
-        temp = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             prefix=filename, dir=os.path.dirname(filename), delete=False
-        )
-        temp.close()
+        ) as temp:
+            # We want file to be created only here
+            pass
         try:
             cls.do_bilingual_update(filename, temp.name, template, **kwargs)
             os.replace(temp.name, filename)

--- a/weblate/formats/tests/test_convert.py
+++ b/weblate/formats/tests/test_convert.py
@@ -43,14 +43,13 @@ class ConvertFormatTest(BaseFormatTest):
     def test_convert(self) -> None:
         if not self.CONVERT_TEMPLATE:
             raise SkipTest(f"Test template not provided for {self.FORMAT.format_id}")
-        template = NamedTemporaryFile(delete=False, mode="w+")
-        translation = NamedTemporaryFile(delete=False, mode="w+")
+        translation = template = None
         try:
             # Generate test files
-            template.write(self.CONVERT_TEMPLATE)
-            template.close()
-            translation.write(self.CONVERT_TRANSLATION)
-            translation.close()
+            with NamedTemporaryFile(delete=False, mode="w+") as template:
+                template.write(self.CONVERT_TEMPLATE)
+            with NamedTemporaryFile(delete=False, mode="w+") as translation:
+                translation.write(self.CONVERT_TRANSLATION)
 
             # Parse
             storage = self.FORMAT(
@@ -78,8 +77,10 @@ class ConvertFormatTest(BaseFormatTest):
             with open(translation.name) as handle:
                 self.assertEqual(handle.read(), self.CONVERT_EXPECTED)
         finally:
-            os.unlink(template.name)
-            os.unlink(translation.name)
+            if template:
+                os.unlink(template.name)
+            if translation:
+                os.unlink(translation.name)
 
 
 class HTMLFormatTest(ConvertFormatTest):

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1096,11 +1096,10 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
                 ) from error
 
             # Create actual file with the uploaded content
-            temp = tempfile.NamedTemporaryFile(
+            with tempfile.NamedTemporaryFile(
                 prefix="weblate-upload", dir=self.component.full_path, delete=False
-            )
-            temp.write(fileobj.read())
-            temp.close()
+            ) as temp:
+                temp.write(fileobj.read())
 
             try:
                 # Prepare msgmerge args based on add-ons (if configured)


### PR DESCRIPTION
## Proposed changes

Use context manager to write out content, but keep it around for the filename and delete that later.

Discovered by ruff: https://docs.astral.sh/ruff/rules/open-file-with-context-handler/

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
