### PR TITLE
feat(api): standardize error responses

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -218,6 +218,17 @@ The status of rate limiting is reported in following headers:
    :envvar:`WEBLATE_API_RATELIMIT_ANON`,
    :envvar:`WEBLATE_API_RATELIMIT_USER`
 
+.. _api-errors:
+
+Error responses
+~~~~~~~~~~~~~~~
+
+.. versionchanged:: 5.10
+
+   Error responses were endpoint specific before this release.
+
+Weblate error responses are formatted based on :doc:`drf-standardized-error:error_response`.
+
 
 API Entry Point
 +++++++++++++++

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,7 +15,7 @@ Not yet released.
 * :guilabel:`Synchronize` on shared repository now operates on all its components.
 * :ref:`check-punctuation-spacing` ignores markup such as Markdown or reStructuredText.
 * :ref:`autofix-punctuation-spacing` does not alter reStructuredText markup.
-* Improved validation errors in :doc:`/api`.
+* Improved validation errors in :doc:`/api`, see :ref:`api-errors`.
 
 **Bug fixes**
 
@@ -29,6 +29,9 @@ Not yet released.
 **Upgrading**
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
+
+* There are several changes in :file:`settings_example.py`, most notable is changes in ``REST_FRAMEWORK`` and ``DRF_STANDARDIZED_ERRORS``, please adjust your settings accordingly.
+* API error responses format has changed, see :ref:`api-errors`.
 
 **Contributors**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -324,6 +324,10 @@ intersphinx_mapping = {
     "borg": ("https://borgbackup.readthedocs.io/en/stable/", None),
     "pip": ("https://pip.pypa.io/en/stable/", None),
     "compressor": ("https://django-compressor.readthedocs.io/en/stable/", None),
+    "drf-standardized-error": (
+        "https://drf-standardized-errors.readthedocs.io/en/latest/",
+        None,
+    ),
 }
 intersphinx_disabled_reftypes = ["*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ dependencies = [
   "djangorestframework>=3.15.2,<3.16",
   "docutils>=0.21.2,<0.22",
   "drf-spectacular[sidecar]>=0.27.2,<0.29",
+  "drf-standardized-errors[openapi]>=0.14.1,<0.15",
   "filelock<4,>=3.16.1",
   "fluent.syntax>=0.18.1,<0.20",
   "GitPython>=3.1.0,<3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1211,6 +1211,25 @@ wheels = [
 ]
 
 [[package]]
+name = "drf-standardized-errors"
+version = "0.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "djangorestframework" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/cc/fd5b8cbc66c361125cba0497573a5ecac94521a715267d7db4d113257a73/drf_standardized_errors-0.14.1.tar.gz", hash = "sha256:0610dcd0096b75365102d276022a22e59a1f8db8825bb0bff05e1b7194ba145d", size = 58730 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/70/589efc32d6f268576e2f3c2a595ef19a305c5d5acbfd26d10ebd45278778/drf_standardized_errors-0.14.1-py3-none-any.whl", hash = "sha256:4941e0f81be94eb0904549999cf221988a5b0f524041c3877530e24f70328ed8", size = 25512 },
+]
+
+[package.optional-dependencies]
+openapi = [
+    { name = "drf-spectacular" },
+    { name = "inflection" },
+]
+
+[[package]]
 name = "elementpath"
 version = "4.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4212,6 +4231,7 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "docutils" },
     { name = "drf-spectacular", extra = ["sidecar"] },
+    { name = "drf-standardized-errors", extra = ["openapi"] },
     { name = "filelock" },
     { name = "fluent-syntax" },
     { name = "gitpython" },
@@ -4456,6 +4476,7 @@ requires-dist = [
     { name = "djangosaml2idp", marker = "extra == 'saml2idp'", specifier = "==0.7.2" },
     { name = "docutils", specifier = ">=0.21.2,<0.22" },
     { name = "drf-spectacular", extras = ["sidecar"], specifier = ">=0.27.2,<0.29" },
+    { name = "drf-standardized-errors", extras = ["openapi"], specifier = ">=0.14.1,<0.15" },
     { name = "filelock", specifier = ">=3.16.1,<4" },
     { name = "fluent-syntax", specifier = ">=0.18.1,<0.20" },
     { name = "git-review", marker = "extra == 'gerrit'", specifier = ">=2.4.0,<2.5.0" },

--- a/weblate/api/spectacular.py
+++ b/weblate/api/spectacular.py
@@ -74,9 +74,20 @@ The OpenAPI specification is available as feature preview, feedback welcome!
         # Flatten enum definitions
         "ENUM_NAME_OVERRIDES": {
             "ColorEnum": "weblate.utils.colors.ColorChoices.choices",
+            "ValidationErrorEnum": "drf_standardized_errors.openapi_serializers.ValidationErrorEnum.choices",
+            "ClientErrorEnum": "drf_standardized_errors.openapi_serializers.ClientErrorEnum.choices",
+            "ServerErrorEnum": "drf_standardized_errors.openapi_serializers.ServerErrorEnum.choices",
+            "ErrorCode401Enum": "drf_standardized_errors.openapi_serializers.ErrorCode401Enum.choices",
+            "ErrorCode403Enum": "drf_standardized_errors.openapi_serializers.ErrorCode403Enum.choices",
+            "ErrorCode404Enum": "drf_standardized_errors.openapi_serializers.ErrorCode404Enum.choices",
+            "ErrorCode405Enum": "drf_standardized_errors.openapi_serializers.ErrorCode405Enum.choices",
+            "ErrorCode406Enum": "drf_standardized_errors.openapi_serializers.ErrorCode406Enum.choices",
+            "ErrorCode415Enum": "drf_standardized_errors.openapi_serializers.ErrorCode415Enum.choices",
+            "ErrorCode429Enum": "drf_standardized_errors.openapi_serializers.ErrorCode429Enum.choices",
+            "ErrorCode500Enum": "drf_standardized_errors.openapi_serializers.ErrorCode500Enum.choices",
         },
         "POSTPROCESSING_HOOKS": [
-            "drf_spectacular.hooks.postprocess_schema_enums",
+            "drf_standardized_errors.openapi_hooks.postprocess_schema_enums",
             "weblate.api.docs.add_middleware_headers",
         ],
         "EXTERNAL_DOCS": {

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1298,9 +1298,12 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "weblate.api.pagination.StandardPagination",
     "PAGE_SIZE": 50,
     "VIEW_DESCRIPTION_FUNCTION": "weblate.api.views.get_view_description",
-    "EXCEPTION_HANDLER": "weblate.api.views.weblate_exception_handler",
+    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
     "UNAUTHENTICATED_USER": "weblate.auth.models.get_anonymous",
-    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_SCHEMA_CLASS": "drf_standardized_errors.openapi.AutoSchema",
+}
+DRF_STANDARDIZED_ERRORS = {
+    "EXCEPTION_HANDLER_CLASS": "weblate.api.views.WeblateExceptionHandler"
 }
 SPECTACULAR_SETTINGS = get_spectacular_settings(INSTALLED_APPS, SITE_URL, SITE_TITLE)
 

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -871,9 +871,12 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "weblate.api.pagination.StandardPagination",
     "PAGE_SIZE": 50,
     "VIEW_DESCRIPTION_FUNCTION": "weblate.api.views.get_view_description",
-    "EXCEPTION_HANDLER": "weblate.api.views.weblate_exception_handler",
+    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
     "UNAUTHENTICATED_USER": "weblate.auth.models.get_anonymous",
-    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_SCHEMA_CLASS": "drf_standardized_errors.openapi.AutoSchema",
+}
+DRF_STANDARDIZED_ERRORS = {
+    "EXCEPTION_HANDLER_CLASS": "weblate.api.views.WeblateExceptionHandler"
 }
 SPECTACULAR_SETTINGS = get_spectacular_settings(INSTALLED_APPS, SITE_URL, SITE_TITLE)
 


### PR DESCRIPTION
## Proposed changes

This is companion to #13541 to make API error response more consistent. We now rely on drf-standardized-erros to do the processing. It also has drf-spectacular integration, so the error states are now documented in OpenAPI.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
