### PR TITLE
Avoid scroll in Add Strings to screenshot

### DIFF
--- a/weblate/static/styles/screenshots/screenshot_detail.css
+++ b/weblate/static/styles/screenshots/screenshot_detail.css
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Michal Čihař <michal@weblate.org>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#sources-listing {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+@media (max-width: 767px) {
+  #sources-listing {
+    max-height: 300px;
+  }
+
+  #sources-listing td > .btn {
+    margin-bottom: 5px;
+  }
+
+  .panel-footer {
+    gap: 20px;
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/weblate/static/styles/screenshots/screenshot_detail.css
+++ b/weblate/static/styles/screenshots/screenshot_detail.css
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#sources-listing {
+#sources-listing #strings-table-container {
   max-height: 400px;
   overflow-y: auto;
 }
 
 @media (max-width: 767px) {
-  #sources-listing {
+  #sources-listing #strings-table-container {
     max-height: 300px;
   }
 

--- a/weblate/static/styles/screenshots/screenshot_detail.css
+++ b/weblate/static/styles/screenshots/screenshot_detail.css
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
- #sources-listing {
+#sources-listing {
   margin-bottom: 0px;
- }
+}
 
 #sources-listing #strings-table-container {
   max-height: 400px;

--- a/weblate/static/styles/screenshots/screenshot_detail.css
+++ b/weblate/static/styles/screenshots/screenshot_detail.css
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+ #sources-listing {
+  margin-bottom: 0px;
+ }
+
 #sources-listing #strings-table-container {
   max-height: 400px;
   overflow-y: auto;

--- a/weblate/static/styles/screenshots/screenshot_detail.css
+++ b/weblate/static/styles/screenshots/screenshot_detail.css
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#sources-listing {
-  margin-bottom: 0px;
-}
-
 #sources-listing #strings-table-container {
   max-height: 400px;
   overflow-y: auto;
+}
+
+#sources-listing table,
+#search-results table {
+  margin-bottom: 0;
 }
 
 @media (max-width: 767px) {

--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -101,8 +101,11 @@ var _rollbarConfig = {
   <meta property="og:title" content="{% if title %}{{ title }}{% elif object %}{{ object }}{% elif page_user %}{{ page_user }}{% else %}{{ site_title }}{% endif %}" />
   <meta property="og:description" content="{{ description }}" />
 
-{% block extra_meta %}
-{% endblock %}
+  {% block extra_meta %}
+  {% endblock %}
+
+  {% block extra_styles %}
+  {% endblock %}
 
  </head>
 

--- a/weblate/templates/screenshots/screenshot_detail.html
+++ b/weblate/templates/screenshots/screenshot_detail.html
@@ -13,6 +13,10 @@
 {% endcompress %}
 {% endblock %}
 
+{% block extra_styles %}
+  <link rel="stylesheet" href="{% static 'styles/screenshots/screenshot_detail.css' %}{{ cache_param }}" />
+{% endblock %}
+
 {% block breadcrumbs %}
 {% path_object_breadcrumbs object.translation.component %}
 <li><a href="{% url 'screenshots' path=object.translation.component.get_url_path %}">{% trans "Screenshots" %}</a></li>

--- a/weblate/templates/screenshots/screenshot_detail.html
+++ b/weblate/templates/screenshots/screenshot_detail.html
@@ -30,8 +30,12 @@
 
 
 <div class="panel panel-default" id="sources-listing" data-href="{% url 'screenshot-js-get' pk=object.pk %}">
-  <div class="panel-heading"><h4 class="panel-title">{% trans "Assigned source strings" %}</h4></div>
-  {% include "screenshots/screenshot_sources_body.html" with sources=objects.units.order %}
+  <div class="panel-heading">
+    <h4 class="panel-title">{% trans "Assigned source strings" %}</h4>
+  </div>
+  <div id="strings-table-container">
+    {% include "screenshots/screenshot_sources_body.html" with sources=objects.units.order %}
+  </div>
   <div class="panel-footer">
     {% trans "Screenshot is shown to add visual context for all listed source strings." %}
   </div>
@@ -56,7 +60,7 @@
     </div>
     <form class="form-inline double-submission">
       {% csrf_token %}
-      <input type="text" required="yes" name="q" id="search-input" placeholder="{% trans "Source string search" %}" />
+      <input class="textinput form-control" type="text" required="yes" name="q" id="search-input" placeholder="{% trans "Source string search" %}" />
       <button data-href="{% url 'screenshot-js-search' pk=object.pk %}" class="btn btn-primary" id="screenshots-search">{% trans "Search" %}</button>
     </form>
   </div>


### PR DESCRIPTION

## Proposed changes
**Avoid scroll in Add Strings to screenshot**

- Added a height limit to the first table showing strings related to the screenshot. to prevent scroll and hiding the second table.
- Fixed buttons overallaping in the actions of the tables on mobile devices

Fixes: #7085

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new CSS file for improved styling of the sources listing component, enhancing usability and aesthetics, especially on mobile devices.
	- Added a flexible `extra_styles` block in the HTML templates to allow for custom CSS in derived templates, improving styling options for the screenshot detail page.

- **Style**
	- Enhanced layout and spacing for the footer and buttons in the sources listing component.
	- Updated the search input element for better styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->