### PR TITLE
fix(machinery): disable rephrashing in OpenAI for missing plurals

### DIFF
--- a/weblate/machinery/openai.py
+++ b/weblate/machinery/openai.py
@@ -143,7 +143,12 @@ class BaseOpenAITranslation(BatchMachineTranslation):
 
         # Separate rephrasing and new translations
         for text, unit in sources:
-            if unit is not None and unit.translated and not unit.readonly:
+            if (
+                unit is not None
+                and unit.translated
+                and not unit.readonly
+                and all(unit.get_target_plurals())
+            ):
                 rephrase.append((text, unit))
             else:
                 texts.append(text)


### PR DESCRIPTION
Rephrasing makes sense only when all plurals are translated, when they are not, it is better to complete translating those.

Fixes #15602

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
