### PR TITLE
fix(git): avoid using custom merge driver in rebase or cherry-pick

### DIFF
--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -206,14 +206,20 @@ class GitSquashAddon(BaseAddon):
                 base = repository.get_last_revision()
                 # Cherry pick current commit (this should work
                 # unless something is messed up)
-                repository.execute(["cherry-pick", commit, *gpg_sign])
+                repository.execute(
+                    ["cherry-pick", commit, *gpg_sign],
+                    environment={"WEBLATE_MERGE_SKIP": "1"},
+                )
                 handled = []
                 # Pick other commits by same author
                 for i, other in enumerate(commits):
                     if other[1] != author:
                         continue
                     try:
-                        repository.execute(["cherry-pick", other[0], *gpg_sign])
+                        repository.execute(
+                            ["cherry-pick", other[0], *gpg_sign],
+                            environment={"WEBLATE_MERGE_SKIP": "1"},
+                        )
                         handled.append(i)
                     except RepositoryError:
                         # If fails, continue to another author, we will

--- a/weblate/examples/git-merge-gettext-po
+++ b/weblate/examples/git-merge-gettext-po
@@ -63,6 +63,10 @@ if git merge-file --stdout "$LOCAL" "$BASE" "$OTHER" > "$TEMP_FILE"; then
 fi
 rm "$TEMP_FILE"
 
+if [ -n "$WEBLATE_MERGE_SKIP" ]; then
+    exit 1
+fi
+
 ##########################################################################
 # Fallback when gettext tools are not installed:
 

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -206,7 +206,7 @@ class GitRepository(Repository):
             cmd = ["rebase"]
             cmd.extend(self.get_gpg_sign_args())
             cmd.append(self.get_remote_branch_name())
-            self.execute(cmd)
+            self.execute(cmd, environment={"WEBLATE_MERGE_SKIP": "1"})
         self.clean_revision_cache()
 
     def has_git_file(self, name):


### PR DESCRIPTION
In regular merge it it useful to merge timestamps in the PO file, but this often causes issues in rebase (because the commits become different) or squash (because it can apply changes before they should be applied).

Fixes #13828

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
