### PR TITLE
Improve Backup doc to help with remote Borg backup setup

### DIFF
--- a/docs/admin/backup.rst
+++ b/docs/admin/backup.rst
@@ -165,7 +165,7 @@ via SSH using the Weblate SSH key:
 5. Add Weblate SSH key to the user's `.ssh/authorized_keys` file, so that Weblate can SSH to the server without a password (see :ref:`weblate-ssh-key`).
 6. Create a user-writable directory where Weblate can remotely set up the Borg backup repository, for example in the home directory (i.e. ``/home/borg/backups``).
 7. Configure the backup location in Weblate as ``user@host:/home/borg/backups`` or ``ssh://user@host:port/home/borg/backups``.
-8. After Weblate has initiated the repository there (which might take a moment for the Celery backup worker to process), you can manually trigger a backup from the Weblate UI.
+8. Once enabled, the backups will be triggered automatically daily. You can also manually trigger a backup from the Weblate UI.
 
 .. hint::
 


### PR DESCRIPTION
As suggested here https://github.com/orgs/WeblateOrg/discussions/16683#discussioncomment-14772464, I think the doc for setting up a remote Borg backup could be clarified a bit. :-)