### PR TITLE
fix(file sync): handle explanation change for TBX

### DIFF
--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -417,8 +417,8 @@ class RepoTestMixin:
             "rc", "winrc/*.rc", "winrc/en-US.rc", edit_template=False
         )
 
-    def create_tbx(self) -> Component:
-        return self._create_component("tbx", "tbx/*.tbx")
+    def create_tbx(self, **kwargs) -> Component:
+        return self._create_component("tbx", "tbx/*.tbx", **kwargs)
 
     def create_link(self, **kwargs) -> Component:
         parent = self.create_iphone(*kwargs)


### PR DESCRIPTION
Certain formats like TBX support writing the explanation to the file. When syncing from these file formats, explanation read from disk should be treated as a data change and not a metadata change.

Fixes #16571.