### PR TITLE
Refactor translation editor save logic to improve focus handling and save timing

### DIFF
--- a/weblate/static/editor/zen.js
+++ b/weblate/static/editor/zen.js
@@ -157,15 +157,8 @@
     const $this = $(this);
     focusTimeout = setTimeout(() => {
       if (!editorHasFocus) {
-        const $row = $this.closest("tr");
-        const checksum = $row.find("[name=checksum]").val();
-        const statusdiv = $(`#status-${checksum}`);
-        const form = $row.find("form");
-        const payload = form.serialize();
-        const lastPayload = statusdiv.data("last-payload");
-
-        // Trigger save if payload has changed or if it's the first save
-        if (payload && (lastPayload === undefined || payload !== lastPayload)) {
+        // Editor lost focus and has changes
+        if ($this.hasClass("has-changes")) {
           handleTranslationChange.call($this[0]);
         }
       }
@@ -191,15 +184,6 @@
       clearTimeout(existingTimer);
       $row.removeData("save-timer");
     }
-    // Guard: skip if nothing has changed
-    if (lastPayload === undefined) {
-      // First save, no need to check
-      statusdiv.data("last-payload", payload);
-      return;
-    }
-    if (payload === lastPayload) {
-      return;
-    }
 
     // Guard: skip if a save is already happening
     if (statusdiv.hasClass("unit-state-saving")) {
@@ -207,6 +191,19 @@
         handleTranslationChange.call($this[0]); // Reinvoke
       }, 500);
       $row.data("save-timer", retryTimer);
+      return;
+    }
+
+    // First save
+    if (lastPayload === undefined) {
+      statusdiv.data("last-payload", payload);
+      // Check if the editor doesn't have changes
+      if (!$this.closest(".translation-editor").hasClass("has-changes")) {
+        return;
+      }
+    }
+    // Guard: skip if nothing has changed
+    if (payload === lastPayload) {
       return;
     }
 

--- a/weblate/static/editor/zen.js
+++ b/weblate/static/editor/zen.js
@@ -67,10 +67,6 @@
       }
     });
 
-    $document.on("change", ".translation-editor", handleTranslationChange);
-    $document.on("change", ".fuzzy_checkbox", handleTranslationChange);
-    $document.on("change", ".review_radio", handleTranslationChange);
-
     Mousetrap.bindGlobal("mod+end", (_e) => {
       $(".zen-unit:last").find(".translation-editor:first").focus();
       return false;
@@ -145,52 +141,105 @@
 
   /* Handlers */
 
+  let focusTimeout = null;
+  let editorHasFocus = false;
+
+  $document.on("focusin", ".translation-editor", () => {
+    editorHasFocus = true;
+    // Focus returned quickly; cancel pending save
+    if (focusTimeout) {
+      clearTimeout(focusTimeout);
+      focusTimeout = null;
+    }
+  });
+
+  $document.on("focusout", ".translation-editor", function () {
+    editorHasFocus = false;
+    const $this = $(this);
+    focusTimeout = setTimeout(() => {
+      if (!editorHasFocus) {
+        // Focus lost for over 1000ms, triggering save
+        handleTranslationChange.call($this[0]);
+      }
+    }, 1000); // Grace period before saving
+  });
+
+  // Allow immediate saves for checkbox/radio changes
+  $document.on("change", ".fuzzy_checkbox", handleTranslationChange);
+  $document.on("change", ".review_radio", handleTranslationChange);
+
   function handleTranslationChange() {
     const $this = $(this);
     const $row = $this.closest("tr");
     const checksum = $row.find("[name=checksum]").val();
-
     const statusdiv = $(`#status-${checksum}`);
+    const form = $row.find("form");
+    const payload = form.serialize();
 
-    /* Wait until previous operation on this field is completed */
+    // Cancel any previously scheduled save for this row
+    const existingTimer = $row.data("save-timer");
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      $row.removeData("save-timer");
+    }
+
+    // Guard: skip if nothing has changed
+    if (payload === statusdiv.data("last-payload")) {
+      $row.find("#unsaved-label").remove();
+      $row.find(".translation-editor").removeClass("has-changes");
+      return;
+    }
+
+    // Guard: skip if a save is already happening
     if (statusdiv.hasClass("unit-state-saving")) {
-      setTimeout(() => {
-        $this.trigger("change");
-      }, 100);
+      const retryTimer = setTimeout(() => {
+        handleTranslationChange.call($this[0]); // Reinvoke
+      }, 500);
+      $row.data("save-timer", retryTimer);
       return;
     }
 
     $row.addClass("translation-modified");
 
-    const form = $row.find("form");
-    statusdiv.addClass("unit-state-saving");
-    const payload = form.serialize();
-    if (payload === statusdiv.data("last-payload")) {
-      return;
-    }
-    statusdiv.data("last-payload", payload);
-    $.ajax({
-      type: "POST",
-      url: form.attr("action"),
-      data: payload,
-      dataType: "json",
-      error: (_jqXhr, _textStatus, errorThrown) => {
-        addAlert(errorThrown);
-      },
-      success: (data) => {
-        statusdiv.attr("class", `unit-state-cell ${data.unit_state_class}`);
-        statusdiv.attr("title", data.unit_state_title);
-        $.each(data.messages, (_i, val) => {
-          addAlert(val.text, val.kind);
-        });
-        $row.removeClass("translation-modified").addClass("translation-saved");
-        $row.find("#unsaved-label").remove();
-        $row.find(".translation-editor").removeClass("has-changes");
-        if (data.translationsum !== "") {
-          $row.find("input[name=translationsum]").val(data.translationsum);
-        }
-      },
-    });
+    // Start a new save operation after delay
+    const saveTimer = setTimeout(() => {
+      statusdiv.addClass("unit-state-saving");
+      statusdiv.data("last-payload", payload);
+
+      $.ajax({
+        type: "POST",
+        url: form.attr("action"),
+        data: payload,
+        dataType: "json",
+        error: (_jqXhr, _textStatus, errorThrown) => {
+          addAlert(errorThrown);
+        },
+        success: (data) => {
+          statusdiv.attr("class", `unit-state-cell ${data.unit_state_class}`);
+          statusdiv.attr("title", data.unit_state_title);
+
+          $.each(data.messages, (_i, val) => {
+            addAlert(val.text, val.kind);
+          });
+
+          $row
+            .removeClass("translation-modified")
+            .addClass("translation-saved");
+          $row.find("#unsaved-label").remove();
+          $row.find(".translation-editor").removeClass("has-changes");
+
+          if (data.translationsum !== "") {
+            $row.find("input[name=translationsum]").val(data.translationsum);
+          }
+        },
+        complete: () => {
+          statusdiv.removeClass("unit-state-saving");
+          $row.removeData("save-timer");
+        },
+      });
+    }, 3000); // Delay actual save
+
+    $row.data("save-timer", saveTimer);
   }
 
   document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
Fixes:
- Stop save triggered when clicking source text or inserting placeholders.
- Cancel save operation after (1000ms) quick refocus
- Reduce possibility of multiple validation popups showing in the UI because of unintended saves

Close: #3410

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
