### PR TITLE
fix(utils): explicitely pass sorting parameters

### DIFF
--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -114,7 +114,12 @@ def list_projects(request: AuthenticatedHttpRequest):
         {
             "allow_index": True,
             "projects": prefetch_project_flags(
-                get_paginator(request, projects, stats=True)
+                get_paginator(
+                    request,
+                    projects,
+                    stats=True,
+                    sort_by=request.GET.get("sort_by"),
+                )
             ),
             "title": gettext("Projects"),
             "query_string": query_string,
@@ -235,7 +240,12 @@ def show_project_language(request: AuthenticatedHttpRequest, obj: ProjectLanguag
     )
 
     translations = translation_prefetch_tasks(
-        get_paginator(request, obj.translation_set, stats=True)
+        get_paginator(
+            request,
+            obj.translation_set,
+            stats=True,
+            sort_by=request.GET.get("sort_by"),
+        )
     )
     extra_translations = []
 
@@ -323,7 +333,12 @@ def show_category_language(request: AuthenticatedHttpRequest, obj):
         .recent()
     )
 
-    translations = get_paginator(request, obj.translation_set, stats=True)
+    translations = get_paginator(
+        request,
+        obj.translation_set,
+        stats=True,
+        sort_by=request.GET.get("sort_by"),
+    )
     extra_translations = []
 
     # Add ghost translations
@@ -392,7 +407,12 @@ def show_project(request: AuthenticatedHttpRequest, obj):
     last_announcements = all_changes.filter_announcements().recent()
 
     all_components = obj.get_child_components_access(user, filter_no_category)
-    all_components = get_paginator(request, all_components, stats=True)
+    all_components = get_paginator(
+        request,
+        all_components,
+        stats=True,
+        sort_by=request.GET.get("sort_by"),
+    )
     for component in all_components:
         component.is_shared = None if component.project == obj else component.project
 
@@ -474,7 +494,12 @@ def show_category(request: AuthenticatedHttpRequest, obj):
     last_announcements = all_changes.filter_announcements().recent()
 
     all_components = obj.get_child_components_access(user)
-    all_components = get_paginator(request, all_components, stats=True)
+    all_components = get_paginator(
+        request,
+        all_components,
+        stats=True,
+        sort_by=request.GET.get("sort_by"),
+    )
 
     language_stats = obj.stats.get_language_stats()
     can_add_language_components = obj.project.components_user_can_add_new_language(user)
@@ -992,6 +1017,7 @@ def show_component_list(request: AuthenticatedHttpRequest, name) -> HttpResponse
             request,
             obj.components.filter_access(request.user).order().prefetch(),
             stats=True,
+            sort_by=request.GET.get("sort_by"),
         )
     )
 

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -156,10 +156,10 @@ def get_paginator(
     *,
     page_limit: int | None = None,
     stats: bool = False,
+    sort_by: str | None = None,
 ):
     """Return paginator and current page."""
     page, limit = get_page_limit(request, page_limit or settings.DEFAULT_PAGE_LIMIT)
-    sort_by = request.GET.get("sort_by")
     stats_fetched = False
     if sort_by:
         # All but ordering by name needs stats


### PR DESCRIPTION
The paginator is used in different scopes as well and those are not expected to accept parameters from GET.

Fixes WEBLATE--RD

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
