### PR TITLE
feat: Disable consecutive duplicate word check for Toki Pona (#14299)

### DIFF
--- a/weblate/checks/duplicate.py
+++ b/weblate/checks/duplicate.py
@@ -28,6 +28,7 @@ IGNORES = {
     "hi": {"कर"},
     "tr": {"tek", "adım", "gıcır", "sık"},
     "sq": {"të"},
+    "tok": set(),
 }
 
 


### PR DESCRIPTION
### Description  
Toki Pona frequently uses repeated words intentionally in various contexts, making the consecutive duplicate word check unnecessary. This PR disables the check specifically for Toki Pona (`tok`) to prevent false positives.  

### Problem  
The duplicate word check is not suitable for Toki Pona because:  
- **Numbers**: Larger numbers require repetition (e.g., `tu tu` = 4, `luka luka wan` = 11).  
- **Double Meanings**: Some words are used in different contexts, leading to valid repetition (e.g., `tawa tawa` = "moving image").  
- **Emphasis**: Words are intentionally repeated to strengthen meaning (e.g., `mute mute` = "very much").  

This results in unnecessary warnings and requires users to manually dismiss them frequently.  

### Solution  
- Disable the consecutive duplicate word check for Toki Pona by adding `tok` to the `IGNORES` dictionary.  

### Alternative Considered  
- A whitelist for specific repeated words was considered but would not cover all valid cases, making a full exclusion more effective.  

### Related Issue  
Fixes: #14299  
