### PR TITLE
fix(accounts): sanitize usernames before generating private e-mail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ dependencies = [
   "tesserocr>=2.6.1,<2.8.0",
   "translate-toolkit>=3.14.1,<3.15",
   "translation-finder>=2.18,<3.0",
+  "unidecode>=1.3.8,<1.4",
   "user-agents>=2.0,<2.3",
   "weblate-language-data>=2024.14",
   "weblate-schemas==2024.2"

--- a/uv.lock
+++ b/uv.lock
@@ -4028,6 +4028,15 @@ wheels = [
 ]
 
 [[package]]
+name = "unidecode"
+version = "1.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/89/19151076a006b9ac0dd37b1354e031f5297891ee507eb624755e58e10d3e/Unidecode-1.3.8.tar.gz", hash = "sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4", size = 192701 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/b7/6ec57841fb67c98f52fc8e4a2d96df60059637cba077edc569a302a8ffc7/Unidecode-1.3.8-py3-none-any.whl", hash = "sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39", size = 235494 },
+]
+
+[[package]]
 name = "uritemplate"
 version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4174,6 +4183,7 @@ dependencies = [
     { name = "tesserocr" },
     { name = "translate-toolkit" },
     { name = "translation-finder" },
+    { name = "unidecode" },
     { name = "user-agents" },
     { name = "weblate-language-data" },
     { name = "weblate-schemas" },
@@ -4416,6 +4426,7 @@ requires-dist = [
     { name = "tesserocr", specifier = ">=2.6.1,<2.8.0" },
     { name = "translate-toolkit", specifier = ">=3.14.1,<3.15" },
     { name = "translation-finder", specifier = ">=2.18,<3.0" },
+    { name = "unidecode", specifier = ">=1.3.8,<1.4" },
     { name = "user-agents", specifier = ">=2.0,<2.3" },
     { name = "weblate", extras = ["alibaba", "amazon", "antispam", "gerrit", "gelf", "google", "ldap", "mercurial", "openai", "postgres", "saml", "zxcvbn"], marker = "extra == 'all'" },
     { name = "weblate-language-data", specifier = ">=2024.14" },

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import datetime
+import re
 from datetime import timedelta
 from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse
@@ -30,6 +31,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from django_otp_webauthn.models import WebAuthnCredential
 from rest_framework.authtoken.models import Token
 from social_django.models import UserSocialAuth
+from unidecode import unidecode
 
 from weblate.accounts.avatar import get_user_display
 from weblate.accounts.data import create_default_notifications
@@ -50,7 +52,7 @@ from weblate.utils.html import mail_quote_value
 from weblate.utils.render import validate_editor
 from weblate.utils.request import get_ip_address, get_user_agent
 from weblate.utils.token import get_token
-from weblate.utils.validators import WeblateURLValidator
+from weblate.utils.validators import EMAIL_BLACKLIST, WeblateURLValidator
 from weblate.wladmin.models import get_support_status
 
 if TYPE_CHECKING:
@@ -130,6 +132,32 @@ class WeblateAccountsConf(AppConf):
 
     class Meta:
         prefix = ""
+
+
+# This is essentially a part for django.core.validators.EmailValidator
+DOT_ATOM_RE = re.compile(
+    r"^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z", re.IGNORECASE
+)
+
+
+def format_private_email(username: str, user_id: int) -> str:
+    if not settings.PRIVATE_COMMIT_EMAIL_TEMPLATE:
+        return ""
+    if username:
+        if username.endswith(".") or ".." in username:
+            # Remove problematic docs
+            username = username.replace(".", "_")
+        if not DOT_ATOM_RE.match(username):
+            # Remove unicode
+            username = unidecode(username)
+        if not DOT_ATOM_RE.match(username) or EMAIL_BLACKLIST.match(username):
+            username = ""
+    if not username:
+        username = f"user-{user_id}"
+    return settings.PRIVATE_COMMIT_EMAIL_TEMPLATE.format(
+        username=username.lower(),
+        site_domain=settings.SITE_DOMAIN.rsplit(":", 1)[0],
+    )
 
 
 class SubscriptionQuerySet(models.QuerySet["Subscription"]):
@@ -904,12 +932,7 @@ class Profile(models.Model):
         return email
 
     def get_site_commit_email(self) -> str:
-        if not settings.PRIVATE_COMMIT_EMAIL_TEMPLATE:
-            return ""
-        return settings.PRIVATE_COMMIT_EMAIL_TEMPLATE.format(
-            username=self.user.username,
-            site_domain=settings.SITE_DOMAIN.rsplit(":", 1)[0],
-        )
+        return format_private_email(self.user.username, self.user.pk)
 
     def _get_second_factors(self) -> Iterable[Device]:
         backend: type[Device]


### PR DESCRIPTION
## Proposed changes

Our username fields is more tolerant than e-mail address specification, so bring these in sync.

Fixes #13225

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
