### PR TITLE
Fix overflow of long unspaced glossary terms

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2348,3 +2348,13 @@ tbody.warning {
 .panel-title .pull-right.text-muted {
   padding: 0 0.5em;
 }
+
+table.table-simple tbody#glossary-terms {
+  table-layout: fixed;
+  width: 100%;
+}
+
+table.table-simple tbody#glossary-terms td {
+  word-break: break-word;
+  white-space: normal;
+}


### PR DESCRIPTION
close: #14142
## Before
![image](https://github.com/user-attachments/assets/6e306632-6191-42ac-a986-f281ea06def0)

## After
![image](https://github.com/user-attachments/assets/03a204f3-7428-4dde-97a6-9a3a4d2f3daa)


<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
