### PR TITLE
Adjust daterange defaults

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1423,11 +1423,8 @@ $(function () {
     {
       autoApply: false,
       autoUpdateInput: false,
-      startDate:
-        $("input[name='period']#id_period").attr("data-start-date") ||
-        moment().subtract(1, "months"),
-      endDate:
-        $("input[name='period']#id_period").attr("data-end-date") || moment(),
+      startDate: $("input[name='period']#id_period").attr("data-start-date"),
+      endDate: $("input[name='period']#id_period").attr("data-end-date"),
       alwaysShowCalendars: true,
       cancelButtonClasses: "btn-warning",
       opens: "left",
@@ -1486,6 +1483,12 @@ $(function () {
     },
     (start, end, label) => {},
   );
+
+  $("input[name='period']").on("apply.daterangepicker", function (ev, picker) {
+    $(this).val(
+      `${picker.startDate.format("MM/DD/YYYY")} - ${picker.endDate.format("MM/DD/YYYY")}`,
+    );
+  });
 
   $("input[name='period']").on("cancel.daterangepicker", (_ev, picker) => {
     picker.element.val("");

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1422,8 +1422,10 @@ $(function () {
   $("input[name='period']").daterangepicker(
     {
       autoApply: false,
+      autoUpdateInput: false,
       startDate:
-        $("input[name='period']#id_period").attr("data-start-date") || moment(),
+        $("input[name='period']#id_period").attr("data-start-date") ||
+        moment().subtract(1, "months"),
       endDate:
         $("input[name='period']#id_period").attr("data-end-date") || moment(),
       alwaysShowCalendars: true,


### PR DESCRIPTION
## Proposed changes

This will adjust the initial values of the daterangepicker to blank.
This solves issue #12558.

Example image:

![Screenshot 2024-09-27 at 06-55-14 Changes @ Devel Weblate](https://github.com/user-attachments/assets/7425b9f4-f635-4781-a02b-bc07ccd17693)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

