### PR TITLE
fix(translate): show unlocked components first while translating

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -275,7 +275,11 @@ class UnitQuerySet(models.QuerySet["Unit"]):
                 sort_list = ["source"]
             elif isinstance(obj, (Project, Category)):
                 sort_list = [
+                    # Show locked components at the end
+                    "translation__component__locked",
+                    # Order by priority for custom ordering
                     "translation__component__priority",
+                    # Show glossaries at the end
                     "translation__component__is_glossary",
                     "translation__component__name",
                     "-priority",


### PR DESCRIPTION
This kind of filters the locked components from project-level translate view, while keeping them present so that the stats match the search results.

When we would be filtering these, user might end up with no strings to translate while the stats show strings to translate.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
