### PR TITLE
fix(bulk-edit): filter out strings at the database level

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -2103,7 +2103,9 @@ class Component(
         for unit in Unit.objects.filter(
             Q(translation__component=self)
             | Q(translation__component__linked_component=self)
-        ).exclude(translation__language_id=self.source_language_id):
+        ).exclude(
+            translation__language_id=self.source_language_id, translation__filename=""
+        ):
             PendingUnitChange.store_unit_change(unit)
 
         self.change_set.create(


### PR DESCRIPTION
This is way more effective than doing it later. Also filters out strings without backing file which cannot be edited.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
