### PR TITLE
fix(docs) using email to authenticate on bitbucket cloud https://gith…

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -963,7 +963,7 @@ List for credentials for Bitbucket Cloud servers.
 
     BITBUCKETCLOUD_CREDENTIALS = {
         "bitbucket.org": {
-            "username": "your-username",
+            "username": "your-email",
             "workspace": "your-workspace-slug",
             "token": "your-api-token",
         },


### PR DESCRIPTION
…ub.com/WeblateOrg/weblate/issues/17525 https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/

Just a small doc change (using email is tested and is working)

Thanks for all!