### PR TITLE
fix(unit): reuse secondary language ids from profile

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1690,14 +1690,14 @@ class Unit(models.Model, LoggerMixin):
             return "html"
         return "none"
 
-    def get_secondary_units(self, user: User):
+    def get_secondary_units(self, user: User) -> list[Unit]:
         """Return list of secondary units."""
-        secondary_langs = user.profile.secondary_languages.exclude(
-            id__in=[
-                self.translation.language_id,
-                self.translation.component.source_language_id,
-            ]
-        )
+        secondary_langs: set[int] = user.profile.secondary_language_ids - {
+            self.translation.language_id,
+            self.translation.component.source_language_id,
+        }
+        if not secondary_langs:
+            return []
         result = get_distinct_translations(
             self.source_unit.unit_set.filter(
                 Q(translation__language__in=secondary_langs)

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from weblate.auth.models import User
     from weblate.auth.permissions import PermissionResult
     from weblate.lang.models import Language
-    from weblate.trans.models import Project, Translation
+    from weblate.trans.models import Project, Translation, Unit
 
 PLURAL_SEPARATOR = "\x1e\x1e"
 LOCALE_SETUP = True
@@ -94,7 +94,7 @@ def is_repo_link(val: str) -> bool:
     return val.startswith("weblate://")
 
 
-def get_distinct_translations(units):
+def get_distinct_translations(units: Iterable[Unit]) -> list[Unit]:
     """
     Return list of distinct translations.
 


### PR DESCRIPTION
This is more effective as in some cases PostgreSQL messes up the join to take seconds. This also makes loading in the zen mode more effective, because secondary langauges are fetched just once.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
