### PR TITLE
chore: avoid using deprecated argparse.FileType

### DIFF
--- a/weblate/addons/management/commands/install_addon.py
+++ b/weblate/addons/management/commands/install_addon.py
@@ -1,8 +1,10 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 from django.core.management.base import CommandError
 
@@ -10,11 +12,14 @@ from weblate.addons.models import ADDONS, Addon
 from weblate.auth.models import User, get_anonymous
 from weblate.trans.management.commands import WeblateComponentCommand
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(WeblateComponentCommand):
     help = "installs add-on to all listed components"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument("--addon", required=True, help="Add-on name")
         parser.add_argument(

--- a/weblate/auth/management/commands/createadmin.py
+++ b/weblate/auth/management/commands/createadmin.py
@@ -1,6 +1,9 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from django.core.management.base import CommandError
 from django.db.models import Q
@@ -9,11 +12,14 @@ from weblate.auth.models import User
 from weblate.utils.backup import make_password
 from weblate.utils.management.base import BaseCommand
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     help = "setups admin user with random password"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--password",
             default=None,

--- a/weblate/auth/management/commands/importusers.py
+++ b/weblate/auth/management/commands/importusers.py
@@ -1,18 +1,25 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
-import argparse
 import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from django.core.management.base import CommandError
 
 from weblate.auth.models import User
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
     help = "imports users from JSON dump of database"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--check",
             action="store_true",
@@ -20,13 +27,17 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "json-file",
-            type=argparse.FileType("r"),
+            type=Path,
             help="JSON file containing user dump to import",
         )
 
     def handle(self, *args, **options) -> None:
-        data = json.load(options["json-file"])
-        options["json-file"].close()
+        try:
+            with options["json-file"].open("r") as handle:
+                data = json.load(handle)
+        except OSError as error:
+            msg = f"Could not open file: {error}"
+            raise CommandError(msg) from error
 
         for line in data:
             if "fields" in line:

--- a/weblate/auth/management/commands/setupgroups.py
+++ b/weblate/auth/management/commands/setupgroups.py
@@ -1,16 +1,22 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.auth.models import create_groups, setup_project_groups
 from weblate.trans.models import Project
 from weblate.utils.management.base import BaseCommand
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     help = "setups default user groups"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--no-privs-update",
             action="store_false",

--- a/weblate/billing/management/commands/billing_check.py
+++ b/weblate/billing/management/commands/billing_check.py
@@ -1,10 +1,16 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.billing.models import Billing
 from weblate.billing.tasks import billing_notify
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
@@ -12,7 +18,7 @@ class Command(BaseCommand):
 
     help = "checks billing limits"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("--valid", action="store_true", help="list valid ones")
         parser.add_argument(
             "--notify", action="store_true", help="send email notifications"

--- a/weblate/lang/management/commands/cleanup_languages.py
+++ b/weblate/lang/management/commands/cleanup_languages.py
@@ -1,15 +1,21 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.lang.models import Language
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
     help = "Move all content from one language to other"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--delete",
             action="store_true",

--- a/weblate/lang/management/commands/list_languages.py
+++ b/weblate/lang/management/commands/list_languages.py
@@ -1,17 +1,23 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from django.utils.translation import activate, gettext
 
 from weblate.lang.models import Language
 from weblate.utils.management.base import BaseCommand
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     help = "List language definitions"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--lower", action="store_true", help="Lowercase translated name"
         )

--- a/weblate/lang/management/commands/move_language.py
+++ b/weblate/lang/management/commands/move_language.py
@@ -1,15 +1,21 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.lang.models import Language
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
     help = "Move all content from one language to other"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("source", help="Source language code")
         parser.add_argument("target", help="Target language code")
 

--- a/weblate/lang/management/commands/setuplang.py
+++ b/weblate/lang/management/commands/setuplang.py
@@ -4,14 +4,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from weblate.lang.models import Language
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
     help = "Populates language definitions"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--no-update",
             action="store_false",

--- a/weblate/machinery/management/commands/install_machinery.py
+++ b/weblate/machinery/management/commands/install_machinery.py
@@ -1,6 +1,9 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from django.core.management.base import CommandError
 
@@ -8,11 +11,14 @@ from weblate.configuration.models import Setting, SettingCategory
 from weblate.machinery.models import validate_service_configuration
 from weblate.utils.management.base import BaseCommand
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     help = "installs site-wide automatic suggestion service"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument("--service", required=True, help="Service name")
         parser.add_argument(

--- a/weblate/memory/management/commands/dump_memory.py
+++ b/weblate/memory/management/commands/dump_memory.py
@@ -1,11 +1,16 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 from weblate.memory.models import Memory
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
@@ -13,7 +18,7 @@ class Command(BaseCommand):
 
     help = "exports translation memory in JSON format"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--indent",

--- a/weblate/memory/management/commands/import_memory.py
+++ b/weblate/memory/management/commands/import_memory.py
@@ -1,13 +1,18 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
-import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from django.core.management.base import CommandError
 
 from weblate.memory.models import Memory, MemoryImportError
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
@@ -15,7 +20,7 @@ class Command(BaseCommand):
 
     help = "imports translation memory"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--language-map",
@@ -32,9 +37,7 @@ class Command(BaseCommand):
             help="Target language of the document when not specified in file",
         )
 
-        parser.add_argument(
-            "file", type=argparse.FileType("rb"), help="File to import (TMX or JSON)"
-        )
+        parser.add_argument("file", type=Path, help="File to import (TMX or JSON)")
 
     def handle(self, *args, **options) -> None:
         """Perform translation memory import."""
@@ -43,15 +46,18 @@ class Command(BaseCommand):
             langmap = dict(z.split(":", 1) for z in options["language_map"].split(","))
 
         try:
-            Memory.objects.import_file(
-                None,
-                options["file"],
-                langmap,
-                source_language=options["source_language"],
-                target_language=options["target_language"],
-            )
-        except MemoryImportError as error:
-            msg = f"Import failed: {error}"
+            with options["file"].open("rb") as handle:
+                try:
+                    Memory.objects.import_file(
+                        None,
+                        handle,
+                        langmap,
+                        source_language=options["source_language"],
+                        target_language=options["target_language"],
+                    )
+                except MemoryImportError as error:
+                    msg = f"Import failed: {error}"
+                    raise CommandError(msg) from error
+        except OSError as error:
+            msg = f"Could not open file: {error}"
             raise CommandError(msg) from error
-        finally:
-            options["file"].close()

--- a/weblate/trans/management/commands/__init__.py
+++ b/weblate/trans/management/commands/__init__.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from django.core.management.base import CommandError
 from django.db import transaction
 
@@ -13,13 +15,16 @@ from weblate.lang.models import Language
 from weblate.trans.models import Component, Translation, Unit
 from weblate.utils.management.base import BaseCommand
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class WeblateComponentCommand(BaseCommand):
     """Command which accepts project/component/--all params to process."""
 
     needs_repo = False
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--all",
             action="store_true",
@@ -129,7 +134,7 @@ class WeblateLangCommand(WeblateComponentCommand):
     It can filter list of languages to process.
     """
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--lang",
@@ -165,7 +170,7 @@ class WeblateLangCommand(WeblateComponentCommand):
 class WeblateTranslationCommand(BaseCommand):
     """Command with target of one translation."""
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("project", help="Slug of project")
         parser.add_argument("component", help="Slug of component")
         parser.add_argument("language", help="Slug of language")

--- a/weblate/trans/management/commands/add_suggestions.py
+++ b/weblate/trans/management/commands/add_suggestions.py
@@ -1,13 +1,18 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
-import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from django.core.management.base import CommandError
 from django.http.request import HttpRequest
 
 from weblate.trans.management.commands import WeblateTranslationCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(WeblateTranslationCommand):
@@ -15,14 +20,14 @@ class Command(WeblateTranslationCommand):
 
     help = "imports suggestions"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--author",
             default="noreply@weblate.org",
             help=("Email address of author (has to be registered in Weblate)"),
         )
-        parser.add_argument("file", type=argparse.FileType("rb"), help="File to import")
+        parser.add_argument("file", type=Path, help="File to import")
 
     def handle(self, *args, **options) -> None:
         # Get translation object
@@ -34,15 +39,18 @@ class Command(WeblateTranslationCommand):
 
         # Process import
         try:
-            translation.handle_upload(
-                request,
-                options["file"],
-                False,
-                method="suggest",
-                author_email=options["author"],
-            )
+            with options["file"].open("rb") as handle:
+                try:
+                    translation.handle_upload(
+                        request,
+                        handle,
+                        False,
+                        method="suggest",
+                        author_email=options["author"],
+                    )
+                except OSError as error:
+                    msg = f"Could not import translation file: {error}"
+                    raise CommandError(msg) from error
         except OSError as error:
-            msg = f"Could not import translation file: {error}"
+            msg = f"Could not open file: {error}"
             raise CommandError(msg) from error
-        finally:
-            options["file"].close()

--- a/weblate/trans/management/commands/auto_translate.py
+++ b/weblate/trans/management/commands/auto_translate.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from django.core.management.base import CommandError
 
 from weblate.auth.models import User
@@ -12,13 +14,16 @@ from weblate.trans.autotranslate import AutoTranslate
 from weblate.trans.management.commands import WeblateTranslationCommand
 from weblate.trans.models import Component
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(WeblateTranslationCommand):
     """Command for mass automatic translation."""
 
     help = "performs automatic translation based on other components"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--user", default="anonymous", help=("User performing the change")

--- a/weblate/trans/management/commands/benchmark.py
+++ b/weblate/trans/management/commands/benchmark.py
@@ -1,7 +1,9 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
 from django.test.utils import override_settings
 
@@ -9,13 +11,16 @@ from weblate.trans.models import Component, Project
 from weblate.utils.management.base import BaseCommand
 from weblate.utils.views import create_component_from_zip
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     """Run simple project import to perform benchmarks."""
 
     help = "performs import benchmark"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument("--template", default="", help="template monolingual files")
         parser.add_argument("--keep", action="store_true", help="keep after testing")

--- a/weblate/trans/management/commands/commit_pending.py
+++ b/weblate/trans/management/commands/commit_pending.py
@@ -4,14 +4,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from weblate.trans.management.commands import WeblateLangCommand
 from weblate.trans.tasks import commit_pending
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(WeblateLangCommand):
     help = "commits pending changes older than given age"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--age",

--- a/weblate/trans/management/commands/import_demo.py
+++ b/weblate/trans/management/commands/import_demo.py
@@ -1,8 +1,10 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from time import sleep
+from typing import TYPE_CHECKING
 
 from django.test.utils import override_settings
 
@@ -11,13 +13,16 @@ from weblate.trans.models import Component, Project
 from weblate.trans.tasks import actual_project_removal
 from weblate.utils.management.base import BaseCommand
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     """Command for creating demo project."""
 
     help = "imports demo project and components"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--additional", type=int, default=0, help="number of additional components"

--- a/weblate/trans/management/commands/import_project.py
+++ b/weblate/trans/management/commands/import_project.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.management.base import CommandError
@@ -21,13 +22,16 @@ from weblate.utils.management.base import BaseCommand
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.models import VCS_REGISTRY
 
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     """Command for mass importing of repositories into Weblate."""
 
     help = "imports projects with more components"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--name-template",

--- a/weblate/trans/management/commands/import_projectbackup.py
+++ b/weblate/trans/management/commands/import_projectbackup.py
@@ -3,9 +3,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from weblate.auth.models import User
 from weblate.trans.backups import ProjectBackup
 from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
@@ -13,7 +18,7 @@ class Command(BaseCommand):
 
     help = "imports project backup"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument("project_name", help="Project name")
         parser.add_argument("project_slug", help="Project slug")

--- a/weblate/trans/management/commands/list_translators.py
+++ b/weblate/trans/management/commands/list_translators.py
@@ -1,14 +1,20 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.trans.management.commands import WeblateComponentCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(WeblateComponentCommand):
     help = "List translators for a component"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--language-code",

--- a/weblate/trans/management/commands/loadpo.py
+++ b/weblate/trans/management/commands/loadpo.py
@@ -1,15 +1,21 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.trans.management.commands import WeblateLangCommand
 from weblate.trans.tasks import perform_load
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(WeblateLangCommand):
     help = "(re)loads translations from disk"
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--force",

--- a/weblate/trans/management/commands/pushgit.py
+++ b/weblate/trans/management/commands/pushgit.py
@@ -1,15 +1,21 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.trans.management.commands import WeblateComponentCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(WeblateComponentCommand):
     help = "pushes all changes to upstream repository"
     needs_repo = True
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--force-commit",

--- a/weblate/trans/management/commands/updategit.py
+++ b/weblate/trans/management/commands/updategit.py
@@ -1,16 +1,22 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weblate.trans.management.commands import WeblateComponentCommand
 from weblate.trans.tasks import perform_update
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
 
 
 class Command(WeblateComponentCommand):
     help = "updates git repos"
     needs_repo = True
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--foreground",


### PR DESCRIPTION
This is deprecated in Python 3.14 because of possible not closing file handles with it.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
