### PR TITLE
fix(appstore): write only files with changed strings

### DIFF
--- a/weblate/formats/txt.py
+++ b/weblate/formats/txt.py
@@ -50,6 +50,7 @@ class TextItem(BaseItem):
         self.line = line
         self.text = text
         self.flags = flags
+        self.needs_save: bool = False
 
     @cached_property
     def location(self) -> str:
@@ -189,6 +190,7 @@ class TextUnit(TranslationUnit):
         """Set translation unit target."""
         self._invalidate_target()
         self.unit.text = target
+        self.unit.needs_save = True
 
     def set_state(self, state) -> None:
         """Set fuzzy /approved flag on translated unit."""
@@ -243,6 +245,8 @@ class AppStoreFormat(TranslationFormat):
     def save(self) -> None:
         """Save underlying store to disk."""
         for unit in self.store.units:
+            if not unit.needs_save:
+                continue
             filename = self.store.get_filename(unit.filename)
             if not unit.text:
                 if os.path.exists(filename):


### PR DESCRIPTION
The appstore backend always updated all files even those which were not changed. This could cause conversion of symlinks to files for unchanged strings (including the ones excluded by the filter).

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
