### PR TITLE
docs(state): add new states

### DIFF
--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -265,7 +265,7 @@ supports the following options:
 * **Commit all translations regardless of quality**: All translations will be committed,
   including those marked as needing editing or not reviewed.
 * **Skip translations marked as needing editing**: Only translations that don't have the
-  "needs editing" flag will be committed.
+  "needs editing", "needs rewriting" or "needs checking" state will be committed.
 * **Only include approved translations**: Only translations that have been approved by a
   reviewer will be committed. This option requires :ref:`project-translation_review`
   to be enabled.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,6 +52,7 @@ Weblate 5.15
 * The API timeout for creating pull requests or forking can now be configured via :setting:`VCS_API_TIMEOUT`.
 * Improved VCS integration documentation to clarify Docker environment variables, commit authorship, hosted vs. self-hosted setup, and authentication options.
 * Timestamps from past are now shown with more detail.
+* Added two new :ref:`states` to provide more detailed tracking of work-in-progress translations.
 
 .. rubric:: Bug fixes
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -63,10 +63,10 @@ Each translated string can be in one of the following states:
 Untranslated
     Translation is empty, it might or not be stored in the file, depending
     on the file format.
-Needs editing
+Needs editing / Needs rewriting / Needs checking
     Translation needs editing, this is usually the result of a source string change, fuzzy matching or translator action.
-    The translation is stored in the file, depending on the file format it might
-    be marked as needing edit (for example as it gets a ``fuzzy`` flag in the gettext file).
+    The translation is stored in the file if the :ref:`project-commit_policy` allows it.
+    Depending on the file format it might be marked as needing edit (for example as it gets a ``fuzzy`` flag in the gettext file).
 Waiting for review
     Translation is made, but not reviewed. It is stored in the file as a valid
     translation.


### PR DESCRIPTION
Adds documentation and changelog entry for #16947.

In my understanding they are functionally equivalent and a commit policy of "Skip translations marked as needing editing" should also skip "Needs rewriting" and "Needs checking".