### PR TITLE
fix(formats): gracefully handle when format changes key upon saving

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Not yet released.
 **Bug fixes**
 
 * Using the ``has:variant`` field now correctly displays strings that have variant(s) in the search language, see :ref:`search-strings`.
+* Saving newly added strings in some formats.
 
 **Compatibility**
 

--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -167,6 +167,22 @@ class TranslationUnit:
         if "target" in self.__dict__:
             del self.__dict__["target"]
 
+    def invalidate_all_caches(self) -> None:
+        """Invalidate attributes cache."""
+        for attr in (
+            "context",
+            "source",
+            "locations",
+            "flags",
+            "notes",
+            "explanation",
+            "source_explanation",
+            "previous_source",
+        ):
+            if attr in self.__dict__:
+                del self.__dict__[attr]
+        self._invalidate_target()
+
     @cached_property
     def locations(self) -> str:
         """Return comma separated list of locations."""
@@ -739,6 +755,9 @@ class TranslationFormat:
 
         # Add it to the file
         self.add_unit(result)
+
+        # Invalidate all attributes
+        result.invalidate_all_caches()
 
         return result
 

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -1747,6 +1747,7 @@ class DTDFormat(TTKitFormat):
     autoload: tuple[str, ...] = ("*.dtd",)
     unit_class = MonolingualSimpleUnit
     new_translation = "\n"
+    can_add_unit: bool = False
 
     @staticmethod
     def mimetype() -> str:


### PR DESCRIPTION
## Proposed changes

This happens in XLIFF, but can happen in other formats using complex keys such as JSON.

Fixes #13213
Fixes WEBLATE-4HT
Fixes WEBLATE-479

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
