### PR TITLE
setuptools: use find_namespace_packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -565,8 +565,8 @@ license-files = []
 zip-safe = false
 
 [tool.setuptools.packages.find]
-namespaces = true
 include = ["weblate*"]
+namespaces = true
 
 [tool.tomlsort]
 ignore_case = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -564,8 +564,9 @@ include-package-data = true
 license-files = []
 zip-safe = false
 
-[tool.setuptools.packages]
-find = {namespaces = false}
+[tool.setuptools.packages.find]
+namespaces = true
+include = ["weblate*"]
 
 [tool.tomlsort]
 ignore_case = true


### PR DESCRIPTION
When building the weblate package, there are several "Package would be ignored" errors. See https://github.com/WeblateOrg/weblate/issues/12778 for details.

These errors stem from the fact that any directory even if it doesn't contain python files can be imported in a python file as a namespace package. The template and local directories included in the weblate build as package data qualify as namespace packages. However, since find_namespace_packages was set to false setuptools wouldn't consider it as importable package leading to an inconsistent configuration.

To fix this issue, set find_namespace_packages to true in pyproject.toml. Since weblate is a "flat layout", the include directive is also needed to exclude other top level directories from being included in the final package.

To test this change, I extracted the source dist and wheels produced before this change and compared them to their respective versions produced after the change. The wheels comparison produced no diff. For source dist, the diff was:
```
567,569c567,568
< [tool.setuptools.packages.find]
< namespaces = true
< include = ["weblate*"]
---
> [tool.setuptools.packages]
> find = {namespaces = false}
```
which is expected.

Fixes #12778 