### PR TITLE
fix(editor): improve unsaved changes indication and reset on submit

### DIFF
--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -36,10 +36,11 @@ WLT.Utils = (() => ({
    */
   indicateChanges: () => {
     const $warning = $("<span class='text-warning'/>");
+    const $editorArea = $(".translator .translation-editor");
     $warning.text(gettext("Unsaved changes!"));
-    if ($(".translation-editor").next(".text-warning").length === 0) {
-      $warning.insertAfter($(".translation-editor"));
-      $(".translation-editor").addClass("has-changes");
+    if ($editorArea.next(".text-warning").length === 0) {
+      $warning.insertAfter($editorArea);
+      $editorArea.addClass("has-changes");
     }
   },
 }))();
@@ -174,6 +175,10 @@ WLT.Editor = (() => {
           gettext("You have unsaved changes. Are you sure you want to skip?"),
         );
       }
+    });
+
+    this.$editor.on("submit", () => {
+      hasChanges = false;
     });
   }
 


### PR DESCRIPTION
### Fixes
- Prevent unsaved changes dialog on **submit** of changes.
- Add unsaved changes indicator only to translation editor (it showed also in `add term to glossary` inputs).

close: #14530

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
