### PR TITLE
feat(vcs): parse API credentials from (push) repository URL

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -2115,6 +2115,10 @@ The configuration dictionary consists of credentials defined for each API host.
 The API host might be different from what you use in the web browser, for
 example GitHub API is accessed as ``api.github.com``.
 
+The credentials can also be overridden in :ref:`component-push` or
+:ref:`component-repo` (if push URL is not configured), these take precedence
+over the ones specified in the configuration file.
+
 The following configuration is available for each host:
 
 ``username``

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Not yet released.
 **New features**
 
 * :ref:`Searching` now supports filtering by object path.
+* Merge requests credentials can now be passed in the repository URL, see :ref:`settings-credentials`.
 
 **Improvements**
 

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -1364,11 +1364,19 @@ class VCSGitLabTest(VCSGitUpstreamTest):
             ),
             "group1%2Fsubgroup%2Fproject",
         )
+
+    def test_parse_repo_url(self) -> None:
         self.assertEqual(
             self.repo.parse_repo_url(
                 "git@gitlab.domain.com:group1/subgroup/project.git"
             ),
-            (None, "gitlab.domain.com", "group1", "subgroup/project"),
+            (None, None, None, "gitlab.domain.com", "group1", "subgroup/project"),
+        )
+        self.assertEqual(
+            self.repo.parse_repo_url(
+                "https://bot:glpat@gitlab.com/path/group/repo.git"
+            ),
+            ("https", "bot", "glpat", "gitlab.com", "path", "group/repo"),
         )
 
     @override_settings(


### PR DESCRIPTION
## Proposed changes

This allows using fine-grained access tokens instead of instance scoped access.

Fixes #12439

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified credential management in the API configuration documentation, emphasizing the precedence of overridden credentials.
	- Enhanced the "Searching" section to allow filtering search results by object path and added details on passing merge request credentials in the repository URL.

- **New Features**
	- Improved handling of repository URLs requiring authentication, enhancing credential management robustness.

- **Tests**
	- Added a new test for validating the parsing of various Git repository URL formats, ensuring comprehensive coverage of the `parse_repo_url` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->