### PR TITLE
fix(lock): refresh lock during long operations

### DIFF
--- a/weblate/addons/tasks.py
+++ b/weblate/addons/tasks.py
@@ -129,6 +129,7 @@ def language_consistency(
                 continue
             component.commit_pending("language consistency", None)
             for language in missing:
+                component.refresh_lock()
                 new_lang = component.add_new_language(
                     language,
                     fake_request,

--- a/weblate/utils/lock.py
+++ b/weblate/utils/lock.py
@@ -105,6 +105,15 @@ class WeblateLock:
             return f"Lock on {self.origin} ({self.scope}) could not be acquired in {self._timeout}s"
         return f"Lock on {self._name} could not be acquired in {self._timeout}s"
 
+    def reacquire(self) -> None:
+        """
+        Refresh the lock.
+
+        This is needed with Redis as the lock is expiring to avoid it stay infinitely.
+        """
+        if self._using_redis:
+            self._redis_lock.reacquire()
+
     def _enter_redis(self) -> None:
         # Make the lock reentrant
         if self._redis_lock.owned():


### PR DESCRIPTION
This avoids lock expiry in redis keeping it locked while processing.

Fixes WEBLATE-373H
Fixes WEBLATE-316H
Fixes WEBLATE-369T

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
