### PR TITLE
fix(checks): impoved overlapping elements highlighting

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,7 @@ Weblate 5.14
 
 * Plurals and :ref:`file_format_params` handling on file upload.
 * :ref:`team-admins` can no longer edit teams besides membership.
+* Highlighting syntax of overlapping elements.
 
 .. rubric:: Compatibility
 

--- a/weblate/checks/tests/test_placeholders.py
+++ b/weblate/checks/tests/test_placeholders.py
@@ -157,6 +157,21 @@ class PlaceholdersTest(CheckTestCase):
             )
         )
 
+    def test_escaped_markup(self) -> None:
+        unit = MockUnit(
+            None,
+            'icu-message-format, placeholders:r"&lt;[a-z/]+&gt;", xml-text',
+            self.default_lang,
+            "&lt;strong&gt;Not limit the amount of videos&lt;/strong&gt; new users can upload",
+        )
+        self.assertEqual(
+            list(self.check.check_highlight(unit.source, unit)),
+            [
+                (0, 14, "&lt;strong&gt;"),
+                (44, 59, "&lt;/strong&gt;"),
+            ],
+        )
+
 
 class PluralPlaceholdersTest(FixtureTestCase):
     def test_plural(self) -> None:

--- a/weblate/checks/tests/test_utils.py
+++ b/weblate/checks/tests/test_utils.py
@@ -62,3 +62,16 @@ class HighlightTestCase(SimpleTestCase):
             highlight_string("Hello *world*", unit, highlight_syntax=True),
             [(6, 7, "*"), (12, 13, "*")],
         )
+
+    def test_escaped_markup(self) -> None:
+        unit = MockUnit(
+            source="&lt;strong&gt;Not limit the amount of videos&lt;/strong&gt; new users can upload",
+            flags='icu-message-format, placeholders:r"&lt;[a-z/]+&gt;", xml-text',
+        )
+        self.assertEqual(
+            highlight_string(unit.source, unit, highlight_syntax=True),
+            [
+                (0, 14, "&lt;strong&gt;"),
+                (44, 59, "&lt;/strong&gt;"),
+            ],
+        )

--- a/weblate/checks/utils.py
+++ b/weblate/checks/utils.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from operator import itemgetter
 from typing import TYPE_CHECKING
 
 from weblate.checks.models import CHECKS
@@ -65,23 +64,26 @@ def highlight_string(
     # Remove empty strings
     highlights = [highlight for highlight in highlights if highlight[2]]
 
-    # Sort by order in string
-    highlights.sort(key=itemgetter(0))
+    # Sort by order in string, longest first
+    highlights.sort(key=lambda item: (item[0], -item[1]))
 
     # Remove overlapping ones
     for hl_idx in range(len(highlights)):
         if hl_idx >= len(highlights):
             break
         elref = highlights[hl_idx]
-        for hl_idx_next in range(hl_idx + 1, len(highlights)):
-            if hl_idx_next >= len(highlights):
-                break
+        hl_idx_next = hl_idx + 1
+        while hl_idx_next < len(highlights):
             eltest = highlights[hl_idx_next]
-            if eltest[0] >= elref[0] and eltest[0] < elref[1]:
+            if eltest[0] >= elref[0] and eltest[1] <= elref[1]:
                 # Elements overlap, remove inner one
                 highlights.pop(hl_idx_next)
+                # Do not increment index here as we've removed the current element
             elif eltest[0] > elref[1]:
                 # This is not an overlapping element
                 break
+            else:
+                # Increase index to test
+                hl_idx_next += 1
 
     return highlights


### PR DESCRIPTION
- the overlapping handling relied on the checks order instead of sorting the elements properly causing short to be prioritized over long ones
- the filtering logic could have skipped an element from check if multiple elements were overlapping single long one

Fixes #16121

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
