### PR TITLE
feat(accounts): differentiate sign in pages

### DIFF
--- a/weblate/accounts/templatetags/authnames.py
+++ b/weblate/accounts/templatetags/authnames.py
@@ -120,3 +120,14 @@ def key_name(device: Device) -> str:
 @register.simple_tag
 def second_factor_name(name: DeviceType) -> str:
     return SECOND_FACTORS[name]
+
+
+@register.simple_tag(takes_context=True)
+def format_site_title(context) -> str:
+    style = ""
+    site_title = context["site_title"]
+    if context["support_status"]["is_hosted_weblate"]:
+        style = "text-info"
+        site_title = "Weblate cloud"
+
+    return format_html('<span class="{}">{}</span>', style, site_title)

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -1583,6 +1583,16 @@ a.format-item:hover {
   }
 }
 
+.label {
+  padding: .2em .6em;
+}
+
+h2 .label {
+  font-size: 12px;
+  vertical-align: middle;
+  text-transform: uppercase;
+}
+
 .label-box:empty {
   width: 1.2em;
   height: 1.2em;

--- a/weblate/templates/accounts/login.html
+++ b/weblate/templates/accounts/login.html
@@ -23,7 +23,10 @@
 
       <div class="col-sm-6 col-sm-push-6">
 
-        <h4>{% translate "Sign in" %}</h4>
+        <h4>
+          {% format_site_title as formatted_site_title %}
+          {% blocktranslate %}Sign in to {{ formatted_site_title }}{% endblocktranslate %}
+        </h4>
         <div class="panel panel-default">
           <div class="panel-body">
             <form method="post" action="{% url 'login' %}">

--- a/weblate/templates/accounts/register.html
+++ b/weblate/templates/accounts/register.html
@@ -31,7 +31,10 @@
 
         <div class="col-sm-6 col-sm-push-6">
 
-          <h4>{% translate "Register in Weblate" %}</h4>
+          <h4>
+            {% format_site_title as formatted_site_title %}
+            {% blocktranslate %}Register in {{ formatted_site_title }}{% endblocktranslate %}
+          </h4>
 
           <div class="panel panel-default">
             <div class="panel-body">

--- a/weblate/templates/accounts/snippets/login-title.html
+++ b/weblate/templates/accounts/snippets/login-title.html
@@ -1,1 +1,13 @@
-{{ site_title }}
+{% load i18n %}
+
+{% if support_status.is_hosted_weblate %}
+  {% translate "Weblate single sign on" %}
+  <span class="label label-info">{% translate "Cloud" context "Badge for site title for Hosted Weblate" %}</span>
+{% else %}
+  {{ site_title }}
+  {% if support_status.is_dedicated %}
+    <span class="label label-primary">{% translate "Dedicated" context "Badge for site title for dedicated instances" %}</span>
+  {% else %}
+    <span class="label label-default">{% translate "Self-hosted" context "Badge for site title for self-hosted instances" %}</span>
+  {% endif %}
+{% endif %}

--- a/weblate/utils/const.py
+++ b/weblate/utils/const.py
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from uuid import UUID
 
-SUPPORT_STATUS_CACHE_KEY = "weblate:support:status:1"
+SUPPORT_STATUS_CACHE_KEY = "weblate:support:status:3"
 HEARTBEAT_FREQUENCY = 120
 WEBLATE_UUID_NAMESPACE = UUID("465608fb-166b-4112-8cef-ebbc518d8722")

--- a/weblate/wladmin/models.py
+++ b/weblate/wladmin/models.py
@@ -352,16 +352,24 @@ class SupportStatusDict(TypedDict):
     in_limits: bool
     has_expired_support: bool
     backup_repository: str
+    name: str
+    is_hosted_weblate: bool
+    is_dedicated: bool
 
 
 def get_support_status(request: AuthenticatedHttpRequest) -> SupportStatusDict:
+    support_status: SupportStatusDict
     if hasattr(request, "weblate_support_status"):
-        support_status: SupportStatusDict = request.weblate_support_status
+        support_status = request.weblate_support_status
     else:
         support_status = cache.get(SUPPORT_STATUS_CACHE_KEY)
         if support_status is None:
             support_status_instance = SupportStatus.objects.get_current()
             support_status = {
+                "name": support_status_instance.name,
+                "is_hosted_weblate": support_status_instance.name
+                == "special:hosted-weblate",
+                "is_dedicated": support_status_instance.name.startswith("dedicated:"),
                 "has_support": support_status_instance.has_support,
                 "has_expired_support": support_status_instance.has_expired_support,
                 "in_limits": support_status_instance.in_limits,


### PR DESCRIPTION
Users are sometimes confused on the sign in page between Weblate instances. This introduces slight differentiation for Hosted Weblate, dedicated instances operated by us and self-hosted instances operated by third-parties.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
