### PR TITLE
feat: import comment api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2296,6 +2296,9 @@ and XLIFF.
     :type id: int
     :<json string scope: comment scope - global, translation (available on all non-source units), report (need review workflow enabled, see :ref:`reviews`)
     :<json string comment: content of the new comment, you can use Markdown and mention users by @username.
+    :<json string user_email: commenter's email, can be set only by project admins and defaults to the authenticated user.
+    :<json string timestamp: creation timestamp of the comment, can be set only by project admins and defaults to now.
+    :>json int id: comment identifier
 
 
 Changes

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -332,8 +332,22 @@ class CommentSerializer(serializers.Serializer):
     )
     comment = serializers.CharField(
         max_length=1000,
-        label=gettext_lazy("New comment"),
+        label=gettext_lazy("Comment text"),
         help_text=gettext_lazy("You can use Markdown and mention users by @username."),
+    )
+    timestamp = serializers.DateTimeField(
+        required=False,
+        label=gettext_lazy("Creation timestamp"),
+        help_text=gettext_lazy(
+            "If you’re an admin, you can set the explicit timestamp at which the comment was created."
+        ),
+    )
+    user_email = serializers.EmailField(
+        required=False,
+        label=gettext_lazy("Commenter’s email"),
+        help_text=gettext_lazy(
+            "If you’re an admin, you can attribute this comment to another user by their email."
+        ),
     )
 
     def validate_scope(self, value):

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -22,6 +22,7 @@ from weblate.screenshots.models import Screenshot
 from weblate.trans.models import (
     Category,
     Change,
+    Comment,
     Component,
     ComponentList,
     Project,
@@ -4142,8 +4143,7 @@ class UnitAPITest(APIBaseTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data["errors"][0]["code"], "not-a-source-unit")
 
-    def test_comments(self):
-        self.authenticate()
+    def test_add_comment(self):
         unit = Unit.objects.get(
             translation__language_code="en", source="Thank you for using Weblate."
         )
@@ -4201,7 +4201,7 @@ class UnitAPITest(APIBaseTest):
             method="post",
             code=201,
         )
-        self.assertEqual(response.data, {"result": True})
+        self.assertIn("id", response.data)
 
         unit_cs = Unit.objects.get(
             translation__language_code="cs", source="Thank you for using Weblate."
@@ -4212,7 +4212,7 @@ class UnitAPITest(APIBaseTest):
             method="post",
             code=201,
         )
-        self.assertEqual(response.data, {"result": True})
+        self.assertIn("id", response.data)
 
         # Reload the object from database
         unit = Unit.objects.get(
@@ -4249,12 +4249,116 @@ class UnitAPITest(APIBaseTest):
         project = unit.translation.component.project
         project.access_control = Project.ACCESS_PROTECTED
         project.save()
-        self.do_request(
+        response = self.do_request(
             reverse("api:unit-comments", kwargs={"pk": unit.pk}),
             request={"scope": "global", "comment": "another test"},
             method="post",
             code=403,
         )
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "You do not have permission to perform this action.",
+        )
+
+    def test_import_comment(self):
+        unit = Unit.objects.get(
+            translation__language_code="en", source="Thank you for using Weblate."
+        )
+        response = self.do_request(
+            reverse("api:unit-comments", kwargs={"pk": unit.pk}),
+            request={"scope": "global", "comment": "test comment", "user_email": 1},
+            method="post",
+            code=400,
+        )
+        self.assertEqual(
+            response.data["errors"][0]["detail"], "Enter a valid email address."
+        )
+        response = self.do_request(
+            reverse("api:unit-comments", kwargs={"pk": unit.pk}),
+            request={"scope": "global", "comment": "test comment", "timestamp": 1},
+            method="post",
+            code=400,
+        )
+        self.assertIn(
+            "Datetime has wrong format.", response.data["errors"][0]["detail"]
+        )
+
+        user2 = User.objects.create_user(
+            "commentimport", "commentimport@example.org", "x"
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + user2.auth_token.key)
+        response = self.do_request(
+            reverse("api:unit-comments", kwargs={"pk": unit.pk}),
+            request={
+                "scope": "global",
+                "comment": "test comment",
+                "timestamp": "20240101T12:00:00.000Z",
+                "user_email": self.user.email,
+            },
+            method="post",
+            authenticated=False,
+            code=403,
+        )
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "You do not have permission to perform this action.",
+        )
+
+        text = "test import comment from different user"
+        timestamp = datetime(2024, 1, 1, 12, 45, 0, tzinfo=UTC)
+        response = self.do_request(
+            reverse("api:unit-comments", kwargs={"pk": unit.pk}),
+            request={
+                "scope": "global",
+                "comment": text,
+                "timestamp": timestamp.isoformat(),
+                "user_email": user2.email,
+            },
+            method="post",
+            superuser=True,
+            code=201,
+        )
+        comment = Comment.objects.get(id=response.data["id"])
+        self.assertEqual(comment.comment, text)
+        self.assertEqual(comment.timestamp, timestamp)
+        self.assertEqual(comment.user, user2)
+
+        text = "test import comment with fallback user"
+        timestamp += +timedelta(hours=1)
+        response = self.do_request(
+            reverse("api:unit-comments", kwargs={"pk": unit.pk}),
+            request={
+                "scope": "global",
+                "comment": text,
+                "timestamp": timestamp.isoformat(),
+                "user_email": "nonexistent@example.org",
+            },
+            method="post",
+            superuser=True,
+            code=201,
+        )
+        comment = Comment.objects.get(id=response.data["id"])
+        self.assertEqual(comment.comment, text)
+        self.assertEqual(comment.timestamp, timestamp)
+        self.assertEqual(comment.user, self.user)
+
+        text = "test import default timestamp"
+        timestamp = datetime.now(UTC)
+        response = self.do_request(
+            reverse("api:unit-comments", kwargs={"pk": unit.pk}),
+            request={
+                "scope": "global",
+                "comment": text,
+                "user_email": "nonexistent@example.org",
+            },
+            method="post",
+            superuser=True,
+            code=201,
+        )
+        comment = Comment.objects.get(id=response.data["id"])
+        self.assertEqual(comment.comment, text)
+        self.assertGreaterEqual(comment.timestamp, timestamp)
+        self.assertEqual(comment.user, self.user)
 
     def test_comment_serializer(self):
         # test CommentSerializer works even if unit is not provided in context

--- a/weblate/trans/models/comment.py
+++ b/weblate/trans/models/comment.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.db import models
+from django.utils import timezone
 from weblate_language_data.utils import gettext_noop
 
 from weblate.trans.actions import ActionEvents
@@ -17,25 +18,38 @@ from weblate.utils.request import get_ip_address, get_user_agent_raw
 from weblate.utils.state import STATE_FUZZY
 
 if TYPE_CHECKING:
-    from weblate.auth.models import AuthenticatedHttpRequest, User
+    from datetime import datetime
+
+    from weblate.auth.models import AuthenticatedHttpRequest, Unit, User
 
 
 class CommentManager(models.Manager):
-    def add(self, request: AuthenticatedHttpRequest, unit, text, scope) -> None:
+    def add(
+        self,
+        request: AuthenticatedHttpRequest,
+        unit: Unit,
+        text: str,
+        scope: str,
+        user: User,
+        timestamp: datetime | None = None,
+    ) -> Comment:
         """Add comment to this unit."""
         # Is this source or target comment?
         unit_scope = unit.source_unit if scope in {"global", "report"} else unit
 
-        user = request.user
-        new_comment = self.create(
-            user=user,
-            unit=unit_scope,
-            comment=text,
-            userdetails={
+        kwargs = {
+            "user": user,
+            "unit": unit_scope,
+            "comment": text,
+            "userdetails": {
                 "address": get_ip_address(request),
                 "agent": get_user_agent_raw(request),
             },
-        )
+        }
+        if timestamp is not None:
+            kwargs["timestamp"] = timestamp
+
+        new_comment = self.create(**kwargs)
         user.profile.increase_count("commented")
         unit_scope.change_set.create(
             comment=new_comment,
@@ -63,6 +77,8 @@ class CommentManager(models.Manager):
                 )[0]
                 unit_scope.labels.add(label)
 
+        return new_comment
+
 
 class CommentQuerySet(models.QuerySet):
     def order(self):
@@ -78,7 +94,7 @@ class Comment(models.Model, UserDisplayMixin):
         blank=True,
         on_delete=models.deletion.CASCADE,
     )
-    timestamp = models.DateTimeField(auto_now_add=True, db_index=True)
+    timestamp = models.DateTimeField(default=timezone.now, db_index=True)
     resolved = models.BooleanField(default=False, db_index=True)
     userdetails = models.JSONField(default=dict)
 

--- a/weblate/trans/tests/test_tasks.py
+++ b/weblate/trans/tests/test_tasks.py
@@ -77,9 +77,9 @@ class CleanupTest(ViewTestCase):
     def test_cleanup_old_comments(self, expected=2) -> None:
         request = self.get_request()
         unit = self.get_unit()
-        Comment.objects.add(request, unit, "Zkouška", "global")
+        Comment.objects.add(request, unit, "Zkouška", "global", self.user)
         Comment.objects.all().update(timestamp=timezone.now() - timedelta(days=30))
-        Comment.objects.add(request, unit, "Zkouška 2", "global")
+        Comment.objects.add(request, unit, "Zkouška 2", "global", self.user)
         cleanup_old_comments()
         self.assertEqual(Comment.objects.count(), expected)
 

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -817,7 +817,7 @@ def comment(request: AuthenticatedHttpRequest, pk):
     if form.is_valid():
         text = form.cleaned_data["comment"]
         scope = form.cleaned_data["scope"]
-        Comment.objects.add(request, unit, text, scope)
+        Comment.objects.add(request, unit, text, scope, request.user)
         messages.success(request, gettext("Posted new comment"))
     else:
         messages.error(request, gettext("Could not add comment!"))


### PR DESCRIPTION
Update the /api/units/{unit_id}/comments/ endpoint to accept user and timestamp for a comment if the user making the request is a project admin. Return the comment id in the response as it is useful in testing and can also be useful in future resolve/delete comment APIs.

Fixes #14232.
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
