### PR TITLE
chore: improve error message for incompatible backups restore

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2443,10 +2443,12 @@ class ProjectImportForm(BillingMixin, forms.Form):
         try:
             backup.validate()
         except jsonschema.exceptions.ValidationError as error:
+            version = backup.data.get("metadata", {}).get("version", "unknown")
             raise ValidationError(
                 gettext(
-                    "Could not load project backup: The backup is from an incompatible version. Please upgrade your Weblate instance."
+                    "Could not load project backup: The backup is from an incompatible version (%(version)s). Please upgrade your Weblate instance."
                 )
+                % {"version": version}
             ) from error
         except Exception as error:
             raise ValidationError(


### PR DESCRIPTION
Trying to restore backups from a newer version of Weblate into an older version, for example hosted weblate to self-hosted stable release instance, can lead to errors. The full error message is very gnarly and not useful to users, hence replace such errors with a simpler message.

Fix #15372.