### PR TITLE
fix(download): add missing prefetch when downloading multiple translations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Weblate 5.10.1
 
 .. rubric:: Bug fixes
 
+* :ref:`download` performs faster and project and language scopes.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/weblate/trans/views/files.py
+++ b/weblate/trans/views/files.py
@@ -138,7 +138,9 @@ def download(request: AuthenticatedHttpRequest, path):
         components = obj.project.component_set.filter_access(request.user)
         return download_multi(
             request,
-            Translation.objects.filter(component__in=components, language=obj.language),
+            Translation.objects.filter(
+                component__in=components, language=obj.language
+            ).prefetch(),
             [obj.project],
             request.GET.get("format"),
             name=f"{obj.project.slug}-{obj.language.code}",
@@ -147,7 +149,7 @@ def download(request: AuthenticatedHttpRequest, path):
         components = obj.component_set.filter_access(request.user)
         return download_multi(
             request,
-            Translation.objects.filter(component__in=components),
+            Translation.objects.filter(component__in=components).prefetch(),
             [obj],
             request.GET.get("format"),
             name=obj.slug,
@@ -158,7 +160,9 @@ def download(request: AuthenticatedHttpRequest, path):
         ).filter(pk__in=obj.category.all_component_ids)
         return download_multi(
             request,
-            Translation.objects.filter(component__in=components, language=obj.language),
+            Translation.objects.filter(
+                component__in=components, language=obj.language
+            ).prefetch(),
             [obj.category.project],
             request.GET.get("format"),
             name=f"{obj.category.slug}-{obj.language.code}",
@@ -169,7 +173,7 @@ def download(request: AuthenticatedHttpRequest, path):
         )
         return download_multi(
             request,
-            Translation.objects.filter(component__in=components),
+            Translation.objects.filter(component__in=components).prefetch(),
             [obj.project],
             request.GET.get("format"),
             name=obj.slug,


### PR DESCRIPTION


This heavily reduces overhead when downloading huge project, category or project/language scopes.

Fixes WEBLATE-1BJP

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
