### PR TITLE
fix(component): faster creating source units

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1299,7 +1299,11 @@ class Component(
                     create["state"] = STATE_READONLY
 
                 # Create source unit
-                source = source_units.create(id_hash=id_hash, **create)
+                source = Unit(
+                    translation=self.source_translation, id_hash=id_hash, **create
+                )
+                source.save(force_insert=True, only_save=True)
+
                 # Avoid fetching empty list of checks from the database
                 source.all_checks = []
                 source.source_updated = True

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -567,15 +567,16 @@ class Unit(models.Model, LoggerMixin):
             using=using,
             update_fields=update_fields,
         )
-        if only_save:
-            return
 
         # Set source_unit for source units, this needs to be done after
         # having a primary key
-        if self.is_source and not self.source_unit:
+        if self.is_source and not self.source_unit_id:
             self.source_unit = self
             # Avoid using save() for recursion
             Unit.objects.filter(pk=self.pk).update(source_unit=self)
+
+        if only_save:
+            return
 
         # Update checks if content or fuzzy flag has changed
         if run_checks:


### PR DESCRIPTION
There is no need to run checks on freshly created source units as it has none related units and the source check will be triggered later anyway.

Issue #15427

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
