### PR TITLE
fix(add-ons): corectly track user when adding add-on

### DIFF
--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -691,6 +691,8 @@ class ViewTests(ViewTestCase):
             follow=True,
         )
         self.assertContains(response, "Installed 1 add-on")
+        change = self.component.change_set.get(action=ActionEvents.ADDON_CREATE)
+        self.assertEqual(change.user, self.user)
 
     def test_add_simple_project_addon(self) -> None:
         response = self.client.post(
@@ -758,6 +760,8 @@ class ViewTests(ViewTestCase):
             follow=True,
         )
         self.assertContains(response, "Installed 1 add-on")
+        change = self.component.change_set.get(action=ActionEvents.ADDON_CREATE)
+        self.assertEqual(change.user, self.user)
 
     def test_add_config_site_wide_addon(self) -> None:
         response = self.client.post(

--- a/weblate/addons/views.py
+++ b/weblate/addons/views.py
@@ -132,7 +132,9 @@ class AddonList(PathViewMixin, ListView):
 
         form = None
         if addon.settings_form is None:
-            addon.create(component=obj_component, project=obj_project)
+            addon.create(
+                component=obj_component, project=obj_project, acting_user=request.user
+            )
             return self.redirect_list()
 
         if "form" in request.POST:


### PR DESCRIPTION
It was not tracked when add-on didn't have a configuration.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
