### PR TITLE
fix(search): corrected behavior of the implicit AND operator

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Weblate 5.10.2
 
 .. rubric:: Bug fixes
 
+* Consistency of :ref:`search-boolean` in :doc:`/user/search`.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -113,11 +113,29 @@ Fields
 ``screenshot:TEXT``
    Search in screenshots.
 
+.. _search-boolean:
+
 Boolean operators
 -----------------
 
 You can combine lookups using ``AND``, ``OR``, ``NOT`` and parentheses to
-form complex queries. For example: ``state:translated AND (source:hello OR source:bar)``
+form complex queries.
+
+The ``NOT`` operator has higher precedence than the ``AND`` operator; the
+``AND`` operator has higher precedence than the ``OR`` operator. You can add
+parenthesis to define a precedence of your own.
+
+Omitting the operator will make the query behave like the ``AND`` operator was
+used.
+
+.. list-table:: Equivalent expressions
+
+   * - ``(state:translated AND source:hello) OR source:bar``
+     - Parenthesized expression to clearly show the precedence.
+   * - ``state:translated AND source:hello OR source:bar``
+     - The ``AND`` operator has higher precedence than the ``OR`` operator.
+   * - ``state:translated source:hello OR source:bar``
+     - Query using an implicit ``AND`` operator.
 
 .. _search-operators:
 


### PR DESCRIPTION
The implicit operator would have been overriden by an explicit one when both are used in a single query.

See #13978

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
