### PR TITLE
refactor(js): get rid of biome noforeach rule exceptions

### DIFF
--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -24,10 +24,9 @@
       const $el = $(e.target);
       const raw = $el.parent().parent().data("raw");
 
-      // biome-ignore lint/complexity/noForEach: TODO
-      raw.plural_forms.forEach((pluralForm) => {
+      for (const pluralForm of raw.plural_forms) {
         $(this.$translationArea.get(pluralForm)).replaceValue(raw.text);
-      });
+      }
       autosize.update(this.$translationArea);
       WLT.Utils.markFuzzy(this.$translationForm);
     });
@@ -37,10 +36,9 @@
       const $el = $(e.target);
       const raw = $el.parent().parent().data("raw");
 
-      // biome-ignore lint/complexity/noForEach: TODO
-      raw.plural_forms.forEach((pluralForm) => {
+      for (const pluralForm of raw.plural_forms) {
         $(this.$translationArea.get(pluralForm)).replaceValue(raw.text);
-      });
+      }
       autosize.update(this.$translationArea);
       WLT.Utils.markTranslated(this.$translationForm);
       submitForm({ target: this.$translationArea });
@@ -72,12 +70,11 @@
         }
         $deleteEntriesDialog.modal("hide");
 
-        // biome-ignore lint/complexity/noForEach: TODO
-        Object.entries($deleteEntries).forEach(([_, entry]) => {
+        for (const [_, entry] of Object.entries($deleteEntries)) {
           if (typeof entry.id !== "undefined") {
             this.removeTranslationEntry(entry.id);
           }
-        });
+        }
         return false;
       });
     });
@@ -171,14 +168,13 @@
     if (restoreValue !== null) {
       const translationRestore = JSON.parse(restoreValue);
 
-      // biome-ignore lint/complexity/noForEach: TODO
-      translationRestore.forEach((restoreArea) => {
+      for (const restoreArea of translationRestore) {
         const target = document.getElementById(restoreArea.id);
         if (target) {
           target.value = restoreArea.value;
           autosize.update(target);
         }
-      });
+      }
       localStorage.removeItem(restoreKey);
     }
 
@@ -221,13 +217,10 @@
     this.isMachineryLoaded = true;
     this.machinery = new Machinery();
 
-    // biome-ignore lint/complexity/noForEach: TODO
-    $("#js-translate")
-      .data("services")
-      .forEach((serviceName) => {
-        increaseLoading("machinery");
-        this.fetchMachinery(serviceName);
-      });
+    for (const serviceName of $("#js-translate").data("services")) {
+      increaseLoading("machinery");
+      this.fetchMachinery(serviceName);
+    }
 
     this.$editor.on("submit", "#memory-search", (e) => {
       const $form = $(e.currentTarget);
@@ -635,8 +628,7 @@
       const translations = this.state.translations;
       const modalBody = $("<label>").text("");
 
-      // biome-ignore lint/complexity/noForEach: TODO
-      translations.forEach((translation) => {
+      for (const translation of translations) {
         if (
           text === translation.text &&
           typeof translation.delete_url !== "undefined"
@@ -656,14 +648,13 @@
             .append(inputElement, labelElement);
           modalBody.append(divElement);
         }
-      });
+      }
       return modalBody;
     }
 
     render(translations) {
       const $translations = $("#machinery-translations");
-      // biome-ignore lint/complexity/noForEach: TODO
-      translations.forEach((translation) => {
+      for (const translation of translations) {
         const service = this.renderService(translation);
         let insertBefore = null;
         let done = false;
@@ -708,7 +699,7 @@
             $translations.append(newRow);
           }
         }
-      });
+      }
     }
   }
 

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -365,15 +365,15 @@ function quoteSearch(value) {
   return value;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO
 function initHighlight(root) {
   if (typeof ResizeObserver === "undefined") {
     return;
   }
-  // biome-ignore lint/complexity/noForEach: TODO
-  root.querySelectorAll("textarea[name='q']").forEach((input) => {
+  for (const input of root.querySelectorAll("textarea[name='q']")) {
     const parent = input.parentElement;
     if (parent.classList.contains("editor-wrap")) {
-      return;
+      continue;
     }
 
     input.addEventListener("keydown", (event) => {
@@ -429,16 +429,13 @@ function initHighlight(root) {
     });
 
     resizeObserver.observe(input);
-  });
-  // biome-ignore lint/complexity/noForEach: TODO
-  // biome-ignore lint/complexity/useSimplifiedLogicExpression: TODO
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO
-  root.querySelectorAll(".highlight-editor").forEach((editor) => {
+  }
+  for (const editor of root.querySelectorAll(".highlight-editor")) {
     const parent = editor.parentElement;
     const hasFocus = editor === document.activeElement;
 
     if (parent.classList.contains("editor-wrap")) {
-      return;
+      continue;
     }
 
     const mode = editor.getAttribute("data-mode");
@@ -546,7 +543,7 @@ function initHighlight(root) {
     resizeObserver.observe(editor);
     /* Autosizing */
     autosize(editor);
-  });
+  }
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO
@@ -1250,13 +1247,12 @@ $(function () {
     },
   });
   tribute.attach(document.querySelectorAll(".markdown-editor"));
-  // biome-ignore lint/complexity/noForEach: TODO
-  document.querySelectorAll(".markdown-editor").forEach((editor) => {
+  for (const editor of document.querySelectorAll(".markdown-editor")) {
     editor.addEventListener("tribute-active-true", (_e) => {
       $(".tribute-container").addClass("open");
       $(".tribute-container ul").addClass("dropdown-menu");
     });
-  });
+  }
 
   /* forset fields adding */
   $(".add-multifield").on("click", function () {
@@ -1308,90 +1304,88 @@ $(function () {
   });
 
   /* Notifications removal */
-  // biome-ignore lint/complexity/noForEach: TODO
-  document
-    .querySelectorAll(".nav-pills > li > a > button.close")
-    .forEach((button) => {
-      button.addEventListener("click", (_e) => {
-        const link = button.parentElement;
-        // biome-ignore lint/complexity/noForEach: TODO
-        document
-          .querySelectorAll(`${link.getAttribute("href")} select`)
-          .forEach((select) => select.remove());
-        //      document.getElementById(link.getAttribute("href").substring(1)).remove();
-        link.parentElement.remove();
-        /* Activate watched tab */
-        $("a[href='#notifications__1']").tab("show");
-        addAlert(
-          gettext(
-            "Notification settings removed, please do not forget to save the changes.",
-          ),
-          "info",
-        );
-      });
+  for (const button of document.querySelectorAll(
+    ".nav-pills > li > a > button.close",
+  )) {
+    button.addEventListener("click", (_e) => {
+      const link = button.parentElement;
+      for (const select of document.querySelectorAll(
+        `${link.getAttribute("href")} select`,
+      )) {
+        select.remove();
+      }
+      //      document.getElementById(link.getAttribute("href").substring(1)).remove();
+      link.parentElement.remove();
+      /* Activate watched tab */
+      $("a[href='#notifications__1']").tab("show");
+      addAlert(
+        gettext(
+          "Notification settings removed, please do not forget to save the changes.",
+        ),
+        "info",
+      );
     });
+  }
 
   /* User autocomplete */
-  // biome-ignore lint/complexity/noForEach: TODO
-  document
-    .querySelectorAll(".user-autocomplete")
-    .forEach((autoCompleteInput) => {
-      const autoCompleteJs = new autoComplete({
-        selector: () => {
-          return autoCompleteInput;
+  for (const autoCompleteInput of document.querySelectorAll(
+    ".user-autocomplete",
+  )) {
+    const autoCompleteJs = new autoComplete({
+      selector: () => {
+        return autoCompleteInput;
+      },
+      debounce: 300,
+      resultsList: {
+        class: "autoComplete dropdown-menu",
+      },
+      resultItem: {
+        class: "autoComplete_result",
+        element: (item, data) => {
+          item.textContent = "";
+          const child = document.createElement("a");
+          child.textContent = data.value.full_name;
+          item.appendChild(child);
         },
-        debounce: 300,
-        resultsList: {
-          class: "autoComplete dropdown-menu",
+        selected: "autoComplete_selected",
+      },
+      data: {
+        keys: ["username"],
+        src: async (query) => {
+          try {
+            // Fetch Data from external Source
+            const source = await fetch(`/api/users/?username=${query}`);
+            // Data should be an array of `Objects` or `Strings`
+            const data = await source.json();
+            return data.results.map((user) => {
+              return {
+                username: user.username,
+                // biome-ignore lint/style/useNamingConvention: special case
+                full_name: `${user.full_name} (${user.username})`,
+              };
+            });
+          } catch (error) {
+            return error;
+          }
         },
-        resultItem: {
-          class: "autoComplete_result",
-          element: (item, data) => {
-            item.textContent = "";
-            const child = document.createElement("a");
-            child.textContent = data.value.full_name;
-            item.appendChild(child);
-          },
-          selected: "autoComplete_selected",
-        },
-        data: {
-          keys: ["username"],
-          src: async (query) => {
-            try {
-              // Fetch Data from external Source
-              const source = await fetch(`/api/users/?username=${query}`);
-              // Data should be an array of `Objects` or `Strings`
-              const data = await source.json();
-              return data.results.map((user) => {
-                return {
-                  username: user.username,
-                  // biome-ignore lint/style/useNamingConvention: special case
-                  full_name: `${user.full_name} (${user.username})`,
-                };
-              });
-            } catch (error) {
-              return error;
+      },
+      events: {
+        input: {
+          focus() {
+            if (autoCompleteInput.value.length > 0) {
+              autoCompleteJs.start();
             }
           },
-        },
-        events: {
-          input: {
-            focus() {
-              if (autoCompleteInput.value.length > 0) {
-                autoCompleteJs.start();
-              }
-            },
-            selection(event) {
-              const feedback = event.detail;
-              autoCompleteInput.blur();
-              const selection =
-                feedback.selection.value[feedback.selection.key];
-              autoCompleteInput.value = selection;
-            },
+          selection(event) {
+            const feedback = event.detail;
+            autoCompleteInput.blur();
+            const selection = feedback.selection.value[feedback.selection.key];
+            autoCompleteInput.value = selection;
           },
         },
-      });
+      },
     });
+  }
 
   /* Site-wide search */
   const siteSearch = new autoComplete({
@@ -1440,8 +1434,7 @@ $(function () {
   });
 
   /* Workflow customization form */
-  // biome-ignore lint/complexity/noForEach: TODO
-  document.querySelectorAll("#id_workflow-enable").forEach((enableInput) => {
+  for (const enableInput of document.querySelectorAll("#id_workflow-enable")) {
     enableInput.addEventListener("click", () => {
       if (enableInput.checked) {
         document.getElementById("workflow-enable-target").style.visibility =
@@ -1454,7 +1447,7 @@ $(function () {
       }
     });
     enableInput.dispatchEvent(new Event("click"));
-  });
+  }
 
   /* Move current translation into the view */
   $('a[data-toggle="tab"][href="#nearby"]').on("shown.bs.tab", (_e) => {
@@ -1465,17 +1458,15 @@ $(function () {
     });
   });
 
-  // biome-ignore lint/complexity/noForEach: TODO
-  document.querySelectorAll("[data-visibility]").forEach((toggle) => {
+  for (const toggle of document.querySelectorAll("[data-visibility]")) {
     toggle.addEventListener("click", (_event) => {
-      // biome-ignore lint/complexity/noForEach: TODO
-      document
-        .querySelectorAll(toggle.getAttribute("data-visibility"))
-        .forEach((element) => {
-          element.classList.toggle("visible");
-        });
+      for (const element of document.querySelectorAll(
+        toggle.getAttribute("data-visibility"),
+      )) {
+        element.classList.toggle("visible");
+      }
     });
-  });
+  }
 
   $("input[name='period']").daterangepicker({
     autoApply: false,

--- a/weblate/templates/addons/js/weblate-code.js
+++ b/weblate/templates/addons/js/weblate-code.js
@@ -15,13 +15,12 @@ const getCookie = (name) => {
 };
 
 const translateDocument = (data) => {
-  // biome-ignore lint/complexity/noForEach: TODO
   // biome-ignore lint/correctness/noUndeclaredVariables: weblate_selector defined externally
-  document.querySelectorAll(weblate_selector).forEach((element) => {
+  for (const element of document.querySelectorAll(weblate_selector)) {
     if (element.children.length === 0 && element.textContent in data) {
       element.textContent = data[element.textContent];
     }
-  });
+  }
 };
 
 ready(() => {


### PR DESCRIPTION
This switches all [noForEach rule](https://biomejs.dev/linter/rules/no-for-each/) exceptions to the biome linter's preferred syntax.