### PR TITLE
feat(tools): add search preview to bulk edit tool

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Not yet released.
 
 * A shortcut to duplicate a component is now available directly in the menu (:guilabel:`Manage` → :guilabel:`Duplicate Component`)
 * Included username when generating :ref:`credits`.
+* :ref:`bulk-edit` shows a preview of matched strings.
 
 **Bug fixes**
 
@@ -111,7 +112,7 @@ Released on October 15th 2024.
 * Stale, empty glossaries are now automatically removed.
 * :kbd:`?` now displays available :ref:`keyboard`.
 * Translation and language view in the project now include basic information about the language and plurals.
-* :ref:`bulk-edit` shows a preview of matched strings.
+* :ref:`search-replace` shows a preview of matched strings.
 * :ref:`aresource` now supports translatable attribute in its strings.
 * Creating component via file upload (Translate document) now supports bilingual files.
 

--- a/weblate/static/editor/tools/search.js
+++ b/weblate/static/editor/tools/search.js
@@ -4,6 +4,7 @@
 
 $(document).ready(() => {
   searchPreview("#replace", "#id_replace_q");
+  searchPreview("#bulk-edit", "#id_bulk_q");
 
   /**
    * Add preview to the search input search results.

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2626,7 +2626,8 @@ class BulkEditForm(forms.Form):
     ) -> None:
         project = kwargs.pop("project", None)
         kwargs["auto_id"] = "id_bulk_%s"
-        kwargs["initial"] = {"path": getattr(obj, "full_slug", None)}
+        if obj is not None:
+            kwargs["initial"] = {"path": obj.full_slug}
         super().__init__(*args, **kwargs)
         labels = Label.objects.all() if project is None else project.label_set.all()
         if labels:

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2601,6 +2601,7 @@ class BulkEditForm(forms.Form):
         label=gettext_lazy("State to set"),
         choices=[(-1, gettext_lazy("Do not change"))],
     )
+    path = forms.CharField(widget=forms.HiddenInput, required=False)
     add_flags = FlagField(
         label=gettext_lazy("Translation flags to add"), required=False
     )
@@ -2625,6 +2626,7 @@ class BulkEditForm(forms.Form):
     ) -> None:
         project = kwargs.pop("project", None)
         kwargs["auto_id"] = "id_bulk_%s"
+        kwargs["initial"] = {"path": getattr(obj, "full_slug", None)}
         super().__init__(*args, **kwargs)
         labels = Label.objects.all() if project is None else project.label_set.all()
         if labels:
@@ -2651,6 +2653,7 @@ class BulkEditForm(forms.Form):
         self.helper.layout = Layout(
             Div(template="snippets/bulk-help.html"),
             SearchField("q"),
+            Field("path"),
             Field("state"),
             Field("add_flags"),
             Field("remove_flags"),


### PR DESCRIPTION
## Proposed changes

Adds the same search preview from _Search and replace_ to the _Bulk edit_ tool.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

Related to #4106, #4108 and #7563.

Does not affect the _Bulk edit_ add-on.
