### PR TITLE
fix(comments): normalize newlines before validating comment text

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -27,7 +27,7 @@ from django.utils import timezone
 from django.utils.html import format_html, format_html_join
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-from django.utils.text import slugify
+from django.utils.text import normalize_newlines, slugify
 from django.utils.translation import gettext, gettext_lazy
 from translation_finder import DiscoveryResult, discover
 
@@ -70,6 +70,7 @@ from weblate.utils.forms import (
     ColorWidget,
     ContextDiv,
     EmailField,
+    NormalizedNewlineCharField,
     QueryField,
     SearchField,
     SortedSelect,
@@ -402,7 +403,7 @@ class PluralTextarea(forms.Textarea):
             if fieldname not in data:
                 break
             ret.append(data.get(fieldname, ""))
-        return [r.replace("\r", "") for r in ret]
+        return [normalize_newlines(r) for r in ret]
 
 
 class PluralField(forms.CharField):
@@ -1109,7 +1110,7 @@ class CommentForm(forms.Form):
             ),
         ),
     )
-    comment = forms.CharField(
+    comment = NormalizedNewlineCharField(
         widget=MarkdownTextarea,
         label=gettext_lazy("New comment"),
         help_text=gettext_lazy("You can use Markdown and mention users by @username."),

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -818,6 +818,7 @@ def comment(request: AuthenticatedHttpRequest, pk):
         Comment.objects.add(request, unit, text, scope)
         messages.success(request, gettext("Posted new comment"))
     else:
+        show_form_errors(request, form)
         messages.error(request, gettext("Could not add comment!"))
 
     return redirect_next(request.POST.get("next"), unit)

--- a/weblate/utils/forms.py
+++ b/weblate/utils/forms.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.forms.models import ModelChoiceIterator
 from django.template.loader import render_to_string
+from django.utils.text import normalize_newlines
 from django.utils.translation import gettext, gettext_lazy
 from pyparsing import ParseException
 
@@ -253,3 +254,8 @@ class CachedModelMultipleChoiceField(
 
 class WeblateServiceURLField(forms.URLField):
     default_validators = [WeblateServiceURLValidator()]
+
+
+class NormalizedNewlineCharField(forms.CharField):
+    def to_python(self, value):
+        return normalize_newlines(super().to_python(value))


### PR DESCRIPTION
The browsers count newline as a single character, but post it as \r\n making Django count it as two characters. This makes it reject strings which are okay for the browser. Normalizing newlines makes it behave consistently.

Fixes #14952

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
