### PR TITLE
fix: always apply format settings for msgmerge

### DIFF
--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -936,20 +936,14 @@ class BilingualUpdateMixin:
 
         This is used to pass additional arguments to update command.
         """
-        from weblate.addons.gettext import MsgmergeAddon
-
         params = component.file_format_params
         args: list[str] = []
-        if component.get_addon(MsgmergeAddon.name):
-            if not params.get("po_fuzzy_matching", True):
-                args.append("--no-fuzzy-matching")
-            if params.get("po_keep_previous", True):
-                args.append("--previous")
-            if params.get("po_no_location", False):
-                args.append("--no-location")
-        else:
+        if not params.get("po_fuzzy_matching", True):
+            args.append("--no-fuzzy-matching")
+        if params.get("po_keep_previous", True):
             args.append("--previous")
-
+        if params.get("po_no_location", False):
+            args.append("--no-location")
         if int(params.get("po_line_wrap", 77)) != 77:
             args.append("--no-wrap")
         return args

--- a/weblate/trans/file_format_params.py
+++ b/weblate/trans/file_format_params.py
@@ -29,7 +29,7 @@ class FieldKwargsDict(TypedDict, total=False):
 
 class FileFormatParams(TypedDict, total=False):
     json_sort_keys: bool
-    json_indent: bool
+    json_indent: int
     json_indent_style: Literal["spaces", "tabs"]
     json_use_compact_separators: bool
     po_line_wrap: int
@@ -37,8 +37,8 @@ class FileFormatParams(TypedDict, total=False):
     po_no_location: bool
     po_fuzzy_matching: bool
     yaml_indent: int
-    yaml_line_wrap: bool
-    yaml_line_break: bool
+    yaml_line_wrap: int
+    yaml_line_break: str
     xml_closing_tags: bool
     flatxml_root_name: str
     flatxml_value_name: str
@@ -133,10 +133,10 @@ def get_params_for_file_format(file_format: str) -> list[type[BaseFileFormatPara
     return [param for param in FILE_FORMATS_PARAMS if file_format in param.file_formats]
 
 
-def get_default_params_for_file_format(file_format: str) -> dict[str, str | int | bool]:
+def get_default_params_for_file_format(file_format: str) -> FileFormatParams:
     """Get default values for all registered file format parameters."""
     params = get_params_for_file_format(file_format)
-    return {param.name: param.default for param in params}
+    return cast("FileFormatParams", {param.name: param.default for param in params})
 
 
 def strip_unused_file_format_params(


### PR DESCRIPTION
The reason for the condition was that the settings was not present without the add-on before, but now it is.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
