### PR TITLE
feat(menu): merge Tools and Manage menu into Operations

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -60,7 +60,7 @@ Limit user access to individual projects by selecting a different
    **Choose this on your own Weblate instance if you want to define access in a specific, finely customizable way.**
 
 :guilabel:`Access control` can be changed in the :guilabel:`Access` tab of the
-configuration (:guilabel:`Manage` ↓ :guilabel:`Settings`) of each respective
+configuration (:guilabel:`Operations` ↓ :guilabel:`Settings`) of each respective
 project.
 
 .. image:: /screenshots/project-access.webp
@@ -138,7 +138,7 @@ For `Protected` and `Private` projects only:
 .. image:: /screenshots/manage-users.webp
 
 These features are available on the :guilabel:`Access control` page in
-the project’s menu :guilabel:`Manage` ↓ :guilabel:`Users`.
+the project’s menu :guilabel:`Operations` ↓ :guilabel:`Users`.
 
 .. hint::
 

--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -4,7 +4,7 @@ Add-ons
 =======
 
 Add-ons provide ways to customize and automate the translation workflow.
-Admins can add and manage add-ons from the :guilabel:`Manage` ↓ :guilabel:`Add-ons` menu of each respective
+Admins can add and manage add-ons from the :guilabel:`Operations` ↓ :guilabel:`Add-ons` menu of each respective
 translation project or component. Add-ons can be also installed site-wide in :ref:`management-interface`.
 
 .. hint::
@@ -433,7 +433,7 @@ Matching files:
    Component discovery add-on uses :ref:`internal-urls`. It’s a convenient way to share
    VCS setup between multiple components. Linked components use the local repository of
    the main component set up by filling ``weblate://project/main-component``
-   into the :ref:`component-repo` field (in :guilabel:`Manage` ↓ :guilabel:`Settings` ↓
+   into the :ref:`component-repo` field (in :guilabel:`Operations` ↓ :guilabel:`Settings` ↓
    :guilabel:`Version control system`) of each respective component.
    This saves time with configuration and system resources too.
 

--- a/docs/admin/announcements.rst
+++ b/docs/admin/announcements.rst
@@ -15,7 +15,7 @@ projects (unless they opt out).
 This can be useful for various things from announcing the purpose of the website to
 specifying targets for translations.
 
-The announcements can posted on each level in the :guilabel:`Manage` menu, using
+The announcements can posted on each level in the :guilabel:`Operations` menu, using
 :guilabel:`Post announcement`:
 
 .. image:: /screenshots/announcement-project.webp

--- a/docs/admin/backup.rst
+++ b/docs/admin/backup.rst
@@ -18,7 +18,7 @@ The project backups all translation content from Weblate (project, components,
 translations, string comments, suggestions or checks). It is suitable for
 transferring a project to another Weblate instance.
 
-You can perform a project backup in :guilabel:`Manage` ↓ :guilabel:`Backups`.
+You can perform a project backup in :guilabel:`Operations` ↓ :guilabel:`Backups`.
 The backup can be restored when creating a project (see
 :ref:`adding-projects`).
 

--- a/docs/admin/checks.rst
+++ b/docs/admin/checks.rst
@@ -387,7 +387,7 @@ The :ref:`check-max-size` check used to calculate dimensions of the rendered
 text needs font to be loaded into Weblate and selected using a translation flag
 (see :ref:`custom-checks`).
 
-Weblate font management tool in :guilabel:`Fonts` under the :guilabel:`Manage`
+Weblate font management tool in :guilabel:`Fonts` under the :guilabel:`Operations`
 menu of your translation project provides interface to upload and manage fonts.
 TrueType or OpenType fonts can be uploaded, set up font-groups and use those in
 the check.

--- a/docs/admin/memory.rst
+++ b/docs/admin/memory.rst
@@ -13,7 +13,7 @@ Weblate comes with a built-in translation memory consisting of:
 Content in the translation memory can be applied to strings in several ways:
 
 * User can accept suggestions from the :ref:`machine-translation` tab while editing the string.
-* The selected strings can be processed using :ref:`auto-translation` from the :guilabel:`Tools` menu.
+* The selected strings can be processed using :ref:`auto-translation` from the :guilabel:`Operations` menu.
 * :ref:`addon-weblate.autotranslate.autotranslate` add-on can automatically apply changes to new and existing strings.
 
 For installation tips, see :ref:`mt-weblate-translation-memory`, which is

--- a/docs/admin/translating.rst
+++ b/docs/admin/translating.rst
@@ -125,7 +125,7 @@ The uploaded screenshot is shown in the translation context sidebar:
 .. image:: /screenshots/screenshot-context.webp
 
 In addition to :ref:`additional`, screenshots have a separate management
-interface under the :guilabel:`Tools` menu.
+interface under the :guilabel:`Operations` menu.
 Upload screenshots, assign them to source strings manually, or use optical
 character recognition (OCR) to do so by pressing the :guilabel:`Automatically
 recognize` button.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 5.13
 * A new :envvar:`SENTRY_MONITOR_BEAT_TASKS` setting allows disabling Sentry monitoring of Celery Beat tasks.
 * :envvar:`WEBLATE_SOCIAL_AUTH_OIDC_TITLE` and :envvar:`WEBLATE_SOCIAL_AUTH_OIDC_IMAGE` allow configuring the appearance of the generic OIDC authentication.
 * Background commits are now identified by an internal user.
+* Reorganized navigation menu.
 
 .. rubric:: Bug fixes
 
@@ -529,7 +530,7 @@ Weblate 5.9
 .. rubric:: Improvements
 
 * :ref:`mt-google-translate-api-v3` now supports :ref:`glossary-mt` (optional).
-* A shortcut to duplicate a component is now available directly in the menu (:guilabel:`Manage` → :guilabel:`Duplicate this component`).
+* A shortcut to duplicate a component is now available directly in the menu (:guilabel:`Operations` → :guilabel:`Duplicate this component`).
 * Included username when generating :ref:`credits`.
 * :ref:`bulk-edit` shows a preview of matched strings.
 * :http:get:`/api/components/(string:project)/(string:component)/` exposes component lock state.

--- a/docs/devel/integration.rst
+++ b/docs/devel/integration.rst
@@ -75,7 +75,7 @@ Any way of adding strings will be picked up, but consider using
 When translation files are separated from the code, the following ways can
 introduce new strings into Weblate.
 
-* Manually, using :guilabel:`Add new translation string` from :guilabel:`Tools`
+* Manually, using :guilabel:`Add new translation string` from :guilabel:`Operations`
   menu in the source language. You can choose between the radio buttons
   :guilabel:`Singular` and :guilabel:`Plural` inside the form. Select the
   appropriate form of the new translation string to be added.

--- a/docs/devel/translations.rst
+++ b/docs/devel/translations.rst
@@ -73,7 +73,7 @@ Removing existing translations
 ------------------------------
 
 Languages, components, or the projects they are in, can be removed (deleted from Weblate
-and remote repository if used) from the menu :guilabel:`Manage` ↓ :guilabel:`Removal`
+and remote repository if used) from the menu :guilabel:`Operations` ↓ :guilabel:`Removal`
 of each project, component, or language.
 
 Initiating the :guilabel:`Removal` action shows the list of components to be removed.
@@ -87,7 +87,7 @@ If you want to remove just some specific strings, there are following ways:
 
 .. versionadded:: 4.5
 
-- In Weblate’s UI via button :guilabel:`Tools` ↓ :guilabel:`Remove` while editing the string.
+- In Weblate’s UI via button :guilabel:`Operations` ↓ :guilabel:`Remove` while editing the string.
   This has differences between file formats, see: :ref:`component-manage_units`
 
 .. note::

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -40,7 +40,7 @@ both Weblate and the upstream repository concurrently. You can usually avoid thi
 Weblate translations prior to making changes in the translation files (e.g.
 before running msgmerge). Just tell Weblate to commit all pending
 translations (you can do it in :guilabel:`Repository maintenance` in the
-:guilabel:`Manage` menu) and merge the repository (if automatic push is not
+:guilabel:`Operations` menu) and merge the repository (if automatic push is not
 on).
 
 If you've already encountered a merge conflict, the easiest way to solve all

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -197,7 +197,7 @@ Turning on reviews
 
 Reviews can be turned on in the project configuration, from the
 :guilabel:`Workflow` subpage of project settings (to be found in the
-:guilabel:`Manage` → :guilabel:`Settings` menu):
+:guilabel:`Operations` → :guilabel:`Settings` menu):
 
 .. image:: /screenshots/project-workflow.webp
 

--- a/weblate/templates/category-language.html
+++ b/weblate/templates/category-language.html
@@ -47,7 +47,7 @@
     </li>
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-        {% translate "Tools" %} <span class="caret"></span>
+        {% translate "Operations" %} <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
         {% if replace_form %}

--- a/weblate/templates/category.html
+++ b/weblate/templates/category.html
@@ -82,7 +82,7 @@
     </li>
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-        {% translate "Tools" %} <span class="caret"></span>
+        {% translate "Operations" %} <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
         {% if replace_form %}
@@ -95,38 +95,30 @@
             <a href="#bulk-edit" data-toggle="tab">{% translate "Bulk edit" %}</a>
           </li>
         {% endif %}
+        <li role="separator" class="divider"></li>
+        {% if user_can_edit_project %}
+          {% if add_form %}
+            <li>
+              <a href="#add-category" data-toggle="tab">{% translate "Add new category" %}</a>
+            </li>
+          {% endif %}
+          <li>
+            <a href="{% url 'create-component' %}?project={{ object.project.pk }}&amp;category={{ object.pk }}">{% translate "Add new translation component" %}</a>
+          </li>
+        {% endif %}
+        {% if announcement_form %}
+          <li>
+            <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
+          </li>
+        {% endif %}
+        {% if delete_form or rename_form %}
+          <li role="separator" class="divider"></li>
+          <li>
+            <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
+          </li>
+        {% endif %}
       </ul>
     </li>
-    {% if user_can_edit_project or announcement_form %}
-      <li class="dropdown">
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          {% translate "Manage" %} <span class="caret"></span>
-        </a>
-        <ul class="dropdown-menu">
-          {% if user_can_edit_project %}
-            {% if add_form %}
-              <li>
-                <a href="#add-category" data-toggle="tab">{% translate "Add new category" %}</a>
-              </li>
-            {% endif %}
-            <li>
-              <a href="{% url 'create-component' %}?project={{ object.project.pk }}&amp;category={{ object.pk }}">{% translate "Add new translation component" %}</a>
-            </li>
-          {% endif %}
-          {% if announcement_form %}
-            <li>
-              <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
-            </li>
-          {% endif %}
-          {% if delete_form or rename_form %}
-            <li role="separator" class="divider"></li>
-            <li>
-              <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
-            </li>
-          {% endif %}
-        </ul>
-      </li>
-    {% endif %}
     {% include "snippets/share-menu.html" with object=object.project %}
   </ul>
 

--- a/weblate/templates/component.html
+++ b/weblate/templates/component.html
@@ -94,7 +94,7 @@
     </li>
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-        {% translate "Tools" %} <span class="caret"></span>
+        {% translate "Operations" %} <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
         {% if replace_form %}
@@ -115,62 +115,54 @@
             <a href="{% url "new-language" path=object.get_url_path %}">{% translate "Start new translation" %}</a>
           </li>
         {% endif %}
-      </ul>
-    </li>
-    {% if user.is_authenticated %}
-      <li class="dropdown">
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          {% translate "Manage" %} <span class="caret"></span>
-        </a>
-        <ul class="dropdown-menu">
-          {% if user_can_see_repository_status %}
-            <li>
-              <a href="#repository"
-                 data-toggle="tab"
-                 data-href="{% url 'git_status' path=object.get_url_path %}">{% translate "Repository maintenance" %}</a>
-            </li>
-            <li role="separator" class="divider"></li>
-          {% endif %}
+        <li role="separator" class="divider"></li>
+        {% if user_can_see_repository_status %}
           <li>
-            <a href="{% url 'screenshots' path=object.get_url_path %}">{% translate "Screenshots" %}</a>
+            <a href="#repository"
+               data-toggle="tab"
+               data-href="{% url 'git_status' path=object.get_url_path %}">{% translate "Repository maintenance" %}</a>
+          </li>
+          <li role="separator" class="divider"></li>
+        {% endif %}
+        <li>
+          <a href="{% url 'screenshots' path=object.get_url_path %}">{% translate "Screenshots" %}</a>
+        </li>
+        <li>
+          <a href="{% url 'memory' project=object.project.slug %}">{% translate "Translation memory" %}</a>
+        </li>
+        {% if announcement_form %}
+          <li>
+            <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
+          </li>
+        {% endif %}
+        {% if user_can_manage_acl %}
+          <li>
+            <a href="{% url 'manage-access' project=object.project.slug %}">{% translate "Users" %}</a>
+          </li>
+        {% endif %}
+        {% if user_can_edit_component %}
+          <li>
+            <a href="{% url 'create-component' %}?component={{ object.id }}#existing">{% translate "Duplicate this component" %}</a>
           </li>
           <li>
-            <a href="{% url 'memory' project=object.project.slug %}">{% translate "Translation memory" %}</a>
+            <a href="{% url 'addons' path=object.get_url_path %}">{% translate "Add-ons" %}</a>
           </li>
-          {% if announcement_form %}
-            <li>
-              <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
-            </li>
-          {% endif %}
-          {% if user_can_manage_acl %}
-            <li>
-              <a href="{% url 'manage-access' project=object.project.slug %}">{% translate "Users" %}</a>
-            </li>
-          {% endif %}
+        {% endif %}
+        {% if delete_form or rename_form or user_can_edit_component %}
+          <li role="separator" class="divider"></li>
           {% if user_can_edit_component %}
             <li>
-              <a href="{% url 'create-component' %}?component={{ object.id }}#existing">{% translate "Duplicate this component" %}</a>
+              <a href="{% url 'settings' path=object.get_url_path %}">{% translate "Settings" %}</a>
             </li>
+          {% endif %}
+          {% if delete_form or rename_form %}
             <li>
-              <a href="{% url 'addons' path=object.get_url_path %}">{% translate "Add-ons" %}</a>
+              <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
             </li>
           {% endif %}
-          {% if delete_form or rename_form or user_can_edit_component %}
-            <li role="separator" class="divider"></li>
-            {% if user_can_edit_component %}
-              <li>
-                <a href="{% url 'settings' path=object.get_url_path %}">{% translate "Settings" %}</a>
-              </li>
-            {% endif %}
-            {% if delete_form or rename_form %}
-              <li>
-                <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
-              </li>
-            {% endif %}
-          {% endif %}
-        </ul>
-      </li>
-    {% endif %}
+        {% endif %}
+      </ul>
+    </li>
     {% include "snippets/share-menu.html" with object=object %}
   </ul>
 

--- a/weblate/templates/language-project.html
+++ b/weblate/templates/language-project.html
@@ -71,7 +71,7 @@
     </li>
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-        {% translate "Tools" %} <span class="caret"></span>
+        {% translate "Operations" %} <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
         {% if replace_form %}
@@ -84,33 +84,25 @@
             <a href="#bulk-edit" data-toggle="tab">{% translate "Bulk edit" %}</a>
           </li>
         {% endif %}
+        <li role="separator" class="divider"></li>
+        {% if user_can_edit_project %}
+          <li>
+            <a href="{% url 'settings' path=object.get_url_path %}">{% translate "Settings" %}</a>
+          </li>
+        {% endif %}
+        {% if announcement_form %}
+          <li>
+            <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
+          </li>
+        {% endif %}
+        {% if delete_form %}
+          <li role="separator" class="divider"></li>
+          <li>
+            <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
+          </li>
+        {% endif %}
       </ul>
     </li>
-    {% if user_can_edit_project or announcement_form or delete_form %}
-      <li class="dropdown">
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          {% translate "Manage" %} <span class="caret"></span>
-        </a>
-        <ul class="dropdown-menu">
-          {% if user_can_edit_project %}
-            <li>
-              <a href="{% url 'settings' path=object.get_url_path %}">{% translate "Settings" %}</a>
-            </li>
-          {% endif %}
-          {% if announcement_form %}
-            <li>
-              <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
-            </li>
-          {% endif %}
-          {% if delete_form %}
-            <li role="separator" class="divider"></li>
-            <li>
-              <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
-            </li>
-          {% endif %}
-        </ul>
-      </li>
-    {% endif %}
     {% include "snippets/share-menu.html" with object=object %}
     {% include "snippets/watch-dropdown.html" %}
   </ul>

--- a/weblate/templates/project.html
+++ b/weblate/templates/project.html
@@ -93,7 +93,7 @@
     </li>
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-        {% translate "Tools" %} <span class="caret"></span>
+        {% translate "Operations" %} <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
         {% if replace_form %}
@@ -106,101 +106,93 @@
             <a href="#bulk-edit" data-toggle="tab">{% translate "Bulk edit" %}</a>
           </li>
         {% endif %}
+        <li role="separator" class="divider"></li>
+        {% if user_can_see_repository_status %}
+          <li>
+            <a href="#repository"
+               data-toggle="tab"
+               data-href="{% url 'git_status' path=object.get_url_path %}">{% translate "Repository maintenance" %}</a>
+          </li>
+          <li role="separator" class="divider"></li>
+        {% endif %}
+        <li>
+          <a href="{% url 'memory' project=object.slug %}">{% translate "Translation memory" %}</a>
+        </li>
+        {% if announcement_form %}
+          <li>
+            <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
+          </li>
+        {% endif %}
         <li>
           <a href="{% url "new-language" path=object.get_url_path %}">{% translate "Start new translation" %}</a>
         </li>
-      </ul>
-    </li>
-    {% if user_can_manage_acl or user_can_edit_project or user_can_see_repository_status or user.is_authenticated %}
-      <li class="dropdown">
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          {% translate "Manage" %} <span class="caret"></span>
-        </a>
-        <ul class="dropdown-menu">
-          {% if user_can_see_repository_status %}
-            <li>
-              <a href="#repository"
-                 data-toggle="tab"
-                 data-href="{% url 'git_status' path=object.get_url_path %}">{% translate "Repository maintenance" %}</a>
-            </li>
-            <li role="separator" class="divider"></li>
-          {% endif %}
+        {% if user_can_edit_project %}
           <li>
-            <a href="{% url 'memory' project=object.slug %}">{% translate "Translation memory" %}</a>
+            <a href="#add-category" data-toggle="tab">{% translate "Add new category" %}</a>
           </li>
-          {% if announcement_form %}
-            <li>
-              <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
-            </li>
-          {% endif %}
-          {% if user_can_edit_project %}
-            <li>
-              <a href="#add-category" data-toggle="tab">{% translate "Add new category" %}</a>
-            </li>
-            <li>
-              <a href="{% url 'create-component' %}?project={{ object.pk }}">{% translate "Add new translation component" %}</a>
-            </li>
-            {% if offer_hosting %}
-              {% for billing in object.billings %}
-                {% if billing.is_libre_trial %}
-                  <li>
-                    <a href="{{ billing.get_absolute_url }}">{% translate "Request approval for Libre hosting" %}</a>
-                  </li>
-                {% endif %}
-              {% endfor %}
-            {% endif %}
-          {% endif %}
-          {% if user_can_manage_acl %}
-            <li>
-              <a href="{% url 'manage-access' project=object.slug %}#users">{% translate "Users" %}</a>
-            </li>
-            <li>
-              <a href="{% url 'manage-access' project=object.slug %}#api">{% translate "API access" %}</a>
-            </li>
-          {% endif %}
-          {% if user_can_edit_project %}
-            <li>
-              <a href="{% url 'fonts' project=object.slug %}">{% translate "Fonts" %}</a>
-            </li>
-            <li>
-              <a href="{% url 'labels' project=object.slug %}">{% translate "Labels" %}</a>
-            </li>
-            <li>
-              <a href="{% url 'machinery-list' project=object.slug %}">{% translate "Automatic suggestions" %}</a>
-            </li>
-            <li>
-              <a href="{% url 'backups' project=object.slug %}">{% translate "Backups" %}</a>
-            </li>
-            <li>
-              <a href="{% url 'addons' path=object.get_url_path %}">{% translate "Add-ons" %}</a>
-            </li>
-          {% endif %}
-
-          {% if user_can_view_billing and object.billings %}
+          <li>
+            <a href="{% url 'create-component' %}?project={{ object.pk }}">{% translate "Add new translation component" %}</a>
+          </li>
+          {% if offer_hosting %}
             {% for billing in object.billings %}
-              <li>
-                <a href="{{ billing.get_absolute_url }}">{% translate "Billing" %}</a>
-              </li>
+              {% if billing.is_libre_trial %}
+                <li>
+                  <a href="{{ billing.get_absolute_url }}">{% translate "Request approval for Libre hosting" %}</a>
+                </li>
+              {% endif %}
             {% endfor %}
           {% endif %}
+        {% endif %}
+        {% if user_can_manage_acl %}
+          <li>
+            <a href="{% url 'manage-access' project=object.slug %}#users">{% translate "Users" %}</a>
+          </li>
+          <li>
+            <a href="{% url 'manage-access' project=object.slug %}#api">{% translate "API access" %}</a>
+          </li>
+        {% endif %}
+        {% if user_can_edit_project %}
+          <li>
+            <a href="{% url 'fonts' project=object.slug %}">{% translate "Fonts" %}</a>
+          </li>
+          <li>
+            <a href="{% url 'labels' project=object.slug %}">{% translate "Labels" %}</a>
+          </li>
+          <li>
+            <a href="{% url 'machinery-list' project=object.slug %}">{% translate "Automatic suggestions" %}</a>
+          </li>
+          <li>
+            <a href="{% url 'backups' project=object.slug %}">{% translate "Backups" %}</a>
+          </li>
+          <li>
+            <a href="{% url 'addons' path=object.get_url_path %}">{% translate "Add-ons" %}</a>
+          </li>
+        {% endif %}
 
-          {% if delete_form or rename_form or user_can_edit_project %}
-            <li role="separator" class="divider"></li>
+        {% if user_can_view_billing and object.billings %}
+          {% for billing in object.billings %}
+            <li>
+              <a href="{{ billing.get_absolute_url }}">{% translate "Billing" %}</a>
+            </li>
+          {% endfor %}
+        {% endif %}
 
-            {% if user_can_edit_project %}
-              <li>
-                <a href="{% url 'settings' path=object.get_url_path %}">{% translate "Settings" %}</a>
-              </li>
-            {% endif %}
-            {% if delete_form or rename_form %}
-              <li>
-                <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
-              </li>
-            {% endif %}
+        {% if delete_form or rename_form or user_can_edit_project %}
+          <li role="separator" class="divider"></li>
+
+          {% if user_can_edit_project %}
+            <li>
+              <a href="{% url 'settings' path=object.get_url_path %}">{% translate "Settings" %}</a>
+            </li>
           {% endif %}
-        </ul>
-      </li>
-    {% endif %}
+          {% if delete_form or rename_form %}
+            <li>
+              <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
+            </li>
+          {% endif %}
+        {% endif %}
+      </ul>
+    </li>
     {% include "snippets/share-menu.html" with object=object %}
   </ul>
 

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -55,6 +55,9 @@
         <li>
           <a href="{% url 'checks' path=object.get_url_path %}">{% translate "Failing checks" %}</a>
         </li>
+        <li>
+          <a href="{% url 'data_project' project=object.component.project.slug %}">{% translate "Data exports" %}</a>
+        </li>
       </ul>
     </li>
     <li class="dropdown">
@@ -79,7 +82,7 @@
     </li>
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-        {% translate "Tools" %} <span class="caret"></span>
+        {% translate "Operations" %} <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
         {% if replace_form %}
@@ -97,44 +100,33 @@
             <a href="#auto" data-toggle="tab">{% translate "Automatic translation" %}</a>
           </li>
         {% endif %}
-        <li>
-          <a href="{% url 'data_project' project=object.component.project.slug %}">{% translate "Data exports" %}</a>
-        </li>
+        <li role="separator" class="divider"></li>
         {% if user_can_add_unit %}
           <li>
             <a href="#new" data-toggle="tab">{{ object.component.get_add_label }}</a>
           </li>
         {% endif %}
+        {% if user_can_see_repository_status %}
+          <li>
+            <a href="#repository"
+               data-toggle="tab"
+               data-href="{% url 'git_status' path=object.get_url_path %}">{% translate "Repository maintenance" %}</a>
+          </li>
+        {% endif %}
+        {% if announcement_form %}
+          <li role="separator" class="divider"></li>
+          <li>
+            <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
+          </li>
+        {% endif %}
+        {% if delete_form %}
+          <li role="separator" class="divider"></li>
+          <li>
+            <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
+          </li>
+        {% endif %}
       </ul>
     </li>
-    {% if user_can_see_repository_status or announcement_form %}
-      <li class="dropdown">
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          {% translate "Manage" %} <span class="caret"></span>
-        </a>
-        <ul class="dropdown-menu">
-          {% if user_can_see_repository_status %}
-            <li>
-              <a href="#repository"
-                 data-toggle="tab"
-                 data-href="{% url 'git_status' path=object.get_url_path %}">{% translate "Repository maintenance" %}</a>
-            </li>
-          {% endif %}
-          {% if announcement_form %}
-            <li role="separator" class="divider"></li>
-            <li>
-              <a href="#announcement" data-toggle="tab">{% translate "Post announcement" %}</a>
-            </li>
-          {% endif %}
-          {% if delete_form %}
-            <li role="separator" class="divider"></li>
-            <li>
-              <a href="#organize" data-toggle="tab">{% translate "Organize or remove" %}</a>
-            </li>
-          {% endif %}
-        </ul>
-      </li>
-    {% endif %}
     {% include "snippets/share-menu.html" with object=object %}
   </ul>
 

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -491,7 +491,7 @@ class SeleniumTests(
         self.click("Components")
         with self.wait_for_page_load():
             self.click("Django")
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Screenshots")
         self.screenshot("screenshot-filemask-repository-filename.png")
@@ -553,7 +553,7 @@ class SeleniumTests(
         self.click("Components")
         with self.wait_for_page_load():
             self.click("Django")
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Screenshots")
 
@@ -648,7 +648,7 @@ class SeleniumTests(
             self.click("Browse all projects")
         with self.wait_for_page_load():
             self.click("WeblateOrg")
-        self.click("Manage")
+        self.click("Operations")
         self.click("Post announcement")
         self.screenshot("announcement-project.png")
 
@@ -760,7 +760,7 @@ class SeleniumTests(
         self.screenshot("project-overview.png")
 
         # User management
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Users")
         element = self.driver.find_element(By.ID, "id_user")
@@ -774,7 +774,7 @@ class SeleniumTests(
         self.click(htmlid="projects-menu")
         with self.wait_for_page_load():
             self.click("WeblateOrg")
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Automatic suggestions")
         self.screenshot("project-machinery.png")
@@ -782,7 +782,7 @@ class SeleniumTests(
         self.click(htmlid="projects-menu")
         with self.wait_for_page_load():
             self.click("WeblateOrg")
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Settings")
         self.click("Access")
@@ -810,10 +810,10 @@ class SeleniumTests(
             self.click("Language names")
 
         # Repository
-        self.click("Manage")
+        self.click("Operations")
         self.click("Repository maintenance")
         time.sleep(0.2)
-        self.click("Manage")
+        self.click("Operations")
         self.screenshot("component-repository.png")
 
         # Add-ons
@@ -858,7 +858,7 @@ class SeleniumTests(
         self.screenshot("reporting.png")
 
         # Contributor license agreement
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Settings")
         element = self.driver.find_element(By.ID, "id_agreement")
@@ -888,10 +888,10 @@ class SeleniumTests(
         self.click("Customize download")
         self.click("Files")
         self.screenshot("file-download.png")
-        self.click("Tools")
+        self.click("Operations")
         self.click("Automatic translation")
         self.click(htmlid="id_auto_source_1")
-        self.click("Tools")
+        self.click("Operations")
         self.screenshot("automatic-translation.png")
         self.click("Search")
         element = self.driver.find_element(By.ID, "id_q")
@@ -1072,7 +1072,7 @@ class SeleniumTests(
             self.click("Browse all projects")
         with self.wait_for_page_load():
             self.click("WeblateOrg")
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Fonts")
 
@@ -1179,7 +1179,7 @@ class SeleniumTests(
             self.click("Browse all projects")
         with self.wait_for_page_load():
             self.click("WeblateOrg")
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Labels")
         element = self.driver.find_element(By.ID, "id_name")
@@ -1202,7 +1202,7 @@ class SeleniumTests(
             self.click("Android")
 
         # Edit variant configuration
-        self.click("Manage")
+        self.click("Operations")
         with self.wait_for_page_load():
             self.click("Settings")
         self.click("Translation")


### PR DESCRIPTION
The division between Tools and Manage was never clear and lead to inconsistencies (some Add options being in Tools and some in Manage). Merging these two will make it more obvious where to look for actions.

Issue #15017

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
