### PR TITLE
fix(lang): properly filter language aliases

### DIFF
--- a/weblate/lang/models.py
+++ b/weblate/lang/models.py
@@ -848,7 +848,7 @@ class Language(models.Model, CacheKeyMixin):
             aliases.extend(
                 default_lang
                 for default_lang in DEFAULT_LANGS
-                if default_lang.startswith(self.code)
+                if default_lang.startswith(f"{self.code}_")
             )
         return sorted(aliases)
 

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -917,3 +917,7 @@ class LanguageAliasesChangeTest(ViewTestCase):
         )
         self.component.add_new_language(it_xx, None)
         self.do_alias_language_update_and_check(False, False)
+
+    def test_get_aliases(self) -> None:
+        language = Language.objects.get(code="ka")
+        self.assertEqual(language.get_aliases_names(), ["geo", "ka_ge", "kat"])


### PR DESCRIPTION
Three letter language codes can be subset of two letter, so include underscore when filtering.

Fixes #16937

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
