### PR TITLE
fix: do not send authid parameter in saml backend

### DIFF
--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -1338,7 +1338,7 @@ def social_auth(request: AuthenticatedHttpRequest, backend: str):
         msg = "Backend not found"
         raise Http404(msg) from None
 
-    # Store session ID for OpenID or SAML based auth. The session cookies will
+    # Store session ID for OpenID based auth. The session cookies will
     # not be sent on returning POST request due to SameSite cookie policy
     if isinstance(request.backend, OpenIdAuth):
         request.backend.redirect_uri += "?authid={}".format(

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -1340,7 +1340,7 @@ def social_auth(request: AuthenticatedHttpRequest, backend: str):
 
     # Store session ID for OpenID or SAML based auth. The session cookies will
     # not be sent on returning POST request due to SameSite cookie policy
-    if isinstance(request.backend, OpenIdAuth) or backend == "saml":
+    if isinstance(request.backend, OpenIdAuth):
         request.backend.redirect_uri += "?authid={}".format(
             dumps(
                 (request.session.session_key, get_ip_address(request)),


### PR DESCRIPTION
Describe the problem:
Currently, the SAML integration appends an `authid` query parameter to the Assertion Consumer Service (ACS) URL to restore the session after SAML authentication. Many SAML Identity Providers (IdP) require the ACS URL to match exactly, and the extra parameter causes authentication to fail with errors such as:

```
Invalid request, ACS Url in request ... doesn't match configured ACS Url ...
```

This strict matching breaks SAML login for platforms that do not allow query parameters in the ACS URL.

Solution brainstorm:
The session restoration mechanism should use the SAML RelayState parameter for passing `authid` or similar session data instead of appending it to the ACS URL as a query parameter. The SAML RelayState is designed for this purpose and is returned unmodified by the IdP, making it suitable for state restoration without breaking ACS URL matching.

Describe alternatives you have considered:
- Making the inclusion of `authid` in the ACS URL optional/configurable (not robust, still breaks for most strict IdPs)
- Documenting the issue and asking users to relax ACS URL matching (not always possible)

Screenshots:

Additional context:
This problem is tracked in the following function in the codebase:
https://github.com/WeblateOrg/weblate/blob/main/weblate/accounts/views.py#L1343

Fixing this would improve compatibility with a wider range of SAML IdPs and make SAML authentication more robust.

Related to the issue: https://github.com/WeblateOrg/weblate/issues/14923