### PR TITLE
tests: add test for sync/resync while editing

### DIFF
--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -726,6 +726,32 @@ class EditPropagateTest(EditTest):
                     unit.change_set.filter(action=Change.ACTION_CHANGE).count(), 1
                 )
 
+        # Bring strins out of sync
+        unit = self.get_unit()
+        test_edit = "Test edit\n"
+        unit.translate(
+            None,
+            test_edit,
+            STATE_TRANSLATED,
+            change_action=Change.ACTION_AUTO,
+            propagate=False,
+        )
+        self.assertEqual(set(get_targets()), {self.second_target, test_edit})
+        self.assertEqual(
+            {"inconsistent"}, set(unit.check_set.values_list("name", flat=True))
+        )
+
+        # Resync them
+        unit.translate(
+            None,
+            self.second_target,
+            STATE_TRANSLATED,
+            change_action=Change.ACTION_AUTO,
+            propagate=False,
+        )
+        self.assertEqual(set(get_targets()), {self.second_target})
+        self.assertEqual(set(), set(unit.check_set.values_list("name", flat=True)))
+
 
 class EditTSTest(EditTest):
     def create_component(self):


### PR DESCRIPTION
I was hoping this is the cause for #14189, but the test is useful even if it is not.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
