### PR TITLE
fix(glossary): update stats after glossary sync

### DIFF
--- a/weblate/glossary/tests.py
+++ b/weblate/glossary/tests.py
@@ -423,6 +423,10 @@ class GlossaryTest(TransactionsTestMixin, ViewTestCase):
         self.assertEqual(Unit.objects.count(), start + 4)
         self.assertEqual(unit.unit_set.count(), 4)
 
+        # Verify stats have been updated
+        translation = self.glossary_component.translation_set.get(language_code="de")
+        self.assertEqual(translation.stats.all, translation.unit_set.count())
+
         # Terminology sync should be no-op now
         sync_terminology(unit.translation.component.id, unit.translation.component)
         self.assertEqual(Unit.objects.count(), start + 4)

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1937,12 +1937,14 @@ class Translation(
             return
         expected_count = self.component.translation_set.count()
         author: User | None = None
+        added: bool = False
         for source in self.component.get_all_sources():
             # Is the string a terminology
             if "terminology" not in source.all_flags:
                 continue
             if source.unit_set.count() == expected_count:
                 continue
+            added = True
             if author is None:
                 author = User.objects.get_or_create_bot(
                     scope="glossary",
@@ -1959,7 +1961,9 @@ class Translation(
                 skip_existing=True,
                 author=author,
             )
-        self.store_update_changes()
+        if added:
+            self.store_update_changes()
+            self.component.invalidate_cache()
 
     def validate_new_unit_data(
         self,


### PR DESCRIPTION
As the stats are not updated during individual units sync, it needs to be updated after all work has been done.

Fixes #15704

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
