### PR TITLE
fix: gracefully handle uninstalled checks

### DIFF
--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -156,7 +156,7 @@ class Check(models.Model):
         return str(self.get_name())
 
     @cached_property
-    def check_obj(self):
+    def check_obj(self) -> BaseCheck | None:
         try:
             return CHECKS[self.name]
         except KeyError:

--- a/weblate/checks/views.py
+++ b/weblate/checks/views.py
@@ -271,4 +271,8 @@ def render_check(request: AuthenticatedHttpRequest, unit_id, check_id):
         obj = Check(unit=unit, dismissed=False, name=check_id)
     request.user.check_access_component(obj.unit.translation.component)
 
+    if obj.check_obj is None:
+        msg = "No check object found."
+        raise Http404(msg)
+
     return obj.check_obj.render(request, obj.unit)

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -4,8 +4,10 @@
 
 """Test for translation views."""
 
+from __future__ import annotations
+
 import time
-from typing import NoReturn
+from typing import TYPE_CHECKING, NoReturn, cast
 
 from django.urls import reverse
 
@@ -16,6 +18,9 @@ from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.util import join_plural
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.state import STATE_FUZZY, STATE_TRANSLATED
+
+if TYPE_CHECKING:
+    from weblate.checks.base import BaseCheck
 
 
 class EditTest(ViewTestCase):
@@ -904,7 +909,9 @@ class EditComplexTest(ViewTestCase):
         self.assertEqual(unit.translation.stats.allchecks, 0)
 
         # Ignore check for all languages
-        ignore_flag = Check.objects.get(pk=int(check_id)).check_obj.ignore_string
+        check_obj = Check.objects.get(pk=int(check_id)).check_obj
+        self.assertIsNotNone(check_obj)
+        ignore_flag = cast("BaseCheck", check_obj).ignore_string
         ignore_url = reverse("js-ignore-check-source", kwargs={"check_id": check_id})
         response = self.client.post(ignore_url)
         self.assertEqual(response.status_code, 403)

--- a/weblate/trans/views/js.py
+++ b/weblate/trans/views/js.py
@@ -69,7 +69,11 @@ def ignore_check_source(request: AuthenticatedHttpRequest, check_id):
         raise PermissionDenied
 
     # Mark check for ignoring
-    ignore = obj.check_obj.ignore_string
+    if obj.check_obj is None:
+        # Disabled check
+        ignore = f'ignore-{obj.name.replace("_", "-")}'
+    else:
+        ignore = obj.check_obj.ignore_string
     flags = Flags(unit.extra_flags)
     if ignore not in flags:
         flags.merge(ignore)


### PR DESCRIPTION

## Proposed changes

When check is no longer installed, Weblate can not get its object and processs it.

Fixes #13020
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
