### PR TITLE
Exclude glossary counts from stats in OpenGraph image

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 5.11
 
 * Weblate now uses OpenAPI Specification 3.1.1 to generate the schema for :ref:`api`.
 * :ref:`credits` and :ref:`stats` include translator's join date. Additionally, both reports can be sorted either by the join date or the number of strings translated.
+* Widgets show better stats.
 
 .. rubric:: Bug fixes
 

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -63,6 +63,7 @@ from weblate.utils.stats import (
     CategoryLanguage,
     GhostProjectLanguageStats,
     ProjectLanguage,
+    get_non_glossary_stats,
     prefetch_stats,
 )
 from weblate.utils.views import (
@@ -145,22 +146,6 @@ def show_engage(request: AuthenticatedHttpRequest, path):
         try_set_language(language.code)
         translate_object = obj
         project = obj.project
-        stats_obj = obj.stats
-
-        all_count = strings_count = stats_obj.all
-        translated_count = stats_obj.translated
-
-        # Remove glossary from counts
-        glossaries = prefetch_stats(
-            Translation.objects.filter(
-                language=language, component__in=project.glossaries
-            ).prefetch()
-        )
-        for glossary in glossaries:
-            all_count -= glossary.stats.all
-            translated_count -= glossary.stats.translated
-            strings_count -= glossary.stats.all
-
     else:
         project = obj
         language = None
@@ -174,17 +159,8 @@ def show_engage(request: AuthenticatedHttpRequest, path):
             translate_object = ProjectLanguage(
                 project=project, language=guessed_language
             )
-        stats_obj = obj.stats
 
-        all_count = stats_obj.all
-        strings_count = stats_obj.source_strings
-        translated_count = stats_obj.translated
-
-        # Remove glossary from counts
-        for glossary in prefetch_stats(project.glossaries):
-            all_count -= glossary.stats.all
-            translated_count -= glossary.stats.translated
-            strings_count -= glossary.stats.source_strings
+    stats = get_non_glossary_stats(obj.stats)
 
     return render(
         request,
@@ -194,9 +170,9 @@ def show_engage(request: AuthenticatedHttpRequest, path):
             "object": obj,
             "path_object": obj,
             "project": project,
-            "strings_count": strings_count,
+            "strings_count": stats["source_strings"],
             "languages_count": project.stats.languages,
-            "percent": translation_percent(translated_count, all_count),
+            "percent": translation_percent(stats["translated"], stats["all"]),
             "language": language,
             "translate_object": translate_object,
             "project_link": format_html(

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -26,7 +26,7 @@ from weblate.fonts.utils import configure_fontconfig, render_size
 from weblate.lang.models import Language
 from weblate.trans.models import Project
 from weblate.trans.templatetags.translations import number_format
-from weblate.trans.util import sort_unicode
+from weblate.trans.util import sort_unicode, translation_percent
 from weblate.utils.icons import find_static_file
 from weblate.utils.site import get_site_url
 from weblate.utils.stats import (
@@ -35,6 +35,7 @@ from weblate.utils.stats import (
     ProjectLanguage,
     ProjectLanguageStats,
     TranslationStats,
+    get_non_glossary_stats,
 )
 from weblate.utils.views import get_percent_color
 
@@ -87,7 +88,10 @@ class Widget:
         else:
             stats = obj.stats
         self.stats = stats
-        self.percent = stats.translated_percent
+        self.non_glossary_stats = get_non_glossary_stats(stats)
+        self.percent = translation_percent(
+            self.non_glossary_stats["translated"], self.non_glossary_stats["all"]
+        )
 
     def get_color_name(self, color):
         """Return color name based on allowed ones."""
@@ -121,9 +125,9 @@ class BitmapWidget(Widget):
         super().__init__(obj, color, lang)
         # Get object and related params
         if isinstance(self.stats, TranslationStats):
-            self.total = self.stats.all
+            self.total = self.non_glossary_stats["all"]
         else:
-            self.total = self.stats.source_strings
+            self.total = self.non_glossary_stats["source_strings"]
         self.languages = self.stats.languages
         self.params = self.get_text_params()
 

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -133,6 +133,40 @@ def prefetch_stats(queryset):
     return result
 
 
+def get_non_glossary_stats(stats_obj) -> dict[str, int]:
+    """Return a dictionary with all, source_strings, and translated strings count excluding glossary content."""
+    result = {
+        "all": stats_obj.all,
+        "translated": stats_obj.translated,
+        "source_strings": getattr(stats_obj, "source_strings", stats_obj.all),
+    }
+
+    if isinstance(stats_obj, ProjectLanguageStats):
+        from weblate.trans.models import Translation
+
+        glossaries = Translation.objects.filter(
+            language=stats_obj.language, component__in=stats_obj.project.glossaries
+        ).prefetch()
+    elif isinstance(stats_obj, ProjectStats):
+        glossaries = stats_obj._object.glossaries  # noqa: SLF001
+    elif isinstance(stats_obj, GlobalStats):
+        from weblate.trans.models import Component
+
+        glossaries = Component.objects.filter(is_glossary=True)
+    else:
+        # other stat types do not concern glossaries
+        return result
+
+    for glossary in prefetch_stats(glossaries):
+        result["all"] -= glossary.stats.all
+        result["translated"] -= glossary.stats.translated
+        result["source_strings"] -= getattr(
+            glossary.stats, "source_strings", glossary.stats.all
+        )
+
+    return result
+
+
 class BaseStats:
     """Caching statistics calculator."""
 


### PR DESCRIPTION
Since #10094, glossary counts have been excluded from the engage page. Refactor the logic into a `get_non_glossary_stats` function and reuse it to exclude stats from OpenGraph images and other widgets output.

Fixes #14218.