### PR TITLE
Fix verb to plural in changes.rst

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -214,7 +214,7 @@ Released on October 15th 2024.
 * :kbd:`?` now displays available :ref:`keyboard`.
 * Translation and language view in the project now include basic information about the language and plurals.
 * :ref:`search-replace` shows a preview of matched strings.
-* :ref:`aresource` now supports translatable attribute in its strings.
+* :ref:`aresource` now support translatable attribute in its strings.
 * Creating component via file upload (Translate document) now supports bilingual files.
 
 **Bug fixes**


### PR DESCRIPTION
## Proposed changes

Adjust the verb conjugation so that it matches the plural in "Android string resources" title.

Current rendered text in [Changes page](https://docs.weblate.org/en/latest/changes.html#weblate-5-8) is:
> [Android string resources](https://docs.weblate.org/en/latest/formats/android.html#aresource) now supports translatable attribute in its strings.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
