### PR TITLE
fix(checks): consolidate format string matching to use re.Match

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Not yet released.
 
 * Displaying :ref:`workflow-customization` setting in some cases.
 * Users can add component in any language already existing in a project.
+* :ref:`check-unnamed-format` better handles some strings, such as :ref:`check-python-brace-format`.
 
 **Compatibility**
 

--- a/weblate/checks/same.py
+++ b/weblate/checks/same.py
@@ -66,7 +66,7 @@ def strip_format(msg, flags):
 
     These are quite often not changed by translators.
     """
-    for format_flag, (regex, _is_position_based) in FLAG_RULES.items():
+    for format_flag, (regex, _is_position_based, _extract_string) in FLAG_RULES.items():
         if format_flag in flags:
             return regex.sub("", msg)
 

--- a/weblate/checks/tests/test_format_checks.py
+++ b/weblate/checks/tests/test_format_checks.py
@@ -1626,3 +1626,18 @@ class MultipleUnnamedFormatsCheckTestCase(SimpleTestCase):
                 ["Test %s"], MockUnit(flags="c-format,python-format")
             )
         )
+
+    def test_good_brace_format(self) -> None:
+        self.assertFalse(
+            self.check.check_source(
+                ["Recognition {progress}% ({current_job}/{total_jobs})"],
+                MockUnit(flags="python-brace-format"),
+            )
+        )
+
+    def test_bad_brace_format(self) -> None:
+        self.assertTrue(
+            self.check.check_source(
+                ["Recognition {}% ({}/{})"], MockUnit(flags="python-brace-format")
+            )
+        )


### PR DESCRIPTION
## Proposed changes

Relying on findall and finditer resulted in off by one for some of the matches causing false positives in some checks.

The code now consistely uses finiter which return re.Match objects and not a tuple matches as findall.

Fixes #12746

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
