### PR TITLE
fix(auth): shorten session expiry while in 2fa

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1812,6 +1812,16 @@ Configure sampling rate for profiling monitoring. Set to 1 to trace all events, 
 
    `Sentry Profiling <https://docs.sentry.io/product/explore/profiling/>`_
 
+.. setting:: SESSION_COOKIE_AGE_2FA
+
+SESSION_COOKIE_AGE_2FA
+----------------------
+
+.. versionadded:: 5.13.1
+
+Set session expiry while in :ref:`2fa`. This complements
+:setting:`django:SESSION_COOKIE_AGE` which is used for unauthenticated users.
+
 .. setting:: SESSION_COOKIE_AGE_AUTHENTICATED
 
 SESSION_COOKIE_AGE_AUTHENTICATED

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,7 @@ Weblate 5.13.1
 * Access control for :http:get:`/api/users/(str:username)/`.
 * :ref:`file_format_params` were not properly applied in some situations.
 * :ref:`mt-libretranslate` compatibility with LibreTranslate 1.7.0.
+* Shorten session expiry while in :ref:`2fa`.
 
 .. rubric:: Compatibility
 
@@ -20,6 +21,8 @@ Weblate 5.13.1
 .. rubric:: Upgrading
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
+
+* There is a change in :file:`settings_example.py`, ``django_otp.middleware.OTPMiddleware`` was removed from ``MIDDLEWARE``; please adjust your settings accordingly.
 
 .. rubric:: Contributors
 

--- a/weblate/accounts/pipeline.py
+++ b/weblate/accounts/pipeline.py
@@ -455,7 +455,7 @@ def notify_connect(
             action = "auth-connect"
         else:
             action = "login"
-            adjust_session_expiry(strategy.request)
+            adjust_session_expiry(request=strategy.request, user=user)
         AuditLog.objects.create(
             user,
             strategy.request,

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -62,6 +62,7 @@ from weblate.utils.validators import CRUD_RE, validate_fullname, validate_userna
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
+    from django_otp.models import Device
     from social_core.backends.base import BaseAuth
     from social_django.models import DjangoStorage
     from social_django.strategy import DjangoStrategy
@@ -506,6 +507,9 @@ class User(AbstractBaseUser):
     # social_auth integration
     social_auth: DjangoStorage
 
+    # django_otp integration (via OTPMiddleware)
+    otp_device: Device
+
     EMAIL_FIELD = "email"
     USERNAME_FIELD = "username"
     REQUIRED_FIELDS = ["email", "full_name"]
@@ -593,6 +597,10 @@ class User(AbstractBaseUser):
     @cached_property
     def is_anonymous(self):
         return self.username == settings.ANONYMOUS_USER_NAME
+
+    def is_verified(self) -> bool:
+        # django_otp overrides this method in OTPMiddleware
+        return False
 
     @cached_property
     def is_authenticated(self) -> bool:  # type: ignore[override]
@@ -1253,7 +1261,9 @@ class WeblateAuthConf(AppConf):
 
     # Anonymous user name
     ANONYMOUS_USER_NAME = "anonymous"
+
     SESSION_COOKIE_AGE_AUTHENTICATED = 1209600
+    SESSION_COOKIE_AGE_2FA = 180
 
     class Meta:
         prefix = ""

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -707,7 +707,6 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "weblate.accounts.middleware.AuthenticationMiddleware",
-    "django_otp.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -395,7 +395,6 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "weblate.accounts.middleware.AuthenticationMiddleware",
-    "django_otp.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",


### PR DESCRIPTION
The 2fa should have a short session expiry as this is expected to happen interactively. Previously 2fa input got the session expiry for authenticated users what was wrong.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
