### PR TITLE
fix(api): various small fixes for schema generation

### DIFF
--- a/weblate/api/spectacular.py
+++ b/weblate/api/spectacular.py
@@ -157,7 +157,7 @@ The OpenAPI specification is available as feature preview, feedback welcome!
             },
             {
                 "name": "tasks",
-                "description": "Added in version 4.4.",
+                "description": "Added in version 4.4.\n\nListing of the tasks is currently not available.",
             },
             {
                 "name": "statistics",

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -2225,6 +2225,7 @@ class ComponentListViewSet(viewsets.ModelViewSet):
     @extend_schema(
         description="Disassociate a component from the component list.",
         methods=["delete"],
+        parameters=[OpenApiParameter("component_slug", str, OpenApiParameter.PATH)],
     )
     @action(
         detail=True,

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -2330,6 +2330,8 @@ class Metrics(APIView):
 class Search(APIView):
     """Site-wide search endpoint."""
 
+    serializer_class = None
+
     def get(self, request: Request, format=None):  # noqa: A002
         """Return site-wide search results as a list."""
         user = request.user

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -2383,9 +2383,6 @@ class Search(APIView):
         return Response(results)
 
 
-@extend_schema_view(
-    list=extend_schema(description="Listing of the tasks is currently not available.")
-)
 class TasksViewSet(ViewSet):
     def get_task(
         self, request, pk, permission: str | None = None

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -2384,6 +2384,10 @@ class Search(APIView):
 
 
 class TasksViewSet(ViewSet):
+    # Task-related data is handled and queried to Celery.
+    # There is no Django model associated with tasks.
+    serializer_class = None
+
     def get_task(
         self, request, pk, permission: str | None = None
     ) -> tuple[AsyncResult, Component | None]:

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -652,7 +652,7 @@ class GroupViewSet(viewsets.ModelViewSet):
     @extend_schema(
         description="Delete a language from a group.",
         methods=["delete"],
-        parameters=[OpenApiParameter("language_code", str, OpenApiParameter.PATH)]
+        parameters=[OpenApiParameter("language_code", str, OpenApiParameter.PATH)],
     )
     @action(
         detail=True, methods=["delete"], url_path="languages/(?P<language_code>[^/.]+)"
@@ -1504,7 +1504,7 @@ class ComponentViewSet(
     @extend_schema(
         description="Remove association of a project with a component.",
         methods=["delete"],
-        parameters=[OpenApiParameter("project_slug", str, OpenApiParameter.PATH)]
+        parameters=[OpenApiParameter("project_slug", str, OpenApiParameter.PATH)],
     )
     @action(detail=True, methods=["delete"], url_path="links/(?P<project_slug>[^/.]+)")
     def delete_links(self, request: Request, project__slug, slug, project_slug):

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -649,7 +649,11 @@ class GroupViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data, status=HTTP_200_OK)
 
-    @extend_schema(description="Delete a language from a group.", methods=["delete"])
+    @extend_schema(
+        description="Delete a language from a group.",
+        methods=["delete"],
+        parameters=[OpenApiParameter("language_code", str, OpenApiParameter.PATH)]
+    )
     @action(
         detail=True, methods=["delete"], url_path="languages/(?P<language_code>[^/.]+)"
     )

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1504,6 +1504,7 @@ class ComponentViewSet(
     @extend_schema(
         description="Remove association of a project with a component.",
         methods=["delete"],
+        parameters=[OpenApiParameter("project_slug", str, OpenApiParameter.PATH)]
     )
     @action(detail=True, methods=["delete"], url_path="links/(?P<project_slug>[^/.]+)")
     def delete_links(self, request: Request, project__slug, slug, project_slug):


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->

# Changelog

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

## Fixed

- [GroupViewSet]: Unable to derive type of path parameter "language_code" because model "weblate.auth.models.Group" contained no such field.
- [ComponentViewSet]: Unable to derive type of path parameter "project_slug" because model "weblate.trans.models.component.Component" contained no such field.
- [ComponentListViewSet]: Unable to derive type of path parameter "component_slug" because model "weblate.trans.models.componentlist.ComponentList" contained no such field.
- Annotated non-existent method on TasksViewSet.
- [TasksViewSet]: Unable to guess serializer.
- [Search]: Unable to guess serializer.

---

The purpose of this PR is to fix most the remaining error and warning log messages which are issued when a user sends a GET request to `/api/docs/`.

Relates to #12584.
