### PR TITLE
fix(api): use default database connection for memory

### DIFF
--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1569,7 +1569,9 @@ class MemoryViewSet(viewsets.ModelViewSet, DestroyModelMixin):
     def get_queryset(self):
         if not self.request.user.is_superuser:
             self.permission_denied(self.request, "Access not allowed")
-        return Memory.objects.order_by("id")
+        # Use default database connection and not memory_db one (in case
+        # a custom router is used).
+        return Memory.objects.using("default").order_by("id")
 
     def perm_check(self, request: Request, instance) -> None:
         if not request.user.has_perm("memory.delete", instance):


### PR DESCRIPTION
It might be diverted to memory_db replica using a custom router and it won't work for delete queries as it is read-only.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
