### PR TITLE
fix(add-ons): avoid crash when listing unknown add-ons

### DIFF
--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -623,6 +623,28 @@ class ViewTests(ViewTestCase):
         response = self.client.get(reverse("addons", kwargs=self.kw_component))
         self.assertContains(response, "Generate MO files")
 
+    def test_nonexisting(self) -> None:
+        identifier = "weblate.addon.nonexisting"
+        # Use bulk_create to avoid hitting save() which relies on class existence
+        Addon.objects.bulk_create([Addon(component=self.component, name=identifier)])
+
+        # Listing of unknown add-on should not crash
+        response = self.client.get(reverse("addons", kwargs=self.kw_component))
+        self.assertContains(response, "Generate MO files")
+        self.assertContains(response, identifier)
+
+        # Deleting unknown add-on should work
+        addon = Addon.objects.get(name=identifier)
+        response = self.client.post(
+            addon.get_absolute_url(), {"delete": "1"}, follow=True
+        )
+        self.assertContains(response, "No add-ons currently installed")
+        self.assertContains(response, "Generate MO files")
+        # History entry
+        self.assertContains(response, identifier)
+
+        self.assertFalse(Addon.objects.filter(name=identifier).exists())
+
     def test_addon_logs(self) -> None:
         response = self.client.post(
             reverse("addons", kwargs=self.kw_component),

--- a/weblate/addons/views.py
+++ b/weblate/addons/views.py
@@ -74,7 +74,7 @@ class AddonList(PathViewMixin, ListView):
             result["last_changes"] = target.change_set.filter(
                 action__in=Change.ACTIONS_ADDON, component=None
             ).order()[:10]
-        installed = {x.addon.name for x in result["object_list"]}
+        installed = {x.addon_name for x in result["object_list"]}
 
         if isinstance(target, Component):
             result["available"] = sorted(

--- a/weblate/templates/addons/addon_list.html
+++ b/weblate/templates/addons/addon_list.html
@@ -49,7 +49,13 @@
           <tbody>
             {% for addon in object_list %}
               <tr>
-                <td>{% include 'addons/addon_head.html' with addon=addon.addon %}</td>
+                <td>
+                  {% if addon.is_valid %}
+                    {% include 'addons/addon_head.html' with addon=addon.addon %}
+                  {% else %}
+                    {{ addon.addon_name }}
+                  {% endif %}
+                </td>
                 <td class="bottom-button">
                   <form method="post" action="{{ addon.get_absolute_url }}" class="inlineform">
                     {% csrf_token %}
@@ -57,7 +63,7 @@
                     <button type="submit" class="btn btn-danger">{% translate "Uninstall" %}</button>
                   </form>
                   <a class="btn btn-primary" href="{% url 'addon-logs' addon.id %}">{% translate "View Logs" %}</a>
-                  {% if addon.addon.has_settings %}
+                  {% if addon.is_valid and addon.addon.has_settings %}
                     <a class="btn btn-primary" href="{{ addon.get_absolute_url }}">{% translate "Configure" %}</a>
                   {% endif %}
                 </td>


### PR DESCRIPTION
This can be result of broken migration as seen in #15983 or user disabling the add-on.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
