### PR TITLE
fix: improve translation propagation performance

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 5.11
 .. rubric:: Bug fixes
 
 * Fixed captcha verification when some time zone was configured.
+* Improved translation propagation performance.
 
 .. rubric:: Compatibility
 

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 import sentry_sdk
 from django.http import Http404
@@ -49,7 +49,7 @@ class BaseCheck:
     ignore_untranslated = True
     ignore_readonly = True
     default_disabled = False
-    propagates: bool = False
+    propagates: Literal["source", "target"] | None = None
     param_type = None
     always_display = False
     batch_project_wide = False
@@ -57,16 +57,6 @@ class BaseCheck:
 
     def get_identifier(self) -> str:
         return self.check_id
-
-    def get_propagated_value(self, unit: Unit) -> str | None:
-        return None
-
-    def get_propagated_units(
-        self, unit: Unit, target: str | None = None
-    ) -> Iterable[Unit]:
-        from weblate.trans.models import Unit
-
-        return Unit.objects.none()
 
     def __init__(self) -> None:
         id_dash = self.check_id.replace("_", "-")

--- a/weblate/trans/tests/test_remote.py
+++ b/weblate/trans/tests/test_remote.py
@@ -114,14 +114,14 @@ class MultiRepoTest(ViewTestCase):
         # Propagate edit
         unit = self.get_unit()
         self.assertEqual(len(unit.all_checks), 0)
-        self.assertEqual(len(unit.same_source_units), 1)
+        self.assertEqual(len(unit.propagated_units), 1)
         unit.translate(self.user, [new_text], STATE_TRANSLATED)
 
         # Verify new content
         unit = self.get_unit()
         self.assertEqual(unit.target, new_text)
-        self.assertEqual(len(unit.same_source_units), 1)
-        other_unit = unit.same_source_units[0]
+        self.assertEqual(len(unit.propagated_units), 1)
+        other_unit = unit.propagated_units[0]
         self.assertEqual(other_unit.target, new_text)
 
         # There should be no checks on both


### PR DESCRIPTION
- do not perform a full prefetch, that is not really needed, this might address #14274
- filter out matching translations at the database level
- rename property to propagated_units to better match the content

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
