### PR TITLE
fix(projectbackup): ignore conflicts when restoring votes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Weblate 5.12.2
 
 .. rubric:: Bug fixes
 
+* Restoring :ref:`projectbackup` with votes.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading


### PR DESCRIPTION
The non-existing users are mapped to anonymous, so in case there were more users involved in voting, this results in unique key violation.

Fixes #15179

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
