### PR TITLE
fix(lang): show pagination controls on language page

### DIFF
--- a/weblate/lang/views.py
+++ b/weblate/lang/views.py
@@ -79,17 +79,18 @@ def show_language(request: AuthenticatedHttpRequest, lang):
             return redirect("languages")
 
     last_changes = Change.objects.last_changes(user, language=obj).recent()
-    projects = user.allowed_projects
     projects = prefetch_project_flags(
         get_paginator(
             request,
-            projects.filter(component__translation__language=obj).distinct(),
+            user.allowed_projects.filter(
+                component__translation__language=obj
+            ).distinct(),
             stats=True,
         )
     )
-    projects = [ProjectLanguage(project, obj) for project in projects]
+    project_languages = [ProjectLanguage(project, obj) for project in projects]
 
-    ProjectLanguageStats.prefetch_many([project.stats for project in projects])
+    ProjectLanguageStats.prefetch_many([project.stats for project in project_languages])
 
     return render(
         request,
@@ -100,6 +101,7 @@ def show_language(request: AuthenticatedHttpRequest, lang):
             "last_changes": last_changes,
             "search_form": SearchForm(user, language=obj),
             "projects": projects,
+            "project_languages": project_languages,
         },
     )
 

--- a/weblate/templates/language.html
+++ b/weblate/templates/language.html
@@ -67,7 +67,7 @@
 
     <div class="tab-pane active" id="overview">
 
-      {% include "snippets/list-objects.html" with show_admin_badge=True objects=projects name_source="project" label=_("Project") language=object global_base="stats" %}
+      {% include "snippets/list-objects.html" with show_admin_badge=True objects=project_languages name_source="project" label=_("Project") language=object global_base="stats" %}
 
       {% include "paginator.html" with page_obj=projects %}
 


### PR DESCRIPTION
The pagination object was shadowed by a list of ProjectLanguage instances.

Fixes #14100

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
