### PR TITLE
fix(component): trigger background task on transaction commit

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,7 @@ Weblate 5.11
 
 * Fixed captcha verification when some time zone was configured.
 * Improved translation propagation performance.
+* Fixed background parsing of newly added translation files.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -313,7 +313,7 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
         if old is not None:
             # Update alerts if needed
             if old.web != self.web:
-                component_alerts.delay(
+                component_alerts.delay_on_commit(
                     list(self.component_set.values_list("id", flat=True))
                 )
 

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1531,7 +1531,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
             author=user,
         )
         if not self.component.is_glossary:
-            cleanup_stale_glossaries.delay(self.component.project.id)
+            cleanup_stale_glossaries.delay_on_commit(self.component.project.id)
 
     def handle_store_change(
         self,


### PR DESCRIPTION
Without that the create_translations might be executed before the transaction is committed and operates on stale data. This was not issue before 966378a0bbfb92fc748c911f24d22fbf00d8ff56 where there was a 60 seconds delay which gave the transaction enough time to complete.

Fixes #14401

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
