### PR TITLE
docs: remove deprecated DeepL usage

### DIFF
--- a/docs/admin/machine.rst
+++ b/docs/admin/machine.rst
@@ -289,18 +289,12 @@ as well as a free and a paid version of the v2 API.
 ``https://api.deepl.com/v1/``
     Is meant for CAT tools and is usable with a per-user subscription.
 
-Previously Weblate was classified as a CAT tool by DeepL, so it was supposed to
-use the v1 API, but now is supposed to use the v2 API.
-Therefore it defaults to v2, and you can change it to v1 in case you have
-an existing CAT subscription and want Weblate to use that.
+.. note::
 
-The easiest way to find out which one to use is to open an URL like the
-following in your browser:
-
-https://api.deepl.com/v2/translate?text=Hello&target_lang=FR&auth_key=XXX
-
-Replace the XXX with your auth_key. If you receive a JSON object which contains
-"Bonjour", you have the correct URL; if not, try the other three.
+   Previously Weblate was classified as a CAT tool by DeepL, so it was supposed
+   to use the v1 API, but now is supposed to use the v2 API. Therefore it
+   defaults to v2, and you can change it to v1 in case you have an existing CAT
+   subscription and want Weblate to use that.
 
 Weblate supports DeepL formality, it will choose matching one based on the
 language (for example, there is ``de@formal`` and ``de@informal``).


### PR DESCRIPTION
The URL will no longer work in near future and it is no longer important to describe this to the users (it was merely a migration documentation when Weblate category changed at DeepL), so let's remove it.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
