### PR TITLE
docs: clarify that there can be multiple team administrators

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -155,7 +155,7 @@ Team administrators
 
 .. versionadded:: 4.15
 
-Each team can have a team administrator, who can add and remove users within the team.
+Each team can have team administrators, who can add and remove users within the team.
 
 This is useful in case you want to build self-governed teams.
 


### PR DESCRIPTION
Just a very small change to make it clear that there can be multiple team administrators.
