### PR TITLE
fix(weblate): Server Side Template Injection on render_template `jinja2.sandbox`

### DIFF
--- a/weblate/utils/render.py
+++ b/weblate/utils/render.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.template import Context, Engine, Template, TemplateSyntaxError
+from django.template import Context, Engine, TemplateSyntaxError
+from jinja2.sandbox import SandboxedEnvironment
 from django.urls import reverse
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import gettext, override
@@ -96,9 +97,9 @@ def render_template(template: str, **kwargs):
     kwargs["site_url"] = get_site_url()
 
     with override("en"):
-        return Template(template, engine=RestrictedEngine()).render(
-            Context(kwargs, autoescape=False)
-        )
+        env = SandboxedEnvironment()
+        t = env.from_string(template)
+        return t.render(kwargs)
 
 
 def validate_render(value: str, **kwargs) -> str:

--- a/weblate/utils/render.py
+++ b/weblate/utils/render.py
@@ -9,11 +9,11 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.template import Context, Engine, TemplateSyntaxError
-from jinja2.sandbox import SandboxedEnvironment
+from django.template import Engine, TemplateSyntaxError
 from django.urls import reverse
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import gettext, override
+from jinja2.sandbox import SandboxedEnvironment
 
 from weblate.utils.site import get_site_url
 from weblate.utils.validators import WeblateEditorURLValidator, WeblateURLValidator


### PR DESCRIPTION
https://github.com/WeblateOrg/weblate/blob/10ca938b5fe85a5fb9ada89483c84c5db8feb7a3/weblate/utils/render.py#L99-L99

Fix the issue `render_template` function should use a sandboxed environment for template rendering. Django's template system does not provide a built-in sandbox, but switching to Jinja2's `SandboxedEnvironment` can address this issue. The `SandboxedEnvironment` restricts access to unsafe methods and attributes, preventing remote code execution.

Steps to implement the fix:
1. Import `SandboxedEnvironment` from `jinja2.sandbox`.
2. Replace the `Template` constructor with `SandboxedEnvironment().from_string(template)` in the `render_template` function.
3. Ensure that the `kwargs` passed to the template rendering are properly escaped to prevent cross-site scripting (XSS).


[Server-Side Template Injection](https://portswigger.net/web-security/server-side-template-injection)