### PR TITLE
fix(git): move remote prune to the cleanup

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -580,6 +580,9 @@ class GitRepository(Repository):
 
     def remove_stale_branches(self) -> None:
         """Remove stale branches and tags from the repository."""
+        # Prune remote branches, this can fail if repository is unreachable
+        with suppress(RepositoryError):
+            self.execute([*self.get_auth_args(), "remote", "prune", "origin"])
         # Remove possible stale branches
         for branch in self.list_branches():
             if branch != self.branch:
@@ -606,10 +609,8 @@ class GitRepository(Repository):
 
     def update_remote(self) -> None:
         """Update remote repository."""
-        auth_args = self.get_auth_args()
-        self.execute([*auth_args, "remote", "prune", "origin"])
         # Update existing branch only, not changing depth
-        self.execute([*auth_args, "fetch", "origin", self.branch])
+        self.execute([*self.get_auth_args(), "fetch", "origin", self.branch])
         self.clean_revision_cache()
 
     def push(self, branch: str) -> None:


### PR DESCRIPTION
This needs to access the remote repository making the update consume double time than needed. Moving it to the cleanup serves well the purpose and moves this from frequently called path.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
