### PR TITLE
Change Weblate installation command for yunohost in docs

### DIFF
--- a/docs/admin/deployments.rst
+++ b/docs/admin/deployments.rst
@@ -47,4 +47,4 @@ It also is possible to use the command-line interface:
 
 .. code-block:: sh
 
-    yunohost app install https://github.com/YunoHost-Apps/weblate_ynh
+    yunohost app install weblate


### PR DESCRIPTION
Apps in the yunohost catalog are installed via their names directly. Using the repo url is for installing apps that aren't in the catalog or installing testing branch (for beta testers)

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
