### PR TITLE
fix(memory): improve translation memory matching

### DIFF
--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
     from weblate.auth.models import AuthenticatedHttpRequest, User
     from weblate.trans.models import Project
 
+NON_WORD_RE = re.compile(r"\W")
 
 SUPPORTED_FORMATS = (
     "json",
@@ -112,8 +114,11 @@ class MemoryQuerySet(models.QuerySet):
 
         PostgreSQL similarity threshold needs to be higher to avoid too slow
         queries.
+
+        We exclude non-word characters while calculating this as those are
+        excluded in the trigram matching.
         """
-        length = len(text)
+        length = len(NON_WORD_RE.sub("", text))
 
         base = 0.172489 * math.log(threshold) + 0.207051
         bonus = 7.03436 * math.exp(-6.07957 * base)

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -436,6 +436,11 @@ class ThresholdTestCase(SimpleTestCase):
         self.assertAlmostEqual(
             Memory.objects.threshold_to_similarity("x" * 500, 10), 0.74, delta=0.006
         )
+        self.assertAlmostEqual(
+            Memory.objects.threshold_to_similarity("<" * 50 + "x" * 50 + ">" * 50, 10),
+            0.71,
+            delta=0.006,
+        )
 
     def test_auto(self) -> None:
         self.assertAlmostEqual(
@@ -446,6 +451,11 @@ class ThresholdTestCase(SimpleTestCase):
         )
         self.assertAlmostEqual(
             Memory.objects.threshold_to_similarity("x" * 500, 80), 0.98, delta=0.006
+        )
+        self.assertAlmostEqual(
+            Memory.objects.threshold_to_similarity("<" * 50 + "x" * 50 + ">" * 50, 80),
+            0.98,
+            delta=0.006,
         )
 
     def test_machine(self) -> None:
@@ -458,6 +468,11 @@ class ThresholdTestCase(SimpleTestCase):
         self.assertAlmostEqual(
             Memory.objects.threshold_to_similarity("x" * 500, 75), 0.97, delta=0.006
         )
+        self.assertAlmostEqual(
+            Memory.objects.threshold_to_similarity("<" * 50 + "x" * 50 + ">" * 50, 75),
+            0.97,
+            delta=0.006,
+        )
 
     def test_machine_exact(self) -> None:
         self.assertAlmostEqual(
@@ -468,4 +483,9 @@ class ThresholdTestCase(SimpleTestCase):
         )
         self.assertAlmostEqual(
             Memory.objects.threshold_to_similarity("x" * 500, 100), 1.0, delta=0.006
+        )
+        self.assertAlmostEqual(
+            Memory.objects.threshold_to_similarity("<" * 50 + "x" * 50 + ">" * 50, 100),
+            1.0,
+            delta=0.006,
         )


### PR DESCRIPTION
Exclude non-word characters when calculating similarity threshold. This produces better matches for strings that contain a lot of non-word characters because these are not considered in the trigram search.

Fixes #13733

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
