### PR TITLE
ui: add option to hide local repositories in admin repo status page

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2217,6 +2217,9 @@ h5.list-group-item-heading {
 #show-linked-repo-toggle:not(:checked) ~ .repo-linked {
   display: none;
 }
+#show-local-repo-toggle:not(:checked) ~ .repo-local {
+  display: none;
+}
 label .text-muted {
   font-weight: normal;
 }

--- a/weblate/templates/manage/repos.html
+++ b/weblate/templates/manage/repos.html
@@ -14,8 +14,11 @@
 {% block content %}
   <input type="checkbox" id="show-linked-repo-toggle" checked />
   <label for="show-linked-repo-toggle">{% translate "Show components with linked repositories" %}</label>
+  <br>
+  <input type="checkbox" id="show-local-repo-toggle" checked />
+  <label for="show-local-repo-toggle">{% translate "Show components without a remote VCS" %}</label>
   {% for sp in components %}
-    <div class="repo{% if sp.is_repo_link %}-linked{% endif %}">
+    <div class="{% if sp.is_repo_link %}repo-linked{% endif %} {% if sp.is_repo_local %}repo-local{% endif %}">
       <h3 id="component-{{ sp.pk }}">
         <a href="{{ sp.get_absolute_url }}">{{ sp }}</a>
       </h3>


### PR DESCRIPTION
Similar to #9950 this adds another checkbox to hide all components without a remote VCS (like glossaries) in the admin repositories page.

This helps to diagnose VCS integration issues by hiding all other components.