### PR TITLE
fix(add-ons): add delay to fedora messaging tests reset

### DIFF
--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -11,6 +11,7 @@ import tempfile
 from datetime import timedelta
 from io import StringIO
 from pathlib import Path
+from time import sleep
 from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import patch
 
@@ -2072,9 +2073,7 @@ class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):
 
 class SlackWebhooksAddonsTest(BaseWebhookTests, ViewTestCase):
     WEBHOOK_CLS = SlackWebhookAddon
-    WEBHOOK_URL = (
-        "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
-    )
+    WEBHOOK_URL = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"  # kingfisher:ignore
 
     addon_configuration: ClassVar[dict] = {
         "webhook_url": WEBHOOK_URL,
@@ -2111,6 +2110,9 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         return self.mock_class.call_count
 
     def reset_calls(self) -> None:
+        # Wait short time so that previous messages are delivered. Fedora Messaging
+        # uses background thread to deliver, so the delivery might happen later.
+        sleep(0.1)
         self.mock_class.call_count = 0
 
     def test_topic(self):


### PR DESCRIPTION
The messages are delivered in a different thread, so we add a short delay for testing (proper synchronization would need too much digging into internals).

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
