### PR TITLE
fix(machinery): do not interpret replacement string for placeholders

### DIFF
--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -368,9 +368,16 @@ class BatchMachineTranslation:
 
         return "".join(parts), replacements
 
+    def uncleanup_text_item(self, text: str, source: str, target: str) -> str:
+        def replace_target(_match: re.Match) -> str:
+            return target
+
+        # Use callable for replacement to avoid interpreting escape sequences
+        return re.sub(self.make_re_placeholder(source), replace_target, text)
+
     def uncleanup_text(self, replacements: dict[str, str], text: str) -> str:
         for source, target in replacements.items():
-            text = re.sub(self.make_re_placeholder(source), target, text)
+            text = self.uncleanup_text_item(text, source, target)
         return self.unescape_text(text)
 
     def uncleanup_results(

--- a/weblate/machinery/dummy.py
+++ b/weblate/machinery/dummy.py
@@ -71,6 +71,13 @@ class DummyTranslation(MachineTranslation):
                 "service": "Dummy",
                 "source": text,
             }
+        if source_language == "en" and text.strip() == r"Hello, [X7X] C:\Windows!":
+            yield {
+                "text": r"Nazdar [X7X ] C:\Windows!",
+                "quality": self.max_score,
+                "service": "Dummy",
+                "source": text,
+            }
 
 
 class DummyGlossaryTranslation(DummyTranslation, GlossaryMachineTranslationMixin):

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -446,6 +446,52 @@ class MachineTranslationTest(BaseMachineTranslationTest):
             ],
         )
 
+    def test_placeholders_backslash(self) -> None:
+        machine_translation = self.get_machine()
+        unit = MockUnit(code="cs", source=r"Hello, %s C:\Windows!", flags="c-format")
+        self.assertEqual(
+            machine_translation.cleanup_text(unit.source, unit),
+            (r"Hello, [X7X] C:\Windows!", {"[X7X]": "%s"}),
+        )
+        self.assertEqual(
+            machine_translation.translate(unit),
+            [
+                [
+                    {
+                        "quality": 100,
+                        "service": "Dummy",
+                        "source": r"Hello, %s C:\Windows!",
+                        "original_source": r"Hello, %s C:\Windows!",
+                        "text": r"Nazdar %s C:\Windows!",
+                    }
+                ]
+            ],
+        )
+
+    def test_placeholders_rst(self) -> None:
+        machine_translation = self.get_machine()
+        unit = MockUnit(
+            code="cs", source=r"Hello, :file:`C:\Windows\System.exe`!", flags="rst-text"
+        )
+        self.assertEqual(
+            machine_translation.cleanup_text(unit.source, unit),
+            ("Hello, [X7X]!", {"[X7X]": r":file:`C:\Windows\System.exe`"}),
+        )
+        self.assertEqual(
+            machine_translation.translate(unit),
+            [
+                [
+                    {
+                        "quality": 100,
+                        "service": "Dummy",
+                        "source": r"Hello, :file:`C:\Windows\System.exe`!",
+                        "original_source": r"Hello, :file:`C:\Windows\System.exe`!",
+                        "text": r"Nazdar :file:`C:\Windows\System.exe`!",
+                    }
+                ]
+            ],
+        )
+
     def test_batch(self) -> None:
         machine_translation = self.get_machine()
         units = [


### PR DESCRIPTION
Avoid interpreting escape characters in the replacement string.

Fixes #17048

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
