### PR TITLE
feat: avoid duplicate note display

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2103,12 +2103,6 @@ a.language:hover {
 .divisor {
   color: #bfc3c8;
 }
-.source-comment {
-  font-weight: normal;
-  vertical-align: top;
-  white-space: normal;
-  font-size: 14px;
-}
 .unit-state-cell {
   width: 6px;
   padding: 0px !important;

--- a/weblate/templates/snippets/note-badge.html
+++ b/weblate/templates/snippets/note-badge.html
@@ -1,6 +1,0 @@
-{% load i18n translations %}
-
-{% if unit.note %}
-  <span class="badge source-comment"
-        title="{% translate "Source string description" %}">{{ unit.note|urlize_ugc }}</span>
-{% endif %}

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -100,9 +100,6 @@
                 {% for secondary_unit in secondary %}
                   <div class="form-group">
                     <a class="language" href="{{ secondary_unit.get_absolute_url }}">{{ secondary_unit.translation.language }}</a>
-                    {% if user.profile.hide_source_secondary %}
-                      {% include "snippets/note-badge.html" with unit=unit %}
-                    {% endif %}
                     {% format_unit_target secondary_unit search_match=search_query show_copy=True %}
                   </div>
                 {% endfor %}
@@ -177,7 +174,6 @@
                            href="#"
                            class="btn btn-link btn-xs bug-comment">{% icon "bug.svg" %}</a>
                       {% endif %}
-                      {% include "snippets/note-badge.html" with unit=unit %}
                       <div class="clearfix"></div>
                     </div>
                     {% format_unit_source unit search_match=search_query glossary=glossary show_copy=True %}

--- a/weblate/templates/zen-units.html
+++ b/weblate/templates/zen-units.html
@@ -40,6 +40,18 @@
           </div>
         </td>
       </tr>
+    {% elif item.unit.note %}
+      <tr id="row-explanation-{{ item.unit.checksum }}">
+        <td class="unit-state-cell"></td>
+        <td colspan="2" class="translatetext">
+          <label>{% translate "Source string description" %}</label>
+          <div class="list-group">
+            <div class="list-group-item">
+              <div class="list-group-item-text">{{ item.unit.note|urlize_ugc }}</div>
+            </div>
+          </div>
+        </td>
+      </tr>
     {% endif %}
 
 
@@ -53,9 +65,6 @@
           {% for unit in item.secondary %}
             <div class="form-group">
               <a href="{{ unit.get_absolute_url }}" class="language" tabindex="-1">{{ unit.translation.language }}</a>
-              {% if user.profile.hide_source_secondary %}
-                {% include "snippets/note-badge.html" with unit=item.unit %}
-              {% endif %}
               {% format_unit_target unit show_copy=True %}
             </div>
           {% endfor %}
@@ -74,7 +83,6 @@
               <a href="{{ item.unit.source_unit.get_absolute_url }}"
                  class="language"
                  tabindex="-1">{{ item.unit.translation.component.source_language }}</a>
-              {% include "snippets/note-badge.html" with unit=item.unit %}
               {% format_unit_source item.unit search_match=search_query glossary=item.glossary show_copy=True %}
             </div>
           {% endif %}


### PR DESCRIPTION
Since 5.13 is it should as text and badge, the badge is a bad placement for that as it can be possibly long. This also consolidates the behavior of full editor and zen mode.

See #16602

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
