### PR TITLE
fix(projectbackup): correctly name JSON with component data

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,7 @@ Weblate 5.13.3
 .. rubric:: Bug fixes
 
 * Components pagination.
+* :ref:`projectbackup` with same named components in different categories.
 * Source string location display.
 * Correctly track team adding via invitation in :ref:`audit-log`.
 * :ref:`addon-weblate.consistency.languages` no longer includes shared component languages.

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -391,7 +391,9 @@ class ProjectBackup:
 
         validate_schema(data, "weblate-component.schema.json")
         self.backup_json(
-            backupzip, data, f"{self.COMPONENTS_PREFIX}{component.slug}.json"
+            backupzip,
+            data,
+            f"{self.COMPONENTS_PREFIX}{self.full_slug_without_project(component)}.json",
         )
 
         # Store VCS repo in case it is present

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -430,19 +430,22 @@ class RepoTestMixin:
                 new_lang="contact",
             )
 
-    def create_link_existing(self) -> Component:
+    def create_link_existing(
+        self, name: str = "Test2", slug: str = "test2", **kwargs
+    ) -> Component:
         component = self.component
         if "linked_children" in component.__dict__:
             del component.__dict__["linked_children"]
         with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
             return Component.objects.create(
-                name="Test2",
-                slug="test2",
+                name=name,
+                slug=slug,
                 project=self.project,
                 repo=component.get_repo_link_url(),
                 file_format="po",
                 filemask="po-duplicates/*.dpo",
                 new_lang="contact",
+                **kwargs,
             )
 
 


### PR DESCRIPTION
Using just slug is not enough because it does not have to be unique across categories.

Fixes WEBLATE-354X

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
