### PR TITLE
fix(style): Fix String is available for translation email layout

### DIFF
--- a/weblate/templates/mail/style.css
+++ b/weblate/templates/mail/style.css
@@ -207,6 +207,7 @@ pre {
   margin: 0 auto;
   width: 100%;
   padding: 0 20px;
+  flex-direction: column;
 }
 @media (min-width: 768px) {
   .container {


### PR DESCRIPTION
I tracked the email rendering issue to be related to wrong `flex-direction` default to `row `of `.container` instead of `column `that's why the footer is broken.

> [!NOTE]  
> This is the structure of the sent out email. The footer should be a child of `body` not nested as below.

```HTML
<body>
      <div class="content">
         <div class="container">
            <div class="box">...</div>
            <div class="footer">...</div>
            ...
         </div>
      </div>
   </body>
```

> [!IMPORTANT]  
> @nijel  I only tested the effect of this change on `String is available for translation` email. Not sure how it will effect the other emails.

How to setup weblate with an email server. I tried with [github.com/maildev/maildev](https://github.com/maildev/maildev) it works fine with `./manage.py sendtestemail` but when I enable the emails for an account and trigger them I don't receive any (I am running Weblate without docker).

Related: #14312

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
