### PR TITLE
docs: add rsvg dependency to suse install command

### DIFF
--- a/docs/admin/install/venv-suse.rst
+++ b/docs/admin/install/venv-suse.rst
@@ -9,7 +9,7 @@ Installing on SUSE and openSUSE
 
    zypper install \
       libxslt-devel libxml2-devel freetype-devel libjpeg-devel zlib-devel \
-      libyaml-devel libffi-devel cairo-devel pango-devel \
+      libyaml-devel libffi-devel cairo-devel pango-devel librsvg-devel \
       gobject-introspection-devel libacl-devel liblz4-devel libzstd-devel libxxhash-devel \
       python3-devel git
 


### PR DESCRIPTION
Without it you get a `ValueError: Namespace Rsvg not available`.