### PR TITLE
fix(autofix): make HTML cleanup honor ignore flag

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@ Not yet released.
 **Bug fixes**
 
 * Fixed translations caching in :ref:`machine-translation-setup`.
+* :ref:`autofix-html` automatic fixups honors the ``ignore-safe-html`` flag.
 
 **Compatibility**
 

--- a/weblate/trans/autofixes/html.py
+++ b/weblate/trans/autofixes/html.py
@@ -21,7 +21,7 @@ class BleachHTML(AutoFix):
 
     def fix_single_target(self, target: str, source: str, unit):
         flags = unit.all_flags
-        if "safe-html" not in flags:
+        if "safe-html" not in flags or "ignore-safe-html" in flags:
             return target, False
 
         sanitizer = HTMLSanitizer()

--- a/weblate/trans/tests/test_autofix.py
+++ b/weblate/trans/tests/test_autofix.py
@@ -74,6 +74,16 @@ class AutoFixTest(TestCase):
             (["%(percent)s %%"], False),
         )
 
+    def test_html_ignored(self) -> None:
+        fix = BleachHTML()
+        unit = MockUnit(
+            source='<a href="script:foo()">link</a>', flags="safe-html,ignore-safe-html"
+        )
+        self.assertEqual(
+            fix.fix_target(["Allow <b>"], unit),
+            (["Allow <b>"], False),
+        )
+
     def test_html_markdown(self) -> None:
         fix = BleachHTML()
         unit = MockUnit(


### PR DESCRIPTION
Once the check is ignored on the string, the cleanup should also not happen.

Fixes #13544

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
