### PR TITLE
fix(machinery): correctly map source languages for DeepL

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 5.13
 .. rubric:: Bug fixes
 
 * :ref:`upload` correctly tracks authorship when using :guilabel:`Replace existing translation file`.
+* :ref:`mt-deepl` integration now correctly handle all supported source languages.
 
 .. rubric:: Compatibility
 

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -20,7 +20,10 @@ from .base import (
 from .forms import DeepLMachineryForm
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from weblate.auth.models import User
+    from weblate.lang.models import Language
     from weblate.trans.models import Unit
 
 
@@ -54,6 +57,15 @@ class DeepLTranslation(
     def map_language_code(self, code):
         """Convert language to service specific code."""
         return super().map_language_code(code).replace("_", "-").upper()
+
+    def get_language_possibilities(self, language: Language) -> Iterator[str]:
+        for value in super().get_language_possibilities(language):
+            yield value
+            # Add variant without suffix, this is needed for source languages
+            # as DeepL does not differentiate most language variants on the source
+            # string side.
+            if "-" in value:
+                yield value.split("-", 1)[0]
 
     def get_headers(self) -> dict[str, str]:
         return {"Authorization": f"DeepL-Auth-Key {self.settings['key']}"}


### PR DESCRIPTION
The codes for the source language differ from target ones as DeepL does not support country suffixes here.

Fixes #15432

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
