### PR TITLE
Change default values of XMLClosingTags

### DIFF
--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -1033,6 +1033,15 @@ class TSFormatTest(XMLMixin, BaseFormatTest):
         testdata = testdata.replace(b"<!DOCTYPE TS>", b"")
         super().assert_same(newdata, testdata)
 
+    def test_default_self_closing_tag(self) -> None:
+        """Test that location tag is self-closed by default."""
+        storage = self.parse_file(self.FILE)
+        unit = storage.all_units[0]
+        unit.mainunit.addlocation("main.c:11")
+        serialized = self.format_class.serialize(storage.store)
+        self.assertIn(b'<location filename="main.c" line="11"/>', serialized)
+        self.assertNotIn(rb"<\location>", serialized)
+
 
 class DTDFormatTest(BaseFormatTest):
     format_class = DTDFormat

--- a/weblate/trans/file_format_params.py
+++ b/weblate/trans/file_format_params.py
@@ -216,7 +216,7 @@ class GettextNoLocation(BaseGettextFormatParam):
     name = "po_no_location"
     label = gettext_lazy("Do not include location information in the file")
     field_class = forms.BooleanField
-    default = False
+    default = True
 
 
 @register_file_format_param
@@ -224,7 +224,7 @@ class GettextFuzzyMatching(BaseGettextFormatParam):
     name = "po_fuzzy_matching"
     label = gettext_lazy("Use fuzzy matching")
     field_class = forms.BooleanField
-    default = True
+    default = False
 
 
 class BaseYAMLFormatParam(BaseFileFormatParam):
@@ -291,7 +291,7 @@ class XMLClosingTags(BaseFileFormatParam):
     name = "xml_closing_tags"
     label = gettext_lazy("Include closing tag for blank XML tags")
     field_class = forms.BooleanField
-    default = True
+    default = False
 
     @classproperty
     def file_formats(self) -> Sequence[str]:


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
Now the default behavior of file format params matches the one without the corresponding addons
- fixes #15888 