### PR TITLE
fix(machinery): LibreTranslate 1.7.0 compatiblity

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 5.13.1
 
 * Access control for :http:get:`/api/users/(str:username)/`.
 * :ref:`file_format_params` were not properly applied in some situations.
+* :ref:`mt-libretranslate` compatibility with LibreTranslate 1.7.0.
 
 .. rubric:: Compatibility
 

--- a/weblate/machinery/libretranslate.py
+++ b/weblate/machinery/libretranslate.py
@@ -20,9 +20,6 @@ class LibreTranslateTranslation(BatchMachineTranslation):
 
     name = "LibreTranslate"
     max_score = 89
-    language_map = {
-        "zh_Hans": "zh",
-    }
     settings_form = LibreTranslateMachineryForm
     request_timeout = 20
 
@@ -32,6 +29,10 @@ class LibreTranslateTranslation(BatchMachineTranslation):
             self.get_api_url("languages"),
         )
         return [x["code"] for x in response.json()]
+
+    def map_language_code(self, code):
+        """Convert language to service specific code."""
+        return super().map_language_code(code).replace("_", "-")
 
     def download_multiple_translations(
         self,


### PR DESCRIPTION
LibreTranslate now uses ISO codes instead of model ones, so the logic needs to be adjusted.

Fixes #15967

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
