### PR TITLE
fix(utils): use strcoll for sorting strings instead of strxfrm

### DIFF
--- a/weblate/trans/tests/test_sort.py
+++ b/weblate/trans/tests/test_sort.py
@@ -6,14 +6,10 @@
 
 from django.test import TestCase
 
-import weblate.trans.util
+from weblate.trans.util import sort_choices
 
 
 class SortTest(TestCase):
     def test_sort(self) -> None:
-        if not weblate.trans.util.USE_STRXFRM:
-            self.skipTest("strxfrm not available")
-        result = weblate.trans.util.sort_choices(
-            ((2, "zkouška"), (3, "zkouzka"), (1, "zkouaka"))
-        )
+        result = sort_choices(((2, "zkouška"), (3, "zkouzka"), (1, "zkouaka")))
         self.assertEqual([1, 2, 3], [x[0] for x in result])


### PR DESCRIPTION
This one works more reliably across platforms and typically better deals with some corner cases which cannot be handled by strxfrm.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
