### PR TITLE
Add an api to get all string translations

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2271,6 +2271,12 @@ and XLIFF.
     :param id: Unit ID
     :type id: int
 
+.. http:get:: /api/units/(int:id)/translations/
+
+   .. versionadded:: 5.11
+
+   Returns a list of all target translation units for the given source translation unit.
+
 Changes
 +++++++
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Weblate 5.11
 
 .. rubric:: New features
 
+* Added :http:get:`/api/units/(int:id)/translations/` to retrieve a list of all target translation units for the given source translation unit.
+
 .. rubric:: Improvements
 
 * Weblate now uses OpenAPI Specification 3.1.1 to generate the schema for :ref:`api`.

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -4075,14 +4075,18 @@ class UnitAPITest(APIBaseTest):
         unit = Unit.objects.get(
             translation__language_code="en", source="Thank you for using Weblate."
         )
-        response = self.client.get(reverse("api:unit-translations", kwargs={"pk": unit.pk}))
+        response = self.client.get(
+            reverse("api:unit-translations", kwargs={"pk": unit.pk})
+        )
         # translations units do not include source unit
         self.assertEqual(len(response.data), 3)
 
         unit_cs = Unit.objects.get(
             translation__language_code="cs", source="Thank you for using Weblate."
         )
-        response = self.client.get(reverse("api:unit-translations", kwargs={"pk": unit_cs.pk}))
+        response = self.client.get(
+            reverse("api:unit-translations", kwargs={"pk": unit_cs.pk})
+        )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data["errors"][0]["code"], "not-a-source-unit")
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -4071,6 +4071,21 @@ class UnitAPITest(APIBaseTest):
         self.assertNotEqual(revision, component.repository.last_revision)
         self.assertEqual(component.stats.all, 12)
 
+    def test_unit_translations(self):
+        unit = Unit.objects.get(
+            translation__language_code="en", source="Thank you for using Weblate."
+        )
+        response = self.client.get(reverse("api:unit-translations", kwargs={"pk": unit.pk}))
+        # translations units do not include source unit
+        self.assertEqual(len(response.data), 3)
+
+        unit_cs = Unit.objects.get(
+            translation__language_code="cs", source="Thank you for using Weblate."
+        )
+        response = self.client.get(reverse("api:unit-translations", kwargs={"pk": unit_cs.pk}))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["errors"][0]["code"], "not-a-source-unit")
+
 
 class ScreenshotAPITest(APIBaseTest):
     def setUp(self) -> None:

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1984,7 +1984,7 @@ class UnitViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelM
         user = request.user
         user.check_access_component(unit.translation.component)
 
-        if unit.pk != unit.source_unit.pk:
+        if not unit.is_source:
             raise NotSourceUnit
 
         translation_units = (

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -38,9 +38,9 @@ from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
     HTTP_423_LOCKED,
     HTTP_500_INTERNAL_SERVER_ERROR,
-    HTTP_400_BAD_REQUEST,
 )
 from rest_framework.utils import formatting
 from rest_framework.views import APIView
@@ -1985,12 +1985,14 @@ class UnitViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelM
         user.check_access_component(unit.translation.component)
 
         if unit.pk != unit.source_unit.pk:
-            raise NotSourceUnit()
+            raise NotSourceUnit
 
-        translation_units = unit.source_unit.unit_set.exclude(pk=unit.pk) \
-            .prefetch() \
-            .prefetch_full()
-        serializer = UnitSerializer(translation_units, many=True, context={"request": request})
+        translation_units = (
+            unit.source_unit.unit_set.exclude(pk=unit.pk).prefetch().prefetch_full()
+        )
+        serializer = UnitSerializer(
+            translation_units, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
 


### PR DESCRIPTION
Added a translations action to UnitViewSet to retrieve all target source units for a given source unit. A 400 error is returned if the specified unit is not a source unit.

Fixes #13186