### PR TITLE
fix(api): expose file-sync and file-scan in serializer

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -69612,6 +69612,8 @@ components:
       - push
       - reset
       - cleanup
+      - file-sync
+      - file-scan
       type: string
       description: |-
         * `commit` - commit
@@ -69619,6 +69621,8 @@ components:
         * `push` - push
         * `reset` - reset
         * `cleanup` - cleanup
+        * `file-sync` - file-sync
+        * `file-scan` - file-scan
     PaginatedAddonList:
       type: object
       required:

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -1065,7 +1065,7 @@ class UploadRequestSerializer(ReadOnlySerializer):
 
 class RepoRequestSerializer(ReadOnlySerializer):
     operation = serializers.ChoiceField(
-        choices=("commit", "pull", "push", "reset", "cleanup")
+        choices=("commit", "pull", "push", "reset", "cleanup", "file-sync", "file-scan")
     )
 
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1273,14 +1273,17 @@ class ProjectAPITest(APIBaseTest):
         )
         self.assertEqual(response.data["slug"], "test")
 
-    def test_repo_op_denied(self) -> None:
+    def test_repo_ops(self) -> None:
         for operation in (
             "push",
             "pull",
             "reset",
             "cleanup",
             "commit",
+            "file-sync",
+            "file-scan",
         ):
+            # No access for regular user
             self.do_request(
                 "api:project-repository",
                 self.project_kwargs,
@@ -1288,9 +1291,7 @@ class ProjectAPITest(APIBaseTest):
                 method="post",
                 request={"operation": operation},
             )
-
-    def test_repo_ops(self) -> None:
-        for operation in ("push", "pull", "reset", "cleanup", "commit"):
+            # Admin access
             self.do_request(
                 "api:project-repository",
                 self.project_kwargs,


### PR DESCRIPTION
This was implemented some time ago, but was missing in the serializer so it could not be actually triggered.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
