### PR TITLE
fix(html): lock project nh3.clean

### DIFF
--- a/weblate/utils/html.py
+++ b/weblate/utils/html.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import re
+import threading
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -75,6 +76,7 @@ CLEAN_CONTENT_TAGS = {"script", "style"}
 # Allow some chars:
 # - non breakable space
 SANE_CHARS = re.compile(r"[\xa0]")
+NH3_LOCK = threading.Lock()
 
 
 class MarkupExtractor(ParserTarget):
@@ -117,13 +119,14 @@ class HTMLSanitizer:
 
         tags, attributes = extract_html_tags(source)
 
-        text = nh3.clean(
-            text,
-            link_rel=None,
-            tags=tags,
-            attributes=attributes,
-            clean_content_tags=CLEAN_CONTENT_TAGS - tags,
-        )
+        with NH3_LOCK:
+            text = nh3.clean(
+                text,
+                link_rel=None,
+                tags=tags,
+                attributes=attributes,
+                clean_content_tags=CLEAN_CONTENT_TAGS - tags,
+            )
 
         return self.add_back_special(text)
 


### PR DESCRIPTION
It seems that nh3 is using single instance, so running clean in parallel threads can result in weird results.

Fixes #14485

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
