### PR TITLE
chore: turn zipfile warnings into errors

### DIFF
--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from collections import defaultdict
 from datetime import datetime
 from functools import partial
@@ -56,6 +57,8 @@ if TYPE_CHECKING:
     from django.db.models import Model
 
     from weblate.billing.models import Billing
+
+warnings.filterwarnings("error", module="zipfile")
 
 PROJECTBACKUP_PREFIX = "projectbackups"
 


### PR DESCRIPTION
Turn warnings from zipfile module into errors. Fixes #15665.

1. Tested manually by applying the same fix to Weblate 5.10 and the warning is turned into an error. I couldn't add a test for this to the tests because pytest's warning configuration seems to take precedence during tests.
2. I do see the errors in the logs but I don't think errors in the backup process are surfaced to the user (at least in Weblate 5.10).
3. I am not sure if the best place for the warnings filter is the backup file itself. Off the top of my head, I can't think of other places that create zip files. The best place would be `settings.py` I guess as it would then apply always but that requires existing installations to manually update their settings files which is not ideal.