### PR TITLE
fix(ci): downgrade ldc on macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,6 +38,8 @@ jobs:
     - run: brew untap homebrew/core
     - run: brew untap aws/tap
     - run: brew upgrade
+    - run: brew install ldc@1.28
+    - run: brew link --force --overwrite ldc@1.28
     - run: brew cleanup
     - run: brew list --versions
     - run: brew deps --tree --installed


### PR DESCRIPTION
This should be a workaround for the crashes, see
https://www.devgem.io/posts/resolve-segmentation-fault-11-issue-in-d-executable-after-macos-15-4-upgrade

Fixes #14645

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
