### PR TITLE
fix(translate): hide needs editing checkbox on read-only strings

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -517,8 +517,9 @@ class TranslationForm(UnitForm):
             kwargs["auto_id"] = f"id_{unit.checksum}_%s"
         super().__init__(unit, *args, **kwargs)
         if unit.readonly:
-            for field in ["target", "fuzzy", "review"]:
-                self.fields[field].widget.attrs["readonly"] = 1
+            self.fields["target"].widget.attrs["readonly"] = 1
+            # checkbox cannot be read-only, so hide it instead
+            self.fields["fuzzy"].widget = forms.HiddenInput()
             self.fields["review"].choices = [
                 (state, label)
                 for state, label in StringState.choices


### PR DESCRIPTION
It was rendered with the readonly attribute, but it doesn't work for checkboxes in HTML, only for inputs.

Fixes #15685

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
