### PR TITLE
Fix colors to match system color scheme

### DIFF
--- a/weblate/templates/configuration/custom.css
+++ b/weblate/templates/configuration/custom.css
@@ -1,74 +1,134 @@
 {% comment %} Light theme color variables {% endcomment %}
 {% if header_color_light %}
-body {
---header-color: {{ header_color_light }};
+@media (prefers-color-scheme: light) {
+  body {
+    --header-color: {{ header_color_light }};
+  }
+}
+body[data-theme="light"] {
+--header-color: {{ header_color_light }}!important;
 }
 {% endif %}
 
 {% if header_text_color_light %}
-body {
---header-text-color: {{ header_text_color_light }};
+@media (prefers-color-scheme: light) {
+  body {
+    --header-text-color: {{ header_text_color_light }};    
+  }
+}
+body[data-theme="light"] {
+--header-text-color: {{ header_text_color_light }}!important;
 }
 {% endif %}
 
 {% if navi_color_light %}
-body {
---navi-color: {{ navi_color_light }};
+@media (prefers-color-scheme: light) {
+  body {
+    --navi-color: {{ navi_color_light }};    
+  }
+}
+body[data-theme="light"] {
+--navi-color: {{ navi_color_light }}!important;
 }
 {% endif %}
 
 {% if navi_text_color_light %}
-body {
---navi-text-color: {{ navi_text_color_light }};
+@media (prefers-color-scheme: light) {
+  body {
+    --navi-text-color: {{ navi_text_color_light }};    
+  }
+}
+body[data-theme="light"] {
+--navi-text-color: {{ navi_text_color_light }}!important;
 }
 {% endif %}
 
 {% if focus_color_light %}
-body {
---focus-color: {{ focus_color_light }};
+@media (prefers-color-scheme: light) {
+  body {
+    --focus-color: {{ focus_color_light }};    
+  }
+}
+body[data-theme="light"] {
+--focus-color: {{ focus_color_light }}!important;
 }
 {% endif %}
 
 {% if hover_color_light %}
-body {
---hover-color: {{ hover_color_light }};
+@media (prefers-color-scheme: light) {
+  body {
+    --hover-color: {{ hover_color_light }};    
+  }
+}
+body[data-theme="light"] {
+--hover-color: {{ hover_color_light }}!important;
 }
 {% endif %}
 
 {% comment %} Dark theme  color variables {% endcomment %}
 {% if header_color_dark %}
+@media (prefers-color-scheme: dark) {
+  body {
+    --header-color: {{ header_color_dark }};
+  }
+}
 body[data-theme="dark"] {
---header-color: {{ header_color_dark }};
+--header-color: {{ header_color_dark }}!important;
 }
 {% endif %}
 
 {% if header_text_color_dark %}
+@media (prefers-color-scheme: dark) {
+  body {
+    --header-text-color: {{ header_text_color_dark }};
+  }
+}
 body[data-theme="dark"] {
---header-text-color: {{ header_text_color_dark }};
+--header-text-color: {{ header_text_color_dark }}!important;
 }
 {% endif %}
 
 {% if navi_color_dark %}
+@media (prefers-color-scheme: dark) {
+  body {
+    --navi-color: {{ navi_color_dark }};
+  }
+}
 body[data-theme="dark"] {
---navi-color: {{ navi_color_dark }};
+--navi-color: {{ navi_color_dark }}!important;
 }
 {% endif %}
 
 {% if navi_text_color_dark %}
+@media (prefers-color-scheme: dark) {
+  body {
+  --navi-text-color: {{ navi_text_color_dark }};
+  }
+}
 body[data-theme="dark"] {
---navi-text-color: {{ navi_text_color_dark }};
+--navi-text-color: {{ navi_text_color_dark }}!important;
 }
 {% endif %}
 
 {% if focus_color_dark %}
+@media (prefers-color-scheme: dark) {
+  body {
+    --focus-color: {{ focus_color_dark }};
+  }
+}
 body[data-theme="dark"] {
-  --focus-color: {{ focus_color_dark }};
+  --focus-color: {{ focus_color_dark }}!important;
 }
 {% endif %}
 
 {% if hover_color_dark %}
+@media (prefers-color-scheme: dark) {
+  body {
+    --hover-color: {{ hover_color_dark }};
+  }
+}
 body[data-theme="dark"] {
-  --hover-color: {{ hover_color_dark }};
+  --hover-color: {{ hover_color_dark }}!important;
 }
 {% endif %}
 


### PR DESCRIPTION


## Proposed changes
When users are unauthenticated by default the theme is set to `auto` (which was before [this fix](https://github.com/meel-hd/weblate/commit/e93d765a802c2e2a12f60f255f09960b0ad4c7a6) **selects incorrect colors**). But when the user is logged in, the theme is set to his preference: `light` or `dark` instead of the auto theme.

The fix now selects the configured(dark/light) theme colors to match the sytem(dark/light) theme in `auto` theme. But only when the user is unauthenticated or he chose to.
Close: #13376
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
