### PR TITLE
fix(lang): prioritize handling aliases before getting by name

### DIFF
--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -253,8 +253,6 @@ class LanguageQuerySet(models.QuerySet):
             Q(code__iexact=code.replace("-", "_")),
             # Replace plus with underscore (for things as zh+Hant+HK on Android)
             Q(code__iexact=code.replace("+", "_")),
-            # Try using name
-            Q(name__iexact=code) & Q(code__in=data.NO_CODE_LANGUAGES),
         ]
 
         # Country codes used without underscore (ptbr insteat of pt_BR)
@@ -308,6 +306,11 @@ class LanguageQuerySet(models.QuerySet):
                 ret = self.try_get(code=expanded_code[:2])
             if ret is not None:
                 return ret
+
+        # Try using name
+        ret = self.try_get(Q(name__iexact=code) & Q(code__in=data.NO_CODE_LANGUAGES))
+        if ret is not None:
+            return ret
 
         return newcode
 

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -365,6 +365,11 @@ class LanguagesTest(BaseTestCase, metaclass=LanguageTestSequenceMeta):
             "czech", "cs", "ltr", "(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2", "Czech", False
         )
 
+    def test_dan(self) -> None:
+        """Test that aliases have higher priority than language names."""
+        language = Language.objects.auto_get_or_create("dan")
+        self.assertEqual(language.code, "da")
+
     def test_chinese_fuzzy_get(self) -> None:
         """Test handling of manually created zh_CN language."""
         language = Language.objects.create(code="zh_CN", name="Chinese")


### PR DESCRIPTION
Getting by name is the most fuzzy option as there are confusing language names (Dan language mathes ISO 639-2 code for Danish).

Fixes #14238

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
