### PR TITLE
Add option to hide glossary matches

### DIFF
--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -629,6 +629,24 @@ notification about any source string comments made in Weblate.
 With the :ref:`gettext` format, this address is also saved by Weblate in the
 :mailheader:`Report-Msgid-Bugs-To` header of the file.
 
+.. _component-hide_glossary_matches:
+
+Do not show glossary matches
+++++++++++++++++++++++++++++
+
+Hides the glossary panel and its matches in the translation editor for this component.
+When enabled, glossary suggestions for this component are not computed and the Glossary
+panel (including its “Add term to glossary” action) is hidden in the editor.
+
+Notes:
+- Glossary self-references are always excluded from matches even when this option is disabled.
+- Newly created glossary components enable this by default.
+
+.. seealso::
+
+   * :ref:`glossary`
+   * :ref:`component-is_glossary`
+
 .. _component-allow_translation_propagation:
 
 Allow translation propagation

--- a/docs/specs/schemas/weblate-component.schema.json
+++ b/docs/specs/schemas/weblate-component.schema.json
@@ -33,6 +33,7 @@
         "new_base",
         "file_format",
         "locked",
+        "hide_glossary_matches",
         "allow_translation_propagation",
         "enable_suggestions",
         "suggestion_voting",
@@ -172,6 +173,11 @@
         "locked": {
           "$id": "#root/component/locked",
           "title": "Locked",
+          "type": "boolean"
+        },
+        "hide_glossary_matches": {
+          "$id": "#root/component/hide_glossary_matches",
+          "title": "Do not show glossary matches",
           "type": "boolean"
         },
         "allow_translation_propagation": {

--- a/weblate/checks/tests/test_checks.py
+++ b/weblate/checks/tests/test_checks.py
@@ -72,6 +72,7 @@ class MockComponent:
         self.name = "MockComponent"
         self.file_format = "auto"
         self.is_multivalue = False
+        self.hide_glossary_matches = False
 
 
 class MockTranslation:

--- a/weblate/glossary/models.py
+++ b/weblate/glossary/models.py
@@ -109,6 +109,10 @@ def fetch_glossary_terms(  # noqa: C901
         project = component.project
         source_language = component.source_language
 
+        # Do not get glossary matches when display is disabled
+        if component.hide_glossary_matches:
+            continue
+
         # Short circuit source language
         if language == source_language:
             continue
@@ -153,6 +157,11 @@ def fetch_glossary_terms(  # noqa: C901
             base_units = get_glossary_units(project, source_language, language)
             # Variant is used for variant grouping below, source unit for flags
             base_units = base_units.select_related("source_unit", "variant")
+
+            # Exclude currently edited unit items to prevent self-referencing glossary items
+            current_unit_ids = [u.pk for u in translation_units[translation_id] if u.pk]
+            if current_unit_ids:
+                base_units = base_units.exclude(pk__in=current_unit_ids)
 
             if full:
                 # Include full details needed for rendering

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -685,40 +685,42 @@
         {% endif %}
 
 
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h4 class="panel-title">
-              {% for glossary in unit.translation.get_glossaries %}
-                <a class="pull-right flip btn btn-link btn-xs btn-{{ glossary.component.glossary_color }}"
-                   title="{% blocktranslate with name=glossary.component.name %}Browse glossary {{ name }}{% endblocktranslate %}"
-                   href="{% url 'browse' glossary.get_url_path %}">{% icon "folder-search-outline.svg" %}</a>
-              {% endfor %}
-              {% loading_icon "glossary-add" %}
-              {% translate "Glossary" %}
-            </h4>
-          </div>
-          <table class="table table-condensed table-simple">
-            <thead>
-              <tr>
-                <th>{{ unit.translation.component.source_language }}</th>
-                <th>{{ unit.translation.language }}</th>
-                <th></th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody id="glossary-terms">
-              {% include "snippets/glossary.html" %}
-            </tbody>
-          </table>
-          {% if user_can_add_glossary and addterm_form.fields.translation.queryset %}
-            <div class="panel-footer panel-footer-links">
-              <a class="btn btn-link green"
-                 href="#"
-                 data-toggle="modal"
-                 data-target="#add-glossary-form">{% icon "plus-circle.svg" %} {% translate "Add term to glossary" %}</a>
+        {% if not unit.translation.component.hide_glossary_matches %}
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h4 class="panel-title">
+                {% for glossary in unit.translation.get_glossaries %}
+                  <a class="pull-right flip btn btn-link btn-xs btn-{{ glossary.component.glossary_color }}"
+                     title="{% blocktranslate with name=glossary.component.name %}Browse glossary {{ name }}{% endblocktranslate %}"
+                     href="{% url 'browse' glossary.get_url_path %}">{% icon "folder-search-outline.svg" %}</a>
+                {% endfor %}
+                {% loading_icon "glossary-add" %}
+                {% translate "Glossary" %}
+              </h4>
             </div>
-          {% endif %}
-        </div>
+            <table class="table table-condensed table-simple">
+              <thead>
+                <tr>
+                  <th>{{ unit.translation.component.source_language }}</th>
+                  <th>{{ unit.translation.language }}</th>
+                  <th></th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="glossary-terms">
+                {% include "snippets/glossary.html" %}
+              </tbody>
+            </table>
+            {% if user_can_add_glossary and addterm_form.fields.translation.queryset %}
+              <div class="panel-footer panel-footer-links">
+                <a class="btn btn-link green"
+                   href="#"
+                   data-toggle="modal"
+                   data-target="#add-glossary-form">{% icon "plus-circle.svg" %} {% translate "Add term to glossary" %}</a>
+              </div>
+            {% endif %}
+          </div>
+        {% endif %}
 
         <div class="panel panel-default string-info">
           <div class="panel-heading">
@@ -1015,7 +1017,7 @@
       <!-- /.modal -->
     </form>
   {% endif %}
-  {% if user_can_add_glossary and addterm_form.fields.translation.queryset %}
+  {% if not unit.translation.component.hide_glossary_matches and user_can_add_glossary and addterm_form.fields.translation.queryset %}
     <form action="{% url 'js-add-glossary' unit_id=unit.id %}"
           method="post"
           class="add-dict-inline double-submission">

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1526,6 +1526,7 @@ class ComponentSettingsForm(
             "report_source_bugs",
             "license",
             "agreement",
+            "hide_glossary_matches",
             "allow_translation_propagation",
             "contribute_project_tm",
             "enable_suggestions",
@@ -1626,6 +1627,7 @@ class ComponentSettingsForm(
                     ),
                     Fieldset(
                         gettext("Translation settings"),
+                        "hide_glossary_matches",
                         "allow_translation_propagation",
                         "contribute_project_tm",
                         "manage_units",

--- a/weblate/trans/migrations/0046_component_hide_glossary_matches.py
+++ b/weblate/trans/migrations/0046_component_hide_glossary_matches.py
@@ -1,0 +1,23 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0045_alter_change_action"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="component",
+            name="hide_glossary_matches",
+            field=models.BooleanField(
+                default=False,
+                verbose_name="Do not show glossary matches",
+                help_text="Hides the glossary panel in the translation editor.",
+            ),
+        ),
+    ]

--- a/weblate/trans/migrations/0047_set_hide_glossary_matches.py
+++ b/weblate/trans/migrations/0047_set_hide_glossary_matches.py
@@ -1,0 +1,21 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    Component = apps.get_model("trans", "Component")
+    # For glossary components, hide  hide glossary matches by default
+    Component.objects.filter(is_glossary=True).update(hide_glossary_matches=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0046_component_hide_glossary_matches"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -540,6 +540,11 @@ class Component(
             "Locked component will not get any translation updates."
         ),
     )
+    hide_glossary_matches = models.BooleanField(
+        verbose_name=gettext_lazy("Do not show glossary matches"),
+        default=False,
+        help_text=gettext_lazy("Hides the glossary panel in the translation editor."),
+    )
     allow_translation_propagation = models.BooleanField(
         verbose_name=gettext_lazy("Allow translation propagation"),
         default=settings.DEFAULT_TRANSLATION_PROPAGATION,
@@ -1127,6 +1132,7 @@ class Component(
             is_glossary=True,
             has_template=False,
             allow_translation_propagation=False,
+            hide_glossary_matches=True,
             license=self.license,
         )
 


### PR DESCRIPTION
This PR adds an option to hide the glossary panel in the translation editor:

<img width="1221" height="492" alt="image" src="https://github.com/user-attachments/assets/4eb7435a-34c4-4705-97c8-fd4cfd07f4a2" />

The option is enabled by default for glossary components.
(might be debatable)

The rationale behind this is this:

- A glossary component can be used for various purposes, like
  - Adding explanations for translators
  - Providing/enforcing consistent translations of specific terms
  - Indicating certain terms as non-translatable
- In all of those (and probably most other) cases, the glossary component is meant to be NORMATIVE and binding for translators to follow
- In this regard, a glossary is logically the SOURCE of information, and shouldn't depend on or take input from other glossary components

=> That's why I think that a glossary should not show matches form itself or other glossary components

BTW, I also think that "Contribute to project translation memory" and "Allow translation propagation" should be off by default for glossary components.


This PR also includes a related fix:

Also prevents showing self-referencing matches in glossary panel (regardless of the new option)

Currently, when editing a glossary entry, you see that exact entry in the glossary panel..