### PR TITLE
Add `site.webmanifest` to `LOGIN_REQUIRED_URLS_EXCEPTIONS` list

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -136,6 +136,7 @@ class WeblateAccountsConf(AppConf):
         r"{URL_PREFIX}/contact/$",  # Optional for contact form
         r"{URL_PREFIX}/legal/(.*)$",  # Optional for legal app
         r"{URL_PREFIX}/avatar/(.*)$",  # Optional for avatars
+        r"{URL_PREFIX}/site.webmanifest$",  # The request for the manifest is made without credentials
     )
 
     class Meta:

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1323,6 +1323,7 @@ LOGIN_REQUIRED_URLS_EXCEPTIONS = get_env_list(
         rf"{URL_PREFIX}/contact/$",  # Optional for contact form
         rf"{URL_PREFIX}/legal/(.*)$",  # Optional for legal app
         rf"{URL_PREFIX}/avatar/(.*)$",  # Optional for avatars
+        rf"{URL_PREFIX}/site.webmanifest$",  # The request for the manifest is made without credentials
     ],
 )
 modify_env_list(LOGIN_REQUIRED_URLS_EXCEPTIONS, "LOGIN_REQUIRED_URLS_EXCEPTIONS")

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -899,6 +899,7 @@ if REQUIRE_LOGIN:
 #    rf"{URL_PREFIX}/contact/$",  # Optional for contact form
 #    rf"{URL_PREFIX}/legal/(.*)$",  # Optional for legal app
 #    rf"{URL_PREFIX}/avatar/(.*)$",  # Optional for avatars
+#    rf"{URL_PREFIX}/site.webmanifest$",  # The request for the manifest is made without credentials
 # )
 
 # Silence some of the Django system checks


### PR DESCRIPTION
Just noticed that when Weblate runs with `REQUIRE_LOGIN`, requests for the manifest fail because they are made without credentials.