### PR TITLE
fix(upload): select_for_update all translation units

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1009,7 +1009,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
             .exists()
         )
 
-        unit_set = self.unit_set.all()
+        unit_set = self.unit_set.select_for_update()
 
         for set_fuzzy, unit2 in store2.iterate_merge(fuzzy):
             try:
@@ -1191,6 +1191,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin):
         filecopy = fileobj.read()
         fileobj.close()
         fileobj = NamedBytesIO(fileobj.name, filecopy)
+        self.unit_set.select_for_update()
         with self.component.repository.lock:
             try:
                 if self.is_source:


### PR DESCRIPTION
This should make locking more straightforward to the server instead of locking each row individually.

Fixes WEBLATE-20ZY
Fixes WEBLATE-15BD
Fixes WEBLATE-2101
Fixes WEBLATE-1MKN
Issue #13626

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
