### PR TITLE
fix(machinery): use matching cache key while caching translations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Not yet released.
 
 **Bug fixes**
 
+* Fixed translations caching in :ref:`machine-translation-setup`.
+
 **Compatibility**
 
 **Upgrading**


### PR DESCRIPTION
## Proposed changes

Since 63af651 the batch translating would use last cache key to store translations instead of using matching one. This commit keeps track of cache keys and stores translations in matching ones. Type annotations were also added.

Fixes #13388


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
