### PR TITLE
chore(vcs): rewrite git config update to not sync on each change

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -153,10 +153,13 @@ class GitRepository(Repository):
                         continue
                     if old == value:
                         continue
-                except (NoSectionError, NoOptionError):
+                except NoSectionError:
+                    if value is not None:
+                        config.add_section(section)
+                except NoOptionError:
                     pass
                 if value is not None:
-                    config.set_value(section, key, value)
+                    config.set(section, key, value)
 
     def config_update(self, *updates: tuple[str, str, str | None]) -> None:
         filename = Path(self.path) / ".git" / "config"


### PR DESCRIPTION
## Proposed changes

The set_value interface immediatelly writes out any change making our batching ineffective. Sticking to native ConfigParser set interface makes it write the file when leaving the context. This also needs we need to manually create missing sections.


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
