### PR TITLE
fix(diff): better render changes in nonspacing marks

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,7 @@ Weblate 5.13.2
 .. rubric:: Bug fixes
 
 * Sign-in could not be completed with LDAP.
+* Nonspacing mark changes highlighting in history.
 
 .. rubric:: Compatibility
 

--- a/weblate/utils/tests/test_diff.py
+++ b/weblate/utils/tests/test_diff.py
@@ -94,3 +94,12 @@ Description: Fake package - module manually installed in site_perl
             ),
             "由 {username} 邀请至 {<del>site_title}</del><ins>project} 项目</ins>。",
         )
+
+    def test_github_15995(self) -> None:
+        self.assertEqual(
+            self.differ.highlight(
+                "تُثبَّت التحديثات...",
+                "تُثبّت التحديثات...",
+            ),
+            "تُث<del>بّ</del><ins>بَّ</ins>ت التحديثات...",
+        )


### PR DESCRIPTION
When multiple nonspacing marks are used, the diff did not merge it with the real character making the diff hard to understand.

Fixes #15995

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
