### PR TITLE
fix(unit): corrected check propagation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,7 @@ Weblate 5.10
 
 .. rubric:: Bug fixes
 
+* :ref:`check-reused` wrongly triggered after fixing the error.
 * Dark theme behavior in some situations.
 * Translation propagation sometimes did not work as expected.
 * :http:header:`Content-Security-Policy` is now automatically set for AWS.

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1150,7 +1150,7 @@ class Unit(models.Model, LoggerMixin):
                 user, change_action, author=author, request=request
             )
 
-        changed = (
+        unchanged = (
             self.old_unit["state"] == self.state
             and self.old_unit["target"] == self.target
             and self.old_unit["explanation"] == self.explanation
@@ -1158,7 +1158,7 @@ class Unit(models.Model, LoggerMixin):
         # Return if there was no change
         # We have to explicitly check for fuzzy flag change on monolingual
         # files, where we handle it ourselves without storing to backend
-        if changed and not was_propagated:
+        if unchanged and not was_propagated:
             return False
 
         update_fields = ["target", "state", "original_state", "pending", "explanation"]
@@ -1180,7 +1180,7 @@ class Unit(models.Model, LoggerMixin):
         self.save(
             update_fields=update_fields,
             run_checks=run_checks,
-            propagate_checks=was_propagated or changed,
+            propagate_checks=was_propagated or not unchanged,
         )
 
         # Generate change and process it


### PR DESCRIPTION
Due to a confusingly named variable the logic was inverted and the checks were not propagated on a strings change.

Fixes #13264

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
