### PR TITLE
feat(tests): utilize abstract classes for base tests

### DIFF
--- a/.github/workflows/rundev.yml
+++ b/.github/workflows/rundev.yml
@@ -36,7 +36,8 @@ jobs:
     - run: ./rundev.sh wait
     - run: ./rundev.sh check
     - run: ./rundev.sh compilemessages
-    - run: ./rundev.sh test --failfast weblate
+    - run: ./rundev.sh test --exitfirst
+    - run: ./rundev.sh test weblate/checks/tests/test_chars_checks.py
     - run: ./rundev.sh logs
       if: always()
     - run: ./rundev.sh stop

--- a/ci/run-test
+++ b/ci/run-test
@@ -6,19 +6,14 @@
 
 # Testsuite executor
 
-. ci/lib.sh
+set -x
 
-run_coverage ./manage.py compilemessages
-check
+./manage.py compilemessages
 
-run_coverage ./manage.py collectstatic --noinput --verbosity 0
-check
+./manage.py collectstatic --noinput --verbosity 0
 
-run_coverage ./manage.py migrate --noinput --traceback
-check
+./manage.py migrate --noinput --traceback
 
-run_coverage ./manage.py check
-check
+./manage.py check
 
-run_coverage ./manage.py test
-check
+pytest

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -23,7 +23,7 @@ run-selenium:
 	@cd .. && \
 		. scripts/test-database.sh && \
 		./manage.py collectstatic --noinput && \
-		./manage.py test --keepdb --failfast weblate.trans.tests.test_selenium.SeleniumTests
+		pytest weblate/trans/tests/test_selenium.py
 
 SCREENSHOTS = $(wildcard screenshots/*.webp)
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,8 @@ Not yet released.
 
 **Compatibility**
 
+* Running tests using Django test executor is no longer supported, see :doc:`/contributing/tests`.
+
 **Upgrading**
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.

--- a/docs/contributing/start.rst
+++ b/docs/contributing/start.rst
@@ -57,7 +57,7 @@ sources.
    .. code-block:: sh
 
       . scripts/test-database.sh
-      ./manage.py test
+      pytest
 
 .. seealso::
 
@@ -91,7 +91,7 @@ for example running only tests in the ``weblate.machine`` module:
 
 .. code-block:: sh
 
-   ./rundev.sh test --failfast weblate.machine
+   ./rundev.sh test --exitfirst weblate/machine
 
 .. note::
 

--- a/docs/contributing/tests.rst
+++ b/docs/contributing/tests.rst
@@ -50,6 +50,7 @@ Before running test, please ensure test dependencies are installed. This can be 
 
 Testing using pytest
 ~~~~~~~~~~~~~~~~~~~~
+
 Prior to running tests you should collect static files as some tests rely on them being present:
 
 .. code-block:: sh
@@ -67,15 +68,6 @@ Running an individual test file:
 .. code-block:: sh
 
    pytest weblate/utils/tests/test_search.py
-
-Testing using Django
-~~~~~~~~~~~~~~~~~~~~
-
-Alternatively, Django built-in tests should also work:
-
-.. code-block:: sh
-
-    DJANGO_SETTINGS_MODULE=weblate.settings_test ./manage.py test
 
 .. hint::
 
@@ -96,18 +88,6 @@ The :file:`weblate/settings_test.py` is used in CI environment as well (see
    export CI_DB_HOST=127.0.0.1
    export CI_DB_PORT=60000
    export DJANGO_SETTINGS_MODULE=weblate.settings_test
-
-Prior to running tests you should collect static files as some tests rely on them being present:
-
-.. code-block:: sh
-
-    DJANGO_SETTINGS_MODULE=weblate.settings_test ./manage.py collectstatic
-
-You can also specify individual tests to run:
-
-.. code-block:: sh
-
-    DJANGO_SETTINGS_MODULE=weblate.settings_test ./manage.py test weblate.gitexport
 
 .. hint::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -439,7 +439,7 @@ ignore = [
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "weblate.settings_test"
 FAIL_INVALID_TEMPLATE_VARS = true
-addopts = "--reuse-db --cov=weblate --cov-report= --durations=20 --durations-min=2"
+addopts = "--reuse-db --cov=weblate --cov-report= --durations=20 --durations-min=2 --ignore=data --ignore=data-test --ignore=dev-docker --ignore=scripts"
 python_files = ["test_*.py", "tests.py"]
 
 [tool.ruff.lint]

--- a/rundev.sh
+++ b/rundev.sh
@@ -65,7 +65,8 @@ test)
         --env CI_DB_USER=weblate \
         --env CI_DB_PASSWORD=weblate \
         --env DJANGO_SETTINGS_MODULE=weblate.settings_test \
-        weblate weblate test --noinput "$@"
+        --workdir /app/src \
+        weblate pytest "$@"
     ;;
 check)
     shift

--- a/weblate/checks/tests/test_checks.py
+++ b/weblate/checks/tests/test_checks.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import random
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from django.test import SimpleTestCase
@@ -144,10 +145,9 @@ class MockUnit:
         return self.source
 
 
-class CheckTestCase(SimpleTestCase):
+class CheckTestCase(SimpleTestCase, ABC):
     """Generic test, also serves for testing base class."""
 
-    check: BaseCheck | None = None
     default_lang = "cs"
 
     def setUp(self) -> None:
@@ -166,12 +166,19 @@ class CheckTestCase(SimpleTestCase):
         )
         self.test_highlight: tuple[str, str, list[tuple[int, int, str]]] | None = None
 
-    def do_test(self, expected, data, lang=None) -> None:
+    @property
+    @abstractmethod
+    def check(self) -> BaseCheck:
+        raise NotImplementedError
+
+    def do_test(
+        self, expected: bool, data: tuple[str, str, str] | None, lang: str | None = None
+    ) -> None:
         """Perform single check if we have data to test."""
+        if data is None:
+            self.skipTest("Not supported")
         if lang is None:
             lang = self.default_lang
-        if not data or self.check is None:
-            return
         params = '"{}"/"{}" ({})'.format(*data)
 
         unit = MockUnit(None, data[2], lang, source=data[0])
@@ -215,8 +222,8 @@ class CheckTestCase(SimpleTestCase):
         self.do_test(True, self.test_failure_3)
 
     def test_check_good_flag(self) -> None:
-        if self.check is None or self.test_good_flag is None:
-            return
+        if self.test_good_flag is None:
+            self.skipTest("Not supported")
         self.assertFalse(
             self.check.check_target(
                 [self.test_good_flag[0]],
@@ -231,8 +238,6 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_good_matching_singular(self) -> None:
-        if self.check is None:
-            return
         self.assertFalse(
             self.check.check_target(
                 [self.test_good_matching[0]],
@@ -247,8 +252,6 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_good_none_singular(self) -> None:
-        if self.check is None:
-            return
         self.assertFalse(
             self.check.check_target(
                 [self.test_good_none[0]],
@@ -263,8 +266,8 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_good_ignore_singular(self) -> None:
-        if self.check is None or self.test_good_ignore is None:
-            return
+        if self.test_good_ignore is None:
+            self.skipTest("Not supported")
         self.assertFalse(
             self.check.check_target(
                 [self.test_good_ignore[0]],
@@ -279,8 +282,6 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_good_matching_plural(self) -> None:
-        if self.check is None:
-            return
         self.assertFalse(
             self.check.check_target(
                 [self.test_good_matching[0]] * 2,
@@ -295,8 +296,8 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_failure_1_singular(self) -> None:
-        if self.test_failure_1 is None or self.check is None:
-            return
+        if self.test_failure_1 is None:
+            self.skipTest("Not supported")
         self.assertTrue(
             self.check.check_target(
                 [self.test_failure_1[0]],
@@ -311,8 +312,8 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_failure_1_plural(self) -> None:
-        if self.test_failure_1 is None or self.check is None:
-            return
+        if self.test_failure_1 is None:
+            self.skipTest("Not supported")
         self.assertTrue(
             self.check.check_target(
                 [self.test_failure_1[0]] * 2,
@@ -327,8 +328,8 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_failure_2_singular(self) -> None:
-        if self.test_failure_2 is None or self.check is None:
-            return
+        if self.test_failure_2 is None:
+            self.skipTest("Not supported")
         self.assertTrue(
             self.check.check_target(
                 [self.test_failure_2[0]],
@@ -343,8 +344,8 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_failure_3_singular(self) -> None:
-        if self.test_failure_3 is None or self.check is None:
-            return
+        if self.test_failure_3 is None:
+            self.skipTest("Not supported")
         self.assertTrue(
             self.check.check_target(
                 [self.test_failure_3[0]],
@@ -359,8 +360,6 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_ignore_check(self) -> None:
-        if self.check is None:
-            return
         self.assertFalse(
             self.check.check_target(
                 [self.test_ignore_check[0]] * 2,
@@ -375,8 +374,8 @@ class CheckTestCase(SimpleTestCase):
         )
 
     def test_check_highlight(self) -> None:
-        if self.check is None or self.test_highlight is None:
-            return
+        if self.test_highlight is None:
+            self.skipTest("Not supported")
         unit = MockUnit(
             None,
             self.test_highlight[0],

--- a/weblate/formats/tests/test_convert.py
+++ b/weblate/formats/tests/test_convert.py
@@ -41,7 +41,9 @@ class ConvertFormatTest(BaseFormatTest):
 
     def test_convert(self) -> None:
         if not self.CONVERT_TEMPLATE:
-            self.skipTest(f"Test template not provided for {self.FORMAT.format_id}")
+            self.skipTest(
+                f"Test template not provided for {self.format_class.format_id}"
+            )
         translation = template = None
         try:
             # Generate test files
@@ -51,9 +53,9 @@ class ConvertFormatTest(BaseFormatTest):
                 translation.write(self.CONVERT_TRANSLATION)
 
             # Parse
-            storage = self.FORMAT(
+            storage = self.format_class(
                 translation.name,
-                template_store=self.FORMAT(template.name, is_template=True),
+                template_store=self.format_class(template.name, is_template=True),
                 existing_units=self.CONVERT_EXISTING,
             )
 
@@ -83,7 +85,7 @@ class ConvertFormatTest(BaseFormatTest):
 
 
 class HTMLFormatTest(ConvertFormatTest):
-    FORMAT = HTMLFormat
+    format_class = HTMLFormat
     FILE = HTML_FILE
     MIME = "text/html"
     EXT = "html"
@@ -104,7 +106,7 @@ class HTMLFormatTest(ConvertFormatTest):
 
 
 class MarkdownFormatTest(ConvertFormatTest):
-    FORMAT = MarkdownFormat
+    format_class = MarkdownFormat
     FILE = MARKDOWN_FILE
     MIME = "text/markdown"
     EXT = "md"
@@ -143,9 +145,9 @@ Nazdar
             handle.write(testdata)
 
         # Parse test file
-        storage = self.FORMAT(
+        storage = self.format_class(
             testfile,
-            template_store=self.FORMAT(testfile, is_template=True),
+            template_store=self.format_class(testfile, is_template=True),
             existing_units=[
                 MockUnit(
                     source="Orangutan has five bananas.",
@@ -175,7 +177,7 @@ Try Weblate at [weblate.org](https://demo.weblate.org/)!
 
 
 class OpenDocumentFormatTest(ConvertFormatTest):
-    FORMAT = OpenDocumentFormat
+    format_class = OpenDocumentFormat
     FILE = OPENDOCUMENT_FILE
     MIME = "application/vnd.oasis.opendocument.text"
     EXT = "odt"
@@ -206,7 +208,7 @@ class OpenDocumentFormatTest(ConvertFormatTest):
 
 
 class IDMLFormatTest(ConvertFormatTest):
-    FORMAT = IDMLFormat
+    format_class = IDMLFormat
     FILE = IDML_FILE
     MIME = "application/octet-stream"
     EXT = "idml"
@@ -235,7 +237,7 @@ class IDMLFormatTest(ConvertFormatTest):
 
 
 class WindowsRCFormatTest(ConvertFormatTest):
-    FORMAT = WindowsRCFormat
+    format_class = WindowsRCFormat
     FILE = TEST_RC
     BASE = TEST_RC
     MIME = "text/plain"
@@ -274,7 +276,7 @@ END
 
 
 class PlainTextFormatTest(ConvertFormatTest):
-    FORMAT = PlainTextFormat
+    format_class = PlainTextFormat
     FILE = TEST_TXT
     BASE = TEST_TXT
     MIME = "text/plain"

--- a/weblate/formats/tests/test_external.py
+++ b/weblate/formats/tests/test_external.py
@@ -19,7 +19,7 @@ FRENCH_FILE = get_test_file("fr.xlsx")
 
 
 class XlsxFormatTest(BaseFormatTest):
-    FORMAT = XlsxFormat
+    format_class = XlsxFormat
     FILE = XLSX_FILE
     MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     EXT = "xlsx"
@@ -45,14 +45,14 @@ class XlsxFormatTest(BaseFormatTest):
         )
 
     def test_japanese(self) -> None:
-        storage = self.FORMAT(JAPANESE_FILE)
+        storage = self.format_class(JAPANESE_FILE)
         self.assertEqual(len(storage.all_units), 1)
         self.assertEqual(storage.all_units[0].target, "秒")
         with tempfile.NamedTemporaryFile(suffix="xlsx") as temp_file:
             storage.save_atomic(temp_file.name, storage.save_content)
 
     def test_fr(self) -> None:
-        storage = self.FORMAT(FRENCH_FILE)
+        storage = self.format_class(FRENCH_FILE)
         self.assertEqual(len(storage.all_units), 4)
         self.assertEqual(storage.all_units[0].target, "Traitement A")
         with tempfile.NamedTemporaryFile(suffix="xlsx") as temp_file:

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 import os.path
 import shutil
+from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
 from typing import NoReturn
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 
 from lxml import etree
 from translate.storage.po import pofile
@@ -159,8 +160,7 @@ class AutoLoadTest(TestCase):
         self.assertIsInstance(store.store, pofile)
 
 
-class BaseFormatTest(FixtureTestCase, TempDirMixin):
-    FORMAT: type[TranslationFormat] = TranslationFormat
+class BaseFormatTest(FixtureTestCase, TempDirMixin, ABC):
     FILE = TEST_PO
     BASE = TEST_POT
     TEMPLATE = None
@@ -185,13 +185,6 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
     EDIT_TARGET: str | list[str] = "Nazdar, svete!\n"
     MONOLINGUAL = False
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        if cls.FORMAT is TranslationFormat:
-            msg = "Base test class not intended for execution."
-            raise SkipTest(msg)
-        super().setUpClass()
-
     def setUp(self) -> None:
         super().setUp()
         self.create_temp()
@@ -200,15 +193,20 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
         super().tearDown()
         self.remove_temp()
 
+    @property
+    @abstractmethod
+    def format_class(self) -> TranslationFormat:
+        raise NotImplementedError
+
     def parse_file(self, filename: str, template: str | None = None):
         if self.MONOLINGUAL:
-            return self.FORMAT(
+            return self.format_class(
                 filename,
-                template_store=self.FORMAT(
+                template_store=self.format_class(
                     template or self.TEMPLATE or filename, is_template=True
                 ),
             )
-        return self.FORMAT(filename)
+        return self.format_class(filename)
 
     def test_parse(self) -> None:
         storage = self.parse_file(self.FILE)
@@ -286,9 +284,9 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
             self.assertEqual(unit.target, self.FIND_MATCH)
 
     def test_add(self) -> None:
-        self.assertTrue(self.FORMAT.is_valid_base_for_new(self.BASE, True))
+        self.assertTrue(self.format_class.is_valid_base_for_new(self.BASE, True))
         out = os.path.join(self.tempdir, f"test.{self.EXT}")
-        self.FORMAT.add_language(out, Language.objects.get(code="cs"), self.BASE)
+        self.format_class.add_language(out, Language.objects.get(code="cs"), self.BASE)
         self.parse_file(out)  # check the parser agrees that the new file is valid.
         if self.MATCH is None:
             self.assertTrue(os.path.isdir(out))
@@ -300,14 +298,14 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
 
     def test_get_language_filename(self) -> None:
         self.assertEqual(
-            self.FORMAT.get_language_filename(
-                self.MASK, self.FORMAT.get_language_code("cs_CZ")
+            self.format_class.get_language_filename(
+                self.MASK, self.format_class.get_language_code("cs_CZ")
             ),
             self.EXPECTED_PATH,
         )
 
     def test_new_unit(self) -> None:
-        if not self.FORMAT.can_add_unit:
+        if not self.format_class.can_add_unit:
             self.skipTest("Not supported")
         # Read test content
         with open(self.FILE, "rb") as handle:
@@ -363,7 +361,7 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
         This is used when Weblate is translating string not present in the translation
         in Translation.update_units().
         """
-        if not self.MONOLINGUAL or not self.FORMAT.can_add_unit:
+        if not self.MONOLINGUAL or not self.format_class.can_add_unit:
             self.skipTest("Not supported")
 
         temp_dir = Path(self.tempdir)
@@ -394,7 +392,7 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
 
         # Create the template under test with a single string
         shutil.copy(self.FILE, template_file)
-        template_storage = self.FORMAT(template_file, is_template=True)
+        template_storage = self.format_class(template_file, is_template=True)
         template_unit = template_storage.new_unit(self.NEW_UNIT_KEY, "Source string")
         if self.SUPPORTS_NOTES:
             template_unit.unit.addnote(self.NOTE_FOR_TEST)
@@ -403,7 +401,9 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin):
         template_content = template_file.read_text()
 
         # Add a new language and translate the new string.
-        self.FORMAT.add_language(main_file, Language.objects.get(code="cs"), self.BASE)
+        self.format_class.add_language(
+            main_file, Language.objects.get(code="cs"), self.BASE
+        )
         target_storage = self.parse_file(main_file, template=template_file)
         target_unit, add = target_storage.find_unit(self.NEW_UNIT_KEY, "Source string")
         self.assertTrue(add)
@@ -449,12 +449,14 @@ class XMLMixin:
 
 
 class PoFormatTest(BaseFormatTest):
-    FORMAT = PoFormat
+    format_class = PoFormat
     EDIT_OFFSET = 1
 
     def test_add_encoding(self) -> None:
         out = os.path.join(self.tempdir, "test.po")
-        self.FORMAT.add_language(out, Language.objects.get(code="cs"), TEST_POT_UNICODE)
+        self.format_class.add_language(
+            out, Language.objects.get(code="cs"), TEST_POT_UNICODE
+        )
         with open(out) as handle:
             data = handle.read()
         self.assertIn("Michal Čihař", data)
@@ -484,25 +486,27 @@ class PoFormatTest(BaseFormatTest):
             handle.write("")
 
         # Test file content is updated
-        self.FORMAT.update_bilingual(test_file, TEST_POT)
+        self.format_class.update_bilingual(test_file, TEST_POT)
         with open(test_file) as handle:
             self.assertEqual(len(handle.read()), 340)
 
         # Backup flag is not compatible with others
         with self.assertRaises(UpdateError):
-            self.FORMAT.update_bilingual(test_file, TEST_POT, args=["--backup=none"])
+            self.format_class.update_bilingual(
+                test_file, TEST_POT, args=["--backup=none"]
+            )
         with open(test_file) as handle:
             self.assertEqual(len(handle.read()), 340)
 
         # Test warning in output (used Unicode POT file without charset specified)
         with self.assertRaises(UpdateError):
-            self.FORMAT.update_bilingual(test_file, TEST_POT_UNICODE)
+            self.format_class.update_bilingual(test_file, TEST_POT_UNICODE)
         with open(test_file) as handle:
             self.assertEqual(len(handle.read()), 340)
 
     def test_obsolete(self) -> None:
         # Test adding unit matching obsolete one
-        storage = self.FORMAT(TEST_PO)
+        storage = self.format_class(TEST_PO)
         # Remove duplicate entry
         unit = storage.all_units[0]
         self.assertEqual(unit.source, "Hello, world!\n")
@@ -526,7 +530,7 @@ class PoFormatTest(BaseFormatTest):
 
 
 class PropertiesFormatTest(BaseFormatTest):
-    FORMAT: type[TranslationFormat] = PropertiesFormat
+    format_class: type[TranslationFormat] = PropertiesFormat
     FILE = TEST_PROPERTIES
     MIME = "text/plain"
     COUNT = 12
@@ -549,7 +553,7 @@ class PropertiesFormatTest(BaseFormatTest):
 
 
 class GWTFormatTest(BaseFormatTest):
-    FORMAT = GWTFormat
+    format_class = GWTFormat
     FILE = TEST_GWT
     MIME = "text/plain"
     COUNT = 1
@@ -585,7 +589,7 @@ class GWTFormatTest(BaseFormatTest):
 
 
 class JoomlaFormatTest(BaseFormatTest):
-    FORMAT = JoomlaFormat
+    format_class = JoomlaFormat
     FILE = TEST_JOOMLA
     MIME = "text/plain"
     COUNT = 4
@@ -602,7 +606,7 @@ class JoomlaFormatTest(BaseFormatTest):
 
 
 class JSONFormatTest(BaseFormatTest):
-    FORMAT = JSONFormat
+    format_class = JSONFormat
     FILE = TEST_JSON
     MIME = "application/json"
     COUNT = 4
@@ -619,7 +623,7 @@ class JSONFormatTest(BaseFormatTest):
 
 
 class JSONNestedFormatTest(JSONFormatTest):
-    FORMAT = JSONNestedFormat
+    format_class = JSONNestedFormat
     FILE = TEST_NESTED_JSON
     COUNT = 4
     MASK = "json-nested/*.json"
@@ -632,7 +636,7 @@ class JSONNestedFormatTest(JSONFormatTest):
 
 
 class WebExtesionJSONFormatTest(JSONFormatTest):
-    FORMAT = WebExtensionJSONFormat
+    format_class = WebExtensionJSONFormat
     FILE = TEST_WEBEXT_JSON
     COUNT = 4
     MASK = "webextension/_locales/*/messages.json"
@@ -647,7 +651,7 @@ class WebExtesionJSONFormatTest(JSONFormatTest):
 
 
 class GoI18NV1JSONFormatTest(JSONFormatTest):
-    FORMAT = GoI18JSONFormat
+    format_class = GoI18JSONFormat
     FILE = TEST_GO18N_V1_JSON
     COUNT = 4
     MASK = "go-i18n-json/*.json"
@@ -661,7 +665,7 @@ class GoI18NV1JSONFormatTest(JSONFormatTest):
 
 
 class GoI18NV2JSONFormatTest(JSONFormatTest):
-    FORMAT = GoI18V2JSONFormat
+    format_class = GoI18V2JSONFormat
     FILE = TEST_GO18N_V2_JSON
     COUNT = 4
     MASK = "go-i18n-json-v2/*.json"
@@ -672,7 +676,7 @@ class GoI18NV2JSONFormatTest(JSONFormatTest):
 
 
 class PhpFormatTest(BaseFormatTest):
-    FORMAT = PhpFormat
+    format_class = PhpFormat
     FILE = TEST_PHP
     MIME = "text/x-php"
     COUNT = 4
@@ -692,7 +696,7 @@ class PhpFormatTest(BaseFormatTest):
 
 
 class LaravelPhpFormatTest(PhpFormatTest):
-    FORMAT = LaravelPhpFormat
+    format_class = LaravelPhpFormat
     FILE = TEST_LARAVEL
     FIND = "return[]->'apples'"
     FIND_CONTEXT = "return[]->'apples'"
@@ -701,7 +705,7 @@ class LaravelPhpFormatTest(PhpFormatTest):
 
 
 class AndroidFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = AndroidFormat
+    format_class = AndroidFormat
     FILE = TEST_ANDROID
     MIME = "application/xml"
     EXT = "xml"
@@ -718,15 +722,15 @@ class AndroidFormatTest(XMLMixin, BaseFormatTest):
 
     def test_get_language_filename(self) -> None:
         self.assertEqual(
-            self.FORMAT.get_language_filename(
-                self.MASK, self.FORMAT.get_language_code("sr_Latn")
+            self.format_class.get_language_filename(
+                self.MASK, self.format_class.get_language_code("sr_Latn")
             ),
             "res/values-b+sr+Latn/strings.xml",
         )
 
 
 class XliffFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = XliffFormat
+    format_class = XliffFormat
     FILE = TEST_XLIFF
     BASE = TEST_XLIFF
     MIME = "application/x-xliff"
@@ -780,7 +784,7 @@ class XliffFormatTest(XMLMixin, BaseFormatTest):
 
 
 class RichXliffFormatTest(XliffFormatTest):
-    FORMAT = RichXliffFormat
+    format_class = RichXliffFormat
     EXPECTED_FLAGS = "c-format, max-length:100, xml-text"
 
 
@@ -800,9 +804,9 @@ class XliffIdFormatTest(RichXliffFormatTest):
         translated_name = os.path.join(self.tempdir, "cs.xliff")
         shutil.copy(self.FILE, template_name)
         shutil.copy(self.FILE, translated_name)
-        template = self.FORMAT(template_name)
-        source = self.FORMAT(template_name, template, is_template=True)
-        translation = self.FORMAT(translated_name, template)
+        template = self.format_class(template_name)
+        source = self.format_class(template_name, template, is_template=True)
+        translation = self.format_class(translated_name, template)
 
         unit = source.all_units[0]
         self.assertEqual(unit.source, "Hello, world!\n")
@@ -846,7 +850,7 @@ class XliffIdFormatTest(RichXliffFormatTest):
 
 
 class PoXliffFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = PoXliffFormat
+    format_class = PoXliffFormat
     FILE = TEST_XLIFF
     BASE = TEST_XLIFF
     MIME = "application/x-xliff"
@@ -876,7 +880,7 @@ class PoXliffFormatTest2(PoXliffFormatTest):
 
 
 class RESXFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = RESXFormat
+    format_class = RESXFormat
     FILE = TEST_RESX
     MIME = "text/microsoft-resx"
     EXT = "resx"
@@ -896,7 +900,7 @@ class RESXFormatTest(XMLMixin, BaseFormatTest):
 
 
 class YAMLFormatTest(BaseFormatTest):
-    FORMAT = YAMLFormat
+    format_class = YAMLFormat
     FILE = TEST_YAML
     BASE = TEST_YAML
     MIME = "text/yaml"
@@ -922,7 +926,7 @@ class YAMLFormatTest(BaseFormatTest):
 
 
 class RubyYAMLFormatTest(YAMLFormatTest):
-    FORMAT = RubyYAMLFormat
+    format_class = RubyYAMLFormat
     FILE = TEST_RUBY_YAML
     BASE = TEST_RUBY_YAML
     NEW_UNIT_MATCH = b"\n  key: Source string\n"
@@ -931,7 +935,7 @@ class RubyYAMLFormatTest(YAMLFormatTest):
 
 
 class TSFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = TSFormat
+    format_class = TSFormat
     FILE = TEST_TS
     BASE = TEST_TS
     MIME = "application/x-linguist"
@@ -951,7 +955,7 @@ class TSFormatTest(XMLMixin, BaseFormatTest):
 
 
 class DTDFormatTest(BaseFormatTest):
-    FORMAT = DTDFormat
+    format_class = DTDFormat
     FILE = TEST_DTD
     BASE = TEST_DTD
     MIME = "application/xml-dtd"
@@ -969,7 +973,7 @@ class DTDFormatTest(BaseFormatTest):
 
 
 class CSVFormatTest(BaseFormatTest):
-    FORMAT = CSVFormat
+    format_class = CSVFormat
     FILE = TEST_CSV
     MIME = "text/csv"
     COUNT = 4
@@ -997,12 +1001,12 @@ class CSVFormatNoHeadTest(CSVFormatTest):
 
 
 class CSVSimpleFormatNoHeadTest(CSVFormatNoHeadTest):
-    FORMAT = CSVSimpleFormat
+    format_class = CSVSimpleFormat
     EXPECTED_FLAGS = ""
 
 
 class FlatXMLFormatTest(BaseFormatTest):
-    FORMAT = FlatXMLFormat
+    format_class = FlatXMLFormat
     FILE = TEST_FLATXML
     MIME = "text/xml"
     COUNT = 2
@@ -1021,7 +1025,7 @@ class FlatXMLFormatTest(BaseFormatTest):
 
 
 class ResourceDictionaryFormatTest(BaseFormatTest):
-    FORMAT = ResourceDictionaryFormat
+    format_class = ResourceDictionaryFormat
     FILE = TEST_RESOURCEDICTIONARY
     MIME = "application/xaml+xml"
     COUNT = 2
@@ -1040,7 +1044,7 @@ class ResourceDictionaryFormatTest(BaseFormatTest):
 
 
 class INIFormatTest(BaseFormatTest):
-    FORMAT = INIFormat
+    format_class = INIFormat
     FILE = TEST_INI
     MIME = "text/plain"
     COUNT = 4
@@ -1060,12 +1064,12 @@ class INIFormatTest(BaseFormatTest):
 
 
 class InnoSetupINIFormatTest(INIFormatTest):
-    FORMAT = InnoSetupINIFormat
+    format_class = InnoSetupINIFormat
     EXT = "islu"
 
 
 class XWikiPropertiesFormatTest(PropertiesFormatTest):
-    FORMAT = XWikiPropertiesFormat
+    format_class = XWikiPropertiesFormat
     FILE = TEST_XWIKI_PROPERTIES
     BASE = ""
     MIME = "text/plain"
@@ -1087,9 +1091,9 @@ class XWikiPropertiesFormatTest(PropertiesFormatTest):
         self.maxDiff = None
         out = os.path.join(self.tempdir, f"test_new_language.{self.EXT}")
         language = Language.objects.get(code="cs")
-        self.FORMAT.add_language(out, language, self.BASE)
+        self.format_class.add_language(out, language, self.BASE)
         template_storage = self.parse_file(self.FILE)
-        new_language = self.FORMAT(out, template_storage, language.code)
+        new_language = self.format_class(out, template_storage, language.code)
         unit, add = new_language.find_unit("job.status.success", "")
         self.assertTrue(add)
         unit.set_target("Fait")
@@ -1107,7 +1111,7 @@ class XWikiPropertiesFormatTest(PropertiesFormatTest):
 
 
 class XWikiPagePropertiesFormatTest(XMLMixin, PropertiesFormatTest):
-    FORMAT = XWikiPagePropertiesFormat
+    format_class = XWikiPagePropertiesFormat
     FILE = TEST_XWIKI_PAGE_PROPERTIES
     SOURCE_FILE = TEST_XWIKI_PAGE_PROPERTIES_SOURCE
     BASE = ""
@@ -1126,8 +1130,8 @@ class XWikiPagePropertiesFormatTest(XMLMixin, PropertiesFormatTest):
 
     def test_get_language_filename(self) -> None:
         self.assertEqual(
-            self.FORMAT.get_language_filename(
-                self.MASK, self.FORMAT.get_language_code("cs")
+            self.format_class.get_language_filename(
+                self.MASK, self.format_class.get_language_code("cs")
             ),
             self.EXPECTED_PATH,
         )
@@ -1177,10 +1181,10 @@ class XWikiPagePropertiesFormatTest(XMLMixin, PropertiesFormatTest):
         translation_file = os.path.join(
             self.tempdir, os.path.basename(self.EXPECTED_PATH)
         )
-        self.FORMAT.add_language(
+        self.format_class.add_language(
             translation_file, Language.objects.get(code="fr"), self.BASE
         )
-        translation_data = self.FORMAT(
+        translation_data = self.format_class(
             storefile=translation_file,
             template_store=storage.template_store,
             language_code="fr",
@@ -1216,7 +1220,7 @@ class XWikiPagePropertiesFormatTest(XMLMixin, PropertiesFormatTest):
 
 
 class XWikiFullPageFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = XWikiFullPageFormat
+    format_class = XWikiFullPageFormat
     FILE = TEST_XWIKI_FULL_PAGE
     SOURCE_FILE = TEST_XWIKI_FULL_PAGE_SOURCE
     BASE = ""
@@ -1242,8 +1246,8 @@ class XWikiFullPageFormatTest(XMLMixin, BaseFormatTest):
 
     def test_get_language_filename(self) -> None:
         self.assertEqual(
-            self.FORMAT.get_language_filename(
-                self.MASK, self.FORMAT.get_language_code("cs")
+            self.format_class.get_language_filename(
+                self.MASK, self.format_class.get_language_code("cs")
             ),
             self.EXPECTED_PATH,
         )
@@ -1299,10 +1303,10 @@ class XWikiFullPageFormatTest(XMLMixin, BaseFormatTest):
         translation_file = os.path.join(
             self.tempdir, os.path.basename(self.EXPECTED_PATH)
         )
-        self.FORMAT.add_language(
+        self.format_class.add_language(
             translation_file, Language.objects.get(code="it"), self.BASE
         )
-        translation_data = self.FORMAT(
+        translation_data = self.format_class(
             storefile=translation_file,
             template_store=storage.template_store,
             language_code="it",
@@ -1334,7 +1338,7 @@ class XWikiFullPageFormatTest(XMLMixin, BaseFormatTest):
 
 
 class TBXFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = TBXFormat
+    format_class = TBXFormat
     FILE = TEST_TBX
     BASE = ""
     MIME = "application/x-tbx"
@@ -1350,7 +1354,7 @@ class TBXFormatTest(XMLMixin, BaseFormatTest):
 
 
 class StringsdictFormatTest(XMLMixin, BaseFormatTest):
-    FORMAT = StringsdictFormat
+    format_class = StringsdictFormat
     FILE = TEST_STRINGSDICT
     MIME = "application/xml"
     EXT = "stringsdict"
@@ -1392,7 +1396,7 @@ class StringsdictFormatTest(XMLMixin, BaseFormatTest):
 
 
 class FluentFormatTest(BaseFormatTest):
-    FORMAT = FluentFormat
+    format_class = FluentFormat
     FILE = TEST_FLUENT
     MIME = "text/x-fluent"
     EXT = "ftl"

--- a/weblate/formats/tests/test_multi.py
+++ b/weblate/formats/tests/test_multi.py
@@ -16,7 +16,7 @@ TEST_MONO_BASE_CSV = get_test_file("en-multi.csv")
 
 
 class MultiCSVUtf8FormatTest(BaseFormatTest):
-    FORMAT = MultiCSVUtf8Format
+    format_class = MultiCSVUtf8Format
     FILE = TEST_CSV
     MIME = "text/csv"
     COUNT = 2

--- a/weblate/formats/tests/test_txt.py
+++ b/weblate/formats/tests/test_txt.py
@@ -14,7 +14,7 @@ APPSTORE_FILE = get_test_file("short_description.txt")
 
 
 class AppStoreFormatTest(BaseFormatTest):
-    FORMAT = AppStoreFormat
+    format_class = AppStoreFormat
     FILE = APPSTORE_FILE
     MIME = "text/plain"
     EXT = "txt"
@@ -31,4 +31,4 @@ class AppStoreFormatTest(BaseFormatTest):
     def parse_file(self, filename):
         if not os.path.isdir(filename):
             filename = os.path.dirname(filename)
-        return self.FORMAT(filename)
+        return self.format_class(filename)


### PR DESCRIPTION
## Proposed changes

We used custom logic to skip testing these, but using abstractclasses makes it possible at discovery time in pytest. Unfortunately this doesn't work in Django discovery, so this makes our testsuite pytest only.


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
