### PR TITLE
fix(docker): correctly set oidc title and image

### DIFF
--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -512,8 +512,8 @@ if SOCIAL_AUTH_OIDC_OIDC_ENDPOINT:
         "social_core.backends.open_id_connect.OpenIdConnectAuth",
     )
     SOCIAL_AUTH_OIDC_KEY = get_env_str("WEBLATE_SOCIAL_AUTH_OIDC_KEY", required=True)
-    SOCIAL_AUTH_AUTH0_TITLE = get_env_str("WEBLATE_SOCIAL_AUTH_OIDC_TITLE")
-    SOCIAL_AUTH_AUTH0_IMAGE = get_env_str("WEBLATE_SOCIAL_AUTH_OIDC_IMAGE")
+    SOCIAL_AUTH_OIDC_TITLE = get_env_str("WEBLATE_SOCIAL_AUTH_OIDC_TITLE")
+    SOCIAL_AUTH_OIDC_IMAGE = get_env_str("WEBLATE_SOCIAL_AUTH_OIDC_IMAGE")
     SOCIAL_AUTH_OIDC_SECRET = get_env_str(
         "WEBLATE_SOCIAL_AUTH_OIDC_SECRET", required=True
     )


### PR DESCRIPTION
Due to a copy-paste error, the OIDC title and images were set on the oauth0 OIDC title and image. This commit corrects it.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
