### PR TITLE
fix(bulk-edit): remove no longer needed commit pending

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -197,6 +197,7 @@ class BaseAddon:
             self.post_commit(component, True)
         if AddonEvent.EVENT_POST_UPDATE in self.events:
             component.log_debug("running post_update add-on: %s", self.name)
+            # The post_update typically operates on files, so make sure these are updated
             component.commit_pending("add-on", None)
             self.post_update(component, "", False)
         if AddonEvent.EVENT_COMPONENT_UPDATE in self.events:

--- a/weblate/addons/generate.py
+++ b/weblate/addons/generate.py
@@ -231,6 +231,7 @@ class PrefillAddon(LocaleGenerateAddonBase):
                 query=Q(state=STATE_EMPTY),
             )
         if updated:
+            # Commit generated changes to the files
             component.commit_pending("add-on", None)
 
 
@@ -262,4 +263,5 @@ class FillReadOnlyAddon(LocaleGenerateAddonBase):
                 query=Q(state=STATE_READONLY) & ~Q(target=F("source")),
             )
         if updated:
+            # Commit generated changes to the files
             component.commit_pending("add-on", None)

--- a/weblate/glossary/tasks.py
+++ b/weblate/glossary/tasks.py
@@ -35,6 +35,7 @@ def sync_glossary_languages(pk: int, component: Component | None = None) -> None
         return
     with component.repository.lock:
         component.log_info("Adding glossary languages: %s", missing)
+        # Make sure changes are committed, create_translations might discard pending ones
         component.commit_pending("glossary languages", None)
         needs_create = False
         for language in missing:

--- a/weblate/trans/bulk.py
+++ b/weblate/trans/bulk.py
@@ -46,7 +46,6 @@ def bulk_perform(  # noqa: C901
         prev_updated = updated
         component.batch_checks = True
         with transaction.atomic(), component.lock:
-            component.commit_pending("bulk edit", user)
             component_units = matching.filter(translation__component=component)
 
             source_unit_ids = set()


### PR DESCRIPTION
The bulk edit operation should no longer need to commit pending changes since #15070 allows to stack changes.

Issue #13623

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
