### PR TITLE
fix(search): handle multiple label filtering with AND

### DIFF
--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -273,6 +273,27 @@ class SearchViewTest(TransactionsTestMixin, ViewTestCase):
     def test_checksum(self) -> None:
         self.do_search({"checksum": "invalid"}, None, anchor="")
 
+    def test_search_multiple_labels(self) -> None:
+        """Test that searching with label:ABC AND label:XYZ works correctly."""
+        label1 = self.project.label_set.create(name="ABC", color="black")
+        label2 = self.project.label_set.create(name="XYZ", color="blue")
+
+        unit = self.get_unit()
+        source_unit = unit.source_unit
+        source_unit.labels.add(label1, label2)
+
+        unit.translation.stats.clear()
+
+        self.do_search({"q": "label:ABC"}, "Hello, world!")
+        self.do_search({"q": "label:XYZ"}, "Hello, world!")
+        self.do_search({"q": "label:ABC AND label:XYZ"}, "Hello, world!")
+        self.do_search({"q": "label:ABC label:XYZ"}, "Hello, world!")
+
+        source_unit.labels.remove(label2)
+        unit.translation.stats.clear()
+        self.do_search({"q": "label:ABC AND label:XYZ"}, None)
+        self.do_search({"q": "label:ABC label:XYZ"}, None)
+
 
 class ReplaceTest(ViewTestCase):
     """Test for search and replace functionality."""

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -438,11 +438,6 @@ class UnitQueryParserTest(SearchTestCase):
             Q(check__name__iexact="ellipsis") & Q(check__dismissed=True),
         )
 
-    def test_labels(self) -> None:
-        self.assert_query(
-            "label:'test label'", Q(source_unit__labels__name__iexact="test label")
-        )
-
     def test_screenshot(self) -> None:
         self.assert_query(
             "screenshot:'test screenshot'",


### PR DESCRIPTION
Use Exists with a subquery to ensure each label condition gets its own join so that filtering on multiple labels with AND works.

Fixes https://github.com/WeblateOrg/weblate/issues/17720