### PR TITLE
feat(add-ons): improve configuration listing logic

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Weblate 5.14
 * Admins can configure :ref:`expiring-accounts`.
 * Rate limiting of notification e-mails, configurable by :setting:`RATELIMIT_NOTIFICATION_LIMITS`.
 * :guilabel:`Repository maintenance` now supports resetting the repository while keeping the current state of translations in Weblate.
+* Improved listing of :ref:`addon-weblate.autotranslate.autotranslate` configuration.
 
 .. rubric:: Bug fixes
 

--- a/weblate/templates/addons/addon_head.html
+++ b/weblate/templates/addons/addon_head.html
@@ -12,15 +12,11 @@
   {% documentation_icon "admin/addons" addon.doc_anchor %}
 </h4>
 <p>{{ addon.description }}</p>
-{% if addon.instance %}
-  {% with form=addon.get_ui_form %}
-    {% if form %}
+{% if addon.instance and addon.instance.pk %}
+  {% with settings=addon.get_settings_fields %}
+    {% if settings %}
       <div>
-        {% for field in form %}
-          {% if not field.is_hidden and field.value %}
-            <span class="format-item">{{ field.label }} <span>{{ field|choiceval }}</span></span>
-          {% endif %}
-        {% endfor %}
+        {% for label, value in settings %}<span class="format-item">{{ label }} <span>{{ value }}</span></span>{% endfor %}
       </div>
     {% endif %}
   {% endwith %}

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -65,7 +65,6 @@ if TYPE_CHECKING:
 
     from django import forms
     from django.db.models import Model, QuerySet
-    from django.forms.boundfield import BoundField
     from django.template.context import Context
     from django.utils.safestring import SafeString
     from django_stubs_ext import StrOrPromise
@@ -1394,30 +1393,6 @@ def indicate_alerts(
 @register.filter(is_safe=True)
 def markdown(text: str) -> str:
     return format_html('<div class="markdown">{}</div>', render_markdown(text))
-
-
-@register.filter
-def choiceval(boundfield: BoundField) -> str:
-    """
-    Get literal value from a field's choices.
-
-    Empty value is returned if value is not selected or invalid.
-    """
-    value = boundfield.value()
-    if value is None:
-        return ""
-    if value is True:
-        return gettext("enabled")
-    if not hasattr(boundfield.field, "choices"):
-        return value
-    choices: dict[str, str] = {
-        str(choice): value for choice, value in boundfield.field.choices
-    }
-    if isinstance(value, list):
-        return format_html_join_comma(
-            "{}", list_to_tuples(choices.get(val, val) for val in value)
-        )
-    return choices.get(value, value)
 
 
 @register.filter


### PR DESCRIPTION
Move the logic to the Python code allowing add-on classes to customize this. The automatic translation add-on now lists only applied configuration.

See #15964

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
