### PR TITLE
fix: make team admins behave as documented

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -148,14 +148,15 @@ the project’s menu :guilabel:`Operations` ↓ :guilabel:`Users`.
     You can limit teams to languages or components,
     and assign them designated access roles (see :ref:`privileges`).
 
+.. _team-admins:
 
 Team administrators
 +++++++++++++++++++
 
 .. versionadded:: 4.15
 
-Each team can have team administrator,
-who can add and remove users within the team.
+Each team can have a team administrator, who can add and remove users within the team.
+
 This is useful in case you want to build self-governed teams.
 
 .. _invite-user:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 5.14
 .. rubric:: Bug fixes
 
 * Plurals and :ref:`file_format_params` handling on file upload.
+* :ref:`team-admins` can no longer edit teams besides membership.
 
 .. rubric:: Compatibility
 

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -916,7 +916,8 @@ class GroupViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post"], url_path="admins")
     def grant_admin(self, request: Request, id):  # noqa: A002
         group = self.get_object()
-        self.perm_check(request, group)
+        if not request.user.has_perm("meta:team.users", group):
+            self.perm_check(request, group)
         user_id = request.data.get("user_id")
         if not user_id:
             msg = "User ID is required"
@@ -935,7 +936,8 @@ class GroupViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["delete"], url_path="admins/(?P<user_pk>[0-9]+)")
     def revoke_admin(self, request: Request, id, user_pk):  # noqa: A002
         group = self.get_object()
-        self.perm_check(request, group)
+        if not request.user.has_perm("meta:team.users", group):
+            self.perm_check(request, group)
         try:
             user = group.admins.get(pk=user_pk)  # Using user_pk from the URL path
         except User.DoesNotExist as error:

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -551,19 +551,18 @@ def check_repository_status(
 def check_team_edit(user: User, permission: str, obj: Group) -> bool:
     from weblate.auth.models import Group
 
-    if check_global_permission(user, "group.edit"):
-        return True
-
-    if isinstance(obj, Group):
-        return (
-            obj.defining_project
+    return (
+        check_global_permission(user, "group.edit")
+        or (
+            isinstance(obj, Group)
+            and obj.defining_project
             and check_permission(user, "project.permissions", obj.defining_project)
-        ) or obj.admins.filter(pk=user.pk).exists()
-
-    if isinstance(obj, Project):
-        return check_permission(user, "project.permissions", obj)
-
-    return False
+        )
+        or (
+            isinstance(obj, Project)
+            and check_permission(user, "project.permissions", obj)
+        )
+    )
 
 
 @register_perm("meta:team.users")

--- a/weblate/auth/views.py
+++ b/weblate/auth/views.py
@@ -139,7 +139,7 @@ class TeamUpdateView(UpdateView):
 
         form = self.get_form()
         if form is None:
-            return self.form_invalid(form, None)
+            raise PermissionDenied
 
         if "delete" in request.POST:
             return self.handle_delete(request)

--- a/weblate/templates/project.html
+++ b/weblate/templates/project.html
@@ -91,7 +91,7 @@
             <a href="#bulk-edit" data-toggle="tab">{% translate "Bulk edit" %}</a>
           </li>
         {% endif %}
-        <li role="separator" class="divider"></li>
+        {% if replace_form and bulk_state_form %}<li role="separator" class="divider"></li>{% endif %}
         {% if user_can_see_repository_status %}
           <li>
             <a href="#repository"
@@ -137,6 +137,12 @@
           <li>
             <a href="{% url 'manage-access' project=object.slug %}#api">{% translate "API access" %}</a>
           </li>
+        {% elif managed_teams %}
+          {% for team in managed_teams %}
+            <li>
+              <a href="{{ team.get_absolute_url }}">{% blocktranslate %}Manage {{ team }}{% endblocktranslate %}</a>
+            </li>
+          {% endfor %}
         {% endif %}
         {% if user_can_edit_project %}
           <li>

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -419,6 +419,7 @@ def show_project(request: AuthenticatedHttpRequest, obj):
             "delete_form": optional_form(
                 ProjectDeleteForm, user, "project.edit", obj, obj=obj
             ),
+            "managed_teams": obj.defined_groups.filter(admins=request.user),
             "rename_form": optional_form(
                 ProjectRenameForm,
                 user,


### PR DESCRIPTION
It was possible to change team properties by the team admins, but the desired behavior was only to change team members. This also changes the admin view visibility, it is now added to the project menu.

Fixes #16186

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
