### PR TITLE
fix: check pending changes only on components that have one

### DIFF
--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from glob import glob
 from operator import itemgetter
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from celery.schedules import crontab
 from django.conf import settings
@@ -47,6 +47,9 @@ from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.stats import prefetch_stats
 from weblate.utils.views import parse_path
 from weblate.vcs.base import RepositoryError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @app.task(
@@ -118,11 +121,18 @@ def perform_push(pk, *args, **kwargs) -> None:
 
 
 @app.task(trail=False)
-def commit_pending(hours=None, pks=None, logger=None) -> None:
+def commit_pending(
+    hours: int | None = None,
+    pks: set[int] | None = None,
+    logger: Callable[[str], None] | None = None,
+) -> None:
     if pks is None:
         components = Component.objects.all()
     else:
-        components = Component.objects.filter(translation__pk__in=pks).distinct()
+        components = Component.objects.filter(translation__pk__in=pks)
+
+    # All components with pending units
+    components = components.filter(translation__unit__pending=True).distinct()
 
     for component in prefetch_stats(components.prefetch()):
         age = timezone.now() - timedelta(


### PR DESCRIPTION
This avoids repeated querying of pending units on components that have none.

Fixes WEBLATE-SQ

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
