### PR TITLE
fix: improve tab naming consistency

### DIFF
--- a/weblate/templates/category-language.html
+++ b/weblate/templates/category-language.html
@@ -13,7 +13,7 @@
       <a href="#overview" data-toggle="tab">{% translate "Components" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Info" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     <li>
       <a href="#search" data-toggle="tab">{% translate "Search" %}</a>

--- a/weblate/templates/category.html
+++ b/weblate/templates/category.html
@@ -29,7 +29,7 @@
       <a href="#languages" data-toggle="tab">{% translate "Languages" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Info" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     <li>
       <a href="#search" data-toggle="tab">{% translate "Search" %}</a>

--- a/weblate/templates/component-list.html
+++ b/weblate/templates/component-list.html
@@ -15,7 +15,7 @@
       <a href="#overview" data-toggle="tab">{% translate "Components" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Information" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">

--- a/weblate/templates/component.html
+++ b/weblate/templates/component.html
@@ -29,7 +29,7 @@
       <a href="#translations" data-toggle="tab">{% translate "Languages" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Info" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     {% if alerts %}
       <li>

--- a/weblate/templates/language-project.html
+++ b/weblate/templates/language-project.html
@@ -20,7 +20,7 @@
       <a href="#overview" data-toggle="tab">{% translate "Components" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Info" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     <li>
       <a href="#search" data-toggle="tab">{% translate "Search" %}</a>

--- a/weblate/templates/language.html
+++ b/weblate/templates/language.html
@@ -26,7 +26,7 @@
       <a href="#overview" data-toggle="tab">{% translate "Projects" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Information" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     <li>
       <a href="#search" data-toggle="tab">{% translate "Search" %}</a>

--- a/weblate/templates/project.html
+++ b/weblate/templates/project.html
@@ -31,7 +31,7 @@
       <a href="#languages" data-toggle="tab">{% translate "Languages" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Info" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     <li>
       <a href="#search" data-toggle="tab">{% translate "Search" %}</a>

--- a/weblate/templates/snippets/info.html
+++ b/weblate/templates/snippets/info.html
@@ -6,7 +6,7 @@
     {% if language or project or component or translation %}
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h4 class="panel-title">{% translate "Overview" %}</h4>
+          <h4 class="panel-title">{% translate "Summary" %}</h4>
         </div>
 
         <table class="table table-striped table-autowidth">

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -30,10 +30,10 @@
 
   <ul class="nav nav-pills">
     <li class="active">
-      <a href="#overview" data-toggle="tab">{% translate "Overview" %}</a>
+      <a href="#translation" data-toggle="tab">{% translate "Translation" %}</a>
     </li>
     <li>
-      <a href="#information" data-toggle="tab">{% translate "Info" %}</a>
+      <a href="#information" data-toggle="tab">{% translate "Overview" %}</a>
     </li>
     <li>
       <a href="#search" data-toggle="tab">{% translate "Search" %}</a>
@@ -140,7 +140,7 @@
 
 
   <div class="tab-content">
-    <div class="tab-pane active" id="overview">
+    <div class="tab-pane active" id="translation">
 
       <div class="panel {% if object.is_source %}panel-warning{% else %}panel-default{% endif %}">
         <div class="panel-heading">


### PR DESCRIPTION
- use "Overview" instead of "Info"/"Information" as that better describes the tab
- replace "Overview" by "Summary" in the panels to avoid repeating the label
- the top level translation label is now "Translation", not "Overview" to make it consistent with other levels

Fixes #14171

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
