### PR TITLE
fix(models): count pending unit not changes

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -3636,14 +3636,13 @@ class Component(
         return self.translation_set.filter(language__code__in=AMBIGUOUS.keys())
 
     @property
-    def pending_units(self):
-        """Return queryset with pending units."""
-        return PendingUnitChange.objects.for_component(self)
-
-    @property
     def count_pending_units(self):
         """Return count of pending units."""
-        return PendingUnitChange.objects.for_component(self).count()
+        from weblate.trans.models import Unit
+
+        return Unit.objects.filter(
+            translation__component=self, pending_changes__isnull=False
+        ).count()
 
     @property
     def count_repo_missing(self):

--- a/weblate/trans/models/pending.py
+++ b/weblate/trans/models/pending.py
@@ -22,14 +22,10 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from weblate.auth.models import User
-    from weblate.trans.models import Component, Project, Translation, Unit
+    from weblate.trans.models import Component, Translation, Unit
 
 
 class PendingChangeQuerySet(models.QuerySet):
-    def for_project(self, project: Project):
-        """Return pending changes for a specific component."""
-        return self.filter(unit__translation__component__project=project)
-
     def for_component(self, component: Component):
         """Return pending changes for a specific component."""
         return self.filter(unit__translation__component=component)

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -24,7 +24,6 @@ from weblate.memory.tasks import import_memory
 from weblate.trans.actions import ActionEvents
 from weblate.trans.defines import PROJECT_NAME_LENGTH
 from weblate.trans.mixins import CacheKeyMixin, LockMixin, PathMixin
-from weblate.trans.models.pending import PendingUnitChange
 from weblate.trans.validators import validate_check_flags
 from weblate.utils.site import get_site_url
 from weblate.utils.stats import ProjectLanguage, ProjectStats, prefetch_stats
@@ -459,7 +458,11 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
     @property
     def count_pending_units(self):
         """Check whether there are any uncommitted changes."""
-        return PendingUnitChange.objects.for_project(self).count()
+        from weblate.trans.models import Unit
+
+        return Unit.objects.filter(
+            translation__component__project=self, pending_changes__isnull=False
+        ).count()
 
     def needs_commit(self):
         """Check whether there are some not committed changes."""


### PR DESCRIPTION
This is the actual meaning of the UI shown values, so move to counting units instead of pending changes. This also workarounds performance issue seen in #16628.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
