### PR TITLE
fix(utils): avoid using strxfrm on macOS 15

### DIFF
--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import locale
 import os
+import platform
 import re
 import sys
 from operator import itemgetter
@@ -52,8 +53,12 @@ CJK_PATTERN = re.compile(
     r"([\u1100-\u11ff\u2e80-\u2fdf\u2ff0-\u9fff\ua960-\ua97f\uac00-\ud7ff\uf900-\ufaff\ufe30-\ufe4f\uff00-\uffef\U0001aff0-\U0001b16f\U0001f200-\U0001f2ff\U00020000-\U0003FFFF]+)"
 )
 
-# Initialize to sane Unicode locales for strxfrm
-if locale.strxfrm("a") == "a":
+if platform.system() == "Darwin" and platform.mac_ver()[0].split(".", 1)[0] == "15":
+    # Avoid triggering strxfrm on macOS 15 where it either crashes with OSError
+    # or causes Python segmentation fault.
+    USE_STRXFRM = False
+elif locale.strxfrm("a") == "a":
+    # Initialize to sane Unicode locales for strxfrm
     try:
         locale.setlocale(locale.LC_ALL, ("en_US", "UTF-8"))
     except locale.Error:


### PR DESCRIPTION
In previous macOS 15 releases it crashed with OSError, with current macOS 15 release it seems to silently corrupt memory leading to segmentation fault after several executions.
    
Fixes #14645

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
