### PR TITLE
Fix for Unused local variable

### DIFF
--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -263,9 +263,7 @@ class RedirectMiddleware:
                     path_offset = len(path) - (language_len)
                     try:
                         # Check if component exists
-                        parse_path(
-                            request, path[:path_offset], (Component,)
-                        )
+                        parse_path(request, path[:path_offset], (Component,))
                     except UnsupportedPathObjectError:
                         return None
                     except Http404:


### PR DESCRIPTION
To fix the problem, simply remove the unnecessary assignment of the unused variable `component` on line 266. We should keep the call to `parse_path` for its intended effect of checking component existence, but since the result is not used, the assignment should be dropped. Replace `component = parse_path(...)` with just `parse_path(...)`, keeping exception handling and all control flow unchanged.

Only lines within the shown code should be changed, specifically line 266 in `weblate/middleware.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._