### PR TITLE
fix: OpenMetrics format parse issue

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,7 @@ Weblate 5.13.1
 * Shorten session expiry while in :ref:`2fa`.
 * Statistics when using :ref:`component-links`.
 * :ref:`componentlists` are no longer blocking dashboard loading.
+* OpenMetrics format parsing.
 
 .. rubric:: Compatibility
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,7 +22,7 @@ Weblate 5.13.1
 * Shorten session expiry while in :ref:`2fa`.
 * Statistics when using :ref:`component-links`.
 * :ref:`componentlists` are no longer blocking dashboard loading.
-* OpenMetrics format parsing.
+* OpenMetrics API format.
 
 .. rubric:: Compatibility
 

--- a/weblate/api/renderers.py
+++ b/weblate/api/renderers.py
@@ -23,7 +23,7 @@ class OpenMetricsRenderer(BaseRenderer):
             elif isinstance(value, dict):
                 # Celery queues
                 for queue, stat in value.items():
-                    result.append(f'{key}(queue="{queue}") {stat}')
+                    result.append(f'{key}{{queue="{queue}"}} {stat}')
 
         result.append("# EOF")
         return "\n".join(result)


### PR DESCRIPTION
This fixes the format of OpenMetrics in the endpoint `/api/metrics/?format=openmetrics`. The error is caused by using parenthesis instead of curly brackets in specifying labels. 

This fixes issue #15689.

A screenshot of a successful target scrape in Prometheus after the fix:

<img width="846" height="203" alt="Screenshot 2025-09-04 at 04-24-24 Prometheus Time Series Collection and Processing Server" src="https://github.com/user-attachments/assets/00fa9aa3-4f8f-44d4-9fa1-3d653de76da9" />
