### PR TITLE
fix(api): avoid listing duplicate groups

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -440,6 +440,46 @@ class GroupAPITest(APIBaseTest):
         )
         self.assertEqual(response.data["name"], "Users")
 
+    def test_get_user(self) -> None:
+        response = self.do_request(
+            "api:group-detail",
+            kwargs={"id": Group.objects.get(name="Users").id},
+            method="get",
+            code=200,
+        )
+        self.assertEqual(response.data["name"], "Users")
+
+    def test_get_user_admin(self) -> None:
+        group = Group.objects.create(name="Test Group")
+
+        # No access to the group
+        response = self.do_request(
+            "api:group-detail",
+            kwargs={"id": group.id},
+            method="get",
+            code=404,
+        )
+
+        # User access the group
+        self.user.groups.add(group)
+        response = self.do_request(
+            "api:group-detail",
+            kwargs={"id": group.id},
+            method="get",
+            code=200,
+        )
+        self.assertEqual(response.data["name"], "Test Group")
+
+        # Admin access to the group
+        group.admins.add(self.user)
+        response = self.do_request(
+            "api:group-detail",
+            kwargs={"id": group.id},
+            method="get",
+            code=200,
+        )
+        self.assertEqual(response.data["name"], "Test Group")
+
     def test_create(self) -> None:
         self.do_request(
             "api:group-list", method="post", code=403, request={"name": "Group"}

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -625,10 +625,12 @@ class GroupViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         if self.request.user.has_perm("group.edit"):
-            return Group.objects.order_by("id")
-        return self.request.user.groups.order_by(
-            "id"
-        ) | self.request.user.administered_group_set.order_by("id")
+            queryset = Group.objects.all()
+        else:
+            queryset = Group.objects.filter(
+                Q(user=self.request.user) | Q(admins=self.request.user)
+            ).distinct()
+        return queryset.order_by("id")
 
     def perm_check(
         self,


### PR DESCRIPTION
When user is both member and admin, the outer join can list it multiple times.

Fixes WEBLATE-31J7
Fixes WEBLATE-31HT

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
