### PR TITLE
feat: quote audit log values to avoid auto linking

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -46,6 +46,7 @@ from weblate.trans.models import Change, ComponentList
 from weblate.utils import messages
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.fields import EmailField
+from weblate.utils.html import mail_quote_value
 from weblate.utils.render import validate_editor
 from weblate.utils.request import get_ip_address, get_user_agent
 from weblate.utils.token import get_token
@@ -351,10 +352,12 @@ class AuditLog(models.Model):
             "site_title": settings.SITE_TITLE,
         }
         for name, value in self.params.items():
-            if name in {"old", "new", "name", "email", "username"}:
-                value = format_html("<code>{}</code>", value)
+            if value is None:
+                value = format_html("<em>{}</em>", value)
+            elif name in {"old", "new", "name", "email", "username"}:
+                value = format_html("<code>{}</code>", mail_quote_value(value))
             elif name in {"device", "project", "site_title", "method"}:
-                value = format_html("<strong>{}</strong>", value)
+                value = format_html("<strong>{}</strong>", mail_quote_value(value))
 
             result[name] = value
 

--- a/weblate/utils/tests/test_html.py
+++ b/weblate/utils/tests/test_html.py
@@ -7,7 +7,12 @@ from __future__ import annotations
 from django.test import SimpleTestCase
 
 from weblate.checks.flags import Flags
-from weblate.utils.html import HTML2Text, HTMLSanitizer, extract_html_tags
+from weblate.utils.html import (
+    HTML2Text,
+    HTMLSanitizer,
+    extract_html_tags,
+    mail_quote_value,
+)
 
 
 class HTMLSanitizerTestCase(SimpleTestCase):
@@ -103,4 +108,24 @@ text text text text text
         self.assertEqual(
             html2text.handle("text<ins> </ins>"),
             "text{+ +}\n\n",
+        )
+
+
+class MailQuoteTestCase(SimpleTestCase):
+    def test_plain(self):
+        self.assertEqual(
+            mail_quote_value("text"),
+            "text",
+        )
+
+    def test_dot(self):
+        self.assertEqual(
+            mail_quote_value("example.com"),
+            "example<span>.</span>com",
+        )
+
+    def test_url(self):
+        self.assertEqual(
+            mail_quote_value("https://test.example.com"),
+            "https<span>:</span>//test<span>.</span>example<span>.</span>com",
         )


### PR DESCRIPTION
## Proposed changes

Some e-mail services such as Gmail automatically convert things that look like a link into links even in HTML mails. This could be problematic for audit log entries as want to display the information as is without turning that into links.

Adding `<span>` seems to help in this according to https://stackoverflow.com/a/23404042/225718

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
