### PR TITLE
Make .panel-heading match .panel border-radius

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2308,7 +2308,7 @@ tbody.warning {
   background-color: #e9eaec60;
   border: var(--border);
 }
-.panel-danger > .panel-heading {
+.panel-heading {
   border-top-left-radius: var(--border-radius);
   border-top-right-radius: var(--border-radius);
 }


### PR DESCRIPTION
Fixes mismatched border radii between the panel heading and its container. The issue is not particularly visible in the light theme but is noticeable in the dark theme.