### PR TITLE
Multi-Level Rate Limiting for Notification E-Mails

### DIFF
--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -44,7 +44,7 @@ from weblate.trans.models import (
 )
 from weblate.utils.errors import report_error
 from weblate.utils.markdown import get_mention_users
-from weblate.utils.ratelimit import rate_limit
+from weblate.utils.ratelimit import multi_level_rate_limit
 from weblate.utils.site import get_site_domain, get_site_url
 from weblate.utils.stats import prefetch_stats
 from weblate.utils.version import USER_AGENT
@@ -282,11 +282,14 @@ class Notification:
         self, address: str, subject: str, body: str, headers: dict[str, str]
     ) -> None:
         encoded_email = siphash("Weblate notifier", address)
-        if rate_limit(f"notify:rate:{encoded_email}", 1000, 86400):
+        is_blocked, reason = multi_level_rate_limit(encoded_email, settings.RATELIMIT_NOTIFICATION_LIMITS)
+        
+        if is_blocked:
             LOGGER.info(
-                "discarding notification %s to %s after sending too many",
+                "discarding notification %s to %s due to rate limit: %s",
                 self.get_name(),
                 address,
+                reason,
             )
         else:
             self.outgoing.append(

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -950,6 +950,14 @@ DATABASE_BACKUP = "plain"
 # Enable auto updating
 AUTO_UPDATE = False
 
+# Multi-level rate limiting for email notifications
+# Each tuple contains (max_emails, time_window_seconds)
+RATELIMIT_NOTIFICATION_LIMITS = [
+    (3, 120),    # Prevent burst sends - 3 emails per 2 minutes
+    (10, 3600),  # Equalize to avoid getting blocked for too long - 10 emails per hour
+    (50, 86400), # Daily limit: 50 emails per day
+]
+
 # PGP commits signing
 WEBLATE_GPG_IDENTITY = None
 

--- a/weblate/utils/ratelimit.py
+++ b/weblate/utils/ratelimit.py
@@ -159,3 +159,57 @@ def session_ratelimit_post(scope: str, logout_user: bool = True):
         return wraps(function)(_rate_wrap)
 
     return _session_ratelimit_post_controller
+
+
+class RateLimitCache:
+    """Cache wrapper for rate limiting with atomic check/decrement operations."""
+    
+    def __init__(self, base_key: str, attempts: int, window: int):
+        self.cache_key = f"notify:rate:{base_key}:{attempts}:{window}"
+        self.attempts = attempts
+        self.window = window
+        
+        # Initialize the bucket (atomically on redis) if it doesn't exist
+        if not is_redis_cache():
+            if cache.get(self.cache_key) is None:
+                cache.set(self.cache_key, self.attempts, self.window)
+        else:
+            cast("RedisCache", cache).set(self.cache_key, self.attempts, self.window, nx=True)
+    
+    def would_block(self) -> bool:
+        """Check if rate limit would be exceeded without decrementing counter."""
+        
+        current = cache.get(self.cache_key, 0)
+        return current <= 0 
+    
+    def decrement(self) -> None:
+        """Decrement rate limit counter for an email that will be sent."""
+        
+        with suppress(ValueError):
+            cache.decr(self.cache_key)
+
+
+def multi_level_rate_limit(encoded_email: str, rate_limits) -> tuple[bool, str]:
+    """
+    Multi-level rate limiting for email notifications.
+    
+    Returns:
+        tuple: (is_blocked, reason)
+    """
+
+    level_caches = [
+        RateLimitCache(encoded_email, attempts, window)
+        for attempts, window in rate_limits
+    ]
+    
+    # Check all without decrementing
+    for level_cache in level_caches:
+        if level_cache.would_block():
+            return True, f"rate limit exceeded ({level_cache.attempts}/{level_cache.window}s)"
+    
+    # If we get here, we can send - so decrement ALL counters
+    for level_cache in level_caches:
+        level_cache.decrement()
+    
+    return False, ""
+


### PR DESCRIPTION
Multi-Level Rate Limiting for Notification E-Mails

Yesterday, a user had received almost 1000 notification e-mails after enabling notifications on new strings.

I've seen that there's a hardcoded rate lmit of 1000 e-mails per user per day - which is not much of a limit of course.
The problem why it's often increased after introduction, is that users get cut off from receiving e-mails for  any hours.

For example: User recives 1000 e-mails at once within 1h - then they are blocked from receiving any further e-mails for 23h.

A multi-level rate-limt method allows to equalize this and avoid bursts.
You'll probably  want to change the default values. The number of levels is not fixed. You can also define just one level with the previous values and you get the same result like before (if somebody really wants that).
