### PR TITLE
fix(login): do not show login form when not configured

### DIFF
--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -860,7 +860,7 @@ class WeblateLoginView(BaseLoginView):
         context = super().get_context_data(**kwargs)
         auth_backends = get_auth_keys()
         context["login_backends"] = [x for x in sorted(auth_backends) if x != "email"]
-        context["can_reset"] = "email" in auth_backends
+        context["login_email"] = context["can_reset"] = "email" in auth_backends
         context["title"] = gettext("Sign in")
         return context
 
@@ -874,6 +874,9 @@ class WeblateLoginView(BaseLoginView):
         auth_backends = get_auth_keys()
         if len(auth_backends) == 1 and "email" not in auth_backends:
             return redirect_single(request, auth_backends.pop())
+
+        if request.method == "POST" and "email" not in auth_backends:
+            return redirect("login")
 
         return super().dispatch(request, *args, **kwargs)
 

--- a/weblate/templates/accounts/login.html
+++ b/weblate/templates/accounts/login.html
@@ -29,16 +29,18 @@
         </h4>
         <div class="panel panel-default">
           <div class="panel-body">
-            <form method="post" action="{% url 'login' %}">
-              {% csrf_token %}
-              {{ form|crispy }}
+            {% if login_email %}
+              <form method="post" action="{% url 'login' %}">
+                {% csrf_token %}
+                {{ form|crispy }}
 
-              <input type="hidden" name="next" value="{{ next }}" />
+                <input type="hidden" name="next" value="{{ next }}" />
 
-              <input type="submit"
-                     value="{% translate "Sign in" %}"
-                     class="btn btn-primary btn-full" />
-            </form>
+                <input type="submit"
+                       value="{% translate "Sign in" %}"
+                       class="btn btn-primary btn-full" />
+              </form>
+            {% endif %}
 
             {% if login_backends %}
 


### PR DESCRIPTION
In most cases there is single auth method and Weblate redirects, but in case more of them are configured, the login page is shown and shows form for disabled password authentication as well.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
