### PR TITLE
fix(component): gracefully handle corrupted repositories

### DIFF
--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -959,6 +959,7 @@ class ComponentErrorTest(RepoTestCase):
     def test_failed_reset(self) -> None:
         # Corrupt Git database so that reset fails
         remove_tree(os.path.join(self.component.full_path, ".git", "objects", "pack"))
+        self.component.repository.clean_revision_cache()
         self.assertFalse(self.component.do_reset(None))
 
     def test_invalid_templatename(self) -> None:

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -187,7 +187,11 @@ class Repository:
         return real_path[len(repository_path) :].lstrip("/")
 
     @staticmethod
-    def _getenv(environment: dict[str, str] | None = None) -> dict[str, str]:
+    def _getenv(
+        environment: dict[str, str] | None = None,
+        *,
+        cwd: str | None = None,
+    ) -> dict[str, str]:
         """Generate environment for process execution."""
         base: dict[str, str] = {
             # Avoid prompts from Git
@@ -198,6 +202,8 @@ class Repository:
             "GIT_SSH_COMMAND": SSH_WRAPPER.filename.as_posix(),
             "SVN_SSH": SSH_WRAPPER.filename.as_posix(),
         }
+        if cwd:
+            base["GIT_DIR"] = os.path.join(cwd, ".git")
         if environment:
             base.update(environment)
         return get_clean_env(base, extra_path=SSH_WRAPPER.path.as_posix())
@@ -234,7 +240,7 @@ class Repository:
             process = subprocess.run(
                 args=args,
                 cwd=cwd,
-                env=environment or {} if local else cls._getenv(environment),
+                env=environment or {} if local else cls._getenv(environment, cwd=cwd),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT if merge_err else subprocess.PIPE,
                 text=not raw,


### PR DESCRIPTION
- Avoid crashing on getting last revision when doing reset. Still the repository needs to be fetched manually again.
- Limit VCS integration to avoid looking into parent directories as that might cause confusion with corrupted repos.

Fixes #17408

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
