### PR TITLE
feat(unit): show propagation failure reason from PermissionResult

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1035,26 +1035,21 @@ class Unit(models.Model, LoggerMixin):
 
     def propagate(self, user: User, change_action=None, author=None, request=None):
         """Propagate current translation to all others."""
-        from weblate.trans.models import ContributorAgreement
+        from weblate.auth.permissions import PermissionResult
 
         result = False
         for unit in self.same_source_units:
             if unit.target == self.target and unit.state == self.state:
                 continue
-            if user is not None and not user.has_perm("unit.edit", unit):
+            if user is not None and not (denied := user.has_perm("unit.edit", unit)):
                 component = unit.translation.component
-                if (
-                    request
-                    and component.agreement
-                    and not ContributorAgreement.objects.has_agreed(user, component)
-                ):
+                if request and isinstance(denied, PermissionResult):
                     messages.warning(
                         request,
                         gettext(
-                            "String could not be propagated to %(component)s because "
-                            "you have not agreed with a contributor agreement."
+                            "String could not be propagated to %(component)s: %(reason)s"
                         )
-                        % {"component": component},
+                        % {"component": component, "reason": denied.reason},
                     )
                 continue
             unit.target = self.target


### PR DESCRIPTION

## Proposed changes

Since introduction of PermissionResult the has_perm gives exact reason why string can't be edited, so display it to the user instead of checking a single condition only.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
