### PR TITLE
fix(add-ons): use only direct project languages for consistency

### DIFF
--- a/docs/admin/addons.rst
+++ b/docs/admin/addons.rst
@@ -277,7 +277,7 @@ Add missing languages
 :Triggers: :ref:`addon-event-install`, :ref:`addon-event-daily`, :ref:`addon-event-repository-post-add`
 
 Ensures a consistent set of languages is used for all components within a
-project.
+project. The components shared from other projects are not considered in this.
 
 Missing languages are checked once every 24 hours, and when new languages
 are added in Weblate.

--- a/weblate/addons/consistency.py
+++ b/weblate/addons/consistency.py
@@ -11,9 +11,11 @@ from django.utils.translation import gettext_lazy
 from weblate.addons.base import BaseAddon
 from weblate.addons.events import AddonEvent
 from weblate.addons.tasks import language_consistency
+from weblate.lang.models import Language
 
 if TYPE_CHECKING:
     from weblate.addons.models import Addon
+    from weblate.trans.models import Component, Translation
 
 
 class LanguageConsistencyAddon(BaseAddon):
@@ -29,14 +31,20 @@ class LanguageConsistencyAddon(BaseAddon):
     user_name = "languages"
     user_verbose = "Languages add-on"
 
-    def daily(self, component) -> None:
+    def daily(self, component: Component) -> None:
+        # The languages list is built here because we want to exclude shared
+        # component's languages that are included in Project.languages
         language_consistency.delay_on_commit(
             self.instance.id,
-            [language.id for language in component.project.languages],
+            list(
+                Language.objects.filter(
+                    translation__component__project=component.project
+                ).values_list("id", flat=True)
+            ),
             component.project_id,
         )
 
-    def post_add(self, translation) -> None:
+    def post_add(self, translation: Translation) -> None:
         language_consistency.delay_on_commit(
             self.instance.id,
             [translation.language_id],


### PR DESCRIPTION
It might not be desired to include shared compoent's languages in the set and it was not the behavior before 5.13.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
