### PR TITLE
feat(lang): extend plural mapper for subset matching

### DIFF
--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -1194,6 +1194,7 @@ class PluralMapper:
         for i in range(target_plural.number):
             examples = target_plural.examples.get(i, [])
             if len(examples) == 1:
+                # Map plurals 1:1
                 number = int(examples[0])
                 if number in exact_source_map:
                     result.append((exact_source_map[number], None))
@@ -1202,9 +1203,25 @@ class PluralMapper:
                 else:
                     result.append((-1, number))
             elif i == last:
+                # Map last plural
                 result.append((-1, None))
             else:
-                result.append((None, None))
+                # Look for examples subset
+                values = []
+                for example in examples:
+                    try:
+                        value = int(example)
+                    except ValueError:
+                        continue
+                    values.append(value)
+                mapped = {
+                    all_source_map[value] for value in values if value in all_source_map
+                }
+                if len(mapped) == 1:
+                    result.append((mapped.pop(), None))
+                else:
+                    # Fall back to not mapping
+                    result.append((None, None))
         return tuple(result)
 
     def map(self, unit: Unit, other_unit: Unit | None = None) -> list[str]:

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -710,13 +710,17 @@ class PluralMapperTestCase(FixtureTestCase):
         english = Language.objects.get(code="en")
         czech = Language.objects.get(code="cs")
         mapper = PluralMapper(english.plural, czech.plural)
-        self.assertEqual(mapper.target_map, ((0, None), (None, None), (-1, None)))
+        self.assertEqual(mapper.target_map, ((0, None), (1, None), (-1, None)))
         unit = Unit.objects.get(
             translation__language=english, id_hash=2097404709965985808
         )
         self.assertEqual(
             mapper.map(unit),
-            ["Orangutan has %d banana.\n", "", "Orangutan has %d bananas.\n"],
+            [
+                "Orangutan has %d banana.\n",
+                "Orangutan has %d bananas.\n",
+                "Orangutan has %d bananas.\n",
+            ],
         )
 
     def test_czech_german(self) -> None:


### PR DESCRIPTION
This helps getting a viable translation for more plurals - where translation is subset of source. It might be not accurate enough, but still better than ommitting one of the plurals.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
