### PR TITLE
feat(machinery): automatically switch to free API for free api keys

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Not yet released.
 * :ref:`autofix-punctuation-spacing` does not alter reStructuredText markup.
 * Improved validation errors in :doc:`/api`, see :ref:`api-errors`.
 * :ref:`check-duplicate` better works with markup such as Markdown or reStructuredText.
+* Automatically use DeepL API Free endpoint for the DeepL API Free authentication keys in :ref:`mt-deepl`.
 
 **Bug fixes**
 

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -43,6 +43,13 @@ class DeepLTranslation(
     settings_form = DeepLMachineryForm
     glossary_count_limit = 1000
 
+    @property
+    def api_base_url(self):
+        url = super().api_base_url
+        if self.settings["key"].endswith(":fx") and url == "https://api.deepl.com/v2":
+            return "https://api-free.deepl.com/v2"
+        return url
+
     def map_language_code(self, code):
         """Convert language to service specific code."""
         return super().map_language_code(code).replace("_", "-").upper()

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -1856,6 +1856,30 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         )
         self.assertEqual(len(responses.calls), 0)
 
+    def test_api_url(self) -> None:
+        self.assertEqual(
+            self.MACHINE_CLS(self.CONFIGURATION).api_base_url,
+            "https://api.deepl.com/v2",
+        )
+        self.assertEqual(
+            self.MACHINE_CLS(
+                {
+                    "key": "KEY:fx",
+                    "url": "https://api.deepl.com/v2",
+                }
+            ).api_base_url,
+            "https://api-free.deepl.com/v2",
+        )
+        self.assertEqual(
+            self.MACHINE_CLS(
+                {
+                    "key": "KEY:fx",
+                    "url": "https://example.com/v2",
+                }
+            ).api_base_url,
+            "https://example.com/v2",
+        )
+
 
 class LibreTranslateTranslationTest(BaseMachineTranslationTest):
     MACHINE_CLS = LibreTranslateTranslation


### PR DESCRIPTION
DeepL API Free tokens are suffixed with :fx, we can use this to automatically use matching endpoint.

See #13581

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
