### PR TITLE
Fix issue #13942

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -232,6 +232,8 @@ ul.legend li {
 .translator .form-group,
 .zen-unit .form-group {
   margin-bottom: 5px;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .translator .list-group {


### PR DESCRIPTION
Fix overflow where long unspaced strings overflow the editor, like in urls.

## Before 
![image](https://github.com/user-attachments/assets/9ce0fd65-9a85-4c1a-a5a7-a6d552e8b175)

## After
![image](https://github.com/user-attachments/assets/46feaf8d-c9c3-4553-b3d0-edc3fa8ac2c9)


Close: #13942

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
