### PR TITLE
fix(docs): avoid linkcheck for freedesktop.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -396,6 +396,8 @@ linkcheck_ignore = [
     "https://translate.yandex.com/",
     "https://www.gnu.org/",
     "https://dev.mysql.com/",
+    # Responds with HTTP 418 I'm a teapot
+    "https://www.freedesktop.org/",
 ]
 
 # HTTP docs


### PR DESCRIPTION
It responds with HTTP 418 I'm a teapot.

With all the AI crawlers, the linkcheck is not that useful...

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
