### PR TITLE
Hide screenshot modal details link when no URL is available

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -764,9 +764,15 @@ $(function () {
     $("#screenshotModal").text($this.attr("title"));
 
     const detailsLink = $("#modalDetailsLink");
-    detailsLink.attr("href", this.getAttribute("data-details-url"));
-    if (this.getAttribute("data-can-edit")) {
-      detailsLink.text(detailsLink.getAttribute("data-edit-text"));
+    const detailsUrl = this.getAttribute("data-details-url");
+    if (detailsUrl) {
+      detailsLink.attr("href", detailsUrl).show();
+      if (this.getAttribute("data-can-edit")) {
+        detailsLink.text(detailsLink.getAttribute("data-edit-text"));
+      }
+    } else {
+      // No details for generic images (static pages) — hide the button
+      detailsLink.hide();
     }
 
     $("#imagemodal").modal("show");


### PR DESCRIPTION
Check data-details-url to hide the screenshot-details button for non-screenshot images.

This allows to use the thumbnail feature to be used for non-screenshot images.