### PR TITLE
fix(translation): do not trigger full save when storing pending changes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,7 @@ Weblate 5.15
 * :ref:`mt-deepl` integration now correctly handles translating to Chinese variants.
 * :doc:`/formats/csv` format saving translations with empty source fields when using monolingual base files.
 * Tighter validation of user and full names to avoid confusing homoglyphs.
+* Avoid false positive checks upon committing pending changes.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1092,7 +1092,7 @@ class Translation(
                 "state": pending_change.state,
                 "explanation": pounit.explanation,
             }
-            unit.save(update_fields=["details"])
+            unit.save(update_fields=["details"], only_save=True)
 
         # Did we do any updates?
         if not updated:

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -1267,6 +1267,23 @@ class EditComplexTest(ViewTestCase):
         self.assertFalse(Unit.objects.filter(pk=source_unit.pk).exists())
         self.assertEqual(unit_count - 4, Unit.objects.count())
 
+    def test_edit_checks(self) -> None:
+        source = "Thank you for using Weblate."
+        self.change_unit(
+            target="Díky za použití Weblate",
+            source=source,
+            user=self.anotheruser,
+        )
+        self.change_unit(
+            target="Díky za použití Weblate.",
+            source=source,
+            user=self.user,
+        )
+        unit = self.get_unit(source=source)
+        self.assertEqual(set(unit.check_set.values_list("name", flat=True)), set())
+        self.component.commit_pending("test", None)
+        self.assertEqual(set(unit.check_set.values_list("name", flat=True)), set())
+
 
 class EditSourceTest(ViewTestCase):
     def create_component(self):


### PR DESCRIPTION
This does trigger check run, what makes it slower and might trigger invalid check results due to excecuting them on an intermediate state.

Fixes #17128

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
