### PR TITLE
Switch translation editor buttons colors

### DIFF
--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -202,7 +202,7 @@
         </div>
       {% endif %}
     {% endwith %}
-    <button class="btn btn-primary" type="submit" name="save"
+    <button class="btn btn-warning" type="submit" name="save"
     {% if locked %}
         disabled="disabled"
     {% elif not user_can_translate and not user_can_edit_flags %}
@@ -212,7 +212,7 @@
     {% endif %}
     >{% trans "Save and continue" %}</button>
 
-    <button class="btn btn-warning btn-spaced" type="submit" name="save-stay"
+    <button class="btn btn-primary btn-spaced" type="submit" name="save-stay"
     {% if locked %}
         disabled="disabled"
     {% elif not user_can_translate and not user_can_edit_flags %}
@@ -223,7 +223,7 @@
     >{% trans "Save and stay" %}</button>
 
     {% if unit.translation.enable_suggestions %}
-    <button class="btn btn-warning btn-spaced" type="submit" name="suggest"
+    <button class="btn btn-primary btn-spaced" type="submit" name="suggest"
     {% if project_locked or not user_can_suggest or unit.readonly %}disabled="disabled"{% endif %}
       {% if not user_can_suggest %}
         title="{% trans "Insufficient privileges for adding suggestions." %}"
@@ -234,7 +234,7 @@
       {% endif %}
     >{% icon "suggest.svg" %} {% trans "Suggest" %}</button>
     {% endif %}
-    <a class="btn btn-warning btn-spaced skip" href="{{ next_unit_url }}" rel="next">{% if LANGUAGE_BIDI %}{% icon "rewind.svg" %}{% else %}{% icon "fast-forward.svg" %}{% endif %} {% trans "Skip" %}</a>
+    <a class="btn btn-primary btn-spaced skip" href="{{ next_unit_url }}" rel="next">{% if LANGUAGE_BIDI %}{% icon "rewind.svg" %}{% else %}{% icon "fast-forward.svg" %}{% endif %} {% trans "Skip" %}</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION

## Proposed changes
Switched translation editor buttons colors from btn-primary to btn-warning. And vice versa for the secondary action buttons.

See #13065 and  #13050
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
See priview in [here](https://github.com/WeblateOrg/weblate/pull/13065#issuecomment-2485281904)
<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
