### PR TITLE
fix(alerts): adjust DuplicateString upon unit removal

### DIFF
--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -195,6 +195,8 @@ class DuplicateString(MultiAlert):
     verbose = gettext_lazy("Duplicated string found in the file.")
     on_import = True
 
+    # Note: The removal of this alert can be also done in Translation.delete_unit
+
 
 @register
 class DuplicateLanguage(MultiAlert):


### PR DESCRIPTION
The unit removal should affect DuplicateString alert. But as we don't parse all the files, the import alert itself is not triggered properly.

Fixes #13511

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
