### PR TITLE
fix(auth): show login form for third-party authentication backends

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 5.13.1
 
 .. rubric:: Bug fixes
 
+* Sign-in form not shown for LDAP.
 * Access control for :http:get:`/api/users/(str:username)/`.
 * :ref:`file_format_params` were not properly applied in some situations.
 * :ref:`mt-libretranslate` compatibility with LibreTranslate 1.7.0.

--- a/weblate/templates/accounts/login.html
+++ b/weblate/templates/accounts/login.html
@@ -29,7 +29,7 @@
         </h4>
         <div class="panel panel-default">
           <div class="panel-body">
-            {% if login_email %}
+            {% if show_login_form %}
               <form method="post" action="{% url 'login' %}">
                 {% csrf_token %}
                 {{ form|crispy }}


### PR DESCRIPTION
The login form should be also shown for any third-party Django authentication backends such as LDAP.

Fixes #15978

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
