### PR TITLE
fix(widgets): bring back automatic color for multilanguage widgets

### DIFF
--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -488,7 +488,7 @@ class MultiLanguageWidget(SVGWidget):
                 continue
             language = stats.language
             percent = stats.translated_percent
-            if color is None:
+            if self.color == "auto" or color is None:
                 color = get_percent_color(percent)
             language_name = str(language)
 


### PR DESCRIPTION
It was always using color of the first bar.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
