### PR TITLE
bugfix(pending-unit): source string explanation commit to file

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -2008,10 +2008,16 @@ class Unit(models.Model, LoggerMixin):
                     unit=unit,
                     author=user,
                 )
-            PendingUnitChange.store_unit_change(
-                unit=self,
-                author=user,
-            )
+
+            # translation file does not exist for source strings in bilingual formats
+            if (
+                not self.is_source
+                or self.translation.component.file_format_cls.monolingual
+            ):
+                PendingUnitChange.store_unit_change(
+                    unit=self,
+                    author=user,
+                )
 
         if save:
             self.save(update_fields=["explanation"], only_save=True)


### PR DESCRIPTION
No translation file exists for source strings in bilingual formats, hence we should not try to commit explanation changes for the same to a file. Do not create a PendingUnitChange entry is a source unit and the file format is bilingual.

Fixes #15344.