### PR TITLE
docs: fix author params in api upload endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2188,8 +2188,8 @@ Translations
     :type language: string
     :form string conflicts: How to deal with conflicts (``ignore``, ``replace-translated`` or ``replace-approved``), see :ref:`upload-conflicts`
     :form file file: Uploaded file
-    :form string email: Author e-mail
-    :form string author: Author name
+    :form string author_email: Author e-mail
+    :form string author_name: Author name
     :form string method: Upload method (``translate``, ``approve``, ``suggest``, ``fuzzy``, ``replace``, ``source``, ``add``), see :ref:`upload-method`
     :form string fuzzy: Fuzzy (marked for edit) strings processing (*empty*, ``process``, ``approve``)
 


### PR DESCRIPTION
This commit[^1] changed the author parameters in the API upload endpoint from `email` and `author` to `author_email` and `author_name`.

This commit updates the API documentation to reflect this change.

[^1]: https://github.com/WeblateOrg/weblate/commit/c8e472124c65f5e2de02abbc50b0ce58857e2b92

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
