### PR TITLE
fix(unit): corrected enforced checks handling

### DIFF
--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -1070,6 +1070,14 @@ class EditComplexTest(ViewTestCase):
         self.assertEqual(len(unit.all_checks), 1)
         self.assertEqual(len(unit.active_checks), 1)
         self.assertEqual(unit.translation.stats.allchecks, 1)
+        # There should be a change for enforced check
+        self.assertTrue(
+            unit.change_set.filter(action=ActionEvents.ENFORCED_CHECK).exists()
+        )
+        # The pending change should be only fuzzy
+        pending_changes = unit.pending_changes.all()
+        self.assertEqual(len(pending_changes), 1)
+        self.assertEqual(pending_changes[0].state, STATE_FUZZY)
 
     def test_commit_push(self) -> None:
         response = self.edit_unit("Hello, world!\n", "Nazdar svete!\n")


### PR DESCRIPTION
- the Change entry was missing for enforced checks making the history confusing
- the PendingUnitChange was set to user provided state rather than to STATE_FUZZY

Fixes #16588

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
