### PR TITLE
bugfix(commit groups): avoid unnecessary group breaking

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -751,7 +751,7 @@ class Translation(
         grouped according to the following logic:
 
         1. Maintain active groups per author in a dict ({author_id: {"changes": [...], "units": {...}}})
-        2. For each pending change, check if the unit conflicts with ANY active group
+        2. For each pending change, check if the unit conflicts with ANY active group EXCEPT the change author's own group.
         3. If conflict found: finalize conflicting group(s)
         4. Add change to the author's existing group or create a new one if needed
 
@@ -762,12 +762,13 @@ class Translation(
             - A2: Author 2 edits Unit A -> Unit A conflicts -> Finalize Group 1, start Group 2: Author2
             - B3: Author 1 edits Unit B -> No conflicts -> Start Group 3: Author1
             - C4: Author 2 edits Unit C -> No conflicts -> Add to Group 2: Author2
-            - D5: Author 1 edits Unit D -> No conflicts -> Add to Group 3: Author1
+            - B5: Author 1 edits Unit B -> conflicts with own change -> Do not break group, Add to Group 3: Author1
+            - D6: Author 1 edits Unit D -> No conflicts -> Add to Group 3: Author1
 
         Result:
             - Commit 1: Author1 [A1]
             - Commit 2: Author2 [A2, C4]
-            - Commit 3: Author1 [B3, D5]
+            - Commit 3: Author1 [B3, B5, D6]
 
         """
         author_map = {
@@ -785,7 +786,7 @@ class Translation(
 
             conflicting_authors = []
             for other_author_id, group_data in active_groups.items():
-                if unit_id in group_data["units"]:
+                if unit_id in group_data["units"] and author_id != other_author_id:
                     conflicting_authors.append(other_author_id)
 
             for conflicting_author_id in conflicting_authors:

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -341,6 +341,34 @@ class TranslationTest(RepoTestCase):
         self.assertEqual(len(changes), 1)
         self.assertEqual([c.unit for c in changes], [units[3]])
 
+    def test_group_changes_by_author_single_author(self) -> None:
+        """Test that multiple changes to a unit by single author are grouped."""
+        component = self.create_component()
+        translation = component.translation_set.get(language_code="cs")
+        user = create_test_user()
+
+        units = list(translation.unit_set.all())
+        units[0].translate(user, "test1", STATE_TRANSLATED)
+        units[1].translate(user, "test2", STATE_TRANSLATED)
+        units[2].translate(user, "test3", STATE_TRANSLATED)
+        # change conflicts with earlier change to unit but
+        # don't split groups as all changes from same author
+        units[1].translate(user, "test2!", STATE_TRANSLATED)
+        units[3].translate(user, "test4", STATE_TRANSLATED)
+
+        all_changes = list(
+            PendingUnitChange.objects.for_translation(translation).order_by("timestamp")
+        )
+        groups = Translation._group_changes_by_author(all_changes)  # noqa: SLF001
+        self.assertEqual(len(groups), 1)
+
+        author, changes = groups[0]
+        self.assertEqual(author, user)
+        self.assertEqual(
+            [c.unit for c in changes],
+            [units[0], units[1], units[2], units[1], units[3]],
+        )
+
     def test_commit_explanation(self):
         user = create_test_user()
         component = self.create_tbx()


### PR DESCRIPTION
Avoid breaking groups when the same author makes multiple changes to a single unit.

Fixes #15430