### PR TITLE
docs(auth): clarify that RelayState needs to be passed

### DIFF
--- a/docs/admin/auth.rst
+++ b/docs/admin/auth.rst
@@ -557,6 +557,16 @@ configure your IDP to provide them:
    The example above and the Docker image define an IDP called ``weblate``.
    You might need to configure this string as :guilabel:`Relay` in your IDP.
 
+.. note::
+
+   Weblate authentication relies on the ``RelayState`` parameter to be passed
+   through the authentication process. This needs to be configured with some
+   identity providers:
+
+   * `How to Send a Custom RelayState with Okta`_
+
+.. _How to Send a Custom RelayState with Okta: https://support.okta.com/help/s/article/How-to-send-a-custom-relaystate-to-application-through-idp-initiated-authentication-urls
+
 .. seealso::
 
    * :ref:`Configuring SAML in Docker <docker-saml>`


### PR DESCRIPTION
Apparently Okta doesn't do this by default, so mention it in the documentation.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
