### PR TITLE
fix(unit): add some missing prefetch() calls

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Not yet released.
 **Bug fixes**
 
 * Update outdated plural definitions during the database migration.
+* Reduced number of database queries when updating multiple strings.
 
 **Compatibility**
 

--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -137,7 +137,12 @@ class AutoTranslate:
             .filter(source__in=translations.keys())
             .values_list("id", flat=True)
         )
-        units = Unit.objects.filter(pk__in=unit_ids).prefetch_bulk().select_for_update()
+        units = (
+            Unit.objects.filter(pk__in=unit_ids)
+            .prefetch()
+            .prefetch_bulk()
+            .select_for_update()
+        )
         self.progress_steps = len(units)
 
         for pos, unit in enumerate(units):

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1475,6 +1475,7 @@ class Unit(models.Model, LoggerMixin):
             return []
         return (
             self.variant.unit_set.filter(translation=self.translation)
+            .prefetch()
             .prefetch_full()
             .order_by("context")
         )
@@ -1647,6 +1648,7 @@ class Unit(models.Model, LoggerMixin):
     def same_source_units(self) -> UnitQuerySet:
         return (
             Unit.objects.same(self)
+            .prefetch()
             .prefetch_full()
             .filter(
                 translation__component__allow_translation_propagation=True,


### PR DESCRIPTION
## Proposed changes

The prefetch_bulk() and prefetch_full() do prefetch unit data, but not parent objects with assumption that these are typically called from translation.unit_set where such prefetch is not needed. But when it originates from Unit.objects, it needs to be added.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
