### PR TITLE
docs: clarify description of enforced checks

### DIFF
--- a/docs/admin/checks.rst
+++ b/docs/admin/checks.rst
@@ -368,7 +368,7 @@ This means that certain checks will be automatically enabled depending on where 
 Enforcing checks
 ----------------
 
-You can configure a list of checks which can not be ignored by setting
+You can configure a list of checks which can not be dismissed by setting
 :ref:`component-enforced_checks` in :ref:`component`. Each listed check can not
 be dismissed in the user interface and any string failing this check is marked as
 :guilabel:`Needs editing` (see :ref:`states`).

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -672,7 +672,7 @@ Customization of quality checks and other Weblate behavior, see :ref:`custom-che
 Enforced checks
 +++++++++++++++
 
-List of checks which can not be ignored, see :ref:`enforcing-checks`.
+List of checks which can not be dismissed, see :ref:`enforcing-checks`.
 
 .. note::
 

--- a/weblate/trans/migrations/0001_squashed_weblate_5.py
+++ b/weblate/trans/migrations/0001_squashed_weblate_5.py
@@ -869,7 +869,7 @@ class Migration(migrations.Migration):
                     models.JSONField(
                         blank=True,
                         default=list,
-                        help_text="List of checks which can not be ignored.",
+                        help_text="List of checks which can not be dismissed.",
                         verbose_name="Enforced checks",
                     ),
                 ),

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -589,7 +589,7 @@ class Component(
     )
     enforced_checks = models.JSONField(
         verbose_name=gettext_lazy("Enforced checks"),
-        help_text=gettext_lazy("List of checks which can not be ignored."),
+        help_text=gettext_lazy("List of checks which can not be dismissed."),
         default=list,
         blank=True,
     )


### PR DESCRIPTION
The original text was written in time when the button to hide failing check was called "Ignore" and this i t was okay to wtite "checks which can not be ignored". But the button is called "Dismiss" for years and the description is no longer consisten with it.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
