### PR TITLE
fix(api): duplicate security scheme objs in openapi schema

### DIFF
--- a/weblate/api/authentication.py
+++ b/weblate/api/authentication.py
@@ -17,11 +17,11 @@ class BearerAuthentication(TokenAuthentication):
 class BearerScheme(OpenApiAuthenticationExtension):
     """Fix an issue where the drf-spectacular library duplicates the `tokenAuth` security scheme when generating the OpenAPI schema."""
 
-    target_class = 'weblate.api.authentication.BearerAuthentication'
-    name = 'bearerAuth'
+    target_class = "weblate.api.authentication.BearerAuthentication"
+    name = "bearerAuth"
 
     def get_security_definition(self, auto_schema):
         return build_bearer_security_scheme_object(
-            header_name='Authorization',
+            header_name="Authorization",
             token_prefix=self.target.keyword,
         )

--- a/weblate/api/authentication.py
+++ b/weblate/api/authentication.py
@@ -1,7 +1,10 @@
 # Copyright © Michal Čihař <michal@weblate.org>
+# SPDX-FileCopyrightText: 2025 Javier Pérez <jdbp@protonmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from drf_spectacular.plumbing import build_bearer_security_scheme_object
 from rest_framework.authentication import TokenAuthentication
 
 
@@ -9,3 +12,16 @@ class BearerAuthentication(TokenAuthentication):
     """RFC 6750 compatible Bearer authentication."""
 
     keyword = "Bearer"
+
+
+class BearerScheme(OpenApiAuthenticationExtension):
+    """Fix an issue where the drf-spectacular library duplicates the `tokenAuth` security scheme when generating the OpenAPI schema."""
+
+    target_class = 'weblate.api.authentication.BearerAuthentication'
+    name = 'bearerAuth'
+
+    def get_security_definition(self, auto_schema):
+        return build_bearer_security_scheme_object(
+            header_name='Authorization',
+            token_prefix=self.target.keyword,
+        )


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

- Fix an issue with the `rest_framework.authentication.TokenAuthentication` and the `weblate.api.authentication.BearerAuthentication` authentication classes when `drf-spectacular` generates the OpenAPI schema and warnings are issued in the log about duplication of the `tokenAuth` security scheme objects.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->

Fixes #13502.