### PR TITLE
fix(translation): hide some checklist items without counterpart

### DIFF
--- a/weblate/trans/checklists.py
+++ b/weblate/trans/checklists.py
@@ -10,10 +10,12 @@ from weblate.trans.filter import FILTERS
 class TranslationChecklist(UserList):
     """Simple list wrapper for translation checklist."""
 
-    def add_if(self, stats, name, level) -> None:
+    def add_if(self, stats, name, level) -> bool:
         """Add to list if there are matches."""
         if getattr(stats, name) > 0:
             self.add(stats, name, level)
+            return True
+        return False
 
     def add(self, stats, name, level) -> None:
         """Add item to the list."""

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -973,8 +973,8 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
             result.add_if(self.stats, "fuzzy", "")
 
             # Translations with suggestions
-            result.add_if(self.stats, "suggestions", "")
-            result.add_if(self.stats, "nosuggestions", "")
+            if result.add_if(self.stats, "suggestions", ""):
+                result.add_if(self.stats, "nosuggestions", "")
 
         # All checks
         result.add_if(self.stats, "allchecks", "")
@@ -997,13 +997,15 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
         # Include labels
         labels = self.component.project.label_set.order_by("name")
         if labels:
+            has_label = False
             for label in labels:
-                result.add_if(
+                has_label |= result.add_if(
                     self.stats,
                     f"label:{label.name}",
                     f"label label-{label.color}",
                 )
-            result.add_if(self.stats, "unlabeled", "")
+            if has_label:
+                result.add_if(self.stats, "unlabeled", "")
 
         return result
 


### PR DESCRIPTION
- show unlabeled category only with labeled strings
- show strings without suggestions only when there are some

It is not useful to show only one side of the checklist when the
positive counterpart is missing.

Fixes #14567

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
