### PR TITLE
chore(utils): avoid overriding lookup_type in mixin

### DIFF
--- a/weblate/utils/db.py
+++ b/weblate/utils/db.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import time
 
 from django.db import ProgrammingError, connections, transaction
-from django.db.models.lookups import PatternLookup, Regex
+from django.db.models.lookups import Lookup, PatternLookup, Regex
 
 from .inv_regex import invert_re
 
@@ -59,7 +59,7 @@ def count_alnum(string):
     return sum(map(str.isalnum, string))
 
 
-class PostgreSQLFallbackLookupMixin:
+class PostgreSQLFallbackLookupMixin(Lookup):
     """
     Mixin to block PostgreSQL from using trigram index.
 
@@ -69,8 +69,6 @@ class PostgreSQLFallbackLookupMixin:
 
     It is performed by concatenating empty string which will prevent index usage.
     """
-
-    lookup_name: str
 
     def process_lhs(self, compiler, connection, lhs=None):
         if self._needs_fallback:  # type: ignore[attr-defined]


### PR DESCRIPTION
The type definitions got incompatible with Django 6, so use inheritance instead of duplicating it.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
