### PR TITLE
chore: cleanup translation create interface

### DIFF
--- a/weblate/addons/tasks.py
+++ b/weblate/addons/tasks.py
@@ -135,7 +135,7 @@ def language_consistency(
             else:
                 new_lang.log_info("added for language consistency")
         try:
-            component.create_translations_task()
+            component.create_translations_immediate()
         except FileParseError as error:
             component.log_error("could not parse translation files: %s", error)
 

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -632,7 +632,7 @@ class JsonAddonTest(ViewTestCase):
         SameEditAddon.create(component=self.component)
 
         Unit.objects.filter(translation__language__code="cs").delete()
-        self.component.create_translations(force=True)
+        self.component.create_translations_immediate(force=True)
         self.assertFalse(
             Unit.objects.filter(translation__language__code="cs")
             .exclude(state__in=(STATE_FUZZY, STATE_EMPTY))
@@ -640,7 +640,7 @@ class JsonAddonTest(ViewTestCase):
         )
 
         Unit.objects.all().delete()
-        self.component.create_translations(force=True)
+        self.component.create_translations_immediate(force=True)
         self.assertFalse(
             Unit.objects.exclude(
                 state__in=(STATE_FUZZY, STATE_EMPTY, STATE_READONLY)

--- a/weblate/glossary/tasks.py
+++ b/weblate/glossary/tasks.py
@@ -45,7 +45,7 @@ def sync_glossary_languages(pk: int, component: Component | None = None) -> None
                 needs_create = True
 
         if needs_create:
-            component.create_translations_task()
+            component.create_translations_immediate()
 
 
 @app.task(trail=False, autoretry_for=(Project.DoesNotExist, WeblateLockTimeoutError))

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1547,9 +1547,7 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
         # delete_unit might do changes in the database only and not touch the files
         # for pending new units
         if self.is_source:
-            self.component.create_translations(
-                request=request, change=change, run_async=True
-            )
+            self.component.create_translations(request=request, change=change)
             self.component.invalidate_cache()
         else:
             self.check_sync(request=request, change=change)

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -83,6 +83,7 @@ def perform_update(cls, pk, auto=False, obj=None) -> None:
 )
 def perform_load(
     pk: int,
+    *,
     force: bool = False,
     langs: list[str] | None = None,
     changed_template: bool = False,
@@ -90,7 +91,7 @@ def perform_load(
     change: int | None = None,
 ) -> None:
     component = Component.objects.get(pk=pk)
-    component.create_translations_task(
+    component.create_translations_immediate(
         force=force,
         langs=langs,
         changed_template=changed_template,

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -382,7 +382,7 @@ class EditResourceTest(EditTest):
         self.assertEqual(
             Unit.objects.filter(context="key", state=STATE_TRANSLATED).count(), 2
         )
-        self.component.create_translations(force=True)
+        self.component.create_translations_immediate(force=True)
         self.assertEqual(
             Unit.objects.filter(context="key", state=STATE_TRANSLATED).count(), 2
         )
@@ -1193,7 +1193,7 @@ class EditSourceTest(ViewTestCase):
         )
 
         # Check sync should be no-op now
-        self.component.create_translations()
+        self.component.create_translations_immediate()
 
         # Check that translation was preserved
         self.assertEqual(

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -360,7 +360,7 @@ class TranslationManipulationTest(ViewTestCase):
         translation = self.component.translation_set.get(language_code="de")
         translation.remove(self.user)
         # Force scanning of the repository
-        self.component.create_translations()
+        self.component.create_translations_immediate()
         self.assertFalse(
             self.component.translation_set.filter(language_code="de").exists()
         )

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -760,9 +760,7 @@ def new_language(request: AuthenticatedHttpRequest, path):
                             ),
                         )
                 try:
-                    if added and not obj.create_translations(
-                        request=request, run_async=True
-                    ):
+                    if added and not obj.create_translations(request=request):
                         messages.success(
                             request,
                             gettext(


### PR DESCRIPTION
Historically there was `create_translations` which decided whether to make the processing immediate or in a task based on the configuration and parameter. Remove that parameter and make it always use background processing if available. Also renames the immediate processing method to make it clear what it does and use it where sync behavior is needed.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
