### PR TITLE
fix: use union only when needed

### DIFF
--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -566,8 +566,10 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
 
     def get_child_components_filter(self, filter_callback):
         own = filter_callback(self.component_set.defer_huge())
-        shared = filter_callback(self.shared_components.defer_huge())
-        return own.union(shared)
+        if self.shared_components.exists():
+            shared = filter_callback(self.shared_components.defer_huge())
+            return own.union(shared)
+        return own
 
     @cached_property
     def child_components(self):


### PR DESCRIPTION
Shared components are rare so optimize for case when they are not used and avoid using union query in that case.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
