### PR TITLE
Fix glossary term duplication bug

### DIFF
--- a/weblate/glossary/views.py
+++ b/weblate/glossary/views.py
@@ -41,16 +41,24 @@ def add_glossary_term(request: AuthenticatedHttpRequest, unit_id):
             translation = form.cleaned_data["translation"]
             added = translation.add_unit(request, **form.as_kwargs())
             terms = form.cleaned_data["terms"]
-            terms.append(added.pk)
+            # Only append the new term if it's not already in the list
+            if added.pk not in terms:
+                terms.append(added.pk)
             code = 200
 
             # Fetch matching terms
             all_terms = get_glossary_terms(unit)
-            # Add newly added one
-            all_terms.append(added)
 
-            # Add previously present ones
-            missing_terms = set(terms) - {term.pk for term in all_terms}
+            # Create a set of existing term IDs
+            existing_term_ids = {term.pk for term in all_terms}
+
+            # Add newly added term if not already present
+            if added.pk not in existing_term_ids:
+                all_terms.append(added)
+                existing_term_ids.add(added.pk)
+
+            # Add any missing terms that aren't already present
+            missing_terms = set(terms) - existing_term_ids
             if missing_terms:
                 all_terms.extend(translation.unit_set.filter(pk__in=missing_terms))
 

--- a/weblate/templates/snippets/glossary.html
+++ b/weblate/templates/snippets/glossary.html
@@ -3,8 +3,8 @@
 {% load icons %}
 
 {% for item in glossary %}
-  <tbody class="glossary-embed {% if "forbidden" in item.all_flags %}unclickable-row danger{% elif "read-only" in item.all_flags %}clickable-row warning{% else %}clickable-row{% endif %}">
   <tr
+    class="glossary-embed {% if "forbidden" in item.all_flags %}unclickable-row danger{% elif "read-only" in item.all_flags %}clickable-row warning{% else %}clickable-row{% endif %}"
     title="
       {% if "forbidden" in item.all_flags %}
         {% trans "This translation is forbidden." %}
@@ -53,7 +53,6 @@
         </td>
       </tr>
     {% endif %}
-  </tbody>
 {% empty %}
     <tr>
     <td colspan="4"><em>{% trans "No related strings found in the glossary." %}</em></td>


### PR DESCRIPTION
## Proposed changes
### Fix glossary term duplication bug
Because of  add_glossary_term view handler that duplicates the term in the returned results. Plus bad returned html table template that breaks rendering when injected into the right side panel.
closes: #12624
closes: #12693

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
### Preview
see the right side panel, (new term just h've been added, it isn't duplicated + rendered correctly). Also, UI persists after refresh.
<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
![Screenshot 2024-11-05 134352](https://github.com/user-attachments/assets/c4d3b1ef-f562-469e-a910-f719c484cd01)
