### PR TITLE
fix(models): avoid using union when not needed

### DIFF
--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -570,7 +570,7 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
         own = filter_callback(self.component_set.defer_huge())
         if self.has_shared_components:
             shared = filter_callback(self.shared_components.defer_huge())
-            return own.union(shared)
+            return own | shared
         return own
 
     @cached_property

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -135,11 +135,9 @@ def get_other_units(unit):
 
         units = base.filter(query)
         if unit.target:
-            units = units.union(
-                base.filter(
-                    Q(target__lower__md5=MD5(Lower(Value(unit.target))))
-                    & Q(state__gte=STATE_TRANSLATED)
-                )
+            units |= base.filter(
+                Q(target__lower__md5=MD5(Lower(Value(unit.target))))
+                & Q(state__gte=STATE_TRANSLATED)
             )
 
         # Use memory_db for the query in case it exists. This is supposed

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -1119,7 +1119,7 @@ class ProjectLanguage(BaseURLMixin):
         all_langs = self.language.translation_set.prefetch()
         result = all_langs.filter(component__project=self.project)
         if self.project.has_shared_components:
-            result = result.union(all_langs.filter(component__links=self.project))
+            result |= all_langs.filter(component__links=self.project)
         for item in result:
             item.is_shared = (
                 None


### PR DESCRIPTION
There is no need to use union when the base queryset is the same, it is more effective to merge two querysets with or and Django ORM will handle that as a single query.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
