### PR TITLE
fix(search): handlep plurals in search and replace

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,7 @@ Weblate 5.12
 * :ref:`addon-weblate.webhook.webhook` delivery of project-wide events.
 * False reports of :ref:`check-translated` with flags or explanation changes.
 * Creating new translations in :doc:`/formats/appstore`.
+* :ref:`search-replace` correctly handles plurals.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -344,6 +344,42 @@ class ReplaceTest(ViewTestCase):
             )
         )
 
+    def test_replace_plurals(self) -> None:
+        unit = self.get_unit("Orangutan")
+        url = reverse("replace", kwargs=self.kw_translation)
+        self.edit_unit(
+            "Orangutan",
+            "Opice má %d banán.\n",
+            target_1="Opice má %d banány.\n",
+            target_2="Opice má %d banánů.\n",
+        )
+        response = self.client.post(
+            url, {"q": "", "search": "Opice", "replacement": "Orangutan"}, follow=True
+        )
+        self.assertContains(
+            response, "Please review and confirm the search and replace results."
+        )
+        payload = {
+            "q": "",
+            "search": "Opice",
+            "replacement": "Orangutan",
+            "confirm": "1",
+            "units": unit.pk,
+        }
+        response = self.client.post(url, payload, follow=True)
+        unit = self.get_unit("Orangutan")
+        self.assertContains(
+            response, "Search and replace completed, 1 string was updated."
+        )
+        self.assertEqual(
+            unit.get_target_plurals(),
+            [
+                "Orangutan má %d banán.\n",
+                "Orangutan má %d banány.\n",
+                "Orangutan má %d banánů.\n",
+            ],
+        )
+
 
 class BulkEditTest(ViewTestCase):
     """Test for build edit functionality."""

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -83,6 +83,7 @@ def search_replace(request: AuthenticatedHttpRequest, path):
 
         if not confirm.is_valid():
             for unit in matching:
+                # This is rendered using format_unit_target which does split_plurals
                 unit.replacement = unit.target.replace(search_text, replacement)
             context.update(
                 {
@@ -104,7 +105,10 @@ def search_replace(request: AuthenticatedHttpRequest, path):
                     continue
                 unit.translate(
                     request.user,
-                    unit.target.replace(search_text, replacement),
+                    [
+                        plural.replace(search_text, replacement)
+                        for plural in unit.get_target_plurals()
+                    ],
                     unit.state,
                     change_action=ActionEvents.REPLACE,
                 )


### PR DESCRIPTION
The translate method expects plurals list, not concatenated value.

Fixes #15089

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
