### PR TITLE
feat(machinery): make cache expiry overridable per backend

### DIFF
--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -125,6 +125,8 @@ class BatchMachineTranslation:
     is_available = True
     replacement_start = "[X"
     replacement_end = "X]"
+    # Cache results for 30 days
+    cache_expiry = 30 * 24 * 3600
 
     @classmethod
     def get_rank(cls):
@@ -590,7 +592,7 @@ class BatchMachineTranslation:
                     for item in partial:
                         item["original_source"] = original_source
                     if cache_key := cache_keys[text]:
-                        cache.set(cache_key, partial, 30 * 86400)
+                        cache.set(cache_key, partial, self.cache_expiry)
                     if replacements or self.force_uncleanup:
                         self.uncleanup_results(replacements, partial)
                     output[original_source] = partial

--- a/weblate/machinery/weblatetm.py
+++ b/weblate/machinery/weblatetm.py
@@ -16,6 +16,9 @@ class WeblateTranslation(InternalMachineTranslation):
 
     name = "Weblate"
     rank_boost = 1
+    cache_translations = True
+    # Cache results for 1 hour to avoid frequent database hits
+    cache_expiry = 3600
 
     def download_translations(
         self,


### PR DESCRIPTION
This allows to use short cache expiry for Weblate backend to avoid hitting database too often with expensive queries.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
