### PR TITLE
chore: remove not needed filter from same_target

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -201,6 +201,12 @@ class UnitQuerySet(models.QuerySet["Unit"]):
         return result
 
     def same_target(self, unit: Unit, target: str | None = None) -> UnitQuerySet:
+        """
+        Get units with same target but different source.
+
+        This is skipped for languages with a single plural form as that causes too
+        many false positives, see https://github.com/WeblateOrg/weblate/issues/9450
+        """
         if target is None:
             target = unit.target
         if not target or not any(split_plural(target)):
@@ -212,7 +218,6 @@ class UnitQuerySet(models.QuerySet["Unit"]):
             target__lower__md5=MD5(Lower(Value(target))),
             target=target,
             translation__component__project_id=component.project_id,
-            translation__language_id=translation.language_id,
             translation__component__source_language_id=component.source_language_id,
             translation__component__allow_translation_propagation=True,
             translation__plural_id=translation.plural_id,


### PR DESCRIPTION
The plural is bound to a language, so filtering based on plural is good enough.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
