### PR TITLE
fix(memory): exclude blank context from matching

### DIFF
--- a/weblate/memory/machine.py
+++ b/weblate/memory/machine.py
@@ -46,9 +46,8 @@ class WeblateMemory(InternalMachineTranslation):
             quality = self.comparer.similarity(text, result.source)
             if result.status == Memory.STATUS_PENDING:
                 quality = round(quality * PENDING_MEMORY_PENALTY_FACTOR)
-            if unit.context != result.context and not (
-                result.from_file and not result.context
-            ):
+            # Compare context when translation memory has one
+            if result.context and unit.context != result.context:
                 quality = round(quality * DIFFERENT_CONTEXT_PENALTY_FACTOR)
 
             if quality < threshold:


### PR DESCRIPTION
The historical translation memory entries do not store context and are now suddenly 95% matches instead of 100% ones. This is confusing to users, as nothing has changed and the automatic translation with a 100 quality threshold no longer works.

The downside of this is that we ignore the actual blank context when translating strings with a non-blank context.

@gersona What do you think about this approach? I'm not sure if it will work better long-term, but for the existing entries, it might work better.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
