### PR TITLE
Correct documentation for WEBLATE_SECURE_PROXY_SSL_HEADER env variable

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -766,8 +766,8 @@ Client protocol
    .. important::
 
       The header value is case-sensitive in the configuration, so
-      ``WEBLATE_SECURE_PROXY_SSL_HEADER=HTTP_X_CUSTOM_PROTO,https`` and
-      ``WEBLATE_SECURE_PROXY_SSL_HEADER=HTTP_X_CUSTOM_PROTO,HTTPS`` are not
+      ``WEBLATE_SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https`` and
+      ``WEBLATE_SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,HTTPS`` are not
       interchangeable.
 
    .. hint::


### PR DESCRIPTION
Update `WEBLATE_SECURE_PROXY_SSL_HEADER` docs to show `HTTP_X_FORWARDED_PROTO` in examples

Fix: https://github.com/WeblateOrg/weblate/issues/17706