### PR TITLE
fix(autotranslate): do not lock component for autotranslate

### DIFF
--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -534,27 +534,26 @@ def auto_translate_component(
 ):
     component_obj = Component.objects.get(pk=component_id)
 
-    with component_obj.lock:
-        for translation in component_obj.translation_set.iterator():
-            if translation.is_source:
-                continue
+    for translation in component_obj.translation_set.iterator():
+        if translation.is_source:
+            continue
 
-            auto = AutoTranslate(
-                user=None,
-                translation=translation,
-                filter_type=filter_type,
-                mode=mode,
-                component_wide=True,
-            )
-            auto.perform(
-                auto_source=auto_source,
-                engines=engines,
-                threshold=threshold,
-                source=component,
-            )
-        component_obj.update_source_checks()
-        component_obj.run_batched_checks()
-        return {"component": component_obj.id}
+        auto = AutoTranslate(
+            user=None,
+            translation=translation,
+            filter_type=filter_type,
+            mode=mode,
+            component_wide=True,
+        )
+        auto.perform(
+            auto_source=auto_source,
+            engines=engines,
+            threshold=threshold,
+            source=component,
+        )
+    component_obj.update_source_checks()
+    component_obj.run_batched_checks()
+    return {"component": component_obj.id}
 
 
 @app.task(trail=False)


### PR DESCRIPTION
The locking was removed for the translation level autotranslate so it can be done here as well.

Fixes WEBLATE-2ZV1
Issue #13623

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
