### PR TITLE
Add separate dark theme color settings

### DIFF
--- a/weblate/accounts/templatetags/custom_filters.py
+++ b/weblate/accounts/templatetags/custom_filters.py
@@ -1,0 +1,13 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def split(value, key):
+    """Split the string by the given key."""
+    return value.split(key)

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2114,3 +2114,7 @@ tbody.warning {
 .daterangepicker {
   border: var(--border) !important;
 }
+
+#appearance-settings input[type="color"] {
+  width: 50%;
+}

--- a/weblate/templates/configuration/custom.css
+++ b/weblate/templates/configuration/custom.css
@@ -1,53 +1,80 @@
+{% load custom_filters %}
+
+{% with header_color_split=header_color|split:"," %}
+{% with header_text_color_split=header_text_color|split:"," %}
+{% with navi_color_split=navi_color|split:"," %}
+{% with nav_text_color_split=navi_text_color|split:"," %}
+{% with focus_color_split=focus_color|split:"," %}
+{% with hover_color_split=hover_color|split:"," %}
+
+body {
+  --header-color: {{ header_color_split.0 }};
+  --header-text-color: {{ header_text_color_split.0 }};
+  --navi-color: {{ navi_color_split.0 }};
+  --navi-text-color: {{ nav_text_color_split.0 }};
+  --focus-color: {{ focus_color_split.0 }};
+  --hover-color: {{ hover_color_split.0 }};
+}
+
+body[data-theme="dark"] {
+  --header-color: {{ header_color_split.1 }};
+  --header-text-color: {{ header_text_color_split.1 }};
+  --navi-color: {{ navi_color_split.1 }};
+  --navi-text-color: {{ nav_text_color_split.1 }};
+  --focus-color: {{ focus_color_split.1 }};
+  --hover-color: {{ hover_color_split.1 }};
+}
+
 {% if header_color %}
   .navbar-inverse {
-    background-color: {{ header_color }};
+    background-color: var(--header-color);
   }
 {% endif %}
 {% if header_text_color %}
 .navbar-inverse .navbar-brand,
 .navbar-inverse .navbar-nav > li > a {
-  color: {{ header_text_color }};
+  color: var(--header-text-color);
 }
 .navbar a path {
-  fill: {{ navi_text_color }};
+  fill: var(--navi-text-color);
 }
 {% endif %}
 {% if navi_color %}
   .sort-cell:hover {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .nav-pills > li > a,
   .btn-default {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .btn-link:hover path {
-    fill: {{ navi_color }};
+    fill: var(--navi-color);
   }
 
   .green path,
   .btn-default path {
-    fill: {{ navi_color }};
+    fill: var(--navi-color);
   }
   .btn-group-settings a:hover {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .format-item span {
-    background-color: {{ navi_color }};
+    background-color: var(--navi-color);
   }
   a {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .btn-info {
-    color: {{ navi_color }};
+    color: var(--navi-color);};
   }
   .btn-info:focus,
   .btn-info.focus {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .btn-info:active,
   .btn-info.active,
   .open > .dropdown-toggle.btn-info {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .btn-info:active:hover,
   .btn-info.active:hover,
@@ -58,46 +85,46 @@
   .btn-info:active.focus,
   .btn-info.active.focus,
   .open > .dropdown-toggle.btn-info.focus {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .btn-link {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   .nav .open > a,
   .nav .open > a:hover,
   .nav .open > a:focus {
-    border-color: {{ navi_color }};
+    border-color: var(--navi-color);
   }
   .navbar-inverse .navbar-nav > .active > a,
   .navbar-inverse .navbar-nav > .active > a:hover,
   .navbar-inverse .navbar-nav > .active > a:focus {
-    background-color: {{ navi_color }};
+    background-color: var(--navi-color);
   }
   .navbar-inverse .navbar-nav > .open > a,
   .navbar-inverse .navbar-nav > .open > a:hover,
   .navbar-inverse .navbar-nav > .open > a:focus {
-    background-color: {{ navi_color }};
+    background-color: var(--navi-color);
   }
   @media (max-width: 767px) {
     .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a,
     .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover,
     .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
-      background-color: {{ navi_color }};
+      background-color: var(--navi-color);
     }
   }
   .pagination > li > a,
   .pagination > li > span {
-    color: {{ navi_color }};
+    color: var(--navi-color);
   }
   a.thumbnail:hover,
   a.thumbnail:focus,
   a.thumbnail.active {
-    border-color: {{ navi_color }};
+    border-color: var(--navi-color);
   }
 {% endif %}
 {% if focus_color %}
   .btn-info {
-    border-color: {{ focus_color }};
+    border-color: var(--focus-color);
   }
   .btn-info.disabled:hover,
   .btn-info[disabled]:hover,
@@ -108,10 +135,10 @@
   .btn-info.disabled.focus,
   .btn-info[disabled].focus,
   fieldset[disabled] .btn-info.focus {
-    border-color: {{ focus_color }};
+    border-color: var(--focus-color);
   }
   .btn-warning {
-    background-color: {{ focus_color }};
+    background-color: var(--focus-color);
   }
   .btn-warning.disabled:hover,
   .btn-warning[disabled]:hover,
@@ -122,80 +149,80 @@
   .btn-warning.disabled.focus,
   .btn-warning[disabled].focus,
   fieldset[disabled] .btn-warning.focus {
-    background-color: {{ focus_color }};
+    background-color: var(--focus-color);
   }
   .btn-warning .badge {
-    color: {{ focus_color }};
+    color: var(--focus-color);
   }
   .navbar-inverse .navbar-brand:hover,
   .navbar-inverse .navbar-brand:focus {
-    color: {{ focus_color }};
+    color: var(--focus-color);
   }
   .navbar-inverse .navbar-nav > li > a:hover,
   .navbar-inverse .navbar-nav > li > a:focus {
-    color: {{ focus_color }};
+    color: var(--focus-color);
   }
   @media (max-width: 767px) {
     .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
     .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
-      color: {{ focus_color }};
+      color: var(--focus-color);
     }
   }
   .navbar-inverse .navbar-link:hover {
-    color: {{ focus_color }};
+    color: var(--focus-color);
   }
   .navbar-inverse .btn-link:hover,
   .navbar-inverse .btn-link:focus {
-    color: {{ focus_color }};
+    color: var(--focus-color);
   }
 
   .btn-info {
-    border: 1px solid {{ focus_color }};
+    border: 1px solid var(--focus-color);
   }
   .navbar .navbar-brand:focus path,
   .navbar .navbar-brand:active path,
   .navbar a:hover path {
-    fill: {{ focus_color }};
+    fill: var(--focus-color);
   }
   .btn-primary:hover {
-    background-color: {{ focus_color }};
+    background-color: var(--focus-color);
   }
 
   .btn-info:hover {
-    background-color: {{ focus_color }};
+    background-color: var(--focus-color);
   }
 {% endif %}
 
 {% if hover_color %}
   a:hover,
   a:focus {
-    color: {{ hover_color }};
+    color: var(--hover-color);
   }
   .text-primary {
-    color: {{ hover_color }};
+    color: var(--hover-color);
   }
   .bg-primary {
-    background-color: {{ hover_color }};
+    background-color: var(--hover-color);
   }
   .btn-link:hover,
   .btn-link:focus {
-    color: {{ hover_color }};
+    color: var(--hover-color);
   }
   .dropdown-menu > .active > a,
   .dropdown-menu > .active > a:hover,
   .dropdown-menu > .active > a:focus {
-    background-color: {{ hover_color }};
+    background-color: var(--hover-color);
   }
   .nav-pills > li.active > a,
   .nav-pills > li.active > a:hover,
   .nav-pills > li.active > a:focus {
-    background-color: {{ hover_color }};
+    background-color: var(--hover-color);
   }
   .pagination > li > a:hover,
   .pagination > li > span:hover,
   .pagination > li > a:focus,
   .pagination > li > span:focus {
-    color: {{ hover_color }};
+    color: var(--hover-color);
   }
   .pagination > .active > a,
   .pagination > .active > span,
@@ -203,18 +230,18 @@
   .pagination > .active > span:hover,
   .pagination > .active > a:focus,
   .pagination > .active > span:focus {
-    background-color: {{ hover_color }};
-    border-color: {{ hover_color }};
+    background-color: var(--hover-color);
+    border-color: var(--hover-color);
   }
   .list-group-item.active,
   .list-group-item.active:hover,
   .list-group-item.active:focus {
-    background-color: {{ hover_color }};
-    border-color: {{ hover_color }};
+    background-color: var(--hover-color);
+    border-color: var(--hover-color);
   }
   .nav-pills > .active > a,
   .nav > .active > a:hover {
-    border: 1px solid {{ hover_color }};
+    border: 1px solid var(--hover-color);
   }
   .btn-default:hover,
   .nav-pills > li > a:hover,
@@ -222,18 +249,18 @@
   .nav-pills .open > a,
   .nav-pills .open > a:hover,
   .nav-pills .open > a:focus {
-    color: {{ hover_color }};
+    color: var(--hover-color);
   }
   .btn-default:hover path,
   .green.btn-link:hover path {
-    fill: {{ hover_color }};
+    fill: var(--hover-color);
   }
   .format-item {
-    background-color: {{ hover_color }};
+    background-color: var(--hover-color);
   }
   .nav-pills > .active > a,
   .nav > .active > a:hover {
-    border: 1px solid {{ hover_color }};
+    border: 1px solid var(--hover-color);
   }
   .btn-default:hover,
   .nav-pills > li > a:hover,
@@ -241,10 +268,9 @@
   .nav-pills .open > a,
   .nav-pills .open > a:hover,
   .nav-pills .open > a:focus {
-    color: {{ hover_color }};
+    color: var(--hover-color);
   }
 {% endif %}
-
 
 {% if enforce_hamburger %}
   {% comment %}From https://stackoverflow.com/a/56229201/225718{% endcomment %}
@@ -329,7 +355,7 @@
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
     {% if focus_color %}
-      color: {{ focus_color }};
+      color: var(--focus-color);
     {% else %}
       color: #2eccaa;
     {% endif %}
@@ -340,7 +366,7 @@
   .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #ffffff;
     {% if navi_color %}
-      background-color: {{ navi_color }};
+      background-color: var(--navi-color);
     {% else %}
       background-color: #1fa385;
     {% endif %}
@@ -369,3 +395,9 @@
     font-family: {{ brand_font }};
   }
 {% endif %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}

--- a/weblate/templates/manage/appearance.html
+++ b/weblate/templates/manage/appearance.html
@@ -16,7 +16,7 @@
 {% csrf_token %}
 <div class="panel panel-default">
 <div class="panel-heading"><h4 class="panel-title">{% trans "Customize appearance" %}</h4></div>
-  <div class="panel-body">
+  <div class="panel-body" id="appearance-settings">
   {% crispy form %}
   </div>
   <div class="panel-footer">

--- a/weblate/wladmin/forms.py
+++ b/weblate/wladmin/forms.py
@@ -4,6 +4,7 @@
 
 from crispy_forms.helper import FormHelper
 from django import forms
+from django.forms.widgets import MultiWidget
 from django.utils.translation import gettext_lazy
 
 from weblate.accounts.forms import EmailField
@@ -59,29 +60,52 @@ class FontField(forms.CharField):
         )
 
 
-class ColorField(forms.CharField):
-    def __init__(self, **kwargs) -> None:
-        super().__init__(widget=forms.TextInput(attrs={"type": "color"}), **kwargs)
+class ThemeColorWidget(MultiWidget):
+    def __init__(self, attrs=None):
+        widgets = (
+            forms.TextInput(attrs={"type": "color", "class": "light-theme"}),
+            forms.TextInput(attrs={"type": "color", "class": "dark-theme"}),
+        )
+        super().__init__(widgets, attrs)
+
+    def decompress(self, value):
+        if value:
+            return value.split(",")
+        return [None, None]
+
+
+class ThemeColorField(forms.MultiValueField):
+    widget = ThemeColorWidget
+
+    def __init__(self, **kwargs):
+        fields = (forms.CharField(required=False), forms.CharField(required=False))
+        super().__init__(fields=fields, require_all_fields=False, **kwargs)
+
+    def compress(self, data_list):
+        return ",".join(data_list) if data_list else None
 
 
 class AppearanceForm(forms.Form):
     page_font = FontField(label=gettext_lazy("Page font"), required=False)
     brand_font = FontField(label=gettext_lazy("Header font"), required=False)
-    header_color = ColorField(
-        label=("Navigation color"), required=False, initial="#2a3744"
+
+    header_color = ThemeColorField(
+        label=gettext_lazy("Navigation color (Light, Dark)"), initial="#2a3744,#1a2634"
     )
-    header_text_color = ColorField(
-        label=("Navigation text color"), required=False, initial="#bfc3c7"
+    header_text_color = ThemeColorField(
+        label=gettext_lazy("Navigation text color (Light, Dark)"),
+        initial="#bfc3c7,#e0e3e7",
     )
-    navi_color = ColorField(
-        label=("Navigation color"), required=False, initial="#1fa385"
+    navi_color = ThemeColorField(
+        label=gettext_lazy("Navigation color (Light, Dark)"), initial="#1fa385,#0f9375"
     )
-    focus_color = ColorField(
-        label=gettext_lazy("Focus color"), required=False, initial="#2eccaa"
+    focus_color = ThemeColorField(
+        label=gettext_lazy("Focus color (Light, Dark)"), initial="#2eccaa,#1ebc9a"
     )
-    hover_color = ColorField(
-        label=gettext_lazy("Hover color"), required=False, initial="#144d3f"
+    hover_color = ThemeColorField(
+        label=gettext_lazy("Hover color (Light, Dark)"), initial="#144d3f,#0a3d2f"
     )
+
     hide_footer = forms.BooleanField(
         label=gettext_lazy("Hide page footer"), required=False
     )


### PR DESCRIPTION

## Proposed changes

- Modifed the form to have two color fields (one for dark and one for light theme).
- The colors are stored  in this form"#ffffff,#000000". Where the first one is for light theme and the other for dark theme.
- Then the custom.css consumes the values and performs a split(defined in custom_filters.py) on the color string to get the two colors.
- Those colors then are defined in css variables and consumed by the elements that need them.
- The css variables change base on the current theme (for dark values to be applied it is expected that the body tag has `data-theme="dark"`)

Closes: #9372 

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
### Preview
#### Dark theme selected + (manually added data-theme="dark" to the body tag, I will add it later in the second commit)
![Screenshot 2024-09-27 125432](https://github.com/user-attachments/assets/c3197e2d-fa8c-48fe-9043-4e4f187585c8)
#### Light theme selected
![Screenshot 2024-09-27 125537](https://github.com/user-attachments/assets/991eeef3-6d6b-4e0f-a003-9b9af19c8558)

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
