### PR TITLE
fix(tests): use the same unit instead of getting random one

### DIFF
--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -144,7 +144,7 @@ class ProjectTest(RepoTestCase):
             )
             user = create_test_user()
             translation = component.translation_set.get(language_code="cs")
-            unit = translation.unit_set.all()[0]
+            unit = translation.unit_set.get(source="Hello, world!\n")
             suggestion = Suggestion.objects.add(unit, ["Test"], None)
             Vote.objects.create(suggestion=suggestion, value=Vote.POSITIVE, user=user)
         component.project.delete()
@@ -157,7 +157,7 @@ class ProjectTest(RepoTestCase):
             user = create_test_user()
             another_user = create_another_user()
             translation = component.translation_set.get(language_code="cs")
-            unit: Unit = translation.unit_set.all()[0]
+            unit = translation.unit_set.get(source="Hello, world!\n")
 
             unit.translate(user, "Translation of unit ", STATE_TRANSLATED)
 


### PR DESCRIPTION
Ordering of the units is not defined, so .all()[0] returns a random unit. When it ends up to be one with plurals, the logic fails.

Fixes #13904

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
