### PR TITLE
fix(component): correctly generate template for repoweb URL

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@ Weblate 5.16
 .. rubric:: Bug fixes
 
 * Adding plural strings with singular matching existing string is now prohibited for bilingual translations (see :ref:`bimono`).
+* Automatic :ref:`component-repoweb` URL for common code hosting sites.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -220,6 +220,10 @@ AZURE_REPOS_REGEXP = [
     r"(?:git@ssh.dev.azure.com:v3)\/([^/]*)\/([^/]*)\/([^/]*)",
 ]
 
+REPOWEB_BRANCH = "{{branch}}"
+REPOWEB_FILENAME = "{{filename}}"
+REPOWEB_LINE = "{{line}}"
+
 
 def perform_on_link(func):
     """Perform operation on repository link."""
@@ -1548,7 +1552,7 @@ class Component(
         filename: str,
         line: str,
         template: str | None = None,
-        user=None,
+        user: User | None = None,
     ):
         """
         Generate link to source code browser for given file and line.
@@ -1626,9 +1630,7 @@ class Component(
             owner = matches.group(1)
             slug = self.get_clean_slug(matches.group(2))
         if owner and slug:
-            return (
-                f"https://{domain}/{owner}/{slug}/blob/{{branch}}/{{filename}}#{{line}}"
-            )
+            return f"https://{domain}/{owner}/{slug}/blob/{REPOWEB_BRANCH}/{REPOWEB_FILENAME}#{REPOWEB_LINE}"
 
         return None
 
@@ -1642,7 +1644,7 @@ class Component(
             owner = matches.group(1)
             slug = self.get_clean_slug(matches.group(2))
         if owner and slug:
-            return f"https://{domain}/{owner}/{slug}/blob/{{branch}}/{{filename}}#L{{line}}"
+            return f"https://{domain}/{owner}/{slug}/blob/{REPOWEB_BRANCH}/{REPOWEB_FILENAME}#L{REPOWEB_LINE}"
 
         return None
 
@@ -1654,7 +1656,7 @@ class Component(
             slug = matches.group(2)
 
         if owner and slug:
-            return f"https://{domain}/{owner}/{slug}/blob/{{branch}}/f/{{filename}}/#_{{line}}"
+            return f"https://{domain}/{owner}/{slug}/blob/{REPOWEB_BRANCH}/f/{REPOWEB_FILENAME}/#_{REPOWEB_LINE}"
 
         return None
 
@@ -1675,7 +1677,7 @@ class Component(
             repository = matches.group(3)
 
         if organization and project and repository:
-            return f"https://{domain}/{organization}/{project}/_git/{repository}/blob/{{branch}}/{{filename}}#L{{line}}"
+            return f"https://{domain}/{organization}/{project}/_git/{repository}/blob/{REPOWEB_BRANCH}/{REPOWEB_FILENAME}#L{REPOWEB_LINE}"
 
         return None
 

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -19,7 +19,7 @@ from weblate.trans.actions import ActionEvents
 from weblate.trans.exceptions import FileParseError
 from weblate.trans.models import Component, Project, Unit
 from weblate.trans.tests.test_models import RepoTestCase
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
 from weblate.utils.files import remove_tree
 from weblate.utils.state import STATE_EMPTY, STATE_READONLY, STATE_TRANSLATED
 
@@ -647,69 +647,6 @@ class ComponentChangeTest(RepoTestCase):
         component.repo = cast("Component", component.linked_component).repo
         component.save()
 
-    def test_repo_link_generation_bitbucket(self) -> None:
-        """Test changing repo attribute to check repo generation links."""
-        component = self.create_component()
-        component.repo = "ssh://git@bitbucket.org/marcus/project-x.git"
-        result = component.get_bitbucket_git_repoweb_template()
-        self.assertEqual(
-            result,
-            "https://bitbucket.org/marcus/project-x/blob/{branch}/{filename}#{line}",
-        )
-        component.repo = "git@bitbucket.org:marcus/project-x.git"
-        result = component.get_bitbucket_git_repoweb_template()
-        self.assertEqual(
-            result,
-            "https://bitbucket.org/marcus/project-x/blob/{branch}/{filename}#{line}",
-        )
-
-    def test_repo_link_generation_github(self) -> None:
-        """Test changing repo attribute to check repo generation links."""
-        component = self.create_component()
-        component.repo = "git://github.com/marcus/project-x.git"
-        result = component.get_github_repoweb_template()
-        self.assertEqual(
-            result,
-            "https://github.com/marcus/project-x/blob/{branch}/{filename}#L{line}",
-        )
-        component.repo = "git@github.com:marcus/project-x.git"
-        result = component.get_github_repoweb_template()
-        self.assertEqual(
-            result,
-            "https://github.com/marcus/project-x/blob/{branch}/{filename}#L{line}",
-        )
-
-    def test_repo_link_generation_pagure(self) -> None:
-        """Test changing repo attribute to check repo generation links."""
-        component = self.create_component()
-        component.repo = "https://pagure.io/f/ATEST"
-        result = component.get_pagure_repoweb_template()
-        self.assertEqual(
-            result, "https://pagure.io/f/ATEST/blob/{branch}/f/{filename}/#_{line}"
-        )
-
-    def test_repo_link_generation_azure(self) -> None:
-        """Test changing repo attribute to check repo generation links."""
-        component = self.create_component()
-        component.repo = "f@vs-ssh.visualstudio.com:v3/f/c/ATEST"
-        result = component.get_azure_repoweb_template()
-        self.assertEqual(
-            result,
-            "https://dev.azure.com/f/c/_git/ATEST/blob/{branch}/{filename}#L{line}",
-        )
-        component.repo = "git@ssh.dev.azure.com:v3/f/c/ATEST"
-        result = component.get_azure_repoweb_template()
-        self.assertEqual(
-            result,
-            "https://dev.azure.com/f/c/_git/ATEST/blob/{branch}/{filename}#L{line}",
-        )
-        component.repo = "https://f.visualstudio.com/c/_git/ATEST"
-        result = component.get_azure_repoweb_template()
-        self.assertEqual(
-            result,
-            "https://dev.azure.com/f/c/_git/ATEST/blob/{branch}/{filename}#L{line}",
-        )
-
     def test_change_project(self) -> None:
         component = self.create_component()
 
@@ -1169,3 +1106,91 @@ class ComponentKeyFilterTest(ViewTestCase):
             "To use the key filter, the file format must be monolingual.",
         ):
             component.clean()
+
+
+class ComponentRepoWebTestCase(FixtureTestCase):
+    def get_url(self) -> str | None:
+        return self.component.get_repoweb_link("test.py", "42", user=self.user)
+
+    def test_provided(self):
+        self.component.repoweb = (
+            "https://example.com/{{branch}}/f/{{filename}}#_{{line}}"
+        )
+        self.assertEqual("https://example.com/main/f/test.py#_42", self.get_url())
+
+    def test_blank(self):
+        self.assertIsNone(self.get_url())
+
+    def test_repo_link_generation_bitbucket(self) -> None:
+        """Test changing repo attribute to check repo generation links."""
+        self.component.repo = "ssh://git@bitbucket.org/marcus/project-x.git"
+        self.assertEqual(
+            self.component.get_bitbucket_git_repoweb_template(),
+            "https://bitbucket.org/marcus/project-x/blob/{{branch}}/{{filename}}#{{line}}",
+        )
+
+        self.component.repo = "git@bitbucket.org:marcus/project-x.git"
+        self.assertEqual(
+            self.component.get_bitbucket_git_repoweb_template(),
+            "https://bitbucket.org/marcus/project-x/blob/{{branch}}/{{filename}}#{{line}}",
+        )
+
+        self.assertEqual(
+            "https://bitbucket.org/marcus/project-x/blob/main/test.py#42",
+            self.get_url(),
+        )
+
+    def test_repo_link_generation_github(self) -> None:
+        """Test changing repo attribute to check repo generation links."""
+        self.component.repo = "git://github.com/marcus/project-x.git"
+        self.assertEqual(
+            self.component.get_github_repoweb_template(),
+            "https://github.com/marcus/project-x/blob/{{branch}}/{{filename}}#L{{line}}",
+        )
+
+        self.component.repo = "git@github.com:marcus/project-x.git"
+        self.assertEqual(
+            self.component.get_github_repoweb_template(),
+            "https://github.com/marcus/project-x/blob/{{branch}}/{{filename}}#L{{line}}",
+        )
+
+        self.assertEqual(
+            "https://github.com/marcus/project-x/blob/main/test.py#L42", self.get_url()
+        )
+
+    def test_repo_link_generation_pagure(self) -> None:
+        """Test changing repo attribute to check repo generation links."""
+        self.component.repo = "https://pagure.io/f/ATEST"
+        self.assertEqual(
+            self.component.get_pagure_repoweb_template(),
+            "https://pagure.io/f/ATEST/blob/{{branch}}/f/{{filename}}/#_{{line}}",
+        )
+
+        self.assertEqual(
+            "https://pagure.io/f/ATEST/blob/main/f/test.py/#_42", self.get_url()
+        )
+
+    def test_repo_link_generation_azure(self) -> None:
+        """Test changing repo attribute to check repo generation links."""
+        self.component.repo = "f@vs-ssh.visualstudio.com:v3/f/c/ATEST"
+        self.assertEqual(
+            self.component.get_azure_repoweb_template(),
+            "https://dev.azure.com/f/c/_git/ATEST/blob/{{branch}}/{{filename}}#L{{line}}",
+        )
+
+        self.component.repo = "git@ssh.dev.azure.com:v3/f/c/ATEST"
+        self.assertEqual(
+            self.component.get_azure_repoweb_template(),
+            "https://dev.azure.com/f/c/_git/ATEST/blob/{{branch}}/{{filename}}#L{{line}}",
+        )
+
+        self.component.repo = "https://f.visualstudio.com/c/_git/ATEST"
+        self.assertEqual(
+            self.component.get_azure_repoweb_template(),
+            "https://dev.azure.com/f/c/_git/ATEST/blob/{{branch}}/{{filename}}#L{{line}}",
+        )
+
+        self.assertEqual(
+            "https://dev.azure.com/f/c/_git/ATEST/blob/main/test.py#L42",
+            self.get_url(),
+        )


### PR DESCRIPTION
The templating was wrong in the generated template so the links contained template markup instead of the actual values.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
