### PR TITLE
docs: Note component discovery requirement for at least one translation

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -446,7 +446,7 @@ Matching files:
 
    To be discovered a new component must contain a file that matches ``base_file_template``
    **and** at least one file with a name that matches ``match`` -- i.e., the component must
-   contain a base language file and at least one existing translation. Otherwise it will be
+   contain a base language file and at least one existing translation. Otherwise, it will be
    ignored.
 
 .. seealso::

--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -437,6 +437,18 @@ Matching files:
    :guilabel:`Version control system`) of each respective component.
    This saves time with configuration and system resources too.
 
+.. hint::
+
+   Ensure the new component contains the full set of translatable languages with
+   :ref:`addon-weblate.consistency.languages`.
+
+.. warning::
+
+   To be discovered a new component must contain a file that matches ``base_file_template``
+   **and** at least one file with a name that matches ``match`` -- i.e., the component must
+   contain a base language file and at least one existing translation. Otherwise it will be
+   ignored.
+
 .. seealso::
 
    :ref:`markup`,

--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -444,7 +444,7 @@ Matching files:
 
 .. warning::
 
-   To be discovered a new component must contain a file that matches ``base_file_template``
+   To be discovered, a new component must contain a file that matches ``base_file_template``
    **and** at least one file with a name that matches ``match`` -- i.e., the component must
    contain a base language file and at least one existing translation. Otherwise, it will be
    ignored.


### PR DESCRIPTION
Component discovery doesn't work if a base file exists but there are no translations (https://github.com/WeblateOrg/weblate/issues/2084).

Document this requirement as a warning.

While I'm here, add a hint that recommends pairing with the "Add missing languages" add-on to ensure that newly discovered components converge on a consistent set of languages.