### PR TITLE
Cache key collision in render checks for suggestions

### DIFF
--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -165,12 +165,15 @@ class BaseCheck:
     def render(self, request: AuthenticatedHttpRequest, unit: Unit) -> StrOrPromise:
         raise Http404("Not supported")
 
-    def get_cache_key(self, unit: Unit, pos: int) -> str:
-        return "check:{}:{}:{}:{}".format(
+    def get_cache_key(
+        self, unit: Unit, pos: int, fake_discriminator: int | None = None
+    ) -> str:
+        return "check:{}:{}:{}:{}:{}".format(
             self.check_id,
             unit.pk,
             siphash("Weblate   Checks", unit.all_flags.format()),
             pos,
+            unit.suggestion_id if hasattr(unit, "suggestion_id") else "",
         )
 
     def get_replacement_function(self, unit: Unit):

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -165,15 +165,12 @@ class BaseCheck:
     def render(self, request: AuthenticatedHttpRequest, unit: Unit) -> StrOrPromise:
         raise Http404("Not supported")
 
-    def get_cache_key(
-        self, unit: Unit, pos: int, fake_discriminator: int | None = None
-    ) -> str:
-        return "check:{}:{}:{}:{}:{}".format(
+    def get_cache_key(self, unit: Unit, pos: int) -> str:
+        return "check:{}:{}:{}:{}".format(
             self.check_id,
             unit.pk,
             siphash("Weblate   Checks", unit.all_flags.format()),
             pos,
-            unit.suggestion_id if hasattr(unit, "suggestion_id") else "",
         )
 
     def get_replacement_function(self, unit: Unit):

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -224,6 +224,7 @@ class Suggestion(models.Model, UserDisplayMixin):
         fake_unit = copy(self.unit)
         fake_unit.target = self.target
         fake_unit.state = STATE_TRANSLATED
+        fake_unit.suggestion_id = self.pk
         source = fake_unit.get_source_plurals()
         target = fake_unit.get_target_plurals()
 

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -224,7 +224,7 @@ class Suggestion(models.Model, UserDisplayMixin):
         fake_unit = copy(self.unit)
         fake_unit.target = self.target
         fake_unit.state = STATE_TRANSLATED
-        fake_unit.suggestion_id = self.pk
+        fake_unit.id = -self.pk
         source = fake_unit.get_source_plurals()
         target = fake_unit.get_target_plurals()
 


### PR DESCRIPTION
## Proposed changes

There is a cache key collision between renders generated in checks for the unit and for its suggestions.

How to reproduce the collision:
  1. Create a component with the max-size check
  2. Create a unit in the source language and translate it in a target language
  3. The render check (whether valid or incorrect) will display the render for the target string
  4. Add a different suggestion to the same unit
  5. The render check will display the render for the suggestion instead of the target string

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.
