### PR TITLE
fix(ui): only apply styling to auth icons in dark mode to certain icons

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1627,6 +1627,16 @@ $(function () {
     form.submit();
   });
 
+  /* Allow styling of auth icons that we ship */
+  document.querySelectorAll(".auth-image").forEach((el) => {
+    src = el.getAttribute("src");
+    if (src !== null) {
+      if ((src.endsWith("password.svg")) || src.endsWith("email.svg")) {
+        el.classList.add("auth-image-filter");
+      }
+    }
+  })
+
   /* Warn users that they do not want to use developer console in most cases */
   console.log(
     "%c%s",

--- a/weblate/static/style-dark.css
+++ b/weblate/static/style-dark.css
@@ -2943,7 +2943,7 @@ tbody.warning {
   border: 1px solid #dabc87 !important;
 }
 
-.auth-image {
+.auth-image-filter {
   filter: invert(90%) sepia(19%) saturate(258%) hue-rotate(316deg)
     brightness(108%) contrast(102%);
 }


### PR DESCRIPTION
Fixes #15901 by applying the class only to `password.svg` and `email.svg` using javascript.

@nijel are there any other icons that need recoloring for dark mode? Looking at it we may also want to extend this to the X and GitHub icons. 

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
