### PR TITLE
feat: add openapi spec for weblate rest api

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,0 +1,541 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+# Weblate version in test Docker container: 5.7.2
+
+openapi: 3.1.0
+info:
+  title: Weblate REST API
+  description: |
+    The API is based on [Django REST framework](https://www.django-rest-framework.org).
+    You can interact with the API using the [Weblate Client](https://docs.weblate.org/en/latest/wlc.html)
+    or a third-party REST client of your choice.
+
+    ## Authentication
+
+    Authentication works with tokens placed in the `Authorization` HTTP request header:
+
+    - Each user has a personal access token which can be obtained in their respective user profile. Newly generated user tokens have the `wlu_` prefix.
+    - It is possible to create project-scoped tokens to grant a project access to the API. These tokens can be identified by the `wlp_` prefix.
+
+    Although some of the API operations are available without authentication,
+    it is still recommended to authenticate your requests:
+
+    - Operations such as `GET /api/users/` return an incomplete representation of the
+    requested resources if the request has not been authenticated and authorized.
+    - Unauthenticated requests are heavily rate limited, by default, to 100
+    requests per day. On the other hand, authenticated requests are rate limited
+    to 5000 requests per hour by default.
+
+    ## API rate limiting
+
+    Rate limiting can be adjusted in the `settings.py` file; see [Throttling in Django REST framework documentation](https://www.django-rest-framework.org/api-guide/throttling/)
+    for more details on how to configure it.
+
+    In the Docker container, this can be configured with the [WEBLATE_API_RATELIMIT_ANON](https://docs.weblate.org/en/latest/admin/install/docker.html#envvar-WEBLATE_API_RATELIMIT_ANON) and the [WEBLATE_API_RATELIMIT_USER](https://docs.weblate.org/en/latest/admin/install/docker.html#envvar-WEBLATE_API_RATELIMIT_USER) environment variables.
+
+    **Changed in version 4.1:**
+    Added HTTP response headers indicating status of rate-limiting.
+
+    Those HTTP headers are:
+
+    <table>
+      <thead>
+        <tr>
+          <td>Header name</td>
+          <td>Description</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>X-RateLimit-Limit</td>
+          <td>Rate limiting limit of requests to perform.</td>
+        </tr>
+        <tr>
+          <td>X-RateLimit-Remaining</td>
+          <td>Remaining limit of requests.</td>
+        </tr>
+        <tr>
+          <td>X-RateLimit-Reset</td>
+          <td>Number of seconds until ratelimit window resets.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    ## Components and categories
+
+    To access a component which is nested inside a [Category](https://docs.weblate.org/en/latest/admin/projects.html#category),
+    you need to URL encode the category name into a component name separated with a slash.
+
+    For example, usage placed in a `docs` category needs to be used as `docs%252Fusage`.
+    In this case, the full URL could be:
+
+    `https://weblate.example.com/api/components/hello/docs%252Fusage/repository/`
+  license:
+    name: GNU General Public License v3.0 or later
+    identifier: GPL-3.0-or-later
+  version: 0.1.0
+
+servers:
+  - url: https://hosted.weblate.org/api
+    description: The official Weblate cloud instance
+  - url: '{scheme}://{hostname}{port}/api'
+    description: A Weblate instance of your choice
+    variables:
+      scheme:
+        enum:
+          - http
+          - https
+        default: https
+        description: The HTTP protocol variant used for connecting to the API.
+      hostname:
+        default: ""
+        description: The host where the Weblate API is exposed.
+      port:
+        default: ""
+        description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080"'
+
+paths:
+  /:
+    get:
+      tags:
+        - root
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RootObject'
+              example:
+                users: https://weblate.example.com/api/users/
+                groups: https://weblate.example.com/api/groups/
+                roles: https://weblate.example.com/api/roles/
+                projects: https://weblate.example.com/api/projects/
+                components: https://weblate.example.com/api/components/
+                translations: https://weblate.example.com/api/translations/
+                memory: https://weblate.example.com/api/memory/
+                languages: https://weblate.example.com/api/languages/
+                component-lists: https://weblate.example.com/api/component-lists/
+                changes: https://weblate.example.com/api/changes/
+                units: https://weblate.example.com/api/units/
+                screenshots: https://weblate.example.com/api/screenshots/
+                addons: https://weblate.example.com/api/addons/
+                categories: https://weblate.example.com/api/categories/
+
+  # Resource: User
+  /users/:
+    $ref: 'resources/users.yaml#/paths/~1users~1'
+
+  /users/{username}/:
+    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1'
+
+  /users/{username}/groups/:
+    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1groups~1'
+
+  /users/{username}/statistics/:
+    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1statistics~1'
+
+  /users/{username}/notifications/:
+    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1notifications~1'
+
+  /users/{username}/notifications/{subscription_id}/:
+    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1notifications~1{subscription_id}~1'
+
+  # Resource: Group
+  /groups/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1'
+
+  /groups/{id}/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1'
+
+  /groups/{id}/roles/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1roles~1'
+
+  /groups/{id}/components/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1components~1'
+
+  /groups/{id}/components/{component_id}/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1components~1{component_id}~1'
+
+  /groups/{id}/projects/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1projects~1'
+
+  /groups/{id}/projects/{project_id}/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1projects~1{project_id}~1'
+
+  /groups/{id}/languages/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1languages~1'
+
+  /groups/{id}/languages/{language_code}/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1languages~1{language_code}~1'
+
+  /groups/{id}/componentlists/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1componentlists~1'
+
+  /groups/{id}/componentlists/{component_list_id}/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1componentlists~1{component_list_id}~1'
+
+  /groups/{id}/admins/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1admins~1'
+
+  /groups/{id}/admins/{user_id}/:
+    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1admins~1{user_id}~1'
+
+  # Resource: Role
+  /roles/:
+    $ref: 'resources/roles.yaml#/paths/~1roles~1'
+
+  /roles/{id}/:
+    $ref: 'resources/roles.yaml#/paths/~1roles~1{id}~1'
+
+  # Resource: Language
+  /languages/:
+    $ref: 'resources/languages.yaml#/paths/~1languages~1'
+
+  /languages/{language_code}/:
+    $ref: 'resources/languages.yaml#/paths/~1languages~1{language_code}~1'
+
+  /languages/{language_code}/statistics/:
+    $ref: 'resources/languages.yaml#/paths/~1languages~1{language_code}~1statistics~1'
+
+  # Resource: Project
+  /projects/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1'
+
+  /projects/{project}/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1'
+
+  /projects/{project}/changes/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1changes~1'
+
+  /projects/{project}/file/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1file~1'
+
+  /projects/{project}/repository/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1repository~1'
+
+  /projects/{project}/components/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1components~1'
+
+  /projects/{project}/languages/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1languages~1'
+
+  /projects/{project}/statistics/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1statistics~1'
+
+  /projects/{project}/categories/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1categories~1'
+
+  /projects/{project}/labels/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1labels~1'
+
+  /projects/{project}/credits/:
+    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1credits~1'
+
+  # Resource: Component
+  /components/:
+    $ref: 'resources/components.yaml#/paths/~1components~1'
+
+  /components/{project}/{component}/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1'
+
+  /components/{project}/{component}/changes/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1changes~1'
+
+  /components/{project}/{component}/file/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1file~1'
+
+  /components/{project}/{component}/screenshots/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1screenshots~1'
+
+  /components/{project}/{component}/lock/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1lock~1'
+
+  /components/{project}/{component}/repository/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1repository~1'
+
+  /components/{project}/{component}/monolingual_base/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1monolingual_base~1'
+
+  /components/{project}/{component}/new_template/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1new_template~1'
+
+  /components/{project}/{component}/translations/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1translations~1'
+
+  /components/{project}/{component}/statistics/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1statistics~1'
+
+  /components/{project}/{component}/links/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1links~1'
+
+  /components/{project}/{component}/links/{project_slug}/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1links~1{project_slug}~1'
+
+  /components/{project}/{component}/credits/:
+    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1credits~1'
+
+  # Resource: Translation
+  /translations/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1'
+
+  /translations/{project}/{component}/{language}/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1'
+
+  /translations/{project}/{component}/{language}/changes/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1changes~1'
+
+  /translations/{project}/{component}/{language}/units/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1units~1'
+
+  /translations/{project}/{component}/{language}/autotranslate/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1autotranslate~1'
+
+  /translations/{project}/{component}/{language}/file/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1file~1'
+
+  /translations/{project}/{component}/{language}/repository/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1repository~1'
+
+  /translations/{project}/{component}/{language}/statistics/:
+    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1statistics~1'
+
+  # Resource: Memory
+  /memory/:
+    $ref: 'resources/memory.yaml#/paths/~1memory~1'
+
+  /memory/{memory_object_id}/:
+    $ref: 'resources/memory.yaml#/paths/~1memory~1{memory_object_id}~1'
+
+  # Resource: Unit
+  /units/:
+    $ref: 'resources/units.yaml#/paths/~1units~1'
+
+  /units/{id}/:
+    $ref: 'resources/units.yaml#/paths/~1units~1{id}~1'
+
+  # Resource: Change
+  /changes/:
+    $ref: 'resources/changes.yaml#/paths/~1changes~1'
+
+  /changes/{id}/:
+    $ref: 'resources/changes.yaml#/paths/~1changes~1{id}~1'
+
+  # Resource: Screenshot
+  /screenshots/:
+    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1'
+
+  /screenshots/{id}/:
+    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1'
+
+  /screenshots/{id}/file/:
+    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1file~1'
+
+  /screenshots/{id}/units/:
+    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1units~1'
+
+  /screenshots/{id}/units/{unit_id}/:
+    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1units~1{unit_id}~1'
+
+  # Resource: Addon
+  /addons/:
+    $ref: 'resources/addons.yaml#/paths/~1addons~1'
+
+  /addons/{id}/:
+    $ref: 'resources/addons.yaml#/paths/~1addons~1{id}~1'
+
+  /components/{project}/{component}/addons/:
+    $ref: 'resources/addons.yaml#/paths/~1components~1{project}~1{component}~1addons~1'
+
+  # Resource: Component List
+  /component-lists/:
+    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1'
+
+  /component-lists/{slug}/:
+    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1'
+
+  /component-lists/{slug}/components/:
+    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1components~1'
+
+  /component-lists/{slug}/components/{component_slug}/:
+    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1components~1{component_slug}~1'
+
+  # Resource: Task
+  /tasks/:
+    $ref: 'resources/tasks.yaml#/paths/~1tasks~1'
+
+  /tasks/{uuid}/:
+    $ref: 'resources/tasks.yaml#/paths/~1tasks~1{uuid}~1'
+
+  # Resource: Metrics
+  /metrics/:
+    $ref: 'resources/metrics.yaml#/paths/~1metrics~1'
+
+  # Resource: Search
+  /search/:
+    $ref: 'resources/search.yaml#/paths/~1search~1'
+
+  # Resource: Category
+  /categories/:
+    $ref: 'resources/categories.yaml#/paths/~1categories~1'
+
+  /categories/{id}/:
+    $ref: 'resources/categories.yaml#/paths/~1categories~1{id}~1'
+
+  /categories/{id}/statistics/:
+    $ref: 'resources/categories.yaml#/paths/~1categories~1{id}~1statistics~1'
+
+  # Resource: Hook
+  /hooks/update/{project}/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1update~1{project}~1'
+
+  /hooks/update/{project}/{component}/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1update~1{project}~1{component}~1'
+
+  /hooks/github/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1github~1'
+
+  /hooks/gitlab/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1gitlab~1'
+
+  /hooks/bitbucket/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1bitbucket~1'
+
+  /hooks/pagure/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1pagure~1'
+
+  /hooks/azure/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1azure~1'
+
+  /hooks/gitea/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1gitea~1'
+
+  /hooks/gitee/:
+    $ref: 'resources/hooks.yaml#/paths/~1hooks~1gitee~1'
+
+  # Resource: Export
+  /exports/stats/{project}/{component}/:
+    $ref: 'resources/exports.yaml#/paths/~1exports~1stats~1{project}~1{component}~1'
+
+  # Resource: RSS Feed
+  /exports/rss/:
+    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1'
+
+  /exports/rss/{project}/:
+    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1'
+
+  /exports/rss/{project}/{component}/:
+    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1{component}~1'
+
+  /exports/rss/{project}/{component}/{language}/:
+    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1{component}~1{language}~1'
+
+  /exports/rss/language/{language}/:
+    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1language~1{language}~1'
+
+components:
+  schemas:
+    RootObject:
+      type: object
+      properties:
+        users:
+          type: string
+          format: uri
+        groups:
+          type: string
+          format: uri
+        roles:
+          type: string
+          format: uri
+        projects:
+          type: string
+          format: uri
+        components:
+          type: string
+          format: uri
+        translations:
+          type: string
+          format: uri
+        memory:
+          type: string
+          format: uri
+        languages:
+          type: string
+          format: uri
+        component-lists:
+          type: string
+          format: uri
+        changes:
+          type: string
+          format: uri
+        units:
+          type: string
+          format: uri
+        screenshots:
+          type: string
+          format: uri
+        addons:
+          type: string
+          format: uri
+        categories:
+          type: string
+          format: uri
+
+  securitySchemes:
+    TokenAuth:
+      type: apiKey
+      description: |
+        For example:
+
+        `Token wlu_ztrPajDM3BowB13vKSeqidWY3LzvPf2rJZaW`
+      name: Authorization
+      in: header
+
+security:
+  - {}
+  - TokenAuth: []
+
+tags:
+  - name: root
+    description: The API root entry point.
+  - name: users
+    description: Added in version 4.0.
+  - name: groups
+    description: Added in version 4.0.
+  - name: roles
+  - name: languages
+  - name: projects
+  - name: components
+  - name: translations
+  - name: memory
+    description: Added in version 4.14.
+  - name: units
+    description: A unit is a single piece of a translation which pairs a source string with a corresponding translated string and also contains some related metadata. The term is derived from the Translate Toolkit and XLIFF.
+  - name: changes
+  - name: screenshots
+  - name: addons
+    description: Added in version 4.4.1.
+  - name: componentLists
+    description: Added in version 4.0.
+  - name: glossary
+    description: '**Changed in version 4.5:** Glossaries are now stored as regular components, translations and strings, please use respective API instead.'
+  - name: tasks
+    description: Added in version 4.4.
+  - name: statistics
+    description: Many endpoints support displaying statistics for their objects.
+  - name: metrics
+  - name: search
+    description: Added in version 4.18.
+  - name: categories
+  - name: hooks
+    description: |
+      Notification hooks allow external applications to notify Weblate that the VCS repository has been updated.
+
+      You can use repository endpoints for projects, components and translations to update individual repositories.
+  - name: exports
+    description: Weblate provides various exports to allow you to further process the data.
+  - name: rssFeeds
+    description: Changes in translations are exported in RSS feeds.
+
+externalDocs:
+  description: Official documentation for the latest version of Weblate
+  url: https://docs.weblate.org

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -75,29 +75,29 @@ info:
   version: 0.1.0
 
 servers:
-  - url: https://hosted.weblate.org/api
-    description: The official Weblate cloud instance
-  - url: '{scheme}://{hostname}{port}/api'
-    description: A Weblate instance of your choice
-    variables:
-      scheme:
-        enum:
-          - http
-          - https
-        default: https
-        description: The HTTP protocol variant used for connecting to the API.
-      hostname:
-        default: ""
-        description: The host where the Weblate API is exposed.
-      port:
-        default: ""
-        description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080"'
+- url: https://hosted.weblate.org/api
+  description: The official Weblate cloud instance
+- url: '{scheme}://{hostname}{port}/api'
+  description: A Weblate instance of your choice
+  variables:
+    scheme:
+      enum:
+      - http
+      - https
+      default: https
+      description: The HTTP protocol variant used for connecting to the API.
+    hostname:
+      default: ''
+      description: The host where the Weblate API is exposed.
+    port:
+      default: ''
+      description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080"'
 
 paths:
   /:
     get:
       tags:
-        - root
+      - root
       responses:
         '200':
           description: OK
@@ -123,314 +123,314 @@ paths:
 
   # Resource: User
   /users/:
-    $ref: 'resources/users.yaml#/paths/~1users~1'
+    $ref: resources/users.yaml#/paths/~1users~1
 
   /users/{username}/:
-    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1'
+    $ref: resources/users.yaml#/paths/~1users~1{username}~1
 
   /users/{username}/groups/:
-    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1groups~1'
+    $ref: resources/users.yaml#/paths/~1users~1{username}~1groups~1
 
   /users/{username}/statistics/:
-    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1statistics~1'
+    $ref: resources/users.yaml#/paths/~1users~1{username}~1statistics~1
 
   /users/{username}/notifications/:
-    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1notifications~1'
+    $ref: resources/users.yaml#/paths/~1users~1{username}~1notifications~1
 
   /users/{username}/notifications/{subscription_id}/:
-    $ref: 'resources/users.yaml#/paths/~1users~1{username}~1notifications~1{subscription_id}~1'
+    $ref: resources/users.yaml#/paths/~1users~1{username}~1notifications~1{subscription_id}~1
 
   # Resource: Group
   /groups/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1
 
   /groups/{id}/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1
 
   /groups/{id}/roles/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1roles~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1roles~1
 
   /groups/{id}/components/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1components~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1components~1
 
   /groups/{id}/components/{component_id}/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1components~1{component_id}~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1components~1{component_id}~1
 
   /groups/{id}/projects/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1projects~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1projects~1
 
   /groups/{id}/projects/{project_id}/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1projects~1{project_id}~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1projects~1{project_id}~1
 
   /groups/{id}/languages/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1languages~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1languages~1
 
   /groups/{id}/languages/{language_code}/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1languages~1{language_code}~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1languages~1{language_code}~1
 
   /groups/{id}/componentlists/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1componentlists~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1componentlists~1
 
   /groups/{id}/componentlists/{component_list_id}/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1componentlists~1{component_list_id}~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1componentlists~1{component_list_id}~1
 
   /groups/{id}/admins/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1admins~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1admins~1
 
   /groups/{id}/admins/{user_id}/:
-    $ref: 'resources/groups.yaml#/paths/~1groups~1{id}~1admins~1{user_id}~1'
+    $ref: resources/groups.yaml#/paths/~1groups~1{id}~1admins~1{user_id}~1
 
   # Resource: Role
   /roles/:
-    $ref: 'resources/roles.yaml#/paths/~1roles~1'
+    $ref: resources/roles.yaml#/paths/~1roles~1
 
   /roles/{id}/:
-    $ref: 'resources/roles.yaml#/paths/~1roles~1{id}~1'
+    $ref: resources/roles.yaml#/paths/~1roles~1{id}~1
 
   # Resource: Language
   /languages/:
-    $ref: 'resources/languages.yaml#/paths/~1languages~1'
+    $ref: resources/languages.yaml#/paths/~1languages~1
 
   /languages/{language_code}/:
-    $ref: 'resources/languages.yaml#/paths/~1languages~1{language_code}~1'
+    $ref: resources/languages.yaml#/paths/~1languages~1{language_code}~1
 
   /languages/{language_code}/statistics/:
-    $ref: 'resources/languages.yaml#/paths/~1languages~1{language_code}~1statistics~1'
+    $ref: resources/languages.yaml#/paths/~1languages~1{language_code}~1statistics~1
 
   # Resource: Project
   /projects/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1
 
   /projects/{project}/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1
 
   /projects/{project}/changes/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1changes~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1changes~1
 
   /projects/{project}/file/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1file~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1file~1
 
   /projects/{project}/repository/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1repository~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1repository~1
 
   /projects/{project}/components/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1components~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1components~1
 
   /projects/{project}/languages/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1languages~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1languages~1
 
   /projects/{project}/statistics/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1statistics~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1statistics~1
 
   /projects/{project}/categories/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1categories~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1categories~1
 
   /projects/{project}/labels/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1labels~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1labels~1
 
   /projects/{project}/credits/:
-    $ref: 'resources/projects.yaml#/paths/~1projects~1{project}~1credits~1'
+    $ref: resources/projects.yaml#/paths/~1projects~1{project}~1credits~1
 
   # Resource: Component
   /components/:
-    $ref: 'resources/components.yaml#/paths/~1components~1'
+    $ref: resources/components.yaml#/paths/~1components~1
 
   /components/{project}/{component}/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1
 
   /components/{project}/{component}/changes/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1changes~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1changes~1
 
   /components/{project}/{component}/file/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1file~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1file~1
 
   /components/{project}/{component}/screenshots/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1screenshots~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1screenshots~1
 
   /components/{project}/{component}/lock/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1lock~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1lock~1
 
   /components/{project}/{component}/repository/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1repository~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1repository~1
 
   /components/{project}/{component}/monolingual_base/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1monolingual_base~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1monolingual_base~1
 
   /components/{project}/{component}/new_template/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1new_template~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1new_template~1
 
   /components/{project}/{component}/translations/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1translations~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1translations~1
 
   /components/{project}/{component}/statistics/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1statistics~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1statistics~1
 
   /components/{project}/{component}/links/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1links~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1links~1
 
   /components/{project}/{component}/links/{project_slug}/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1links~1{project_slug}~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1links~1{project_slug}~1
 
   /components/{project}/{component}/credits/:
-    $ref: 'resources/components.yaml#/paths/~1components~1{project}~1{component}~1credits~1'
+    $ref: resources/components.yaml#/paths/~1components~1{project}~1{component}~1credits~1
 
   # Resource: Translation
   /translations/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1
 
   /translations/{project}/{component}/{language}/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1
 
   /translations/{project}/{component}/{language}/changes/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1changes~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1changes~1
 
   /translations/{project}/{component}/{language}/units/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1units~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1units~1
 
   /translations/{project}/{component}/{language}/autotranslate/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1autotranslate~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1autotranslate~1
 
   /translations/{project}/{component}/{language}/file/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1file~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1file~1
 
   /translations/{project}/{component}/{language}/repository/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1repository~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1repository~1
 
   /translations/{project}/{component}/{language}/statistics/:
-    $ref: 'resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1statistics~1'
+    $ref: resources/translations.yaml#/paths/~1translations~1{project}~1{component}~1{language}~1statistics~1
 
   # Resource: Memory
   /memory/:
-    $ref: 'resources/memory.yaml#/paths/~1memory~1'
+    $ref: resources/memory.yaml#/paths/~1memory~1
 
   /memory/{memory_object_id}/:
-    $ref: 'resources/memory.yaml#/paths/~1memory~1{memory_object_id}~1'
+    $ref: resources/memory.yaml#/paths/~1memory~1{memory_object_id}~1
 
   # Resource: Unit
   /units/:
-    $ref: 'resources/units.yaml#/paths/~1units~1'
+    $ref: resources/units.yaml#/paths/~1units~1
 
   /units/{id}/:
-    $ref: 'resources/units.yaml#/paths/~1units~1{id}~1'
+    $ref: resources/units.yaml#/paths/~1units~1{id}~1
 
   # Resource: Change
   /changes/:
-    $ref: 'resources/changes.yaml#/paths/~1changes~1'
+    $ref: resources/changes.yaml#/paths/~1changes~1
 
   /changes/{id}/:
-    $ref: 'resources/changes.yaml#/paths/~1changes~1{id}~1'
+    $ref: resources/changes.yaml#/paths/~1changes~1{id}~1
 
   # Resource: Screenshot
   /screenshots/:
-    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1'
+    $ref: resources/screenshots.yaml#/paths/~1screenshots~1
 
   /screenshots/{id}/:
-    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1'
+    $ref: resources/screenshots.yaml#/paths/~1screenshots~1{id}~1
 
   /screenshots/{id}/file/:
-    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1file~1'
+    $ref: resources/screenshots.yaml#/paths/~1screenshots~1{id}~1file~1
 
   /screenshots/{id}/units/:
-    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1units~1'
+    $ref: resources/screenshots.yaml#/paths/~1screenshots~1{id}~1units~1
 
   /screenshots/{id}/units/{unit_id}/:
-    $ref: 'resources/screenshots.yaml#/paths/~1screenshots~1{id}~1units~1{unit_id}~1'
+    $ref: resources/screenshots.yaml#/paths/~1screenshots~1{id}~1units~1{unit_id}~1
 
   # Resource: Addon
   /addons/:
-    $ref: 'resources/addons.yaml#/paths/~1addons~1'
+    $ref: resources/addons.yaml#/paths/~1addons~1
 
   /addons/{id}/:
-    $ref: 'resources/addons.yaml#/paths/~1addons~1{id}~1'
+    $ref: resources/addons.yaml#/paths/~1addons~1{id}~1
 
   /components/{project}/{component}/addons/:
-    $ref: 'resources/addons.yaml#/paths/~1components~1{project}~1{component}~1addons~1'
+    $ref: resources/addons.yaml#/paths/~1components~1{project}~1{component}~1addons~1
 
   # Resource: Component List
   /component-lists/:
-    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1'
+    $ref: resources/componentlists.yaml#/paths/~1component-lists~1
 
   /component-lists/{slug}/:
-    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1'
+    $ref: resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1
 
   /component-lists/{slug}/components/:
-    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1components~1'
+    $ref: resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1components~1
 
   /component-lists/{slug}/components/{component_slug}/:
-    $ref: 'resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1components~1{component_slug}~1'
+    $ref: resources/componentlists.yaml#/paths/~1component-lists~1{slug}~1components~1{component_slug}~1
 
   # Resource: Task
   /tasks/:
-    $ref: 'resources/tasks.yaml#/paths/~1tasks~1'
+    $ref: resources/tasks.yaml#/paths/~1tasks~1
 
   /tasks/{uuid}/:
-    $ref: 'resources/tasks.yaml#/paths/~1tasks~1{uuid}~1'
+    $ref: resources/tasks.yaml#/paths/~1tasks~1{uuid}~1
 
   # Resource: Metrics
   /metrics/:
-    $ref: 'resources/metrics.yaml#/paths/~1metrics~1'
+    $ref: resources/metrics.yaml#/paths/~1metrics~1
 
   # Resource: Search
   /search/:
-    $ref: 'resources/search.yaml#/paths/~1search~1'
+    $ref: resources/search.yaml#/paths/~1search~1
 
   # Resource: Category
   /categories/:
-    $ref: 'resources/categories.yaml#/paths/~1categories~1'
+    $ref: resources/categories.yaml#/paths/~1categories~1
 
   /categories/{id}/:
-    $ref: 'resources/categories.yaml#/paths/~1categories~1{id}~1'
+    $ref: resources/categories.yaml#/paths/~1categories~1{id}~1
 
   /categories/{id}/statistics/:
-    $ref: 'resources/categories.yaml#/paths/~1categories~1{id}~1statistics~1'
+    $ref: resources/categories.yaml#/paths/~1categories~1{id}~1statistics~1
 
   # Resource: Hook
   /hooks/update/{project}/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1update~1{project}~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1update~1{project}~1
 
   /hooks/update/{project}/{component}/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1update~1{project}~1{component}~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1update~1{project}~1{component}~1
 
   /hooks/github/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1github~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1github~1
 
   /hooks/gitlab/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1gitlab~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1gitlab~1
 
   /hooks/bitbucket/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1bitbucket~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1bitbucket~1
 
   /hooks/pagure/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1pagure~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1pagure~1
 
   /hooks/azure/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1azure~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1azure~1
 
   /hooks/gitea/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1gitea~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1gitea~1
 
   /hooks/gitee/:
-    $ref: 'resources/hooks.yaml#/paths/~1hooks~1gitee~1'
+    $ref: resources/hooks.yaml#/paths/~1hooks~1gitee~1
 
   # Resource: Export
   /exports/stats/{project}/{component}/:
-    $ref: 'resources/exports.yaml#/paths/~1exports~1stats~1{project}~1{component}~1'
+    $ref: resources/exports.yaml#/paths/~1exports~1stats~1{project}~1{component}~1
 
   # Resource: RSS Feed
   /exports/rss/:
-    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1'
+    $ref: resources/rssfeeds.yaml#/paths/~1exports~1rss~1
 
   /exports/rss/{project}/:
-    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1'
+    $ref: resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1
 
   /exports/rss/{project}/{component}/:
-    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1{component}~1'
+    $ref: resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1{component}~1
 
   /exports/rss/{project}/{component}/{language}/:
-    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1{component}~1{language}~1'
+    $ref: resources/rssfeeds.yaml#/paths/~1exports~1rss~1{project}~1{component}~1{language}~1
 
   /exports/rss/language/{language}/:
-    $ref: 'resources/rssfeeds.yaml#/paths/~1exports~1rss~1language~1{language}~1'
+    $ref: resources/rssfeeds.yaml#/paths/~1exports~1rss~1language~1{language}~1
 
 components:
   schemas:
@@ -491,50 +491,50 @@ components:
       in: header
 
 security:
-  - {}
-  - TokenAuth: []
+- {}
+- TokenAuth: []
 
 tags:
-  - name: root
-    description: The API root entry point.
-  - name: users
-    description: Added in version 4.0.
-  - name: groups
-    description: Added in version 4.0.
-  - name: roles
-  - name: languages
-  - name: projects
-  - name: components
-  - name: translations
-  - name: memory
-    description: Added in version 4.14.
-  - name: units
-    description: A unit is a single piece of a translation which pairs a source string with a corresponding translated string and also contains some related metadata. The term is derived from the Translate Toolkit and XLIFF.
-  - name: changes
-  - name: screenshots
-  - name: addons
-    description: Added in version 4.4.1.
-  - name: componentLists
-    description: Added in version 4.0.
-  - name: glossary
-    description: '**Changed in version 4.5:** Glossaries are now stored as regular components, translations and strings, please use respective API instead.'
-  - name: tasks
-    description: Added in version 4.4.
-  - name: statistics
-    description: Many endpoints support displaying statistics for their objects.
-  - name: metrics
-  - name: search
-    description: Added in version 4.18.
-  - name: categories
-  - name: hooks
-    description: |
-      Notification hooks allow external applications to notify Weblate that the VCS repository has been updated.
+- name: root
+  description: The API root entry point.
+- name: users
+  description: Added in version 4.0.
+- name: groups
+  description: Added in version 4.0.
+- name: roles
+- name: languages
+- name: projects
+- name: components
+- name: translations
+- name: memory
+  description: Added in version 4.14.
+- name: units
+  description: A unit is a single piece of a translation which pairs a source string with a corresponding translated string and also contains some related metadata. The term is derived from the Translate Toolkit and XLIFF.
+- name: changes
+- name: screenshots
+- name: addons
+  description: Added in version 4.4.1.
+- name: componentLists
+  description: Added in version 4.0.
+- name: glossary
+  description: '**Changed in version 4.5:** Glossaries are now stored as regular components, translations and strings, please use respective API instead.'
+- name: tasks
+  description: Added in version 4.4.
+- name: statistics
+  description: Many endpoints support displaying statistics for their objects.
+- name: metrics
+- name: search
+  description: Added in version 4.18.
+- name: categories
+- name: hooks
+  description: |
+    Notification hooks allow external applications to notify Weblate that the VCS repository has been updated.
 
-      You can use repository endpoints for projects, components and translations to update individual repositories.
-  - name: exports
-    description: Weblate provides various exports to allow you to further process the data.
-  - name: rssFeeds
-    description: Changes in translations are exported in RSS feeds.
+    You can use repository endpoints for projects, components and translations to update individual repositories.
+- name: exports
+  description: Weblate provides various exports to allow you to further process the data.
+- name: rssFeeds
+  description: Changes in translations are exported in RSS feeds.
 
 externalDocs:
   description: Official documentation for the latest version of Weblate

--- a/docs/openapi/resources/addons.yaml
+++ b/docs/openapi/resources/addons.yaml
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /addons/:
+    get:
+      tags:
+        -  addons
+      summary: Returns a list of add-ons
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Addon'
+
+  /addons/{id}/:
+    get:
+      tags:
+        - addons
+      summary: Returns information about add-on information
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Addon'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - addons
+      summary: Edit full information about add-on
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/AddonUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - addons
+      summary: Edit partial information about add-on
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/AddonUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - addons
+      summary: Delete add-on
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /components/{project}/{component}/addons/:
+    post:
+      tags:
+        - addons
+      summary: Creates a new add-on
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '201':
+          $ref: '#/components/responses/AddonCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Addon:
+      type: object
+      properties:
+        component:
+          type: string
+          format: uri
+        project:
+          type: string
+          format: uri
+          nullable: true
+        name:
+          type: string
+        id:
+          type: integer
+        configuration:
+          type: object
+        url:
+          type: string
+          format: uri
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            AddonNotFound:
+              value:
+                detail: No Addon matches the given query.
+
+    AddonCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Addon'
+
+    AddonUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Addon'
+
+  parameters:
+    idInPath:
+      $ref: 'common.yaml#/components/parameters/idInPath'
+
+    projectInPath:
+      $ref: 'projects.yaml#/components/parameters/projectInPath'
+
+    componentInPath:
+      $ref: 'components.yaml#/components/parameters/componentInPath'

--- a/docs/openapi/resources/addons.yaml
+++ b/docs/openapi/resources/addons.yaml
@@ -4,11 +4,11 @@ paths:
   /addons/:
     get:
       tags:
-        -  addons
+      - addons
       summary: Returns a list of add-ons
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -35,10 +35,10 @@ paths:
   /addons/{id}/:
     get:
       tags:
-        - addons
+      - addons
       summary: Returns information about add-on information
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           description: OK
@@ -51,10 +51,10 @@ paths:
 
     put:
       tags:
-        - addons
+      - addons
       summary: Edit full information about add-on
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/AddonUpdated'
@@ -63,14 +63,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - addons
+      - addons
       summary: Edit partial information about add-on
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/AddonUpdated'
@@ -79,14 +79,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - addons
+      - addons
       summary: Delete add-on
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -95,16 +95,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /components/{project}/{component}/addons/:
     post:
       tags:
-        - addons
+      - addons
       summary: Creates a new add-on
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '201':
           $ref: '#/components/responses/AddonCreated'
@@ -113,7 +113,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -139,16 +139,16 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -180,10 +180,10 @@ components:
 
   parameters:
     idInPath:
-      $ref: 'common.yaml#/components/parameters/idInPath'
+      $ref: common.yaml#/components/parameters/idInPath
 
     projectInPath:
-      $ref: 'projects.yaml#/components/parameters/projectInPath'
+      $ref: projects.yaml#/components/parameters/projectInPath
 
     componentInPath:
-      $ref: 'components.yaml#/components/parameters/componentInPath'
+      $ref: components.yaml#/components/parameters/componentInPath

--- a/docs/openapi/resources/categories.yaml
+++ b/docs/openapi/resources/categories.yaml
@@ -4,7 +4,7 @@ paths:
   /categories/:
     get:
       tags:
-        - categories
+      - categories
       summary: Lists available categories
       description: Added in version 5.0.
       responses:
@@ -32,7 +32,7 @@ paths:
 
     post:
       tags:
-        - categories
+      - categories
       summary: Creates a new category
       description: Added in version 5.0.
       responses:
@@ -41,15 +41,15 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /categories/{id}/:
     get:
       tags:
-        - categories
+      - categories
       description: Added in version 5.0.
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           description: OK
@@ -62,11 +62,11 @@ paths:
 
     put:
       tags:
-        - categories
+      - categories
       summary: Edit full information about category
       description: Added in version 5.0.
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/CategoryUpdated'
@@ -75,15 +75,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - categories
+      - categories
       summary: Edit partial information about category
       description: Added in version 5.0.
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/CategoryUpdated'
@@ -92,15 +92,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - categories
+      - categories
       summary: Delete category
       description: Added in version 5.0.
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -109,17 +109,17 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /categories/{id}/statistics/:
     get:
       tags:
-        - categories
-        - statistics
+      - categories
+      - statistics
       summary: Returns statistics for a category
       description: Added in version 5.5.
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           description: OK
@@ -155,20 +155,20 @@ components:
           format: uri
 
     CategoryStatistics:
-      $ref: 'statistics.yaml#/components/schemas/StatisticsUrl'
+      $ref: statistics.yaml#/components/schemas/StatisticsUrl
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -200,4 +200,4 @@ components:
 
   parameters:
     idInPath:
-      $ref: 'common.yaml#/components/parameters/idInPath'
+      $ref: common.yaml#/components/parameters/idInPath

--- a/docs/openapi/resources/categories.yaml
+++ b/docs/openapi/resources/categories.yaml
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /categories/:
+    get:
+      tags:
+        - categories
+      summary: Lists available categories
+      description: Added in version 5.0.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Category'
+
+    post:
+      tags:
+        - categories
+      summary: Creates a new category
+      description: Added in version 5.0.
+      responses:
+        '201':
+          $ref: '#/components/responses/CategoryCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+
+  /categories/{id}/:
+    get:
+      tags:
+        - categories
+      description: Added in version 5.0.
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - categories
+      summary: Edit full information about category
+      description: Added in version 5.0.
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/CategoryUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - categories
+      summary: Edit partial information about category
+      description: Added in version 5.0.
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/CategoryUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - categories
+      summary: Delete category
+      description: Added in version 5.0.
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /categories/{id}/statistics/:
+    get:
+      tags:
+        - categories
+        - statistics
+      summary: Returns statistics for a category
+      description: Added in version 5.5.
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryStatistics'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        slug:
+          type: string
+        project:
+          type: string
+          format: uri
+        category:
+          type: string
+          nullable: true
+        url:
+          type: string
+          format: uri
+        statistics_url:
+          type: string
+          format: uri
+
+    CategoryStatistics:
+      $ref: 'statistics.yaml#/components/schemas/StatisticsUrl'
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            CategoryNotFound:
+              value:
+                detail: No Category matches the given query.
+
+    CategoryCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Category'
+
+    CategoryUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Category'
+
+  parameters:
+    idInPath:
+      $ref: 'common.yaml#/components/parameters/idInPath'

--- a/docs/openapi/resources/changes.yaml
+++ b/docs/openapi/resources/changes.yaml
@@ -4,12 +4,12 @@ paths:
   /changes/:
     get:
       tags:
-        - changes
+      - changes
       summary: Returns a list of translation changes
       description: '**Changed in version 4.1:** Filtering of changes was introduced in the 4.1 release.'
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -36,10 +36,10 @@ paths:
   /changes/{id}/:
     get:
       tags:
-        - changes
+      - changes
       summary: Returns information about translation change
       parameters:
-        - $ref: 'common.yaml#/components/parameters/idInPath'
+      - $ref: common.yaml#/components/parameters/idInPath
       responses:
         '200':
           $ref: '#/components/responses/Change'
@@ -82,32 +82,32 @@ components:
           type: string
         details:
           oneOf:
-            - type: object
-              properties:
-                new_head:
+          - type: object
+            properties:
+              new_head:
+                type: string
+              previous_head:
+                type: string
+          - type: object
+            properties:
+              repos:
+                type: array
+                items:
                   type: string
-                previous_head:
-                  type: string
-            - type: object
-              properties:
-                repos:
-                  type: array
-                  items:
-                    type: string
-                    format: uri
-            - type: object
-              properties:
-                state:
-                  type: integer
-                source:
-                  type: string
-                old_state: integer
-            - type: object
-              properties:
-                reason:
-                  type: string
-                filename:
-                  type: string
+                  format: uri
+          - type: object
+            properties:
+              state:
+                type: integer
+              source:
+                type: string
+              old_state: integer
+          - type: object
+            properties:
+              reason:
+                type: string
+              filename:
+                type: string
         id:
           type: integer
         action_name:
@@ -140,4 +140,4 @@ components:
 
   parameters:
     idInPath:
-      $ref: 'common.yaml#/components/parameters/idInPath'
+      $ref: common.yaml#/components/parameters/idInPath

--- a/docs/openapi/resources/changes.yaml
+++ b/docs/openapi/resources/changes.yaml
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /changes/:
+    get:
+      tags:
+        - changes
+      summary: Returns a list of translation changes
+      description: '**Changed in version 4.1:** Filtering of changes was introduced in the 4.1 release.'
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Change'
+
+  /changes/{id}/:
+    get:
+      tags:
+        - changes
+      summary: Returns information about translation change
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Change'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  schemas:
+    Change:
+      type: object
+      properties:
+        unit:
+          type: string
+          format: uri
+          nullable: true
+        component:
+          type: string
+          format: uri
+          nullable: true
+        translation:
+          type: string
+          format: uri
+          nullable: true
+        user:
+          type: string
+          format: uri
+          nullable: true
+        author:
+          type: string
+          format: uri
+          nullable: true
+        timestamp:
+          type: string
+          format: date-time
+        action:
+          type: integer
+        target:
+          type: string
+        old:
+          type: string
+        details:
+          oneOf:
+            - type: object
+              properties:
+                new_head:
+                  type: string
+                previous_head:
+                  type: string
+            - type: object
+              properties:
+                repos:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
+            - type: object
+              properties:
+                state:
+                  type: integer
+                source:
+                  type: string
+                old_state: integer
+            - type: object
+              properties:
+                reason:
+                  type: string
+                filename:
+                  type: string
+        id:
+          type: integer
+        action_name:
+          type: string
+        url:
+          type: string
+          format: uri
+
+  responses:
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            ChangeNotFound:
+              value:
+                detail: No Change matches the given query.
+
+    Change:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Change'
+
+  parameters:
+    idInPath:
+      $ref: 'common.yaml#/components/parameters/idInPath'

--- a/docs/openapi/resources/common.yaml
+++ b/docs/openapi/resources/common.yaml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+components:
+  responses:
+    OK:
+      description: OK
+
+    Created:
+      description: Created
+
+    NoContent:
+      description: No Content
+
+    BadRequest:
+      description: Bad Request
+
+    Unauthorized:
+      description: Unauthorized
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+            example: Token
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            AuthCredsNotProvided:
+              value:
+                detail: Authentication credentials were not provided
+            InvalidToken:
+              value:
+                detail: Invalid token
+
+    Forbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            AccessNotAllowed:
+              value:
+                detail: Access not allowed
+            NotPermission:
+              value:
+                detail: You do not have permission to perform this action.
+
+    NotFound:
+      description: Not Found
+
+  parameters:
+    idInPath:
+      name: id
+      in: path
+      description: Numerical identifier of a given resource.
+      required: true
+      schema:
+        type: integer
+
+    pageInQuery:
+      name: page
+      in: query
+      schema:
+        type: integer
+
+    pageSizeInQuery:
+      name: page_size
+      in: query
+      schema:
+        type: integer
+        maximum: 1000
+        default: 50

--- a/docs/openapi/resources/componentlists.yaml
+++ b/docs/openapi/resources/componentlists.yaml
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /component-lists/:
+    get:
+      tags:
+        - componentLists
+      summary: Returns a list of component lists
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ComponentList'
+
+    post:
+      tags:
+        - componentLists
+      summary: Creates a new component list
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentListCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /component-lists/{slug}/:
+    get:
+      tags:
+        - componentLists
+      summary: Returns information about component list
+      parameters:
+        - $ref: '#/components/parameters/slugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentList'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - componentLists
+      summary: Changes the component list parameters
+      parameters:
+        - $ref: '#/components/parameters/slugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentListUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - componentLists
+      summary: Changes the component list parameters
+      parameters:
+        - $ref: '#/components/parameters/slugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentListUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - componentLists
+      summary: Deletes the component list
+      parameters:
+        - $ref: '#/components/parameters/slugInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /component-lists/{slug}/components/:
+    get:
+      tags:
+        - componentLists
+      description: '**Added in version 5.0.1:** List components in a component list.'
+      parameters:
+        - $ref: '#/components/parameters/slugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - componentLists
+      summary: Associate component with a component list
+      parameters:
+        - $ref: '#/components/parameters/slugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /component-lists/{slug}/components/{component_slug}/:
+    delete:
+      tags:
+        - componentLists
+      summary: Disassociate a component from the component list
+      parameters:
+        - $ref: '#/components/parameters/slugInPath'
+        - $ref: '#/components/parameters/componentSlugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+
+components:
+  schemas:
+    ComponentList:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of a component list.
+        slug:
+          type: string
+          description: Slug of a component list.
+        show_dashboard:
+          type: boolean
+          description: Whether to show it on a dashboard.
+        components:
+          type: array
+          description: Link to associated components.
+          items:
+            $ref: 'components.yaml#/components/schemas/Component'
+        auto_assign:
+          type: array
+          description: Automatic assignment rules.
+          items:
+            type: string
+
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            ComponentListNotFound:
+              value:
+                detail: No ComponentList matches the given query.
+
+    ComponentList:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ComponentList'
+
+    ComponentListCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ComponentList'
+
+    ComponentListUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ComponentList'
+
+  parameters:
+    slugInPath:
+      name: slug
+      in: path
+      description: Component list slug.
+      required: true
+      schema:
+        type: string
+
+    componentSlugInPath:
+      name: component_slug
+      in: path
+      description: Component slug.
+      required: true
+      schema:
+        type: string
+
+    componentListIdInPath:
+      name: component_list_id
+      in: path
+      required: true
+      schema:
+        type: integer

--- a/docs/openapi/resources/componentlists.yaml
+++ b/docs/openapi/resources/componentlists.yaml
@@ -4,11 +4,11 @@ paths:
   /component-lists/:
     get:
       tags:
-        - componentLists
+      - componentLists
       summary: Returns a list of component lists
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -34,7 +34,7 @@ paths:
 
     post:
       tags:
-        - componentLists
+      - componentLists
       summary: Creates a new component list
       responses:
         '200':
@@ -44,15 +44,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /component-lists/{slug}/:
     get:
       tags:
-        - componentLists
+      - componentLists
       summary: Returns information about component list
       parameters:
-        - $ref: '#/components/parameters/slugInPath'
+      - $ref: '#/components/parameters/slugInPath'
       responses:
         '200':
           $ref: '#/components/responses/ComponentList'
@@ -61,10 +61,10 @@ paths:
 
     put:
       tags:
-        - componentLists
+      - componentLists
       summary: Changes the component list parameters
       parameters:
-        - $ref: '#/components/parameters/slugInPath'
+      - $ref: '#/components/parameters/slugInPath'
       responses:
         '200':
           $ref: '#/components/responses/ComponentListUpdated'
@@ -73,14 +73,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - componentLists
+      - componentLists
       summary: Changes the component list parameters
       parameters:
-        - $ref: '#/components/parameters/slugInPath'
+      - $ref: '#/components/parameters/slugInPath'
       responses:
         '200':
           $ref: '#/components/responses/ComponentListUpdated'
@@ -89,14 +89,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - componentLists
+      - componentLists
       summary: Deletes the component list
       parameters:
-        - $ref: '#/components/parameters/slugInPath'
+      - $ref: '#/components/parameters/slugInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -105,15 +105,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /component-lists/{slug}/components/:
     get:
       tags:
-        - componentLists
+      - componentLists
       description: '**Added in version 5.0.1:** List components in a component list.'
       parameters:
-        - $ref: '#/components/parameters/slugInPath'
+      - $ref: '#/components/parameters/slugInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -122,10 +122,10 @@ paths:
 
     post:
       tags:
-        - componentLists
+      - componentLists
       summary: Associate component with a component list
       parameters:
-        - $ref: '#/components/parameters/slugInPath'
+      - $ref: '#/components/parameters/slugInPath'
       responses:
         '200':
           $ref: '#/components/responses/ComponentList'
@@ -134,16 +134,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /component-lists/{slug}/components/{component_slug}/:
     delete:
       tags:
-        - componentLists
+      - componentLists
       summary: Disassociate a component from the component list
       parameters:
-        - $ref: '#/components/parameters/slugInPath'
-        - $ref: '#/components/parameters/componentSlugInPath'
+      - $ref: '#/components/parameters/slugInPath'
+      - $ref: '#/components/parameters/componentSlugInPath'
       responses:
         '200':
           $ref: '#/components/responses/ComponentList'
@@ -152,7 +152,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 
 components:
@@ -173,7 +173,7 @@ components:
           type: array
           description: Link to associated components.
           items:
-            $ref: 'components.yaml#/components/schemas/Component'
+            $ref: components.yaml#/components/schemas/Component
         auto_assign:
           type: array
           description: Automatic assignment rules.
@@ -183,16 +183,16 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found

--- a/docs/openapi/resources/components.yaml
+++ b/docs/openapi/resources/components.yaml
@@ -1,0 +1,965 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /components/:
+    get:
+      tags:
+        - components
+      summary: Returns a list of translation components
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Component'
+
+  /components/{project}/{component}/:
+    get:
+      tags:
+        - components
+      summary: Returns information about translation component
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Component'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - components
+      summary: Edit a component by a PUT request
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateComponent'
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - components
+      summary: Edit a component by a PATCH request
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateComponent'
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - components
+      summary: Deletes a component
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /components/{project}/{component}/changes/:
+    get:
+      tags:
+        - components
+      summary: Returns a list of component changes
+      description: This is essentially a component-scoped `GET /api/changes/` which accepts the same parameters.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          $ref: 'changes.yaml#/components/responses/Change'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /components/{project}/{component}/file/:
+    get:
+      tags:
+        - components
+      description: |
+        Added in version 4.9.
+
+        Downloads all available translations associated with the component as an archive file using the requested format.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /components/{project}/{component}/screenshots/:
+    get:
+      tags:
+        - components
+      summary: Returns a list of component screenshots
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: 'screenshots.yaml#/components/schemas/Screenshot'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /components/{project}/{component}/lock/:
+    get:
+      tags:
+        - components
+      summary: Returns component lock status
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  locked:
+                    type: boolean
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - components
+      summary: Sets component lock status
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  locked:
+                    type: boolean
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /components/{project}/{component}/repository/:
+    get:
+      tags:
+        - components
+      summary: Returns information about VCS repository status
+      description: This endpoint contains only an overall summary for all repositories for the project.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'projects.yaml#/components/schemas/Repository'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - components
+      summary: Performs the given operation on a VCS repository
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/OperateOnComponentRepository'
+      responses:
+        '200':
+          description: OK
+          content:
+            schema:
+              type: object
+              properties:
+                result:
+                  type: boolean
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /components/{project}/{component}/monolingual_base/:
+    get:
+      tags:
+        - components
+      summary: Downloads base file for monolingual translations
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /components/{project}/{component}/new_template/:
+    get:
+      tags:
+        - components
+      summary: Downloads template file for new translations
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /components/{project}/{component}/translations/:
+    get:
+      tags:
+        - components
+      summary: Returns a list of translation objects in the given component
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                    $ref: 'languages.yaml#/components/schemas/Language'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - components
+      summary: Creates new translation in the given component
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateComponentTranslation'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    $ref: 'translations.yaml#/components/schemas/Translation'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /components/{project}/{component}/statistics/:
+    get:
+      tags:
+        - components
+        - statistics
+      summary: Returns paginated statistics for all translations within component
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ComponentStatistics'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /components/{project}/{component}/links/:
+    get:
+      tags:
+        - components
+      summary: Returns projects linked with a component
+      description: Added in version 4.5.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: 'projects.yaml#/components/schemas/Project'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - components
+      summary: Associate project with a component
+      description: Added in version 4.5.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+            $ref: '#/components/responses/Unauthorized'
+        '404':
+            $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /components/{project}/{component}/links/{project_slug}/:
+    delete:
+      tags:
+        - components
+      summary: Remove association of a project with a component
+      description: Added in version 4.5.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/projectSlugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /components/{project}/{component}/credits/:
+    #TODO: returns 400 Bad Request
+    get:
+      tags:
+        - components
+      summary: Returns contributor credits for a project
+      description: Added in version 5.7.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  email:
+                    type: string
+                    format: email
+                    description: Email of the contributor.
+                  full_name:
+                    type: string
+                    description: Full name of the contributor.
+                  change_count:
+                    type: string
+                    description: Number of changes done in the time range.
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  schemas:
+    # The difference with 'projects.yaml#/schemas/ProjectComponent'
+    # is that this schema has a 'project' property pointing to a Project object.
+    Component:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        id:
+          type: integer
+        source_language:
+          $ref: 'languages.yaml#/components/schemas/Language'
+        project:
+          $ref: 'projects.yaml#/components/schemas/Project'
+        vcs:
+          type: string
+        repo:
+          type: string
+          format: uri
+          description: Source code repository, this is the actual repository URL even when Weblate internal URLs are used, use linked_component to detect this situation.
+        git_export:
+          type: string
+          format: uri
+        branch:
+          type: string
+          description: Repository branch, this is the actual repository branch even when Weblate internal URLs are used.
+        push_branch:
+          type: string
+          description: Push branch, this is the actual repository branch even when Weblate internal URLs are used.
+        filemask:
+          type: string
+        screenshot_filemask:
+          type: string
+        template:
+          type: string
+        edit_template:
+          type: boolean
+        intermediate:
+          type: string
+        new_base:
+          type: string
+        file_format:
+          type: string
+        license:
+          type: string
+        license_url:
+          type: string
+          format: uri
+          nullable: true
+        agreement:
+          type: string
+        web_url:
+          type: string
+          format: uri
+        url:
+          type: string
+          format: uri
+        repository_url:
+          type: string
+          format: uri
+        translations_url:
+          type: string
+          format: uri
+        statistics_url:
+          type: string
+          format: uri
+        lock_url:
+          type: string
+          format: uri
+        links_url:
+          type: string
+          format: uri
+        changes_list_url:
+          type: string
+          format: uri
+        task_url:
+          type: string
+          format: uri
+          nullable: true
+        credits_url:
+          type: string
+          format: uri
+        new_lang:
+          type: string
+        language_code_style:
+          type: string
+        push:
+          type: string
+          nullable: true
+        check_flags:
+          type: string
+        priority:
+          type: integer
+        enforced_checks:
+          type: array
+        restricted:
+          type: boolean
+        repoweb:
+          type: string
+        report_source_bugs:
+          type: string
+        merge_style:
+          type: string
+        commit_message:
+          type: string
+        add_message:
+          type: string
+        delete_message:
+          type: string
+        merge_message:
+          type: string
+        addon_message:
+          type: string
+        pull_message:
+          type: string
+        allow_translation_propagation:
+          type: boolean
+        manage_units:
+          type: boolean
+        enable_suggestions:
+          type: boolean
+        suggestion_voting:
+          type: boolean
+        suggestion_autoaccept:
+          type: integer
+        push_on_commit:
+          type: boolean
+        commit_pending_age:
+          type: integer
+        auto_lock_error:
+          type: boolean
+        language_regex:
+          type: string
+          format: regex
+        variant_regex:
+          type: string
+          format: regex
+        addons:
+          type: array
+          items:
+            type: string
+            format: uri
+        is_glossary:
+          type: boolean
+        glossary_color:
+          type: string
+        category:
+          type: string
+          format: uri
+          nullable: true
+        linked_component:
+          type: string
+          format: uri
+          description: Component whose repository is linked via [Weblate internal URLs](https://docs.weblate.org/en/latest/vcs.html#internal-urls).
+          nullable: true
+      examples:
+        Component:
+          name: Test Component 2
+          slug: test-component-2
+          id: 5
+          source_language:
+            id: 177
+            code: en
+            name: English
+            plural:
+              id: 177
+              source: 0
+              number: 2
+              formula: n != 1
+              type: 1
+            aliases:
+              - en_en
+              - base
+              - source
+              - enp
+              - eng
+            direction: ltr
+            population: 1636485517
+            web_url: http://weblate.example.com/languages/en/
+            url: http://weblate.example.com/api/languages/en/
+            statistics_url: http://weblate.example.com/api/languages/en/statistics/
+          project:
+            name: Test Project
+            slug: test-project
+            id: 2
+            web: https://example.com/lelele
+            web_url: http://weblate.example.com/projects/test-project/
+            url: http://weblate.example.com/api/projects/test-project/
+            components_list_url: http://weblate.example.com/api/projects/test-project/components/
+            repository_url: http://weblate.example.com/api/projects/test-project/repository/
+            statistics_url: http://weblate.example.com/api/projects/test-project/statistics/
+            categories_url: http://weblate.example.com/api/projects/test-project/categories/
+            changes_list_url: http://weblate.example.com/api/projects/test-project/changes/
+            languages_url: http://weblate.example.com/api/projects/test-project/languages/
+            labels_url: http://weblate.example.com/api/projects/test-project/labels/
+            credits_url: http://weblate.example.com/api/projects/test-project/credits/
+            translation_review: false
+            source_review: false
+            set_language_team: true
+            instructions: ""
+            enable_hooks: true
+            language_aliases: ""
+            enforced_2fa: false
+          vcs: git
+          repo: https://github.com/WeblateOrg/hello.git
+          git_export: http://weblate.example.com/git/test-project/test-component-2/
+          branch: main
+          push_branch: ""
+          filemask: po/*.po
+          screenshot_filemask: ""
+          template: ""
+          edit_template: true
+          intermediate: ""
+          new_base: po/hello.pot
+          file_format: po
+          license: ""
+          license_url: null
+          agreement: ""
+          web_url: http://weblate.example.com/projects/test-project/test-component-2/
+          url: http://weblate.example.com/api/components/test-project/test-component-2/
+          repository_url: http://weblate.example.com/api/components/test-project/test-component-2/repository/
+          translations_url: http://weblate.example.com/api/components/test-project/test-component-2/translations/
+          statistics_url: http://weblate.example.com/api/components/test-project/test-component-2/statistics/
+          lock_url: http://weblate.example.com/api/components/test-project/test-component-2/lock/
+          links_url: http://weblate.example.com/api/components/test-project/test-component-2/links/
+          changes_list_url: http://weblate.example.com/api/components/test-project/test-component-2/changes/
+          task_url: http://weblate.example.com/api/tasks/6d83b7ea-e8e2-4eb3-903e-24596427ac49/
+          credits_url: http://weblate.example.com/api/components/test-project/test-component-2/credits/
+          new_lang: none
+          language_code_style: ""
+          push: ""
+          check_flags: ""
+          priority: 100
+          enforced_checks: []
+          restricted: false
+          repoweb: ""
+          report_source_bugs: ""
+          merge_style: rebase
+          commit_message: "Translated using Weblate ({{ language_name }})\n\nCurrently translated at {{ stats.translated_percent }}% ({{ stats.translated }} of {{ stats.all }} strings)\n\nTranslation: {{ project_name }}/{{ component_name }}\nTranslate-URL: {{ url }}"
+          add_message: "Added translation using Weblate ({{ language_name }})\n\n"
+          delete_message: "Deleted translation using Weblate ({{ language_name }})\n\n"
+          merge_message: "Merge branch '{{ component_remote_branch }}' into Weblate.\n\n"
+          addon_message: "Update translation files\n\nUpdated by \"{{ addon_name }}\" add-on in Weblate.\n\nTranslation: {{ project_name }}/{{ component_name }}\nTranslate-URL: {{ url }}"
+          pull_message: "Translations update from {{ site_title }}\n\nTranslations update from [{{ site_title }}]({{ site_url }}) for [{{ project_name }}/{{ component_name }}]({{url}}).\n\n{% if component_linked_childs %}\nIt also includes following components:\n{% for linked in component_linked_childs %}\n* [{{ linked.project_name }}/{{ linked.name }}]({{ linked.url }})\n{% endfor %}\n{% endif %}\n\nCurrent translation status:\n\n![Weblate translation status]({{widget_url}})\n"
+          allow_translation_propagation: true
+          manage_units: false
+          enable_suggestions: true
+          suggestion_voting: false
+          suggestion_autoaccept: 0
+          push_on_commit: true
+          commit_pending_age: 24
+          auto_lock_error: true
+          language_regex: "^[^.]+$"
+          variant_regex: ""
+          addons: []
+          is_glossary: false,
+          glossary_color: silver
+          category: null
+          linked_component: null
+
+    ComponentStatistics:
+      $ref: 'statistics.yaml#/components/schemas/Statistics'
+
+    ComponentTranslation:
+      type: object
+      properties:
+        language:
+          $ref: 'languages.yaml#/components/schemas/Language'
+        language_code:
+          type: string
+        id:
+          type: integer
+        filename:
+          type: string
+          format: uri
+        revision:
+          type: string
+          format: uri
+        web_url:
+          type: string
+          format: uri
+        share_url:
+          type: string
+          format: uri
+        translate_url:
+          type: string
+          format: uri
+        url:
+          type: string
+          format: uri
+        is_template:
+          type: boolean
+        is_source:
+          type: boolean
+        total:
+          type: integer
+        total_words:
+          type: integer
+        translated:
+          type: integer
+        translated_words:
+          type: integer
+        translated_percent:
+          type: integer
+        fuzzy:
+          type: integer
+        fuzzy_words:
+          type: integer
+        fuzzy_percent:
+          type: integer
+        failing_checks:
+          type: integer
+        failing_checks_words:
+          type: integer
+        failing_checks_percent:
+          type: integer
+        have_suggestion:
+          type: boolean
+        have_comment:
+          type: boolean
+        last_change:
+          type: string
+          format: date-time
+        last_author:
+          type: string
+          format: uri
+          nullable: true
+        repository_url:
+          type: string
+          format: uri
+        file_url:
+          type: string
+          format: uri
+        statistics_url:
+          type: string
+          format: uri
+        changes_list_url:
+          type: string
+          format: uri
+        units_list_url:
+          type: string
+          format: uri
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    BadRequest:
+      $ref: 'common.yaml#/components/responses/BadRequest'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    Forbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            NoComponent:
+              value:
+                detail: Can not edit component
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            ComponentNotFound:
+              value:
+                detail: No Component matches the given query.
+            ProjectNotFound:
+              value:
+                detail: Project not found
+
+    Component:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Component'
+
+    ComponentCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Component'
+
+    ComponentUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Component'
+
+  parameters:
+    projectInPath:
+      $ref: 'projects.yaml#/components/parameters/projectInPath'
+
+    projectSlugInPath:
+      $ref: 'projects.yaml#/components/parameters/projectSlugInPath'
+
+    componentInPath:
+      name: component
+      in: path
+      required: true
+      schema:
+        type: string
+
+    componentIdInPath:
+      name: component_id
+      in: path
+      required: true
+      schema:
+        type: integer
+
+  requestBodies:
+    UpdateComponent:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Component'
+
+    OperateOnComponentRepository:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              operation:
+                type: string
+                description: Operation to perform.
+                enum:
+                  - push
+                  - pull
+                  - commit
+                  - reset
+                  - cleanup
+
+    CreateComponentTranslation:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              language_code:
+                type: string
+                description: Translation language code.
+            required:
+              - language_code
+          example:
+            language_code: pl

--- a/docs/openapi/resources/components.yaml
+++ b/docs/openapi/resources/components.yaml
@@ -4,11 +4,11 @@ paths:
   /components/:
     get:
       tags:
-        - components
+      - components
       summary: Returns a list of translation components
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -35,11 +35,11 @@ paths:
   /components/{project}/{component}/:
     get:
       tags:
-        - components
+      - components
       summary: Returns information about translation component
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           $ref: '#/components/responses/Component'
@@ -48,11 +48,11 @@ paths:
 
     put:
       tags:
-        - components
+      - components
       summary: Edit a component by a PUT request
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateComponent'
       responses:
@@ -63,15 +63,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - components
+      - components
       summary: Edit a component by a PATCH request
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateComponent'
       responses:
@@ -82,15 +82,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - components
+      - components
       summary: Deletes a component
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -99,34 +99,34 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /components/{project}/{component}/changes/:
     get:
       tags:
-        - components
+      - components
       summary: Returns a list of component changes
       description: This is essentially a component-scoped `GET /api/changes/` which accepts the same parameters.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
-          $ref: 'changes.yaml#/components/responses/Change'
+          $ref: changes.yaml#/components/responses/Change
         '404':
           $ref: '#/components/responses/NotFound'
 
   /components/{project}/{component}/file/:
     get:
       tags:
-        - components
+      - components
       description: |
         Added in version 4.9.
 
         Downloads all available translations associated with the component as an archive file using the requested format.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           description: OK
@@ -141,13 +141,13 @@ paths:
   /components/{project}/{component}/screenshots/:
     get:
       tags:
-        - components
+      - components
       summary: Returns a list of component screenshots
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -169,18 +169,18 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: 'screenshots.yaml#/components/schemas/Screenshot'
+                      $ref: screenshots.yaml#/components/schemas/Screenshot
         '404':
           $ref: '#/components/responses/NotFound'
 
   /components/{project}/{component}/lock/:
     get:
       tags:
-        - components
+      - components
       summary: Returns component lock status
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           description: OK
@@ -196,11 +196,11 @@ paths:
 
     post:
       tags:
-        - components
+      - components
       summary: Sets component lock status
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           description: OK
@@ -216,34 +216,34 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /components/{project}/{component}/repository/:
     get:
       tags:
-        - components
+      - components
       summary: Returns information about VCS repository status
       description: This endpoint contains only an overall summary for all repositories for the project.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: 'projects.yaml#/components/schemas/Repository'
+                $ref: projects.yaml#/components/schemas/Repository
         '404':
           $ref: '#/components/responses/NotFound'
 
     post:
       tags:
-        - components
+      - components
       summary: Performs the given operation on a VCS repository
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       requestBody:
         $ref: '#/components/requestBodies/OperateOnComponentRepository'
       responses:
@@ -260,16 +260,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /components/{project}/{component}/monolingual_base/:
     get:
       tags:
-        - components
+      - components
       summary: Downloads base file for monolingual translations
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -279,11 +279,11 @@ paths:
   /components/{project}/{component}/new_template/:
     get:
       tags:
-        - components
+      - components
       summary: Downloads template file for new translations
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -293,13 +293,13 @@ paths:
   /components/{project}/{component}/translations/:
     get:
       tags:
-        - components
+      - components
       summary: Returns a list of translation objects in the given component
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -321,17 +321,17 @@ paths:
                   results:
                     type: array
                     items:
-                    $ref: 'languages.yaml#/components/schemas/Language'
+                    $ref: languages.yaml#/components/schemas/Language
         '404':
           $ref: '#/components/responses/NotFound'
 
     post:
       tags:
-        - components
+      - components
       summary: Creates new translation in the given component
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       requestBody:
         $ref: '#/components/requestBodies/CreateComponentTranslation'
       responses:
@@ -343,25 +343,25 @@ paths:
                 type: object
                 properties:
                   result:
-                    $ref: 'translations.yaml#/components/schemas/Translation'
+                    $ref: translations.yaml#/components/schemas/Translation
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /components/{project}/{component}/statistics/:
     get:
       tags:
-        - components
-        - statistics
+      - components
+      - statistics
       summary: Returns paginated statistics for all translations within component
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -390,14 +390,14 @@ paths:
   /components/{project}/{component}/links/:
     get:
       tags:
-        - components
+      - components
       summary: Returns projects linked with a component
       description: Added in version 4.5.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -419,38 +419,18 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: 'projects.yaml#/components/schemas/Project'
+                      $ref: projects.yaml#/components/schemas/Project
         '404':
           $ref: '#/components/responses/NotFound'
 
     post:
       tags:
-        - components
+      - components
       summary: Associate project with a component
       description: Added in version 4.5.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-      responses:
-        '200':
-          $ref: '#/components/responses/OK'
-        '401':
-            $ref: '#/components/responses/Unauthorized'
-        '404':
-            $ref: '#/components/responses/NotFound'
-      security:
-        - TokenAuth: []
-
-  /components/{project}/{component}/links/{project_slug}/:
-    delete:
-      tags:
-        - components
-      summary: Remove association of a project with a component
-      description: Added in version 4.5.
-      parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/projectSlugInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -459,18 +439,38 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
+
+  /components/{project}/{component}/links/{project_slug}/:
+    delete:
+      tags:
+      - components
+      summary: Remove association of a project with a component
+      description: Added in version 4.5.
+      parameters:
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectSlugInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+      - TokenAuth: []
 
   /components/{project}/{component}/credits/:
     #TODO: returns 400 Bad Request
     get:
       tags:
-        - components
+      - components
       summary: Returns contributor credits for a project
       description: Added in version 5.7.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           description: OK
@@ -506,9 +506,9 @@ components:
         id:
           type: integer
         source_language:
-          $ref: 'languages.yaml#/components/schemas/Language'
+          $ref: languages.yaml#/components/schemas/Language
         project:
-          $ref: 'projects.yaml#/components/schemas/Project'
+          $ref: projects.yaml#/components/schemas/Project
         vcs:
           type: string
         repo:
@@ -666,11 +666,11 @@ components:
               formula: n != 1
               type: 1
             aliases:
-              - en_en
-              - base
-              - source
-              - enp
-              - eng
+            - en_en
+            - base
+            - source
+            - enp
+            - eng
             direction: ltr
             population: 1636485517
             web_url: http://weblate.example.com/languages/en/
@@ -694,25 +694,25 @@ components:
             translation_review: false
             source_review: false
             set_language_team: true
-            instructions: ""
+            instructions: ''
             enable_hooks: true
-            language_aliases: ""
+            language_aliases: ''
             enforced_2fa: false
           vcs: git
           repo: https://github.com/WeblateOrg/hello.git
           git_export: http://weblate.example.com/git/test-project/test-component-2/
           branch: main
-          push_branch: ""
+          push_branch: ''
           filemask: po/*.po
-          screenshot_filemask: ""
-          template: ""
+          screenshot_filemask: ''
+          template: ''
           edit_template: true
-          intermediate: ""
+          intermediate: ''
           new_base: po/hello.pot
           file_format: po
-          license: ""
-          license_url: null
-          agreement: ""
+          license: ''
+          license_url:
+          agreement: ''
           web_url: http://weblate.example.com/projects/test-project/test-component-2/
           url: http://weblate.example.com/api/components/test-project/test-component-2/
           repository_url: http://weblate.example.com/api/components/test-project/test-component-2/repository/
@@ -724,14 +724,14 @@ components:
           task_url: http://weblate.example.com/api/tasks/6d83b7ea-e8e2-4eb3-903e-24596427ac49/
           credits_url: http://weblate.example.com/api/components/test-project/test-component-2/credits/
           new_lang: none
-          language_code_style: ""
-          push: ""
-          check_flags: ""
+          language_code_style: ''
+          push: ''
+          check_flags: ''
           priority: 100
           enforced_checks: []
           restricted: false
-          repoweb: ""
-          report_source_bugs: ""
+          repoweb: ''
+          report_source_bugs: ''
           merge_style: rebase
           commit_message: "Translated using Weblate ({{ language_name }})\n\nCurrently translated at {{ stats.translated_percent }}% ({{ stats.translated }} of {{ stats.all }} strings)\n\nTranslation: {{ project_name }}/{{ component_name }}\nTranslate-URL: {{ url }}"
           add_message: "Added translation using Weblate ({{ language_name }})\n\n"
@@ -747,22 +747,22 @@ components:
           push_on_commit: true
           commit_pending_age: 24
           auto_lock_error: true
-          language_regex: "^[^.]+$"
-          variant_regex: ""
+          language_regex: ^[^.]+$
+          variant_regex: ''
           addons: []
           is_glossary: false,
           glossary_color: silver
-          category: null
-          linked_component: null
+          category:
+          linked_component:
 
     ComponentStatistics:
-      $ref: 'statistics.yaml#/components/schemas/Statistics'
+      $ref: statistics.yaml#/components/schemas/Statistics
 
     ComponentTranslation:
       type: object
       properties:
         language:
-          $ref: 'languages.yaml#/components/schemas/Language'
+          $ref: languages.yaml#/components/schemas/Language
         language_code:
           type: string
         id:
@@ -840,19 +840,19 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     BadRequest:
-      $ref: 'common.yaml#/components/responses/BadRequest'
+      $ref: common.yaml#/components/responses/BadRequest
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     Forbidden:
       description: Forbidden
@@ -908,10 +908,10 @@ components:
 
   parameters:
     projectInPath:
-      $ref: 'projects.yaml#/components/parameters/projectInPath'
+      $ref: projects.yaml#/components/parameters/projectInPath
 
     projectSlugInPath:
-      $ref: 'projects.yaml#/components/parameters/projectSlugInPath'
+      $ref: projects.yaml#/components/parameters/projectSlugInPath
 
     componentInPath:
       name: component
@@ -944,11 +944,11 @@ components:
                 type: string
                 description: Operation to perform.
                 enum:
-                  - push
-                  - pull
-                  - commit
-                  - reset
-                  - cleanup
+                - push
+                - pull
+                - commit
+                - reset
+                - cleanup
 
     CreateComponentTranslation:
       content:
@@ -960,6 +960,6 @@ components:
                 type: string
                 description: Translation language code.
             required:
-              - language_code
+            - language_code
           example:
             language_code: pl

--- a/docs/openapi/resources/exports.yaml
+++ b/docs/openapi/resources/exports.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /exports/stats/{project}/{component}/:
+    get:
+      tags:
+        - exports
+      summary: Retrieves statistics for given component in given format
+      description: '**Deprecated since version 2.6:** Please use `GET /api/components/{project}/{component}/statistics/` and `GET /api/translations/{project}/{component}/{language}/statistics/` instead; it allows access to ACL controlled projects as well.'
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'statistics.yaml#/components/schemas/Statistics'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      deprecated: true
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+
+components:
+  responses:
+    NotFound:
+      $ref: 'common.yaml#/components/responses/NotFound'
+
+  parameters:
+    projectInPath:
+      $ref: 'projects.yaml#/components/parameters/projectInPath'
+
+    componentInPath:
+      $ref: 'components.yaml#/components/parameters/componentInPath'

--- a/docs/openapi/resources/exports.yaml
+++ b/docs/openapi/resources/exports.yaml
@@ -4,12 +4,12 @@ paths:
   /exports/stats/{project}/{component}/:
     get:
       tags:
-        - exports
+      - exports
       summary: Retrieves statistics for given component in given format
       description: '**Deprecated since version 2.6:** Please use `GET /api/components/{project}/{component}/statistics/` and `GET /api/translations/{project}/{component}/{language}/statistics/` instead; it allows access to ACL controlled projects as well.'
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           description: OK
@@ -18,38 +18,38 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: 'statistics.yaml#/components/schemas/Statistics'
+                  $ref: statistics.yaml#/components/schemas/Statistics
         '404':
           $ref: '#/components/responses/NotFound'
       deprecated: true
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
 
 components:
   responses:
     NotFound:
-      $ref: 'common.yaml#/components/responses/NotFound'
+      $ref: common.yaml#/components/responses/NotFound
 
   parameters:
     projectInPath:
-      $ref: 'projects.yaml#/components/parameters/projectInPath'
+      $ref: projects.yaml#/components/parameters/projectInPath
 
     componentInPath:
-      $ref: 'components.yaml#/components/parameters/componentInPath'
+      $ref: components.yaml#/components/parameters/componentInPath

--- a/docs/openapi/resources/groups.yaml
+++ b/docs/openapi/resources/groups.yaml
@@ -1,0 +1,638 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /groups/:
+    get:
+      tags:
+        - groups
+      description: Returns a list of groups if you have permissions to manage groups. If not, then you get to see only the groups the user is a part of.
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Group'
+
+    post:
+      tags:
+        - groups
+      summary: Creates a new group
+      requestBody:
+        $ref: '#/components/requestBodies/CreateGroup'
+      responses:
+        '201':
+          $ref: '#/components/responses/GroupCreated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/NoManageGroups'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/:
+    get:
+      tags:
+        - groups
+      summary: Returns information about a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Group'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - groups
+      summary: Changes the group parameters
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroup'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: array
+                    items:
+                      type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - groups
+      summary: Changes the group parameters
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroup'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - groups
+      summary: Deletes the group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/roles/:
+    post:
+      tags:
+        - groups
+      summary: Associate roles with a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroupRoles'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/components/:
+    post:
+      tags:
+        - groups
+      summary: Associate components with a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroupComponents'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/components/{component_id}/:
+    delete:
+      tags:
+        - groups
+      summary: Delete a component from a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+        - $ref: 'components.yaml#/components/parameters/componentIdInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/projects/:
+    post:
+      tags:
+        - groups
+      summary: Associate projects with a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroupProjects'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/projects/{project_id}/:
+    delete:
+      tags:
+        - groups
+      summary: Delete a project from a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+        - $ref: 'projects.yaml#/components/parameters/projectIdInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/languages/:
+    post:
+      tags:
+        - groups
+      summary: Associate languages with a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroupLanguages'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/languages/{language_code}/:
+    delete:
+      tags:
+        - groups
+      summary: Delete a language from a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+        - $ref: 'languages.yaml#/components/parameters/languageCodeInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/componentlists/:
+    post:
+      tags:
+        - groups
+      summary: Associate componentlists with a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroupComponentLists'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/componentlists/{component_list_id}/:
+    delete:
+      tags:
+        - groups
+      summary: Delete a componentlist from a group
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+        - $ref: 'componentlists.yaml#/components/parameters/componentListIdInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/admins/:
+    post:
+      tags:
+        - groups
+      summary: Make user a group admin
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateGroupAdmins'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+            example:
+              - Administration rights granted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /groups/{id}/admins/{user_id}/:
+    delete:
+      tags:
+        - groups
+      summary: Delete a user from group admins
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+        - $ref: 'users.yaml#/components/parameters/userIdInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/GroupUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Group:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          description: Name of a group.
+        defining_project:
+          type: string
+          description: Link to the defining project, used for Managing per-project access control.
+          nullable: true
+        project_selection:
+          type: integer
+          description: Integer corresponding to group of projects.
+        language_selection:
+          type: integer
+          description: Integer corresponding to group of languages.
+        url:
+          type: string
+          format: uri
+        roles:
+          type: array
+          description: Link to associated roles.
+          items:
+            type: string
+            format: uri
+        languages:
+          type: array
+          items:
+            type: string
+            format: uri
+        projects:
+          type: array
+          description: Link to associated projects.
+          items:
+            type: string
+            format: uri
+        componentlists:
+          type: array
+          description: – Link to associated componentlist.
+          items:
+            type: string
+            format: uri
+        components:
+          type: array
+          description: Link to associated components.
+          items:
+            type: string
+            format: uri
+        enforced_2fa:
+          type: boolean
+      example:
+        id: 1
+        name: Viewers
+        defining_project: null
+        project_selection: 3
+        language_selection: 1
+        url: http://weblate.example.com/api/groups/1/
+        roles:
+          - http://weblate.example.com/api/roles/1/
+          - http://weblate.example.com/api/roles/2/
+        languages:
+          - http://weblate.example.com/api/languages/en/
+          - http://weblate.example.com/api/languages/cs/
+        projects: []
+        componentlists: []
+        components:
+          - http://weblate.example.com/api/components/demo/weblate/
+        enforced_2fa: false
+
+    UserGroup:
+      type: object
+      properties:
+        username:
+          type: string
+        project_selection:
+          type: integer
+        language_selection:
+          type: integer
+        roles:
+          type: array
+          items:
+            type: integer
+        projects:
+          type: string
+        components:
+          type: string
+        componentlists:
+          type: string
+        defining_project:
+          type: string
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    BadRequest:
+      $ref: 'common.yaml#/components/responses/BadRequest'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            GroupNotFound:
+              value:
+                detail: No Group matches the given query.
+            GroupComponentNotFound:
+              value:
+                detail: Component matching query does not exist.
+
+    NoManageGroups:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          example:
+            detail: Can not manage groups
+
+    Group:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Group'
+
+    GroupCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Group'
+
+    GroupUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Group'
+
+  parameters:
+    idInPath:
+      $ref: 'common.yaml#/components/parameters/idInPath'
+
+  requestBodies:
+    CreateGroup:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: name
+              defining_project:
+                type: string
+                description: Link to the defining project, used for [Managing per-project access control](https://docs.weblate.org/en/latest/admin/access.html#manage-acl).
+              project_selection:
+                type: integer
+                description: Group of project selection from given options.
+              language_selection:
+                type: integer
+                description: Group of languages selected from given options.
+              enforced_2fa:
+                type: boolean
+                default: false
+            required:
+              - name
+      required: true
+
+    UpdateGroup:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: name
+              defining_project:
+                type: string
+                description: Link to the defining project, used for [Managing per-project access control](https://docs.weblate.org/en/latest/admin/access.html#manage-acl).
+              project_selection:
+                type: integer
+                description: Group of project selection from given options.
+              language_selection:
+                type: integer
+                description: Group of languages selected from given options.
+              enforced_2fa:
+                type: boolean
+                default: false
+            required:
+              - name
+      required: true
+
+    UpdateGroupRoles:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              role_id:
+                type: string
+                description: The unique role ID.
+            required:
+              - role_id
+      required: true
+
+    UpdateGroupComponents:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              component_id:
+                type: string
+                description: The unique component ID.
+      required: true
+
+    UpdateGroupProjects:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              project_id:
+                type: string
+                description: The unique project ID.
+      required: true
+
+    UpdateGroupLanguages:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              language_code:
+                type: string
+                description: The unique language code.
+            required:
+              - language_code
+      required: true
+
+    UpdateGroupComponentLists:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              component_list_id:
+                type: string
+                description: The unique componentlist ID.
+      required: true
+
+    UpdateGroupAdmins:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              user_id:
+                type: string
+                description: The user’s ID.
+            required:
+              - user_id
+      required: true

--- a/docs/openapi/resources/groups.yaml
+++ b/docs/openapi/resources/groups.yaml
@@ -4,11 +4,11 @@ paths:
   /groups/:
     get:
       tags:
-        - groups
+      - groups
       description: Returns a list of groups if you have permissions to manage groups. If not, then you get to see only the groups the user is a part of.
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -34,7 +34,7 @@ paths:
 
     post:
       tags:
-        - groups
+      - groups
       summary: Creates a new group
       requestBody:
         $ref: '#/components/requestBodies/CreateGroup'
@@ -48,15 +48,15 @@ paths:
         '403':
           $ref: '#/components/responses/NoManageGroups'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/:
     get:
       tags:
-        - groups
+      - groups
       summary: Returns information about a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/Group'
@@ -65,10 +65,10 @@ paths:
 
     put:
       tags:
-        - groups
+      - groups
       summary: Changes the group parameters
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroup'
       responses:
@@ -90,14 +90,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - groups
+      - groups
       summary: Changes the group parameters
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroup'
       responses:
@@ -108,14 +108,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - groups
+      - groups
       summary: Deletes the group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -124,15 +124,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/roles/:
     post:
       tags:
-        - groups
+      - groups
       summary: Associate roles with a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroupRoles'
       responses:
@@ -151,15 +151,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/components/:
     post:
       tags:
-        - groups
+      - groups
       summary: Associate components with a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroupComponents'
       responses:
@@ -170,16 +170,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/components/{component_id}/:
     delete:
       tags:
-        - groups
+      - groups
       summary: Delete a component from a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
-        - $ref: 'components.yaml#/components/parameters/componentIdInPath'
+      - $ref: '#/components/parameters/idInPath'
+      - $ref: components.yaml#/components/parameters/componentIdInPath
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -189,15 +189,15 @@ paths:
           $ref: '#/components/responses/NotFound'
 
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/projects/:
     post:
       tags:
-        - groups
+      - groups
       summary: Associate projects with a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroupProjects'
       responses:
@@ -208,16 +208,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/projects/{project_id}/:
     delete:
       tags:
-        - groups
+      - groups
       summary: Delete a project from a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
-        - $ref: 'projects.yaml#/components/parameters/projectIdInPath'
+      - $ref: '#/components/parameters/idInPath'
+      - $ref: projects.yaml#/components/parameters/projectIdInPath
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -226,15 +226,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/languages/:
     post:
       tags:
-        - groups
+      - groups
       summary: Associate languages with a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroupLanguages'
       responses:
@@ -245,16 +245,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/languages/{language_code}/:
     delete:
       tags:
-        - groups
+      - groups
       summary: Delete a language from a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
-        - $ref: 'languages.yaml#/components/parameters/languageCodeInPath'
+      - $ref: '#/components/parameters/idInPath'
+      - $ref: languages.yaml#/components/parameters/languageCodeInPath
       responses:
         '200':
           $ref: '#/components/responses/GroupUpdated'
@@ -265,15 +265,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/componentlists/:
     post:
       tags:
-        - groups
+      - groups
       summary: Associate componentlists with a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroupComponentLists'
       responses:
@@ -284,16 +284,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/componentlists/{component_list_id}/:
     delete:
       tags:
-        - groups
+      - groups
       summary: Delete a componentlist from a group
       parameters:
-        - $ref: '#/components/parameters/idInPath'
-        - $ref: 'componentlists.yaml#/components/parameters/componentListIdInPath'
+      - $ref: '#/components/parameters/idInPath'
+      - $ref: componentlists.yaml#/components/parameters/componentListIdInPath
       responses:
         '200':
           $ref: '#/components/responses/GroupUpdated'
@@ -302,15 +302,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/admins/:
     post:
       tags:
-        - groups
+      - groups
       summary: Make user a group admin
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateGroupAdmins'
       responses:
@@ -323,22 +323,22 @@ paths:
                 items:
                   type: string
             example:
-              - Administration rights granted.
+            - Administration rights granted.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /groups/{id}/admins/{user_id}/:
     delete:
       tags:
-        - groups
+      - groups
       summary: Delete a user from group admins
       parameters:
-        - $ref: '#/components/parameters/idInPath'
-        - $ref: 'users.yaml#/components/parameters/userIdInPath'
+      - $ref: '#/components/parameters/idInPath'
+      - $ref: users.yaml#/components/parameters/userIdInPath
       responses:
         '200':
           $ref: '#/components/responses/GroupUpdated'
@@ -347,7 +347,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -406,20 +406,20 @@ components:
       example:
         id: 1
         name: Viewers
-        defining_project: null
+        defining_project:
         project_selection: 3
         language_selection: 1
         url: http://weblate.example.com/api/groups/1/
         roles:
-          - http://weblate.example.com/api/roles/1/
-          - http://weblate.example.com/api/roles/2/
+        - http://weblate.example.com/api/roles/1/
+        - http://weblate.example.com/api/roles/2/
         languages:
-          - http://weblate.example.com/api/languages/en/
-          - http://weblate.example.com/api/languages/cs/
+        - http://weblate.example.com/api/languages/en/
+        - http://weblate.example.com/api/languages/cs/
         projects: []
         componentlists: []
         components:
-          - http://weblate.example.com/api/components/demo/weblate/
+        - http://weblate.example.com/api/components/demo/weblate/
         enforced_2fa: false
 
     UserGroup:
@@ -446,19 +446,19 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     BadRequest:
-      $ref: 'common.yaml#/components/responses/BadRequest'
+      $ref: common.yaml#/components/responses/BadRequest
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -512,7 +512,7 @@ components:
 
   parameters:
     idInPath:
-      $ref: 'common.yaml#/components/parameters/idInPath'
+      $ref: common.yaml#/components/parameters/idInPath
 
   requestBodies:
     CreateGroup:
@@ -537,7 +537,7 @@ components:
                 type: boolean
                 default: false
             required:
-              - name
+            - name
       required: true
 
     UpdateGroup:
@@ -562,7 +562,7 @@ components:
                 type: boolean
                 default: false
             required:
-              - name
+            - name
       required: true
 
     UpdateGroupRoles:
@@ -575,7 +575,7 @@ components:
                 type: string
                 description: The unique role ID.
             required:
-              - role_id
+            - role_id
       required: true
 
     UpdateGroupComponents:
@@ -610,7 +610,7 @@ components:
                 type: string
                 description: The unique language code.
             required:
-              - language_code
+            - language_code
       required: true
 
     UpdateGroupComponentLists:
@@ -634,5 +634,5 @@ components:
                 type: string
                 description: The user’s ID.
             required:
-              - user_id
+            - user_id
       required: true

--- a/docs/openapi/resources/hooks.yaml
+++ b/docs/openapi/resources/hooks.yaml
@@ -4,11 +4,11 @@ paths:
   /hooks/update/{project}/:
     get:
       tags:
-        - hooks
+      - hooks
       summary: Triggers update of all components in a project (pulling from VCS and scanning for translation changes)
       description: '**Deprecated since version 2.6:** Please use `POST /api/projects/{project}/repository/` instead which works properly with authentication for ACL limited projects.'
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -18,35 +18,35 @@ paths:
           $ref: '#/components/responses/NotFound'
       deprecated: true
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/update/{project}/{component}/:
     get:
       tags:
-        - hooks
+      - hooks
       summary: Triggers update of a component (pulling from VCS and scanning for translation changes)
       description: '**Deprecated since version 2.6:** Please use `POST /api/components/{project}/{component}/repository/` instead which works properly with authentication for ACL limited projects.'
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -56,30 +56,30 @@ paths:
           $ref: '#/components/responses/NotFound'
       deprecated: true
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/github/:
     post:
       tags:
-        - hooks
+      - hooks
       summary: Special hook for handling GitHub notifications and automatically updating matching components
       description: |
         **Note:**
@@ -99,30 +99,30 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/gitlab/:
     post:
       tags:
-        - hooks
+      - hooks
       summary: Special hook for handling GitLab notifications and automatically updating matching components
       description: |
         **See also:**
@@ -138,30 +138,30 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/bitbucket/:
     post:
       tags:
-        - hooks
+      - hooks
       summary: Special hook for handling BitBucket notifications and automatically updating matching components
       description: |
         **See also:**
@@ -177,30 +177,30 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/pagure/:
     post:
       tags:
-        - hooks
+      - hooks
       summary: Special hook for handling Pagure notifications and automatically updating matching components
       description: |
         **See also:**
@@ -216,30 +216,30 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/azure/:
     post:
       tags:
-        - hooks
+      - hooks
       summary: Special hook for handling Azure DevOps notifications and automatically updating matching components
       description: |
         **Note:**
@@ -259,30 +259,30 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/gitea/:
     post:
       tags:
-        - hooks
+      - hooks
       summary: Special hook for handling Gitea notifications and automatically updating matching components
       description: |
         [Automatically receiving changes from Gitea](https://docs.weblate.org/en/latest/admin/continuous.html#gitea-setup)
@@ -296,30 +296,30 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /hooks/gitee/:
     post:
       tags:
-        - hooks
+      - hooks
       summary: Special hook for handling Gitee notifications and automatically updating matching components
       description: |
         [Automatically receiving changes from Gitee](https://docs.weblate.org/en/latest/admin/continuous.html#gitee-setup)
@@ -333,40 +333,40 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
 components:
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
-      $ref: 'common.yaml#/components/responses/NotFound'
+      $ref: common.yaml#/components/responses/NotFound
 
   parameters:
     projectInPath:
-      $ref: 'projects.yaml#/components/parameters/projectInPath'
+      $ref: projects.yaml#/components/parameters/projectInPath
 
     componentInPath:
-      $ref: 'components.yaml#/components/parameters/componentInPath'
+      $ref: components.yaml#/components/parameters/componentInPath

--- a/docs/openapi/resources/hooks.yaml
+++ b/docs/openapi/resources/hooks.yaml
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /hooks/update/{project}/:
+    get:
+      tags:
+        - hooks
+      summary: Triggers update of all components in a project (pulling from VCS and scanning for translation changes)
+      description: '**Deprecated since version 2.6:** Please use `POST /api/projects/{project}/repository/` instead which works properly with authentication for ACL limited projects.'
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      deprecated: true
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/update/{project}/{component}/:
+    get:
+      tags:
+        - hooks
+      summary: Triggers update of a component (pulling from VCS and scanning for translation changes)
+      description: '**Deprecated since version 2.6:** Please use `POST /api/components/{project}/{component}/repository/` instead which works properly with authentication for ACL limited projects.'
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      deprecated: true
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/github/:
+    post:
+      tags:
+        - hooks
+      summary: Special hook for handling GitHub notifications and automatically updating matching components
+      description: |
+        **Note:**
+
+        GitHub includes direct support for notifying Weblate: enable Weblate service hook in repository settings and set the URL to the URL of your Weblate installation.
+
+        **See also:**
+
+          [Automatically receiving changes from GitHub on Weblate](https://docs.weblate.org/en/latest/admin/continuous.html#github-setup)
+
+          [About webhooks on GitHub](https://docs.github.com/en/get-started/customizing-your-github-workflow/exploring-integrations/about-webhooks)
+
+          [Enabling hooks for a whole Weblate instance with ENABLE_HOOKS](https://docs.weblate.org/en/latest/admin/config.html#std-setting-ENABLE_HOOKS)
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/gitlab/:
+    post:
+      tags:
+        - hooks
+      summary: Special hook for handling GitLab notifications and automatically updating matching components
+      description: |
+        **See also:**
+
+        [Automatically receiving changes from GitLab on Weblate](https://docs.weblate.org/en/latest/admin/continuous.html#gitlab-setup)
+
+        [About webhooks on GitLab](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html)
+
+        [Enabling hooks for a whole Weblate instance with ENABLE_HOOKS](https://docs.weblate.org/en/latest/admin/config.html#std-setting-ENABLE_HOOKS)
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/bitbucket/:
+    post:
+      tags:
+        - hooks
+      summary: Special hook for handling BitBucket notifications and automatically updating matching components
+      description: |
+        **See also:**
+
+        [Automatically receiving changes from Bitbucket on Weblate](https://docs.weblate.org/en/latest/admin/continuous.html#bitbucket-setup)
+
+        [About webhooks on BitBucket](https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/)
+
+        [Enabling hooks for a whole Weblate instance with ENABLE_HOOKS](https://docs.weblate.org/en/latest/admin/config.html#std-setting-ENABLE_HOOKS)
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/pagure/:
+    post:
+      tags:
+        - hooks
+      summary: Special hook for handling Pagure notifications and automatically updating matching components
+      description: |
+        **See also:**
+
+        [Automatically receiving changes from Pagure on Weblate](https://docs.weblate.org/en/latest/admin/continuous.html#pagure-setup)
+
+        [About webhooks on Pagure](https://docs.pagure.org/pagure/usage/using_webhooks.html)
+
+        [Enabling hooks for a whole Weblate instance with ENABLE_HOOKS](https://docs.weblate.org/en/latest/admin/config.html#std-setting-ENABLE_HOOKS)
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/azure/:
+    post:
+      tags:
+        - hooks
+      summary: Special hook for handling Azure DevOps notifications and automatically updating matching components
+      description: |
+        **Note:**
+
+        Please ensure that `Resource details to send` is set to All, otherwise Weblate will not be able to match your Azure repository.
+
+        **See also:**
+
+        [Automatically receiving changes from Azure DevOps](https://docs.weblate.org/en/latest/admin/continuous.html#azure-setup)
+
+        [About webhooks on Azure Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/service-hooks/services/webhooks?view=azure-devops)
+
+        [Enabling hooks for a whole Weblate instance with ENABLE_HOOKS](https://docs.weblate.org/en/latest/admin/config.html#std-setting-ENABLE_HOOKS)
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/gitea/:
+    post:
+      tags:
+        - hooks
+      summary: Special hook for handling Gitea notifications and automatically updating matching components
+      description: |
+        [Automatically receiving changes from Gitea](https://docs.weblate.org/en/latest/admin/continuous.html#gitea-setup)
+
+        [About webhooks on Gitea](https://docs.gitea.io/en-us/webhooks/)
+
+        [Enabling hooks for a whole Weblate instance with ENABLE_HOOKS](https://docs.weblate.org/en/latest/admin/config.html#std-setting-ENABLE_HOOKS)
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /hooks/gitee/:
+    post:
+      tags:
+        - hooks
+      summary: Special hook for handling Gitee notifications and automatically updating matching components
+      description: |
+        [Automatically receiving changes from Gitee](https://docs.weblate.org/en/latest/admin/continuous.html#gitee-setup)
+
+        [About webhooks on Gitee](https://gitee.com/help/categories/40)
+
+        [Enabling hooks for a whole Weblate instance with ENABLE_HOOKS](https://docs.weblate.org/en/latest/admin/config.html#std-setting-ENABLE_HOOKS)
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+components:
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      $ref: 'common.yaml#/components/responses/NotFound'
+
+  parameters:
+    projectInPath:
+      $ref: 'projects.yaml#/components/parameters/projectInPath'
+
+    componentInPath:
+      $ref: 'components.yaml#/components/parameters/componentInPath'

--- a/docs/openapi/resources/languages.yaml
+++ b/docs/openapi/resources/languages.yaml
@@ -4,11 +4,11 @@ paths:
   /languages/:
     get:
       tags:
-        - languages
+      - languages
       summary: Returns a list of all languages the user has access to
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -34,7 +34,7 @@ paths:
 
     post:
       tags:
-        - languages
+      - languages
       summary: Creates a new language
       requestBody:
         $ref: '#/components/requestBodies/CreateLanguage'
@@ -44,15 +44,15 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /languages/{language_code}/:
     get:
       tags:
-        - languages
+      - languages
       summary: Returns information about a language
       parameters:
-        - $ref: '#/components/parameters/languageCodeInPath'
+      - $ref: '#/components/parameters/languageCodeInPath'
       responses:
         '200':
           $ref: '#/components/responses/Language'
@@ -61,10 +61,10 @@ paths:
 
     put:
       tags:
-        - languages
+      - languages
       summary: Changes the language parameters
       parameters:
-        - $ref: '#/components/parameters/languageCodeInPath'
+      - $ref: '#/components/parameters/languageCodeInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateLanguage'
       responses:
@@ -75,14 +75,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - languages
+      - languages
       summary: Changes the language parameters
       parameters:
-        - $ref: '#/components/parameters/languageCodeInPath'
+      - $ref: '#/components/parameters/languageCodeInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateLanguage'
       responses:
@@ -93,14 +93,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - languages
+      - languages
       summary: Deletes the language
       parameters:
-        - $ref: '#/components/parameters/languageCodeInPath'
+      - $ref: '#/components/parameters/languageCodeInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -109,16 +109,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /languages/{language_code}/statistics/:
     get:
       tags:
-        - languages
-        - statistics
+      - languages
+      - statistics
       summary: Returns statistics for a language
       parameters:
-        - $ref: '#/components/parameters/languageCodeInPath'
+      - $ref: '#/components/parameters/languageCodeInPath'
       responses:
         '200':
           description: OK
@@ -131,7 +131,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -190,7 +190,7 @@ components:
           formula: n != 1
           type: 1
         aliases:
-          - aar
+        - aar
         direction: ltr
         population: 2119662
         web_url: http://weblate.example.com/languages/aa/
@@ -198,20 +198,20 @@ components:
         statistics_url: http://weblate.example.com/api/languages/aa/statistics/
 
     LanguageStatistics:
-      $ref: 'statistics.yaml#/components/schemas/StatisticsUrl'
+      $ref: statistics.yaml#/components/schemas/StatisticsUrl
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -288,8 +288,8 @@ components:
                   type:
                     type: integer
             required:
-              - code
-              - plural
+            - code
+            - plural
       required: true
 
     UpdateLanguage:
@@ -304,5 +304,5 @@ components:
               plural:
                 type: object
             required:
-              - code
+            - code
       required: true

--- a/docs/openapi/resources/languages.yaml
+++ b/docs/openapi/resources/languages.yaml
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /languages/:
+    get:
+      tags:
+        - languages
+      summary: Returns a list of all languages the user has access to
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Language'
+
+    post:
+      tags:
+        - languages
+      summary: Creates a new language
+      requestBody:
+        $ref: '#/components/requestBodies/CreateLanguage'
+      responses:
+        '201':
+          $ref: '#/components/responses/LanguageCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+
+  /languages/{language_code}/:
+    get:
+      tags:
+        - languages
+      summary: Returns information about a language
+      parameters:
+        - $ref: '#/components/parameters/languageCodeInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Language'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - languages
+      summary: Changes the language parameters
+      parameters:
+        - $ref: '#/components/parameters/languageCodeInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateLanguage'
+      responses:
+        '200':
+          $ref: '#/components/responses/LanguageUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - languages
+      summary: Changes the language parameters
+      parameters:
+        - $ref: '#/components/parameters/languageCodeInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateLanguage'
+      responses:
+        '200':
+          $ref: '#/components/responses/LanguageUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - languages
+      summary: Deletes the language
+      parameters:
+        - $ref: '#/components/parameters/languageCodeInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /languages/{language_code}/statistics/:
+    get:
+      tags:
+        - languages
+        - statistics
+      summary: Returns statistics for a language
+      parameters:
+        - $ref: '#/components/parameters/languageCodeInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LanguageStatistics'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Language:
+      type: object
+      properties:
+        id:
+          type: integer
+        code:
+          type: string
+          description: Language code.
+        name:
+          type: string
+          description: Display name for the language.
+        plural:
+          type: object
+          description: Object of language plural information.
+          properties:
+            id:
+              type: integer
+            source:
+              type: integer
+            number:
+              type: integer
+            formula:
+              type: string
+            type:
+              type: integer
+        aliases:
+          type: array
+          description: Array of aliases for language.
+          items:
+            type: string
+        direction:
+          type: string
+          description: Text direction.
+        population:
+          type: integer
+        web_url:
+          type: string
+          format: uri
+        url:
+          type: string
+          format: uri
+        statistics_url:
+          type: string
+          format: uri
+      example:
+        id: 1
+        code: aa
+        name: Afar
+        plural:
+          id: 1
+          source: 0
+          number: 2
+          formula: n != 1
+          type: 1
+        aliases:
+          - aar
+        direction: ltr
+        population: 2119662
+        web_url: http://weblate.example.com/languages/aa/
+        url: http://weblate.example.com/api/languages/aa/
+        statistics_url: http://weblate.example.com/api/languages/aa/statistics/
+
+    LanguageStatistics:
+      $ref: 'statistics.yaml#/components/schemas/StatisticsUrl'
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            LanguageNotFound:
+              value:
+                detail: No Language matches the given query.
+
+    Language:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Language'
+
+    LanguageCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Language'
+
+    LanguageUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Language'
+
+  parameters:
+    languageInPath:
+      name: language
+      in: path
+      required: true
+      schema:
+        type: string
+
+    languageCodeInPath:
+      name: language_code
+      in: path
+      required: true
+      schema:
+        type: integer
+
+  requestBodies:
+    CreateLanguage:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                description: Language code.
+              plural:
+                type: object
+                description: Object of language plural information.
+                properties:
+                  id:
+                    type: integer
+                  source:
+                    type: integer
+                  number:
+                    type: integer
+                  formula:
+                    type: string
+                  type:
+                    type: integer
+            required:
+              - code
+              - plural
+      required: true
+
+    UpdateLanguage:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                description: Language code.
+              plural:
+                type: object
+            required:
+              - code
+      required: true

--- a/docs/openapi/resources/memory.yaml
+++ b/docs/openapi/resources/memory.yaml
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /memory/:
+    get:
+      tags:
+        - memory
+      summary: Returns a list of memory results
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Memory'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      security:
+        - TokenAuth: []
+
+  /memory/{memory_object_id}/:
+    delete:
+      tags:
+        - memory
+      summary: Deletes a memory object
+      parameters:
+        - $ref: '#/components/parameters/memoryObjectIdInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Memory:
+      type: object
+      properties:
+        id:
+          type: integer
+        source:
+          type: string
+        target:
+          type: string
+        source_language:
+          type: integer
+        target_language:
+          type: integer
+        origin:
+          type: string
+        project:
+          type: integer
+          nullable: true
+        from_file:
+          type: boolean
+        shared:
+          type: boolean
+
+  responses:
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    Forbidden:
+      $ref: 'common.yaml#/components/responses/Forbidden'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            MemoryNotFound:
+              value:
+                detail: No Memory matches the given query.
+
+  parameters:
+    memoryObjectIdInPath:
+      name: memory_object_id
+      in: path
+      required: true
+      schema:
+        type: integer

--- a/docs/openapi/resources/memory.yaml
+++ b/docs/openapi/resources/memory.yaml
@@ -4,11 +4,11 @@ paths:
   /memory/:
     get:
       tags:
-        - memory
+      - memory
       summary: Returns a list of memory results
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -36,15 +36,15 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /memory/{memory_object_id}/:
     delete:
       tags:
-        - memory
+      - memory
       summary: Deletes a memory object
       parameters:
-        - $ref: '#/components/parameters/memoryObjectIdInPath'
+      - $ref: '#/components/parameters/memoryObjectIdInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -55,7 +55,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -84,13 +84,13 @@ components:
 
   responses:
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     Forbidden:
-      $ref: 'common.yaml#/components/responses/Forbidden'
+      $ref: common.yaml#/components/responses/Forbidden
 
     NotFound:
       description: Not Found

--- a/docs/openapi/resources/metrics.yaml
+++ b/docs/openapi/resources/metrics.yaml
@@ -4,15 +4,15 @@ paths:
   /metrics/:
     get:
       tags:
-        - metrics
+      - metrics
       summary: Returns server metrics
-      description: "**Changed in version 5.6.1:** Metrics can now be exposed in OpenMetrics compatible format with `?format=openmetrics`."
+      description: '**Changed in version 5.6.1:** Metrics can now be exposed in OpenMetrics compatible format with `?format=openmetrics`.'
       parameters:
-        - name: format
-          in: query
-          schema:
-            type: string
-            example: openmetrics
+      - name: format
+        in: query
+        schema:
+          type: string
+          example: openmetrics
       responses:
         '200':
           $ref: '#/components/responses/Statistics'

--- a/docs/openapi/resources/metrics.yaml
+++ b/docs/openapi/resources/metrics.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /metrics/:
+    get:
+      tags:
+        - metrics
+      summary: Returns server metrics
+      description: "**Changed in version 5.6.1:** Metrics can now be exposed in OpenMetrics compatible format with `?format=openmetrics`."
+      parameters:
+        - name: format
+          in: query
+          schema:
+            type: string
+            example: openmetrics
+      responses:
+        '200':
+          $ref: '#/components/responses/Statistics'
+
+components:
+  schemas:
+    Metrics:
+      type: object
+      properties:
+        units:
+          type: integer
+          description: Number of units.
+        units_translated:
+          type: integer
+          description: Number of translated units.
+        users:
+          type: integer
+          description: Number of users.
+        changes:
+          type: integer
+          description: Number of changes.
+        projects:
+          type: integer
+          description: Number of projects.
+        components:
+          type: integer
+          description: Number of components.
+        translations:
+          type: integer
+          description: Number of translations.
+        languages:
+          type: integer
+          description: Number of used languages.
+        checks:
+          type: integer
+          description: Number of triggered quality checks.
+        configuration_errors:
+          type: integer
+          description: Number of configuration errors.
+        suggestions:
+          type: integer
+          description: Number of pending suggestions.
+        celery_queues:
+          type: object
+        name:
+          type: string
+          description: Configured server name.
+
+  responses:
+    Statistics:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Metrics'

--- a/docs/openapi/resources/projects.yaml
+++ b/docs/openapi/resources/projects.yaml
@@ -4,11 +4,11 @@ paths:
   /projects/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns a list of all projects
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -34,7 +34,7 @@ paths:
 
     post:
       tags:
-        - projects
+      - projects
       summary: Creates a new project
       requestBody:
         $ref: '#/components/requestBodies/CreateProject'
@@ -44,15 +44,15 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /projects/{project}/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns information about a project
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           $ref: '#/components/responses/Project'
@@ -61,10 +61,10 @@ paths:
 
     put:
       tags:
-        - projects
+      - projects
       summary: Edit a project by a PUT request
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           $ref: '#/components/responses/ProjectUpdated'
@@ -75,14 +75,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - projects
+      - projects
       summary: Edit a project by a PATCH request
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           $ref: '#/components/responses/ProjectUpdated'
@@ -91,14 +91,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - projects
+      - projects
       summary: Deletes a project
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -107,18 +107,18 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /projects/{project}/changes/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns a list of project changes
       description: This is essentially a project-scoped `GET /api/changes/` which accepts the same parameters.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -140,17 +140,17 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: 'changes.yaml#/components/schemas/Change'
+                      $ref: changes.yaml#/components/schemas/Change
         '404':
           $ref: '#/components/responses/NotFound'
 
   /projects/{project}/file/:
     get:
       tags:
-        - projects
+      - projects
       description: Downloads all available translations associated with the project as an archive file using the requested format and language.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           description: OK
@@ -165,11 +165,11 @@ paths:
   /projects/{project}/repository/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns information about VCS repository status
       description: This endpoint contains only an overall summary for all repositories for the project. To get more detailed status use `GET /api/components/{project}/{component}/repository/`.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           description: OK
@@ -182,14 +182,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     post:
       tags:
-        - projects
+      - projects
       summary: Performs the given operation on the VCS repository
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateProjectRepository'
       responses:
@@ -209,17 +209,17 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /projects/{project}/components/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns a list of translation components in the given project
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -247,8 +247,8 @@ paths:
 
     post:
       tags:
-        - projects
-        - components
+      - projects
+      - components
       summary: Creates translation components in the given project
       description: |
         **Changed in version 4.3:** The `zipfile` and `docfile` parameters are now accepted for VCS-less components, see [Local files](https://docs.weblate.org/en/latest/vcs.html#vcs-local).
@@ -263,7 +263,7 @@ paths:
 
         Most of the component creation happens in the background. Check the `task_url` attribute of created component and follow the progress there.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       requestBody:
         $ref: '#/components/requestBodies/CreateProjectComponent'
       responses:
@@ -274,15 +274,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /projects/{project}/languages/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns paginated statistics for all languages within a project
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           description: OK
@@ -291,18 +291,18 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: 'statistics.yaml#/components/schemas/Statistics'
+                  $ref: statistics.yaml#/components/schemas/Statistics
         '404':
           $ref: '#/components/responses/NotFound'
 
   /projects/{project}/statistics/:
     get:
       tags:
-        - projects
-        - statistics
+      - projects
+      - statistics
       summary: Returns statistics for a project
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           description: OK
@@ -316,13 +316,13 @@ paths:
   /projects/{project}/categories/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns categories for a project
       description: Added in version 5.0.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -344,20 +344,20 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: 'categories.yaml#/components/schemas/Category'
+                      $ref: categories.yaml#/components/schemas/Category
         '404':
           $ref: '#/components/responses/NotFound'
 
   /projects/{project}/labels/:
     get:
       tags:
-        - projects
+      - projects
       summary: Returns labels for a project
       description: Added in version 5.3.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -385,10 +385,10 @@ paths:
 
     post:
       tags:
-        - projects
+      - projects
       summary: Creates a label for a project
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       requestBody:
         $ref: '#/components/requestBodies/CreateProjectLabel'
       responses:
@@ -401,19 +401,19 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /projects/{project}/credits/:
     #TODO: returns 400 Bad Request, need to check requestBody
     get:
       tags:
-        - projects
+      - projects
       summary: Returns contributor credits for a project
       description: Added in version 5.7.
       requestBody:
         $ref: '#/components/requestBodies/ReadProjectCredits'
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           description: OK
@@ -434,7 +434,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -519,9 +519,9 @@ components:
         translation_review: false
         source_review: false
         set_language_team: true
-        instructions: ""
+        instructions: ''
         enable_hooks: true
-        language_aliases: ""
+        language_aliases: ''
         enforced_2fa: false
 
     # The difference with 'components.yaml#/schemas/Component'
@@ -536,7 +536,7 @@ components:
         id:
           type: integer
         source_language:
-          $ref: 'languages.yaml#/components/schemas/Language'
+          $ref: languages.yaml#/components/schemas/Language
         vcs:
           type: string
         repo:
@@ -740,7 +740,7 @@ components:
           linked_component:
 
     ProjectStatistics:
-      $ref: 'statistics.yaml#/components/schemas/StatisticsUrl'
+      $ref: statistics.yaml#/components/schemas/StatisticsUrl
 
     ProjectLabel:
       type: object
@@ -774,22 +774,22 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     BadRequest:
-      $ref: 'common.yaml#/components/responses/BadRequest'
+      $ref: common.yaml#/components/responses/BadRequest
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     Forbidden:
-      $ref: 'common.yaml#/components/responses/Forbidden'
+      $ref: common.yaml#/components/responses/Forbidden
 
     NotFound:
       description: Not Found
@@ -831,7 +831,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: 'components.yaml#/components/schemas/Component'
+            $ref: components.yaml#/components/schemas/Component
 
     ProjectLabelCreated:
       description: Created
@@ -880,9 +880,9 @@ components:
                 format: uri
                 description: Project website.
             required:
-              - name
-              - slug
-              - web
+            - name
+            - slug
+            - web
       required: true
 
     UpdateProject:
@@ -902,9 +902,9 @@ components:
                 format: uri
                 description: Project website.
             required:
-              - name
-              - slug
-              - web
+            - name
+            - slug
+            - web
       required: true
 
     UpdateProjectRepository:
@@ -916,11 +916,11 @@ components:
               operation:
                 type: string
                 enum:
-                  - commit
-                  - pull
-                  - push
-                  - reset
-                  - cleanup
+                - commit
+                - pull
+                - push
+                - reset
+                - cleanup
           example:
             operation: pull
 
@@ -933,7 +933,7 @@ components:
             type: object
             properties:
               name:
-               type: string
+                type: string
               slug:
                 type: string
               repo:
@@ -950,18 +950,18 @@ components:
                 type: string
                 description: How to handle requests for creating new translations.
                 enum:
-                  - contact
-                  - url
-                  - add
-                  - none
+                - contact
+                - url
+                - add
+                - none
             required:
-              - name
-              - slug
-              - repo
-              - filemask
-              - file_format
-              - new_base
-              - new_lang
+            - name
+            - slug
+            - repo
+            - filemask
+            - file_format
+            - new_base
+            - new_lang
           examples:
             NewComponentFromGit:
               name: Weblate
@@ -994,8 +994,8 @@ components:
               color:
                 type: string
             required:
-              - name
-              - color
+            - name
+            - color
       required: true
 
     ReadProjectCredits:
@@ -1016,6 +1016,6 @@ components:
                 type: string
                 description: Language code to search for.
             required:
-              - start
-              - end
+            - start
+            - end
       required: true

--- a/docs/openapi/resources/projects.yaml
+++ b/docs/openapi/resources/projects.yaml
@@ -1,0 +1,1021 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /projects/:
+    get:
+      tags:
+        - projects
+      summary: Returns a list of all projects
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Project'
+
+    post:
+      tags:
+        - projects
+      summary: Creates a new project
+      requestBody:
+        $ref: '#/components/requestBodies/CreateProject'
+      responses:
+        '201':
+          $ref: '#/components/responses/ProjectCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+
+  /projects/{project}/:
+    get:
+      tags:
+        - projects
+      summary: Returns information about a project
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Project'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - projects
+      summary: Edit a project by a PUT request
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ProjectUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - projects
+      summary: Edit a project by a PATCH request
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ProjectUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - projects
+      summary: Deletes a project
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /projects/{project}/changes/:
+    get:
+      tags:
+        - projects
+      summary: Returns a list of project changes
+      description: This is essentially a project-scoped `GET /api/changes/` which accepts the same parameters.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: 'changes.yaml#/components/schemas/Change'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /projects/{project}/file/:
+    get:
+      tags:
+        - projects
+      description: Downloads all available translations associated with the project as an archive file using the requested format and language.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /projects/{project}/repository/:
+    get:
+      tags:
+        - projects
+      summary: Returns information about VCS repository status
+      description: This endpoint contains only an overall summary for all repositories for the project. To get more detailed status use `GET /api/components/{project}/{component}/repository/`.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Repository'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    post:
+      tags:
+        - projects
+      summary: Performs the given operation on the VCS repository
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateProjectRepository'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                example:
+                  result: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /projects/{project}/components/:
+    get:
+      tags:
+        - projects
+      summary: Returns a list of translation components in the given project
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProjectComponent'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - projects
+        - components
+      summary: Creates translation components in the given project
+      description: |
+        **Changed in version 4.3:** The `zipfile` and `docfile` parameters are now accepted for VCS-less components, see [Local files](https://docs.weblate.org/en/latest/vcs.html#vcs-local).
+
+        **Changed in version 4.6:** The cloned repositories are now automatically shared within a project using [Weblate internal URLs](https://docs.weblate.org/en/latest/vcs.html#internal-urls). Use `disable_autoshare` to turn off this.
+
+        **Hint:**
+
+        Use [Weblate internal URLs](https://docs.weblate.org/en/latest/vcs.html#internal-urls) when creating multiple components from a single VCS repository.
+
+        **Note:**
+
+        Most of the component creation happens in the background. Check the `task_url` attribute of created component and follow the progress there.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateProjectComponent'
+      responses:
+        '201':
+          $ref: '#/components/responses/ProjectComponentCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /projects/{project}/languages/:
+    get:
+      tags:
+        - projects
+      summary: Returns paginated statistics for all languages within a project
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'statistics.yaml#/components/schemas/Statistics'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /projects/{project}/statistics/:
+    get:
+      tags:
+        - projects
+        - statistics
+      summary: Returns statistics for a project
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectStatistics'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /projects/{project}/categories/:
+    get:
+      tags:
+        - projects
+      summary: Returns categories for a project
+      description: Added in version 5.0.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: 'categories.yaml#/components/schemas/Category'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /projects/{project}/labels/:
+    get:
+      tags:
+        - projects
+      summary: Returns labels for a project
+      description: Added in version 5.3.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProjectLabel'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - projects
+      summary: Creates a label for a project
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateProjectLabel'
+      responses:
+        '201':
+          $ref: '#/components/responses/ProjectLabelCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /projects/{project}/credits/:
+    #TODO: returns 400 Bad Request, need to check requestBody
+    get:
+      tags:
+        - projects
+      summary: Returns contributor credits for a project
+      description: Added in version 5.7.
+      requestBody:
+        $ref: '#/components/requestBodies/ReadProjectCredits'
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  email:
+                    type: string
+                    format: email
+                  full_name:
+                    type: string
+                  change_count:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Project:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Project name.
+        slug:
+          type: string
+          description: Project slug.
+        id:
+          type: integer
+        web:
+          type: string
+          format: uri
+          description: Project website.
+        web_url:
+          type: string
+          format: uri
+        url:
+          type: string
+          format: uri
+        components_list_url:
+          type: string
+          format: uri
+          description: URL to components list.
+        repository_url:
+          type: string
+          format: uri
+          description: URL to repository status.
+        statistics_url:
+          type: string
+          format: uri
+        categories_url:
+          type: string
+          format: uri
+        changes_list_url:
+          type: string
+          format: uri
+          description: URL to changes list.
+        languages_url:
+          type: string
+          format: uri
+        labels_url:
+          type: string
+          format: uri
+        credits_url:
+          type: string
+          format: uri
+          description: URL to list contributor credits.
+        translation_review:
+          type: boolean
+        source_review:
+          type: boolean
+        set_language_team:
+          type: boolean
+        instructions:
+          type: string
+        enable_hooks:
+          type: boolean
+        language_aliases:
+          type: string
+        enforced_2fa:
+          type: boolean
+      example:
+        name: Test Project
+        slug: test-project
+        id: 2
+        web: https://example.com/testproject
+        web_url: http://weblate.example.com/projects/test-project/
+        url: http://weblate.example.com/api/projects/test-project/
+        components_list_url: http://weblate.example.com/api/projects/test-project/components/
+        repository_url: http://weblate.example.com/api/projects/test-project/repository/
+        statistics_url: http://weblate.example.com/api/projects/test-project/statistics/
+        categories_url: http://weblate.example.com/api/projects/test-project/categories/
+        changes_list_url: http://weblate.example.com/api/projects/test-project/changes/
+        languages_url: http://weblate.example.com/api/projects/test-project/languages/
+        labels_url: http://weblate.example.com/api/projects/test-project/labels/
+        credits_url: http://weblate.example.com/api/projects/test-project/credits/
+        translation_review: false
+        source_review: false
+        set_language_team: true
+        instructions: ""
+        enable_hooks: true
+        language_aliases: ""
+        enforced_2fa: false
+
+    # The difference with 'components.yaml#/schemas/Component'
+    # is that this schema does NOT have a 'project' property, it is implicit.
+    ProjectComponent:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        id:
+          type: integer
+        source_language:
+          $ref: 'languages.yaml#/components/schemas/Language'
+        vcs:
+          type: string
+        repo:
+          type: string
+          format: uri
+          description: Source code repository, this is the actual repository URL even when Weblate internal URLs are used, use linked_component to detect this situation.
+        git_export:
+          type: string
+          format: uri
+        branch:
+          type: string
+          description: Repository branch, this is the actual repository branch even when Weblate internal URLs are used.
+        push_branch:
+          type: string
+          description: Push branch, this is the actual repository branch even when Weblate internal URLs are used.
+        filemask:
+          type: string
+        screenshot_filemask:
+          type: string
+        template:
+          type: string
+        edit_template:
+          type: boolean
+        intermediate:
+          type: string
+        new_base:
+          type: string
+        file_format:
+          type: string
+        license:
+          type: string
+        license_url:
+          type: string
+          format: uri
+          nullable: true
+        agreement:
+          type: string
+        web_url:
+          type: string
+          format: uri
+        url:
+          type: string
+          format: uri
+        repository_url:
+          type: string
+          format: uri
+        translations_url:
+          type: string
+          format: uri
+        statistics_url:
+          type: string
+          format: uri
+        lock_url:
+          type: string
+          format: uri
+        links_url:
+          type: string
+          format: uri
+        changes_list_url:
+          type: string
+          format: uri
+        task_url:
+          type: string
+          format: uri
+          nullable: true
+        credits_url:
+          type: string
+          format: uri
+        new_lang:
+          type: string
+        language_code_style:
+          type: string
+        push:
+          type: string
+        check_flags:
+          type: string
+        priority:
+          type: integer
+        enforced_checks:
+          type: array
+        restricted:
+          type: boolean
+        repoweb:
+          type: string
+        report_source_bugs:
+          type: string
+        merge_style:
+          type: string
+        commit_message:
+          type: string
+        add_message:
+          type: string
+        delete_message:
+          type: string
+        merge_message:
+          type: string
+        addon_message:
+          type: string
+        pull_message:
+          type: string
+        allow_translation_propagation:
+          type: boolean
+        manage_units:
+          type: boolean
+        enable_suggestions:
+          type: boolean
+        suggestion_voting:
+          type: boolean
+        suggestion_autoaccept:
+          type: integer
+        push_on_commit:
+          type: boolean
+        commit_pending_age:
+          type: integer
+        auto_lock_error:
+          type: boolean
+        language_regex:
+          type: string
+          format: regex
+        variant_regex:
+          type: string
+          format: regex
+        addons:
+          type: array
+          items:
+            type: string
+            format: uri
+        is_glossary:
+          type: boolean
+        glossary_color:
+          type: string
+        category:
+          type: string
+          format: uri
+          nullable: true
+        linked_component:
+          type: string
+          format: uri
+          description: Component whose repository is linked via [Weblate internal URLs](https://docs.weblate.org/en/latest/vcs.html#internal-urls).
+          nullable: true
+      examples:
+        NewProjectComponent:
+          slug:
+          id: 3
+          source_language:
+          vcs:
+          repo:
+          git_export:
+          branch:
+          push_branch:
+          filemask:
+          screenshot_filemask:
+          template:
+          edit_template:
+          intermediate:
+          new_base:
+          file_format:
+          license:
+          license_url:
+          agreement:
+          web_url:
+          url:
+          repository_url:
+          translations_url:
+          statistics_url:
+          lock_url:
+          links_url:
+          changes_list_url:
+          task_url:
+          credits_url:
+          new_lang:
+          language_code_style:
+          push:
+          check_flags:
+          priority:
+          enforced_checks:
+          restricted:
+          repoweb:
+          report_source_bugs:
+          merge_style:
+          commit_message:
+          add_message:
+          delete_message:
+          merge_message:
+          addon_message:
+          pull_message:
+          allow_translation_propagation:
+          manage_units:
+          enable_suggestions:
+          suggestion_voting:
+          suggestion_autoaccept:
+          push_on_commit:
+          commit_pending_age:
+          auto_lock_error:
+          language_regex:
+          variant_regex:
+          addons:
+          is_glossary:
+          glossary_color:
+          category:
+          linked_component:
+
+    ProjectStatistics:
+      $ref: 'statistics.yaml#/components/schemas/StatisticsUrl'
+
+    ProjectLabel:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        color:
+          type: string
+
+    Repository:
+      type: object
+      properties:
+        needs_commit:
+          type: boolean
+        needs_merge:
+          type: boolean
+        needs_push:
+          type: boolean
+        url:
+          type: string
+          format: uri
+      example:
+        needs_commit: false
+        needs_merge: false
+        needs_push: false
+        url: http://weblate.example.com/api/projects/test-project/repository/
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    BadRequest:
+      $ref: 'common.yaml#/components/responses/BadRequest'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    Forbidden:
+      $ref: 'common.yaml#/components/responses/Forbidden'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            ProjectNotFound:
+              value:
+                detail: No Project matches the given query.
+
+    Project:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Project'
+
+    ProjectCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Project'
+
+    ProjectUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Project'
+
+    ProjectComponentCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: 'components.yaml#/components/schemas/Component'
+
+    ProjectLabelCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProjectLabel'
+
+  parameters:
+    projectInPath:
+      name: project
+      in: path
+      required: true
+      schema:
+        type: string
+
+    projectSlugInPath:
+      name: project_slug
+      in: path
+      required: true
+      schema:
+        type: string
+
+    projectIdInPath:
+      name: project_id
+      in: path
+      required: true
+      schema:
+        type: integer
+
+  requestBodies:
+    CreateProject:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Project name.
+              slug:
+                type: string
+                description: Project slug.
+              web:
+                type: string
+                format: uri
+                description: Project website.
+            required:
+              - name
+              - slug
+              - web
+      required: true
+
+    UpdateProject:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Project name.
+              slug:
+                type: string
+                description: Project slug.
+              web:
+                type: string
+                format: uri
+                description: Project website.
+            required:
+              - name
+              - slug
+              - web
+      required: true
+
+    UpdateProjectRepository:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              operation:
+                type: string
+                enum:
+                  - commit
+                  - pull
+                  - push
+                  - reset
+                  - cleanup
+          example:
+            operation: pull
+
+      required: true
+
+    CreateProjectComponent:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+               type: string
+              slug:
+                type: string
+              repo:
+                type: string
+                format: uri
+                description: Source code repository, this is the actual repository URL even when Weblate internal URLs are used, use linked_component to detect this situation.
+              filemask:
+                type: string
+              file_format:
+                type: string
+              new_base:
+                type: string
+              new_lang:
+                type: string
+                description: How to handle requests for creating new translations.
+                enum:
+                  - contact
+                  - url
+                  - add
+                  - none
+            required:
+              - name
+              - slug
+              - repo
+              - filemask
+              - file_format
+              - new_base
+              - new_lang
+          examples:
+            NewComponentFromGit:
+              name: Weblate
+              slug: weblate
+              repo: https://github.com/WeblateOrg/hello.git
+              filemask: po/*.po
+              file_format: po
+              new_base: po/hello.pot
+              new_lang: pl
+            NewComponentFromComponent:
+              name: Weblate
+              slug: weblate
+              repo: weblate://weblate/hello
+              filemask: po/*.po
+              file_format: po
+              new_base: po/hello.pot
+              new_lang: pl
+      required: true
+
+    CreateProjectLabel:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              color:
+                type: string
+            required:
+              - name
+              - color
+      required: true
+
+    ReadProjectCredits:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              start:
+                type: string
+                format: date
+                description: Lower-bound ISO 8601 timestamp.
+              end:
+                type: string
+                format: date
+                description: Upper-bound ISO 8601 timestamp.
+              lang:
+                type: string
+                description: Language code to search for.
+            required:
+              - start
+              - end
+      required: true

--- a/docs/openapi/resources/roles.yaml
+++ b/docs/openapi/resources/roles.yaml
@@ -4,12 +4,12 @@ paths:
   /roles/:
     get:
       tags:
-        - roles
+      - roles
       summary: Returns a list of all roles associated with the user
       description: If the user is superuser, then a list of all existing roles is returned.
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -31,11 +31,11 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: "#/components/schemas/Role"
+                      $ref: '#/components/schemas/Role'
 
     post:
       tags:
-        - roles
+      - roles
       summary: Creates a new role
       requestBody:
         $ref: '#/components/requestBodies/CreateRole'
@@ -45,15 +45,15 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /roles/{id}/:
     get:
       tags:
-        - roles
+      - roles
       summary: Returns information about a role
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/Role'
@@ -62,10 +62,10 @@ paths:
 
     put:
       tags:
-        - roles
+      - roles
       summary: Changes the role parameters
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateRole'
       responses:
@@ -76,14 +76,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - roles
+      - roles
       summary: Changes the role parameters
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateRole'
       responses:
@@ -94,14 +94,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - roles
+      - roles
       summary: Deletes a role
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -110,7 +110,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -131,19 +131,19 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     BadRequest:
-      $ref: 'common.yaml#/components/responses/BadRequest'
+      $ref: common.yaml#/components/responses/BadRequest
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -164,7 +164,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Role"
+            $ref: '#/components/schemas/Role'
 
     RoleCreated:
       description: Created
@@ -182,7 +182,7 @@ components:
 
   parameters:
     idInPath:
-      $ref: 'common.yaml#/components/parameters/idInPath'
+      $ref: common.yaml#/components/parameters/idInPath
 
   requestBodies:
     CreateRole:
@@ -198,8 +198,8 @@ components:
                 items:
                   type: string
             required:
-              - name
-              - permissions
+            - name
+            - permissions
       required: true
 
     UpdateRole:
@@ -215,6 +215,6 @@ components:
                 items:
                   type: string
             required:
-              - name
-              - permissions
+            - name
+            - permissions
       required: true

--- a/docs/openapi/resources/roles.yaml
+++ b/docs/openapi/resources/roles.yaml
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /roles/:
+    get:
+      tags:
+        - roles
+      summary: Returns a list of all roles associated with the user
+      description: If the user is superuser, then a list of all existing roles is returned.
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Role"
+
+    post:
+      tags:
+        - roles
+      summary: Creates a new role
+      requestBody:
+        $ref: '#/components/requestBodies/CreateRole'
+      responses:
+        '201':
+          $ref: '#/components/responses/RoleCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+
+  /roles/{id}/:
+    get:
+      tags:
+        - roles
+      summary: Returns information about a role
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Role'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - roles
+      summary: Changes the role parameters
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateRole'
+      responses:
+        '200':
+          $ref: '#/components/responses/RoleUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - roles
+      summary: Changes the role parameters
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateRole'
+      responses:
+        '200':
+          $ref: '#/components/responses/RoleUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - roles
+      summary: Deletes a role
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Role:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+        url:
+          type: string
+          format: uri
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    BadRequest:
+      $ref: 'common.yaml#/components/responses/BadRequest'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            RoleNotFound:
+              value:
+                detail: No Role matches the given query.
+
+    Role:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Role"
+
+    RoleCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Role'
+
+    RoleUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Role'
+
+  parameters:
+    idInPath:
+      $ref: 'common.yaml#/components/parameters/idInPath'
+
+  requestBodies:
+    CreateRole:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              permissions:
+                type: array
+                items:
+                  type: string
+            required:
+              - name
+              - permissions
+      required: true
+
+    UpdateRole:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              permissions:
+                type: array
+                items:
+                  type: string
+            required:
+              - name
+              - permissions
+      required: true

--- a/docs/openapi/resources/rssfeeds.yaml
+++ b/docs/openapi/resources/rssfeeds.yaml
@@ -4,164 +4,164 @@ paths:
   /exports/rss/:
     get:
       tags:
-        - rssFeeds
+      - rssFeeds
       summary: Retrieves RSS feed with recent changes for Weblate instance
       responses:
         '200':
           $ref: '#/components/responses/RSSFeed'
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /exports/rss/{project}/:
     get:
       tags:
-        - rssFeeds
+      - rssFeeds
       summary: Retrieves RSS feed with recent changes for a project
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/projectInPath'
       responses:
         '200':
           $ref: '#/components/responses/RSSFeed'
         '404':
           $ref: '#/components/responses/NotFound'
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /exports/rss/{project}/{component}/:
     get:
       tags:
-        - rssFeeds
+      - rssFeeds
       summary: Retrieves RSS feed with recent changes for a component
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
       responses:
         '200':
           $ref: '#/components/responses/RSSFeed'
         '404':
           $ref: '#/components/responses/NotFound'
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /exports/rss/{project}/{component}/{language}/:
     get:
       tags:
-        - rssFeeds
+      - rssFeeds
       summary: Retrieves RSS feed with recent changes for a translation
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/RSSFeed'
         '404':
           $ref: '#/components/responses/NotFound'
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
   /exports/rss/language/{language}/:
     get:
       tags:
-        - rssFeeds
+      - rssFeeds
       summary: Retrieves RSS feed with recent changes for a language
       parameters:
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/RSSFeed'
         '404':
           $ref: '#/components/responses/NotFound'
       servers:
-        - url: https://hosted.weblate.org
-          description: The official Weblate cloud instance
-        - url: '{scheme}://{hostname}{port}'
-          description: A Weblate instance of your choice
-          variables:
-            scheme:
-              enum:
-                - http
-                - https
-              default: https
-              description: The HTTP protocol variant used for connecting to the API.
-            hostname:
-              default: ""
-              description: The host where the Weblate API is exposed.
-            port:
-              default: ""
-              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+      - url: https://hosted.weblate.org
+        description: The official Weblate cloud instance
+      - url: '{scheme}://{hostname}{port}'
+        description: A Weblate instance of your choice
+        variables:
+          scheme:
+            enum:
+            - http
+            - https
+            default: https
+            description: The HTTP protocol variant used for connecting to the API.
+          hostname:
+            default: ''
+            description: The host where the Weblate API is exposed.
+          port:
+            default: ''
+            description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
 
 components:
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     NotFound:
-      $ref: 'common.yaml#/components/responses/NotFound'
+      $ref: common.yaml#/components/responses/NotFound
 
     RSSFeed:
       description: OK
@@ -172,10 +172,10 @@ components:
 
   parameters:
     projectInPath:
-      $ref: 'projects.yaml#/components/parameters/projectInPath'
+      $ref: projects.yaml#/components/parameters/projectInPath
 
     componentInPath:
-      $ref: 'components.yaml#/components/parameters/componentInPath'
+      $ref: components.yaml#/components/parameters/componentInPath
 
     languageInPath:
-      $ref: 'languages.yaml#/components/parameters/languageInPath'
+      $ref: languages.yaml#/components/parameters/languageInPath

--- a/docs/openapi/resources/rssfeeds.yaml
+++ b/docs/openapi/resources/rssfeeds.yaml
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /exports/rss/:
+    get:
+      tags:
+        - rssFeeds
+      summary: Retrieves RSS feed with recent changes for Weblate instance
+      responses:
+        '200':
+          $ref: '#/components/responses/RSSFeed'
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /exports/rss/{project}/:
+    get:
+      tags:
+        - rssFeeds
+      summary: Retrieves RSS feed with recent changes for a project
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/RSSFeed'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /exports/rss/{project}/{component}/:
+    get:
+      tags:
+        - rssFeeds
+      summary: Retrieves RSS feed with recent changes for a component
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/RSSFeed'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /exports/rss/{project}/{component}/{language}/:
+    get:
+      tags:
+        - rssFeeds
+      summary: Retrieves RSS feed with recent changes for a translation
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/RSSFeed'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+  /exports/rss/language/{language}/:
+    get:
+      tags:
+        - rssFeeds
+      summary: Retrieves RSS feed with recent changes for a language
+      parameters:
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/RSSFeed'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      servers:
+        - url: https://hosted.weblate.org
+          description: The official Weblate cloud instance
+        - url: '{scheme}://{hostname}{port}'
+          description: A Weblate instance of your choice
+          variables:
+            scheme:
+              enum:
+                - http
+                - https
+              default: https
+              description: The HTTP protocol variant used for connecting to the API.
+            hostname:
+              default: ""
+              description: The host where the Weblate API is exposed.
+            port:
+              default: ""
+              description: '(Optional) The transport layer port number where the API is listening to, preceded by a colon. For example: ":8080".'
+
+components:
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    NotFound:
+      $ref: 'common.yaml#/components/responses/NotFound'
+
+    RSSFeed:
+      description: OK
+      content:
+        application/rss+xml:
+          schema:
+            type: string
+
+  parameters:
+    projectInPath:
+      $ref: 'projects.yaml#/components/parameters/projectInPath'
+
+    componentInPath:
+      $ref: 'components.yaml#/components/parameters/componentInPath'
+
+    languageInPath:
+      $ref: 'languages.yaml#/components/parameters/languageInPath'

--- a/docs/openapi/resources/screenshots.yaml
+++ b/docs/openapi/resources/screenshots.yaml
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /screenshots/:
+    get:
+      tags:
+        - screenshots
+      summary: Returns a list of screenshot string information
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Screenshot'
+
+    post:
+      tags:
+        - screenshots
+      summary: Creates a new screenshot
+      requestBody:
+        $ref: '#/components/requestBodies/CreateScreenshot'
+      responses:
+        '201':
+          $ref: '#/components/responses/ScreenshotCreated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+
+  /screenshots/{id}/:
+    get:
+      tags:
+        - screenshots
+      summary: Returns information about screenshot information
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Screenshot'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - screenshots
+      summary: Edit full information about screenshot
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ScreenshotUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - screenshots
+      summary: Edit partial information about screenshot
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ScreenshotUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - screenshots
+      summary: Delete screenshot
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /screenshots/{id}/file/:
+    get:
+      tags:
+        - screenshots
+      summary: Download the screenshot image
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ScreenshotFile'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - screenshots
+      summary: Replace screenshot image
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ScreenshotFileUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /screenshots/{id}/units/:
+    post:
+      tags:
+        - screenshots
+      summary: Associate source string with screenshot
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ScreenshotUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /screenshots/{id}/units/{unit_id}/:
+    delete:
+      tags:
+        - screenshots
+      summary: Remove source string association with screenshot
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+        - $ref: '#/components/parameters/unitIdInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/ScreenshotUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Screenshot:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          description: Name of a screenshot.
+        repository_filename:
+          type: string
+        translation:
+          type: string
+          format: uri
+        file_url:
+          type: string
+          format: uri
+          description: URL to download a file.
+        units:
+          type: array
+          items:
+            type: string
+            format: uri
+          example:
+            - https://weblate.example.com/api/units/95376/
+            - https://weblate.example.com/api/units/95377/
+        url:
+          type: string
+          format: uri
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    BadRequest:
+      $ref: 'common.yaml#/components/responses/BadRequest'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    Forbidden:
+      $ref: 'common.yaml#/components/responses/Forbidden'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            ScreenshotNotFound:
+              value:
+                detail: No Screenshot matches the given query.
+
+    Screenshot:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Screenshot'
+
+    ScreenshotCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Screenshot'
+
+    ScreenshotUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Screenshot'
+
+    ScreenshotFile:
+      description: OK
+      content:
+        application/binary:
+          schema:
+            type: string
+            format: binary
+
+    ScreenshotFileUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Screenshot'
+
+  parameters:
+    idInPath:
+      $ref: 'common.yaml#/components/parameters/idInPath'
+
+    unitIdInPath:
+      $ref: 'units.yaml#/components/parameters/unitIdInPath'
+
+  requestBodies:
+    CreateScreenshot:
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              component_slug:
+                type: string
+              project_slug:
+                type: string
+              language_code:
+                type: string
+              name:
+                type: string
+              image:
+                type: string
+                format: binary
+            required:
+              - component_slug
+              - project_slug
+              - language_code
+              - name
+              - image
+      required: true

--- a/docs/openapi/resources/screenshots.yaml
+++ b/docs/openapi/resources/screenshots.yaml
@@ -4,11 +4,11 @@ paths:
   /screenshots/:
     get:
       tags:
-        - screenshots
+      - screenshots
       summary: Returns a list of screenshot string information
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -34,7 +34,7 @@ paths:
 
     post:
       tags:
-        - screenshots
+      - screenshots
       summary: Creates a new screenshot
       requestBody:
         $ref: '#/components/requestBodies/CreateScreenshot'
@@ -48,15 +48,15 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /screenshots/{id}/:
     get:
       tags:
-        - screenshots
+      - screenshots
       summary: Returns information about screenshot information
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/Screenshot'
@@ -65,10 +65,10 @@ paths:
 
     put:
       tags:
-        - screenshots
+      - screenshots
       summary: Edit full information about screenshot
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/ScreenshotUpdated'
@@ -81,14 +81,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - screenshots
+      - screenshots
       summary: Edit partial information about screenshot
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/ScreenshotUpdated'
@@ -101,14 +101,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - screenshots
+      - screenshots
       summary: Delete screenshot
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -119,15 +119,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /screenshots/{id}/file/:
     get:
       tags:
-        - screenshots
+      - screenshots
       summary: Download the screenshot image
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/ScreenshotFile'
@@ -136,10 +136,10 @@ paths:
 
     post:
       tags:
-        - screenshots
+      - screenshots
       summary: Replace screenshot image
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/ScreenshotFileUpdated'
@@ -150,15 +150,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /screenshots/{id}/units/:
     post:
       tags:
-        - screenshots
+      - screenshots
       summary: Associate source string with screenshot
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/ScreenshotUpdated'
@@ -169,16 +169,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /screenshots/{id}/units/{unit_id}/:
     delete:
       tags:
-        - screenshots
+      - screenshots
       summary: Remove source string association with screenshot
       parameters:
-        - $ref: '#/components/parameters/idInPath'
-        - $ref: '#/components/parameters/unitIdInPath'
+      - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/unitIdInPath'
       responses:
         '200':
           $ref: '#/components/responses/ScreenshotUpdated'
@@ -187,7 +187,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -214,30 +214,30 @@ components:
             type: string
             format: uri
           example:
-            - https://weblate.example.com/api/units/95376/
-            - https://weblate.example.com/api/units/95377/
+          - https://weblate.example.com/api/units/95376/
+          - https://weblate.example.com/api/units/95377/
         url:
           type: string
           format: uri
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     BadRequest:
-      $ref: 'common.yaml#/components/responses/BadRequest'
+      $ref: common.yaml#/components/responses/BadRequest
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     Forbidden:
-      $ref: 'common.yaml#/components/responses/Forbidden'
+      $ref: common.yaml#/components/responses/Forbidden
 
     NotFound:
       description: Not Found
@@ -291,10 +291,10 @@ components:
 
   parameters:
     idInPath:
-      $ref: 'common.yaml#/components/parameters/idInPath'
+      $ref: common.yaml#/components/parameters/idInPath
 
     unitIdInPath:
-      $ref: 'units.yaml#/components/parameters/unitIdInPath'
+      $ref: units.yaml#/components/parameters/unitIdInPath
 
   requestBodies:
     CreateScreenshot:
@@ -315,9 +315,9 @@ components:
                 type: string
                 format: binary
             required:
-              - component_slug
-              - project_slug
-              - language_code
-              - name
-              - image
+            - component_slug
+            - project_slug
+            - language_code
+            - name
+            - image
       required: true

--- a/docs/openapi/resources/search.yaml
+++ b/docs/openapi/resources/search.yaml
@@ -4,7 +4,7 @@ paths:
   /search/:
     get:
       tags:
-        - search
+      - search
       summary: Returns site-wide search results as a list
       description: |
         Added in version 4.18.

--- a/docs/openapi/resources/search.yaml
+++ b/docs/openapi/resources/search.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /search/:
+    get:
+      tags:
+        - search
+      summary: Returns site-wide search results as a list
+      description: |
+        Added in version 4.18.
+
+        There is no pagination on the result set, only the first few matches are returned for each category.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Name of the matched item.
+                  url:
+                    type: string
+                    format: uri
+                    description: Web URL of the matched item.
+                  category:
+                    type: string
+                    description: Category of the matched item.

--- a/docs/openapi/resources/statistics.yaml
+++ b/docs/openapi/resources/statistics.yaml
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+components:
+  schemas:
+    # The Statistics object has variants according to what combination of these
+    # additional properties it has:
+    # 1. code
+    # 2. url
+    # 3. translate_url
+
+    # This Statistics variant has all 3 additional properties.
+    Statistics:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of strings.
+        total_words:
+          type: integer
+          description: Total number of words.
+        total_chars:
+          type: integer
+          description: Total number of characters.
+        last_change:
+          type: string
+          format: date-time
+          description: Date of last change.
+        recent_changes:
+          type: integer
+        translated:
+          type: integer
+          description: Number of translated strings.
+        translated_words:
+          type: integer
+          description: Number of translated words.
+        translated_percent:
+          type: number
+          format: float
+          description: Percentage of translated strings.
+        translated_words_percent:
+          type: number
+          format: float
+          description: Percentage of translated words.
+        translated_chars:
+          type: integer
+          description: Number of translated characters.
+        translated_chars_percent:
+          type: number
+          format: float
+          description: Percentage of translated characters.
+        fuzzy:
+          type: integer
+          description: Number of fuzzy (marked for edit) strings.
+        fuzzy_percent:
+          type: number
+          format: float
+          description: Percentage of fuzzy (marked for edit) strings.
+        fuzzy_words:
+          type: integer
+          description: Number of fuzzy (marked for edit) words.
+        fuzzy_words_percent:
+          type: number
+          format: float
+          description: Percentage of fuzzy (marked for edit) words.
+        fuzzy_chars:
+          type: integer
+          description: Number of fuzzy (marked for edit) characters.
+        fuzzy_chars_percent:
+          type: number
+          format: float
+          description: Percentage of fuzzy (marked for edit) characters.
+        failing:
+          type: integer
+          description: Number of failing checks.
+        failing_percent:
+          type: number
+          format: float
+          description: Percentage of failing checks.
+        approved:
+          type: integer
+          description: Number of approved strings.
+        approved_percent:
+          type: number
+          format: float
+          description: Percentage of approved strings.
+        approved_words:
+          type: integer
+          description: Number of approved words.
+        approved_words_percent:
+          type: number
+          format: float
+          description: Percentage of approved words.
+        approved_chars:
+          type: integer
+          description: Number of approved characters.
+        approved_chars_percent:
+          type: number
+          format: float
+          description: Percentage of approved characters.
+        readonly:
+          type: integer
+          description: Number of read-only strings.
+        readonly_percent:
+          type: number
+          format: float
+          description: Percentage of read-only strings.
+        readonly_words:
+          type: integer
+          description: Number of read-only words.
+        readonly_words_percent:
+          type: number
+          format: float
+          description: Percentage of read-only words.
+        readonly_chars:
+          type: integer
+          description: Number of read-only characters.
+        readonly_char_percent:
+          type: number
+          format: float
+          description: Percentage of read-only characters.
+        suggestions:
+          type: integer
+          description: Number of strings with suggestions.
+        comments:
+          type: integer
+          description: Number of strings with comments.
+        code:
+          type: string
+          description: Language code.
+        name:
+          type: string
+          description: Object name.
+        url:
+          type: string
+          format: uri
+          description: URL to access the object.
+        translate_url:
+          type: string
+          format: uri
+          description: URL to access the translation.
+
+    # This Statistics variant has only the "url" additional property.
+    StatisticsUrl:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of strings.
+        total_words:
+          type: integer
+          description: Total number of words.
+        total_chars:
+          type: integer
+          description: Total number of characters.
+        last_change:
+          type: string
+          format: date-time
+          description: Date of last change.
+        recent_changes:
+          type: integer
+        translated:
+          type: integer
+          description: Number of translated strings.
+        translated_words:
+          type: integer
+          description: Number of translated words.
+        translated_percent:
+          type: number
+          format: float
+          description: Percentage of translated strings.
+        translated_words_percent:
+          type: number
+          format: float
+          description: Percentage of translated words.
+        translated_chars:
+          type: integer
+          description: Number of translated characters.
+        translated_chars_percent:
+          type: number
+          format: float
+          description: Percentage of translated characters.
+        fuzzy:
+          type: integer
+          description: Number of fuzzy (marked for edit) strings.
+        fuzzy_percent:
+          type: number
+          format: float
+          description: Percentage of fuzzy (marked for edit) strings.
+        fuzzy_words:
+          type: integer
+          description: Number of fuzzy (marked for edit) words.
+        fuzzy_words_percent:
+          type: number
+          format: float
+          description: Percentage of fuzzy (marked for edit) words.
+        fuzzy_chars:
+          type: integer
+          description: Number of fuzzy (marked for edit) characters.
+        fuzzy_chars_percent:
+          type: number
+          format: float
+          description: Percentage of fuzzy (marked for edit) characters.
+        failing:
+          type: integer
+          description: Number of failing checks.
+        failing_percent:
+          type: number
+          format: float
+          description: Percentage of failing checks.
+        approved:
+          type: integer
+          description: Number of approved strings.
+        approved_percent:
+          type: number
+          format: float
+          description: Percentage of approved strings.
+        approved_words:
+          type: integer
+          description: Number of approved words.
+        approved_words_percent:
+          type: number
+          format: float
+          description: Percentage of approved words.
+        approved_chars:
+          type: integer
+          description: Number of approved characters.
+        approved_chars_percent:
+          type: number
+          format: float
+          description: Percentage of approved characters.
+        readonly:
+          type: integer
+          description: Number of read-only strings.
+        readonly_percent:
+          type: number
+          format: float
+          description: Percentage of read-only strings.
+        readonly_words:
+          type: integer
+          description: Number of read-only words.
+        readonly_words_percent:
+          type: number
+          format: float
+          description: Percentage of read-only words.
+        readonly_chars:
+          type: integer
+          description: Number of read-only characters.
+        readonly_char_percent:
+          type: number
+          format: float
+          description: Percentage of read-only characters.
+        suggestions:
+          type: integer
+          description: Number of strings with suggestions.
+        comments:
+          type: integer
+          description: Number of strings with comments.
+        name:
+          type: string
+          description: Object name.
+        url:
+          type: string
+          format: uri
+          description: URL to access the object.

--- a/docs/openapi/resources/tasks.yaml
+++ b/docs/openapi/resources/tasks.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /tasks/:
+    get:
+      tags:
+        - tasks
+      summary: Listing of the tasks is currently not available
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+
+  /tasks/{uuid}/:
+    get:
+      tags:
+        - tasks
+      summary: Returns information about a task
+      parameters:
+        - $ref: '#/components/parameters/uuidInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Screenshot'
+
+
+components:
+  schemas:
+    Task:
+      type: object
+      properties:
+        completed:
+          type: boolean
+          description: Whether the task has completed.
+        progress:
+          type: integer
+          description: Task progress in percent.
+        result:
+          type: object
+          description: Task result or progress details.
+          nullable: true
+        log:
+          type: string
+          description: Task log.
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Screenshot:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Task'
+
+  parameters:
+    uuidInPath:
+      name: uuid
+      in: path
+      required: true
+      schema:
+        type: string

--- a/docs/openapi/resources/tasks.yaml
+++ b/docs/openapi/resources/tasks.yaml
@@ -4,7 +4,7 @@ paths:
   /tasks/:
     get:
       tags:
-        - tasks
+      - tasks
       summary: Listing of the tasks is currently not available
       responses:
         '200':
@@ -13,10 +13,10 @@ paths:
   /tasks/{uuid}/:
     get:
       tags:
-        - tasks
+      - tasks
       summary: Returns information about a task
       parameters:
-        - $ref: '#/components/parameters/uuidInPath'
+      - $ref: '#/components/parameters/uuidInPath'
       responses:
         '200':
           $ref: '#/components/responses/Screenshot'
@@ -43,7 +43,7 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Screenshot:
       description: OK

--- a/docs/openapi/resources/translations.yaml
+++ b/docs/openapi/resources/translations.yaml
@@ -4,11 +4,11 @@ paths:
   /translations/:
     get:
       tags:
-        - translations
+      - translations
       summary: Returns a list of translations
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -35,12 +35,12 @@ paths:
   /translations/{project}/{component}/{language}/:
     get:
       tags:
-        - translations
+      - translations
       summary: Returns information about a translation
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/Translation'
@@ -49,12 +49,12 @@ paths:
 
     delete:
       tags:
-        - translations
+      - translations
       summary: Deletes a translation
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -63,20 +63,20 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /translations/{project}/{component}/{language}/changes/:
     get:
       tags:
-        - translations
+      - translations
       summary: Returns a list of translation changes
       description: This is essentially a translations-scoped GET /api/changes/ accepting the same parameters.
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -98,21 +98,21 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: 'changes.yaml#/components/schemas/Change'
+                      $ref: changes.yaml#/components/schemas/Change
         '404':
           $ref: '#/components/responses/NotFound'
 
   /translations/{project}/{component}/{language}/units/:
     get:
       tags:
-        - translations
+      - translations
       summary: Returns a list of translation units
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -134,21 +134,21 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: 'units.yaml#/components/schemas/Unit'
+                      $ref: units.yaml#/components/schemas/Unit
         '404':
           $ref: '#/components/responses/NotFound'
 
     post:
       tags:
-        - translations
+      - translations
       summary: Add a new unit
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
-          $ref: 'units.yaml#/components/responses/Unit'
+          $ref: units.yaml#/components/responses/Unit
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -165,18 +165,18 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /translations/{project}/{component}/{language}/autotranslate/:
     #TODO: 200 response is undocumented, needs testing: what does it return?
     post:
       tags:
-        - translations
+      - translations
       summary: Trigger automatic translation
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -196,17 +196,17 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /translations/{project}/{component}/{language}/file/:
     get:
       tags:
-        - translations
+      - translations
       description: Download current translation file as it is stored in the VCS (without the format parameter) or converted to another format (see [Downloading translations](https://docs.weblate.org/en/latest/user/files.html#download)).
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -226,16 +226,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     post:
       tags:
-        - translations
+      - translations
       summary: Upload new file with translations
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -244,17 +244,17 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /translations/{project}/{component}/{language}/repository/:
     get:
       tags:
-        - translations
+      - translations
       summary: Returns information about VCS repository status
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/TranslationRepository'
@@ -263,12 +263,12 @@ paths:
 
     post:
       tags:
-        - translations
+      - translations
       summary: Performs given operation on the VCS repository
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           description: OK
@@ -284,18 +284,18 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /translations/{project}/{component}/{language}/statistics/:
     get:
       tags:
-        - translations
-        - statistics
+      - translations
+      - statistics
       summary: Returns detailed translation statistics
       parameters:
-        - $ref: '#/components/parameters/projectInPath'
-        - $ref: '#/components/parameters/componentInPath'
-        - $ref: '#/components/parameters/languageInPath'
+      - $ref: '#/components/parameters/projectInPath'
+      - $ref: '#/components/parameters/componentInPath'
+      - $ref: '#/components/parameters/languageInPath'
       responses:
         '200':
           $ref: '#/components/responses/TranslationStatistics'
@@ -308,9 +308,9 @@ components:
       type: object
       properties:
         language:
-          $ref: 'languages.yaml#/components/schemas/Language'
+          $ref: languages.yaml#/components/schemas/Language
         component:
-          $ref: 'components.yaml#/components/schemas/Component'
+          $ref: components.yaml#/components/schemas/Component
         language_code:
           type: string
           description: Language code used in the repository; this can be different from language code in the language object.
@@ -423,11 +423,11 @@ components:
               formula: n != 1
               type: 1
             aliases:
-              - en_en
-              - base
-              - source
-              - enp
-              - eng
+            - en_en
+            - base
+            - source
+            - enp
+            - eng
             direction: ltr
             population: 1636485517
             web_url: http://weblate.example.com/languages/en/
@@ -448,11 +448,11 @@ components:
                 formula: n != 1
                 type: 1
               aliases:
-                - en_en
-                - base
-                - source
-                - enp
-                - eng
+              - en_en
+              - base
+              - source
+              - enp
+              - eng
               direction: ltr
               population: 1636485517
               web_url: http://weblate.example.com/languages/en/
@@ -476,25 +476,25 @@ components:
               translation_review: false
               source_review: false
               set_language_team: true
-              instructions: ""
+              instructions: ''
               enable_hooks: true
-              language_aliases: ""
+              language_aliases: ''
               enforced_2fa: false
             vcs: git
             repo: https://weblate.example.com/project.git
             git_export: http://weblate.example.com/git/test-project/test-component/
             branch: master
-            push_branch: ""
+            push_branch: ''
             filemask: assets/voxygen/i18n/*/main.ftl
-            screenshot_filemask: ""
-            template: ""
+            screenshot_filemask: ''
+            template: ''
             edit_template: true
-            intermediate: ""
-            new_base: ""
+            intermediate: ''
+            new_base: ''
             file_format: fluent
-            license: ""
-            license_url: null
-            agreement: ""
+            license: ''
+            license_url:
+            agreement: ''
             web_url: http://weblate.example.com/projects/test-project/test-component/
             url: http://weblate.example.com/api/components/test-project/test-component/
             repository_url: http://weblate.example.com/api/components/test-project/test-component/repository/
@@ -503,17 +503,17 @@ components:
             lock_url: http://weblate.example.com/api/components/test-project/test-component/lock/
             links_url: http://weblate.example.com/api/components/test-project/test-component/links/
             changes_list_url: http://weblate.example.com/api/components/test-project/test-component/changes/
-            task_url: null
+            task_url:
             credits_url: http://weblate.example.com/api/components/test-project/test-component/credits/
             new_lang: contact
-            language_code_style: ""
-            push: ""
-            check_flags: ""
+            language_code_style: ''
+            push: ''
+            check_flags: ''
             priority: 100
             enforced_checks: []
             restricted: false
-            repoweb: ""
-            report_source_bugs: ""
+            repoweb: ''
+            report_source_bugs: ''
             merge_style: rebase
             commit_message: "Translated using Weblate ({{ language_name }})\n\nCurrently translated at {{ stats.translated_percent }}% ({{ stats.translated }} of {{ stats.all }} strings)\n\nTranslation: {{ project_name }}/{{ component_name }}\nTranslate-URL: {{ url }}"
             add_message: "Added translation using Weblate ({{ language_name }})\n\n"
@@ -529,17 +529,17 @@ components:
             push_on_commit: true
             commit_pending_age: 24
             auto_lock_error: true
-            language_regex: "^[^.]+$"
-            variant_regex: ""
+            language_regex: ^[^.]+$
+            variant_regex: ''
             addons: []
             is_glossary: false
             glossary_color: silver
-            category: null
-            linked_component: null
+            category:
+            linked_component:
           language_code: en
           id: 63
-          filename: ""
-          revision: ""
+          filename: ''
+          revision: ''
           web_url: http://weblate.example.com/projects/test-project/test-component/en/
           share_url: http://weblate.example.com/engage/test-project/-/en/
           translate_url: http://weblate.example.com/translate/test-project/test-component/en/
@@ -559,8 +559,8 @@ components:
           failing_checks_percent: 52.9
           have_suggestion: 0
           have_comment: 0
-          last_change: "2024-09-19T18:48:47.104585Z"
-          last_author: null
+          last_change: '2024-09-19T18:48:47.104585Z'
+          last_author:
           repository_url: http://weblate.example.com/api/translations/test-project/test-component/en/repository/
           file_url: http://weblate.example.com/api/translations/test-project/test-component/en/file/
           statistics_url: http://weblate.example.com/api/translations/test-project/test-component/en/statistics/
@@ -568,7 +568,7 @@ components:
           units_list_url: http://weblate.example.com/api/translations/test-project/test-component/en/units/
 
     TranslationStatistics:
-      $ref: 'statistics.yaml#/components/schemas/Statistics'
+      $ref: statistics.yaml#/components/schemas/Statistics
 
     # Similar to the 'projects.yaml#/schemas/Repository' schema,
     # but with additional fields
@@ -627,35 +627,35 @@ components:
           needs_merge: false
           needs_push: false
           url: http://weblate.example.com/api/translations/test-project/test-component/en/repository/
-          remote_commit: null
+          remote_commit:
           weblate_commit:
             revision: 9d8a98d840dfe5a17c0627be4007139730ff5faf
             shortrevision: 9d8a98d84
             author: John Doe <johndoe@example.com>
             author_name: johndoe
             author_email: johndoe@example.com@gmail.com
-            authordate: "2024-09-18T08:02:16Z"
+            authordate: '2024-09-18T08:02:16Z'
             commit: johndoe <johndoe@example.com@gmail.com>
             commit_name: johndoe
             commit_email: johndoe@example.com@gmail.com
-            commitdate: "2024-09-18T08:02:16Z"
+            commitdate: '2024-09-18T08:02:16Z'
             message: Merge branch 'weblate-translation' into 'master'\n\nUpdate translation files (Weblate)
             summary: Merge branch 'weblate-translation' into 'master'
           status: On branch master\nYour branch is up to date with 'origin/master'.\n\nnothing to commit, working tree clean\n
-          merge_failure: null
+          merge_failure:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -694,10 +694,10 @@ components:
 
   parameters:
     projectInPath:
-      $ref: 'projects.yaml#/components/parameters/projectInPath'
+      $ref: projects.yaml#/components/parameters/projectInPath
 
     componentInPath:
-      $ref: 'components.yaml#/components/parameters/componentInPath'
+      $ref: components.yaml#/components/parameters/componentInPath
 
     languageInPath:
-      $ref: 'languages.yaml#/components/parameters/languageInPath'
+      $ref: languages.yaml#/components/parameters/languageInPath

--- a/docs/openapi/resources/translations.yaml
+++ b/docs/openapi/resources/translations.yaml
@@ -1,0 +1,703 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /translations/:
+    get:
+      tags:
+        - translations
+      summary: Returns a list of translations
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Translation'
+
+  /translations/{project}/{component}/{language}/:
+    get:
+      tags:
+        - translations
+      summary: Returns information about a translation
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Translation'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags:
+        - translations
+      summary: Deletes a translation
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /translations/{project}/{component}/{language}/changes/:
+    get:
+      tags:
+        - translations
+      summary: Returns a list of translation changes
+      description: This is essentially a translations-scoped GET /api/changes/ accepting the same parameters.
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: 'changes.yaml#/components/schemas/Change'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /translations/{project}/{component}/{language}/units/:
+    get:
+      tags:
+        - translations
+      summary: Returns a list of translation units
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: 'units.yaml#/components/schemas/Unit'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - translations
+      summary: Add a new unit
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: 'units.yaml#/components/responses/Unit'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                example:
+                  detail: Adding strings is disabled in the component configuration.
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /translations/{project}/{component}/{language}/autotranslate/:
+    #TODO: 200 response is undocumented, needs testing: what does it return?
+    post:
+      tags:
+        - translations
+      summary: Trigger automatic translation
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                example:
+                  detail: Can not auto translate
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /translations/{project}/{component}/{language}/file/:
+    get:
+      tags:
+        - translations
+      description: Download current translation file as it is stored in the VCS (without the format parameter) or converted to another format (see [Downloading translations](https://docs.weblate.org/en/latest/user/files.html#download)).
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                example:
+                  detail: You do not have permission to perform this action.
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    post:
+      tags:
+        - translations
+      summary: Upload new file with translations
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /translations/{project}/{component}/{language}/repository/:
+    get:
+      tags:
+        - translations
+      summary: Returns information about VCS repository status
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/TranslationRepository'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - translations
+      summary: Performs given operation on the VCS repository
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /translations/{project}/{component}/{language}/statistics/:
+    get:
+      tags:
+        - translations
+        - statistics
+      summary: Returns detailed translation statistics
+      parameters:
+        - $ref: '#/components/parameters/projectInPath'
+        - $ref: '#/components/parameters/componentInPath'
+        - $ref: '#/components/parameters/languageInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/TranslationStatistics'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  schemas:
+    Translation:
+      type: object
+      properties:
+        language:
+          $ref: 'languages.yaml#/components/schemas/Language'
+        component:
+          $ref: 'components.yaml#/components/schemas/Component'
+        language_code:
+          type: string
+          description: Language code used in the repository; this can be different from language code in the language object.
+        id:
+          type: integer
+        filename:
+          type: string
+          description: Translation filename.
+        revision:
+          type: string
+          description: Revision hash for the file.
+        web_url:
+          type: string
+          format: uri
+        share_url:
+          type: string
+          format: uri
+          description: URL for sharing leading to engagement page.
+        translate_url:
+          type: string
+          format: uri
+          description: URL for translating.
+        url:
+          type: string
+          format: uri
+        is_template:
+          type: boolean
+          description: Whether the translation has a monolingual base.
+        is_source:
+          type: boolean
+        total:
+          type: integer
+          description: Total number of strings.
+        total_words:
+          type: integer
+          description: Total number of words.
+        translated:
+          type: integer
+          description: Number of translated strings.
+        translated_words:
+          type: integer
+          description: Number of translated words.
+        translated_percent:
+          type: number
+          format: float
+          description: Percentage of translated strings.
+        fuzzy:
+          type: integer
+          description: Number of fuzzy (marked for edit) strings.
+        fuzzy_words:
+          type: integer
+          description: Number of words in fuzzy (marked for edit) strings.
+        fuzzy_percent:
+          type: number
+          format: float
+          description: Percentage of fuzzy (marked for edit) strings.
+        failing_checks:
+          type: integer
+          description: Number of strings failing checks.
+        failing_checks_words:
+          type: integer
+          description: Number of words with failing checks.
+        failing_checks_percent:
+          type: number
+          format: float
+          description: Percentage of strings failing checks.
+        have_suggestion:
+          type: integer
+          description: Number of strings with suggestion.
+        have_comment:
+          type: integer
+          description: Number of strings with comment.
+        last_change:
+          type: string
+          format: date-time
+          description: Last change timestamp.
+        last_author:
+          type: string
+          description: Name of last author.
+          nullable: true
+        repository_url:
+          type: string
+          format: uri
+          description: URL to repository status.
+        file_url:
+          type: string
+          format: uri
+          description: URL to file object.
+        statistics_url:
+          type: string
+          format: uri
+        changes_list_url:
+          type: string
+          format: uri
+          description: URL to changes list.
+        units_list_url:
+          type: string
+          format: uri
+          description: URL to strings list.
+      examples:
+        Translation:
+          language:
+            id: 177
+            code: en
+            name: English
+            plural:
+              id: 177
+              source: 0
+              number: 2
+              formula: n != 1
+              type: 1
+            aliases:
+              - en_en
+              - base
+              - source
+              - enp
+              - eng
+            direction: ltr
+            population: 1636485517
+            web_url: http://weblate.example.com/languages/en/
+            url: http://weblate.example.com/api/languages/en/
+            statistics_url: http://weblate.example.com/api/languages/en/statistics/
+          component:
+            name: test component
+            slug: test-component
+            id: 3
+            source_language:
+              id: 177
+              code: en
+              name: English
+              plural:
+                id: 177
+                source: 0
+                number: 2
+                formula: n != 1
+                type: 1
+              aliases:
+                - en_en
+                - base
+                - source
+                - enp
+                - eng
+              direction: ltr
+              population: 1636485517
+              web_url: http://weblate.example.com/languages/en/
+              url: http://weblate.example.com/api/languages/en/
+              statistics_url: http://weblate.example.com/api/languages/en/statistics/
+            project:
+              name: Test Project
+              slug: test-project
+              id: 2
+              web: https://example.com/testproject
+              web_url: http://weblate.example.com/projects/test-project/
+              url: http://weblate.example.com/api/projects/test-project/
+              components_list_url: http://weblate.example.com/api/projects/test-project/components/
+              repository_url: http://weblate.example.com/api/projects/test-project/repository/
+              statistics_url: http://weblate.example.com/api/projects/test-project/statistics/
+              categories_url: http://weblate.example.com/api/projects/test-project/categories/
+              changes_list_url: http://weblate.example.com/api/projects/test-project/changes/
+              languages_url: http://weblate.example.com/api/projects/test-project/languages/
+              labels_url: http://weblate.example.com/api/projects/test-project/labels/
+              credits_url: http://weblate.example.com/api/projects/test-project/credits/
+              translation_review: false
+              source_review: false
+              set_language_team: true
+              instructions: ""
+              enable_hooks: true
+              language_aliases: ""
+              enforced_2fa: false
+            vcs: git
+            repo: https://weblate.example.com/project.git
+            git_export: http://weblate.example.com/git/test-project/test-component/
+            branch: master
+            push_branch: ""
+            filemask: assets/voxygen/i18n/*/main.ftl
+            screenshot_filemask: ""
+            template: ""
+            edit_template: true
+            intermediate: ""
+            new_base: ""
+            file_format: fluent
+            license: ""
+            license_url: null
+            agreement: ""
+            web_url: http://weblate.example.com/projects/test-project/test-component/
+            url: http://weblate.example.com/api/components/test-project/test-component/
+            repository_url: http://weblate.example.com/api/components/test-project/test-component/repository/
+            translations_url: http://weblate.example.com/api/components/test-project/test-component/translations/
+            statistics_url: http://weblate.example.com/api/components/test-project/test-component/statistics/
+            lock_url: http://weblate.example.com/api/components/test-project/test-component/lock/
+            links_url: http://weblate.example.com/api/components/test-project/test-component/links/
+            changes_list_url: http://weblate.example.com/api/components/test-project/test-component/changes/
+            task_url: null
+            credits_url: http://weblate.example.com/api/components/test-project/test-component/credits/
+            new_lang: contact
+            language_code_style: ""
+            push: ""
+            check_flags: ""
+            priority: 100
+            enforced_checks: []
+            restricted: false
+            repoweb: ""
+            report_source_bugs: ""
+            merge_style: rebase
+            commit_message: "Translated using Weblate ({{ language_name }})\n\nCurrently translated at {{ stats.translated_percent }}% ({{ stats.translated }} of {{ stats.all }} strings)\n\nTranslation: {{ project_name }}/{{ component_name }}\nTranslate-URL: {{ url }}"
+            add_message: "Added translation using Weblate ({{ language_name }})\n\n"
+            delete_message: "Deleted translation using Weblate ({{ language_name }})\n\n"
+            merge_message: "Merge branch '{{ component_remote_branch }}' into Weblate.\n\n"
+            addon_message: "Update translation files\n\nUpdated by \"{{ addon_name }}\" add-on in Weblate.\n\nTranslation: {{ project_name }}/{{ component_name }}\nTranslate-URL: {{ url }}"
+            pull_message: "Translations update from {{ site_title }}\n\nTranslations update from [{{ site_title }}]({{ site_url }}) for [{{ project_name }}/{{ component_name }}]({{url}}).\n\n{% if component_linked_childs %}\nIt also includes following components:\n{% for linked in component_linked_childs %}\n* [{{ linked.project_name }}/{{ linked.name }}]({{ linked.url }})\n{% endfor %}\n{% endif %}\n\nCurrent translation status:\n\n![Weblate translation status]({{widget_url}})\n"
+            allow_translation_propagation: true
+            manage_units: false
+            enable_suggestions: true
+            suggestion_voting: false
+            suggestion_autoaccept: 0
+            push_on_commit: true
+            commit_pending_age: 24
+            auto_lock_error: true
+            language_regex: "^[^.]+$"
+            variant_regex: ""
+            addons: []
+            is_glossary: false
+            glossary_color: silver
+            category: null
+            linked_component: null
+          language_code: en
+          id: 63
+          filename: ""
+          revision: ""
+          web_url: http://weblate.example.com/projects/test-project/test-component/en/
+          share_url: http://weblate.example.com/engage/test-project/-/en/
+          translate_url: http://weblate.example.com/translate/test-project/test-component/en/
+          url: http://weblate.example.com/api/translations/test-project/test-component/en/
+          is_template: false
+          is_source: true
+          total: 68
+          total_words: 68
+          translated: 68
+          translated_words: 68
+          translated_percent: 100
+          fuzzy: 0
+          fuzzy_words: 0
+          fuzzy_percent: 0
+          failing_checks: 36
+          failing_checks_words: 36
+          failing_checks_percent: 52.9
+          have_suggestion: 0
+          have_comment: 0
+          last_change: "2024-09-19T18:48:47.104585Z"
+          last_author: null
+          repository_url: http://weblate.example.com/api/translations/test-project/test-component/en/repository/
+          file_url: http://weblate.example.com/api/translations/test-project/test-component/en/file/
+          statistics_url: http://weblate.example.com/api/translations/test-project/test-component/en/statistics/
+          changes_list_url: http://weblate.example.com/api/translations/test-project/test-component/en/changes/
+          units_list_url: http://weblate.example.com/api/translations/test-project/test-component/en/units/
+
+    TranslationStatistics:
+      $ref: 'statistics.yaml#/components/schemas/Statistics'
+
+    # Similar to the 'projects.yaml#/schemas/Repository' schema,
+    # but with additional fields
+    TranslationRepository:
+      type: object
+      properties:
+        needs_commit:
+          type: boolean
+        needs_merge:
+          type: boolean
+        needs_push:
+          type: boolean
+        url:
+          type: string
+          format: uri
+        remote_commit:
+          nullable: true
+        weblate_commit:
+          type: object
+          properties:
+            revision:
+              type: string
+            shortrevision:
+              type: 9d8a98d84
+            author:
+              type: string
+            author_name:
+              type: string
+            author_email:
+              type: string
+              format: email
+            authordate:
+              type: string
+              format: date-time
+            commit:
+              type: string
+            commit_name:
+              type: string
+            commit_email:
+              type: string
+              format: email
+            commitdate:
+              type: string
+              format: date-time
+            message:
+              type: string
+            summary:
+              type: string
+        status:
+          type: string
+        merge_failure:
+          nullable: true
+      examples:
+        TranslationRepository:
+          needs_commit: false
+          needs_merge: false
+          needs_push: false
+          url: http://weblate.example.com/api/translations/test-project/test-component/en/repository/
+          remote_commit: null
+          weblate_commit:
+            revision: 9d8a98d840dfe5a17c0627be4007139730ff5faf
+            shortrevision: 9d8a98d84
+            author: John Doe <johndoe@example.com>
+            author_name: johndoe
+            author_email: johndoe@example.com@gmail.com
+            authordate: "2024-09-18T08:02:16Z"
+            commit: johndoe <johndoe@example.com@gmail.com>
+            commit_name: johndoe
+            commit_email: johndoe@example.com@gmail.com
+            commitdate: "2024-09-18T08:02:16Z"
+            message: Merge branch 'weblate-translation' into 'master'\n\nUpdate translation files (Weblate)
+            summary: Merge branch 'weblate-translation' into 'master'
+          status: On branch master\nYour branch is up to date with 'origin/master'.\n\nnothing to commit, working tree clean\n
+          merge_failure: null
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            TranslationNotFound:
+              value:
+                detail: No Translation matches the given query.
+
+    Translation:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Translation'
+
+    TranslationRepository:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TranslationRepository'
+
+    TranslationStatistics:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TranslationStatistics'
+
+  parameters:
+    projectInPath:
+      $ref: 'projects.yaml#/components/parameters/projectInPath'
+
+    componentInPath:
+      $ref: 'components.yaml#/components/parameters/componentInPath'
+
+    languageInPath:
+      $ref: 'languages.yaml#/components/parameters/languageInPath'

--- a/docs/openapi/resources/units.yaml
+++ b/docs/openapi/resources/units.yaml
@@ -4,11 +4,11 @@ paths:
   /units/:
     get:
       tags:
-        - units
+      - units
       summary: Returns list of translation units
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -35,10 +35,10 @@ paths:
   /units/{id}/:
     get:
       tags:
-        - units
+      - units
       summary: Returns information about translation unit
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/Unit'
@@ -47,10 +47,10 @@ paths:
 
     put:
       tags:
-        - units
+      - units
       summary: Performs full update on translation unit
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUnit'
       responses:
@@ -61,14 +61,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - units
+      - units
       summary: Performs partial update on translation unit
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '200':
           $ref: '#/components/responses/OK'
@@ -77,14 +77,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - units
+      - units
       summary: Deletes a translation unit
       parameters:
-        - $ref: '#/components/parameters/idInPath'
+      - $ref: '#/components/parameters/idInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -93,7 +93,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 components:
   schemas:
@@ -205,15 +205,15 @@ components:
         Unit:
           translation: http://weblate.example.com/api/translations/test-project/test-component/en/
           source:
-            - main-username
-          previous_source: ""
+          - main-username
+          previous_source: ''
           target:
-            - main-username
+          - main-username
           id_hash: 6147199891469790000
           content_hash: 6147199891469790000
-          location: ""
-          context: ""
-          note: ""
+          location: ''
+          context: ''
+          note: ''
           flags: fluent-type:Message
           labels: []
           state: 100
@@ -230,23 +230,23 @@ components:
           id: 1427
           web_url: http://weblate.example.com/translate/test-project/test-component/en/?checksum=d54f3dbb66606bb6
           url: http://weblate.example.com/api/units/1427/
-          explanation: ""
-          extra_flags: ""
+          explanation: ''
+          extra_flags: ''
           pending: false
-          timestamp: "2024-09-19T18:48:44.563186Z"
-          last_updated: "2024-09-19T18:48:44.563198Z"
+          timestamp: '2024-09-19T18:48:44.563186Z'
+          last_updated: '2024-09-19T18:48:44.563198Z'
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     Created:
-      $ref: 'common.yaml#/components/responses/Created'
+      $ref: common.yaml#/components/responses/Created
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -271,7 +271,7 @@ components:
 
   parameters:
     idInPath:
-      $ref: 'common.yaml#/components/parameters/idInPath'
+      $ref: common.yaml#/components/parameters/idInPath
 
     unitIdInPath:
       name: unit_id
@@ -296,5 +296,5 @@ components:
                 items:
                   type: string
             required:
-              - target
-              - labels
+            - target
+            - labels

--- a/docs/openapi/resources/units.yaml
+++ b/docs/openapi/resources/units.yaml
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /units/:
+    get:
+      tags:
+        - units
+      summary: Returns list of translation units
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Unit'
+
+  /units/{id}/:
+    get:
+      tags:
+        - units
+      summary: Returns information about translation unit
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/Unit'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - units
+      summary: Performs full update on translation unit
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUnit'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - units
+      summary: Performs partial update on translation unit
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - units
+      summary: Deletes a translation unit
+      parameters:
+        - $ref: '#/components/parameters/idInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+components:
+  schemas:
+    Unit:
+      type: object
+      properties:
+        translation:
+          type: string
+          format: uri
+          description: URL of a related translation object.
+        source:
+          type: array
+          items:
+            type: string
+          description: Source string.
+        previous_source:
+          type: string
+        target:
+          type: array
+          items:
+            type: string
+          description: Target string.
+        id_hash:
+          type: integer
+          description: Unique identifier of the unit.
+        content_hash:
+          type: integer
+          description: Unique identifier of the source string.
+        location:
+          type: string
+          description: Location of the unit in source code.
+        context:
+          type: string
+          description: Translation unit context.
+        note:
+          type: string
+          description: Translation unit note.
+        flags:
+          type: string
+          description: Translation unit flags.
+        labels:
+          type: array
+          items:
+            type: string
+          description: Translation unit labels, available on source units.
+        state:
+          type: integer
+          description: Unit state, 0 - untranslated, 10 - needs editing, 20 - translated, 30 - approved, 100 - read only
+          enum: [0, 10, 20, 30, 100]
+        fuzzy:
+          type: boolean
+          description: Whether the unit is fuzzy or marked for review.
+        translated:
+          type: boolean
+          description: Whether the unit is translated.
+        approved:
+          type: boolean
+          description: Whether the translation is approved.
+        position:
+          type: integer
+          description: Unit position in translation file.
+        has_suggestion:
+          type: boolean
+          description: Whether the unit has suggestions.
+        has_comment:
+          type: boolean
+          description: Whether the unit has comments.
+        has_failing_check:
+          type: boolean
+          description: Whether the unit has failing checks.
+        num_words:
+          type: integer
+          description: Number of source words.
+        source_unit:
+          type: string
+          description: Source unit link.
+        priority:
+          type: integer
+          default: 100
+          description: Translation priority; 100 is default.
+        id:
+          type: integer
+          description: Unit identifier.
+        web_url:
+          type: string
+          format: uri
+          description: URL where the unit can be edited.
+        url:
+          type: string
+          format: uri
+        explanation:
+          type: string
+          description: String explanation, available on source units.
+        extra_flags:
+          type: string
+          description: Additional string flags, available on source units.
+        pending:
+          type: boolean
+          description: Whether the unit is pending for write.
+        timestamp:
+          type: string
+          format: date-time
+          description: String age.
+        last_updated:
+          type: string
+          format: date-time
+          description: Last string update.
+      examples:
+        Unit:
+          translation: http://weblate.example.com/api/translations/test-project/test-component/en/
+          source:
+            - main-username
+          previous_source: ""
+          target:
+            - main-username
+          id_hash: 6147199891469790000
+          content_hash: 6147199891469790000
+          location: ""
+          context: ""
+          note: ""
+          flags: fluent-type:Message
+          labels: []
+          state: 100
+          fuzzy: false
+          translated: true
+          approved: false
+          position: 1
+          has_suggestion: false
+          has_comment: false
+          has_failing_check: false
+          num_words: 1
+          source_unit: http://weblate.example.com/api/units/1427/
+          priority: 100
+          id: 1427
+          web_url: http://weblate.example.com/translate/test-project/test-component/en/?checksum=d54f3dbb66606bb6
+          url: http://weblate.example.com/api/units/1427/
+          explanation: ""
+          extra_flags: ""
+          pending: false
+          timestamp: "2024-09-19T18:48:44.563186Z"
+          last_updated: "2024-09-19T18:48:44.563198Z"
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    Created:
+      $ref: 'common.yaml#/components/responses/Created'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            UnitNotFound:
+              value:
+                detail: No Unit matches the given query.
+
+    Unit:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Unit'
+
+  parameters:
+    idInPath:
+      $ref: 'common.yaml#/components/parameters/idInPath'
+
+    unitIdInPath:
+      name: unit_id
+      in: path
+      schema:
+        type: integer
+      required: true
+
+  requestBodies:
+    UpdateUnit:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              target:
+                type: array
+                items:
+                  type: string
+              labels:
+                type: array
+                items:
+                  type: string
+            required:
+              - target
+              - labels

--- a/docs/openapi/resources/users.yaml
+++ b/docs/openapi/resources/users.yaml
@@ -1,0 +1,627 @@
+# SPDX-FileCopyrightText: 2024 Javier Pérez <68171111+walpox@users.noreply.github.com>
+
+paths:
+  /users/:
+    get:
+      tags:
+        - users
+      description: Returns a list of users if you have permission to manage users. If not, then you get to see limited details about user accounts.
+      parameters:
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      oneOf:
+                        - $ref: '#/components/schemas/User'
+                        - $ref: '#/components/schemas/UserSimple'
+
+    post:
+      tags:
+        - users
+      summary: Creates a new user
+      requestBody:
+        $ref: '#/components/requestBodies/CreateUser'
+      responses:
+        '201':
+          $ref: '#/components/responses/UserCreated'
+        '400':
+          $ref: '#/components/responses/UserAlreadyExists'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - TokenAuth: []
+
+  /users/{username}/:
+    get:
+      tags:
+        - users
+      summary: Returns information about users
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - users
+      summary: Changes the user parameters
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUser'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - users
+      summary: Changes the user parameters
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUser'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserUpdated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - users
+      summary: Deletes all user information and marks the user inactive
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /users/{username}/groups/:
+    post:
+      tags:
+        - users
+      summary: Associate groups with a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUserGroup'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - users
+      summary: Remove user from a group
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUserGroup'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /users/{username}/statistics/:
+    get:
+      tags:
+        - users
+        - statistics
+      summary: List statistics of a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserStatistics'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /users/{username}/notifications/:
+    get:
+      tags:
+        - users
+      summary: List subscriptions of a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+        - $ref: 'common.yaml#/components/parameters/pageInQuery'
+        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UserNotification'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+        - users
+      summary: Associate subscriptions with a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUserNotification'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserNotification'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+  /users/{username}/notifications/{subscription_id}/:
+    get:
+      tags:
+        - users
+      summary: Get a subscription associated with a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+        - $ref: '#/components/parameters/subscriptionIdInPath'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserNotification'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      tags:
+        - users
+      summary: Edit a subscription associated with a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+        - $ref: '#/components/parameters/subscriptionIdInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUserNotification'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserNotification'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/NoManageUsers'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    patch:
+      tags:
+        - users
+      summary: Edit a subscription associated with a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+        - $ref: '#/components/parameters/subscriptionIdInPath'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateUserNotification'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserNotification'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/NoManageUsers'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+    delete:
+      tags:
+        - users
+      summary: Delete a subscription associated with a user
+      parameters:
+        - $ref: '#/components/parameters/usernameInPath'
+        - $ref: '#/components/parameters/subscriptionIdInPath'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/NoManageUsers'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - TokenAuth: []
+
+
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+          format: email
+          nullable: true
+        full_name:
+          type: string
+        username:
+          type: string
+        groups:
+          type: array
+          items:
+            type: string
+            format: uri
+        notifications:
+          type: string
+          format: uri
+        is_superuser:
+          type: boolean
+          default: false
+        is_active:
+          type: boolean
+          default: true
+        is_bot:
+          type: boolean
+          default: false
+        date_joined:
+          type: string
+          format: date-time
+        last_login:
+          type: string
+          format: date-time
+          nullable: true
+        url:
+          type: string
+          format: uri
+        statistics_url:
+          type: string
+          format: uri
+      example:
+        id: 1
+        email: noreply@weblate.example.com
+        full_name: Anonymous
+        username: anonymous
+        groups:
+          - http://weblate.example.com/api/groups/2/
+          - http://weblate.example.com/api/groups/1/
+        notifications: http://weblate.example.com/api/users/anonymous/notifications/
+        is_superuser: false
+        is_active: false
+        is_bot: false
+        date_joined: "2024-09-17T10:09:10.262130Z"
+        last_login: null
+        url: http://weblate.example.com/api/users/anonymous/
+        statistics_url: http://weblate.example.com/api/users/anonymous/statistics/
+
+    UserSimple:
+      type: object
+      description: If you don't have permissions to see manage users, you can only see limited details about users.
+      properties:
+        id:
+          type: integer
+        full_name:
+          type: string
+        username:
+          type: string
+      example:
+        id: 1
+        full_name: Anonymous
+        username: anonymous
+
+    UserStatistics:
+      type: object
+      properties:
+        translated:
+          type: integer
+          description: Number of translations by user.
+        suggested:
+          type: integer
+          description: Number of suggestions by user.
+        uploaded:
+          type: integer
+          description: Number of uploads by user.
+        commented:
+          type: integer
+          description: Number of comments by user.
+        languages:
+          type: integer
+          description: Number of languages user can translate.
+
+    UserNotification:
+      type: object
+      properties:
+        notification:
+          type: string
+          description: Name of notification registered.
+        id:
+          type: integer
+        scope:
+          type: integer
+          description: Scope of notification from the available choices.
+        frequency:
+          type: string
+          description: Frequency choices for notifications.
+        project:
+          type: string
+          format: uri
+          nullable: true
+        component:
+          type: string
+          format: uri
+          nullable: true
+
+  responses:
+    OK:
+      $ref: 'common.yaml#/components/responses/OK'
+
+    NoContent:
+      $ref: 'common.yaml#/components/responses/NoContent'
+
+    BadRequest:
+      $ref: 'common.yaml#/components/responses/BadRequest'
+
+    Unauthorized:
+      $ref: 'common.yaml#/components/responses/Unauthorized'
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          examples:
+            UserNotFound:
+              value:
+                detail: No User matches the given query.
+            UserSubscriptionNotFound:
+              value:
+                detail: Subscription matching query does not exist.
+
+    NoManageUsers:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+          example:
+            detail: Can not manage Users
+
+    User:
+      description: OK
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/User'
+              - $ref: '#/components/schemas/UserSimple'
+
+    UserCreated:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/User'
+
+    UserUpdated:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/User'
+
+    UserAlreadyExists:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              username:
+                type: string
+          example:
+            username: A user with that username already exists.
+
+    UserNotification:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UserNotification'
+
+  parameters:
+    usernameInPath:
+      name: username
+      in: path
+      required: true
+      schema:
+        type: string
+
+    userIdInPath:
+      name: user_id
+      in: path
+      required: true
+      schema:
+        type: integer
+
+    subscriptionIdInPath:
+      name: subscription_id
+      in: path
+      required: true
+      schema:
+        type: integer
+
+  requestBodies:
+    CreateUser:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              username:
+                type: string
+              full_name:
+                type: string
+              email:
+                type: string
+                format: email
+                default: null
+              is_superuser:
+                type: boolean
+                default: false
+              is_active:
+                type: boolean
+                default: true
+              is_bot:
+                type: boolean
+                default: false
+              date_joined:
+                  type: string
+                  format: date-time
+              last_login:
+                type: string
+                format: date-time
+            required:
+              - full_name
+              - username
+      required: true
+
+    UpdateUser:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              username:
+                type: string
+              full_name:
+                type: string
+              email:
+                type: string
+                format: email
+              is_superuser:
+                type: boolean
+              is_active:
+                type: boolean
+              is_bot:
+                type: boolean
+              date_joined:
+                type: string
+                format: date-time
+              last_login:
+                type: string
+                format: date-time
+            required:
+              - full_name
+              - username
+      required: true
+
+    UpdateUserGroup:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              group_id:
+                type: integer
+            required:
+              - group_id
+      required: true
+
+    UpdateUserNotification:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              notification:
+                type: string
+              scope:
+                type: integer
+              frequency:
+                type: integer
+            required:
+              - notification
+              - scope
+              - frequency
+      required: true

--- a/docs/openapi/resources/users.yaml
+++ b/docs/openapi/resources/users.yaml
@@ -4,11 +4,11 @@ paths:
   /users/:
     get:
       tags:
-        - users
+      - users
       description: Returns a list of users if you have permission to manage users. If not, then you get to see limited details about user accounts.
       parameters:
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -31,12 +31,12 @@ paths:
                     type: array
                     items:
                       oneOf:
-                        - $ref: '#/components/schemas/User'
-                        - $ref: '#/components/schemas/UserSimple'
+                      - $ref: '#/components/schemas/User'
+                      - $ref: '#/components/schemas/UserSimple'
 
     post:
       tags:
-        - users
+      - users
       summary: Creates a new user
       requestBody:
         $ref: '#/components/requestBodies/CreateUser'
@@ -48,15 +48,15 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /users/{username}/:
     get:
       tags:
-        - users
+      - users
       summary: Returns information about users
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       responses:
         '200':
           $ref: '#/components/responses/User'
@@ -65,10 +65,10 @@ paths:
 
     put:
       tags:
-        - users
+      - users
       summary: Changes the user parameters
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUser'
       responses:
@@ -79,14 +79,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - users
+      - users
       summary: Changes the user parameters
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUser'
       responses:
@@ -97,14 +97,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - users
+      - users
       summary: Deletes all user information and marks the user inactive
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -113,15 +113,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /users/{username}/groups/:
     post:
       tags:
-        - users
+      - users
       summary: Associate groups with a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUserGroup'
       responses:
@@ -134,14 +134,14 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - users
+      - users
       summary: Remove user from a group
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUserGroup'
       responses:
@@ -154,16 +154,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /users/{username}/statistics/:
     get:
       tags:
-        - users
-        - statistics
+      - users
+      - statistics
       summary: List statistics of a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       responses:
         '200':
           description: OK
@@ -177,12 +177,12 @@ paths:
   /users/{username}/notifications/:
     get:
       tags:
-        - users
+      - users
       summary: List subscriptions of a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
-        - $ref: 'common.yaml#/components/parameters/pageInQuery'
-        - $ref: 'common.yaml#/components/parameters/pageSizeInQuery'
+      - $ref: '#/components/parameters/usernameInPath'
+      - $ref: common.yaml#/components/parameters/pageInQuery
+      - $ref: common.yaml#/components/parameters/pageSizeInQuery
       responses:
         '200':
           description: OK
@@ -210,10 +210,10 @@ paths:
 
     post:
       tags:
-        - users
+      - users
       summary: Associate subscriptions with a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/usernameInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUserNotification'
       responses:
@@ -228,16 +228,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
   /users/{username}/notifications/{subscription_id}/:
     get:
       tags:
-        - users
+      - users
       summary: Get a subscription associated with a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
-        - $ref: '#/components/parameters/subscriptionIdInPath'
+      - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/subscriptionIdInPath'
       responses:
         '200':
           $ref: '#/components/responses/UserNotification'
@@ -246,11 +246,11 @@ paths:
 
     put:
       tags:
-        - users
+      - users
       summary: Edit a subscription associated with a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
-        - $ref: '#/components/parameters/subscriptionIdInPath'
+      - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/subscriptionIdInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUserNotification'
       responses:
@@ -263,15 +263,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     patch:
       tags:
-        - users
+      - users
       summary: Edit a subscription associated with a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
-        - $ref: '#/components/parameters/subscriptionIdInPath'
+      - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/subscriptionIdInPath'
       requestBody:
         $ref: '#/components/requestBodies/UpdateUserNotification'
       responses:
@@ -284,15 +284,15 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
     delete:
       tags:
-        - users
+      - users
       summary: Delete a subscription associated with a user
       parameters:
-        - $ref: '#/components/parameters/usernameInPath'
-        - $ref: '#/components/parameters/subscriptionIdInPath'
+      - $ref: '#/components/parameters/usernameInPath'
+      - $ref: '#/components/parameters/subscriptionIdInPath'
       responses:
         '204':
           $ref: '#/components/responses/NoContent'
@@ -303,7 +303,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security:
-        - TokenAuth: []
+      - TokenAuth: []
 
 
 components:
@@ -357,14 +357,14 @@ components:
         full_name: Anonymous
         username: anonymous
         groups:
-          - http://weblate.example.com/api/groups/2/
-          - http://weblate.example.com/api/groups/1/
+        - http://weblate.example.com/api/groups/2/
+        - http://weblate.example.com/api/groups/1/
         notifications: http://weblate.example.com/api/users/anonymous/notifications/
         is_superuser: false
         is_active: false
         is_bot: false
-        date_joined: "2024-09-17T10:09:10.262130Z"
-        last_login: null
+        date_joined: '2024-09-17T10:09:10.262130Z'
+        last_login:
         url: http://weblate.example.com/api/users/anonymous/
         statistics_url: http://weblate.example.com/api/users/anonymous/statistics/
 
@@ -427,16 +427,16 @@ components:
 
   responses:
     OK:
-      $ref: 'common.yaml#/components/responses/OK'
+      $ref: common.yaml#/components/responses/OK
 
     NoContent:
-      $ref: 'common.yaml#/components/responses/NoContent'
+      $ref: common.yaml#/components/responses/NoContent
 
     BadRequest:
-      $ref: 'common.yaml#/components/responses/BadRequest'
+      $ref: common.yaml#/components/responses/BadRequest
 
     Unauthorized:
-      $ref: 'common.yaml#/components/responses/Unauthorized'
+      $ref: common.yaml#/components/responses/Unauthorized
 
     NotFound:
       description: Not Found
@@ -473,8 +473,8 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: '#/components/schemas/User'
-              - $ref: '#/components/schemas/UserSimple'
+            - $ref: '#/components/schemas/User'
+            - $ref: '#/components/schemas/UserSimple'
 
     UserCreated:
       description: Created
@@ -545,7 +545,7 @@ components:
               email:
                 type: string
                 format: email
-                default: null
+                default:
               is_superuser:
                 type: boolean
                 default: false
@@ -556,14 +556,14 @@ components:
                 type: boolean
                 default: false
               date_joined:
-                  type: string
-                  format: date-time
+                type: string
+                format: date-time
               last_login:
                 type: string
                 format: date-time
             required:
-              - full_name
-              - username
+            - full_name
+            - username
       required: true
 
     UpdateUser:
@@ -592,8 +592,8 @@ components:
                 type: string
                 format: date-time
             required:
-              - full_name
-              - username
+            - full_name
+            - username
       required: true
 
     UpdateUserGroup:
@@ -605,7 +605,7 @@ components:
               group_id:
                 type: integer
             required:
-              - group_id
+            - group_id
       required: true
 
     UpdateUserNotification:
@@ -621,7 +621,7 @@ components:
               frequency:
                 type: integer
             required:
-              - notification
-              - scope
-              - frequency
+            - notification
+            - scope
+            - frequency
       required: true


### PR DESCRIPTION
# Changelog

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

## Added

  - OpenAPI document describing the Weblate REST API.

---

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

It closes #12584 .

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [X] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->

I tried to use a tool called `drf-spectacular` to generate the OpenAPI document automatically from Weblate's source code, but it didn't work for me at all, so I decided to do it manually with information gathered from testing (with Weblate v5.7.2 instances) and from what is already written in [the API documentation](https://docs.weblate.org/en/weblate-5.7.2/api.html).

 The OpenAPI document shows fine in my local Swagger UI installation, as shown in the screenshot in the linked issue.

**I don't think the PR is ready yet. The OpenAPI document is missing:**

- Response bodies operations such as POST, PUT and PATCH. In the operations where the body is present, it usually has only the mandatory properties documented, excluding the optional properties you can set for a resource.
- A few `#TODO`s in the documents.
- Some response codes for operations are missing the appropriate response from the server and are using generic response template instead.

I'm happy to discuss further changes to do here.
