### PR TITLE
fix: do not show ghosts when paginating results

### DIFF
--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -259,7 +259,7 @@ def show_project_language(request: AuthenticatedHttpRequest, obj: ProjectLanguag
     extra_translations = []
 
     # Add ghost translations
-    if user.is_authenticated and translations.number == 1:
+    if user.is_authenticated and translations.paginator.num_pages == 1:
         existing = {translation.component.slug for translation in obj.translation_set}
         missing = project_object.get_child_components_filter(
             lambda qs: qs.exclude(slug__in=existing)
@@ -333,7 +333,7 @@ def show_category_language(request: AuthenticatedHttpRequest, obj):
     extra_translations = []
 
     # Add ghost translations
-    if user.is_authenticated and translations.number == 1:
+    if user.is_authenticated and translations.paginator.num_pages == 1:
         existing = {translation.component.slug for translation in obj.translation_set}
         missing = category_object.component_set.exclude(slug__in=existing)
         extra_translations = [
@@ -402,7 +402,7 @@ def show_project(request: AuthenticatedHttpRequest, obj):
     for component in all_components:
         if component.can_add_new_language(user, fast=True):
             break
-    if component and all_components.number == 1:
+    if component and all_components.paginator.num_pages == 1:
         add_ghost_translations(
             component,
             user,
@@ -483,7 +483,7 @@ def show_category(request: AuthenticatedHttpRequest, obj):
     for component in all_components:
         if component.can_add_new_language(user, fast=True):
             break
-    if component and all_components.number == 1:
+    if component and all_components.paginator.num_pages == 1:
         add_ghost_translations(
             component,
             user,


### PR DESCRIPTION
The ghost entries make most sense when there is just a few results which can be skimmed visually. This is definitely not the case when pagination is used for the results.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
