### PR TITLE
fix: use prefetch to get other units

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -282,7 +282,6 @@ class ComponentQuerySet(models.QuerySet):
 
     def defer_huge(self):
         return self.defer(
-            "agreement",
             "commit_message",
             "add_message",
             "delete_message",


### PR DESCRIPTION
- reuses defer logic from the component
- reuses source_translation from the source unit
- merging this in the Python seems better than doing too complex query

Fixes WEBLATE-20ZA

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
