### PR TITLE
fix(unit): honor source unit based state even when there are no flags

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -819,18 +819,17 @@ class Unit(models.Model, LoggerMixin):
         if unit.is_readonly():
             return STATE_READONLY
 
-        if flags is not None:
-            # Read-only from the source
-            if (
-                not self.is_source
-                and self.source_unit.state < STATE_TRANSLATED
-                and self.translation.component.intermediate
-            ):
-                return STATE_READONLY
+        # Read-only from the source
+        if (
+            not self.is_source
+            and self.source_unit.state < STATE_TRANSLATED
+            and self.translation.component.intermediate
+        ):
+            return STATE_READONLY
 
-            # Read-only from flags
-            if "read-only" in self.get_all_flags(flags):
-                return STATE_READONLY
+        # Read-only from flags (flags=None indicates skipping this logic)
+        if flags is not None and "read-only" in self.get_all_flags(flags):
+            return STATE_READONLY
 
         # We need to keep approved/fuzzy state for formats which do not
         # support saving it


### PR DESCRIPTION
I don't see a reason to look for flags when inferring state from the source unit. It magically worked for most of the time because we started to pass empty Flags instead instead of None in some cases.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
