### PR TITLE
fix(component): allow users to add languages already present in the project

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Not yet released.
 **Bug fixes**
 
 * Displaying :ref:`workflow-customization` setting in some cases.
+* Users can add component in any language already existing in a project.
 
 **Compatibility**
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1175,7 +1175,11 @@ class NewLanguageForm(NewLanguageOwnerForm):
         codes = BASIC_LANGUAGES
         if settings.BASIC_LANGUAGES is not None:
             codes = settings.BASIC_LANGUAGES
-        return super().get_lang_objects().filter(code__in=codes)
+        return (
+            super()
+            .get_lang_objects()
+            .filter(Q(code__in=codes) | Q(component__project=self.component.project))
+        )
 
     def __init__(self, component, *args, **kwargs) -> None:
         super().__init__(component, *args, **kwargs)


### PR DESCRIPTION

## Proposed changes

There is no reason to block languages which are already used in other components, the intention was to avoid exploding list of languages, not to block adding components in existing language.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users can now add components in any language already existing in a project, enhancing flexibility and customization.
  
- **Bug Fixes**
	- Improved functionality in workflow customization settings to support multi-language projects more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->