### PR TITLE
fix: remove unused security.txt

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,8 +20,7 @@ path = [
   "docs/**.webp",
   "docs/specs/openapi.yaml",
   "docs/specs/sbom/**.json",
-  "README.rst",
-  "weblate/static/security.txt"
+  "README.rst"
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Michal Čihař <michal@weblate.org>"

--- a/weblate/static/security.txt
+++ b/weblate/static/security.txt
@@ -1,5 +1,0 @@
-Contact: security@weblate.org
-Contact: https://github.com/WeblateOrg/weblate/security/advisories/new
-Encryption: https://keybase.io/nijel/pgp_keys.asc
-Acknowledgements: https://hackerone.com/weblate/thanks
-Policy: https://docs.weblate.org/en/latest/security/issues.html


### PR DESCRIPTION
The file is served only via legal integration now which has a template for it (weblate/legal/templates/security.txt).

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
