### PR TITLE
Fix #14019: Degrade key in sort_unicode when not available

### DIFF
--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -265,12 +265,14 @@ def path_separator(path: str) -> str:
         return path.replace(os.path.sep, "/")
     return path
 
+
 def sort_unicode(choices, key):
-   """Unicode aware sorting if available."""
-   try:
-       return sorted(choices, key=lambda tup: locale.strxfrm(key(tup)))
-   except OSError:
-       return sorted(choices, key=key)
+    """Unicode aware sorting if available."""
+    try:
+        return sorted(choices, key=lambda tup: locale.strxfrm(key(tup)))
+    except OSError:
+        return sorted(choices, key=key)
+
 
 def sort_choices(choices):
     """Sort choices alphabetically."""

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -265,11 +265,12 @@ def path_separator(path: str) -> str:
         return path.replace(os.path.sep, "/")
     return path
 
-
 def sort_unicode(choices, key):
-    """Unicode aware sorting if available."""
-    return sorted(choices, key=lambda tup: locale.strxfrm(key(tup)))
-
+   """Unicode aware sorting if available."""
+   try:
+       return sorted(choices, key=lambda tup: locale.strxfrm(key(tup)))
+   except OSError:
+       return sorted(choices, key=key)
 
 def sort_choices(choices):
     """Sort choices alphabetically."""


### PR DESCRIPTION
1. Degrade key in sort_unicode function when the system does not support non-Latin characters. [#14019 ](https://github.com/WeblateOrg/weblate/issues/14019)

2. unit test: test_render.py passed.
```
(weblate-env) ➜  weblate git:(Fix_14019) pytest weblate/utils/tests/test_render.py
======================================================== test session starts =========================================================
platform darwin -- Python 3.13.2, pytest-8.3.4, pluggy-1.5.0
django: version: 5.1.6, settings: weblate.settings_test (from env)
rootdir: /Users/alex/Downloads/Software Revolution/dev_weblate/weblate
configfile: pyproject.toml
plugins: cov-6.0.0, django-4.10.0, anyio-4.8.0
collected 7 items

weblate/utils/tests/test_render.py .......                                                                                     [100%]

========================================================== warnings summary ==========================================================
../../../../weblate-env/lib/python3.13/site-packages/django/conf/__init__.py:190
  /Users/alex/weblate-env/lib/python3.13/site-packages/django/conf/__init__.py:190: RemovedInDjango60Warning: The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== slowest 20 durations ========================================================

(20 durations < 2s hidden.  Use -vv to show these durations.)
==================================================== 7 passed, 1 warning in 0.14s ====================================================
```