### PR TITLE
fix(glossary): do a full preload when adding

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Weblate 5.14.2
 
 .. rubric:: Bug fixes
 
+* Adding terms to glossary was not working in some situations.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/weblate/glossary/tests.py
+++ b/weblate/glossary/tests.py
@@ -371,6 +371,17 @@ class GlossaryTest(TransactionsTestMixin, ViewTestCase):
         # Should be added to the source and translation only
         self.assertEqual(Unit.objects.count(), start + 2)
 
+    def test_add_existing(self) -> None:
+        """Test for adding term from translate page while there is existing one."""
+        glossary = self.glossary_component.translation_set.get(
+            language=self.translation.language
+        )
+        glossary.add_unit(None, "", "Thank", "Díky", author=self.user)
+        start = Unit.objects.count()
+        self.do_add_unit()
+        # Should be added to the source and translation only
+        self.assertEqual(Unit.objects.count(), start + 2)
+
     def test_add_terminology(self) -> None:
         start = Unit.objects.count()
         self.do_add_unit(expected_status=403, terminology=1)

--- a/weblate/glossary/views.py
+++ b/weblate/glossary/views.py
@@ -47,7 +47,7 @@ def add_glossary_term(request: AuthenticatedHttpRequest, unit_id):
             code = 200
 
             # Fetch matching terms
-            all_terms = get_glossary_terms(unit)
+            all_terms = get_glossary_terms(unit, full=True)
 
             # Create a set of existing term IDs
             existing_term_ids = {term.pk for term in all_terms}


### PR DESCRIPTION
The terms are then rendered and when not using full reload the additional fields need to be fetched. This hits some bug insude Django with prefetch and only() lookups.

Fixes WEBLATE-37PQ

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
