### PR TITLE
fix: reduce search query parser cache

### DIFF
--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -841,7 +841,7 @@ def parser_annotations(
     return result
 
 
-@lru_cache(maxsize=512)
+@lru_cache(maxsize=32)
 def parse_string(
     text: str, parser: Literal["unit", "user", "superuser"]
 ) -> ParseResults:


### PR DESCRIPTION
These are typically not needed outside the request, so reduce cache size.

We still want caching inside single request as the query can be parsed multiple times. With multithreaded workers, we still want some buffer to keep parsed result.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
