### PR TITLE
feat(translation): unload store after parsing

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -585,6 +585,11 @@ class Translation(
         if self.is_source:
             self.component.preload_sources(updated)
 
+        # Unload the store, this is intentionally in a way that it would break
+        # further consumers as no further consumer is expected after this and
+        # we do not want to parse the file again.
+        self.__dict__["store"] = None
+
     def store_update_changes(self) -> None:
         # Save change
         Change.objects.bulk_create(self.update_changes, batch_size=500)


### PR DESCRIPTION
This can release significant amount of the memory. It is intentionally in a way that it would break further consumers as no further consumer is expected after this and we do not want to parse the file again.

Issue #15427

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
