### PR TITLE
fix(test): hide depreciation warning in third-party module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -465,6 +465,8 @@ FAIL_INVALID_TEMPLATE_VARS = true
 filterwarnings = [
   # Treat all unfiltered warnings as errors
   "error",
+  # Warning in the third-party module (drf_spectacular)
+  "ignore:'_UnionGenericAlias':DeprecationWarning:drf_spectacular.plumbing",
   # Warning in the third-party module (python3-saml)
   "ignore:datetime.datetime.utcnow:DeprecationWarning:onelogin.saml2.utils",
   # Warning in the third-party module (openid)


### PR DESCRIPTION
This is deprecated in Python 3.14 and scheduled for removal im Python 3.17.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
