### PR TITLE
fix(component): avoid push if needed for not commited changes

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -734,8 +734,15 @@ class Translation(
             changes_status = self.update_units(changes, store, author_name)
             all_changes_status.update(changes_status)
 
-            # Commit changes
-            self.git_commit(user, author_name, timestamp, skip_push=True, signals=False)
+            # Commit changes if there was anything written out
+            if any(changes_status.values()):
+                self.git_commit(
+                    user, author_name, timestamp, skip_push=True, signals=False
+                )
+
+        # Short-circuit when no changes were processed
+        if not any(all_changes_status.values()):
+            return False
 
         # A pending change can be deleted from the database:
         # 1. Always, if it has been applied successfully.


### PR DESCRIPTION
When a change cannot be committed, do not trigger optional push.

Otherwise we end up in an infinite recursion Component.do_update -> Component.commit_pending -> Component.push_if_needed -> Component.do_push -> Component.do_update

Issue #15691

I think this answers why an attempt to commit in #15691 happens so often. Still, we need a solution to make the failed commit less noisy.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
