### PR TITLE
Add REDIS_USER env variable

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1633,6 +1633,10 @@ instance when running Weblate in Docker.
 
     The Redis database number, defaults to ``1``.
 
+.. envvar:: REDIS_USER
+
+    The Redis database user, not used by default.
+
 .. envvar:: REDIS_PASSWORD
 
     The Redis server password, not used by default.

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1635,6 +1635,8 @@ instance when running Weblate in Docker.
 
 .. envvar:: REDIS_USER
 
+   .. versionadded:: 5.13
+
     The Redis database user, not used by default.
 
 .. envvar:: REDIS_PASSWORD

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1241,8 +1241,10 @@ ALLOWED_HOSTS = get_env_list("WEBLATE_ALLOWED_HOSTS", ["*"])
 REDIS_PASSWORD = get_env_str("REDIS_PASSWORD")
 REDIS_USER = get_env_str("REDIS_USER")
 REDIS_USER_PASSWORD = (
-    f"{REDIS_USER}:{REDIS_PASSWORD}" if REDIS_USER and REDIS_PASSWORD
-    else f":{REDIS_PASSWORD}" if REDIS_PASSWORD
+    f"{REDIS_USER}:{REDIS_PASSWORD}"
+    if REDIS_USER and REDIS_PASSWORD
+    else f":{REDIS_PASSWORD}"
+    if REDIS_PASSWORD
     else REDIS_USER  # can be None
 )
 REDIS_PROTO = "rediss" if get_env_bool("REDIS_TLS") else "redis"

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1248,24 +1248,23 @@ REDIS_USER_PASSWORD = (
     else REDIS_USER  # can be None
 )
 REDIS_PROTO = "rediss" if get_env_bool("REDIS_TLS") else "redis"
+REDIS_URL = "{}://{}{}:{}/{}".format(
+    REDIS_PROTO,
+    f"{REDIS_USER_PASSWORD}@" if REDIS_USER_PASSWORD else "",
+    get_env_str("REDIS_HOST", "cache", required=True),
+    get_env_int("REDIS_PORT", 6379),
+    get_env_int("REDIS_DB", 1)
+)
 
 # Configuration for caching
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "{}://{}{}:{}/{}".format(
-            REDIS_PROTO,
-            f"{REDIS_USER}@" if REDIS_USER else "",
-            get_env_str("REDIS_HOST", "cache", required=True),
-            get_env_int("REDIS_PORT", 6379),
-            get_env_int("REDIS_DB", 1),
-        ),
+        "LOCATION": REDIS_URL,
         # If redis is running on same host as Weblate, you might
         # want to use unix sockets instead:
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            # If you set password here, adjust CELERY_BROKER_URL as well
-            "PASSWORD": REDIS_PASSWORD or None,
             "CONNECTION_POOL_KWARGS": {},
         },
         "KEY_PREFIX": "weblate",
@@ -1380,13 +1379,7 @@ SILENCED_SYSTEM_CHECKS.extend(get_env_list("WEBLATE_SILENCED_SYSTEM_CHECKS"))
 
 # Celery worker configuration for production
 CELERY_TASK_ALWAYS_EAGER = get_env_bool("WEBLATE_CELERY_EAGER")
-CELERY_BROKER_URL = "{}://{}{}:{}/{}".format(
-    REDIS_PROTO,
-    f"{REDIS_USER_PASSWORD}@" if REDIS_USER_PASSWORD else "",
-    get_env_str("REDIS_HOST", "cache", required=True),
-    get_env_int("REDIS_PORT", 6379),
-    get_env_int("REDIS_DB", 1),
-)
+CELERY_BROKER_URL = REDIS_URL
 if REDIS_PROTO == "rediss":
     CELERY_BROKER_URL = "{}?ssl_cert_reqs={}".format(
         CELERY_BROKER_URL,

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1239,14 +1239,21 @@ ALLOWED_HOSTS = get_env_list("WEBLATE_ALLOWED_HOSTS", ["*"])
 
 # Extract redis password
 REDIS_PASSWORD = get_env_str("REDIS_PASSWORD")
+REDIS_USER = get_env_str("REDIS_USER")
+REDIS_USER_PASSWORD = (
+    f"{REDIS_USER}:{REDIS_PASSWORD}" if REDIS_USER and REDIS_PASSWORD
+    else f":{REDIS_PASSWORD}" if REDIS_PASSWORD
+    else REDIS_USER  # can be None
+)
 REDIS_PROTO = "rediss" if get_env_bool("REDIS_TLS") else "redis"
 
 # Configuration for caching
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "{}://{}:{}/{}".format(
+        "LOCATION": "{}://{}{}:{}/{}".format(
             REDIS_PROTO,
+            f"{REDIS_USER}@" if REDIS_USER else "",
             get_env_str("REDIS_HOST", "cache", required=True),
             get_env_int("REDIS_PORT", 6379),
             get_env_int("REDIS_DB", 1),
@@ -1373,7 +1380,7 @@ SILENCED_SYSTEM_CHECKS.extend(get_env_list("WEBLATE_SILENCED_SYSTEM_CHECKS"))
 CELERY_TASK_ALWAYS_EAGER = get_env_bool("WEBLATE_CELERY_EAGER")
 CELERY_BROKER_URL = "{}://{}{}:{}/{}".format(
     REDIS_PROTO,
-    f":{REDIS_PASSWORD}@" if REDIS_PASSWORD else "",
+    f"{REDIS_USER_PASSWORD}@" if REDIS_USER_PASSWORD else "",
     get_env_str("REDIS_HOST", "cache", required=True),
     get_env_int("REDIS_PORT", 6379),
     get_env_int("REDIS_DB", 1),

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1253,7 +1253,7 @@ REDIS_URL = "{}://{}{}:{}/{}".format(
     f"{REDIS_USER_PASSWORD}@" if REDIS_USER_PASSWORD else "",
     get_env_str("REDIS_HOST", "cache", required=True),
     get_env_int("REDIS_PORT", 6379),
-    get_env_int("REDIS_DB", 1)
+    get_env_int("REDIS_DB", 1),
 )
 
 # Configuration for caching


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->

Adds support for REDIS_USER env variable as per #15674 

No automatic tests exist for `settings_docker.py`, so I tested this manually to ensure that keeping REDIS_USER blank will not change current behaviour.