### PR TITLE
fix(unit): avoid pending changes cleanup for created units

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1186,7 +1186,9 @@ class Unit(models.Model, LoggerMixin):
             run_checks=not same_source or not same_target or not same_state,
         )
         self.clear_disk_state()
-        PendingUnitChange.objects.filter(unit=self).delete()
+        # Remove pending changes for existing units
+        if not created:
+            PendingUnitChange.objects.filter(unit=self).delete()
 
         if pending:
             PendingUnitChange.store_unit_change(unit=self)


### PR DESCRIPTION
The newly created Unit cannot have PendingUnit objects attached, so avoid this cleanup. This removes extra query per unit on new string import.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
