### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -570,7 +570,7 @@ class GlossaryTranslationTest(BaseMachineTranslationTest):
                 unit, "en", "cs", source_text, 75, {}
             )
             self.assertIsNotNone(cache_key)
-            self.assertTrue(len(result) > 0)
+            self.assertGreater(len(result), 0)
             self.assertIsNotNone(result)
 
         with patch(


### PR DESCRIPTION
To fix this issue, line 573 in `weblate/machinery/tests.py` should be changed from using `self.assertTrue(len(result) > 0)` to `self.assertGreater(len(result), 0)`. This change will improve the informativeness of failing test messages without affecting the functionality. No additional imports or definitions are required since `assertGreater` is a method of `unittest.TestCase`, which this class already inherits.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._