### PR TITLE
feat: add PWA support with caching and offline support

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1609,6 +1609,11 @@ $(function () {
     form.submit();
   });
 
+  // Register service worker of the PWA
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("/service-worker.js");
+  }
+
   /* Warn users that they do not want to use developer console in most cases */
   // biome-ignore lint/suspicious: It is intentional to log a warning
   console.log(

--- a/weblate/templates/js/service-worker.js
+++ b/weblate/templates/js/service-worker.js
@@ -1,0 +1,84 @@
+const APP_VERSION = "{{ version }}";
+const CACHE_NAME = `weblate-pwa-cache-${APP_VERSION}`;
+
+const urlsToCache = [
+  // Core pages
+  "/",
+  "/dashboard/",
+  "/projects/",
+  "/languages/",
+  "/changes/",
+
+  // User account pages
+  "/accounts/profile/",
+  "/accounts/login/",
+  "/accounts/register/",
+
+  // Common static assets
+  "/static/css/style.css",
+  "/static/js/main.js",
+  "/static/weblate.js",
+  "/static/bootstrap/css/bootstrap.min.css",
+  "/static/bootstrap/js/bootstrap.bundle.min.js",
+  "/static/font-awesome/css/font-awesome.min.css",
+  "/static/favicon.ico",
+  "/static/weblate-192.png",
+  "/css/custom.css",
+  "/js/i18n/",
+
+  "/site.webmanifest",
+  "/robots.txt",
+
+  // Common translation paths
+  "/browse/",
+  "/translate/",
+  "/zen/",
+
+  // The service worker itself
+  "/service-worker.js",
+];
+
+// Install event: Pre-cache static assets
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(urlsToCache);
+    }),
+  );
+});
+
+// Fetch event: Network-first strategy that falls back to cache
+self.addEventListener("fetch", (event) => {
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        // Clone the response and store it in the cache
+        const responseToCache = response.clone();
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, responseToCache);
+        });
+        return response; // Return the network response
+      })
+      .catch(() => {
+        // Fallback to cache if the network request fails
+        return caches.match(event.request);
+      }),
+  );
+});
+
+// Activate event: Clean up old caches
+self.addEventListener("activate", (event) => {
+  const cacheWhitelist = [CACHE_NAME];
+
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          if (!cacheWhitelist.includes(cacheName)) {
+            return caches.delete(cacheName);
+          }
+        }),
+      );
+    }),
+  );
+});

--- a/weblate/templates/site.webmanifest
+++ b/weblate/templates/site.webmanifest
@@ -2,6 +2,7 @@
 {
     "name": "{{ site_title }}",
     "short_name": "{{ site_title }}",
+    "start_url": "/",
     "icons": [
         {
             "src": "{% static 'weblate-192.png' %}",

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -54,6 +54,7 @@ from weblate.sitemaps import SITEMAPS
 from weblate.trans.feeds import ChangesFeed, LanguageChangesFeed, TranslationChangesFeed
 from weblate.trans.views.changes import ChangesCSVView, ChangesView, show_change
 from weblate.utils.version import VERSION
+from weblate.views import service_worker
 
 handler400 = weblate.trans.views.error.bad_request
 handler403 = weblate.trans.views.error.denied
@@ -908,6 +909,7 @@ real_patterns = [
             )
         ),
     ),
+    path("service-worker.js", service_worker, name="service-worker"),
     # Redirects for .well-known
     path(
         ".well-known/change-password",

--- a/weblate/views.py
+++ b/weblate/views.py
@@ -1,0 +1,23 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.shortcuts import render
+from django.views.decorators.cache import never_cache
+from django.views.decorators.http import require_GET
+
+from weblate.utils.version import VERSION
+
+
+@require_GET
+@never_cache
+def service_worker(request):
+    response = render(
+        request,
+        "js/service-worker.js",
+        {
+            "version": VERSION,
+        },
+    )
+    response["Content-Type"] = "application/javascript"
+    return response


### PR DESCRIPTION
Weblate now can be installed on users OS as a typical app.
## The install hint shows
![1](https://github.com/user-attachments/assets/b783117d-deba-4542-8d94-1b03e2962def)

## The user can click to install the app
![2](https://github.com/user-attachments/assets/528d2dc4-27bf-42b4-b516-f126d296e2af)

## The app is installed without the browser shell
![3](https://github.com/user-attachments/assets/f9c23f4c-3730-4e36-8605-44420fbf6063)

If the  user go offline he still can use the app(the cached views)
