### PR TITLE
feat(checks): dismissing follows to propagated strings

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Weblate 5.11
 * :ref:`upload` is now tracked in history with details.
 * Changes in string flags are now tracked in history.
 * :ref:`addon-weblate.discovery.discovery` better handles hundredths of matches.
+* Dismissing :ref:`checks` automatically updates propagated strings.
 
 .. rubric:: Bug fixes
 

--- a/weblate/trans/views/js.py
+++ b/weblate/trans/views/js.py
@@ -48,13 +48,13 @@ def get_unit_translations(request: AuthenticatedHttpRequest, unit_id):
 @login_required
 @transaction.atomic
 def ignore_check(request: AuthenticatedHttpRequest, check_id):
-    obj = get_object_or_404(Check, pk=int(check_id))
+    obj = get_object_or_404(Check.objects.select_for_update(), pk=int(check_id))
 
     if not request.user.has_perm("unit.check", obj):
         raise PermissionDenied
 
     # Mark check for ignoring
-    obj.set_dismiss("revert" not in request.GET)
+    obj.set_dismiss(state="revert" not in request.GET)
     # response for AJAX
     return HttpResponse("ok")
 


### PR DESCRIPTION
- The check dismissal now selects for update to better deal with concurrent updates from concurrent clicks.
- The dismissal is propagate to all same checks on propagated units.

Fixes #12588
Fixes WEBLATE-1N8E

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
