### PR TITLE
Fix history events overlay in the editor

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -653,6 +653,10 @@ form + .login-label {
   z-index: 10;
 }
 
+#history {
+  overflow-x: auto;
+}
+
 @media only screen and (max-width: 600px) {
   .btn-float {
     box-shadow: none;


### PR DESCRIPTION
If it overlaps it will be scrollable in boundry.