### PR TITLE
fix: forcibly apply cleanup to XML based machinery backends

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,7 @@ Not yet released.
 * Reduced number of database queries when updating multiple strings.
 * Leading problematic characters in :ref:`glossary` terms are now properly stripped in uploaded files.
 * Improved :ref:`workflow-customization` performance.
+* Fixed XML escaped output in some machine translation integrations.
 
 **Compatibility**
 

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -796,8 +796,9 @@ class GlossaryMachineTranslationMixin(MachineTranslation):
         return re.match(self.glossary_name_format_pattern, string)
 
 
-class XMLMachineTranslationMixin:
+class XMLMachineTranslationMixin(BatchMachineTranslation):
     hightlight_syntax = True
+    force_uncleanup = False
 
     def unescape_text(self, text: str) -> str:
         """Unescaping of the text with replacements."""

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -38,7 +38,6 @@ class DeepLTranslation(
         "pt@formal": "pt-pt@formal",
         "pt@informal": "pt-pt@informal",
     }
-    force_uncleanup = True
     hightlight_syntax = True
     settings_form = DeepLMachineryForm
     glossary_count_limit = 1000


### PR DESCRIPTION
## Proposed changes

We do XML escaping when sending the content to the service, so we should unescape that when returnning back.


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
