### PR TITLE
feat: add navigation for string sections in translation interface

### DIFF
--- a/weblate/templates/snippets/position-field.html
+++ b/weblate/templates/snippets/position-field.html
@@ -6,7 +6,10 @@
   {% if not is_zen %}
     {% if prev_unit_url %}
       <a id="button-first" class="btn btn-default green" href="{{ first_unit_url }}" title="{% trans "First" %}">{% if LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a>
-      <a id="button-prev" class="btn btn-default green" href="{{ prev_unit_url }}" title="{% trans "Previous" %}" rel="prev">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
+      {% if not is_in_browse %}
+        <a id="prev-section" class="btn btn-default green {% if offset < 2 %} disabled {% endif %}" href="{{ prev_section_url }}" title="{% trans "Previous section" %}">{% if LANGUAGE_BIDI %}{% icon "fast-forward.svg" %}{% else %}{% icon "rewind.svg" %}{% endif %}</a>
+      {% endif %}
+       <a id="button-prev" class="btn btn-default green" href="{{ prev_unit_url }}" title="{% trans "Previous" %}" rel="prev">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
     {% else %}
       <a id="button-first" class="btn btn-default green disabled" title="{% trans "First" %}">{% if LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a>
       <a id="button-prev" class="btn btn-default green disabled" title="{% trans "Previous" %}">{% if LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
@@ -28,6 +31,9 @@
   {% if not is_zen %}
     {% if next_unit_url %}
       <a id="button-next" class="btn btn-default green" href="{{ next_unit_url }}" title="{% trans "Next" %}" rel="next">{% if not LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>
+      {% if not is_in_browse %}
+        <a id="next-section" class="btn btn-default green {% if not can_go_next_section %} disabled {% endif %}" href="{{ next_section_url }}" title="{% trans "Next section" %}" rel="next">{% if not LANGUAGE_BIDI %}{% icon "fast-forward.svg" %}{% else %}{% icon "rewind.svg" %}{% endif %}</a>
+      {% endif %}
       <a id="button-end" class="btn btn-default green" href="{{ last_unit_url }}" title="{% trans "Last" %}">{% if not LANGUAGE_BIDI %}{% icon "page-last.svg" %}{% else %}{% icon "page-first.svg" %}{% endif %}</a>
     {% else %}
       <a id="button-next" class="btn btn-default green disabled" title="{% trans "Next" %}">{% if not LANGUAGE_BIDI %}{% icon "page-next.svg" %}{% else %}{% icon "page-previous.svg" %}{% endif %}</a>

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -690,6 +690,10 @@ def translate(request: AuthenticatedHttpRequest, path):
             "this_unit_url": this_unit_url,
             "first_unit_url": base_unit_url + "1",
             "last_unit_url": base_unit_url + str(num_results),
+            "next_section_url": base_unit_url
+            + str(offset + user.profile.nearby_strings),
+            "prev_section_url": base_unit_url
+            + str(max(1, offset - user.profile.nearby_strings)),
             "next_unit_url": next_unit_url,
             "prev_unit_url": base_unit_url + str(offset - 1),
             "object": obj,
@@ -698,6 +702,7 @@ def translate(request: AuthenticatedHttpRequest, path):
             "unit": unit,
             "nearby": unit.nearby(user.profile.nearby_strings),
             "nearby_keys": unit.nearby_keys(user.profile.nearby_strings),
+            "can_go_next_section": offset + user.profile.nearby_strings <= num_results,
             "others": get_other_units(unit) if user.is_authenticated else {"total": 0},
             "search_url": search_result["url"],
             "search_items": search_result["items"],
@@ -1101,6 +1106,7 @@ def browse(request: AuthenticatedHttpRequest, path):
             if offset < num_results
             else None,
             "prev_unit_url": base_unit_url + str(offset - 1) if offset > 1 else None,
+            "is_in_browse": True,
             "sort_name": sort["name"],
             "sort_query": sort["query"],
         },


### PR DESCRIPTION


## Proposed changes
The user now can navigate a full section of strings (based on the nearby strings number in profile preferences)

close: #6393
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information
![image](https://github.com/user-attachments/assets/c7f7eab7-bea3-43f3-9357-0d575fe374c2)

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
