### PR TITLE
Add Modern MT support for sr_Latn language code

### DIFF
--- a/weblate/machinery/modernmt.py
+++ b/weblate/machinery/modernmt.py
@@ -40,7 +40,7 @@ class ModernMTTranslation(GlossaryMachineTranslationMixin):
         "sr": "sr-Cyrl",
         "zh_Hant": "zh-TW",
         "zh_Hans": "zh-CN",
-        "sr_Latn": "sr-Latn"
+        "sr_Latn": "sr-Latn",
     }
     glossary_count_limit = 1000
 


### PR DESCRIPTION
This issue is about the ModernMT compatibility.

Weblate uses the language code "sr_Latn", ModernMT uses "sr-Latn".
This leads to issues with auto suggestions.

An additional mapping in `weblate/machinery/modernmt.py` should fix the issue.

Thanks for keeping up the great work!