### PR TITLE
fix(component): do not try to reacquire not held lock

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -2759,7 +2759,7 @@ class Component(
     def refresh_lock(self) -> None:
         """Refresh the lock to avoid expiry in long operations."""
         self.lock.reacquire()
-        if self.linked_component:
+        if self.linked_component and self.linked_component.lock.is_locked:
             self.linked_component.lock.reacquire()
 
     def _create_translations(  # noqa: C901,PLR0915

--- a/weblate/utils/lock.py
+++ b/weblate/utils/lock.py
@@ -111,6 +111,7 @@ class WeblateLock:
 
         This is needed with Redis as the lock is expiring to avoid it stay infinitely.
         """
+        self.add_breadcrumb("reacquire")
         if self._using_redis:
             self._redis_lock.reacquire()
 


### PR DESCRIPTION
The linked component lock does not have to be held in some contexts.

Fixes WEBLATE-38AZ

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
