### PR TITLE
fix(file-formats) ts2 formatting fix

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Weblate 5.14
 * :ref:`team-admins` can no longer edit teams besides membership.
 * Highlighting syntax of overlapping elements.
 * Searching case sensitivity for short strings.
+* Inconsistent file formatting for new translations.
 
 .. rubric:: Compatibility
 

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -1043,7 +1043,7 @@ class TSFormatTest(XMLMixin, BaseFormatTest):
         unit.mainunit.addlocation("main.c:11")
         serialized = self.format_class.serialize(storage.store)
         self.assertIn(b'<location filename="main.c" line="11"/>', serialized)
-        self.assertNotIn(rb"<\location>", serialized)
+        self.assertNotIn(rb"</location>", serialized)
 
 
 class DTDFormatTest(BaseFormatTest):

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -3117,7 +3117,11 @@ class Component(
         filename = self.get_new_base_filename()
         template = self.has_template()
         return self.file_format_cls.is_valid_base_for_new(
-            filename, template, errors, fast=fast
+            filename,
+            template,
+            errors,
+            fast=fast,
+            file_format_params=self.file_format_params,
         )
 
     def clean_new_lang(self) -> None:
@@ -3407,7 +3411,10 @@ class Component(
         ):
             return
         self.file_format_cls.add_language(
-            fullname, self.source_language, self.get_new_base_filename()
+            fullname,
+            self.source_language,
+            self.get_new_base_filename(),
+            file_format_params=self.file_format_params,
         )
 
         # Skip commit in case Component is not yet saved (called during validation)
@@ -3882,7 +3889,12 @@ class Component(
                 if show_messages:
                     messages.error(request, gettext("Translation file already exists!"))
             else:
-                file_format.add_language(fullname, language, base_filename)
+                file_format.add_language(
+                    fullname,
+                    language,
+                    base_filename,
+                    file_format_params=self.file_format_params,
+                )
                 if send_signal:
                     translation_post_add.send(
                         sender=self.__class__, translation=translation

--- a/weblate/trans/tests/test_file_format_params.py
+++ b/weblate/trans/tests/test_file_format_params.py
@@ -290,7 +290,7 @@ class TSParamsTest(BaseFileFormatsTest):
         units = [
             u for u in self.translation.store.all_units if "Hello, world!\n" in u.source
         ]
-        unit = units[0]  # noqa: RUF015
+        unit = units[0]
         unit.mainunit.addlocation("main.c:11")
         file_path = os.path.join(self.component.full_path, self.translation.filename)
         with open(file_path, "wb") as handle:

--- a/weblate/trans/tests/test_file_format_params.py
+++ b/weblate/trans/tests/test_file_format_params.py
@@ -287,14 +287,10 @@ class TSParamsTest(BaseFileFormatsTest):
 
     def _test_closing_tags(self, closing_tags_active: bool = True) -> None:
         """Check that effect of xml_closing_tags file format param on the location tag."""
-        unit = next(
-            (
-                u
-                for u in self.translation.store.all_units
-                if "Hello, world!\n" in u.source
-            ),
-            None,
-        )
+        units = [
+            u for u in self.translation.store.all_units if "Hello, world!\n" in u.source
+        ]
+        unit = units[0]  # noqa: RUF015
         unit.mainunit.addlocation("main.c:11")
         file_path = os.path.join(self.component.full_path, self.translation.filename)
         with open(file_path, "wb") as handle:
@@ -313,7 +309,6 @@ class TSParamsTest(BaseFileFormatsTest):
 
         # check that parameter is applied when a new language is added
         self.component.add_new_language(Language.objects.get(code="de"), None)
-        translation = self.get_translation("de")
         new_revision = self.component.repository.last_revision
         self.assertNotEqual(rev, new_revision)
         new_commit = self.component.repository.show(new_revision)
@@ -331,7 +326,7 @@ class TSParamsTest(BaseFileFormatsTest):
         self._test_closing_tags(True)
 
     def test_closing_tags_off(self):
-        """Check that closings tags are turned off as default behavior."""
+        """Check that closing tags are turned off as default behavior."""
         self._test_closing_tags(False)
 
 

--- a/weblate/trans/tests/test_file_format_params.py
+++ b/weblate/trans/tests/test_file_format_params.py
@@ -5,11 +5,13 @@
 
 """Test for File format params."""
 
+import os.path
+
 from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.addons.gettext import MsgmergeAddon
-from weblate.lang.models import get_default_lang
+from weblate.lang.models import Language, get_default_lang
 from weblate.trans.file_format_params import get_default_params_for_file_format
 from weblate.trans.models import Component
 from weblate.trans.tests.test_views import ViewTestCase
@@ -277,6 +279,60 @@ class XMLParamsTest(BaseFileFormatsTest):
 
     def test_closing_tags_off(self) -> None:
         self.test_closing_tags(closing_tags_active=False)
+
+
+class TSParamsTest(BaseFileFormatsTest):
+    def create_component(self) -> Component:
+        return self.create_ts(name="TS", new_lang="add", new_base="ts/cs.ts")
+
+    def _test_closing_tags(self, closing_tags_active: bool = True) -> None:
+        """Check that effect of xml_closing_tags file format param on the location tag."""
+        unit = next(
+            (
+                u
+                for u in self.translation.store.all_units
+                if "Hello, world!\n" in u.source
+            ),
+            None,
+        )
+        unit.mainunit.addlocation("main.c:11")
+        file_path = os.path.join(self.component.full_path, self.translation.filename)
+        with open(file_path, "wb") as handle:
+            self.translation.store.save_content(handle)
+        self.edit_unit("Hello, world!\n", "Ahoj svete!\n")
+        translation = self.get_translation()
+
+        translation.commit_pending("test", None)
+        rev = self.component.repository.last_revision
+        commit = self.component.repository.show(rev)
+        if closing_tags_active:
+            self.assertIn('<location filename="main.c" line="11"></location>', commit)
+        else:
+            self.assertIn('<location filename="main.c" line="11"/>', commit)
+            self.assertNotIn("</location>", commit)
+
+        # check that parameter is applied when a new language is added
+        self.component.add_new_language(Language.objects.get(code="de"), None)
+        translation = self.get_translation("de")
+        new_revision = self.component.repository.last_revision
+        self.assertNotEqual(rev, new_revision)
+        new_commit = self.component.repository.show(new_revision)
+        self.assertIn("Added translation using Weblate (German)", new_commit)
+        if closing_tags_active:
+            self.assertIn(
+                '<location filename="main.c" line="11"></location>', new_commit
+            )
+        else:
+            self.assertIn('<location filename="main.c" line="11"/>', new_commit)
+            self.assertNotIn("</location>", new_commit)
+
+    def test_closing_tags(self):
+        self.update_component_file_params(xml_closing_tags=True)
+        self._test_closing_tags(True)
+
+    def test_closing_tags_off(self):
+        """Check that closings tags are turned off as default behavior."""
+        self._test_closing_tags(False)
 
 
 class GettextParamsTest(BaseFileFormatsTest):


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
- fixes #16269
File format parameters were not correctly passed down when adding a new language, which resulted in inconsistent file formatting on (at least) the 1st commit of the new translation.
However, the behavior observed is the opposite of what is described in the issue (i.e empty tags were self closing instead of having a separate closing tag), so I am not entirely sure if this effectively fixes it.