### PR TITLE
fix(ui): file format params checkbox

### DIFF
--- a/weblate/trans/file_format_params.py
+++ b/weblate/trans/file_format_params.py
@@ -48,8 +48,9 @@ class BaseFileFormatParam:
     def get_widget_attrs(self) -> dict:
         field_classes = ["file-format-param-field"]
 
-        if self.field_class != forms.BooleanField:
-            # the default radio/checkbox input looks better than bootstrap one
+        if self.field_class == forms.BooleanField:
+            field_classes.append("form-check-input")
+        else:
             field_classes.append("form-control")
 
         return {


### PR DESCRIPTION
Add bootstrap class to render checkbox inputs in file format params form properly.

Before:
<img width="793" height="238" alt="Screenshot From 2025-12-20 13-09-39" src="https://github.com/user-attachments/assets/3e7f4323-f34c-4451-9b88-0c3f72f9499a" />

After:
<img width="798" height="232" alt="Screenshot From 2025-12-20 14-41-13" src="https://github.com/user-attachments/assets/7d907e99-8bab-4b39-97c5-f79a8b5b4c7a" />
