### PR TITLE
Invalidate automatic suggestion result cache on glossary change

### DIFF
--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -409,11 +409,15 @@ class BatchMachineTranslation:
         msg = "Not supported"
         raise UnsupportedLanguageError(msg)
 
-    def get_cached(self, source, language, text, threshold, replacements):
+    def get_cached(
+        self, unit, source, language, text, threshold, replacements, *extra_parts
+    ):
         if not self.cache_translations:
             return None, None
         cache_key = self.get_cache_key(
-            "translation", parts=(source, language, threshold), text=text
+            "translation",
+            parts=(source, language, threshold, *extra_parts),
+            text=text,
         )
         result = cache.get(cache_key)
         if result and (replacements or self.force_uncleanup):
@@ -510,7 +514,7 @@ class BatchMachineTranslation:
 
             # Try cached results
             cache_key, result = self.get_cached(
-                source, language, text, threshold, replacements
+                unit, source, language, text, threshold, replacements
             )
             if result is not None:
                 output[original_source] = result
@@ -724,6 +728,27 @@ class GlossaryMachineTranslationMixin(MachineTranslation):
         cache.set(cache_key, result, 24 * 3600)
         return result
 
+    def tsv_checksum(self, tsv: str) -> str:
+        """Calculate checksum of given TSV glossary."""
+        return hash_to_checksum(calculate_hash(tsv)) if tsv else ""
+
+    def get_cached(
+        self, unit, source, language, text, threshold, replacements, *extra_parts
+    ):
+        """Retrieve cached translation with glossary checksum."""
+        from weblate.glossary.models import get_glossary_tsv
+
+        return super().get_cached(
+            unit,
+            source,
+            language,
+            text,
+            threshold,
+            replacements,
+            self.tsv_checksum(get_glossary_tsv(unit)),
+            *extra_parts,
+        )
+
     def get_glossary_id(
         self, source_language: str, target_language: str, unit: Unit | None
     ) -> str | None:
@@ -739,12 +764,12 @@ class GlossaryMachineTranslationMixin(MachineTranslation):
             return None
 
         # Check if there is a glossary
-        glossary_tsv = get_glossary_tsv(translation)
+        glossary_tsv = get_glossary_tsv(unit)
         if not glossary_tsv:
             return None
 
         # Calculate hash to check for changes
-        glossary_checksum = hash_to_checksum(calculate_hash(glossary_tsv))
+        glossary_checksum = self.tsv_checksum(glossary_tsv)
         glossary_name = self.glossary_name_format.format(
             project=translation.component.project.id,
             source_language=source_language,

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -745,7 +745,7 @@ class GlossaryMachineTranslationMixin(MachineTranslation):
             text,
             threshold,
             replacements,
-            self.tsv_checksum(get_glossary_tsv(unit)),
+            self.tsv_checksum(get_glossary_tsv(unit.translation)),
             *extra_parts,
         )
 
@@ -764,7 +764,7 @@ class GlossaryMachineTranslationMixin(MachineTranslation):
             return None
 
         # Check if there is a glossary
-        glossary_tsv = get_glossary_tsv(unit)
+        glossary_tsv = get_glossary_tsv(translation)
         if not glossary_tsv:
             return None
 


### PR DESCRIPTION
## Proposed changes
When a glossary term is updated, the result cache is invalidated and new result is fetched.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
- closes #13122 
