### PR TITLE
fix(auth): correct SAML certificate field typo

### DIFF
--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -416,7 +416,7 @@ if WEBLATE_SAML_IDP_ENTITY_ID:
     WEBLATE_SAML_IDP = {
         "entity_id": WEBLATE_SAML_IDP_ENTITY_ID,
         "url": get_env_str("WEBLATE_SAML_IDP_URL"),
-        "x508cert": get_env_str("WEBLATE_SAML_IDP_X509CERT"),
+        "x509cert": get_env_str("WEBLATE_SAML_IDP_X509CERT"),
     }
 
     for field in (


### PR DESCRIPTION
Fix typo in Docker SAML configuration where 'x508cert' was used instead of 'x509cert', causing KeyError: 'IDP must contain x509cert or x509certMulti' when authenticating via SAML.

This resolves the SAML authentication regression introduced in Weblate 5.14 where the certificate field name was misspelled.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
