### PR TITLE
fix(backups): correctly restore repos without refs

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Weblate 5.10.2
 
 * Consistency of :ref:`search-boolean` in :doc:`/user/search`.
 * Fixed some :ref:`addons` trigger upon installation.
+* Fixed restoring of Git repositories from :ref:`projectbackup`.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -122,6 +122,8 @@ class BackupsTest(ViewTestCase):
             set(self.project.component_set.values_list("slug", flat=True)),
             set(restored.component_set.values_list("slug", flat=True)),
         )
+        # Verify that Git operations work on restored repos
+        restored.do_reset()
 
     @skipUnlessDBFeature("can_return_rows_from_bulk_insert")
     def test_restore_supported(self) -> None:

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -20,6 +20,7 @@ from django.utils.translation import gettext_lazy
 from packaging.version import Version
 
 from weblate.trans.util import get_clean_env, path_separator
+from weblate.utils.data import data_path
 from weblate.utils.errors import add_breadcrumb
 from weblate.utils.lock import WeblateLock
 from weblate.vcs.ssh import SSH_WRAPPER
@@ -173,8 +174,12 @@ class Repository:
     def _getenv(environment: dict[str, str] | None = None) -> dict[str, str]:
         """Generate environment for process execution."""
         base: dict[str, str] = {
-            "GIT_SSH": SSH_WRAPPER.filename.as_posix(),
+            # Avoid prompts from Git
             "GIT_TERMINAL_PROMPT": "0",
+            # Avoid Git traversing outside the data dir
+            "GIT_CEILING_DIRECTORIES": data_path("vcs").as_posix(),
+            # Use ssh wrapper
+            "GIT_SSH": SSH_WRAPPER.filename.as_posix(),
             "SVN_SSH": SSH_WRAPPER.filename.as_posix(),
         }
         if environment:


### PR DESCRIPTION
After `git gc` the .git/refs/ directories might be empty what causes their ommision from the backup (the zip file includes files, not directories). Upon restoring that blank directory needs to be recreated, otherwise Git does not recognize the directory as a checkout.

Also limit Git traversing outside data dir as that has actually hidden this error for our testsuite as it made it operate on Weblate in CI environment instead of the data.

Fixes WEBLATE-28N0
Fixes WEBLATE-28N2
Fixes WEBLATE-28MC

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
