### PR TITLE
feat(ui): don't style "sign in" and "lock" messages like errors

### DIFF
--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -186,9 +186,9 @@
             </div>
             <div class="panel-footer">
               {% if locked %}
-                <p class="text-danger">{% translate "This translation is currently locked." %}</p>
+                <p>{% translate "This translation is currently locked." %}</p>
               {% elif not user_can_translate %}
-                <p class="text-danger">{{ user_can_translate.reason }}</p>
+                <p>{{ user_can_translate.reason }}</p>
               {% endif %}
               <div>
                 {% with flag_actions=unit.get_flag_actions %}


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->

Being unauthenticated is not an error state [^1], nor is a locked translation, so the messages should not be styled like errors.

**Before**

<img width="200" height="200" alt="Screenshot 2025-11-10 at 21 06 30@2x" src="https://github.com/user-attachments/assets/64fc42e4-b01f-4900-9ee6-293da551f311" />

**After**


<img width="200" height="234" alt="Screenshot 2025-11-10 at 21 05 46@2x" src="https://github.com/user-attachments/assets/c56e0eac-1a1d-4534-8dbb-f044ea1d8367" />


[^1]: As described in https://github.com/WeblateOrg/weblate/issues/16869, my project's translation workflow _encourages_ translators to be unauthenticated

