### PR TITLE
Add hi_Latn to basic language exceptions

### DIFF
--- a/weblate/lang/data.py
+++ b/weblate/lang/data.py
@@ -27,6 +27,7 @@ UNDERSCORE_EXCEPTIONS = {
     "ro_MD",
     "pt_BR",
     "pa_PK",
+    "hi_Latn",
 }
 AT_EXCEPTIONS = {"ca@valencia"}
 


### PR DESCRIPTION
## Proposed changes

I've added hi_Latn to the list of underscore code exceptions, which based on #8229 should add it to the basic languages list and make it available for selection by translators, without involving the maintainers.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.