### PR TITLE
docs(installation): remove obsolete version

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -35,7 +35,6 @@ behind HTTPS terminating proxy. You can also deploy with a HTTPS proxy, see
 
    .. code-block:: yaml
 
-        version: '3'
         services:
           weblate:
             ports:


### PR DESCRIPTION
This PR solves the next warning when running `docker compose up` when following the installation steps 2 and 3 from https://docs.weblate.org/en/latest/admin/install/docker.html#installation

```sh
WARN[0000] weblate-docker/docker-compose.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

### How to test
1. in `main` branch, follow step 2 and 3 of the installation doc
2. you should see the warning described above
3. run `ctrl+c` to stop the process
4. switch to this branch and run `docker compose up` or some `docker compose` command
5. you should not see the warning anymore

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
