### PR TITLE
feat(docs): filter out strings for translation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -49,6 +49,7 @@ locales/%/LC_MESSAGES/docs.po: locales/docs.pot
 
 locales/docs.pot: gettext
 	@cp _build/gettext/docs.pot $@
+	@./scripts/filter-docs-po.py $@
 
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/scripts/filter-docs-po.py
+++ b/scripts/filter-docs-po.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Remove strings which are not useful for translation from the documentation.
+
+Sphinx does not have a way to achieve that, so filter out strings at the PO file level.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+from translate.storage.pypo import pofile, pounit
+
+EXCLUDE_RE = re.compile(
+    r"""
+    ^(
+        [0-9]+                                      # Numbers
+        |
+        [A-Z]*_[A-Z_]*                              # Environment variables
+        |
+        ``[^`]*``                                   # Literals
+        |
+        :[a-z]*:`[a-z0-9./_\*-]*`                   # Simple roles
+        |
+        [<>]json[ ].*                               # API descriptions
+        |
+        :(ref|doc|setting|envvar):`[^<`]+`          # Unlabeled references
+    )$
+    """,
+    re.VERBOSE,
+)
+
+NAMES_RE = re.compile(r"^[a-z_]+$")
+
+if len(sys.argv) != 2:
+    print("Usage: ./scripts/filter-docs-po.py filename")
+    sys.exit(1)
+
+
+def should_skip(unit: pounit) -> bool:
+    if EXCLUDE_RE.match(unit.source):
+        return True
+    return bool(
+        any("admin/management.rst" in location for location in unit.getlocations())
+        and NAMES_RE.match(unit.source)
+    )
+
+
+storage = pofile.parsefile(sys.argv[1])
+
+storage.units = [unit for unit in storage.units if not should_skip(unit)]
+
+storage.save()


### PR DESCRIPTION
There are many strings which are not meant for translation in the documentation. This introduces tooling to filter out strings when generating POT files and migrates existing mark read-only rules from Weblate to it.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
