### PR TITLE
fix(fonts): pass font weight for size rendering

### DIFF
--- a/weblate/fonts/utils.py
+++ b/weblate/fonts/utils.py
@@ -254,6 +254,7 @@ def render_size(
     pixel_size, line_count, buffer = _render_size(
         text,
         font=font,
+        weight=weight,
         size=size,
         spacing=spacing,
         width=width,


### PR DESCRIPTION
Not sure if this actually fixes a issue, but for completeness' sake I think it should be passed to `_render_size()`.