### PR TITLE
feat: always include From header in notification e-mails

### DIFF
--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -351,9 +351,10 @@ class Notification:
 
         # Set From header to contain user full name
         if user := context.get("user"):
-            headers["From"] = formataddr(
-                (user.get_visible_name(), settings.DEFAULT_FROM_EMAIL)
-            )
+            from_name = user.get_visible_name()
+        else:
+            from_name = settings.SITE_TITLE
+        headers["From"] = formataddr((from_name, settings.DEFAULT_FROM_EMAIL))
 
         # References for unit events
         references = None


### PR DESCRIPTION
## Proposed changes

This was ommitted for digest/non-user originated changes and some services like simplelogin.co tend to fill in the sender name from previous e-mail with the same sender making the notifcations look weirdly originated.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
