### PR TITLE
fix(add-ons): trigger posinstall only on compatible components

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -182,7 +182,8 @@ class BaseAddon:
 
         if project := self.instance.project:
             for component in project.component_set.iterator():
-                self.post_configure_run_component(component)
+                if self.can_install(component, None):
+                    self.post_configure_run_component(component)
 
     def post_configure_run_component(self, component: Component) -> None:
         # Trigger post configure event for a VCS component


### PR DESCRIPTION
The project-wide add-ons should be triggered only on compatbile components. The execution path already does this, but postconfigure was not.

Fixes WEBLATE-1V8Y

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
