### PR TITLE
Update the dependecy weblate-schemas to v2025.5

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -44742,7 +44742,6 @@ components:
             * `git-force-push` - Git with force push
             * `local` - No remote repository
             * `mercurial` - Mercurial
-            * `subversion` - Subversion
         repo:
           type: string
           maxLength: 300
@@ -60702,7 +60701,6 @@ components:
             * `git-force-push` - Git with force push
             * `local` - No remote repository
             * `mercurial` - Mercurial
-            * `subversion` - Subversion
         repo:
           type: string
           maxLength: 300
@@ -69432,7 +69430,6 @@ components:
       - git-force-push
       - local
       - mercurial
-      - subversion
       type: string
       description: |-
         * `gerrit` - Gerrit
@@ -69440,7 +69437,6 @@ components:
         * `git-force-push` - Git with force push
         * `local` - No remote repository
         * `mercurial` - Mercurial
-        * `subversion` - Subversion
     patch_200_Message_response_serializer:
       type: object
       properties:
@@ -69648,6 +69644,9 @@ webhooks:
                   items:
                     title: Category slug
                     type: string
+                context:
+                  title: Translation context or key for monolingual formats
+                  type: string
             examples:
               AuthenticationFailed:
                 value:

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -44742,6 +44742,7 @@ components:
             * `git-force-push` - Git with force push
             * `local` - No remote repository
             * `mercurial` - Mercurial
+            * `subversion` - Subversion
         repo:
           type: string
           maxLength: 300
@@ -60701,6 +60702,7 @@ components:
             * `git-force-push` - Git with force push
             * `local` - No remote repository
             * `mercurial` - Mercurial
+            * `subversion` - Subversion
         repo:
           type: string
           maxLength: 300
@@ -69430,6 +69432,7 @@ components:
       - git-force-push
       - local
       - mercurial
+      - subversion
       type: string
       description: |-
         * `gerrit` - Gerrit
@@ -69437,6 +69440,7 @@ components:
         * `git-force-push` - Git with force push
         * `local` - No remote repository
         * `mercurial` - Mercurial
+        * `subversion` - Subversion
     patch_200_Message_response_serializer:
       type: object
       properties:

--- a/docs/specs/sbom/partial/python.json
+++ b/docs/specs/sbom/partial/python.json
@@ -6391,7 +6391,7 @@
       "version": "2025.8"
     },
     {
-      "bom-ref": "weblate_schemas==2025.4",
+      "bom-ref": "weblate_schemas==2025.5",
       "description": "A collection of JSON schemas used by Weblate",
       "externalReferences": [
         {
@@ -6439,9 +6439,9 @@
         }
       ],
       "name": "weblate_schemas",
-      "purl": "pkg:pypi/weblate-schemas@2025.4",
+      "purl": "pkg:pypi/weblate-schemas@2025.5",
       "type": "library",
-      "version": "2025.4"
+      "version": "2025.5"
     },
     {
       "bom-ref": "wlhosted==2025.1",
@@ -7941,7 +7941,7 @@
         "translation-finder==2.22",
         "user-agents==2.2.0",
         "weblate-language-data==2025.8",
-        "weblate_schemas==2025.4",
+        "weblate_schemas==2025.5",
         "wlhosted==2025.1",
         "wllegal==2025.5"
       ],
@@ -7954,7 +7954,7 @@
         "rfc3987==1.3.8",
         "strict-rfc3339==0.7"
       ],
-      "ref": "weblate_schemas==2025.4"
+      "ref": "weblate_schemas==2025.5"
     },
     {
       "dependsOn": [
@@ -8129,5 +8129,5 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:d551f4b2-5fed-5f2a-a203-d6fbb1d87c9a"
+  "serialNumber": "urn:uuid:17acb685-2da1-5a35-a188-6376eb29c318"
 }

--- a/docs/specs/sbom/sbom.json
+++ b/docs/specs/sbom/sbom.json
@@ -1,7 +1,7 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:5c1ff3fb-04ff-52d6-bdf4-5e54205cbb16",
+  "serialNumber": "urn:uuid:7697fece-153a-5b5a-92ea-2ad6ddea4f3e",
   "version": 1,
   "metadata": {
     "tools": [
@@ -7473,9 +7473,9 @@
     },
     {
       "type": "library",
-      "bom-ref": "weblate_schemas==2025.4",
+      "bom-ref": "weblate_schemas==2025.5",
       "name": "weblate_schemas",
-      "version": "2025.4",
+      "version": "2025.5",
       "description": "A collection of JSON schemas used by Weblate",
       "licenses": [
         {
@@ -7485,7 +7485,7 @@
           }
         }
       ],
-      "purl": "pkg:pypi/weblate-schemas@2025.4",
+      "purl": "pkg:pypi/weblate-schemas@2025.5",
       "externalReferences": [
         {
           "url": "https://github.com/WeblateOrg/weblate_schemas",
@@ -9155,13 +9155,13 @@
         "translation-finder==2.22",
         "user-agents==2.2.0",
         "weblate-language-data==2025.8",
-        "weblate_schemas==2025.4",
+        "weblate_schemas==2025.5",
         "wlhosted==2025.1",
         "wllegal==2025.5"
       ]
     },
     {
-      "ref": "weblate_schemas==2025.4",
+      "ref": "weblate_schemas==2025.5",
       "dependsOn": [
         "fqdn==1.5.1",
         "jsonschema==4.24.0",

--- a/docs/specs/schemas/weblate-memory.schema.json
+++ b/docs/specs/schemas/weblate-memory.schema.json
@@ -28,6 +28,16 @@
         "title": "The String Origin",
         "type": "string"
       },
+      "context": {
+        "$id": "#/items/properties/context",
+        "default": "",
+        "description": "Translation context or key for monolingual formats",
+        "examples": [
+          "Greeting used in emails"
+        ],
+        "title": "The String Context or Key",
+        "type": "string"
+      },
       "source": {
         "$id": "#/items/properties/source",
         "default": "",
@@ -69,6 +79,11 @@
         "pattern": "^[^ ]+$",
         "title": "The Target Language",
         "type": "string"
+      },
+      "status": {
+        "$id": "#/items/properties/status",
+        "title": "Status",
+        "type": "integer"
       }
     },
     "required": [

--- a/docs/specs/schemas/weblate-messaging.schema.json
+++ b/docs/specs/schemas/weblate-messaging.schema.json
@@ -85,6 +85,10 @@
         "title": "Category slug",
         "type": "string"
       }
+    },
+    "context": {
+      "title": "Translation context or key for monolingual formats",
+      "type": "string"
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ dependencies = [
   "unidecode>=1.4.0,<1.5",
   "user-agents>=2.2.0,<2.3",
   "weblate-language-data>=2025.7",
-  "weblate-schemas==2025.4"
+  "weblate-schemas>=2025.5"
 ]
 description = "A web-based continuous localization system with tight version control integration"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -4828,7 +4828,7 @@ requires-dist = [
     { name = "user-agents", specifier = ">=2.2.0,<2.3" },
     { name = "weblate", extras = ["alibaba", "amazon", "antispam", "gerrit", "gelf", "google", "ldap", "mercurial", "openai", "postgres", "zxcvbn"], marker = "extra == 'all'" },
     { name = "weblate-language-data", specifier = ">=2025.7" },
-    { name = "weblate-schemas", specifier = "==2025.4" },
+    { name = "weblate-schemas", specifier = ">=2025.5" },
     { name = "wlhosted", marker = "extra == 'wlhosted'" },
     { name = "wllegal", marker = "extra == 'wllegal'", specifier = ">=2024.6" },
 ]
@@ -4947,7 +4947,7 @@ wheels = [
 
 [[package]]
 name = "weblate-schemas"
-version = "2025.4"
+version = "2025.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fqdn" },
@@ -4955,9 +4955,9 @@ dependencies = [
     { name = "rfc3987" },
     { name = "strict-rfc3339" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/84/774d2b3259b3c98f9d568666243fa6d57ef7abd4931e7ba9d047f0d955ad/weblate_schemas-2025.4.tar.gz", hash = "sha256:4b1072cec959ec7adeaeba7bdc3985969ff20718e9531a8134aea57b9aa122ca", size = 17684, upload-time = "2025-06-19T14:56:07.265Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/8c/99fc6ac74f1cab61fa8fdb87745f2f7bb1669ad953ff6d78592c19b1cc2f/weblate_schemas-2025.5.tar.gz", hash = "sha256:661145dd40fb957fca5d50d914e9fe19cd70fdca73cd5615adba55789f7fc221", size = 18057, upload-time = "2025-07-16T08:44:40.589Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/26/2f8b5afb041fbed8ecd61df1632ec62d87cc1a20cf473092bb79607c4755/weblate_schemas-2025.4-py3-none-any.whl", hash = "sha256:48d021e3f05c418d9a8286a04b306d2fc16a9e8dd3405962a3b76c50917519e5", size = 18939, upload-time = "2025-06-19T14:56:06.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/e87b4d030260e3df1e46aa226551822a82f6fe616e08f37fce4d5994315f/weblate_schemas-2025.5-py3-none-any.whl", hash = "sha256:4864d89c3cf2c0f375b977533749778b01587bea5acb469f6b3fa487f96f469e", size = 19327, upload-time = "2025-07-16T08:44:39.208Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In order for the recent changes in the package `weblate_schemas` to be utilized, its version in dependencies list must be changed to v2025.5.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
