### PR TITLE
feat(machinery): automatically choose source language for cyrtranslit

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,7 +21,7 @@ Weblate 5.11
 * :ref:`addon-weblate.discovery.discovery` better handles hundredths of matches.
 * Dismissing :ref:`checks` automatically updates propagated strings.
 * Improved rendering of :ref:`additional-flags` and :ref:`additional-explanation` changes in history.
-* :ref:`mt-cyrtranslit` now automatically transliterates from matching translation.
+* :ref:`mt-cyrtranslit` now automatically transliterates from a matching translation instead of the source strings.
 
 .. rubric:: Bug fixes
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,7 @@ Weblate 5.11
 * :ref:`addon-weblate.discovery.discovery` better handles hundredths of matches.
 * Dismissing :ref:`checks` automatically updates propagated strings.
 * Improved rendering of :ref:`additional-flags` and :ref:`additional-explanation` changes in history.
+* :ref:`mt-cyrtranslit` now automatically transliterates from matching translation.
 
 .. rubric:: Bug fixes
 


### PR DESCRIPTION
It automatically picks matching translation to use. This allows to use the engine even if the source language is English.

Fixes #13769

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
