### PR TITLE
Add dash to deduplicate translation string

### DIFF
--- a/docs/changes/v4.rst
+++ b/docs/changes/v4.rst
@@ -951,7 +951,7 @@ Weblate 4.3.2
 Released on November 4th 2020.
 
 * Fixed crash on certain component file masks.
-* Improved accuracy of the consecutive duplicated words check.
+* Improved accuracy of the consecutive duplicated-words check.
 * Added support for Pagure pull requests.
 * Improved error messages for failed registrations.
 * Reverted rendering developer comments as Markdown.


### PR DESCRIPTION
## Proposed changes

Changes for 4.14.2 have the exact same sentence, but with dash in "duplicated-words". Due to this small difference, they are two very similar translation strings in Hosted Weblate. This PR is to deduplicate them. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
