### PR TITLE
fix: silent possible warnings from date parsing

### DIFF
--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import threading
+import warnings
 from datetime import datetime
 from functools import lru_cache, reduce
 from itertools import chain
@@ -366,7 +367,15 @@ class BaseTermExpr:
             )
 
         try:
-            result = dateutil_parse(text, default=default)
+            with warnings.catch_warnings():
+                # Ignore ambiguous date warning, it is gracefully handled by datetutil
+                # or raises exception.
+                warnings.filterwarnings(
+                    "ignore",
+                    "Parsing dates involving a day of month without a year specified",
+                    DeprecationWarning,
+                )
+                result = dateutil_parse(text, default=default)
         except ParserError:
             result = None
 


### PR DESCRIPTION
We have no control on the input, so avoid warnings. In most cases dateparser handles this situation gracefully anyway, but the warning from Python is still being shown.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
