### PR TITLE
fix: match displayed percent with progress bar

### DIFF
--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -158,7 +158,7 @@
             <th class="number">{{ object.stats.all|intcomma }}</th>
             <td>{% trans "Strings" %}</td>
             <td class="progress-cell hidden-xs">{% translation_progress object %}</td>
-            <td class="percent">{{ object.stats.translated_percent|percent_format }}</td>
+            <td class="percent">{{ object.stats.translated_without_checks_percent|percent_format }}</td>
             <td rowspan="3" class="buttons-cell full-cell">
               <div class="pull-right flip">
                 {% if user_can_add_unit %}
@@ -175,14 +175,14 @@
             <th class="number">{{ object.stats.all_words|intcomma }}</th>
             <td>{% trans "Words" %}</td>
             <td class="progress-cell hidden-xs">{% words_progress object %}</td>
-            <td class="percent">{{ object.stats.translated_words_percent|percent_format }}</td>
+            <td class="percent">{{ object.stats.translated_without_checks_words_percent|percent_format }}</td>
           </tr>
 
           <tr>
             <th class="number">{{ object.stats.all_chars|intcomma }}</th>
             <td>{% trans "Characters" %}</td>
             <td class="progress-cell hidden-xs">{% chars_progress object %}</td>
-            <td class="percent">{{ object.stats.translated_chars_percent|percent_format }}</td>
+            <td class="percent">{{ object.stats.translated_without_checks_chars_percent|percent_format }}</td>
           </tr>
         </table>
 

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -863,7 +863,7 @@ def translation_progress(obj):
         stats.all,
         stats.readonly,
         stats.approved,
-        stats.translated - stats.translated_checks,
+        stats.translated_without_checks,
         stats.has_review,
     )
 
@@ -875,7 +875,7 @@ def words_progress(obj):
         stats.all_words,
         stats.readonly_words,
         stats.approved_words,
-        stats.translated_words - stats.translated_checks_words,
+        stats.translated_without_checks_words,
         stats.has_review,
     )
 
@@ -887,7 +887,7 @@ def chars_progress(obj):
         stats.all_chars,
         stats.readonly_chars,
         stats.approved_chars,
-        stats.translated_chars - stats.translated_checks_chars,
+        stats.translated_without_checks_chars,
         stats.has_review,
     )
 

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -278,6 +278,14 @@ class BaseStats:
             # Migration path for legacy stat data
             return self._data.get(name, 0)
 
+        # Virtual fields
+        if name == "translated_without_checks":
+            return self.translated - self.translated_checks
+        if name == "translated_without_checks_words":
+            return self.translated_words - self.translated_checks_words
+        if name == "translated_without_checks_chars":
+            return self.translated_chars - self.translated_checks_chars
+
         # Calculate missing data
         if name not in self._data:
             was_pending = self._pending_save


### PR DESCRIPTION
The progress bar excludes failing check on translated strings, the percent shown next to it should match it.

Fixes #13669

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
