### PR TITLE
fix: correctly detect newly added appstore metadata files

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,7 @@ Weblate 5.12
 * Honor DeepL API Free glossary limits in :ref:`mt-deepl`.
 * :ref:`addon-weblate.webhook.webhook` delivery of project-wide events.
 * False reports of :ref:`check-translated` with flags or explanation changes.
+* Creating new translations in :doc:`/formats/appstore`.
 
 .. rubric:: Compatibility
 

--- a/weblate/glossary/tasks.py
+++ b/weblate/glossary/tasks.py
@@ -45,7 +45,8 @@ def sync_glossary_languages(pk: int, component: Component | None = None) -> None
                 needs_create = True
 
         if needs_create:
-            component.create_translations_immediate()
+            # force_scan needed, see add_new_language
+            component.create_translations_immediate(force_scan=True)
 
 
 @app.task(trail=False, autoretry_for=(Project.DoesNotExist, WeblateLockTimeoutError))

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -5,10 +5,12 @@
 from __future__ import annotations
 
 import codecs
+import contextlib
 import os
 import tempfile
 from datetime import UTC
 from itertools import chain
+from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, Literal, NotRequired, TypedDict
 
 import sentry_sdk
@@ -579,13 +581,13 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
     def do_file_scan(self, request: AuthenticatedHttpRequest | None = None):
         return self.component.do_file_scan(request)
 
-    def can_push(self):
+    def can_push(self) -> bool:
         return self.component.can_push()
 
-    def has_push_configuration(self):
+    def has_push_configuration(self) -> bool:
         return self.component.has_push_configuration()
 
-    def get_hash_filenames(self):
+    def get_hash_filenames(self) -> list[str]:
         """Return filenames to include in the hash."""
         component = self.component
         filenames = [self.get_filename()]
@@ -601,13 +603,11 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
 
         return filenames
 
-    def get_git_blob_hash(self):
+    def get_git_blob_hash(self) -> str:
         """Return current VCS blob hash for file."""
         get_object_hash = self.component.repository.get_object_hash
-
-        return ",".join(
-            get_object_hash(filename) for filename in self.get_hash_filenames()
-        )
+        filenames = self.get_hash_filenames()
+        return ",".join(get_object_hash(filename) for filename in filenames)
 
     def store_hash(self) -> None:
         """Store current hash in database."""
@@ -1519,6 +1519,12 @@ class Translation(models.Model, URLMixin, LoggerMixin, CacheKeyMixin, LockMixin)
                     author,
                 )
                 self.component.push_if_needed()
+
+        # Remove blank directory if still present (appstore)
+        filename = Path(self.get_filename())
+        if filename.is_dir():
+            with contextlib.suppress(OSError):
+                filename.rmdir()
 
         # Delete from the database
         self.delete()

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -85,6 +85,7 @@ def perform_load(
     pk: int,
     *,
     force: bool = False,
+    force_scan: bool = False,
     langs: list[str] | None = None,
     changed_template: bool = False,
     from_link: bool = False,
@@ -93,6 +94,7 @@ def perform_load(
     component = Component.objects.get(pk=pk)
     component.create_translations_immediate(
         force=force,
+        force_scan=force_scan,
         langs=langs,
         changed_template=changed_template,
         from_link=from_link,

--- a/weblate/trans/tests/test_newlang.py
+++ b/weblate/trans/tests/test_newlang.py
@@ -102,11 +102,12 @@ class NewLangTest(ViewTestCase):
 
         lang = {"lang": "af"}
         response = self.client.post(
-            reverse("new-language", kwargs=self.kw_component),
-            lang,
+            reverse("new-language", kwargs=self.kw_component), lang, follow=True
         )
         translation = self.component.translation_set.get(language__code="af")
         self.assertRedirects(response, translation.get_absolute_url())
+
+        self.assertNotEqual(translation.unit_set.count(), 0)
 
         # Verify mail
         self.assertEqual(len(mail.outbox), 1)
@@ -178,7 +179,7 @@ class NewLangTest(ViewTestCase):
         )
 
     def test_add_code(self) -> None:
-        def perform(style, code, expected) -> None:
+        def perform(style: str, code: str, expected: str) -> None:
             self.component.language_code_style = style
             self.component.save()
 
@@ -217,3 +218,10 @@ class AndroidNewLangTest(NewLangTest):
 
     def create_component(self):
         return self.create_android(new_lang="add")
+
+
+class AppStoreNewLangTest(NewLangTest):
+    expected_lang_code = "pt-BR"
+
+    def create_component(self):
+        return self.create_appstore(new_lang="add")

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -381,8 +381,10 @@ class RepoTestMixin:
     def create_dtd(self):
         return self._create_component("dtd", "dtd/*.dtd", "dtd/en.dtd")
 
-    def create_appstore(self):
-        return self._create_component("appstore", "metadata/*", "metadata/en-US")
+    def create_appstore(self, **kwargs):
+        return self._create_component(
+            "appstore", "metadata/*", "metadata/en-US", **kwargs
+        )
 
     def create_html(self):
         return self._create_component(

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -760,7 +760,10 @@ def new_language(request: AuthenticatedHttpRequest, path):
                             ),
                         )
                 try:
-                    if added and not obj.create_translations(request=request):
+                    # force_scan needed, see add_new_language
+                    if added and not obj.create_translations(
+                        request=request, force_scan=True
+                    ):
                         messages.success(
                             request,
                             gettext(


### PR DESCRIPTION
These create a blank directory so need a bit specific handling to be detected. Force scan (without force loading existing translations) upon adding.

Fixes #14915

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
