### PR TITLE
fix(formats): use autoload for XLIFF without placeables

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,7 @@ Weblate 5.14
 * Searching case sensitivity for short strings.
 * Inconsistent file formatting for new translations.
 * Memory contents imported via the :wladmin:`import_memory` command are marked as active.
+* Importing some strings from :doc:`/formats/xliff`.
 
 .. rubric:: Compatibility
 

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -146,7 +146,7 @@ class AutoLoadTest(TestCase):
         self.single_test(TEST_ANDROID, AndroidFormat)
 
     def test_xliff(self) -> None:
-        self.single_test(TEST_XLIFF, RichXliffFormat)
+        self.single_test(TEST_XLIFF, XliffFormat)
 
     def test_resx(self) -> None:
         self.single_test(TEST_RESX, RESXFormat)

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -1297,7 +1297,7 @@ class XliffFormat(TTKitFormat):
     name = gettext_lazy("XLIFF 1.2 translation file")
     format_id = "plainxliff"
     loader = xlifffile
-    autoload: tuple[str, ...] = ()
+    autoload: tuple[str, ...] = ("*.xlf", "*.xliff")
     unit_class = XliffUnit
     language_format = "bcp"
     use_settarget = True
@@ -1335,7 +1335,7 @@ class RichXliffFormat(XliffFormat):
     # Translators: File format name
     name = gettext_lazy("XLIFF 1.2 with placeables support")
     format_id = "xliff"
-    autoload: tuple[str, ...] = ("*.xlf", "*.xliff", "*.sdlxliff", "*.mxliff")
+    autoload: tuple[str, ...] = ("*.sdlxliff", "*.mxliff")
     unit_class = RichXliffUnit
 
 

--- a/weblate/trans/tests/test_files.py
+++ b/weblate/trans/tests/test_files.py
@@ -869,3 +869,35 @@ class ImportExportAddTest(ViewTestCase):
             follow=True,
         )
         self.assertContains(response, "(skipped: 0, not found: 0, updated: 1)")
+
+    def test_xliff(self) -> None:
+        self.component.source_translation.add_unit(
+            None, "amp", "Source & translation", author=self.user
+        )
+        response = self.client.get(
+            reverse("download", kwargs=self.kw_translation),
+            {"format": "xliff11"},
+        )
+        content = response.text
+        placeholder = """<source>Source &amp; translation</source>
+        <target></target>"""
+        translation = """<source>Source &amp; translation</source>
+        <target>Zdroj &amp; překlad</target>"""
+
+        self.assertIn(placeholder, content)
+
+        handle = NamedBytesIO(
+            "test.xliff", content.replace(placeholder, translation).encode()
+        )
+        params = {
+            "file": handle,
+            "method": "translate",
+            "author_name": self.user.full_name,
+            "author_email": self.user.email,
+        }
+        response = self.client.post(
+            reverse("upload", kwargs=self.kw_translation),
+            params,
+            follow=True,
+        )
+        self.assertContains(response, "(skipped: 0, not found: 0, updated: 1)")


### PR DESCRIPTION
This is what is created by export, so match the import behavior to it. The XLIFF native translations won't be affected by this as native format is always tried before detection.

Fixes #14830

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
