### PR TITLE
fix: remove component locking form autotranslate and bulk edit

### DIFF
--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -295,36 +295,31 @@ class AutoTranslate:
         source: int | None,
     ) -> str:
         translation = self.translation
-        with translation.component.lock:
-            translation.log_info(
-                "starting automatic translation (%s) %s: %s: %s",
-                self.mode,
-                current_task.request.id
-                if current_task and current_task.request.id
-                else "",
-                auto_source,
-                ", ".join(engines) if engines else source,
-            )
-            try:
-                if auto_source == "mt":
-                    self.process_mt(engines, threshold)
-                else:
-                    self.process_others(source)
-            except (MachineTranslationError, Component.DoesNotExist) as error:
-                translation.log_error("failed automatic translation: %s", error)
-                return gettext("Automatic translation failed: %s") % error
+        translation.log_info(
+            "starting automatic translation (%s) %s: %s: %s",
+            self.mode,
+            current_task.request.id if current_task and current_task.request.id else "",
+            auto_source,
+            ", ".join(engines) if engines else source,
+        )
+        try:
+            if auto_source == "mt":
+                self.process_mt(engines, threshold)
+            else:
+                self.process_others(source)
+        except (MachineTranslationError, Component.DoesNotExist) as error:
+            translation.log_error("failed automatic translation: %s", error)
+            return gettext("Automatic translation failed: %s") % error
 
-            translation.log_info("completed automatic translation")
+        translation.log_info("completed automatic translation")
 
-            if self.updated == 0:
-                return gettext(
-                    "Automatic translation completed, no strings were updated."
-                )
-            return (
-                ngettext(
-                    "Automatic translation completed, %d string was updated.",
-                    "Automatic translation completed, %d strings were updated.",
-                    self.updated,
-                )
-                % self.updated
+        if self.updated == 0:
+            return gettext("Automatic translation completed, no strings were updated.")
+        return (
+            ngettext(
+                "Automatic translation completed, %d string was updated.",
+                "Automatic translation completed, %d strings were updated.",
+                self.updated,
             )
+            % self.updated
+        )

--- a/weblate/trans/bulk.py
+++ b/weblate/trans/bulk.py
@@ -45,7 +45,7 @@ def bulk_perform(  # noqa: C901
     for component in components:
         prev_updated = updated
         component.batch_checks = True
-        with transaction.atomic(), component.lock:
+        with transaction.atomic():
             component.commit_pending("bulk edit", user)
             component_units = matching.filter(translation__component=component)
 


### PR DESCRIPTION
The locking should not be needed here as we use select_for_update and the pending changes no longer trigger commit since #15070.

Issue #13623

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
