### PR TITLE
fix(stats): utilize iterators to avoid Django caching

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1032,11 +1032,15 @@ class Component(
         # Invalidate source language cache just to be sure, as it is relatively
         # cheap to update
         self.project.invalidate_source_language_cache()
-        for project in self.links.all():
+        for project in self.cached_links:
             project.invalidate_source_language_cache()
 
         if update_tm:
             import_memory.delay_on_commit(self.project.id, self.pk)
+
+    @cached_property
+    def cached_links(self) -> models.QuerySet[Component]:
+        return self.links.all()
 
     def generate_changes(self, old) -> None:
         def getvalue(base, attribute):
@@ -2915,7 +2919,7 @@ class Component(
             return
         cache.delete(self.glossary_sources_key)
         self.project.invalidate_glossary_cache()
-        for project in self.links.all():
+        for project in self.cached_links:
             project.invalidate_glossary_cache()
         if "glossary_sources" in self.__dict__:
             del self.__dict__["glossary_sources"]

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -1018,7 +1018,7 @@ class ComponentStats(AggregatingStats):
         # Component lists
         yield from yield_stats(self._object.componentlist_set.only("id"))
 
-        # Projects component is shared to
+        # Projects this component is shared to
         yield from yield_stats(self._object.links.only("id"))
 
         if self._object.category:


### PR DESCRIPTION
We are not going to need the queryset again, so utilize iterator to fetch all stats to update.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
