### PR TITLE
feat(widgets): add language count badge

### DIFF
--- a/weblate/templates/svg/badge.svg
+++ b/weblate/templates/svg/badge.svg
@@ -1,13 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="{{ width }}" height="20" xml:lang="en" role="img" aria-label="{{ translated_text }} {{percent_text }}">
-    <title>{{ translated_text }} {{percent_text }}</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="{{ width }}" height="20" xml:lang="en" role="img" aria-label="{{ label }} {{ value }}">
+    <title>{{ label }} {{value }}</title>
     <linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
     <rect width="{{ width }}" height="20" fill="#555" rx="3"/>
-    <rect width="{{ percent_width }}" height="20" x="{{ translated_width }}" fill="{{ color }}" rx="3"/>
-    <path fill="{{ color }}" d="M{{ translated_width }} 0h4v20h-4z"/><rect width="{{ width }}" height="20" fill="url(#a)" rx="3"/>
+    <rect width="{{ value_width }}" height="20" x="{{ label_width }}" fill="{{ color }}" rx="3"/>
+    <path fill="{{ color }}" d="M{{ label_width }} 0h4v20h-4z"/><rect width="{{ width }}" height="20" fill="url(#a)" rx="3"/>
     <g fill="#fff" font-family="Source Sans,Kurinto Sans,DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11" text-anchor="middle">
-        <text x="{{ translated_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ translated_text }}</text>
-        <text x="{{ translated_offset }}" y="14">{{ translated_text }}</text>
-        <text x="{{ percent_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ percent_text }}</text>
-        <text x="{{ percent_offset }}" y="14">{{ percent_text }}</text>
+        <text x="{{ translated_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ label }}</text>
+        <text x="{{ translated_offset }}" y="14">{{ label }}</text>
+        <text x="{{ percent_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ value }}</text>
+        <text x="{{ percent_offset }}" y="14">{{ value }}</text>
     </g>
 </svg>

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -40,6 +40,7 @@ from weblate.utils.stats import (
 from weblate.utils.views import get_percent_color
 
 if TYPE_CHECKING:
+    from django.http import HttpResponse
     from django_stubs_ext import StrOrPromise
 
 gi.require_version("PangoCairo", "1.0")
@@ -375,45 +376,51 @@ class OpenGraphWidget(NormalWidget):
         PangoCairo.show_layout(ctx, layout)
 
 
-@register_widget
-class SVGBadgeWidget(SVGWidget):
-    name = "svg"
+class BaseSVGBadgeWidget(SVGWidget):
     colors: tuple[str, ...] = ("badge",)
-    order = 80
     template_name = "svg/badge.svg"
+
+    def render_badge(
+        self, response: HttpResponse, label: str, value: str, color: str
+    ) -> None:
+        label_width = render_size(f"   {label}   ")[0].width
+        value_width = render_size(f"  {value}  ")[0].width
+
+        response.write(
+            render_to_string(
+                self.template_name,
+                {
+                    "label": label,
+                    "value": value,
+                    "label_width": label_width,
+                    "value_width": value_width,
+                    "width": label_width + value_width,
+                    "color": color,
+                    "translated_offset": label_width // 2,
+                    "percent_offset": label_width + value_width // 2,
+                    "lang": get_language(),
+                    "fonts_cdn_url": settings.FONTS_CDN_URL,
+                },
+            )
+        )
+
+
+@register_widget
+class SVGBadgeWidget(BaseSVGBadgeWidget):
+    name = "svg"
+    order = 80
     verbose = gettext_lazy("SVG status badge")
 
-    def render(self, response) -> None:
+    def render(self, response: HttpResponse) -> None:
         translated_text = gettext("translated")
-        translated_width = render_size(f"   {translated_text}   ")[0].width
-
         percent_text = self.get_percent_text()
-        percent_width = render_size(f"  {percent_text}  ")[0].width
-
         if self.percent >= 90:
             color = "#4c1"
         elif self.percent >= 75:
             color = "#dfb317"
         else:
             color = "#e05d44"
-
-        response.write(
-            render_to_string(
-                self.template_name,
-                {
-                    "translated_text": translated_text,
-                    "percent_text": percent_text,
-                    "translated_width": translated_width,
-                    "percent_width": percent_width,
-                    "width": translated_width + percent_width,
-                    "color": color,
-                    "translated_offset": translated_width // 2,
-                    "percent_offset": translated_width + percent_width // 2,
-                    "lang": get_language(),
-                    "fonts_cdn_url": settings.FONTS_CDN_URL,
-                },
-            )
-        )
+        self.render_badge(response, translated_text, percent_text, color)
 
 
 @register_widget
@@ -510,3 +517,26 @@ class HorizontalMultiLanguageWidget(MultiLanguageWidget):
     order = 82
     template_name = "svg/multi-language-badge-horizontal.svg"
     verbose = pgettext_lazy("Status widget name", "Horizontal language bar chart")
+
+
+@register_widget
+class LanguageBadgeWidget(BaseSVGBadgeWidget):
+    name = "language"
+    order = 83
+    verbose = gettext_lazy("Language count badge")
+
+    def render(self, response: HttpResponse) -> None:
+        languages: list[BaseStats | ProjectLanguage]
+        if isinstance(self.stats, ProjectLanguageStats | TranslationStats):
+            languages = [self.stats]
+        elif isinstance(self.obj, ProjectLanguage):
+            languages = [self.obj]
+        elif isinstance(self.obj, Language):
+            languages = [self.obj.stats]
+        else:
+            languages = self.stats.get_language_stats()
+
+        language_count = sum(1 for _ in languages)
+        languages_text = gettext("languages")
+
+        self.render_badge(response, languages_text, str(language_count), "#3fed48")


### PR DESCRIPTION
Add a status badge to display the count of translated languages for a project or component.

![svgviewer-png-output](https://github.com/user-attachments/assets/452e3813-87e8-464a-8348-5ce2600da4a0)

Partially fixes #13051.