### PR TITLE
Revamp widget parameterization

### DIFF
--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -72,6 +72,7 @@ CSP_DIRECTIVES: CSP_TYPE = {
 INLINE_PATHS = {
     "social:begin",
     "djangosaml2idp:saml_login_process",
+    "widgets"
 }
 
 

--- a/weblate/static/js/widgets.js
+++ b/weblate/static/js/widgets.js
@@ -14,53 +14,60 @@ $(document).ready(function() {
   $("#component").val(jsonComponent);
 
   function updateLivePreviewAndEmbedCode() {
-    const widgetName = $("#widget_type").val();
-    const componentId = $("#component").val();
-    const component = widgetsData["components"].find(component => String(component.id) === componentId);
+    const widgetName = $('#widget_type').val();
+    const componentId = $('#component').val();
+    const component = widgetsData['components'].find(c => String(c.id) === componentId);
+    const language = $('#translation_language').val();
+    const widget = widgetsData['widgets'][widgetName];
+    const color = $('#color_select').val();
 
-    const language = $("#translation_language").val();
-
-    const widget = widgetsData["widgets"][widgetName];
-    const color = $("#color_select").val();
-
-    let engageUrl = widgetsData["engage_base_url"];
-
-    const widgetBaseUrl = widgetsData["widget_base_url"];
+    let engageUrl = widgetsData['engage_base_url'];
+    const widgetBaseUrl = widgetsData['widget_base_url'];
     let widgetUrl = `${widgetBaseUrl}`;
-    if (component !== undefined && language !== "") {
+    if (component !== undefined && language !== '') {
       widgetUrl = `${widgetUrl}/${component.slug}/${language}`;
-    } else if (component !== undefined && language === "") {
+    } else if (component !== undefined && language === '') {
       widgetUrl = `${widgetUrl}/${component.slug}`;
-    } else if (component === undefined && language !== "") {
+    } else if (component === undefined && language !== '') {
       widgetUrl = `${widgetUrl}/-/${language}`;
     }
 
-    const newUrl = `${widgetUrl}/${widgetName}-${color}.${widget.extension}`;
-    $("#widgetImage").attr("src", newUrl);
+    // Include extra parameters in the URL
+    const params = new URLSearchParams();
+    $('#extra-parameters input').each(function() {
+      const paramName = $(this).attr('name');
+      const paramValue = $(this).val();
+      if (paramValue) {
+        params.set(paramName, paramValue);
+      }
+    });
 
-    let translationStatus = widgetsData["translation_status"];
+    const newUrl = `${widgetUrl}/${widgetName}-${color}.${widget.extension}?${params.toString()}`;
+    $('#widgetImage').attr('src', newUrl);
+
+    let translationStatus = widgetsData['translation_status'];
 
     let code;
-    const codeLanguage = $("#code_language").val();
-    if (codeLanguage === "html") {
+    const codeLanguage = $('#code_language').val();
+    if (codeLanguage === 'html') {
       code = `<a href="${engageUrl}">
 <img src="${newUrl}" alt="${translationStatus}" />
 </a>`;
-    } else if (codeLanguage === "bb-code") {
+    } else if (codeLanguage === 'bb-code') {
       code = `[url=${engageUrl}][img alt="${translationStatus}"]${newUrl}[/img][/url]`;
-    } else if (codeLanguage === "mdk") {
+    } else if (codeLanguage === 'mdk') {
       code = `[![${translationStatus}](${newUrl})](${engageUrl})`;
-    } else if (codeLanguage === "rst") {
+    } else if (codeLanguage === 'rst') {
       code = `.. image:: ${newUrl}
   :alt: ${translationStatus}
   :target: ${engageUrl}`;
-    } else if (codeLanguage === "textile-code") {
+    } else if (codeLanguage === 'textile-code') {
       code = `!${newUrl}!:${engageUrl}`;
     } else {
       code = newUrl;
     }
 
-    $("#embedCode").val(code);
+    $('#embedCode').val(code);
   }
 
   function updateWidgetColors(widgetName) {
@@ -72,7 +79,7 @@ $(document).ready(function() {
       const option = $("<option></option>").val(color).text(color);
       colorSelect.append(option);
     });
-    updateLivePreviewAndEmbedCode(widgetName);
+    updateLivePreviewAndEmbedCode();
   }
 
   function updateQueryParams() {
@@ -83,9 +90,47 @@ $(document).ready(function() {
     window.history.pushState({}, "", newUrl);
   }
 
-  $("#widget_type").click(function() {
+  function renderExtraParameters(widgetName) {
+    const widget = widgetsData["widgets"][widgetName];
+    const extraParamsContainer = $('#extra-parameters');
+    extraParamsContainer.empty();
+
+    if (widget.extra_parameters) {
+      widget.extra_parameters.forEach(param => {
+        let input;
+        if (param.type === 'number') {
+          input = $('<input/>', {
+            type: param.type,
+            id: param.name,
+            name: param.name,
+            min: param.min,
+            max: param.max,
+            step: param.step,
+            value: param.default,
+            class: 'form-control mt-2'
+          });
+        }
+
+        const label = $('<label/>', {
+          for: param.name,
+          text: param.label,
+          class: 'form-label mt-2'
+        });
+        extraParamsContainer.append(label).append(input);
+
+        // Add change event listener to update query params and live preview
+        input.change(function() {
+          updateQueryParams();
+          updateLivePreviewAndEmbedCode();
+        });
+      });
+    }
+  }
+
+  $("#widget_type").change(function() {
     const widgetName = $(this).val();
     updateWidgetColors(widgetName);
+    renderExtraParameters(widgetName);
   });
 
   $("#color_select").change(updateLivePreviewAndEmbedCode);
@@ -100,5 +145,6 @@ $(document).ready(function() {
   $("#code_language").change(updateLivePreviewAndEmbedCode);
 
   updateWidgetColors($("#widget_type").val());
+  renderExtraParameters($("#widget_type").val());
 
 });

--- a/weblate/static/js/widgets.js
+++ b/weblate/static/js/widgets.js
@@ -1,0 +1,104 @@
+$(document).ready(function() {
+  const widgetsData = JSON.parse($("#widgets-data").text());
+
+  let jsonLanguage = widgetsData["language"];
+  if (jsonLanguage === null) {
+    jsonLanguage = "";
+  }
+  $("#translation_language").val(jsonLanguage);
+
+  let jsonComponent = widgetsData["component"];
+  if (jsonComponent === null) {
+    jsonComponent = "";
+  }
+  $("#component").val(jsonComponent);
+
+  function updateLivePreviewAndEmbedCode() {
+    const widgetName = $("#widget_type").val();
+    const componentId = $("#component").val();
+    const component = widgetsData["components"].find(component => String(component.id) === componentId);
+
+    const language = $("#translation_language").val();
+
+    const widget = widgetsData["widgets"][widgetName];
+    const color = $("#color_select").val();
+
+    let engageUrl = widgetsData["engage_base_url"];
+
+    const widgetBaseUrl = widgetsData["widget_base_url"];
+    let widgetUrl = `${widgetBaseUrl}`;
+    if (component !== undefined && language !== "") {
+      widgetUrl = `${widgetUrl}/${component.slug}/${language}`;
+    } else if (component !== undefined && language === "") {
+      widgetUrl = `${widgetUrl}/${component.slug}`;
+    } else if (component === undefined && language !== "") {
+      widgetUrl = `${widgetUrl}/-/${language}`;
+    }
+
+    const newUrl = `${widgetUrl}/${widgetName}-${color}.${widget.extension}`;
+    $("#widgetImage").attr("src", newUrl);
+
+    let translationStatus = widgetsData["translation_status"];
+
+    let code;
+    const codeLanguage = $("#code_language").val();
+    if (codeLanguage === "html") {
+      code = `<a href="${engageUrl}">
+<img src="${newUrl}" alt="${translationStatus}" />
+</a>`;
+    } else if (codeLanguage === "bb-code") {
+      code = `[url=${engageUrl}][img alt="${translationStatus}"]${newUrl}[/img][/url]`;
+    } else if (codeLanguage === "mdk") {
+      code = `[![${translationStatus}](${newUrl})](${engageUrl})`;
+    } else if (codeLanguage === "rst") {
+      code = `.. image:: ${newUrl}
+  :alt: ${translationStatus}
+  :target: ${engageUrl}`;
+    } else if (codeLanguage === "textile-code") {
+      code = `!${newUrl}!:${engageUrl}`;
+    } else {
+      code = newUrl;
+    }
+
+    $("#embedCode").val(code);
+  }
+
+  function updateWidgetColors(widgetName) {
+    const widgets = widgetsData["widgets"];
+    const colors = widgets[widgetName]["colors"];
+    const colorSelect = $("#color_select");
+    colorSelect.empty();
+    $.each(colors, function(index, color) {
+      const option = $("<option></option>").val(color).text(color);
+      colorSelect.append(option);
+    });
+    updateLivePreviewAndEmbedCode(widgetName);
+  }
+
+  function updateQueryParams() {
+    const params = new URLSearchParams(window.location.search);
+    params.set("component", $('#component').val());
+    params.set("lang", $('#translation_language').val());
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.pushState({}, "", newUrl);
+  }
+
+  $("#widget_type").click(function() {
+    const widgetName = $(this).val();
+    updateWidgetColors(widgetName);
+  });
+
+  $("#color_select").change(updateLivePreviewAndEmbedCode);
+  $("#component").change(function() {
+    updateQueryParams();
+    updateLivePreviewAndEmbedCode();
+  });
+  $("#translation_language").change(function() {
+    updateQueryParams();
+    updateLivePreviewAndEmbedCode();
+  });
+  $("#code_language").change(updateLivePreviewAndEmbedCode);
+
+  updateWidgetColors($("#widget_type").val());
+
+});

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -688,12 +688,6 @@ $(function () {
     }
   });
 
-  /* Widgets selector */
-  $(".select-tab").on("change", function (_e) {
-    $(this).parent().find(".tab-pane").removeClass("active");
-    $(`#${$(this).val()}`).addClass("active");
-  });
-
   /* Code samples (on widgets page) */
   $(".code-example").focus(function () {
     $(this).select();

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2358,3 +2358,29 @@ table.table-simple tbody#glossary-terms td {
   word-break: break-word;
   white-space: normal;
 }
+
+.widget-card {
+  border: 1px solid var(--altcha-color-border);
+  border-radius: var(--altcha-border-radius);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+  padding: 15px;
+  background-color: #fff;
+}
+
+.widget-card h4 {
+  margin-bottom: 15px;
+  font-weight: bold;
+}
+
+.widget-card .form-label {
+  font-weight: normal;
+}
+
+.widget-card .form-control {
+  margin-bottom: 10px;
+}
+
+.widget-card #copyCodeButton {
+  margin-top: 10px;
+}

--- a/weblate/templates/svg/badge.svg
+++ b/weblate/templates/svg/badge.svg
@@ -1,13 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="{{ width }}" height="20" xml:lang="en" role="img" aria-label="{{ translated_text }} {{percent_text }}">
-    <title>{{ translated_text }} {{percent_text }}</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="{{ width }}" height="20" xml:lang="en" role="img" aria-label="{{ label }} {{ value }}">
+    <title>{{ label }} {{value }}</title>
     <linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
     <rect width="{{ width }}" height="20" fill="#555" rx="3"/>
-    <rect width="{{ percent_width }}" height="20" x="{{ translated_width }}" fill="{{ color }}" rx="3"/>
-    <path fill="{{ color }}" d="M{{ translated_width }} 0h4v20h-4z"/><rect width="{{ width }}" height="20" fill="url(#a)" rx="3"/>
+    <rect width="{{ value_width }}" height="20" x="{{ label_width }}" fill="{{ color }}" rx="3"/>
+    <path fill="{{ color }}" d="M{{ label_width }} 0h4v20h-4z"/><rect width="{{ width }}" height="20" fill="url(#a)" rx="3"/>
     <g fill="#fff" font-family="Source Sans,Kurinto Sans,DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11" text-anchor="middle">
-        <text x="{{ translated_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ translated_text }}</text>
-        <text x="{{ translated_offset }}" y="14">{{ translated_text }}</text>
-        <text x="{{ percent_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ percent_text }}</text>
-        <text x="{{ percent_offset }}" y="14">{{ percent_text }}</text>
+        <text x="{{ translated_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ label }}</text>
+        <text x="{{ translated_offset }}" y="14">{{ label }}</text>
+        <text x="{{ percent_offset }}" y="15" fill="#010101" fill-opacity=".3">{{ value }}</text>
+        <text x="{{ percent_offset }}" y="14">{{ value }}</text>
     </g>
 </svg>

--- a/weblate/templates/widgets.html
+++ b/weblate/templates/widgets.html
@@ -68,6 +68,7 @@
         <select id="color_select" class="form-control">
           <!-- Options will be populated dynamically -->
         </select>
+        <div id="extra-parameters"></div>
       </div>
     </div>
 

--- a/weblate/templates/widgets.html
+++ b/weblate/templates/widgets.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
 
 {% load i18n %}
+{% load static %}
 
 {% block breadcrumbs %}
   <li>
     <a href="{{ object.get_absolute_url }}">{{ object }}</a>
   </li>
   <li>
-    <a href="{% url 'widgets' path=object.get_url_path %}">{% trans "Widgets" %}</a>
+    <a href="{% url "widgets" path=object.get_url_path %}">{% trans "Widgets" %}</a>
   </li>
 {% endblock %}
 
@@ -23,9 +24,8 @@
   <h3>{% trans "Promoting specific translations" %}</h3>
 
   <form class="autosubmit">
-    {% trans "Besides promoting the whole translation project, you can also choose a specific language or component to promote:" %} {{ form.lang }} {{ form.component }}
+    {% trans "Besides promoting the whole translation project, you can also choose a specific language or component to promote:" %}
   </form>
-
 
   <h3>{% trans "Image widgets" %}</h3>
 
@@ -33,100 +33,65 @@
     {% trans "You can use the following widgets to promote translation of your project. They can increase the visibility of your translation projects and bring in new contributors." %}
   </p>
 
-
-  <ul class="nav nav-pills widgets-selector">
-    {% for widget in widget_list %}
-      <li {% if forloop.first %}class="active"{% endif %}>
-        {% for color in widget.colors %}
-          {% if forloop.first %}
-            <a href="#{{ widget.name }}" data-toggle="tab">
-              <img src="{{ color.url }}" />
-              <br />
-              {{ widget.verbose }}
-            </a>
-          {% endif %}
-        {% endfor %}
-      </li>
-    {% endfor %}
-  </ul>
-
-  <div class="tab-content">
-    {% for widget in widget_list %}
-      <div class="tab-pane {% if forloop.first %}active{% endif %}" id="{{ widget.name }}">
-
-        <p>{% trans "Color variants:" %}</p>
-
-        <p>
-          {% for color in widget.colors %}
-            <a href="{{ engage_url }}">
-              <img src="{{ color.url }}" />
-            </a>
+  <div class="row mt-4">
+    <div class="col-md-4">
+      <div class="widget-card bg-white p-3">
+        <h4>Widget Settings</h4>
+        <label for="widget_type" class="form-label mt-2">{% trans "Widget" %}</label>
+        <select id="widget_type" class="select-tab form-control">
+          {% for widget in widget_list %}
+            <option value="{{ widget.name }}">{% trans widget.verbose %}</option>
           {% endfor %}
-        </p>
-
-        <div>
-          <select class="select-tab form-control">
-            <option value="{{ widget.name }}-html-code">{% trans "HTML" %}</option>
-            <option value="{{ widget.name }}-bb-code">{% trans "BBCode" %}</option>
-            <option value="{{ widget.name }}-mdk-code">{% trans "Markdown" %}</option>
-            <option value="{{ widget.name }}-rst-code">{% trans "reStructuredText" %}</option>
-            <option value="{{ widget.name }}-textile-code">{% trans "Textile code" %}</option>
-            <option value="{{ widget.name }}-url-code">{% trans "Image URL" %}</option>
-          </select>
-
-          <div class="tab-content">
-            <div class="tab-pane active" id="{{ widget.name }}-html-code">
-              {% for color in widget.colors %}
-                <textarea class="code-example form-control">
-&lt;a href="{{ engage_url }}"&gt;
-&lt;img src="{{ color.url }}" alt="{% trans "Translation status" %}" /&gt;
-&lt;/a&gt;</textarea>
-              {% endfor %}
-            </div>
-
-            <div class="tab-pane" id="{{ widget.name }}-bb-code">
-              {% for color in widget.colors %}
-                <textarea class="code-example form-control">
-[url={{ engage_url }}][img alt="{% trans "Translation status" %}"]{{ color.url }}[/img][/url]</textarea>
-              {% endfor %}
-            </div>
-
-            <div class="tab-pane" id="{{ widget.name }}-mdk-code">
-              {% for color in widget.colors %}
-                <textarea class="code-example form-control">
-[![{% trans "Translation status" %}]({{ color.url }})]({{ engage_url }})</textarea>
-              {% endfor %}
-            </div>
-
-            <div class="tab-pane" id="{{ widget.name }}-rst-code">
-              {% for color in widget.colors %}
-                <textarea class="code-example form-control">
-.. image:: {{ color.url }}
-    :alt: {% trans "Translation status" %}
-    :target: {{ engage_url }}</textarea>
-              {% endfor %}
-            </div>
-
-            <div class="tab-pane" id="{{ widget.name }}-textile-code">
-              {% for color in widget.colors %}
-                <textarea class="code-example form-control">
-!{{ color.url }}!:{{ engage_url }}</textarea>
-              {% endfor %}
-            </div>
-
-            <div class="tab-pane" id="{{ widget.name }}-url-code">
-              {% for color in widget.colors %}
-                <textarea class="code-example form-control">
-{{ color.url }}</textarea>
-              {% endfor %}
-            </div>
-
-          </div>
-
-        </div>
-
+        </select>
+        <label for="translation_language" class="form-label mt-2">{% trans "Language" %}</label>
+        <select id="translation_language" class="select-tab form-control">
+          {% for language in form.lang.field.choices %}
+            <option value="{{ language.0 }}">{% trans language.1 %}</option>
+          {% endfor %}
+        </select>
+        <label for="component" class="form-label mt-2">{% trans "Component" %}</label>
+        <select id="component" class="select-tab form-control">
+          {% for component in form.component.field.choices %}
+            <option value="{{ component.0 }}">{% trans component.1 %}</option>
+          {% endfor %}
+        </select>
+        <label for="code_language" class="form-label mt-2">{% trans "Code" %}</label>
+        <select id="code_language" class="select-tab form-control">
+          <option value="html">{% trans "HTML" %}</option>
+          <option value="bb-code">{% trans "BBCode" %}</option>
+          <option value="mdk">{% trans "Markdown" %}</option>
+          <option value="rst">{% trans "reStructuredText" %}</option>
+          <option value="textile-code">{% trans "Textile code" %}</option>
+          <option value="url">{% trans "Image URL" %}</option>
+        </select>
+        <label for="color_select" class="form-label mt-2">{% trans "Color" %}</label>
+        <select id="color_select" class="form-control">
+          <!-- Options will be populated dynamically -->
+        </select>
       </div>
-    {% endfor %}
+    </div>
+
+    <div class="col-md-8">
+      <div class="widget-card bg-white p-3">
+        <h4>Live Preview</h4>
+        <div class="preview-box" id="preview">
+          <img id="widgetImage" src="{{ image_src }}" alt="{% trans "Translation status" %}" style="max-width: 500px;" />
+        </div>
+      </div>
+
+      <div class="widget-card bg-white p-3">
+        <h4>Embed Code</h4>
+        <textarea id="embedCode" class="code-example form-control" rows="3" readonly>
+        </textarea>
+      </div>
+    </div>
   </div>
 
+{% endblock %}
+
+{% block extra_script %}
+  <script type="application/json" id="widgets-data">
+    {{ widgets_json|safe }}
+  </script>
+  <script defer data-cfasync="false" src="{% static "js/widgets.js" %}{{ cache_param }}"></script>
 {% endblock %}

--- a/weblate/trans/views/widgets.py
+++ b/weblate/trans/views/widgets.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.translation import gettext
 from django.views.decorators.cache import cache_control
 from django.views.decorators.vary import vary_on_cookie
 from django.views.generic import RedirectView
@@ -62,40 +64,41 @@ def widgets(request: AuthenticatedHttpRequest, path: list[str]):
         reverse("engage", kwargs={"path": engage_obj.get_url_path()})
     )
     engage_link = format_html('<a href="{0}" id="engage-link">{0}</a>', engage_url)
-    widget_base_url = get_site_url(
-        reverse("widgets", kwargs={"path": project.get_url_path()})
-    )
+
+    engage_base_url = get_site_url(reverse("engage", kwargs={"path": project.get_url_path()}))
+    widget_base_url = f"{get_site_url()}/widget/{'/'.join(project.get_url_path())}"
+
     widget_list = []
+    widgets_json = {}
     for widget_name in sorted(WIDGETS, key=widgets_sorter):
         widget_class = WIDGETS[widget_name]
-        color_list = []
-        for color in widget_class.colors:
-            color_url = reverse(
-                "widget-image",
-                kwargs={
-                    "path": obj.get_url_path(),
-                    "widget": widget_name,
-                    "color": color,
-                    "extension": widget_class.extension,
-                },
-            )
-            color_list.append({"name": color, "url": get_site_url(color_url)})
+        widgets_json[widget_name] = {
+            "name": widget_name,
+            "extension": widget_class.extension,
+            "colors": widget_class.colors,
+        }
         widget_list.append(
-            {"name": widget_name, "colors": color_list, "verbose": widget_class.verbose}
+            {"name": widget_name, "verbose": widget_class.verbose}
         )
 
     return render(
         request,
         "widgets.html",
         {
-            "engage_url": engage_url,
             "engage_link": engage_link,
             "widget_list": widget_list,
-            "widget_base_url": widget_base_url,
             "object": obj,
             "project": project,
-            "image_src": widget_list[0]["colors"][0]["url"],
             "form": form,
+            "widgets_json": json.dumps({
+                "widget_base_url": widget_base_url,
+                "engage_base_url": engage_base_url,
+                "language": lang.code if lang else None,
+                "component": component.id if component else None,
+                "components": [{"id": c.id, "slug": c.slug} for c in form.fields["component"].queryset],
+                "translation_status": gettext("Translation status"),
+                "widgets": widgets_json,
+            }),
         },
     )
 

--- a/weblate/trans/views/widgets.py
+++ b/weblate/trans/views/widgets.py
@@ -76,6 +76,7 @@ def widgets(request: AuthenticatedHttpRequest, path: list[str]):
             "name": widget_name,
             "extension": widget_class.extension,
             "colors": widget_class.colors,
+            "extra_parameters": widget_class.extra_parameters,
         }
         widget_list.append(
             {"name": widget_name, "verbose": widget_class.verbose}
@@ -190,7 +191,7 @@ def render_widget(
 
     # Render widget
     response = HttpResponse(content_type=widget_obj.content_type)
-    widget_obj.render(response)
+    widget_obj.render(request, response)
     return response
 
 
@@ -202,5 +203,5 @@ def render_og(request: AuthenticatedHttpRequest):
 
     # Render widget
     response = HttpResponse(content_type=widget_obj.content_type)
-    widget_obj.render(response)
+    widget_obj.render(request, response)
     return response

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -40,6 +40,7 @@ from weblate.utils.stats import (
 from weblate.utils.views import get_percent_color
 
 if TYPE_CHECKING:
+    from django.http import HttpResponse
     from django_stubs_ext import StrOrPromise
 
 gi.require_version("PangoCairo", "1.0")
@@ -375,45 +376,51 @@ class OpenGraphWidget(NormalWidget):
         PangoCairo.show_layout(ctx, layout)
 
 
-@register_widget
-class SVGBadgeWidget(SVGWidget):
-    name = "svg"
+class BaseSVGBadgeWidget(SVGWidget):
     colors: tuple[str, ...] = ("badge",)
-    order = 80
     template_name = "svg/badge.svg"
+
+    def render_badge(
+        self, response: HttpResponse, label: str, value: str, color: str
+    ) -> None:
+        label_width = render_size(f"   {label}   ")[0].width
+        value_width = render_size(f"  {value}  ")[0].width
+
+        response.write(
+            render_to_string(
+                self.template_name,
+                {
+                    "label": label,
+                    "value": value,
+                    "label_width": label_width,
+                    "value_width": value_width,
+                    "width": label_width + value_width,
+                    "color": color,
+                    "translated_offset": label_width // 2,
+                    "percent_offset": label_width + value_width // 2,
+                    "lang": get_language(),
+                    "fonts_cdn_url": settings.FONTS_CDN_URL,
+                },
+            )
+        )
+
+
+@register_widget
+class SVGBadgeWidget(BaseSVGBadgeWidget):
+    name = "svg"
+    order = 80
     verbose = gettext_lazy("SVG status badge")
 
-    def render(self, response) -> None:
+    def render(self, response: HttpResponse) -> None:
         translated_text = gettext("translated")
-        translated_width = render_size(f"   {translated_text}   ")[0].width
-
         percent_text = self.get_percent_text()
-        percent_width = render_size(f"  {percent_text}  ")[0].width
-
         if self.percent >= 90:
             color = "#4c1"
         elif self.percent >= 75:
             color = "#dfb317"
         else:
             color = "#e05d44"
-
-        response.write(
-            render_to_string(
-                self.template_name,
-                {
-                    "translated_text": translated_text,
-                    "percent_text": percent_text,
-                    "translated_width": translated_width,
-                    "percent_width": percent_width,
-                    "width": translated_width + percent_width,
-                    "color": color,
-                    "translated_offset": translated_width // 2,
-                    "percent_offset": translated_width + percent_width // 2,
-                    "lang": get_language(),
-                    "fonts_cdn_url": settings.FONTS_CDN_URL,
-                },
-            )
-        )
+        self.render_badge(response, translated_text, percent_text, color)
 
 
 @register_widget
@@ -510,3 +517,26 @@ class HorizontalMultiLanguageWidget(MultiLanguageWidget):
     order = 82
     template_name = "svg/multi-language-badge-horizontal.svg"
     verbose = pgettext_lazy("Status widget name", "Horizontal language bar chart")
+
+
+@register_widget
+class LanguageBadgeWidget(BaseSVGBadgeWidget):
+    name = "language"
+    order = 83
+    verbose = gettext_lazy("Language count badge")
+
+    def render(self, response: HttpResponse) -> None:
+        languages: list[BaseStats | ProjectLanguage]
+        if isinstance(self.stats, ProjectLanguageStats | TranslationStats):
+            languages = [self.stats]
+        elif isinstance(self.obj, ProjectLanguage):
+            languages = [self.obj]
+        elif isinstance(self.obj, Language):
+            languages = [self.obj.stats]
+        else:
+            languages = self.stats.get_language_stats()
+
+        language_count = sum(1 for _ in languages)
+        languages_text = gettext("languages")
+
+        self.render_badge(response, languages_text, str(language_count), "#3fed48")

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -1,4 +1,4 @@
-# Copyright © Michal Čihař <michal@weblate.org>
+# Copyright Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import cairo
 import gi
 from django.conf import settings
+from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
 from django.utils.html import format_html
 from django.utils.translation import (
@@ -27,6 +28,7 @@ from weblate.lang.models import Language
 from weblate.trans.models import Project
 from weblate.trans.templatetags.translations import number_format
 from weblate.trans.util import sort_unicode, translation_percent
+from weblate.utils import messages
 from weblate.utils.icons import find_static_file
 from weblate.utils.site import get_site_url
 from weblate.utils.stats import (
@@ -75,6 +77,7 @@ class Widget:
     extension = "png"
     content_type = "image/png"
     order = 100
+    extra_parameters: list[dict] = []
 
     def __init__(self, obj, color=None, lang=None) -> None:
         """Create Widget object."""
@@ -104,6 +107,9 @@ class Widget:
         return pgettext("Translated percents", "%(percent)s%%") % {
             "percent": int(self.percent)
         }
+
+    def render(self, request: HttpRequest, response: HttpResponse) -> None:
+        raise NotImplementedError
 
 
 class BitmapWidget(Widget):
@@ -169,7 +175,7 @@ class BitmapWidget(Widget):
     def render_additional(self, ctx) -> None:
         return
 
-    def render(self, response) -> None:
+    def render(self, request: HttpRequest, response: HttpResponse) -> None:
         """Render widget."""
         configure_fontconfig()
         surface = cairo.ImageSurface.create_from_png(self.get_filename())
@@ -222,7 +228,7 @@ class SVGWidget(Widget):
     content_type = "image/svg+xml; charset=utf-8"
     template_name = ""
 
-    def render(self, response) -> None:
+    def render(self, request: HttpRequest, response: HttpResponse) -> None:
         raise NotImplementedError
 
 
@@ -230,9 +236,9 @@ class PNGWidget(SVGWidget):
     extension = "png"
     content_type = "image/png"
 
-    def render(self, response) -> None:
+    def render(self, request: HttpRequest, response: HttpResponse) -> None:
         with StringIO() as output:
-            super().render(output)
+            super().render(request, output)
             svgdata = output.getvalue()
 
         handle = Rsvg.Handle.new_from_data(svgdata.encode())
@@ -411,7 +417,7 @@ class SVGBadgeWidget(BaseSVGBadgeWidget):
     order = 80
     verbose = gettext_lazy("SVG status badge")
 
-    def render(self, response: HttpResponse) -> None:
+    def render(self, request: HttpRequest, response: HttpResponse) -> None:
         translated_text = gettext("translated")
         percent_text = self.get_percent_text()
         if self.percent >= 90:
@@ -439,7 +445,7 @@ class MultiLanguageWidget(SVGWidget):
 
     COLOR_MAP = {"red": "#fa3939", "green": "#3fed48", "blue": "#3f85ed", "auto": None}
 
-    def render(self, response) -> None:
+    def render(self, request: HttpRequest, response: HttpResponse) -> None:
         translations = []
         offset = 20
         color = self.COLOR_MAP[self.color]
@@ -524,8 +530,28 @@ class LanguageBadgeWidget(BaseSVGBadgeWidget):
     name = "language"
     order = 83
     verbose = gettext_lazy("Language count badge")
+    extra_parameters = [
+        {
+            "name": "threshold",
+            "label": gettext("Threshold"),
+            "type": "number",
+            "default": 0,
+            "min": 0,
+            "max": 100,
+            "step": 1,
+        }
+    ]
 
-    def render(self, response: HttpResponse) -> None:
+    def render(self, request: HttpRequest, response: HttpResponse) -> None:
+        try:
+            threshold = int(request.GET.get("threshold", 0))
+        except ValueError as e:
+            messages.error(request, gettext("Error in parameter %(field)s: %(error)s") % {
+                "field": "threshold",
+                "error": str(e),
+            })
+            threshold = 0
+
         languages: list[BaseStats | ProjectLanguage]
         if isinstance(self.stats, ProjectLanguageStats | TranslationStats):
             languages = [self.stats]
@@ -536,7 +562,10 @@ class LanguageBadgeWidget(BaseSVGBadgeWidget):
         else:
             languages = self.stats.get_language_stats()
 
-        language_count = sum(1 for _ in languages)
+        language_count = sum(
+            1 for lang in languages
+            if lang.translated_percent >= threshold
+        )
         languages_text = gettext("languages")
 
         self.render_badge(response, languages_text, str(language_count), "#3fed48")


### PR DESCRIPTION
Based on https://github.com/WeblateOrg/weblate/issues/13051#issuecomment-2481236851, this PR explores a new way to parameterize widgets. Here is the what the proposed UI looks like:

![image](https://github.com/user-attachments/assets/37b0dfe7-5eb1-4771-9e5c-6523ed497f22)

The widget, language, component, code, and color options are available for all widgets. All the extra options per widget are defined in the `extra_parameters` attribute of the widget class and passed through JSON where jQuery reads it and renders it. Using the options, jQuery generates the urls dynamically, and updates the live preview and the code to embed the images. 

Also, this is just a draft to start discussion.