### PR TITLE
fix(add-ons): allow selecting approved state on site-wide autotranslate

### DIFF
--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -41,7 +41,7 @@ class AutoTranslate:
         self.target_state = STATE_TRANSLATED
         if mode == "fuzzy":
             self.target_state = STATE_FUZZY
-        elif mode == "approved":
+        elif mode == "approved" and translation.enable_review:
             self.target_state = STATE_APPROVED
         self.component_wide = component_wide
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1031,7 +1031,7 @@ class AutoForm(forms.Form):
             ("translate", gettext("Add as translation")),
             ("fuzzy", gettext('Add as "Needing edit"')),
         ]
-        if user is not None and user.has_perm("unit.review", obj):
+        if user is not None and (user.has_perm("unit.review", obj) or obj is None):
             choices.append(("approved", gettext("Add as approved translation")))
         self.fields["mode"].choices = choices
 


### PR DESCRIPTION
- add "Add as approved translation" choice to site-wide automatic translation add-on
- use translated state when approval is not available on the translation when performing automatic translation

Fixes #13766

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
