### PR TITLE
feat: replace re module with regex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ types = [
   "types-openpyxl==3.1.5.20241225",
   "types-Pillow==10.2.0.20240822",
   "types-python-dateutil==2.9.0.20241206",
+  "types-regex==2024.11.6.20241221",
   "types-requests==2.32.0.20241016"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4066,6 +4066,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-regex"
+version = "2024.11.6.20241221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/6a/1f4ede7c1c07cb4ae87bb81cbd247a7d20241bada6664c444b58c1679443/types_regex-2024.11.6.20241221.tar.gz", hash = "sha256:903c7b557d935363ba01f07a75981c78ada7df66623e415f32bda2afecfa5cca", size = 12107 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/96/dbcf9a88f84747809de55eb3ba1da4637f1678e5c6e5d4c9a97115a30ea1/types_regex-2024.11.6.20241221-py3-none-any.whl", hash = "sha256:9d29ab639df22a86e15e2cc037e92ad100a4e8f4ecd2ad261d6f0c6d8d87f54e", size = 10396 },
+]
+
+[[package]]
 name = "types-requests"
 version = "2.32.0.20241016"
 source = { registry = "https://pypi.org/simple" }
@@ -4413,6 +4422,7 @@ dev = [
     { name = "types-openpyxl" },
     { name = "types-pillow" },
     { name = "types-python-dateutil" },
+    { name = "types-regex" },
     { name = "types-requests" },
 ]
 docs = [
@@ -4470,6 +4480,7 @@ types = [
     { name = "types-openpyxl" },
     { name = "types-pillow" },
     { name = "types-python-dateutil" },
+    { name = "types-regex" },
     { name = "types-requests" },
 ]
 
@@ -4605,6 +4616,7 @@ dev = [
     { name = "types-openpyxl", specifier = "==3.1.5.20241225" },
     { name = "types-pillow", specifier = "==10.2.0.20240822" },
     { name = "types-python-dateutil", specifier = "==2.9.0.20241206" },
+    { name = "types-regex", specifier = "==2024.11.6.20241221" },
     { name = "types-requests", specifier = "==2.32.0.20241016" },
 ]
 docs = [
@@ -4658,6 +4670,7 @@ types = [
     { name = "types-openpyxl", specifier = "==3.1.5.20241225" },
     { name = "types-pillow", specifier = "==10.2.0.20240822" },
     { name = "types-python-dateutil", specifier = "==2.9.0.20241206" },
+    { name = "types-regex", specifier = "==2024.11.6.20241221" },
     { name = "types-requests", specifier = "==2.32.0.20241016" },
 ]
 

--- a/weblate/checks/placeholders.py
+++ b/weblate/checks/placeholders.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any, Literal
 
+import regex as re
 from django.utils.functional import SimpleLazyObject
 from django.utils.html import escape, format_html, format_html_join
 from django.utils.safestring import mark_safe

--- a/weblate/checks/placeholders.py
+++ b/weblate/checks/placeholders.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
-import regex as re
+import regex
 from django.utils.functional import SimpleLazyObject
 from django.utils.html import escape, format_html, format_html_join
 from django.utils.safestring import mark_safe
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 def parse_regex(val):
     if isinstance(val, str):
-        return re.compile(val)
+        return regex.compile(val)
     return val
 
 
@@ -36,12 +36,12 @@ class PlaceholderCheck(TargetCheckParametrized):
         return multi_value_flag(lambda x: x)
 
     def get_value(self, unit: Unit):
-        return re.compile(
+        return regex.compile(
             "|".join(
-                re.escape(param) if isinstance(param, str) else param.pattern
+                regex.escape(param) if isinstance(param, str) else param.pattern
                 for param in super().get_value(unit)
             ),
-            re.IGNORECASE if "case-insensitive" in unit.all_flags else 0,
+            regex.IGNORECASE if "case-insensitive" in unit.all_flags else 0,
         )
 
     @staticmethod

--- a/weblate/checks/tests/test_placeholders.py
+++ b/weblate/checks/tests/test_placeholders.py
@@ -235,3 +235,20 @@ class RegexTest(CheckTestCase):
                 (36, 43, "{foo32}"),
             ],
         )
+
+    def test_unicode_regex(self) -> None:
+        unit = MockUnit(
+            None,
+            r'regex:"((?:@:\(|\{)[-_\p{Lo}\p{Ll}\p{N}]+(?:\)|\}))"',
+            self.default_lang,
+            "@:(你好世界一۲༣) | @:(Hello-World123) | @:(你好世界一۲༣!) | @:(-你好世界一۲༣_) "
+            "| {hello-world123}",
+        )
+        self.assertEqual(
+            list(self.check.check_highlight(unit.source, unit)),
+            [
+                (0, 11, "@:(你好世界一۲༣)"),
+                (50, 63, "@:(-你好世界一۲༣_)"),
+                (66, 82, "{hello-world123}"),
+            ],
+        )


### PR DESCRIPTION
This replaces all imports of the `re` regex module with [`regex`](https://pypi.org/project/regex/). This should be backward compatible with `re`, so just changing the import should be enough.

Some tests fail for as yet unknown reasons, as mentioned `regex `should be backward compatible with `re`, so some tweaks to the tests might be needed.

In the UI, all works as expected. You can use the following test regex check to validate.
```
regex:'^[-_\p{Ll}\p{Lo}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$'
```

Fixes #13728 

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->