### PR TITLE
Add fuzzy date parsing for search

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,7 @@ Not yet released.
 
 **New features**
 
-* :ref:`Searching` now supports filtering by object path.
+* :ref:`Searching` now supports filtering by object path and :ref:`date-search`.
 * Merge requests credentials can now be passed in the repository URL, see :ref:`settings-credentials`.
 
 **Improvements**

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -44,9 +44,6 @@ Fields
    String position in the translation file.
 ``added:DATETIME``
    Timestamp for when the string was added to Weblate.
-``added:TEXT``
-   String containing adverb of time like ``yesterday``, ``last month``, and ``2 days ago``.
-   It also supports :ref:`search-operators`.
 ``state:TEXT``
    Search for string states (``approved``, ``translated``, ``needs-editing``, ``empty``, ``read-only``).
 
@@ -82,9 +79,6 @@ Fields
    String was changed by author with given username.
 ``changed:DATETIME``
    String content was changed on date, supports :ref:`search-operators`.
-``changed:TEXT``
-   String containing adverb of time like ``yesterday``, ``last month``, and ``2 days ago``.
-   It also supports :ref:`search-operators`.
 ``change_time:DATETIME``
    String was changed on date, supports :ref:`search-operators`, unlike
    ``changed`` this includes event which don't change content and you can apply
@@ -213,3 +207,17 @@ Additional lookups are available in the :ref:`management-interface`:
    Search for active users.
 ``email:TEXT``
    Search by e-mail.
+
+
+Fuzzy values for DATETIME fields
+++++++++++++++++++++++++++++++++
+
+Instead of using DATETIME values like MM-DD-YYYY, a string containing adverb
+of time like ``yesterday``, ``last month``, and ``2 days ago`` can be used as
+values in the DATETIME fields.
+
+Examples:
+``changed:>="2 weeks ago"``
+    Returns strings that are changed 2 weeks ago from the current date and time.
+``changed:>="yesterday"``
+    Returns strings that are changed starting yesterday.

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -217,6 +217,7 @@ of time like ``yesterday``, ``last month``, and ``2 days ago`` can be used as
 values in the DATETIME fields.
 
 Examples:
+
 ``changed:>="2 weeks ago"``
     Returns strings that are changed 2 weeks ago from the current date and time.
 ``changed:>="yesterday"``

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -44,6 +44,9 @@ Fields
    String position in the translation file.
 ``added:DATETIME``
    Timestamp for when the string was added to Weblate.
+``added:TEXT``
+   String containing adverb of time like ``yesterday``, ``last month``, and ``2 days ago``.
+   It also supports :ref:`search-operators`.
 ``state:TEXT``
    Search for string states (``approved``, ``translated``, ``needs-editing``, ``empty``, ``read-only``).
 
@@ -79,6 +82,9 @@ Fields
    String was changed by author with given username.
 ``changed:DATETIME``
    String content was changed on date, supports :ref:`search-operators`.
+``changed:TEXT``
+   String containing adverb of time like ``yesterday``, ``last month``, and ``2 days ago``.
+   It also supports :ref:`search-operators`.
 ``change_time:DATETIME``
    String was changed on date, supports :ref:`search-operators`, unlike
    ``changed`` this includes event which don't change content and you can apply

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -208,6 +208,7 @@ Additional lookups are available in the :ref:`management-interface`:
 ``email:TEXT``
    Search by e-mail.
 
+.. _date-search:
 
 Fuzzy values for DATETIME fields
 ++++++++++++++++++++++++++++++++
@@ -220,5 +221,5 @@ Examples:
 
 ``changed:>="2 weeks ago"``
     Returns strings that are changed 2 weeks ago from the current date and time.
-``changed:>="yesterday"``
+``changed:>=yesterday``
     Returns strings that are changed starting yesterday.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "cssselect>=1.2,<1.3",
   "Cython>=3.0.0,<3.1",
   "cyrtranslit>=1.1.0,<1.2.0",
+  "dateparser>=1.2.0,<1.3.0",
   "diff-match-patch==20230430",
   "django-appconf>=1.0.3,<1.1",
   "django-celery-beat>=2.6.0,<2.8",

--- a/weblate/templates/snippets/query-builder.html
+++ b/weblate/templates/snippets/query-builder.html
@@ -107,6 +107,11 @@
         <td><code>added:&gt;={{ month_ago|date:"Y-m-d" }} AND state:&lt;=needs-editing</code>
         <td><a href="#" class="btn btn-default search-insert">{% trans "Add" %}</a></td>
     </tr>
+    <tr>
+        <th>{% trans "Filter changed strings 2 weeks ago" %}</th>
+        <td><code>changed:&gt;="2 weeks ago"</code>
+        <td><a href="#" class="btn btn-default search-insert">{% trans "Add" %}</a></td>
+    </tr>
     {% if not language %}
     {% with languages=user.profile.all_languages %}
     <tr>

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -114,7 +114,7 @@ class SearchViewTest(TransactionsTestMixin, ViewTestCase):
         self.do_search({"q": "changed:>2010-01-10 AND changed_by:testuser"}, None)
         self.do_search({"q": "changed_by:testuser"}, None)
         # Review, partial date
-        self.do_search({"q": "changed:>=2010-01-"}, "Unknown string format: 2010-01-")
+        self.do_search({"q": "changed:>=2010-01-"}, None)
 
     def extract_params(self, response):
         search_url = re.findall(r'data-params="([^"]*)"', response.content.decode())[0]

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -12,7 +12,8 @@ from itertools import chain
 from operator import and_, or_
 from typing import Any, cast, overload
 
-from dateutil.parser import ParserError, parse
+from dateparser import parse
+from dateutil.parser import ParserError
 from django.db import transaction
 from django.db.models import Q, Value
 from django.db.utils import DataError
@@ -241,12 +242,7 @@ class BaseTermExpr:
             # Here we inject 5:55:55 time and if that was not changed
             # during parsing, we assume it was not specified while
             # generating the query
-            result = parse(
-                text,
-                default=timezone.now().replace(
-                    hour=hour, minute=minute, second=second, microsecond=microsecond
-                ),
-            )
+            result = parse(text)
         except ParserError as error:
             raise ValueError(gettext("Invalid timestamp: {}").format(error)) from error
         if result.hour == 5 and result.minute == 55 and result.second == 55:

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -177,8 +177,15 @@ class UnitQueryParserTest(TestCase, SearchMixin):
             )
             & action_change,
         )
+        self.assert_query(
+            "changed:>'March 1, 2019'",
+            Q(change__timestamp__gte=datetime(2019, 3, 1, 0, 0, tzinfo=timezone.utc))
+            & action_change,
+        )
         with self.assertRaises(ValueError):
-            self.assert_query("changed:>=2010-01-", Q())
+            self.assert_query("changed:>'Not a date'", Q())
+        with self.assertRaises(ValueError):
+            self.assert_query("changed:>'Invalid 1, 2019'", Q())
 
     def test_date_range(self) -> None:
         self.assert_query(


### PR DESCRIPTION
## Proposed changes
This will enable fuzzy date parsing in the search. This feature uses the `dateparser` library.
This solves issue #5483.

Example image:

![image](https://github.com/user-attachments/assets/89940dd8-0fa0-4c5c-b144-c75481e0acbf)

![image](https://github.com/user-attachments/assets/d73e3558-976f-43dc-9bda-dbdd029e8ffe)


## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new fields for enhanced search functionality: `added:TEXT` for searching adverbs of time and `changed:TEXT` for tracking changes made at specific times.
	- Added a filter option in the query builder to find strings that have changed within the last two weeks.

- **Bug Fixes**
	- Improved handling of partial date formats in search queries to allow for more lenient parsing.

- **Chores**
	- Added a new dependency (`dateparser`) to enhance date parsing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->