### PR TITLE
bugfix(pending-units): KeyError if no units updated

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -956,7 +956,7 @@ class Translation(
 
         # Did we do any updates?
         if not updated:
-            return []
+            return changes_status
 
         # Update po file header
         now = timezone.now()


### PR DESCRIPTION
`update_units` returned an empty list in case no units are updated, but it should always return the changes_status dict.

Fixes #15318