### PR TITLE
feat(batching): improve auto translation and bulk editing perf

### DIFF
--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -123,6 +123,8 @@ class AutoTranslate(BaseAutoTranslate):
             if suggestion:
                 self.updated += 1
         else:
+            # Ensure deferred changes accumulate on the right Translation instance
+            unit.translation = self.translation
             unit.is_batch_update = True
             unit.translate(
                 user or self.user,
@@ -137,6 +139,7 @@ class AutoTranslate(BaseAutoTranslate):
     def post_process(self) -> None:
         if self.updated > 0:
             self.translation.log_info("finalizing automatic translation")
+            self.translation.store_update_changes()
             if not self.component_wide:
                 self.translation.component.update_source_checks()
                 self.translation.component.run_batched_checks()

--- a/weblate/trans/bulk.py
+++ b/weblate/trans/bulk.py
@@ -9,7 +9,7 @@ from django.db import transaction
 
 from weblate.checks.flags import Flags
 from weblate.trans.actions import ActionEvents
-from weblate.trans.models import Component, Unit
+from weblate.trans.models import Change, Component, Unit
 from weblate.trans.models.pending import PendingUnitChange
 from weblate.utils.state import (
     STATE_APPROVED,
@@ -82,6 +82,7 @@ def bulk_perform(  # noqa: C901
             else:
                 to_update = []
                 source_units = []
+                changes = []
                 unit_ids = list(component_units.values_list("id", flat=True))
                 # Generate changes for state change
                 for unit in (
@@ -96,8 +97,14 @@ def bulk_perform(  # noqa: C901
                         # Create change object for edit, update is done outside the loop
                         unit.state = target_state
                         unit.automatically_translated = False
-                        unit.generate_change(
-                            user, user, ActionEvents.BULK_EDIT, check_new=False
+                        changes.append(
+                            unit.generate_change(
+                                user,
+                                user,
+                                ActionEvents.BULK_EDIT,
+                                check_new=False,
+                                save=False,
+                            )
                         )
                         updated += 1
                         to_update.append(unit)
@@ -109,8 +116,16 @@ def bulk_perform(  # noqa: C901
                     state=target_state,
                     automatically_translated=False,
                 )
-                for unit in to_update:
-                    PendingUnitChange.store_unit_change(unit=unit, author=user)
+                Change.objects.bulk_create(changes, batch_size=500)
+                PendingUnitChange.objects.bulk_create(
+                    [
+                        PendingUnitChange.store_unit_change(
+                            unit=unit, author=user, save=False
+                        )
+                        for unit in to_update
+                    ],
+                    batch_size=500,
+                )
                 # Fire source_change event in bulk for source units
                 for unit in source_units:
                     # The change is already done in the database, we

--- a/weblate/trans/models/pending.py
+++ b/weblate/trans/models/pending.py
@@ -365,6 +365,7 @@ class PendingUnitChange(models.Model):
         automatically_translated: bool | None = None,
         timestamp: datetime | None = None,
         store_disk_state: bool = True,
+        save: bool = True,
     ) -> PendingUnitChange:
         """Store complete change data for a unit by a specific author."""
         # update current fields in disk_state details for comparison of
@@ -399,5 +400,6 @@ class PendingUnitChange(models.Model):
             kwargs["timestamp"] = timestamp
 
         pending_unit_change = PendingUnitChange(**kwargs)
-        pending_unit_change.save()
+        if save:
+            pending_unit_change.save()
         return pending_unit_change

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -231,6 +231,7 @@ class Translation(
         self.reason = ""
         self._invalidate_scheduled = False
         self.update_changes: list[Change] = []
+        self.pending_unit_changes: list[PendingUnitChange] = []
         # Project backup integration
         self.original_id = -1
 
@@ -642,6 +643,9 @@ class Translation(
         # Save change
         Change.objects.bulk_create(self.update_changes, batch_size=500)
         self.update_changes.clear()
+        # Save pending unit changes
+        PendingUnitChange.objects.bulk_create(self.pending_unit_changes, batch_size=500)
+        self.pending_unit_changes.clear()
 
     def do_update(
         self, request: AuthenticatedHttpRequest | None = None, method: str | None = None
@@ -1265,6 +1269,8 @@ class Translation(
 
             accepted += 1
 
+            # Ensure deferred changes accumulate on this Translation instance
+            unit.translation = self
             unit.is_batch_update = True
             unit.translate(
                 request.user,
@@ -1278,6 +1284,7 @@ class Translation(
             )
 
         if accepted > 0:
+            self.store_update_changes()
             self.component.update_source_checks()
             self.component.run_batched_checks()
             self.invalidate_cache()

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1451,7 +1451,10 @@ class Unit(models.Model, LoggerMixin):
         self.pending_unit_change = PendingUnitChange.store_unit_change(
             unit=self,
             author=author,
+            save=not self.is_batch_update,
         )
+        if self.is_batch_update:
+            self.translation.pending_unit_changes.append(self.pending_unit_change)
 
         # Update translated flag (not fuzzy and at least one translation)
         translation = any(self.get_target_plurals())
@@ -1469,7 +1472,11 @@ class Unit(models.Model, LoggerMixin):
         )
 
         # Generate change and process it
-        self.post_save(user or author, author, change_action)
+        change = self.post_save(
+            user or author, author, change_action, save=not self.is_batch_update
+        )
+        if self.is_batch_update:
+            self.translation.update_changes.append(change)
 
         # Update related source strings if working on a template
         if self.translation.is_template and self.old_unit["target"] != self.target:
@@ -1967,7 +1974,9 @@ class Unit(models.Model, LoggerMixin):
             if self.pending_unit_change is not None:
                 # Update PendingUnitChange if there is one
                 self.pending_unit_change.state = STATE_NEEDS_REWRITING
-                self.pending_unit_change.save(update_fields=["state"])
+                # if already saved update in DB else deferred via bulk create
+                if self.pending_unit_change.pk is not None:
+                    self.pending_unit_change.save(update_fields=["state"])
             elif saved:
                 # There should be a pending unit if saved
                 msg = "Updating unit, but pending unit change is not set!"

--- a/weblate/trans/tests/test_autotranslate.py
+++ b/weblate/trans/tests/test_autotranslate.py
@@ -10,7 +10,8 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.lang.models import Language
-from weblate.trans.models import Component
+from weblate.trans.actions import ActionEvents
+from weblate.trans.models import Change, Component, PendingUnitChange
 from weblate.trans.tasks import auto_translate
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.stats import ProjectLanguage
@@ -255,6 +256,24 @@ class AutoTranslationTest(ViewTestCase):
         self.assertEqual(
             translation.unit_set.filter(automatically_translated=True).count(),
             0,
+        )
+
+    def test_autotranslate_creates_change_and_pending(self) -> None:
+        """Auto-translation creates Change and PendingUnitChange records in bulk."""
+        self.make_different()
+        translation = self.component2.translation_set.get(language_code="cs")
+
+        initial_change_count = Change.objects.count()
+        initial_pending_count = PendingUnitChange.objects.count()
+
+        self.perform_auto()
+
+        self.assertGreater(Change.objects.count(), initial_change_count)
+        self.assertTrue(Change.objects.filter(action=ActionEvents.AUTO).exists())
+        self.assertGreater(PendingUnitChange.objects.count(), initial_pending_count)
+        auto_translated_unit = translation.unit_set.get(automatically_translated=True)
+        self.assertTrue(
+            PendingUnitChange.objects.filter(unit=auto_translated_unit).exists()
         )
 
     def test_command(self) -> None:

--- a/weblate/trans/tests/test_files.py
+++ b/weblate/trans/tests/test_files.py
@@ -17,7 +17,7 @@ from weblate.formats.helpers import NamedBytesIO
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.forms import SimpleUploadForm
-from weblate.trans.models import ComponentList
+from weblate.trans.models import Change, ComponentList, PendingUnitChange
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import get_test_file
 from weblate.utils.state import STATE_READONLY
@@ -85,6 +85,15 @@ class ImportTest(ImportBaseTest):
 
     def test_import_normal(self) -> None:
         """Test importing normally."""
+        translation = self.get_translation()
+
+        initial_change_count = Change.objects.filter(
+            action=ActionEvents.UPLOAD, translation=translation
+        ).count()
+        initial_pending_count = PendingUnitChange.objects.filter(
+            unit__translation=translation
+        ).count()
+
         response = self.do_import()
         self.assertRedirects(response, self.translation_url)
 
@@ -94,9 +103,21 @@ class ImportTest(ImportBaseTest):
         self.assertEqual(translation.stats.fuzzy, 0)
         self.assertEqual(translation.stats.all, 4)
 
+        self.assertGreater(
+            Change.objects.filter(
+                action=ActionEvents.UPLOAD, translation=translation
+            ).count(),
+            initial_change_count,
+        )
+        self.assertGreater(
+            PendingUnitChange.objects.filter(unit__translation=translation).count(),
+            initial_pending_count,
+        )
+
         # Verify unit
         unit = self.get_unit()
         self.assertEqual(unit.target, TRANSLATION_PO)
+        self.assertTrue(PendingUnitChange.objects.filter(unit=unit).exists())
 
     def test_import_author(self) -> None:
         """Test importing normally."""

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -818,6 +818,33 @@ class UnitTest(ModelTestCase):
         unit.source = "My test source"
         self.assertEqual(unit.get_max_length(), 10000)
 
+    def test_batch_update_defers_change_and_pending_change(self) -> None:
+        """Change objects are deferred to update_changes list when is_batch_update=True."""
+        user = create_test_user()
+        unit = Unit.objects.filter(
+            translation__language_code="cs", source="Hello, world!\n"
+        )[0]
+        PendingUnitChange.objects.filter(unit=unit).delete()
+        initial_count = Change.objects.count()
+
+        unit.is_batch_update = True
+        unit.translate(user, "Nazdar svete!\n", STATE_TRANSLATED)
+
+        # Change and PendingUnitChange should NOT be in DB yet
+        self.assertEqual(Change.objects.count(), initial_count)
+        self.assertFalse(PendingUnitChange.objects.filter(unit=unit).exists())
+
+        # But should be in the deferred list on the translation
+        self.assertEqual(len(unit.translation.update_changes), 1)
+        self.assertEqual(len(unit.translation.pending_unit_changes), 1)
+
+        # After flush, it should be in DB and the list cleared
+        unit.translation.store_update_changes()
+        self.assertEqual(Change.objects.count(), initial_count + 1)
+        self.assertEqual(len(unit.translation.update_changes), 0)
+        self.assertTrue(PendingUnitChange.objects.filter(unit=unit).exists())
+        self.assertEqual(len(unit.translation.pending_unit_changes), 0)
+
 
 class AnnouncementTest(ModelTestCase):
     """Test(s) for Announcement model."""

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -12,7 +12,8 @@ from django.urls import reverse
 
 from weblate.checks.models import Check
 from weblate.screenshots.models import Screenshot
-from weblate.trans.models import Component
+from weblate.trans.actions import ActionEvents
+from weblate.trans.models import Change, Component, PendingUnitChange
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.ratelimit import reset_rate_limit
 from weblate.utils.state import (
@@ -685,3 +686,23 @@ class BulkEditTest(ViewTestCase):
         unit = self.get_unit()
         self.assertEqual(unit.state, STATE_APPROVED)
         self.assertFalse(unit.automatically_translated)
+
+    def test_bulk_edit_creates_change_and_pending_unit_change(self) -> None:
+        """Bulk edit creates Change and PendingUnitChange records via bulk insert."""
+        PendingUnitChange.objects.filter(unit=self.unit).delete()
+        initial_change_count = Change.objects.filter(
+            action=ActionEvents.BULK_EDIT
+        ).count()
+
+        response = self.client.post(
+            reverse("bulk-edit", kwargs=self.kw_translation),
+            {"q": "state:needs-editing", "state": STATE_TRANSLATED},
+            follow=True,
+        )
+        self.assertContains(response, "Bulk edit completed, 1 string was updated.")
+
+        self.assertEqual(
+            Change.objects.filter(action=ActionEvents.BULK_EDIT).count(),
+            initial_change_count + 1,
+        )
+        self.assertTrue(PendingUnitChange.objects.filter(unit=self.unit).exists())


### PR DESCRIPTION
Updated `Unit` and `PendingUnitChange` to defer storing the `PendingUnitChange` object in the db during batch update mode. Also, updated `Translation` model to store pending unit changes temporarily in memory and defer their creation in batch update mode. Autotranslation, bulk edit and merging string during file upload make use of these optimizations.

fix #15212