### PR TITLE
feat(ci): separate linkcheck to standalone workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-name: Docs
+name: Documentation
 
 on:
   push:
@@ -44,38 +44,3 @@ jobs:
       with:
         name: Documentation
         path: docs/_build/html
-
-  linkcheck:
-    runs-on: ubuntu-24.04
-    name: Linkcheck
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-    - uses: astral-sh/setup-uv@v3
-    - name: Install apt dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y graphviz
-    - name: Install Python dependencies
-      run: |
-        uv pip install --system -r docs/requirements.txt
-    - name: Sphinx linkcheck
-      run: |
-        ./ci/run-docs linkcheck
-    - name: Sphinx linkcheck collect
-      if: always()
-      run: |
-        echo "::add-matcher::.github/matchers/sphinx-linkcheck.json"
-        echo "::add-matcher::.github/matchers/sphinx-linkcheck-warn.json"
-        sed 's@^@docs/@' docs/_build/linkcheck/output.txt
-        echo "::remove-matcher owner=sphinx::"
-        echo "::remove-matcher owner=sphinx-warn::"
-    - uses: actions/upload-artifact@v4.4.0
-      if: always()
-      with:
-        name: Linkcheck report
-        path: docs/_build/linkcheck/output.txt

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,58 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Linkcheck
+
+on:
+  push:
+    paths:
+    - docs/**.rst
+    - docs/requirements.txt
+    - .github/workflows/linkcheck.yml
+  pull_request:
+    paths:
+    - docs/**.rst
+    - docs/requirements.txt
+    - .github/workflows/linkcheck.yml
+  schedule:
+  - cron: 30 5 * * *
+
+permissions:
+  contents: read
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-24.04
+    name: Linkcheck
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: astral-sh/setup-uv@v3
+    - name: Install apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y graphviz
+    - name: Install Python dependencies
+      run: |
+        uv pip install --system -r docs/requirements.txt
+    - name: Sphinx linkcheck
+      run: |
+        ./ci/run-docs linkcheck
+    - name: Sphinx linkcheck collect
+      if: always()
+      run: |
+        echo "::add-matcher::.github/matchers/sphinx-linkcheck.json"
+        echo "::add-matcher::.github/matchers/sphinx-linkcheck-warn.json"
+        sed 's@^@docs/@' docs/_build/linkcheck/output.txt
+        echo "::remove-matcher owner=sphinx::"
+        echo "::remove-matcher owner=sphinx-warn::"
+    - uses: actions/upload-artifact@v4.4.0
+      if: always()
+      with:
+        name: Linkcheck report
+        path: docs/_build/linkcheck/output.txt


### PR DESCRIPTION
## Proposed changes

The linkcheck is less and less reliable in past weeks. It seems that some of the sites are broken often, it might be also caused by them blocking GitHub ranges as such probing might be visible on some of them.

Separating the workflow allows us to execute it only on documentation changes (we still want to run regular documentation build on all pull requests to make it required).

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
