### PR TITLE
feat: adds list of reviewers on information tab

### DIFF
--- a/weblate/templates/snippets/info.html
+++ b/weblate/templates/snippets/info.html
@@ -44,6 +44,17 @@
         {% endif %}
         {% endif %}
 
+        {% if project.having_perm %}
+        <tr>
+          <th>{% trans "Project Reviewers" %}</th>
+          <td colspan="2" class="full-cell">
+            {% for reviewer in project.having_perm %}
+              {{ reviewer.profile.get_user_display_link }}
+            {% endfor %}
+          </td>
+        </tr>
+        {% endif %}
+
         {% if project.all_admins %}
         <tr>
           <th>{% trans "Project maintainers" %}</th>


### PR DESCRIPTION
## Proposed changes


Issue #12694 asks about showing the information of the current reviewers in the project. To solve this problem a new item is added on the information tab, showing this information with the `having_perm` method


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
