### PR TITLE
feat: clarify availability of project invitations

### DIFF
--- a/weblate/templates/trans/project-access.html
+++ b/weblate/templates/trans/project-access.html
@@ -194,25 +194,29 @@
             </div>
           </form>
         </div>
-        {% if invite_email_form %}
-          <div class="col-sm-6">
-            <form action="{% url "invite-user" project=object.slug %}" method="post">
-              {% csrf_token %}
-              <div class="card">
-                <div class="card-header">
-                  <h4 class="card-title">
-                    {% documentation_icon 'admin/access' 'invite-user' right=True %}
-                    {% translate "Invite new user" %}
-                  </h4>
-                </div>
+        <div class="col-sm-6">
+          <form action="{% url "invite-user" project=object.slug %}" method="post">
+            {% csrf_token %}
+            <div class="card">
+              <div class="card-header">
+                <h4 class="card-title">
+                  {% documentation_icon 'admin/access' 'invite-user' right=True %}
+                  {% translate "Invite new user" %}
+                </h4>
+              </div>
+              {% if invite_email_form %}
                 <div class="card-body">{{ invite_email_form|crispy }}</div>
                 <div class="card-footer">
                   <input type="submit" class="btn btn-primary" value="{% translate "Invite" %}" />
                 </div>
-              </div>
-            </form>
-          </div>
-        {% endif %}
+              {% else %}
+                <div class="card-body">
+                  {% translate "You are not allowed to invite new users because new registrations are turned off." %}
+                </div>
+              {% endif %}
+            </div>
+          </form>
+        </div>
       </div>
     </div>
 

--- a/weblate/trans/tests/test_acl.py
+++ b/weblate/trans/tests/test_acl.py
@@ -156,6 +156,16 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
         )
         self.assertEqual(response.status_code, 403)
 
+        # It should work for the superuser
+        self.user.is_superuser = True
+        self.user.save()
+        response = self.client.post(
+            reverse("invite-user", kwargs=self.kw_project),
+            {"email": "user@example.com", "group": self.admin_group.pk},
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
     @override_settings(REGISTRATION_OPEN=True, REGISTRATION_CAPTCHA=False)
     def test_invite_user_open(self) -> None:
         """Test inviting user."""

--- a/weblate/trans/views/acl.py
+++ b/weblate/trans/views/acl.py
@@ -169,11 +169,15 @@ def unblock_user(request: AuthenticatedHttpRequest, project):
     return redirect("manage-access", project=obj.slug)
 
 
+def can_invite_users(request: AuthenticatedHttpRequest) -> bool:
+    return settings.REGISTRATION_OPEN or request.user.has_perm("user.edit")
+
+
 @require_POST
 @login_required
 def invite_user(request: AuthenticatedHttpRequest, project):
     """Invite user to a project."""
-    if not settings.REGISTRATION_OPEN:
+    if not can_invite_users(request):
         raise PermissionDenied
     obj, form = check_user_form(
         request, project, form_class=InviteEmailForm, pass_project=True
@@ -289,7 +293,7 @@ def manage_access(request: AuthenticatedHttpRequest, project):
             ),
             "invite_user_form": InviteUserForm(project=obj),
             "invite_email_form": InviteEmailForm(project=obj)
-            if settings.REGISTRATION_OPEN
+            if can_invite_users(request)
             else None,
             "public_ssh_keys": get_all_key_data(),
         },


### PR DESCRIPTION
The project-level invitations are now available to site admins even if registrations are turned off. If user can not invite new users, the message is shown indicating why it is not available.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
