### PR TITLE
Fix language color picker color

### DIFF
--- a/weblate/static/styles/new-language.css
+++ b/weblate/static/styles/new-language.css
@@ -29,6 +29,10 @@
   }
 }
 
+body[data-theme="dark"] .multi-wrapper .item {
+  background-color: #ffffff20;
+}
+
 .multi-wrapper .item:hover {
   transform: scale(1.05);
 }


### PR DESCRIPTION
Fix language picker color when the user picks dark theme and his OS is in light theme the picker shows with a white bg.
## Before
![image](https://github.com/user-attachments/assets/9c1bebb2-b5af-4bca-8157-c2b8bf0e6452)

## After 
![image](https://github.com/user-attachments/assets/abdaf1c4-6401-4921-a580-7fe0341eb935)

Close: #13902

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
