### PR TITLE
🩹 — Use startswith() for comparing deepl URLs

### DIFF
--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -50,7 +50,9 @@ class DeepLTranslation(
     @property
     def api_base_url(self):
         url = super().api_base_url
-        if self.settings["key"].endswith(":fx") and url.startswith("https://api.deepl.com/v2"):
+        if self.settings["key"].endswith(":fx") and url.startswith(
+            "https://api.deepl.com/v2"
+        ):
             return "https://api-free.deepl.com/v2"
         return url
 


### PR DESCRIPTION
In order to catch deepl URL if people add a trailing slash to the URL, let’s use startswith() instead of `==`.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
