### PR TITLE
feat(api): show translation languages of user

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -324,6 +324,7 @@ Users
     :>json string date_joined: date the user is created
     :>json string last_login: date the user last signed in
     :>json array groups: link to associated groups; see :http:get:`/api/groups/(int:id)/`
+    :>json array languages: link to translated languages; see :http:get:`/api/languages/(string:language)/`
 
     **Example JSON data:**
 
@@ -336,6 +337,9 @@ Users
             "groups": [
                 "http://example.com/api/groups/2/",
                 "http://example.com/api/groups/3/"
+            ],
+            "languages": [
+                "http://example.com/api/languages/cs/",
             ],
             "is_superuser": true,
             "is_active": true,

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@ Weblate 5.12
 * :ref:`addon-weblate.webhook.webhook` can be installed multiple times.
 * :http:post:`/api/projects/` allows non-superusers to create projects when :ref:`billing` module is enabled.
 * :http:post:`/api/groups/` supports project-scoped team creation by non-superusers.
+* :http:get:`/api/users/` now includes ``languages``.
 
 .. rubric:: Bug fixes
 

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -227,6 +227,13 @@ class FullUserSerializer(serializers.ModelSerializer[User]):
         many=True,
         read_only=True,
     )
+    languages = serializers.HyperlinkedIdentityField(
+        view_name="api:language-detail",
+        lookup_field="code",
+        source="profile.languages",
+        many=True,
+        read_only=True,
+    )
     notifications = serializers.HyperlinkedIdentityField(
         view_name="api:user-notifications",
         lookup_field="username",
@@ -244,6 +251,7 @@ class FullUserSerializer(serializers.ModelSerializer[User]):
             "full_name",
             "username",
             "groups",
+            "languages",
             "notifications",
             "is_superuser",
             "is_active",

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -74,6 +74,7 @@ class APIBaseTest(APITestCase, RepoTestMixin):
         self.project_kwargs = {"slug": "test"}
         self.tearDown()
         self.user = User.objects.create_user("apitest", "apitest@example.org", "x")
+        self.user.profile.languages.add(Language.objects.get(code="cs"))
         group = Group.objects.get(name="Users")
         self.user.groups.add(group)
 
@@ -138,6 +139,7 @@ class UserAPITest(APIBaseTest):
         self.assertIsNotNone(response.data["results"][0]["email"])
 
     def test_get(self) -> None:
+        language = Language.objects.get(code="cs")
         response = self.do_request(
             "api:user-detail",
             kwargs={"username": User.objects.filter(is_active=True)[0].username},
@@ -146,6 +148,10 @@ class UserAPITest(APIBaseTest):
             code=200,
         )
         self.assertEqual(response.data["username"], "apitest")
+        self.assertIn(
+            f"http://example.com/api/languages/{language.code}/",
+            response.data["languages"],
+        )
 
     def test_filter(self) -> None:
         response = self.client.get(reverse("api:user-list"), {"username": "api"})


### PR DESCRIPTION
This makes the the users [translated languages](https://docs.weblate.org/en/latest/user/profile.html#translated-languages) selection available via API.

I would like to have this data available to be able to automatically create a overview table of who translates which language on our private instance.