### PR TITLE
feat(backup): longer expiry for backup lock

### DIFF
--- a/weblate/utils/backup.py
+++ b/weblate/utils/backup.py
@@ -46,6 +46,7 @@ def backup_lock():
         cache_template="lock:{scope}",
         file_template=".{scope}",
         timeout=120,
+        expiry_timeout=4 * 3600,
     )
 
 

--- a/weblate/utils/lock.py
+++ b/weblate/utils/lock.py
@@ -54,6 +54,7 @@ class WeblateLock:
         cache_template: str = "lock:{scope}:{key}",
         file_template: str = "{slug}-{scope}.lock",
         timeout: int = 1,
+        expiry_timeout: int = 3600,
         origin: str | None = None,
     ) -> None:
         self._timeout = timeout
@@ -65,6 +66,7 @@ class WeblateLock:
         self._using_redis = is_redis_cache()
         self._local = threading.local()
         self._local.depth = 0
+        self._redis_expiry_timeout = expiry_timeout
         if self._using_redis:
             # Prefer Redis locking as it works distributed
             self._name = self._format_template(cache_template)


### PR DESCRIPTION
The full backup can take longer than hour, so give the lock more time as well.

Fixes WEBLATE-357V

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
