### PR TITLE
chore(formats): directly use pypo implementation for gettext PO

### DIFF
--- a/weblate/formats/convert.py
+++ b/weblate/formats/convert.py
@@ -26,7 +26,7 @@ from translate.storage.html import htmlfile
 from translate.storage.idml import INLINE_ELEMENTS, NO_TRANSLATE_ELEMENTS, open_idml
 from translate.storage.odf_io import open_odf
 from translate.storage.odf_shared import inline_elements, no_translate_content_elements
-from translate.storage.po import pofile
+from translate.storage.pypo import pofile
 from translate.storage.rc import rcfile
 from translate.storage.txt import TxtFile
 from translate.storage.xliff import xlifffile

--- a/weblate/formats/exporters.py
+++ b/weblate/formats/exporters.py
@@ -17,9 +17,9 @@ from translate.storage.aresource import AndroidResourceFile
 from translate.storage.csvl10n import csvfile
 from translate.storage.jsonl10n import JsonFile, JsonNestedFile
 from translate.storage.mo import mofile
-from translate.storage.po import pofile
 from translate.storage.poxliff import PoXliffFile
 from translate.storage.properties import stringsutf8file
+from translate.storage.pypo import pofile
 from translate.storage.tbx import tbxfile
 from translate.storage.tmx import tmxfile
 from translate.storage.xliff import xlifffile

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -16,7 +16,7 @@ from typing import NoReturn
 from unittest import TestCase
 
 from lxml import etree
-from translate.storage.po import pofile
+from translate.storage.pypo import pofile
 
 from weblate.checks.flags import Flags
 from weblate.formats.auto import AutodetectFormat, detect_filename, try_load

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -31,8 +31,8 @@ from translate.storage.catkeys import CatkeysFile
 from translate.storage.csvl10n import csvunit
 from translate.storage.jsonl10n import BaseJsonUnit, JsonFile
 from translate.storage.lisa import LISAfile
-from translate.storage.po import pofile, pounit
 from translate.storage.poxliff import PoXliffFile
+from translate.storage.pypo import pofile, pounit
 from translate.storage.resx import RESXFile
 from translate.storage.tbx import tbxfile, tbxunit
 from translate.storage.ts2 import tsfile, tsunit


### PR DESCRIPTION
Weblate relies it for many features and shadowing it behind translate.storage.po make this non-transparent, especially to type checkers.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
