### PR TITLE
feat(unit): reuse cache injection logic for adding units

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1435,6 +1435,7 @@ class Component(
                 source = Unit(
                     translation=self.source_translation, id_hash=id_hash, **create
                 )
+                source.fill_new_unit_cache()
                 source.save(force_insert=True, only_save=True)
                 self._process_new_source(source)
             else:

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -42,7 +42,6 @@ from weblate.trans.models.change import Change
 from weblate.trans.models.pending import PendingUnitChange
 from weblate.trans.models.suggestion import Suggestion
 from weblate.trans.models.unit import Unit
-from weblate.trans.models.variant import Variant
 from weblate.trans.signals import component_post_update, vcs_pre_commit
 from weblate.trans.util import is_plural, join_plural, split_plural
 from weblate.trans.validators import validate_check_flags
@@ -400,12 +399,7 @@ class Translation(
             is_new = False
         except KeyError:
             newunit = Unit(translation=self, id_hash=id_hash, state=-1)
-            # Avoid fetching empty list of checks from the database
-            newunit.all_checks = []
-            # Avoid fetching empty list of variants
-            newunit._prefetched_objects_cache = {  # noqa: SLF001
-                "defined_variants": Variant.objects.none()
-            }
+            newunit.fill_new_unit_cache()
             is_new = True
 
         newunit.store_unit_attributes(
@@ -1939,6 +1933,7 @@ class Translation(
                     position=translation.stats.all + 1,
                     **kwargs,
                 )
+                unit.fill_new_unit_cache()
                 unit.is_batch_update = is_batch_update
                 unit.trigger_update_variants = False
                 try:

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -616,6 +616,19 @@ class Unit(models.Model, LoggerMixin):
     def get_absolute_url(self) -> str:
         return f"{self.translation.get_translate_url()}?checksum={self.checksum}"
 
+    def fill_new_unit_cache(self) -> None:
+        """
+        Populate object cache for new unit.
+
+        This avoids fetching non-existing relations.
+        """
+        # Avoid fetching empty list of checks from the database
+        self.__dict__["all_checks"] = []
+        # Avoid fetching empty list of variants
+        if not hasattr(self, "_prefetched_objects_cache"):
+            self._prefetched_objects_cache = {}
+        self._prefetched_objects_cache["defined_variants"] = Variant.objects.none()
+
     def get_url_path(self):
         return (*self.translation.get_url_path(), str(self.pk))
 


### PR DESCRIPTION
This was already in place for new units, but the same can be appled to new units to fasten adding. These objects cannot exist for just created Unit, so this optimization is safe and saves additional database hits.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
