### PR TITLE
fix(utils): use locale to get current system encoding

### DIFF
--- a/weblate/trans/management/commands/list_versions.py
+++ b/weblate/trans/management/commands/list_versions.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import locale
 import platform
 import sys
 
@@ -50,7 +51,7 @@ class Command(BaseCommand):
         )
         self.write_item(
             "OS encoding",
-            f"filesystem={sys.getfilesystemencoding()}, default={sys.getdefaultencoding()}",
+            f"filesystem={sys.getfilesystemencoding()}, default={sys.getdefaultencoding()}, locale={locale.getlocale()[1].lower()}",
         )
         self.write_item(
             "Celery",

--- a/weblate/utils/tasks.py
+++ b/weblate/utils/tasks.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import gzip
+import locale
 import os
 import shutil
 import subprocess
@@ -45,7 +46,7 @@ def ping():
         "vcs": sorted(VCS_REGISTRY.keys()),
         "formats": sorted(FILE_FORMATS.keys()),
         "mt_services": sorted(MACHINERY.keys()),
-        "encoding": [sys.getfilesystemencoding(), sys.getdefaultencoding()],
+        "encoding": [sys.getfilesystemencoding(), locale.getlocale()[1].lower()],
         "uid": os.getuid(),
         "data_dir": settings.DATA_DIR,
     }
@@ -56,7 +57,7 @@ def heartbeat() -> None:
     cache.set("celery_loaded", time.time())
     cache.set("celery_heartbeat", time.time())
     cache.set(
-        "celery_encoding", [sys.getfilesystemencoding(), sys.getdefaultencoding()]
+        "celery_encoding", [sys.getfilesystemencoding(), locale.getlocale()[1].lower()]
     )
 
 


### PR DESCRIPTION
The sys.getdefaultencoding is fixed to utf-8 on Python 3.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
