### PR TITLE
fix(utils): properly detect encoding for system check

### DIFF
--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import errno
+import locale
 import os
 import sys
 import time
@@ -433,7 +434,11 @@ def check_encoding(
     **kwargs,
 ) -> Iterable[CheckMessage]:
     """Check that the encoding is UTF-8."""
-    if sys.getfilesystemencoding() == "utf-8" and sys.getdefaultencoding() == "utf-8":
+    if (
+        sys.getfilesystemencoding() == "utf-8"
+        and sys.getdefaultencoding() == "utf-8"
+        and locale.getlocale()[1].lower() == "utf-8"
+    ):
         return []
     return [
         weblate_check(


### PR DESCRIPTION
The sys.getdefaultencoding is always returning utf-8 on Python 3, so check it via locales as well.

Fixes #17195

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
