### PR TITLE
chore: avoid using dynamic version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ dependencies = [
   "weblate-schemas==2024.1"
 ]
 description = "A web-based continuous localization system with tight version control integration"
-dynamic = ["version"]
 keywords = [
   "i18n",
   "l10n",
@@ -102,6 +101,7 @@ keywords = [
 license = {text = "GPLv3+"}
 name = "weblate"
 requires-python = ">=3.11"
+version = "5.9-dev"
 
 [project.optional-dependencies]
 alibaba = [
@@ -508,9 +508,6 @@ max-statements = 100
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
-
-[tool.setuptools.dynamic]
-version = {attr = "weblate.utils.version.VERSION"}
 
 [tool.setuptools.packages]
 find = {namespaces = false}

--- a/scripts/set-version
+++ b/scripts/set-version
@@ -68,7 +68,7 @@ if milestone_url is None:
 # Set version in the files
 replace_file("weblate/utils/version.py", "^VERSION =.*", f'VERSION = "{version}-dev"')
 replace_file("docs/conf.py", "release =.*", f'release = "{version}"')
-replace_file("setup.py", "version=.*", f'version="{version}",')
+replace_file("pyproject.toml", "^version = .*", f'version = "{version}"')
 replace_file("client/package.json", '  "version": ".*",', f'  "version": "{version}",')
 
 # Update changelog
@@ -108,7 +108,7 @@ files = [
     "weblate/utils/version.py",
     "docs/conf.py",
     "docs/changes.rst",
-    "setup.py",
+    "pyproject.toml",
     "client/package.json",
     version_contributors.as_posix(),
 ]


### PR DESCRIPTION
## Proposed changes

This can cause tools to build project just to figure the version (see https://github.com/astral-sh/uv/issues/8771), what slows down things and pulls in not needed dependencies. We anyway inject the version into several places manually, so doing that in pyproject.toml as well is not a big deal.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
