### PR TITLE
Unify logic for license requirement when changing project access

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2193,12 +2193,14 @@ class ProjectSettingsForm(SettingsBaseForm, ProjectDocsMixin, ProjectAntispamMix
                     )
                 }
             )
-        if self.changed_access and access in {
-            Project.ACCESS_PUBLIC,
-            Project.ACCESS_PROTECTED,
-        }:
+        if self.changed_access and access == Project.ACCESS_PUBLIC:
             unlicensed = self.instance.component_set.filter(license="")
-            if unlicensed:
+            if (
+                unlicensed
+                and settings.LICENSE_REQUIRED
+                and not settings.LOGIN_REQUIRED_URLS
+                and (settings.LICENSE_FILTER is None or settings.LICENSE_FILTER)
+            ):
                 raise ValidationError(
                     {
                         "access_control": gettext(


### PR DESCRIPTION
This applies the same logic like in alert.py: MissingLicense(BaseAlert)


### Specific problem: 

Vars set according to docs:

```
DEFAULT_ACCESS_CONTROL=200
LICENSE_REQUIRED=False
LICENSE_FILTER = set()
```
This way, you can never make any project public.

### Simplified scenario:

You only set: 

```
LICENSE_FILTER = set()
```

Now, when you change a project to private, you cannot change it back to public anymore.