### PR TITLE
fix: do not check e-mail addresses of not sending out e-mail

### DIFF
--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -262,20 +262,21 @@ def check_settings(
             )
         )
 
-    if settings.SERVER_EMAIL in DEFAULT_MAILS:
-        errors.append(
-            weblate_check(
-                "weblate.E012",
-                "The server e-mail address should be changed from its default value",
+    if settings.EMAIL_BACKEND != "django.core.mail.backends.dummy.EmailBackend":
+        if settings.SERVER_EMAIL in DEFAULT_MAILS:
+            errors.append(
+                weblate_check(
+                    "weblate.E012",
+                    "The server e-mail address should be changed from its default value",
+                )
             )
-        )
-    if settings.DEFAULT_FROM_EMAIL in DEFAULT_MAILS:
-        errors.append(
-            weblate_check(
-                "weblate.E013",
-                'The "From" e-mail address should be changed from its default value',
+        if settings.DEFAULT_FROM_EMAIL in DEFAULT_MAILS:
+            errors.append(
+                weblate_check(
+                    "weblate.E013",
+                    'The "From" e-mail address should be changed from its default value',
+                )
             )
-        )
 
     if settings.SECRET_KEY in DEFAULT_SECRET_KEYS:
         errors.append(


### PR DESCRIPTION
Avoid triggering weblate.E012 and weblate.E013 when e-mail sending is using dummy backend which actually does not send e-mails.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
