### PR TITLE
feat: extend DuplicateFilemask to operate on files

### DIFF
--- a/weblate/templates/trans/alert/duplicatefilemask.html
+++ b/weblate/templates/trans/alert/duplicatefilemask.html
@@ -1,16 +1,17 @@
 {% load i18n %}
 
 <p>
-  {% trans "Some linked components have the same file mask." %}
+  {% trans "Some linked components have the same file mask or share some of the files." %}
   {% trans "Please fix this by removing one of them." %}
 </p>
 
-<p>{% trans "The following file masks were found multiple times:" %}</p>
+<p>{% trans "The following files were found multiple times:" %}</p>
 
 <ul>
-  {% for mask in duplicates %}
+  {% for mask, translations in analysis.duplicates_resolved %}
     <li>
-      <pre>{{ mask }}</pre>
+      <pre>{{ mask }}</pre>:
+      {% for translation in translations %}<a href="{{ translation.get_absolute_url }}">{{ translation }}</a>{% endfor %}
     </li>
   {% endfor %}
 </ul>

--- a/weblate/trans/models/__init__.py
+++ b/weblate/trans/models/__init__.py
@@ -184,7 +184,7 @@ def post_delete_linked(sender, instance, **kwargs) -> None:
     # When removing project, the linked component might be already deleted now
     try:
         if instance.linked_component:
-            instance.linked_component.update_link_alerts(noupdate=True)
+            instance.linked_component.update_alerts()
     except Component.DoesNotExist:
         pass
 

--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import sentry_sdk
 from django.conf import settings
 from django.db import models
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -29,7 +29,9 @@ if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
 
     from weblate.auth.models import User
-    from weblate.trans.models import Component, Translation
+    from weblate.trans.models.component import Component, ComponentQuerySet
+    from weblate.trans.models.translation import Translation, TranslationQuerySet
+
 
 ALERTS: dict[str, type[BaseAlert]] = {}
 ALERTS_IMPORT: set[str] = set()
@@ -227,6 +229,48 @@ class DuplicateFilemask(BaseAlert):
     def __init__(self, instance, duplicates) -> None:
         super().__init__(instance)
         self.duplicates = duplicates
+
+    @staticmethod
+    def get_translations(component: Component) -> TranslationQuerySet:
+        from weblate.trans.models import Translation
+
+        return Translation.objects.filter(
+            Q(component=component) | Q(component__linked_component=component)
+        )
+
+    @classmethod
+    def check_component(cls, component: Component) -> bool | dict | None:
+        if component.is_repo_link:
+            return False
+
+        translations = set(
+            cls.get_translations(component)
+            .values_list("filename")
+            .annotate(count=Count("id"))
+            .filter(count__gt=1)
+            .values_list("filename", flat=True)
+        )
+        translations.discard("")
+        if translations:
+            return {"duplicates": sorted(translations)}
+        return False
+
+    def resolve_filename(
+        self, filename: str
+    ) -> ComponentQuerySet | TranslationQuerySet:
+        if "*" in filename:
+            # Legacy path for old alerts
+            # TODO: Remove in Weblate 6.0
+            return self.instance.component.component_set.filter(filemask=filename)
+        return self.get_translations(self.instance.component).filter(filename=filename)
+
+    def get_analysis(self):
+        return {
+            "duplicates_resolved": [
+                (filename, self.resolve_filename(filename))
+                for filename in self.duplicates
+            ]
+        }
 
 
 @register

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -112,6 +112,24 @@ class AlertTest(ViewTestCase):
             component.alert_set.filter(name="MonolingualTranslation").exists()
         )
 
+    def test_duplicate_mask(self):
+        component = self.component
+        self.assertFalse(component.alert_set.filter(name="DuplicateFilemask").exists())
+        response = self.client.get(component.get_absolute_url())
+        self.assertNotContains(
+            response, "The following files were found multiple times"
+        )
+
+        other = self.create_link_existing()
+
+        self.assertTrue(component.alert_set.filter(name="DuplicateFilemask").exists())
+        response = self.client.get(component.get_absolute_url())
+        self.assertContains(response, "The following files were found multiple times")
+
+        other.delete()
+
+        self.assertFalse(component.alert_set.filter(name="DuplicateFilemask").exists())
+
 
 class LanguageAlertTest(ViewTestCase):
     def create_component(self):
@@ -120,10 +138,8 @@ class LanguageAlertTest(ViewTestCase):
     def test_ambiguous_language(self) -> None:
         component = self.component
         self.assertFalse(component.alert_set.filter(name="AmbiguousLanguage").exists())
-        self.component.add_new_language(
-            Language.objects.get(code="ku"), self.get_request()
-        )
-        self.component.update_alerts()
+        component.add_new_language(Language.objects.get(code="ku"), self.get_request())
+        component.update_alerts()
         self.assertTrue(component.alert_set.filter(name="AmbiguousLanguage").exists())
 
 


### PR DESCRIPTION
## Proposed changes

Reusing filemask does not have to be the only issue, the very same issue can happen when a signle file from one component is reused as source for other component.

This also avoids special-casing this single alert and it now uses generic alerts interface.

Fixes #13259

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
