### PR TITLE
fix: improve listing of project reviewers

### DIFF
--- a/weblate/accounts/avatar.py
+++ b/weblate/accounts/avatar.py
@@ -109,7 +109,7 @@ def get_user_display(user: User, icon: bool = True, link: bool = False):
             avatar = reverse("user_avatar", kwargs={"user": user.username, "size": 32})
 
         username = format_html(
-            '<img src="{}" class="avatar w32" alt="{}" /> {}',
+            '<img src="{}" class="avatar w32" loading="lazy" alt="{}" /> {}',
             avatar,
             gettext("User avatar"),
             username,
@@ -117,7 +117,7 @@ def get_user_display(user: User, icon: bool = True, link: bool = False):
 
     if link and user is not None:
         return format_html(
-            '<a href="{}" title="{}">{}</a>',
+            '<a href="{}" title="{}" class="user-link"><span>{}</span></a>',
             user.get_absolute_url(),
             full_name,
             username,

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -27,6 +27,10 @@
   height: 32px;
 }
 
+.user-link {
+  margin: 3px;
+}
+
 .user-list {
   display: flex;
   flex-wrap: wrap;

--- a/weblate/templates/snippets/info-users.html
+++ b/weblate/templates/snippets/info-users.html
@@ -1,0 +1,11 @@
+{% if user_list %}
+  <tr>
+    <th>
+      {{ user_title }}<span class="badge">{{ user_list|length }}</span>
+    </th>
+    <td colspan="2" class="full-cell">
+      {% for admin in user_list|slice:":25" %}{{ admin.profile.get_user_display_link }}{% endfor %}
+      {% if user_list|length > 25 %}…{% endif %}
+    </td>
+  </tr>
+{% endif %}

--- a/weblate/templates/snippets/info.html
+++ b/weblate/templates/snippets/info.html
@@ -42,23 +42,9 @@
               {% endif %}
             {% endif %}
 
-            {% if project.all_admins %}
-              <tr>
-                <th>{% translate "Project maintainers" %}</th>
-                <td colspan="2" class="full-cell">
-                  {% for admin in project.all_admins %}{{ admin.profile.get_user_display_link }}{% endfor %}
-                </td>
-              </tr>
-            {% endif %}
+            {% include "snippets/info-users.html" with user_title=_("Project maintainers") user_list=project.all_admins %}
 
-            {% if project.all_reviewers %}
-              <tr>
-                <th>{% translate "Project reviewers" %}</th>
-                <td colspan="2" class="full-cell">
-                  {% for reviewer in project.all_reviewers %}{{ reviewer.profile.get_user_display_link }}{% endfor %}
-                </td>
-              </tr>
-            {% endif %}
+            {% include "snippets/info-users.html" with user_title=_("Project reviewers") user_list=project.all_reviewers %}
           {% endif %}
           {% if componentlist %}
             {% for auto in componentlist.autocomponentlist_set.all %}

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -564,14 +564,21 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
     def all_admins(self):
         from weblate.auth.models import User
 
-        return User.objects.all_admins(self).select_related("profile")
+        return (
+            User.objects.all_admins(self).exclude(is_bot=True).select_related("profile")
+        )
 
+    @cached_property
     def all_reviewers(self):
         from weblate.auth.models import User
 
         if not self.enable_review:
             return User.objects.none()
-        return User.objects.all_reviewers(self).select_related("profile")
+        return (
+            User.objects.all_reviewers(self)
+            .exclude(is_bot=True)
+            .select_related("profile")
+        )
 
     def get_child_components_access(self, user: User, filter_callback=None):
         """


### PR DESCRIPTION
- cache the results to avoid double evaluation of the query
- exclude bots from admin and review accounts
- share the rendering template with admins
- show the number of users in the group
- limit listing to first 25 users
- add CSS to make sure there is spacing around the users
- lazily load user avatars

Fixes #15304

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
