### PR TITLE
fix(checks): has been translated should look only at translation changes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Weblate 5.12
 .. rubric:: Bug fixes
 
 * :ref:`dashboard` translations ordering when paginating.
+* False reports of :ref:`check-translated` with flags or explanation changes.
 
 .. rubric:: Compatibility
 


### PR DESCRIPTION
The content changes cover explanation or flags which are not really relevant when looking for a previous translation.

Fixes #14846
Fixes #14847

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
