### PR TITLE
feat: use headers in the support menu

### DIFF
--- a/weblate/templates/base.html
+++ b/weblate/templates/base.html
@@ -373,13 +373,20 @@
                   </span>
                 </a>
                 <ul class="dropdown-menu">
+                  <li class="dropdown-header">{% translate "Get help" %}</li>
+                  <li>
+                    <a href="{% url 'contact' %}">{% translate "Contact server admins" %}</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/orgs/WeblateOrg/discussions">{% translate "Community discussions" %}</a>
+                  </li>
                   {% if support_status.has_support %}
                     <li>
-                      <a href="https://care.weblate.org/">{% translate "Weblate support" %}</a>
+                      <a href="https://care.weblate.org/">{% translate "Professional support" %}</a>
                     </li>
                   {% else %}
                     <li>
-                      <a href="https://weblate.org/support/">{% translate "Get support" %}</a>
+                      <a href="https://weblate.org/support/">{% translate "Get professional support" %}</a>
                     </li>
                     {% if get_help_url %}
                       <li>
@@ -387,32 +394,29 @@
                       </li>
                     {% endif %}
                   {% endif %}
-                  <li>
-                    <a href="https://github.com/orgs/WeblateOrg/discussions">{% translate "Weblate community" %}</a>
-                  </li>
 
+                  <li class="dropdown-header">{% translate "Documentation" %}</li>
                   <li>
-                    <a href="{% url 'contact' %}">{% translate "Contact site administrators" %}</a>
-                  </li>
-                  <li role="separator" class="divider"></li>
-                  <li>
-                    <a href="https://weblate.org/contribute/">{% translate "Contribute to Weblate" %}</a>
-                  </li>
-                  <li>
-                    <a href="{% url 'donate' %}">{% translate "Give to Weblate" %}</a>
-                  </li>
-                  <li role="separator" class="divider"></li>
-                  <li>
-                    <a href="{% url 'about' %}">{% blocktranslate %}About Weblate{% endblocktranslate %}</a>
-                  </li>
-                  <li>
-                    <a href="https://weblate.org/">{% translate "Weblate website" %}</a>
-                  </li>
-                  <li>
-                    <a href="{% documentation 'index' %}">{% translate "Weblate documentation" %}</a>
+                    <a href="{% documentation 'index' %}">{% translate "Documentation" %}</a>
                   </li>
                   <li>
                     <a id="shortcuts-btn" href="#">{% translate "Keyboard shortcuts" %}</a>
+                  </li>
+
+                  <li class="dropdown-header">{% translate "Weblate project" %}</li>
+                  <li>
+                    <a href="https://weblate.org/contribute/">{% translate "Contribute" %}</a>
+                  </li>
+                  {% if not support_status.has_support or support_status.is_hosted_weblate %}
+                    <li>
+                      <a href="{% url 'donate' %}">{% translate "Become a supporter" %}</a>
+                    </li>
+                  {% endif %}
+                  <li>
+                    <a href="{% url 'about' %}">{% translate "About" %}</a>
+                  </li>
+                  <li>
+                    <a href="https://weblate.org/">{% translate "Website" %}</a>
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
I think this better structures the menu items making it easier to navigate. Also hides the donate link for sites with purchased support.

After:

<img width="274" height="435" alt="image" src="https://github.com/user-attachments/assets/2e2a5b79-282e-41ef-af7b-a54e71e0a377" />


Before:

<img width="274" height="435" alt="image" src="https://github.com/user-attachments/assets/1808a377-3b6c-4c3a-9765-38e74885340a" />



<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
