### PR TITLE
fix(add-ons): corrected squash add-on behavior on linked repos

### DIFF
--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -245,6 +245,10 @@ class GitSquashAddon(BaseAddon):
             repository.delete_branch(tmp)
 
     def post_commit(self, component: Component, store_hash: bool) -> None:
+        # Operate on parent
+        if component.linked_component:
+            component = component.linked_component
+
         repository = cast("GitRepository", component.repository)
         branch_updated = False
         with repository.lock:


### PR DESCRIPTION
While we want to deliver the events per component, the squashing needs to happen per repository to see all the translations.

Fixes #13969

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
