### PR TITLE
feat: deleting a unit goes to next entry in batch

### DIFF
--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -208,7 +208,11 @@
                       <ul class="dropdown-menu">
                         {% if user_can_delete %}
                           <li>
-                            <a href="" class="link-post" data-href="{% url "delete-unit" unit_id=unit.pk %}">{% trans "Delete string" %}</a>
+                            <!-- use this_unit_url as the next unit will become the unit at current offset after deletion -->
+                            <a href=""
+                               class="link-post"
+                               data-href="{% url "delete-unit" unit_id=unit.pk %}"
+                               data-params='{"next": "{{ this_unit_url|escapejs }}"}'>{% trans "Delete string" %}</a>
                           </li>
                         {% endif %}
                         {% if user_can_edit_flags and flag_actions %}

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -530,9 +530,11 @@ class EditPoMonoTest(EditTest):
         self.assertEqual(response.status_code, 403)
         # Actual removal
         response = self.client.post(
-            reverse("delete-unit", kwargs={"unit_id": unit.source_unit.pk})
+            reverse("delete-unit", kwargs={"unit_id": unit.source_unit.pk}),
+            data={"next": self.translate_url + "?offset=3"},
         )
         self.assertEqual(response.status_code, 302)
+        self.assert_redirects_offset(response, self.translate_url, 3)
         component = Component.objects.get(pk=self.component.pk)
         self.assertEqual(component.stats.all, 12)
         self.assertEqual(unit_count - 4, Unit.objects.count())

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -1076,7 +1076,7 @@ def delete_unit(request: AuthenticatedHttpRequest, unit_id):
         return redirect(unit)
     # Remove cached search results as we've just removed one of the unit there
     cleanup_session(request.session, delete_all=True)
-    return redirect(unit.translation)
+    return redirect_next(request.POST.get("next"), unit.translation)
 
 
 def browse(request: AuthenticatedHttpRequest, path):


### PR DESCRIPTION
When a unit is deleted, go to the next unit in the batch instead of going back to the component overview page.

fixes #14558