### PR TITLE
fix(add-ons): correctly serialize webhooks payload

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 5.16.1
 
 .. rubric:: Bug fixes
 
+* :ref:`addon-weblate.webhook.slack` properly delivers all events.
 * :ref:`check-punctuation-spacing` better handles XML markup.
 
 .. rubric:: Compatibility


### PR DESCRIPTION
- add proper type annotations to catch non-serializable content in mypy
- convert lazy objects to string before serializing
- use English to render webhook payload consistently

Fixes WEBLATE-36WB

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
