### PR TITLE
fix(add-ons): avoid crash on webhook logs

### DIFF
--- a/weblate/templates/addons/webhook_log.html
+++ b/weblate/templates/addons/webhook_log.html
@@ -1,26 +1,28 @@
 {% load i18n translations %}
 
-<ul class="nav nav-pills">
-  <li role="presentation" class="active">
-    <a href="#response-{{ activity.id }}" data-toggle="tab">{% translate "HTTP Response" %} <span class="badge">{{ details.response.status_code }}</span></a>
-  </li>
-  <li role="presentation">
-    <a href="#request-{{ activity.id }}" data-toggle="tab">{% translate "HTTP Request" %}</a>
-  </li>
-</ul>
+{% if details %}
+  <ul class="nav nav-pills">
+    <li role="presentation" class="active">
+      <a href="#response-{{ activity.id }}" data-toggle="tab">{% translate "HTTP Response" %} <span class="badge">{{ details.response.status_code }}</span></a>
+    </li>
+    <li role="presentation">
+      <a href="#request-{{ activity.id }}" data-toggle="tab">{% translate "HTTP Request" %}</a>
+    </li>
+  </ul>
 
-<div class="tab-content">
-  <div class="tab-pane active" id="response-{{ activity.id }}">
-    <h5>{% translate "HTTP headers" %}</h5>
-    <pre>{{ details.response.headers|format_headers }}</pre>
+  <div class="tab-content">
+    <div class="tab-pane active" id="response-{{ activity.id }}">
+      <h5>{% translate "HTTP headers" %}</h5>
+      <pre>{{ details.response.headers|format_headers }}</pre>
 
-    <h5>{% translate "Response content" %}</h5>
-    <pre>{{ details.response.content }}</pre>
+      <h5>{% translate "Response content" %}</h5>
+      <pre>{{ details.response.content }}</pre>
+    </div>
+    <div class="tab-pane" id="request-{{ activity.id }}">
+      <h5>{% translate "HTTP headers" %}</h5>
+      <pre>{{ details.request.headers|format_headers }}</pre>
+      <h5>{% translate "Request payload" %}</h5>
+      <pre>{{ details.request.payload|format_json }}</pre>
+    </div>
   </div>
-  <div class="tab-pane" id="request-{{ activity.id }}">
-    <h5>{% translate "HTTP headers" %}</h5>
-    <pre>{{ details.request.headers|format_headers }}</pre>
-    <h5>{% translate "Request payload" %}</h5>
-    <pre>{{ details.request.payload|format_json }}</pre>
-  </div>
-</div>
+{% endif %}


### PR DESCRIPTION
The webhook deliveries before 5.11.4 did not have the additional metadata and rendering for it fails.

Fixes #15262

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
