### PR TITLE
fix(utils): register path converters at import time

### DIFF
--- a/weblate/accounts/urls.py
+++ b/weblate/accounts/urls.py
@@ -9,6 +9,10 @@ from django.views.i18n import JavaScriptCatalog
 
 import weblate.accounts.views
 import weblate.auth.views
+from weblate.utils.urls import register_weblate_converters
+
+register_weblate_converters()
+
 
 # Follows copy of social_django.urls with few changes:
 # - authentication requires POST (issue submitted upstream)

--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -25,8 +25,6 @@ from django.db.models.lookups import Lookup, Regex
 from django.utils import timezone
 from packaging.version import Version
 
-from weblate.utils.urls import register_weblate_converters
-
 from .celery import is_celery_queue_long
 from .checks import weblate_check
 from .data import data_dir
@@ -465,7 +463,6 @@ class UtilsConfig(AppConfig):
 
     def ready(self) -> None:
         super().ready()
-        register_weblate_converters()
         init_error_collection()
 
         lookups: list[tuple[type[Lookup]] | tuple[type[Lookup], str]]


### PR DESCRIPTION
## Proposed changes

This is recommended approach by Django and avoids depreciation warning when doing that from app ready because that is apparently called multiple times during the testsuite.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced URL handling capabilities with the introduction of custom URL converters for improved routing functionality.

- **Bug Fixes**
	- Removed unnecessary registration of URL converters during application initialization, streamlining the URL routing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->