### PR TITLE
fix(history): wrap long content in history

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -612,7 +612,7 @@ form + .login-label {
   border-radius: 0 5px 5px 5px;
   background-color: #e5f0f2;
   padding: 8px 10px;
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 .comment-content blockquote {
   border-left: 5px solid #ddd;


### PR DESCRIPTION
Changes the older non-standard `word-wrap` to `overflow-wrap` and uses the `anywhere` value to wrap more aggressively in case of very long words.

Fixes #14956 

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
