### PR TITLE
fix(unit): honor restricted components in path lookup

### DIFF
--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -365,49 +365,49 @@ def parse_path_units(
 ):
     obj = parse_path(request, path, types)
 
+    access_units = Unit.objects.filter_access(request.user)
+
     context = {"components": None, "path_object": obj}
     if isinstance(obj, Translation):
+        # Not using access_units because parse_path performed the permission check
         unit_set = obj.unit_set.all()
         context["translation"] = obj
         context["component"] = obj.component
         context["project"] = obj.component.project
         context["components"] = [obj.component]
     elif isinstance(obj, Component):
+        # Not using access_units because parse_path performed the permission check
         unit_set = Unit.objects.filter(translation__component=obj).prefetch()
         context["component"] = obj
         context["project"] = obj.project
         context["components"] = [obj]
     elif isinstance(obj, Project):
-        unit_set = Unit.objects.filter(translation__component__project=obj).prefetch()
+        unit_set = access_units.filter(translation__component__project=obj).prefetch()
         context["project"] = obj
     elif isinstance(obj, ProjectLanguage):
-        unit_set = Unit.objects.filter(
+        unit_set = access_units.filter(
             translation__component__project=obj.project,
             translation__language=obj.language,
         ).prefetch()
         context["project"] = obj.project
         context["language"] = obj.language
     elif isinstance(obj, Category):
-        unit_set = Unit.objects.filter(
+        unit_set = access_units.filter(
             translation__component_id__in=obj.all_component_ids
         ).prefetch()
         context["project"] = obj.project
     elif isinstance(obj, CategoryLanguage):
-        unit_set = Unit.objects.filter(
+        unit_set = access_units.filter(
             translation__component_id__in=obj.category.all_component_ids,
             translation__language=obj.language,
         ).prefetch()
         context["project"] = obj.category.project
         context["language"] = obj.language
     elif isinstance(obj, Language):
-        unit_set = (
-            Unit.objects.filter_access(request.user)
-            .filter(translation__language=obj)
-            .prefetch()
-        )
+        unit_set = access_units.filter(translation__language=obj).prefetch()
         context["language"] = obj
     elif obj is None:
-        unit_set = Unit.objects.filter_access(request.user)
+        unit_set = access_units
     else:
         msg = f"Unsupported result: {obj}"
         raise TypeError(msg)


### PR DESCRIPTION
Make parse_path_units filter units for component restriction at all levels.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
