### PR TITLE
fix(captcha): altcha verification does not deal with timezones

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,8 @@ Weblate 5.11
 
 .. rubric:: Bug fixes
 
+* Fixed captcha verification when some time zone was configured.
+
 .. rubric:: Compatibility
 
 * Registration now disallows disposable e-mail domains.

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import codecs
 import os
 import tempfile
+from datetime import UTC
 from itertools import chain
 from typing import TYPE_CHECKING, BinaryIO, Literal, NotRequired, TypedDict
 
@@ -874,7 +875,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
         # Update po file header
         now = timezone.now()
         if not timezone.is_aware(now):
-            now = timezone.make_aware(now, timezone.utc)
+            now = timezone.make_aware(now, UTC)
 
         # Prepare headers to update
         headers = {


### PR DESCRIPTION
Pass naive datetime to altcha as it breaks when timezones are involved.

Fixes #14132

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
