### PR TITLE
fix: HTML and lazy formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,6 +143,17 @@ repos:
     args: [--multiline]
     entry: format_html_join\(\s*", "
     language: pygrep
+  - id: py-format-html-join-comma
+    name: Percent format with format_html_join_comma leads to double escaping
+    types: [python]
+    entry: '% format_html_join_comma'
+    language: pygrep
+  - id: py-lazy-format
+    name: Formatting a lazy translation
+    types: [python]
+    args: [--multiline]
+    entry: gettext_lazy\([^\)]*\)(\s*%|.format\()
+    language: pygrep
 - repo: https://github.com/sphinx-contrib/sphinx-lint
   rev: v1.0.2
   hooks:

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal
 
 from django.db.models import Count, Prefetch, Q, Value
 from django.db.models.functions import MD5, Lower
+from django.utils.html import format_html
 from django.utils.translation import gettext, gettext_lazy, ngettext
 
 from weblate.checks.base import BatchCheckMixin, TargetCheck
@@ -188,10 +189,14 @@ class ReusedCheck(TargetCheck, BatchCheckMixin):
             .distinct()
         )
 
-        return ngettext(
-            "Other source string: %s", "Other source strings: %s", len(other_sources)
-        ) % format_html_join_comma(
-            "{}", ((gettext("“%s”") % source,) for source in other_sources)
+        return format_html(
+            "{} {}",
+            ngettext(
+                "Other source string:", "Other source strings:", len(other_sources)
+            ),
+            format_html_join_comma(
+                "{}", ((gettext("“%s”") % source,) for source in other_sources)
+            ),
         )
 
     def check_single(self, source: str, target: str, unit: Unit) -> bool:

--- a/weblate/checks/format.py
+++ b/weblate/checks/format.py
@@ -496,12 +496,14 @@ class BaseFormatCheck(TargetCheck):
             and all(self.is_position_based(flag) for flag in result["missing"])
             and set(result["missing"]) == set(result["extra"])
         ):
-            yield gettext(
-                "The following format strings are in the wrong order: %s"
-            ) % format_html_join_comma(
-                "{}",
-                list_to_tuples(
-                    self.format_string(x) for x in sorted(set(result["missing"]))
+            yield format_html(
+                "{} {}",
+                gettext("The following format strings are in the wrong order:"),
+                format_html_join_comma(
+                    "{}",
+                    list_to_tuples(
+                        self.format_string(x) for x in sorted(set(result["missing"]))
+                    ),
                 ),
             )
         else:

--- a/weblate/checks/icu.py
+++ b/weblate/checks/icu.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from django.utils.html import format_html
 from django.utils.translation import gettext, gettext_lazy
 from pyicumessageformat import Parser
 
@@ -458,66 +459,97 @@ class ICUMessageFormatCheck(ICUCheckMixin, BaseFormatCheck):
 
     def format_result(self, result):
         if result.get("syntax"):
-            yield gettext("Syntax error: %s") % format_html_join_comma(
-                "{}",
-                list_to_tuples(err.msg or "unknown error" for err in result["syntax"]),
+            yield format_html(
+                "{} {}",
+                gettext("Syntax error:"),
+                format_html_join_comma(
+                    "{}",
+                    list_to_tuples(
+                        err.msg or "unknown error" for err in result["syntax"]
+                    ),
+                ),
             )
 
         if result.get("extra"):
-            yield gettext(
-                "One or more unknown placeholders in the translation: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(result["extra"]))
+            yield format_html(
+                "{} {}",
+                gettext("One or more unknown placeholders in the translation:"),
+                format_html_join_comma("{}", list_to_tuples(result["extra"])),
+            )
 
         if result.get("missing"):
-            yield gettext(
-                "One or more placeholders missing in the translation: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(result["missing"]))
+            yield format_html(
+                "{} {}",
+                gettext("One or more placeholders missing in the translation:"),
+                format_html_join_comma("{}", list_to_tuples(result["missing"])),
+            )
 
         if result.get("wrong_type"):
-            yield gettext(
-                "One or more placeholder types are incorrect: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(result["wrong_type"]))
+            yield format_html(
+                "{} {}",
+                gettext("One or more placeholder types are incorrect:"),
+                format_html_join_comma("{}", list_to_tuples(result["wrong_type"])),
+            )
 
         if result.get("no_other"):
-            yield gettext("Missing other sub-message for: %s") % format_html_join_comma(
-                "{}", list_to_tuples(result["no_other"])
+            yield format_html(
+                "{} {}",
+                gettext("Missing other sub-message for:"),
+                format_html_join_comma("{}", list_to_tuples(result["no_other"])),
             )
 
         if result.get("bad_plural"):
-            yield gettext(
-                "Incorrect plural selectors for: %s"
-            ) % format_html_join_comma(
-                "{}", (f"{x[0]} ({', '.join(x[1])})" for x in result["bad_plural"])
+            yield format_html(
+                "{} {}",
+                gettext("Incorrect plural selectors for:"),
+                format_html_join_comma(
+                    "{}", (f"{x[0]} ({', '.join(x[1])})" for x in result["bad_plural"])
+                ),
             )
 
         if result.get("bad_submessage"):
-            yield gettext(
-                "Incorrect sub-message selectors for: %s"
-            ) % format_html_join_comma(
-                "{}", (f"{x[0]} ({', '.join(x[1])})" for x in result["bad_submessage"])
+            yield format_html(
+                "{} {}",
+                gettext("Incorrect sub-message selectors for:"),
+                format_html_join_comma(
+                    "{}",
+                    (f"{x[0]} ({', '.join(x[1])})" for x in result["bad_submessage"]),
+                ),
             )
 
         if result.get("should_be_tag"):
-            yield gettext(
-                "One or more placeholders should have "
-                "a corresponding XML tag in the translation: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(result["should_be_tag"]))
+            yield format_html(
+                "{} {}",
+                gettext(
+                    "One or more placeholders should have a corresponding XML tag in the translation:"
+                ),
+                format_html_join_comma("{}", list_to_tuples(result["should_be_tag"])),
+            )
 
         if result.get("not_tag"):
-            yield gettext(
-                "One or more placeholders should not be "
-                "an XML tag in the translation: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(result["not_tag"]))
+            yield format_html(
+                "{} {}",
+                gettext(
+                    "One or more placeholders should not be an XML tag in the translation:"
+                ),
+                format_html_join_comma("{}", list_to_tuples(result["not_tag"])),
+            )
 
         if result.get("tag_not_empty"):
-            yield gettext(
-                "One or more XML tags has unexpected content in the translation: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(result["tag_not_empty"]))
+            yield format_html(
+                "{} {}",
+                gettext(
+                    "One or more XML tags has unexpected content in the translation:"
+                ),
+                format_html_join_comma("{}", list_to_tuples(result["tag_not_empty"])),
+            )
 
         if result.get("tag_empty"):
-            yield gettext(
-                "One or more XML tags missing content in the translation: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(result["tag_empty"]))
+            yield format_html(
+                "{} {}",
+                gettext("One or more XML tags missing content in the translation:"),
+                format_html_join_comma("{}", list_to_tuples(result["tag_empty"])),
+            )
 
     def check_highlight(self, source: str, unit: Unit):
         if self.should_skip(unit):

--- a/weblate/checks/tests/test_icu_checks.py
+++ b/weblate/checks/tests/test_icu_checks.py
@@ -7,7 +7,10 @@
 from __future__ import annotations
 
 from weblate.checks.icu import ICUMessageFormatCheck, ICUSourceCheck
+from weblate.checks.models import Check
 from weblate.checks.tests.test_checks import CheckTestCase, MockUnit
+from weblate.lang.models import Language
+from weblate.trans.models import Component, Project, Translation, Unit
 
 
 class ICUMessageFormatCheckTest(CheckTestCase):
@@ -296,6 +299,24 @@ class ICUMessageFormatCheckTest(CheckTestCase):
     def test_check_target_plural(self) -> None:
         unit = self.get_mock(["{count} apple", "{count} apples"])
         self.assertFalse(self.check.check_target_unit(unit.sources, unit.sources, unit))
+
+    def test_description(self) -> None:
+        unit = Unit(
+            source="mailing list at iot{'@'}lists.fedoraproject.org",
+            target="lista de discussão em iot{'@'}lists.fedoraproject.org",
+            translation=Translation(
+                component=Component(
+                    file_format="po",
+                    source_language=Language(code="en"),
+                    project=Project(),
+                )
+            ),
+        )
+        check = Check(unit=unit)
+        self.assertEqual(
+            "Syntax error: Expected placeholder name at position 20 but found &quot;&#x27;&quot;",
+            str(self.check.get_description(check)),
+        )
 
 
 # This is a sub-class of our existing test set because this format is an extension

--- a/weblate/memory/forms.py
+++ b/weblate/memory/forms.py
@@ -6,7 +6,8 @@ from pathlib import PurePath
 
 from django import forms
 from django.core.validators import FileExtensionValidator
-from django.utils.translation import gettext_lazy
+from django.utils.html import format_html
+from django.utils.translation import gettext, gettext_lazy
 
 from weblate.lang.models import Language
 from weblate.memory.models import SUPPORTED_FORMATS
@@ -20,8 +21,6 @@ class UploadForm(forms.Form):
     file = forms.FileField(
         label=gettext_lazy("File"),
         validators=[FileExtensionValidator(allowed_extensions=SUPPORTED_FORMATS)],
-        help_text=gettext_lazy("You can upload a file of following formats: %s.")
-        % format_html_join_comma("{}", list_to_tuples(SUPPORTED_FORMATS)),
     )
     source_language = forms.ModelChoiceField(
         widget=SortedSelect,
@@ -41,6 +40,14 @@ class UploadForm(forms.Form):
         queryset=Language.objects.all(),
         required=False,
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["file"].help_text = format_html(
+            "{} {}",
+            gettext("You can upload a file of following formats:"),
+            format_html_join_comma("{}", list_to_tuples(SUPPORTED_FORMATS)),
+        )
 
     def clean(self):
         data = self.cleaned_data

--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -18,7 +18,7 @@ from django.shortcuts import redirect
 from django.urls import is_valid_path, reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.http import MAX_URL_LENGTH, escape_leading_slashes
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext
 from social_core.backends.oauth import OAuthAuth
 from social_core.backends.open_id import OpenIdAuth
 from social_django.utils import load_strategy
@@ -284,9 +284,8 @@ class RedirectMiddleware:
                         messages.add_message(
                             request,
                             messages.INFO,
-                            gettext_lazy(
-                                "%s translation is currently not available, "
-                                "but can be added."
+                            gettext(
+                                "%s translation is currently not available, but can be added."
                             )
                             % language_name,
                         )

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2372,15 +2372,17 @@ class ProjectSettingsForm(SettingsBaseForm, ProjectDocsMixin, ProjectAntispamMix
             if unlicensed:
                 raise ValidationError(
                     {
-                        "access_control": gettext(
-                            "You must specify a license for these components "
-                            "to make them publicly accessible: %s"
-                        )
-                        % format_html_join_comma(
-                            '<a href="{}">{}</a>',
-                            (
-                                (component.get_absolute_url(), component.name)
-                                for component in unlicensed
+                        "access_control": format_html(
+                            "{} {}",
+                            gettext(
+                                "You must specify a license for these components to make them publicly accessible:"
+                            ),
+                            format_html_join_comma(
+                                '<a href="{}">{}</a>',
+                                (
+                                    (component.get_absolute_url(), component.name)
+                                    for component in unlicensed
+                                ),
                             ),
                         )
                     }

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -3286,9 +3286,11 @@ class Component(
             raise ValidationError({"new_base": gettext("File does not exist.")})
         # File is present, but it is not valid
         if errors:
-            message = gettext(
-                "Could not parse base file for new translations: %s"
-            ) % format_html_join_comma("{}", list_to_tuples(errors))
+            message = format_html(
+                "{} {}",
+                gettext("Could not parse base file for new translations:"),
+                format_html_join_comma("{}", list_to_tuples(errors)),
+            )
             raise ValidationError({"new_base": message})
         raise ValidationError(
             {"new_base": gettext("Unrecognized base file for new translations.")}

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -892,8 +892,7 @@ class ZenViewTest(ViewTestCase):
         )
         self.assertContains(
             response,
-            "Following fixups were applied to translation: "
-            "Trailing and leading whitespace",
+            "The following fix-up was applied to the translation: Trailing and leading whitespace",
         )
 
     def test_save_zen_lock(self) -> None:

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -24,7 +24,8 @@ from django.http import (
 )
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.translation import gettext
+from django.utils.html import format_html
+from django.utils.translation import gettext, ngettext
 from django.views.decorators.http import require_POST
 
 from weblate.checks.models import CHECKS, get_display_checks
@@ -85,11 +86,18 @@ if TYPE_CHECKING:
 SESSION_SEARCH_CACHE_TTL = 1800
 
 
-def display_fixups(request: AuthenticatedHttpRequest, fixups) -> None:
+def display_fixups(request: AuthenticatedHttpRequest, fixups: list[str]) -> None:
     messages.info(
         request,
-        gettext("Following fixups were applied to translation: %s")
-        % format_html_join_comma("{}", list_to_tuples(fixups)),
+        format_html(
+            "{} {}",
+            ngettext(
+                "The following fix-up was applied to the translation:",
+                "The following fix-ups were applied to the translation:",
+                len(fixups),
+            ),
+            format_html_join_comma("{}", list_to_tuples(fixups)),
+        ),
     )
 
 


### PR DESCRIPTION
- use format_html to format HTML safe blocks, otherwise they end up double escaped
- avoid formatting lazy strings, these would be evaluated prematurely
- add pre-commit rules to catch these

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
