### PR TITLE
Fix for Duplication in regular expression character class

### DIFF
--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -81,7 +81,7 @@ XML_ENTITY_MATCH = re.compile(
             # NameStartChar
             [:A-Z_a-z\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u10000-\uEFFFF]
             # NameChar
-            [0-9\xB7.:A-Z_a-z\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u10000-\uEFFFF\u0300-\u036F\u203F-\u2040-]*
+            [0-9\xB7.:A-Z_a-z\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u10000-\uEFFFF\u0300-\u036F\u203F-\u2040]*
         )
     # Closing ;
     ;


### PR DESCRIPTION
In general, to fix this type of issue, you should inspect the character class the regex uses, compare it against the intended set of allowed characters (here, the XML `NameChar` definition), and remove any redundant entries or malformed ranges such as stray hyphens at the end of a class. The aim is to keep the semantics (which characters are matched) while simplifying the pattern and avoiding confusing or incorrect constructs that static analysis tools correctly flag as suspicious.

For this specific regex in `weblate/checks/markup.py`, the focus is the `NameChar` character class in the `XML_ENTITY_MATCH` pattern. The tail of that class currently ends with `\u203F-\u2040-]*`. The extra `-` at the end is not introducing a new range and makes the class look malformed; it may also be what prompts CodeQL to report a duplicate character. The best minimal fix is to delete that trailing `-` so that the class ends with `\u203F-\u2040]*`, which matches the same intended range from U+203F to U+2040 and closes the character class cleanly. This change is localized to the regex definition around lines 80–85 and does not alter any surrounding code or imports.

Concretely, edit the `XML_ENTITY_MATCH` definition so that the long `# NameChar` line:

```py
[0-9\xB7.:A-Z_a-z\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u10000-\uEFFFF\u0300-\u036F\u203F-\u2040-]*
```

is changed to:

```py
[0-9\xB7.:A-Z_a-z\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u10000-\uEFFFF\u0300-\u036F\u203F-\u2040]*
```

No new methods, imports, or definitions are required; this is a single-character fix to the regex literal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._