### PR TITLE
feat(editor): add accept and approve button when review workflow is enabled

### DIFF
--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -7,6 +7,8 @@ var WLT = WLT || {};
 
 WLT.Config = (() => ({
   IS_MAC: /Mac|iPod|iPhone|iPad/.test(navigator.platform),
+  HAS_REVIEW_WORKFLOW:
+    $('.translation-form input[name="review"][value="30"]').length > 0,
 }))();
 
 WLT.Utils = (() => ({
@@ -24,6 +26,13 @@ WLT.Utils = (() => ({
     $el.find('input[name="fuzzy"]').prop("checked", false);
     /* Review workflow */
     $el.find('input[name="review"][value="20"]').prop("checked", true);
+  },
+
+  markApproved: ($el) => {
+    /* Standard workflow */
+    $el.find('input[name="fuzzy"]').prop("checked", false);
+    /* Review workflow */
+    $el.find('input[name="review"][value="30"]').prop("checked", true);
   },
 
   /**

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -44,6 +44,19 @@
       submitForm({ target: this.$translationArea });
     });
 
+    /* Copy, approve and save machinery results */
+    this.$editor.on("click", ".js-copy-approve-save-machinery", (e) => {
+      const $el = $(e.target);
+      const raw = $el.parent().parent().data("raw");
+
+      raw.plural_forms.forEach((pluralForm) => {
+        $(this.$translationArea.get(pluralForm)).replaceValue(raw.text);
+      });
+      autosize.update(this.$translationArea);
+      WLT.Utils.markApproved(this.$translationForm);
+      submitForm({ target: this.$translationArea });
+    });
+
     /* Delete machinery results */
     this.$editor.on("click", ".js-delete-machinery", (e) => {
       const $el = $(e.target);
@@ -588,6 +601,18 @@
           )}</a></td>`,
         ),
       );
+
+      if (WLT.Config.HAS_REVIEW_WORKFLOW) {
+        row.append(
+          $(
+            `<td><a class="js-copy-approve-save-machinery btn btn-warning">${gettext(
+              "Accept and approve",
+            )}</a></td>`,
+          ),
+        );
+      } else {
+        row.append($("<td></td>"));
+      }
 
       if (this.state.weblateTranslationMemory.has(el.text)) {
         row.append(


### PR DESCRIPTION
This adds a button "Accept and approve" to the machinery table when the review workflow is enabled.

![image](https://github.com/user-attachments/assets/3bbf4a94-4b13-4a57-8bc6-29975cf9c431)

Fixes #15115 