### PR TITLE
fix(notifications): avoid generating HTML with two body elements

### DIFF
--- a/weblate/accounts/templatetags/site_url.py
+++ b/weblate/accounts/templatetags/site_url.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Provide user friendly names for social authentication methods."""
+"""Convert any links in HTML to absolute."""
 
 from io import StringIO
 
@@ -28,8 +28,15 @@ def add_site_url(content):
         url = link.get("src")
         if url.startswith("/"):
             link.set("src", get_site_url(url))
+
+    body = tree.find("body")
     return mark_safe(  # noqa: S308
-        etree.tostring(
-            tree.getroot(), pretty_print=True, method="html", encoding="unicode"
+        "".join(
+            [
+                etree.tostring(
+                    child, pretty_print=True, method="html", encoding="unicode"
+                )
+                for child in body.iterchildren()
+            ]
         )
     )

--- a/weblate/accounts/tests/test_templatetags.py
+++ b/weblate/accounts/tests/test_templatetags.py
@@ -1,0 +1,38 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.template import Context, Template
+from django.test import SimpleTestCase
+
+
+class TemplateTagsTestCase(SimpleTestCase):
+    def test_simple(self):
+        template = Template("""
+                {% load site_url %}
+                <html><body>
+                {% filter add_site_url %}
+                    text:
+                    <a href="/foo"><span>Foo</span></a>
+
+                {% endfilter %}
+                </body>
+                </html>
+            """)
+        self.assertHTMLEqual(
+            """
+            <html>
+            <body>
+                <p>
+                    text:
+                    <a href="http://example.com/foo">
+                        <span>
+                            Foo
+                        </span>
+                    </a>
+                </p>
+            </body>
+            </html>
+            """,
+            template.render(Context()),
+        )

--- a/weblate/templates/mail/base.html
+++ b/weblate/templates/mail/base.html
@@ -101,7 +101,7 @@
               <a class="button" href="{{ project.get_absolute_url }}">{% trans "View" %}</a>
             </div>
           {% endif %}
-          <div class="footer" style="clear:both">
+          <div class="footer">
             <p>
               <img src="{% if request %}{% static "email-logo-footer.png" %}{% else %}cid:email-logo-footer.png@cid.weblate.org{% endif %}" />
               <br />

--- a/weblate/templates/mail/style.css
+++ b/weblate/templates/mail/style.css
@@ -327,6 +327,7 @@ del {
   color: #e9eaec;
   padding: 20px 20px 30px 20px;
   margin-top: 20px;
+  clear: both;
 }
 .footer p:first-child {
   margin-bottom: 20px;


### PR DESCRIPTION
The add_site_url filter was adding another level of HTML structure.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
