### PR TITLE
fix: show source string location if unit has none

### DIFF
--- a/weblate/templates/mail/snippets/unit-screenshots.html
+++ b/weblate/templates/mail/snippets/unit-screenshots.html
@@ -1,6 +1,6 @@
 {% load i18n translations %}
 
-{% if unit.location %}
+{% if unit.location or unit.source_unit.location %}
   <h2>{% translate "Source string location" %}</h2>
 
   <p>{% get_location_links subscription_user unit %}</p>

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -837,7 +837,7 @@
                 </div>
               </div>
             {% endif %}
-            {% if unit.location %}
+            {% if unit.location or unit.source_unit.location %}
               <div class="list-group-item">
                 <h5>{% translate "Source string location" %}</h5>
                 {% get_location_links user unit %}


### PR DESCRIPTION
The rendering code is there, but the block was not rendered when the unit had no location.

Fixes #15997

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
