### PR TITLE
fix(checks): optimize prefetch for bulk source checks

### DIFF
--- a/weblate/checks/source.py
+++ b/weblate/checks/source.py
@@ -97,9 +97,13 @@ class MultipleFailingCheck(SourceCheck, BatchCheckMixin):
             .annotate(translation_count=Count("unit__translation_id", distinct=True))
             .filter(translation_count__gte=2)
         )
-        return Unit.objects.filter(
-            id__in=unit_id_and_check_count.values_list(
-                "unit__source_unit_id", flat=True
+        return (
+            Unit.objects.prefetch()
+            .prefetch_bulk()
+            .filter(
+                id__in=unit_id_and_check_count.values_list(
+                    "unit__source_unit_id", flat=True
+                )
             )
         )
 
@@ -187,6 +191,8 @@ class LongUntranslatedCheck(SourceCheck, BatchCheckMixin):
                 translated_percent=100 * (F("total") - F("not_translated")) / F("total")
             )
         ).filter(translated_percent__lt=component.stats.translated_percent / 2)
-        return Unit.objects.filter(
-            id__in=result.values_list("source_unit_id", flat=True)
+        return (
+            Unit.objects.prefetch()
+            .prefetch_bulk()
+            .filter(id__in=result.values_list("source_unit_id", flat=True))
         )


### PR DESCRIPTION
The outcome of check_component should have all bits prefetched because additional processin happens.

Fixes WEBLATE-372Y

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
