### PR TITLE
chore(pending): remove MySQL/MariaDB workarounds from pending change query

### DIFF
--- a/weblate/trans/models/pending.py
+++ b/weblate/trans/models/pending.py
@@ -18,7 +18,6 @@ from django.db.models import (
     OuterRef,
     Q,
     Subquery,
-    TextField,
     When,
 )
 from django.db.models.fields.json import KT


### PR DESCRIPTION
Now that MySQL/MariaDB support has been dropped (#18200), simplify the retry eligibility query by removing the `CAST(..., TextField())` around `KT()` which are not needed for postgres.

Fix #18232.