### PR TITLE
Fix for Duplication in regular expression character class

### DIFF
--- a/weblate/checks/same.py
+++ b/weblate/checks/same.py
@@ -54,7 +54,7 @@ RST_MATCH = re.compile(r"(:[a-z:]+:`[^`]+`|``[^`]+``)")
 
 SPLIT_RE = re.compile(
     r"(?:\&(?:nbsp|rsaquo|lt|gt|amp|ldquo|rdquo|times|quot);|"
-    r'[() ,.^`"\'\\/_<>!?;:|{}*^@%#&~=+\r\n✓—‑…\[\]0-9-])+',
+    r'[() ,.^`"\'\\/_<>!?;:|{}*@%#&~=+\r\n✓—‑…\[\]0-9-])+',
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
In general, to fix “duplicate character in a character class” issues, you remove repeated characters from the `[...]` part of the regex (or, if the repetition reveals a typo, replace one occurrence with the intended different character). This preserves semantics while eliminating redundancy and static-analysis noise.

Here, the problematic part is the `SPLIT_RE` pattern:

```py
SPLIT_RE = re.compile(
    r"(?:\&(?:nbsp|rsaquo|lt|gt|amp|ldquo|rdquo|times|quot);|"
    r'[() ,.^`"\'\\/_<>!?;:|{}*^@%#&~=+\r\n✓—‑…\[\]0-9-])+',
    re.IGNORECASE,
)
```

Within the character class `[() ,.^`"\'\\/_<>!?;:|{}*^@%#&~=+\r\n✓—‑…\[\]0-9-]`, the `^` character appears twice. The simplest, behavior-preserving fix is to remove one occurrence, leaving just a single `^` in the class. Since position does not matter for single characters in a character class, we can safely delete the second `^` before `@`. No new imports or helper methods are needed, and nothing else in the file must change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._