### PR TITLE
fix: corrected server side ordering of translations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Weblate 5.12
 
 .. rubric:: Bug fixes
 
+* :ref:`dashboard` translations ordering when paginating.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/weblate/templates/dashboard/user.html
+++ b/weblate/templates/dashboard/user.html
@@ -72,7 +72,7 @@
         {% if usersubscriptions %}
           {% include "snippets/list-objects.html" with objects=usersubscriptions label=_("Translation") hide_completed=user.profile.hide_completed name_source="translation" %}
 
-          {% include "paginator.html" with page_obj=usersubscriptions %}
+          {% include "paginator.html" with page_obj=usersubscriptions anchor="your-subscriptions" %}
         {% else %}
           {% include "list-projects.html" with projects=watched_projects %}
         {% endif %}

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -55,7 +55,11 @@ class UnsupportedPathObjectError(Http404):
 
 
 def key_name(instance):
-    return instance.name if hasattr(instance, "name") else instance.component.name
+    from weblate.trans.templatetags.translations import get_breadcrumbs
+
+    return "/".join(
+        str(item) for item in get_breadcrumbs(instance, flags=False, only_names=True)
+    )
 
 
 def key_translated(instance):


### PR DESCRIPTION
Use full path instead of just a component name. This gives consistent behavior with the client side ordering. It is now based on the breadcrumbs code which was generalized a bit to make it more effective.

Fixes #14476

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
