### PR TITLE
fix(vcs): gracefully handle error responses from code hosting sites

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -1366,7 +1366,11 @@ class GitMergeRequestBase(GitForcePushRepository):
         even though the response was an error. This method exists to let the
         inheritors override it if they have special cases.
         """
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            report_error("Git API request")
+            raise RepositoryError(0, str(error)) from error
 
     def get_random_suffix(self) -> str:
         return str(random.randint(1000, 9999))  # noqa: S311


### PR DESCRIPTION
Using raise_for_status directly will raise HTTPError and we need to convert it to RepositoryError.

Fixes WEBLATE-BKZ

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
