### PR TITLE
fix: do not store read-only state as original

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1582,11 +1582,18 @@ class Unit(models.Model, LoggerMixin):
         if "dos-eol" in self.all_flags:
             self.target = NEWLINES.sub("\r\n", self.target)
 
+        # Update string state
         if not_empty:
             self.state = new_state
         else:
             self.state = STATE_EMPTY
-        self.original_state = self.state
+
+        # Update original state unless we are updating read-only strings. This
+        # does never happen directly, but FillReadOnlyAddon does this.
+        if new_state != STATE_READONLY:
+            self.original_state = self.state
+
+        # Save to the database
         saved = self.save_backend(
             user,
             change_action=change_action,


### PR DESCRIPTION
## Proposed changes

The only user for this is currently the FillReadOnlyAddon which does not actually want to alter the original state so that the strings can be later unmarked as read-only.

Fixes #13248

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
