### PR TITLE
fix(api): restrict add-on listing for project members

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -6137,7 +6137,7 @@ class AddonAPITest(APIBaseTest):
             "api:addon-detail",
             kwargs={"pk": response.data["id"]},
             method="delete",
-            code=403,
+            code=404,
         )
         self.do_request(
             "api:addon-detail",
@@ -6153,13 +6153,13 @@ class AddonAPITest(APIBaseTest):
         expect_access: bool,
         authenticated: bool,
         superuser: bool,
-        add_user: bool = False,
+        add_user: str = "",
     ) -> None:
         project = self.component.project
         project.access_control = Project.ACCESS_PRIVATE
         project.save(update_fields=["access_control"])
         if add_user:
-            project.add_user(self.user, "Translate")
+            project.add_user(self.user, add_user)
 
         addon_component = self.component.addon_set.create(
             name="weblate.gettext.linguas"
@@ -6206,7 +6206,18 @@ class AddonAPITest(APIBaseTest):
 
     def test_access_user_member(self) -> None:
         self.addon_scope_test(
-            expect_access=True, authenticated=True, superuser=False, add_user=True
+            expect_access=False,
+            authenticated=True,
+            superuser=False,
+            add_user="Translate",
+        )
+
+    def test_access_user_admin(self) -> None:
+        self.addon_scope_test(
+            expect_access=True,
+            authenticated=True,
+            superuser=False,
+            add_user="Administration",
         )
 
     def test_configuration(self) -> None:
@@ -6236,7 +6247,7 @@ class AddonAPITest(APIBaseTest):
             "api:addon-detail",
             kwargs={"pk": response.data["id"]},
             method="patch",
-            code=403,
+            code=404,
             format="json",
             request={"configuration": expected},
         )
@@ -6287,7 +6298,7 @@ class AddonAPITest(APIBaseTest):
             "api:addon-detail",
             kwargs={"pk": response.data["id"]},
             method="delete",
-            code=403,
+            code=404,
         )
         self.do_request(
             "api:addon-detail",

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -2836,8 +2836,8 @@ class AddonViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModel
         if self.request.user.has_perm("management.addons"):
             return Addon.objects.order_by("id")
         return Addon.objects.filter(
-            Q(project__in=self.request.user.allowed_projects)
-            | Q(component__project__in=self.request.user.allowed_projects)
+            Q(project__in=self.request.user.managed_projects)
+            | Q(component__project__in=self.request.user.managed_projects)
         ).order_by("id")
 
     def perm_check(self, request: Request, instance: Addon) -> None:


### PR DESCRIPTION
The add-ons now might contain sensitive info, so restrict it to project admins (consistently with the UI).

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
