### PR TITLE
feat(checks): automattic components check

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Weblate 5.11
 
 * Added :http:get:`/api/units/(int:id)/translations/` to retrieve a list of all target translation units for the given source translation unit.
 * Added :http:delete:`/api/groups/(int:id)/roles/(int:role_id)` to delete a role from a group.
+* :ref:`check-automattic-components-format` check to validate placeholders in Automattic components.
 
 .. rubric:: Improvements
 

--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -922,6 +922,23 @@ Vue I18n formatting
    `Vue I18n Formatting <https://kazupon.github.io/vue-i18n/guide/formatting.html>`_,
    `Vue I18n Linked locale messages <https://kazupon.github.io/vue-i18n/guide/messages.html#linked-locale-messages>`_
 
+.. _check-automattic-components-format:
+
+Automattic components formatting
+********************************
+
+:Summary: The Automattic components' placeholders do not match the source
+:Scope: translated strings
+:Check class: ``weblate.checks.format.AutomatticComponentsCheck``
+:Check identifier: ``automattic_components_format``
+:Flag to enable: ``automattic-components-format``
+:Flag to ignore: ``ignore-automattic-components-format``
+:Simple format string example: ``They bought {{strong}}apples{{/strong}}.``
+
+.. seealso::
+
+   :ref:`check-formats`
+
 .. _check-translated:
 
 Has been translated

--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -937,7 +937,8 @@ Automattic components formatting
 
 .. seealso::
 
-   :ref:`check-formats`
+   :ref:`check-formats`,
+   `Interpolate Components <https://github.com/Automattic/wp-calypso/tree/trunk/packages/interpolate-components>`_
 
 .. _check-translated:
 

--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -458,7 +458,7 @@ AngularJS interpolation string
 Automattic components formatting
 ********************************
 
-:Summary: The Automattic components' placeholders do not match the source
+:Summary: The Automattic components' placeholders do not match the source.
 :Scope: translated strings
 :Check class: ``weblate.checks.format.AutomatticComponentsCheck``
 :Check identifier: ``automattic_components_format``

--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -453,6 +453,24 @@ AngularJS interpolation string
    :ref:`check-formats`,
    `AngularJS text interpolation <https://angular.io/guide/interpolation>`_
 
+.. _check-automattic-components-format:
+
+Automattic components formatting
+********************************
+
+:Summary: The Automattic components' placeholders do not match the source
+:Scope: translated strings
+:Check class: ``weblate.checks.format.AutomatticComponentsCheck``
+:Check identifier: ``automattic_components_format``
+:Flag to enable: ``automattic-components-format``
+:Flag to ignore: ``ignore-automattic-components-format``
+:Simple format string example: ``They bought {{strong}}apples{{/strong}}.``
+
+.. seealso::
+
+   :ref:`check-formats`,
+   `Interpolate Components <https://github.com/Automattic/wp-calypso/tree/trunk/packages/interpolate-components>`_
+
 .. _check-c-format:
 
 C format
@@ -921,24 +939,6 @@ Vue I18n formatting
    :ref:`check-formats`,
    `Vue I18n Formatting <https://kazupon.github.io/vue-i18n/guide/formatting.html>`_,
    `Vue I18n Linked locale messages <https://kazupon.github.io/vue-i18n/guide/messages.html#linked-locale-messages>`_
-
-.. _check-automattic-components-format:
-
-Automattic components formatting
-********************************
-
-:Summary: The Automattic components' placeholders do not match the source
-:Scope: translated strings
-:Check class: ``weblate.checks.format.AutomatticComponentsCheck``
-:Check identifier: ``automattic_components_format``
-:Flag to enable: ``automattic-components-format``
-:Flag to ignore: ``ignore-automattic-components-format``
-:Simple format string example: ``They bought {{strong}}apples{{/strong}}.``
-
-.. seealso::
-
-   :ref:`check-formats`,
-   `Interpolate Components <https://github.com/Automattic/wp-calypso/tree/trunk/packages/interpolate-components>`_
 
 .. _check-translated:
 

--- a/weblate/checks/format.py
+++ b/weblate/checks/format.py
@@ -819,7 +819,7 @@ class AutomatticComponentsCheck(BaseFormatCheck):
     check_id = "automattic_components_format"
     name = gettext_lazy("Automattic Components")
     description = gettext_lazy(
-        "The Automattic components' placeholders do not match the source"
+        "The Automattic components' placeholders do not match the source."
     )
 
     def __init__(self) -> None:

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -78,6 +78,7 @@ class WeblateChecksConf(AppConf):
         "weblate.checks.format.VueFormattingCheck",
         "weblate.checks.format.I18NextInterpolationCheck",
         "weblate.checks.format.ESTemplateLiteralsCheck",
+        "weblate.checks.format.AutomatticComponentsCheck",
         "weblate.checks.angularjs.AngularJSInterpolationCheck",
         "weblate.checks.icu.ICUMessageFormatCheck",
         "weblate.checks.icu.ICUSourceCheck",

--- a/weblate/checks/tests/test_format_checks.py
+++ b/weblate/checks/tests/test_format_checks.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from django.test import SimpleTestCase
 
 from weblate.checks.format import (
+    AutomatticComponentsCheck,
     BaseFormatCheck,
     CFormatCheck,
     CSharpFormatCheck,
@@ -1600,6 +1601,55 @@ class VueFormattingCheckTest(CheckTestCase):
         )
         self.assertTrue(
             self.check.check_format("{foo} string", "{bar} string", False, None)
+        )
+
+
+class AutomatticComponentsCheckTest(CheckTestCase):
+    check = AutomatticComponentsCheck()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_highlight = (
+            "automattic-components-format",
+            "{{ strong }} hello, world {{/strong}}, {{ languages /}}",
+            [
+                (0, 12, "{{ strong }}"),
+                (26, 37, "{{/strong}}"),
+                (39, 55, "{{ languages /}}"),
+            ],
+        )
+
+    def test_no_format(self) -> None:
+        self.assertFalse(self.check.check_format("strins", "string", False, None))
+
+    def test_format(self) -> None:
+        self.assertFalse(
+            self.check.check_format(
+                "{{foo}} string {{/foo}}", "{{foo}} string {{/foo}}", False, None
+            )
+        )
+        self.assertFalse(
+            self.check.check_format("{{foo/}} string", "{{foo/}} string", False, None)
+        )
+
+    def test_missing_format(self) -> None:
+        self.assertTrue(
+            self.check.check_format("{{foo}} string", "string", False, None)
+        )
+        self.assertTrue(
+            self.check.check_format(
+                "{{foo}} string {{/foo}}", "{{foo}} string", False, None
+            )
+        )
+
+    def test_wrong_format(self) -> None:
+        self.assertTrue(
+            self.check.check_format(
+                "{{foo}} string {{/foo}}", "{{foo}} string {{/bar}}", False, None
+            )
+        )
+        self.assertTrue(
+            self.check.check_format("{{foo/}} string", "{{baz/}} string", False, None)
         )
 
 

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1113,6 +1113,7 @@ CHECK_LIST = [
     "weblate.checks.format.VueFormattingCheck",
     "weblate.checks.format.I18NextInterpolationCheck",
     "weblate.checks.format.ESTemplateLiteralsCheck",
+    "weblate.checks.format.AutomatticComponentsCheck",
     "weblate.checks.angularjs.AngularJSInterpolationCheck",
     "weblate.checks.icu.ICUMessageFormatCheck",
     "weblate.checks.icu.ICUSourceCheck",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -738,6 +738,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 #     "weblate.checks.format.VueFormattingCheck",
 #     "weblate.checks.format.I18NextInterpolationCheck",
 #     "weblate.checks.format.ESTemplateLiteralsCheck",
+#     "weblate.checks.format.AutomatticComponentsCheck",
 #     "weblate.checks.angularjs.AngularJSInterpolationCheck",
 #     "weblate.checks.icu.ICUMessageFormatCheck",
 #     "weblate.checks.icu.ICUSourceCheck",


### PR DESCRIPTION
Add an AutomatticComponentsCheckTest to ensure placeholders in automattic components are consistent between source and translation units.

Fixes #13634.