### PR TITLE
fix(test): workaround crash in Selenium tests

### DIFF
--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -95,7 +95,13 @@ class SeleniumTests(
     def wait_for_page_load(self, timeout: int = 30) -> Iterator[None]:
         old_page = self.driver.find_element(By.TAG_NAME, "html")
         yield
-        WebDriverWait(self.driver, timeout).until(staleness_of(old_page))
+        try:
+            WebDriverWait(self.driver, timeout).until(staleness_of(old_page))
+        except WebDriverException:
+            # Retry the same condition to workaround issue in Chomedriver/Selenium, see
+            # https://github.com/SeleniumHQ/selenium/issues/15401
+            time.sleep(0.1)
+            WebDriverWait(self.driver, timeout).until(staleness_of(old_page))
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
Chromium 134 seem to broke Selenium and it throws WebDriverException when element is about to get stale. This catches the error and retries the operation after a short delay.

See https://github.com/SeleniumHQ/selenium/issues/15401

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
