### PR TITLE
fix: avoid doing full stats update when changing two languages only

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,8 @@ Weblate 5.14.2
 
 .. rubric:: Improvements
 
+* Performance when adding strings.
+
 .. rubric:: Bug fixes
 
 .. rubric:: Compatibility


### PR DESCRIPTION
When adding to a single language, only this and source is updated, so there is no need to trigger full component rescan.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
