### PR TITLE
fix(formats): hold markdown lock for parsing

### DIFF
--- a/weblate/utils/concurrency.py
+++ b/weblate/utils/concurrency.py
@@ -1,0 +1,8 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import threading
+
+MARKDOWN_LOCK = threading.Lock()

--- a/weblate/utils/markdown.py
+++ b/weblate/utils/markdown.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import re
-import threading
 from functools import reduce
 
 import mistletoe
@@ -14,8 +13,9 @@ from mistletoe import span_token
 
 from weblate.auth.models import User
 
+from .concurrency import MARKDOWN_LOCK
+
 MENTION_RE = re.compile(r"(?<!\w)(@[\w.@+-]+)\b")
-MARKDOWN_LOCK = threading.Lock()
 
 
 def get_mention_users(text):


### PR DESCRIPTION
The Markdown renderer is not thread safe and changes global state, so make sure that two of them are not running in parallel.

Fixes WEBLATE-3888

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
