### PR TITLE
fix(metrics): lazily calculate only todays metrics

### DIFF
--- a/weblate/metrics/models.py
+++ b/weblate/metrics/models.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import datetime
 from itertools import zip_longest
+from typing import cast
 
 from django.core.cache import cache
 from django.db import models, transaction
@@ -21,12 +22,12 @@ from weblate.memory.models import Memory
 from weblate.screenshots.models import Screenshot
 from weblate.trans.models import (
     Category,
-    Change,
     Component,
     ComponentList,
     Project,
     Translation,
 )
+from weblate.trans.models.change import Change, ChangeQuerySet
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.stats import (
     BaseStats,
@@ -189,6 +190,7 @@ class MetricManager(models.Manager["Metric"]):
 
         This is used to fill in blanks in a history.
         """
+        changes: ChangeQuerySet
         if obj is None:
             changes = Change.objects.all()
         elif isinstance(
@@ -201,7 +203,7 @@ class MetricManager(models.Manager["Metric"]):
             | ProjectLanguage
             | CategoryLanguage,
         ):
-            changes = obj.change_set.all()
+            changes = cast("ChangeQuerySet", obj.change_set.all())  # type: ignore[misc]
         elif isinstance(obj, ComponentList):
             changes = Change.objects.filter(component__in=obj.components.all())
         elif isinstance(obj, Category):

--- a/weblate/metrics/wrapper.py
+++ b/weblate/metrics/wrapper.py
@@ -202,7 +202,8 @@ class MetricsWrapper:
     def trend_60_users(self) -> float:
         return self.calculate_trend("users", self.past_30, self.past_60)
 
-    def get_daily_activity(self, start, days) -> dict[date, int]:
+    def get_daily_activity(self, start: date, days: int) -> dict[date, int]:
+        today = timezone.now().date()
         kwargs = {
             "scope": self.scope,
             "relation": self.relation,
@@ -218,7 +219,8 @@ class MetricsWrapper:
         for offset in range(days):
             current = start - timedelta(days=offset)
             if current not in result:
-                if offset == 0:
+                if current == today:
+                    # Lazily calculate today value (if task is not running)
                     result[current] = Metric.objects.calculate_changes(
                         date=current,
                         obj=self.obj,


### PR DESCRIPTION
Since the database is now sparse, it does not contain past entries for newly created objects.

Fixes WEBLATE-23QS
Fixes WEBLATE-9N8

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
