### PR TITLE
feat: sort units by component when translating multiple components

### DIFF
--- a/weblate/lang/views.py
+++ b/weblate/lang/views.py
@@ -99,7 +99,7 @@ def show_language(request: AuthenticatedHttpRequest, lang):
             "allow_index": True,
             "object": obj,
             "last_changes": last_changes,
-            "search_form": SearchForm(user, language=obj),
+            "search_form": SearchForm(request=request, language=obj, obj=obj),
             "projects": projects,
             "project_languages": project_languages,
         },

--- a/weblate/templates/snippets/sort-field.html
+++ b/weblate/templates/snippets/sort-field.html
@@ -8,8 +8,8 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-      {% if sort_name %}
-        <span class="search-label">{{ sort_name }}</span>
+      {% if form.sort_name %}
+        <span class="search-label">{{ form.sort_name }}</span>
       {% else %}
         <span class="search-label">{% translate "Sort By" %}</span>
       {% endif %}
@@ -18,7 +18,7 @@
     <input type="hidden"
            id="id_sort_by"
            name="sort_by"
-           value="{% if sort_query %}{{ sort_query }}{% else %}-priority,position{% endif %}"
+           value="{{ form.sort_query }}"
            aria-label="{% translate "Sort By" %}" />
     <ul class="dropdown-menu">
       {% sort_choices as sort_choices %}

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -763,7 +763,7 @@ class SearchForm(forms.Form):
         self,
         *,
         request: AuthenticatedHttpRequest,
-        language=None,
+        language : Language | None = None,
         show_builder=True,
         obj: type[Model | BaseURLMixin] | None = None,
         **kwargs,

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -89,11 +89,12 @@ from weblate.utils.state import (
     get_state_label,
 )
 from weblate.utils.validators import validate_file_extension
+from weblate.utils.views import get_sort_name
 from weblate.vcs.models import VCS_REGISTRY
 
 if TYPE_CHECKING:
     from weblate.accounts.models import Profile
-    from weblate.trans.mixins import URLMixin
+    from weblate.trans.mixins import BaseURLMixin, URLMixin
     from weblate.trans.models.translation import NewUnitParams
 
 BUTTON_TEMPLATE = """
@@ -758,10 +759,21 @@ class SearchForm(forms.Form):
             return {"q": request.GET["q"]}
         return None
 
-    def __init__(self, user: User, language=None, show_builder=True, **kwargs) -> None:
+    def __init__(
+        self,
+        *,
+        request: AuthenticatedHttpRequest,
+        language=None,
+        show_builder=True,
+        obj: type[Model | BaseURLMixin] | None = None,
+        **kwargs,
+    ) -> None:
         """Generate choices for other components in the same project."""
-        self.user = user
+        self.user = request.user
         self.language = language
+        sort_by = get_sort_name(request, obj)
+        self.sort_name = sort_by["name"]
+        self.sort_query = sort_by["query"]
         super().__init__(**kwargs)
 
         self.helper = FormHelper(self)

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -763,7 +763,7 @@ class SearchForm(forms.Form):
         self,
         *,
         request: AuthenticatedHttpRequest,
-        language : Language | None = None,
+        language: Language | None = None,
         show_builder=True,
         obj: type[Model | BaseURLMixin] | None = None,
         **kwargs,

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -270,7 +270,10 @@ def show_project_language(request: AuthenticatedHttpRequest, obj: ProjectLanguag
             ),
             "title": f"{project_object} - {language_object}",
             "search_form": SearchForm(
-                user, language=language_object, initial=SearchForm.get_initial(request)
+                request=request,
+                language=language_object,
+                initial=SearchForm.get_initial(request),
+                obj=obj,
             ),
             "announcement_form": optional_form(
                 AnnouncementForm, user, "project.edit", obj
@@ -337,7 +340,10 @@ def show_category_language(request: AuthenticatedHttpRequest, obj):
             ),
             "title": f"{category_object} - {language_object}",
             "search_form": SearchForm(
-                user, language=language_object, initial=SearchForm.get_initial(request)
+                request=request,
+                language=language_object,
+                initial=SearchForm.get_initial(request),
+                obj=obj,
             ),
             "language_stats": category_object.stats.get_single_language_stats(
                 language_object
@@ -408,7 +414,7 @@ def show_project(request: AuthenticatedHttpRequest, obj):
             "reports_form": ReportsForm({"project": obj}),
             "language_stats": [stat.obj or stat for stat in language_stats],
             "search_form": SearchForm(
-                request.user, initial=SearchForm.get_initial(request)
+                request=request, initial=SearchForm.get_initial(request), obj=obj
             ),
             "announcement_form": optional_form(
                 AnnouncementForm, user, "project.edit", obj
@@ -490,7 +496,9 @@ def show_category(request: AuthenticatedHttpRequest, obj):
             "last_announcements": last_announcements,
             "reports_form": ReportsForm({"category": obj}),
             "language_stats": [stat.obj or stat for stat in language_stats],
-            "search_form": SearchForm(user, initial=SearchForm.get_initial(request)),
+            "search_form": SearchForm(
+                request=request, initial=SearchForm.get_initial(request), obj=obj
+            ),
             "announcement_form": optional_form(
                 AnnouncementForm, user, "project.edit", obj
             ),
@@ -580,7 +588,7 @@ def show_component(request: AuthenticatedHttpRequest, obj: Component):
                 instance=obj,
             ),
             "search_form": SearchForm(
-                request.user, initial=SearchForm.get_initial(request)
+                request=request, initial=SearchForm.get_initial(request), obj=obj
             ),
             "alerts": obj.all_active_alerts
             if "alerts" not in request.GET
@@ -599,7 +607,10 @@ def show_translation(request: AuthenticatedHttpRequest, obj):
     form = get_upload_form(user, obj)
 
     search_form = SearchForm(
-        request.user, language=obj.language, initial=SearchForm.get_initial(request)
+        request=request,
+        language=obj.language,
+        initial=SearchForm.get_initial(request),
+        obj=obj,
     )
 
     # Translations to same language from other components in this project

--- a/weblate/trans/views/dashboard.py
+++ b/weblate/trans/views/dashboard.py
@@ -277,7 +277,7 @@ def dashboard_user(request: AuthenticatedHttpRequest):
         {
             "allow_index": True,
             "suggestions": suggestions,
-            "search_form": SearchForm(request.user),
+            "search_form": SearchForm(request=request),
             "usersubscriptions": usersubscriptions,
             "componentlists": componentlists,
             "all_componentlists": prefetch_stats(

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -64,7 +64,6 @@ from weblate.utils.ratelimit import revert_rate_limit, session_ratelimit_post
 from weblate.utils.state import STATE_APPROVED, STATE_FUZZY, STATE_TRANSLATED
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.utils.views import (
-    get_sort_name,
     parse_path,
     parse_path_units,
     show_form_errors,
@@ -222,7 +221,9 @@ def search(
     """Perform search or returns cached search results."""
     now = int(time.time())
     # Possible new search
-    form = PositionSearchForm(user=request.user, data=request.GET, show_builder=False)
+    form = PositionSearchForm(
+        request=request, data=request.GET, show_builder=False, obj=base
+    )
 
     # Process form
     form_valid = form.is_valid()
@@ -679,7 +680,6 @@ def translate(request: AuthenticatedHttpRequest, path):
 
     # Prepare form
     form = TranslationForm(user, unit)
-    sort = get_sort_name(request, obj)
 
     screenshot_form = None
     if user.has_perm("screenshot.add", unit.translation):
@@ -713,8 +713,6 @@ def translate(request: AuthenticatedHttpRequest, path):
             "search_items": search_result["items"],
             "search_query": search_result["query"],
             "offset": offset,
-            "sort_name": sort["name"],
-            "sort_query": sort["query"],
             "filter_count": num_results,
             "filter_pos": offset,
             "form": form,
@@ -907,7 +905,6 @@ def zen(request: AuthenticatedHttpRequest, path):
     project = context["project"]
 
     search_result, unitdata = get_zen_unitdata(obj, project, unit_set, request)
-    sort = get_sort_name(request, obj)
 
     # Handle redirects
     if isinstance(search_result, HttpResponse):
@@ -925,8 +922,6 @@ def zen(request: AuthenticatedHttpRequest, path):
             "search_query": search_result["query"],
             "filter_count": len(search_result["ids"]),
             "filter_pos": 0,
-            "sort_name": sort["name"],
-            "sort_query": sort["query"],
             "last_section": search_result["last_section"],
             "search_url": search_result["url"],
             "offset": search_result["offset"],
@@ -1081,7 +1076,6 @@ def browse(request: AuthenticatedHttpRequest, path):
         search_result["url"],
     )
     num_results = ceil(len(search_result["ids"]) / page)
-    sort = get_sort_name(request, obj)
 
     return render(
         request,
@@ -1104,7 +1098,5 @@ def browse(request: AuthenticatedHttpRequest, path):
             else None,
             "prev_unit_url": base_unit_url + str(offset - 1) if offset > 1 else None,
             "is_in_browse": True,
-            "sort_name": sort["name"],
-            "sort_query": sort["query"],
         },
     )

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -921,7 +921,7 @@ def zen(request: AuthenticatedHttpRequest, path):
             "unitdata": unitdata,
             "search_query": search_result["query"],
             "filter_count": len(search_result["ids"]),
-            "filter_pos": 0,
+            "filter_pos": search_result["offset"],
             "last_section": search_result["last_section"],
             "search_url": search_result["url"],
             "offset": search_result["offset"],

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -214,6 +214,7 @@ SORT_CHOICES = {
     "num_failing_checks": gettext_lazy("Number of failing checks"),
     "context": pgettext_lazy("Translation key", "Key"),
     "location": gettext_lazy("String location"),
+    "component,-priority": gettext_lazy("Component and priority"),
 }
 
 SORT_LOOKUP = {key.replace("-", ""): value for key, value in SORT_CHOICES.items()}
@@ -221,7 +222,9 @@ SORT_LOOKUP = {key.replace("-", ""): value for key, value in SORT_CHOICES.items(
 
 def get_sort_name(request: AuthenticatedHttpRequest, obj=None):
     """Get sort name."""
-    if hasattr(obj, "component") and obj.component.is_glossary:
+    if isinstance(obj, Project | Category):
+        default = "component,-priority"
+    elif hasattr(obj, "component") and obj.component.is_glossary:
         default = "source"
     else:
         default = "-priority,position"


### PR DESCRIPTION
Add sort choice to sort by component and unit priority to avoid unnecessary jumping between contexts. The units are sorted by the component in the same order as components are sorted in a project/category.

Further, move the sort name and sort query to the SearchForm from the views to ensure consistent sort defaults on all pages.

Also fix a bug in zen mode when changing the sort in zen mode results in a blank page.

#14296