### PR TITLE
fix: use locks to prevent concurrent parsing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Not yet released.
 
 **Bug fixes**
 
+* Avoid query parser crash in multi-threaded environments.
+
 **Compatibility**
 
 **Upgrading**

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -8,7 +8,7 @@ import uuid
 from collections import defaultdict
 from functools import cache as functools_cache
 from itertools import chain
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
 import sentry_sdk
 from appconf import AppConf
@@ -294,7 +294,12 @@ class UserQuerySet(models.QuerySet["User"]):
     def order(self):
         return self.order_by("username")
 
-    def search(self, query: str, parser: str = "user", **context):
+    def search(
+        self,
+        query: str,
+        parser: Literal["plain", "user", "superuser"] = "user",
+        **context,
+    ):
         """High level wrapper for searching."""
         if parser == "plain":
             result = self.filter(

--- a/weblate/checks/flags.py
+++ b/weblate/checks/flags.py
@@ -15,8 +15,9 @@ from lxml import etree
 
 from weblate.checks.models import CHECKS
 from weblate.checks.parser import (
+    FLAGS_PARSER,
+    FLAGS_PARSER_LOCK,
     SYNTAXCHARS,
-    FlagsParser,
     length_validation,
     multi_value_flag,
     single_value_flag,
@@ -91,7 +92,10 @@ def _parse_flags_text(flags: str) -> Iterator[str | tuple[Any, ...]]:
     state = 0
     name: str
     value: list[Any] = []
-    tokens = list(FlagsParser.parse_string(flags, parseAll=True))
+
+    with FLAGS_PARSER_LOCK:
+        tokens = list(FLAGS_PARSER.parse_string(flags, parse_all=True))
+
     for pos, token in enumerate(tokens):
         if state == 0 and token == ",":
             pass

--- a/weblate/utils/forms.py
+++ b/weblate/utils/forms.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from typing import Literal
+
 from crispy_forms.layout import Div, Field
 from crispy_forms.utils import TEMPLATE_PACK
 from django import forms
@@ -23,7 +25,9 @@ from .validators import WeblateServiceURLValidator, validate_email, validate_use
 
 
 class QueryField(forms.CharField):
-    def __init__(self, parser: str = "unit", **kwargs) -> None:
+    def __init__(
+        self, parser: Literal["unit", "user", "superuser"] = "unit", **kwargs
+    ) -> None:
         if "label" not in kwargs:
             kwargs["label"] = gettext_lazy("Query")
         if "required" not in kwargs:

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -1,8 +1,10 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Literal
 
 from django.db.models import F, Q
 from django.test import TestCase
@@ -24,7 +26,7 @@ from weblate.utils.state import (
 
 class SearchTestCase(TestCase):
     object_class = Unit
-    parser = "unit"
+    parser: Literal["unit", "user", "superuser"] = "unit"
 
     def assert_query(self, string, expected, exists=False, **context) -> None:
         result = parse_query(string, parser=self.parser, **context)


### PR DESCRIPTION
## Proposed changes


The parser instances cannot be shared between threads as PyParsing is not thread-safe, see https://github.com/pyparsing/pyparsing/issues/89.

Fixes WEBLATE-1MFM

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
