### PR TITLE
fix(unit): restore translation state when source string is no longer readonly

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -833,23 +833,26 @@ class Unit(models.Model, LoggerMixin):
         flags: Flags | str | None,
         string_changed: bool = False,
         disk_unit_state: StringState | None = None,
+        include_weblate_readonly: bool = True,
     ) -> StringState:
         """Calculate translated and fuzzy status."""
-        # Read-only from the file format
+        # Read-only from the file format is always considered for the unit state
         if unit.is_readonly():
             return STATE_READONLY
 
-        # Read-only from the source
-        if (
-            not self.is_source
-            and self.source_unit.state < STATE_TRANSLATED
-            and self.translation.component.intermediate
-        ):
-            return STATE_READONLY
+        # when checking for original_state, ignore Weblate originated readonly state
+        if include_weblate_readonly:
+            # Read-only from the source
+            if (
+                not self.is_source
+                and self.source_unit.state < STATE_TRANSLATED
+                and self.translation.component.intermediate
+            ):
+                return STATE_READONLY
 
-        # Read-only from flags (flags=None indicates skipping this logic)
-        if flags is not None and "read-only" in self.get_all_flags(flags):
-            return STATE_READONLY
+            # Read-only from flags (flags=None indicates skipping this logic)
+            if flags is not None and "read-only" in self.get_all_flags(flags):
+                return STATE_READONLY
 
         # We need to keep approved/fuzzy state for formats which do not
         # support saving it
@@ -1058,7 +1061,7 @@ class Unit(models.Model, LoggerMixin):
             string_changed=string_changed,
             disk_unit_state=comparison_state["state"],
         )
-        original_state = self.get_unit_state(unit, None)
+        original_state = self.get_unit_state(unit, None, include_weblate_readonly=False)
 
         automatically_translated = self.get_unit_automatically_translated(
             unit, string_changed, comparison_state["automatically_translated"]

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -669,6 +669,17 @@ class ComponentListTest(RepoTestCase):
         translation_unit = unit.unit_set.get(translation__language__code="cs")
         self.assertEqual(translation_unit.state, STATE_READONLY)
 
+        # Set source back to translated - translation should be restored
+        unit.translate(None, "Hello, world!\n", STATE_TRANSLATED)
+        translation_unit = unit.unit_set.get(translation__language__code="cs")
+        self.assertNotEqual(translation_unit.state, STATE_READONLY)
+
+        # Verify state survives commit + file scan roundtrip
+        component.commit_pending("test", None)
+        component.do_file_scan()
+        translation_unit = unit.unit_set.get(translation__language__code="cs")
+        self.assertNotEqual(translation_unit.state, STATE_READONLY)
+
 
 class ModelTestCase(RepoTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
`get_unit_state()` included the source-based readonly check when computing `original_state` during file syncs, corrupting it to STATE_READONLY. When `update_state()` later tried to restore the state, it saw state == original_state == STATE_READONLY and did nothing. Do not consider weblate originating readonly states when computing `original_state` in file sync.

Fix #18181.