### PR TITLE
search: add mentions to query example

### DIFF
--- a/weblate/templates/snippets/query-builder.html
+++ b/weblate/templates/snippets/query-builder.html
@@ -143,6 +143,15 @@
         </td>
       </tr>
       <tr>
+        <th>{% translate "Strings with comments mentioning you" %}</th>
+        <td>
+          <code>comment:@{{ user.username }}</code>
+        </td>
+        <td>
+          <a href="#" class="btn btn-outline-primary search-insert">{% translate "Add" %}</a>
+        </td>
+      </tr>
+      <tr>
         <th>{% translate "Strings with any failing checks" %}</th>
         <td>
           <code>has:check</code>


### PR DESCRIPTION
This allows to quickly find all unresolved comments where one is mentioned.