### PR TITLE
fix(bulk edit): update unit state before saving PendingUnitChange

### DIFF
--- a/weblate/trans/bulk.py
+++ b/weblate/trans/bulk.py
@@ -72,6 +72,7 @@ def bulk_perform(  # noqa: C901
                         and unit.state in EDITABLE_STATES
                     ):
                         # Create change object for edit, update is done outside the loop
+                        unit.state = target_state
                         unit.generate_change(
                             user, user, ActionEvents.BULK_EDIT, check_new=False
                         )
@@ -92,7 +93,6 @@ def bulk_perform(  # noqa: C901
                     # need it here to recalculate state of translation
                     # units
                     unit.is_batch_update = True
-                    unit.state = target_state
                     unit.source_unit_save()
 
             if update_source and (


### PR DESCRIPTION
The in memory state was updated after PendingUnitChange would could cause wrong data in PendingUnitChange.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
