### PR TITLE
fix(checks): avoid regex marking strings as placeholders

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ Weblate 5.16
 
 .. rubric:: Compatibility
 
+* :ref:`check-regex` no longer marks matched portions as non-translatable to allow generic regular-expression-based checking of strings. Use :ref:`check-placeholders` for checking regular expression matched placeholders.
+
 .. rubric:: Upgrading
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.

--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -1619,6 +1619,10 @@ The matching also supports Unicode codepoint properties, including scripts and b
 
    regex:^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$
 
+.. hint::
+
+   Use :ref:`check-placeholders` for detecting missing placeholders in the string.
+
 .. seealso::
 
    `regex documentation <https://github.com/mrabarnett/mrab-regex>`_

--- a/weblate/checks/placeholders.py
+++ b/weblate/checks/placeholders.py
@@ -153,15 +153,6 @@ class RegexCheck(TargetCheckParametrized):
             return True
         return not self.get_value(unit).pattern
 
-    def check_highlight(self, source: str, unit: Unit):
-        if self.should_skip(unit):
-            return
-
-        check_regex = self.get_value(unit)
-
-        for match in check_regex.finditer(source):
-            yield (match.start(), match.end(), match.group())
-
     def get_description(self, check_obj):
         unit = check_obj.unit
         if not self.has_value(unit):

--- a/weblate/checks/tests/test_placeholders.py
+++ b/weblate/checks/tests/test_placeholders.py
@@ -220,7 +220,7 @@ class RegexTest(CheckTestCase):
         self.test_failure_1 = ("string URL", "string", "regex:URL")
         self.test_failure_2 = ("string URL", "string url", "regex:URL")
         self.test_failure_3 = ("string URL", "string URL", "regex:^URL$")
-        self.test_highlight = ("regex:URL", "See URL", [(4, 7, "URL")])
+        self.test_highlight = ("regex:URL", "See URL", [])
 
     def do_test(self, expected, data, lang=None) -> None:
         # Skip using check_single as the Check does not use that
@@ -242,14 +242,7 @@ class RegexTest(CheckTestCase):
             self.default_lang,
             "@:(foo.bar.baz) | @:(hello.world) | {foo32}",
         )
-        self.assertEqual(
-            list(self.check.check_highlight(unit.source, unit)),
-            [
-                (0, 15, "@:(foo.bar.baz)"),
-                (18, 33, "@:(hello.world)"),
-                (36, 43, "{foo32}"),
-            ],
-        )
+        self.assertEqual(list(self.check.check_highlight(unit.source, unit)), [])
 
     def test_unicode_regex(self) -> None:
         unit = MockUnit(
@@ -261,9 +254,5 @@ class RegexTest(CheckTestCase):
         )
         self.assertEqual(
             list(self.check.check_highlight(unit.source, unit)),
-            [
-                (0, 11, "@:(你好世界一۲༣)"),
-                (50, 63, "@:(-你好世界一۲༣_)"),
-                (66, 82, "{hello-world123}"),
-            ],
+            [],
         )


### PR DESCRIPTION
It is often used to match whole strings, for example to limit used characters, so it is not a good idea to use it as placeholders. There is placeholders check which accepts regular expressions as well and serves this purpose.

See #17452

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
