### PR TITLE
fix: corrected list of ghost translations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,9 @@ Weblate 5.14.1
 
 .. rubric:: Bug fixes
 
+* Counting outgoing commits in the repository status.
+* Listing of other translations.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
+from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -239,9 +240,9 @@ def show_project_language(request: AuthenticatedHttpRequest, obj: ProjectLanguag
 
     # Add ghost translations
     if user.is_authenticated and translations.paginator.num_pages == 1:
-        existing = {translation.component.slug for translation in obj.translation_set}
+        existing = {translation.component.id for translation in obj.translation_set}
         missing = project_object.get_child_components_filter(
-            lambda qs: qs.exclude(slug__in=existing)
+            lambda qs: qs.exclude(id__in=existing)
             .prefetch()
             .prefetch_related("source_language")
         )
@@ -319,8 +320,8 @@ def show_category_language(request: AuthenticatedHttpRequest, obj):
 
     # Add ghost translations
     if user.is_authenticated and translations.paginator.num_pages == 1:
-        existing = {translation.component.slug for translation in obj.translation_set}
-        missing = category_object.component_set.exclude(slug__in=existing)
+        existing = {translation.component.id for translation in obj.translation_set}
+        missing = category_object.component_set.exclude(id__in=existing)
         extra_translations = [
             GhostTranslation(obj.project, language_object, component)
             for component in missing
@@ -638,7 +639,10 @@ def show_translation(request: AuthenticatedHttpRequest, obj):
     # Show up to 10 of them, needs to be list to append ghost ones later
     other_translations = list(
         Translation.objects.prefetch()
-        .filter(component__project=project, language=obj.language)
+        .filter(
+            Q(component__project=project) | Q(component__links=project),
+            language=obj.language,
+        )
         .exclude(component__is_glossary=True)
         .order_by("component__name")
         .exclude(pk=obj.pk)[:10]
@@ -654,15 +658,19 @@ def show_translation(request: AuthenticatedHttpRequest, obj):
         )
         # Include ghost translations for other components, this
         # adds quick way to create translations in other components
-        existing = {translation.component.slug for translation in other_translations}
-        existing.add(component.slug)
+        existing = {translation.component.id for translation in other_translations}
+        existing.add(component.id)
 
         # Figure out missing components
-        all_components = {c.slug for c in project.child_components}
+        available_components = [
+            c for c in project.child_components if not c.is_glossary
+        ]
+
+        all_components = {c.id for c in available_components}
         missing = all_components - existing
-        if len(missing) < 5:
-            for test_component in project.child_components:
-                if test_component.slug in existing:
+        if 0 < len(missing) < 5:
+            for test_component in available_components:
+                if test_component.id in existing:
                     continue
                 if test_component.can_add_new_language(user, fast=True):
                     other_translations.append(


### PR DESCRIPTION
- do not rely on slug which doesn't have to be unique because of categories and links
- exclude glossaries from ghost other translations as it was already included from the listing making all glossaries appear as ghosts
- handle linked components on other translations list

Fixes #16695

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
