### PR TITLE
Add username in translator credits

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,8 @@ Not yet released.
 
 **Improvements**
 
+* Included username when generating :ref:`credits`.
+
 **Bug fixes**
 
 * Update outdated plural definitions during the database migration.

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -154,7 +154,11 @@ class ChangeQuerySet(models.QuerySet["Change"]):
             .values("author")
             .annotate(change_count=Count("id"))
             .values_list(
-                "author__email", "author__username", "author__full_name", "change_count", *values_list
+                "author__email",
+                "author__username",
+                "author__full_name",
+                "change_count",
+                *values_list,
             )
         )
 

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -154,7 +154,7 @@ class ChangeQuerySet(models.QuerySet["Change"]):
             .values("author")
             .annotate(change_count=Count("id"))
             .values_list(
-                "author__email", "author__full_name", "change_count", *values_list
+                "author__email", "author__username", "author__full_name", "change_count", *values_list
             )
         )
 

--- a/weblate/trans/tests/test_reports.py
+++ b/weblate/trans/tests/test_reports.py
@@ -74,6 +74,7 @@ class ReportsTest(BaseReportsTest):
                     {
                         "email": "weblate@example.org",
                         "full_name": "Weblate <b>Test</b>",
+                        "username": "testuser",
                         "change_count": expected_count,
                     }
                 ]
@@ -151,6 +152,7 @@ class ReportsComponentTest(BaseReportsTest):
                         {
                             "email": "weblate@example.org",
                             "full_name": "Weblate <b>Test</b>",
+                            "username": "testuser",
                             "change_count": 1,
                         }
                     ]
@@ -167,7 +169,7 @@ class ReportsComponentTest(BaseReportsTest):
             """
 * Czech
 
-    * Weblate <b>Test</b> <weblate@example.org> (1)
+    * Weblate <b>Test</b> (testuser) <weblate@example.org> - 1
 """.strip(),
         )
 
@@ -179,7 +181,7 @@ class ReportsComponentTest(BaseReportsTest):
             "<table><tbody>\n"
             "<tr>\n<th>Czech</th>\n"
             '<td><ul><li><a href="mailto:weblate@example.org">'
-            "Weblate &lt;b&gt;Test&lt;/b&gt;</a> (1)</li></ul></td>\n</tr>\n"
+            "Weblate &lt;b&gt;Test&lt;/b&gt; (testuser)</a> - 1</li></ul></td>\n</tr>\n"
             "</tbody></table>",
         )
 

--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -86,7 +86,12 @@ def generate_credits(
         .order_by("language__name", "-change_count")
     ):
         result[language].append(
-            {"email": author[0], "username": author[1], "full_name": author[2], "change_count": author[3]}
+            {
+                "email": author[0],
+                "username": author[1],
+                "full_name": author[2],
+                "change_count": author[3],
+            }
         )
 
     return [{language: authors} for language, authors in result.items()]

--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -86,7 +86,7 @@ def generate_credits(
         .order_by("language__name", "-change_count")
     ):
         result[language].append(
-            {"email": author[0], "full_name": author[1], "change_count": author[2]}
+            {"email": author[0], "username": author[1], "full_name": author[2], "change_count": author[3]}
         )
 
     return [{language: authors} for language, authors in result.items()]
@@ -132,14 +132,14 @@ def get_credits(request: AuthenticatedHttpRequest, path=None):
             <td><ul>{translators}</ul></td>
         </tr>
         """
-        translator_format = '<li><a href="mailto:{0}">{1}</a> ({2})</li>'
+        translator_format = '<li><a href="mailto:{0}">{2} ({1})</a> - {3}</li>'
         mime = "text/html"
         format_html_or_plain = format_html
         format_html_or_plain_join = format_html_join
     else:
         wrap_format = "{}"
         language_format = "* {language}\n\n{translators}\n"
-        translator_format = "    * {1} <{0}> ({2})"
+        translator_format = "    * {2} ({1}) <{0}> - {3}"
         mime = "text/plain"
         format_html_or_plain = format_plaintext
         format_html_or_plain_join = format_plaintext_join
@@ -155,7 +155,7 @@ def get_credits(request: AuthenticatedHttpRequest, path=None):
                     "\n",
                     translator_format,
                     (
-                        (t["email"], t["full_name"], t["change_count"])
+                        (t["email"], t["username"], t["full_name"], t["change_count"])
                         for t in translators
                     ),
                 ),


### PR DESCRIPTION
## Proposed changes

This add the field `username` when generating credits. Tests related to this change were also updated.
This solves issue #12800.


## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

