### PR TITLE
fix: properly scope user search to allowed projects only

### DIFF
--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -1619,7 +1619,9 @@ class UserList(ListView):
         if form.is_valid():
             search = form.cleaned_data.get("q", "")
             if search:
-                users = users.search(search, parser=form.fields["q"].parser)
+                users = users.search(
+                    search, parser=form.fields["q"].parser, user=self.request.user
+                )
         else:
             users = users.order()
 

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -790,12 +790,14 @@ class UserTermExpr(BaseTermExpr):
 
     def contributes_field(self, text: str, context: dict) -> Q:
         if "/" not in text:
-            return Q(change__project__slug__iexact=text)
-        return Q(
-            change__component_id__in=list(
-                Component.objects.filter_by_path(text).values_list("id", flat=True)
+            slug_filter = Q(change__project__slug__iexact=text)
+        else:
+            slug_filter = Q(
+                change__component_id__in=list(
+                    Component.objects.filter_by_path(text).values_list("id", flat=True)
+                )
             )
-        )
+        return slug_filter & Q(change__project__in=context["user"].allowed_projects)
 
 
 class SuperuserUserTermExpr(UserTermExpr):

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -675,23 +675,30 @@ class UserQueryParserTest(SearchTestCase):
         )
 
     def test_contributes(self) -> None:
+        user = User.objects.create(is_superuser=True)
         self.assert_query(
             "contributes:test",
-            Q(change__project__slug__iexact="test"),
+            Q(change__project__slug__iexact="test")
+            & Q(change__project__in=user.allowed_projects),
+            user=user,
         )
         self.assert_query(
             "contributes:test/test",
-            Q(change__component_id__in=[]),
+            Q(change__component_id__in=[])
+            & Q(change__project__in=user.allowed_projects),
+            user=user,
         )
         self.assert_query(
             "contributes:test change_time:>'90 days ago'",
             Q(change__project__slug__iexact="test")
+            & Q(change__project__in=user.allowed_projects)
             & Q(
                 change__timestamp__gte=datetime.now(tz=UTC).replace(
                     hour=0, minute=0, second=0, microsecond=0
                 )
                 - timedelta(days=90)
             ),
+            user=user,
         )
 
 


### PR DESCRIPTION
Searching for users in a project that user has no access to should not work.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
