### PR TITLE
Fix nbsp characters from breaking lines in highlight editor

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -482,7 +482,7 @@ function initHighlight(root) {
       const whitespaceRegex = new RegExp(
         [
           "  +|(^) +| +(?=$)| +\n|\n +|\t|",
-          "\u00A0|\u00AD|\u1680|\u2000|\u2001|",
+          "\u00AD|\u1680|\u2000|\u2001|",
           "\u2002|\u2003|\u2004|\u2005|",
           "\u2006|\u2007|\u2008|\u2009|",
           "\u200A|\u202F|\u205F|\u3000",
@@ -490,6 +490,8 @@ function initHighlight(root) {
       );
       // biome-ignore lint/performance/useTopLevelRegex: TODO
       const newlineRegex = /\n/;
+      // biome-ignore lint/performance/useTopLevelRegex: TODO
+      const nonBreakingSpaceRegex = /\u00A0/;
       const extension = {
         hlspace: {
           pattern: whitespaceRegex,
@@ -497,6 +499,9 @@ function initHighlight(root) {
         },
         newline: {
           pattern: newlineRegex,
+        },
+        nbsp: {
+          pattern: nonBreakingSpaceRegex,
         },
       };
       if (placeables) {

--- a/weblate/static/style-dark.css
+++ b/weblate/static/style-dark.css
@@ -2146,7 +2146,8 @@ ul.legend li {
 .hlmatch {
   background-color: #8c690c;
 }
-.hlspace {
+.hlspace,
+.nbsp {
   outline-color: #c50000;
   color: #d5d0c7;
 }

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -289,12 +289,15 @@ textarea#id_check_flags {
 }
 
 .hlspace,
+.nbsp,
 .token.newline {
   outline: 1px dotted red;
   color: #bfc3c7;
   white-space: pre-wrap;
 }
-
+.nbsp {
+  white-space: nowrap !important;
+}
 .space-tab,
 .space-nl,
 .space-space,


### PR DESCRIPTION
## Proposed changes
Previously nbsp characters were treated as normal spaces which breaks line in the end of it.  The current changes prevent that behavior.

Close: #13073

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
