### PR TITLE
fix(zen): remove check for changes in editor when saving

### DIFF
--- a/weblate/static/editor/zen.js
+++ b/weblate/static/editor/zen.js
@@ -154,6 +154,7 @@
       $row.removeData("focus-timer");
     }
   });
+
   $document.on("focusout", ".translation-editor", function () {
     const $this = $(this);
     const $row = $this.closest("tr");
@@ -194,11 +195,6 @@
     // First save
     if (lastPayload === undefined) {
       statusdiv.data("last-payload", payload);
-      // Check if the editor doesn't have changes
-      if (!$this.closest(".translation-editor").hasClass("has-changes")) {
-        statusdiv.removeClass("unit-state-save-timeout");
-        return;
-      }
     }
     // Guard: skip if nothing has changed
     if (payload === lastPayload) {


### PR DESCRIPTION
We're already checking for has-changes in the focusout handler and this check in the save handler was blocking saves of review state

fixes #15668 

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
