### PR TITLE
fix(component): return None from get_*_filename when not present

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -3539,15 +3539,19 @@ class Component(
                 gettext("To use the key filter, the file format must be monolingual.")
             )
 
-    def get_template_filename(self) -> str:
+    def get_template_filename(self) -> str | None:
         """Create absolute filename for template."""
+        if not self.template:
+            return None
         filename = os.path.join(self.full_path, self.template)
         # Throws an exception in case of error
         self.check_file_is_valid(filename)
         return filename
 
-    def get_intermediate_filename(self) -> str:
+    def get_intermediate_filename(self) -> str | None:
         """Create absolute filename for intermediate."""
+        if not self.intermediate:
+            return None
         filename = os.path.join(self.full_path, self.intermediate)
         # Throws an exception in case of error
         self.check_file_is_valid(filename)
@@ -3879,7 +3883,7 @@ class Component(
     def intermediate_store(self) -> TranslationFormat | None:
         """Get translate-toolkit store for intermediate."""
         # Do we need template?
-        if not self.has_template() or not self.intermediate:
+        if not self.has_template():
             return None
 
         try:
@@ -3949,8 +3953,8 @@ class Component(
             return False
 
         # Check if template can be parsed
-        if self.has_template():
-            if not os.path.exists(self.get_template_filename()):
+        if template_filename := self.get_template_filename():
+            if not os.path.exists(template_filename):
                 self.new_lang_error_message = gettext(
                     "The monolingual base language file is invalid."
                 )

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -679,12 +679,11 @@ class Translation(
         component = self.component
         filenames = [self.get_filename()]
 
-        if component.has_template():
+        if filename := component.get_template_filename():
             # Include template
-            filenames.append(component.get_template_filename())
+            filenames.append(filename)
 
-            filename = component.get_intermediate_filename()
-            if component.intermediate and os.path.exists(filename):
+            if filename := component.get_intermediate_filename():
                 # Include intermediate language as it might add new strings
                 filenames.append(filename)
 


### PR DESCRIPTION
Avoid constructing invalid filenames when these are not configured. This would make the problematic code crash rather than be silently broken.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
