### PR TITLE
fix(checks): directly build parser, writer and reader

### DIFF
--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -8,7 +8,8 @@ import re
 from collections import Counter, defaultdict
 from functools import cache, lru_cache
 from itertools import chain
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
@@ -28,8 +29,10 @@ from docutils.nodes import (
     strong,
     substitution_reference,
 )
-from docutils.parsers.rst import languages
-from docutils.parsers.rst.states import Inliner, Struct
+from docutils.parsers.rst import Parser, languages
+from docutils.parsers.rst.states import Inliner
+from docutils.readers.standalone import Reader
+from docutils.writers.null import Writer
 
 from weblate.checks.base import TargetCheck
 from weblate.utils.html import (
@@ -413,10 +416,9 @@ class RSTBaseCheck(TargetCheck):
 
 @lru_cache(maxsize=512)
 def extract_rst_references(text: str) -> tuple[dict[str, str], Counter, list[str]]:
-    memo = Struct()
+    memo = SimpleNamespace()
     publisher = get_rst_publisher()
-    document = utils.new_document(None, publisher.settings)
-    document.reporter.stream = None
+    document = utils.new_document("", publisher.settings)
     memo.reporter = document.reporter
     memo.document = document
     memo.language = languages.get_language(
@@ -521,7 +523,7 @@ class RSTReferencesCheck(RSTBaseCheck):
         unit = check_obj.unit
 
         errors: list[StrOrPromise] = []
-        results: MissingExtraDict = defaultdict(list)
+        results: MissingExtraDict = cast("MissingExtraDict", defaultdict(list))
 
         # Merge plurals
         for result in self.check_target_generator(
@@ -553,11 +555,15 @@ class RSTReferencesCheck(RSTBaseCheck):
 
 @cache
 def get_rst_publisher() -> Publisher:
-    publisher = Publisher(settings=None)
-    publisher.set_components("standalone", "restructuredtext", "null")
+    parser = Parser()
+    reader: Reader = Reader(parser)
+    writer = Writer()
+    publisher = Publisher(settings=None, reader=reader, parser=parser, writer=writer)
     publisher.get_settings(
         # Never halt parsing with an exception
         halt_level=5,
+        # Disable warnings
+        warning_stream=False,
         # Do not allow file insertion
         file_insertion_enabled=False,
         # Following are needed in case django.contrib.admindocs is imported
@@ -573,8 +579,7 @@ def validate_rst_snippet(
     snippet: str, source_tags: tuple[str] | None = None
 ) -> tuple[list[str], list[str]]:
     publisher = get_rst_publisher()
-    document = utils.new_document(None, publisher.settings)
-    document.reporter.stream = None
+    document = utils.new_document("", publisher.settings)
 
     errors: list[str] = []
     roles: list[str] = []
@@ -608,15 +613,13 @@ def validate_rst_snippet(
         errors.append(message)
 
     document.reporter.attach_observer(error_collector)
-    publisher.reader.parser.parse(snippet, document)
+    cast("Parser", publisher.reader.parser).parse(snippet, document)
     transformer = document.transformer
     transformer.populate_from_components(
         (
-            publisher.source,
             publisher.reader,
-            publisher.reader.parser,
+            cast("Parser", publisher.reader.parser),
             publisher.writer,
-            publisher.destination,
         )
     )
     while transformer.transforms:
@@ -624,7 +627,7 @@ def validate_rst_snippet(
             # Unsorted initially, and whenever a transform is added.
             transformer.transforms.sort()
             transformer.transforms.reverse()
-            transformer.sorted = 1
+            transformer.sorted = True
         priority, transform_class, pending, kwargs = transformer.transforms.pop()
         transform = transform_class(transformer.document, startnode=pending)
         transform.apply(**kwargs)
@@ -651,7 +654,7 @@ class RSTSyntaxCheck(RSTBaseCheck):
         unit = check_obj.unit
 
         errors: list[StrOrPromise] = []
-        results: MissingExtraDict = defaultdict(list)
+        results: MissingExtraDict = cast("MissingExtraDict", defaultdict(list))
 
         # Merge plurals
         for result in self.check_target_generator(


### PR DESCRIPTION
This avoids using set_components interface which is deprecated since docutils 0.22.

Fixes #16758

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
