### PR TITLE
feat: add comment api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2286,6 +2286,18 @@ and XLIFF.
 
    Returns a list of all target translation units for the given source translation unit.
 
+.. http:post:: /api/units/(int:id)/comments/
+
+    .. versionadded:: 5.12
+
+    Create a new comment on the given translation unit.
+
+    :param id: Unit ID
+    :type id: int
+    :<json string scope: comment scope - global, translation (available on all non-source units), report (need review workflow enabled, see :ref:`reviews`)
+    :<json string comment: content of the new comment, you can use Markdown and mention users by @username.
+
+
 Changes
 +++++++
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Weblate 5.12
 
 .. rubric:: New features
 
+* Added :http:post:`/api/units/(int:id)/comments/` to create a new comment for the given translation unit.
+
 .. rubric:: Improvements
 
 .. rubric:: Bug fixes

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -14,6 +14,7 @@ from rest_framework.test import APITestCase
 from weblate_language_data.languages import LANGUAGES
 
 from weblate.accounts.models import Subscription
+from weblate.api.serializers import CommentSerializer
 from weblate.auth.models import Group, Role, User
 from weblate.lang.models import Language
 from weblate.memory.models import Memory
@@ -4254,6 +4255,13 @@ class UnitAPITest(APIBaseTest):
             method="post",
             code=403,
         )
+
+    def test_comment_serializer(self):
+        # test CommentSerializer works even if unit is not provided in context
+        serializer = CommentSerializer(
+            data={"scope": "translation", "comment": "note"},
+        )
+        self.assertTrue(serializer.is_valid())
 
 
 class ScreenshotAPITest(APIBaseTest):

--- a/weblate/trans/models/comment.py
+++ b/weblate/trans/models/comment.py
@@ -8,23 +8,28 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.db import models
+from weblate_language_data.utils import gettext_noop
 
 from weblate.trans.actions import ActionEvents
 from weblate.trans.mixins import UserDisplayMixin
 from weblate.utils.antispam import report_spam
 from weblate.utils.request import get_ip_address, get_user_agent_raw
+from weblate.utils.state import STATE_FUZZY
 
 if TYPE_CHECKING:
     from weblate.auth.models import AuthenticatedHttpRequest, User
 
 
 class CommentManager(models.Manager):
-    def add(self, unit, request: AuthenticatedHttpRequest, text) -> None:
+    def add(self, request: AuthenticatedHttpRequest, unit, text, scope) -> None:
         """Add comment to this unit."""
+        # Is this source or target comment?
+        unit_scope = unit.source_unit if scope in {"global", "report"} else unit
+
         user = request.user
         new_comment = self.create(
             user=user,
-            unit=unit,
+            unit=unit_scope,
             comment=text,
             userdetails={
                 "address": get_ip_address(request),
@@ -32,13 +37,31 @@ class CommentManager(models.Manager):
             },
         )
         user.profile.increase_count("commented")
-        unit.change_set.create(
+        unit_scope.change_set.create(
             comment=new_comment,
             action=ActionEvents.COMMENT,
             user=user,
             author=user,
             details={"comment": text},
         )
+
+        component = unit_scope.translation.component
+
+        # Add review label/flag
+        if scope == "report":
+            if component.has_template():
+                if unit_scope.translated and not unit_scope.readonly:
+                    unit_scope.translate(
+                        user,
+                        unit_scope.target,
+                        STATE_FUZZY,
+                        change_action=ActionEvents.MARKED_EDIT,
+                    )
+            else:
+                label = component.project.label_set.get_or_create(
+                    name=gettext_noop("Source needs review"), defaults={"color": "red"}
+                )[0]
+                unit_scope.labels.add(label)
 
 
 class CommentQuerySet(models.QuerySet):

--- a/weblate/trans/tests/test_tasks.py
+++ b/weblate/trans/tests/test_tasks.py
@@ -77,9 +77,9 @@ class CleanupTest(ViewTestCase):
     def test_cleanup_old_comments(self, expected=2) -> None:
         request = self.get_request()
         unit = self.get_unit()
-        Comment.objects.add(unit.source_unit, request, "Zkouška")
+        Comment.objects.add(request, unit, "Zkouška", "global")
         Comment.objects.all().update(timestamp=timezone.now() - timedelta(days=30))
-        Comment.objects.add(unit.source_unit, request, "Zkouška 2")
+        Comment.objects.add(request, unit, "Zkouška 2", "global")
         cleanup_old_comments()
         self.assertEqual(Comment.objects.count(), expected)
 


### PR DESCRIPTION
Add `/api/units/{unit_id}/comments/` endpoint to create comments.

Fixes #14232