### PR TITLE
Update password validation

### DIFF
--- a/docs/admin/auth.rst
+++ b/docs/admin/auth.rst
@@ -455,24 +455,17 @@ Password authentication
 -----------------------
 
 The default :file:`settings.py` comes with a reasonable set of
-:setting:`django:AUTH_PASSWORD_VALIDATORS`:
-
-* Passwords can't be too similar to your other personal info.
-* Passwords must contain at least 10 characters.
-* Passwords can't be a commonly used password.
-* Passwords can't be entirely numeric.
-* Passwords can't consist of a single character or only whitespace.
-* Passwords can't match a password you have used in the past.
-
-You can customize this setting to match your password policy.
+:setting:`django:AUTH_PASSWORD_VALIDATORS` that ensures that weak passwords are
+not allowed. You can customize this setting to match your password policy.
 
 Additionally you can also install
-`django-zxcvbn-password <https://pypi.org/project/django-zxcvbn-password/>`_
+`django-zxcvbn-password-validator <https://github.com/Pierre-Sassoulas/django-zxcvbn-password-validator>`_
 which gives quite realistic estimates of password difficulty and allows rejecting
 passwords below a certain threshold.
 
 .. seealso::
 
+   :setting:`PASSWORD_MINIMAL_STRENGTH`,
    :envvar:`WEBLATE_MIN_PASSWORD_SCORE`
 
 .. _saml-auth:

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1357,6 +1357,23 @@ List for credentials for Pagure servers.
    :ref:`vcs-pagure`,
    `Pagure API <https://pagure.io/api/0/>`_
 
+.. setting:: PASSWORD_MINIMAL_STRENGTH
+
+PASSWORD_MINIMAL_STRENGTH
+-------------------------
+
+.. versionadded:: 5.10.2
+
+Minimal password score as evaluated by the `zxcvbn
+<https://github.com/dwolfhub/zxcvbn-python>`_ password strength estimator.
+
+Defaults to 0, which means strength checking is disabled.
+
+.. seealso::
+
+   :ref:`password-authentication`,
+   :envvar:`WEBLATE_MIN_PASSWORD_SCORE`
+
 
 .. setting:: PRIVACY_URL
 

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1437,8 +1437,13 @@ Other authentication settings
 .. envvar:: WEBLATE_MIN_PASSWORD_SCORE
 
    Minimal password score as evaluated by the `zxcvbn
-   <https://github.com/dropbox/zxcvbn>`_ password strength estimator.
+   <https://github.com/dwolfhub/zxcvbn-python>`_ password strength estimator.
    Defaults to 3, set to 0 to disable strength checking.
+
+   .. seealso::
+
+      :ref:`password-authentication`,
+      :setting:`PASSWORD_MINIMAL_STRENGTH`
 
 
 PostgreSQL database setup

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,8 @@ Weblate 5.10.2
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
+* There are several changes in :file:`settings_example.py`, most notable are changed settings ``AUTH_PASSWORD_VALIDATORS``; please adjust your settings accordingly.
+
 .. rubric:: Contributors
 
 .. include:: changes/contributors/5.10.2.rst

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,11 +19,13 @@ Weblate 5.10.2
 
 .. rubric:: Compatibility
 
+* Weblate has switched to a different library for zxcvbn integration, as the old one is no longer maintained, see :ref:`password-authentication`.
+
 .. rubric:: Upgrading
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
-* There are several changes in :file:`settings_example.py`, most notable are changed settings ``AUTH_PASSWORD_VALIDATORS``; please adjust your settings accordingly.
+* There are several changes in :file:`settings_example.py`, most notable are changed settings ``AUTH_PASSWORD_VALIDATORS`` and ``INSTALLED_APPS``; please adjust your settings accordingly.
 
 .. rubric:: Contributors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ wsgi = [
   "gunicorn==23.0.0"
 ]
 zxcvbn = [
-  "django-zxcvbn-password==2.1.1"
+  "django-zxcvbn-password-validator>=1.4.5,<1.5"
 ]
 
 [project.readme]

--- a/uv.lock
+++ b/uv.lock
@@ -1130,15 +1130,16 @@ wheels = [
 ]
 
 [[package]]
-name = "django-zxcvbn-password"
-version = "2.1.1"
+name = "django-zxcvbn-password-validator"
+version = "1.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "django" },
     { name = "zxcvbn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/08/4cab5e483ccf4c19e2c38ee2d2786ff7a429cd4207e1582e816b8c02a707/django-zxcvbn-password-2.1.1.tar.gz", hash = "sha256:08eb4e5a92e214ba6b6d6fe320d921d4f557582ec567ed3a2b82a4ec175948c2", size = 419007 }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/84/501070029bf091c57063d51745012b151f5ece486cd5c9ffa41914b0bc26/django_zxcvbn_password_validator-1.4.5.tar.gz", hash = "sha256:7cc697f2c2d873e8681374f6b777f06534e70d7c612929f1604427011d8745a4", size = 17351 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/70/eec479706df53b1d4691cdbdc293216f7c2fbccf00a56d708e33c6502e71/django_zxcvbn_password-2.1.1-py2.py3-none-any.whl", hash = "sha256:f0135773a737cfb29fe67420464e2483afc41472aab15cbd3cac5dacbcd69d9b", size = 409354 },
+    { url = "https://files.pythonhosted.org/packages/11/cf/f5bd73b14d21bd759515cf5384f072c161ae63235a08ae02a9d65d0640e3/django_zxcvbn_password_validator-1.4.5-py3-none-any.whl", hash = "sha256:1879f8803e5adbed5462093ccd89a583d2da2af264fbc1347a28785545219327", size = 25877 },
 ]
 
 [[package]]
@@ -4369,7 +4370,7 @@ all = [
     { name = "aliyun-python-sdk-core" },
     { name = "boto3" },
     { name = "django-auth-ldap" },
-    { name = "django-zxcvbn-password" },
+    { name = "django-zxcvbn-password-validator" },
     { name = "git-review" },
     { name = "google-cloud-storage" },
     { name = "google-cloud-translate" },
@@ -4427,7 +4428,7 @@ wsgi = [
     { name = "gunicorn" },
 ]
 zxcvbn = [
-    { name = "django-zxcvbn-password" },
+    { name = "django-zxcvbn-password-validator" },
 ]
 
 [package.dev-dependencies]
@@ -4566,7 +4567,7 @@ requires-dist = [
     { name = "django-otp", specifier = ">=1.5.4,<2.0" },
     { name = "django-otp-webauthn", specifier = ">=0.4.0,<0.5" },
     { name = "django-redis", specifier = ">=5.4.0,<6.0" },
-    { name = "django-zxcvbn-password", marker = "extra == 'zxcvbn'", specifier = "==2.1.1" },
+    { name = "django-zxcvbn-password-validator", marker = "extra == 'zxcvbn'", specifier = ">=1.4.5,<1.5" },
     { name = "djangorestframework", specifier = ">=3.15.2,<3.16" },
     { name = "djangorestframework-csv", specifier = ">=3.0.2,<3.1" },
     { name = "djangosaml2idp", marker = "extra == 'saml2idp'", specifier = "==0.7.2" },

--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -101,7 +101,7 @@ class PasswordField(forms.CharField):
             },
             render_value=False,
         )
-        kwargs["max_length"] = 256
+        kwargs["max_length"] = settings.MAXIMAL_PASSWORD_LENGTH
         kwargs["strip"] = False
         super().__init__(**kwargs)
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -113,6 +113,8 @@ class WeblateAccountsConf(AppConf):
     SOCIAL_AUTH_SAML_IMAGE = "saml.svg"
     SOCIAL_AUTH_SAML_TITLE = "SAML"
 
+    MAXIMAL_PASSWORD_LENGTH = 72
+
     # Login required URLs
     LOGIN_REQUIRED_URLS = []
     LOGIN_REQUIRED_URLS_EXCEPTIONS = (

--- a/weblate/accounts/password_validation.py
+++ b/weblate/accounts/password_validation.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from django.conf import settings
 from django.contrib.auth.hashers import check_password
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext
+from django.utils.translation import gettext, ngettext
 
 from weblate.accounts.models import AuditLog
 
@@ -31,6 +32,31 @@ class CharsPasswordValidator:
         return gettext(
             "Your password can't consist of a single character or only whitespace."
         )
+
+
+class MaximalLengthValidator:
+    """Validate that the password is of a maximal length."""
+
+    def validate(self, password, user=None):
+        if len(password) > settings.MAXIMAL_PASSWORD_LENGTH:
+            raise ValidationError(
+                ngettext(
+                    "This password is too long. It must contain at most "
+                    "%(max_length)d character.",
+                    "This password is too long. It must contain at most "
+                    "%(max_length)d characters.",
+                    settings.MAXIMAL_PASSWORD_LENGTH,
+                ),
+                code="password_too_long",
+                params={"max_length": settings.MAXIMAL_PASSWORD_LENGTH},
+            )
+
+    def get_help_text(self):
+        return ngettext(
+            "Your password must contain at most %(min_length)d character.",
+            "Your password must contain at most %(min_length)d characters.",
+            settings.MAXIMAL_PASSWORD_LENGTH,
+        ) % {"min_length": settings.MAXIMAL_PASSWORD_LENGTH}
 
 
 class PastPasswordsValidator:

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -635,6 +635,9 @@ SOCIAL_AUTH_PROTECTED_USER_FIELDS = ("email",)
 SOCIAL_AUTH_SLUGIFY_USERNAMES = True
 SOCIAL_AUTH_SLUGIFY_FUNCTION = "weblate.accounts.pipeline.slugify_username"
 
+# Value higher than 0 enables validation using zxcvbn
+PASSWORD_MINIMAL_STRENGTH = get_env_int("WEBLATE_MIN_PASSWORD_SCORE", 3)
+
 # Password validation configuration
 AUTH_PASSWORD_VALIDATORS = [
     {
@@ -645,22 +648,23 @@ AUTH_PASSWORD_VALIDATORS = [
         "OPTIONS": {"min_length": 10},
     },
     {"NAME": "weblate.accounts.password_validation.MaximalLengthValidator"},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
-    {"NAME": "weblate.accounts.password_validation.CharsPasswordValidator"},
     {"NAME": "weblate.accounts.password_validation.PastPasswordsValidator"},
 ]
+
 # Optional password strength validation by django-zxcvbn-password
-MIN_PASSWORD_SCORE = get_env_int("WEBLATE_MIN_PASSWORD_SCORE", 3)
-if MIN_PASSWORD_SCORE:
+if PASSWORD_MINIMAL_STRENGTH > 0:
     AUTH_PASSWORD_VALIDATORS.append(
-        {
-            "NAME": "zxcvbn_password.ZXCVBNValidator",
-            "OPTIONS": {
-                "min_score": MIN_PASSWORD_SCORE,
-                "user_attributes": ("username", "email", "full_name"),
+        {"NAME": "django_zxcvbn_password_validator.ZxcvbnPasswordValidator"}
+    )
+else:
+    AUTH_PASSWORD_VALIDATORS.extend(
+        [
+            {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+            {
+                "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"
             },
-        }
+            {"NAME": "weblate.accounts.password_validation.CharsPasswordValidator"},
+        ]
     )
 
 # Password hashing (prefer Argon)
@@ -790,6 +794,10 @@ INSTALLED_APPS = [
     "drf_spectacular_sidecar",
     "drf_standardized_errors",
 ]
+
+# django_zxcvbn_password_validator integration
+if PASSWORD_MINIMAL_STRENGTH > 0:
+    INSTALLED_APPS.append("django_zxcvbn_password_validator")
 
 # Legal integration
 LEGAL_INTEGRATION = get_env_str("WEBLATE_LEGAL_INTEGRATION")

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -644,6 +644,7 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
         "OPTIONS": {"min_length": 10},
     },
+    {"NAME": "weblate.accounts.password_validation.MaximalLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
     {"NAME": "weblate.accounts.password_validation.CharsPasswordValidator"},

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -339,6 +339,9 @@ SOCIAL_AUTH_PROTECTED_USER_FIELDS = ("email",)
 SOCIAL_AUTH_SLUGIFY_USERNAMES = True
 SOCIAL_AUTH_SLUGIFY_FUNCTION = "weblate.accounts.pipeline.slugify_username"
 
+# Value higher than 0 enables validation using zxcvbn
+PASSWORD_MINIMAL_STRENGTH = 0
+
 # Password validation configuration
 AUTH_PASSWORD_VALIDATORS = [
     {
@@ -349,19 +352,24 @@ AUTH_PASSWORD_VALIDATORS = [
         "OPTIONS": {"min_length": 10},
     },
     {"NAME": "weblate.accounts.password_validation.MaximalLengthValidator"},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
-    {"NAME": "weblate.accounts.password_validation.CharsPasswordValidator"},
     {"NAME": "weblate.accounts.password_validation.PastPasswordsValidator"},
-    # Optional password strength validation by django-zxcvbn-password
-    # {
-    #     "NAME": "zxcvbn_password.ZXCVBNValidator",
-    #     "OPTIONS": {
-    #         "min_score": 3,
-    #         "user_attributes": ("username", "email", "full_name")
-    #     }
-    # },
 ]
+
+# Optional password strength validation by django-zxcvbn-password-validator
+if PASSWORD_MINIMAL_STRENGTH > 0:
+    AUTH_PASSWORD_VALIDATORS.append(
+        {"NAME": "django_zxcvbn_password_validator.ZxcvbnPasswordValidator"}
+    )
+else:
+    AUTH_PASSWORD_VALIDATORS.extend(
+        [
+            {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+            {
+                "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"
+            },
+            {"NAME": "weblate.accounts.password_validation.CharsPasswordValidator"},
+        ]
+    )
 
 # Password hashing (prefer Argon)
 PASSWORD_HASHERS = [
@@ -449,6 +457,10 @@ INSTALLED_APPS = [
     "drf_spectacular_sidecar",
     "drf_standardized_errors",
 ]
+
+# django_zxcvbn_password_validator integration
+if PASSWORD_MINIMAL_STRENGTH > 0:
+    INSTALLED_APPS.append("django_zxcvbn_password_validator")
 
 # Custom exception reporter to include some details
 DEFAULT_EXCEPTION_REPORTER_FILTER = "weblate.trans.debug.WeblateExceptionReporterFilter"

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -348,6 +348,7 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
         "OPTIONS": {"min_length": 10},
     },
+    {"NAME": "weblate.accounts.password_validation.MaximalLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
     {"NAME": "weblate.accounts.password_validation.CharsPasswordValidator"},


### PR DESCRIPTION
While we haven't seen any issues with longer passwords, the 72 is the maximal length recommended by zxcvbn-python. Because of unhandled error longer passwords lead to crash.

Also add a length validator that shows this limit visibly to the user.

django-zxcvbn-password is no longer maitained, so better switch to a maintained alternative.


<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
