### PR TITLE
fix(vcs): hold repository lock for git config update

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -190,8 +190,9 @@ class GitRepository(Repository):
                     config.set(section, key, value)
 
     def config_update(self, *updates: tuple[str, str, str | None]) -> None:
-        filename = Path(self.path) / ".git" / "config"
-        self.git_config_update(filename, *updates)
+        with self.lock:
+            filename = Path(self.path) / ".git" / "config"
+            self.git_config_update(filename, *updates)
 
     def check_config(self) -> None:
         """Check VCS configuration."""


### PR DESCRIPTION
There is additional locking in GitPython, but it doesn't wait for the lock to be released.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
