### PR TITLE
fix(hooks): correct repository full_name extraction

### DIFF
--- a/weblate/trans/tests/test_hooks.py
+++ b/weblate/trans/tests/test_hooks.py
@@ -106,40 +106,73 @@ GITHUB_NEW_PAYLOAD = """
 
 GITLAB_PAYLOAD = """
 {
+  "object_kind": "push",
+  "event_name": "push",
   "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
   "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
   "ref": "refs/heads/main",
+  "ref_protected": true,
+  "checkout_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
   "user_id": 4,
   "user_name": "John Smith",
+  "user_username": "jsmith",
+  "user_email": "john@example.com",
+  "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
   "project_id": 15,
-  "repository": {
+  "project":{
+    "id": 15,
+    "name":"Diaspora",
+    "description":"",
+    "web_url":"http://example.com/mike/diaspora",
+    "avatar_url":null,
+    "git_ssh_url":"git@example.com:mike/diaspora.git",
+    "git_http_url":"http://example.com/mike/diaspora.git",
+    "namespace":"Mike",
+    "visibility_level":0,
+    "path_with_namespace":"mike/diaspora",
+    "default_branch":"main",
+    "homepage":"http://example.com/mike/diaspora",
+    "url":"git@example.com:mike/diaspora.git",
+    "ssh_url":"git@example.com:mike/diaspora.git",
+    "http_url":"http://example.com/mike/diaspora.git"
+  },
+  "repository":{
     "name": "Diaspora",
-    "url": "git@example.com:mike/diasporadiaspora.git",
+    "url": "git@example.com:mike/diaspora.git",
     "description": "",
     "homepage": "http://example.com/mike/diaspora",
     "git_http_url":"http://example.com/mike/diaspora.git",
-    "git_ssh_url":"git@example.com:mike/diaspora.git"
+    "git_ssh_url":"git@example.com:mike/diaspora.git",
+    "visibility_level":0
   },
   "commits": [
     {
       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
-      "message": "Update Catalan translation to e38cb41.",
+      "message": "Update Catalan translation to e38cb41.\n\nSee https://gitlab.com/gitlab-org/gitlab for more information",
+      "title": "Update Catalan translation to e38cb41.",
       "timestamp": "2011-12-12T14:27:31+02:00",
-      "url": "http://example.com/diaspora/commits/b6568db1b",
+      "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "author": {
         "name": "Jordi Mallach",
         "email": "jordi@softcatala.org"
-      }
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["app/controller/application.rb"],
+      "removed": []
     },
     {
       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "message": "fixed readme",
+      "title": "fixed readme",
       "timestamp": "2012-01-03T23:36:29+02:00",
-      "url": "http://example.com/diaspora/commits/da1560886",
+      "url": "http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "author": {
         "name": "GitLab dev user",
         "email": "gitlabdev@dv6700.(none)"
-      }
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["app/controller/application.rb"],
+      "removed": []
     }
   ],
   "total_commits_count": 4

--- a/weblate/trans/tests/test_hooks.py
+++ b/weblate/trans/tests/test_hooks.py
@@ -105,7 +105,7 @@ GITHUB_NEW_PAYLOAD = """
 }
 """
 
-GITLAB_PAYLOAD = """
+GITLAB_PAYLOAD = r"""
 {
   "object_kind": "push",
   "event_name": "push",

--- a/weblate/trans/tests/test_hooks.py
+++ b/weblate/trans/tests/test_hooks.py
@@ -5,6 +5,7 @@
 """Test for notification hooks."""
 
 import json
+from abc import ABC, abstractmethod
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
@@ -1582,7 +1583,7 @@ class HooksViewTest(ViewTestCase):
         self.assertContains(response, "Hook working", status_code=201)
 
 
-class HookBackendTestCase(SimpleTestCase):
+class HookBackendTestCase(SimpleTestCase, ABC):
     hook: str = ""
 
     def assert_hook(self, payload, expected) -> None:
@@ -1594,6 +1595,10 @@ class HookBackendTestCase(SimpleTestCase):
             expected["repos"] = sorted(expected["repos"])
         self.maxDiff = None
         self.assertEqual(expected, result)
+
+    @abstractmethod
+    def test_git(self):
+        raise NotImplementedError
 
 
 class GitHubBackendTest(HookBackendTestCase):
@@ -1867,7 +1872,7 @@ class AzureBackendTest(HookBackendTestCase):
             },
         )
 
-    def test_git_new(self) -> None:
+    def test_git(self) -> None:
         self.assert_hook(
             AZURE_PAYLOAD_NEW,
             {

--- a/weblate/trans/views/hooks.py
+++ b/weblate/trans/views/hooks.py
@@ -428,15 +428,13 @@ def gitlab_hook_helper(data, request: AuthenticatedHttpRequest):
         data["repository"]["git_ssh_url"],
         data["repository"]["homepage"],
     ]
-    full_name = ssh_url.split(":", 1)[1]
-    full_name = full_name.removesuffix(".git")
 
     return {
         "service_long_name": "GitLab",
         "repo_url": data["repository"]["homepage"],
         "repos": repos,
         "branch": branch,
-        "full_name": full_name,
+        "full_name": data["project"]["path_with_namespace"],
     }
 
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Replaces manual parsing of the SSH URL with the provided `path_with_namespace` from the GitLab payload. This ensures accurate retrieval of the repository's full name.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
See https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html for example payloads from GitLab
