### PR TITLE
chore: avoid importing stdlib modules from third-party

### DIFF
--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -7,11 +7,13 @@
 
 from __future__ import annotations
 
+import csv
 import importlib
 import inspect
 import os
 import re
 import subprocess
+from io import StringIO
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 from django.core.exceptions import ValidationError
@@ -25,7 +27,7 @@ from translate.misc.multistring import multistring
 from translate.misc.xml_helpers import setXMLspace
 from translate.storage.base import TranslationStore
 from translate.storage.base import TranslationUnit as TranslateToolkitUnit
-from translate.storage.csvl10n import csv, csvunit
+from translate.storage.csvl10n import csvunit
 from translate.storage.jsonl10n import BaseJsonUnit, JsonFile
 from translate.storage.lisa import LISAfile
 from translate.storage.po import pofile, pounit
@@ -1647,7 +1649,7 @@ class CSVFormat(TTKitFormat):
         if store.fieldnames != ["location", "source", "target"]:
             return store
 
-        fileobj = csv.StringIO(
+        fileobj = StringIO(
             store.detect_encoding(content, default_encodings=["utf-8", "utf-16"])[0]
         )
 


### PR DESCRIPTION
There is no need to shadow using stdlib by importing these from translate-toolkit.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
