### PR TITLE
fix(ui): drop theming for REST framework browsable API

### DIFF
--- a/weblate/templates/rest_framework/api.html
+++ b/weblate/templates/rest_framework/api.html
@@ -2,13 +2,8 @@
 
 {% load static %}
 
-{% block bootstrap_theme %}
-  {{ block.super }}
-  {% include "snippets/meta-css.html" %}
-{% endblock bootstrap_theme %}
-
 {% block branding %}
-  {% include "snippets/branding.html" %}
+  <a class="navbar-brand" href="{% url 'home' %}">{{ site_title }}</a>
 {% endblock branding %}
 
 {% block description %}{{ block.super }}{% endblock %}


### PR DESCRIPTION
Unfortunately, Django REST framework is stuck on Bootstrap 3 for the time being, making its templates incompatible with our custom CSS after our upgrade to Bootstrap 5.

This PR fixes the layout issues by dropping our custom theming and using upstream styles.

Fixes #16759 

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
