### PR TITLE
feat(unit): apply delta of stats upon edit

### DIFF
--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import codecs
 import os
 import tempfile
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from datetime import UTC
 from itertools import chain
 from pathlib import Path
@@ -234,6 +234,8 @@ class Translation(
         self.addon_commit_files: list[str] = []
         self.reason = ""
         self._invalidate_scheduled = False
+        self._suppress_cache_invalidation_depth = 0
+        self._stats_delta_requires_full_rebuild = False
         self.update_changes: list[Change] = []
         self.pending_unit_changes: list[PendingUnitChange] = []
         # Project backup integration
@@ -1674,11 +1676,30 @@ class Translation(
 
     def invalidate_cache(self) -> None:
         """Invalidate any cached stats."""
+        if self._suppress_cache_invalidation_depth:
+            return
         # Invalidate summary stats
         if self._invalidate_scheduled:
             return
         self._invalidate_scheduled = True
         transaction.on_commit(self._invalidate_trigger)
+
+    @contextmanager
+    def suppress_cache_invalidation(self):
+        self._suppress_cache_invalidation_depth += 1
+        try:
+            yield
+        finally:
+            self._suppress_cache_invalidation_depth -= 1
+
+    def require_full_stats_rebuild(self) -> None:
+        self._stats_delta_requires_full_rebuild = True
+
+    def consume_full_stats_rebuild_requirement(self) -> bool:
+        if not self._stats_delta_requires_full_rebuild:
+            return False
+        self._stats_delta_requires_full_rebuild = False
+        return True
 
     def detect_completed_translation(self, change: Change, old_translated: int) -> None:
         translated = self.stats.translated

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     from weblate.formats.base import TranslationUnit
     from weblate.machinery.base import UnitMemoryResultDict
     from weblate.trans.models.label import Label
+    from weblate.utils.stats import StatItem, TranslationStats
 
 
 NEWLINES = re.compile(r"\r\n|\r|\n")
@@ -159,6 +160,7 @@ class UnitQuerySet(models.QuerySet["Unit"]):
             .prefetch_source()
             .prefetch_related(
                 "labels",
+                "source_unit__labels",
                 models.Prefetch(
                     "suggestion_set",
                     queryset=Suggestion.objects.order(),
@@ -413,6 +415,12 @@ class UnitAttributesDict(TypedDict):
     pos: int
     id_hash: int
     automatically_translated: bool
+
+
+class TranslationDeltaEntry(TypedDict):
+    stats: TranslationStats
+    base_stats_timestamp: StatItem
+    delta: dict[str, int]
 
 
 class Unit(models.Model, LoggerMixin):
@@ -1550,7 +1558,10 @@ class Unit(models.Model, LoggerMixin):
 
         # Generate change and process it
         change = self.post_save(
-            user or author, author, change_action, save=not self.is_batch_update
+            user or author,
+            author,
+            change_action,
+            save=not self.is_batch_update,
         )
         if self.is_batch_update:
             self.translation.update_changes.append(change)
@@ -1581,7 +1592,6 @@ class Unit(models.Model, LoggerMixin):
             ActionEvents.BULK_EDIT,
         }:
             old_translated = self.translation.stats.translated
-
             # Update translation stats
             self.translation.invalidate_cache()
 
@@ -1610,46 +1620,19 @@ class Unit(models.Model, LoggerMixin):
         """
         with sentry_sdk.start_span(op="unit.update_source_units", name=f"{self.pk}"):
             changes = []
+            translation_parent_stats = {}
+            delta_failed = False
+            translation_delta_data: dict[int, TranslationDeltaEntry] = {}
 
             # Find relevant units
             for unit in self.unit_set.exclude(id=self.id).prefetch().prefetch_bulk():
-                # Update source and number of words
-                unit.source = self.target
-                unit.num_words = self.num_words
-                # Find reverted units
-                if (
-                    unit.state in FUZZY_STATES
-                    and unit.previous_source == self.target
-                    and unit.target
+                if not self.update_unit_from_source_change(
+                    unit,
+                    previous_source,
+                    author,
+                    translation_delta_data,
                 ):
-                    # Unset fuzzy on reverted
-                    unit.original_state = unit.state = STATE_TRANSLATED
-                    PendingUnitChange.store_unit_change(
-                        unit=unit,
-                        author=author,
-                    )
-                    unit.previous_source = ""
-                elif (
-                    unit.original_state in FUZZY_STATES
-                    and unit.previous_source == self.target
-                    and unit.target
-                ):
-                    # Unset fuzzy on reverted
-                    unit.original_state = STATE_TRANSLATED
-                    unit.previous_source = ""
-                elif unit.state >= STATE_TRANSLATED and unit.target:
-                    # Set fuzzy on changed
-                    unit.original_state = STATE_NEEDS_REWRITING
-                    if unit.state < STATE_READONLY:
-                        unit.state = STATE_NEEDS_REWRITING
-                        PendingUnitChange.store_unit_change(
-                            unit=unit,
-                            author=author,
-                        )
-                    unit.previous_source = previous_source
-
-                # Save unit
-                unit.save()
+                    delta_failed = True
                 # Generate change
                 changes.append(
                     unit.generate_change(
@@ -1662,11 +1645,100 @@ class Unit(models.Model, LoggerMixin):
                         save=False,
                     )
                 )
+                for stat in unit.translation.stats.get_update_objects(full=False):
+                    translation_parent_stats[stat.cache_key] = stat
             if changes:
                 # Bulk create changes
                 Change.objects.bulk_create(changes)
-                # Invalidate stats
-                self.translation.component.invalidate_cache()
+                if delta_failed:
+                    self.translation.component.invalidate_cache()
+                    return
+
+                def update_source_stats_on_commit() -> None:
+                    for data in translation_delta_data.values():
+                        stats = data["stats"]
+                        if not stats.apply_source_delta(
+                            data["base_stats_timestamp"], data["delta"]
+                        ):
+                            stats.update_stats(update_parents=False)
+                    for stat in translation_parent_stats.values():
+                        stat.update_stats()
+                    self.translation.component.stats.update_stats()
+                    self.translation.component.stats.update_parents()
+
+                transaction.on_commit(update_source_stats_on_commit)
+
+    def update_source_unit_state(
+        self, unit, previous_source: str, author: User | None
+    ) -> None:
+        # Update source and number of words
+        unit.source = self.target
+        unit.num_words = self.num_words
+        # Find reverted units
+        if (
+            unit.state in FUZZY_STATES
+            and unit.previous_source == self.target
+            and unit.target
+        ):
+            # Unset fuzzy on reverted
+            unit.original_state = unit.state = STATE_TRANSLATED
+            PendingUnitChange.store_unit_change(unit=unit, author=author)
+            unit.previous_source = ""
+            return
+        if (
+            unit.original_state in FUZZY_STATES
+            and unit.previous_source == self.target
+            and unit.target
+        ):
+            # Unset fuzzy on reverted
+            unit.original_state = STATE_TRANSLATED
+            unit.previous_source = ""
+            return
+        if unit.state >= STATE_TRANSLATED and unit.target:
+            # Set fuzzy on changed
+            unit.original_state = STATE_NEEDS_REWRITING
+            if unit.state < STATE_READONLY:
+                unit.state = STATE_NEEDS_REWRITING
+                PendingUnitChange.store_unit_change(unit=unit, author=author)
+            unit.previous_source = previous_source
+
+    def update_unit_from_source_change(
+        self,
+        unit,
+        previous_source: str,
+        author: User | None,
+        translation_delta_data: dict[int, TranslationDeltaEntry],
+    ) -> bool:
+        stats = unit.translation.stats
+        old_stats_snapshot = (
+            stats.capture_unit_snapshot(unit) if stats.can_apply_delta() else None
+        )
+
+        self.update_source_unit_state(unit, previous_source, author)
+        with unit.translation.suppress_cache_invalidation():
+            unit.save()
+
+        if unit.translation.consume_full_stats_rebuild_requirement():
+            return False
+        if old_stats_snapshot is None:
+            return False
+
+        new_stats_snapshot = stats.capture_unit_snapshot(unit)
+        entry = translation_delta_data.setdefault(
+            unit.translation_id,
+            {
+                "stats": stats,
+                "base_stats_timestamp": stats.stats_timestamp,
+                "delta": {},
+            },
+        )
+        old_bucket = stats.snapshot_to_bucket(old_stats_snapshot)
+        new_bucket = stats.snapshot_to_bucket(new_stats_snapshot)
+        for key in stats.UNIT_DELTA_KEYS:
+            delta = new_bucket.get(key, 0) - old_bucket.get(key, 0)
+            if delta:
+                entry["delta"][key] = entry["delta"].get(key, 0) + delta
+        return True
 
     def generate_change(
         self,
@@ -1777,6 +1849,11 @@ class Unit(models.Model, LoggerMixin):
             if not comment.resolved and comment.unit_id == self.id
         ]
 
+    def get_label_count(self) -> int:
+        if "labels" in self._prefetched_objects_cache:
+            return len(self._prefetched_objects_cache["labels"])
+        return self.labels.count()
+
     def run_checks(  # noqa: C901
         self, *, force_propagate: bool = False, skip_propagate: bool = False
     ) -> None:
@@ -1834,6 +1911,7 @@ class Unit(models.Model, LoggerMixin):
                         # Skip disabled/removed checks
                         continue
                     if check_obj.propagates:
+                        self.translation.require_full_stats_rebuild()
                         if check_obj.propagates == "source":
                             propagated_units = self.propagated_units
                             values = set(
@@ -1862,6 +1940,7 @@ class Unit(models.Model, LoggerMixin):
 
         # Propagate checks which need it (for example consistency)
         if propagation:
+            self.translation.require_full_stats_rebuild()
             querymap: dict[Literal["source", "target"], UnitQuerySet] = {
                 "source": self.propagated_units,
                 "target": Unit.objects.same_target(self),
@@ -2019,10 +2098,7 @@ class Unit(models.Model, LoggerMixin):
         if new_state != STATE_READONLY:
             self.original_state = self.state
 
-        if change_action == ActionEvents.AUTO:
-            self.automatically_translated = True
-        else:
-            self.automatically_translated = False
+        self.automatically_translated = change_action == ActionEvents.AUTO
 
         # Save to the database
         saved = self.save_backend(

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -527,6 +527,90 @@ class EditResourceSourceTest(ViewTestCase):
         self.assertEqual(unit.state, STATE_TRANSLATED)
         self.assert_backend(4, "en")
 
+    def test_edit_does_not_rebuild_component_language_stats(self) -> None:
+        self.assertGreater(self.get_translation().stats.all, 0)
+        with patch(
+            "weblate.trans.models.component.Component.invalidate_cache",
+            autospec=True,
+        ) as invalidate_cache:
+            self.edit_unit("Hello, world!\n", "Nazdar svete!\n", "en")
+        invalidate_cache.assert_not_called()
+
+    def test_suppress_cache_invalidation_is_reentrant(self) -> None:
+        translation = self.get_translation()
+        with patch(
+            "weblate.trans.models.translation.transaction.on_commit"
+        ) as on_commit:
+            with translation.suppress_cache_invalidation():
+                translation.invalidate_cache()
+                with translation.suppress_cache_invalidation():
+                    translation.invalidate_cache()
+                translation.invalidate_cache()
+                on_commit.assert_not_called()
+
+            translation.invalidate_cache()
+            translation.invalidate_cache()
+
+        on_commit.assert_called_once()
+
+    def test_source_edit_updates_translation_and_component_stats(self) -> None:
+        translation = self.get_translation()
+        self.edit_unit("Hello, world!\n", "Nazdar svete!\n", "cs")
+        translation = Translation.objects.get(pk=translation.pk)
+        component = Component.objects.get(pk=self.component.pk)
+        unit_before = translation.unit_set.get(context="hello")
+        all_chars_before = translation.stats.all_chars
+        all_words_before = translation.stats.all_words
+        translated_before = translation.stats.translated
+        component_all_chars_before = component.stats.all_chars
+
+        self.edit_unit("Hello, world!\n", "Hello, universe!\n", "en")
+
+        translation = Translation.objects.get(pk=translation.pk)
+        component = Component.objects.get(pk=self.component.pk)
+        unit_after = translation.unit_set.get(context="hello")
+        all_chars_delta = len(unit_after.source) - len(unit_before.source)
+        all_words_delta = unit_after.num_words - unit_before.num_words
+
+        self.assertEqual(
+            translation.stats.all_chars,
+            all_chars_before + all_chars_delta,
+        )
+        self.assertEqual(
+            translation.stats.all_words,
+            all_words_before + all_words_delta,
+        )
+        self.assertEqual(translation.stats.translated, translated_before - 1)
+        self.assertNotEqual(component.stats.all_chars, component_all_chars_before)
+        self.assertEqual(
+            component.stats.all_chars,
+            sum(
+                child.stats.all_chars
+                for child in Component.objects.get(
+                    pk=self.component.pk
+                ).translation_set.all()
+            ),
+        )
+
+    def test_source_edit_falls_back_to_full_recompute_on_nonlocal_checks(self) -> None:
+        def fake_run_checks(unit, *args, **kwargs) -> None:
+            unit.translation.require_full_stats_rebuild()
+
+        with (
+            patch(
+                "weblate.trans.models.unit.Unit.run_checks",
+                autospec=True,
+                side_effect=fake_run_checks,
+            ),
+            patch(
+                "weblate.trans.models.component.Component.invalidate_cache",
+                autospec=True,
+            ) as invalidate_cache,
+        ):
+            self.edit_unit("Hello, world!\n", "Nazdar svete!\n", "en")
+
+        invalidate_cache.assert_called()
+
     def test_edit_revert(self) -> None:
         translation = self.get_translation()
         # Edit translation

--- a/weblate/trans/tests/test_labels.py
+++ b/weblate/trans/tests/test_labels.py
@@ -4,6 +4,11 @@
 
 """Test for variants."""
 
+from typing import cast
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.trans.actions import ActionEvents
@@ -168,3 +173,72 @@ class LabelTest(ViewTestCase):
 
         changes = unit.change_set.filter(action=ActionEvents.LABEL_ADD)
         self.assertEqual(changes.count(), 2)
+
+
+class MonolingualLabelTest(ViewTestCase):
+    def create_component(self):
+        return self.create_ts_mono()
+
+    def test_source_change_recalculates_cached_label_stats(self) -> None:
+        label = self.project.label_set.create(
+            name="Test label",
+            description="Test description for Test Label",
+            color="orange",
+        )
+        target_translation = self.get_translation()
+        target_unit = self.get_unit(language="cs")
+        target_unit.source_unit.labels.add(label)
+
+        label_words = f"label:{label.name}_words"
+        self.assertEqual(
+            getattr(target_translation.stats, label_words),
+            target_unit.source_unit.num_words,
+        )
+
+        self.edit_unit("Hello, world!\n", "Hello, beautiful world!\n", language="en")
+
+        updated_unit = self.get_unit("Hello, beautiful world!\n", language="cs")
+        target_translation = self.get_translation()
+        self.assertEqual(
+            getattr(target_translation.stats, label_words),
+            updated_unit.source_unit.num_words,
+        )
+
+    def test_apply_source_delta_uses_latest_cached_stats(self) -> None:
+        stats = self.get_translation().stats
+        _ = stats.all_words
+        base_timestamp = cast("float", stats.stats_timestamp)
+        latest = stats.get_data_copy()
+        latest["all_words"] = cast("int", latest["all_words"]) + 3
+        cache.set(stats.cache_key, latest, 30 * 86400)
+
+        self.assertTrue(stats.apply_source_delta(base_timestamp, {"all_words": 2}))
+        self.assertEqual(
+            cache.get(stats.cache_key)["all_words"],
+            cast("int", latest["all_words"]) + 2,
+        )
+
+    def test_apply_source_delta_skips_newer_generation(self) -> None:
+        stats = self.get_translation().stats
+        _ = stats.all_words
+        base_timestamp = cast("float", stats.stats_timestamp)
+        latest = stats.get_data_copy()
+        latest["stats_timestamp"] = base_timestamp + 1
+        latest["all_words"] = cast("int", latest["all_words"]) + 7
+        cache.set(stats.cache_key, latest, 30 * 86400)
+
+        self.assertFalse(stats.apply_source_delta(base_timestamp, {"all_words": 2}))
+        self.assertEqual(cache.get(stats.cache_key), latest)
+
+    @override_settings(STATS_LAZY=False)
+    def test_save_holds_lock(self) -> None:
+        stats = self.get_translation().stats
+        original = cache.set
+
+        def wrapped(*args, **kwargs) -> None:
+            if args[0] == stats.cache_key:
+                self.assertTrue(stats.lock.is_locked)
+            original(*args, **kwargs)
+
+        with patch("weblate.utils.stats.cache.set", side_effect=wrapped):
+            stats.update_stats(update_parents=False)

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -4,12 +4,13 @@
 
 from __future__ import annotations
 
+import os
 import time
 from datetime import datetime, timedelta
 from itertools import chain
 from operator import itemgetter
 from types import GeneratorType
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import sentry_sdk
 from django.conf import settings
@@ -27,6 +28,8 @@ from weblate.lang.models import Language
 from weblate.trans.checklists import TranslationChecklistMixin
 from weblate.trans.mixins import BaseURLMixin
 from weblate.trans.util import translation_percent
+from weblate.utils.data import data_dir
+from weblate.utils.lock import WeblateLock
 from weblate.utils.random import get_random_identifier
 from weblate.utils.site import get_site_url
 from weblate.utils.state import (
@@ -46,6 +49,18 @@ if TYPE_CHECKING:
 
 StatItem = int | float | str | datetime | None
 StatDict = dict[str, StatItem]
+
+
+class UnitSnapshot(TypedDict):
+    state: int
+    num_words: int
+    num_chars: int
+    active_checks_count: int
+    dismissed_checks_count: int
+    suggestion_count: int
+    label_count: int
+    comment_count: int
+
 
 BASICS = {
     "all",
@@ -271,6 +286,22 @@ class BaseStats:
     def cache_key(self) -> str:
         return f"stats-{self._object.cache_key}"
 
+    @cached_property
+    def lock(self) -> WeblateLock:
+        lock_path = data_dir("cache", "stats-locks")
+        os.makedirs(lock_path, exist_ok=True)
+        return WeblateLock(
+            lock_path=lock_path,
+            scope="stats-update",
+            key=self.cache_key,
+            slug=self.cache_key,
+            cache_template="lock:{scope}:{key}",
+            file_template="{slug}.lock",
+            timeout=5,
+            expiry_timeout=300,
+            origin=self.cache_key,
+        )
+
     def remove_stats(self, *names: str) -> None:
         self.ensure_loaded()
         if not self._data:
@@ -356,6 +387,7 @@ class BaseStats:
 
     def calculate_by_name(self, name: str) -> None:
         if name in self.basic_keys:
+            self.clear()
             self.calculate_basic()
             self.save()
 
@@ -367,7 +399,8 @@ class BaseStats:
 
     def save(self, update_parents: bool = True) -> None:
         """Save stats to cache."""
-        cache.set(self.cache_key, self._data, 30 * 86400)
+        with self.lock:
+            cache.set(self.cache_key, self._data, 30 * 86400)
 
     def get_update_objects(self, *, full: bool = True) -> Generator[BaseStats]:
         yield GlobalStats()
@@ -525,6 +558,18 @@ class DummyTranslationStats(BaseStats):
 class TranslationStats(BaseStats):
     """Per translation stats."""
 
+    UNIT_DELTA_KEYS = BASIC_KEYS - frozenset(
+        {
+            "languages",
+            "last_changed",
+            "last_author",
+            "recent_changes",
+            "monthly_changes",
+            "total_changes",
+            "stats_timestamp",
+        }
+    )
+
     @cached_property
     def is_source(self):
         return self._object.is_source
@@ -574,6 +619,128 @@ class TranslationStats(BaseStats):
     @cached_property
     def has_review(self):
         return self._object.enable_review
+
+    @staticmethod
+    def capture_unit_snapshot(unit) -> UnitSnapshot:
+        if unit.source_unit_id == unit.pk:
+            labels = unit.get_label_count()
+        else:
+            labels = unit.source_unit.get_label_count()
+        return {
+            "state": unit.state,
+            "num_words": unit.num_words,
+            "num_chars": len(unit.source),
+            "active_checks_count": len(unit.active_checks),
+            "dismissed_checks_count": len(unit.dismissed_checks),
+            "suggestion_count": len(unit.suggestions),
+            "label_count": labels,
+            "comment_count": len(unit.unresolved_comments),
+        }
+
+    @staticmethod
+    def _update_bucket(
+        bucket: dict[str, int],
+        prefix: str,
+        num_words: int,
+        num_chars: int,
+        present: bool = True,
+    ) -> None:
+        if not present:
+            return
+        bucket[prefix] = bucket.get(prefix, 0) + 1
+        bucket[f"{prefix}_words"] = bucket.get(f"{prefix}_words", 0) + num_words
+        bucket[f"{prefix}_chars"] = bucket.get(f"{prefix}_chars", 0) + num_chars
+
+    @classmethod
+    def snapshot_to_bucket(cls, snapshot: UnitSnapshot) -> dict[str, int]:
+        bucket: dict[str, int] = {}
+        state = snapshot["state"]
+        num_words = snapshot["num_words"]
+        num_chars = snapshot["num_chars"]
+        has_active_checks = snapshot["active_checks_count"] > 0
+        has_dismissed_checks = snapshot["dismissed_checks_count"] > 0
+        has_suggestions = snapshot["suggestion_count"] > 0
+        has_labels = snapshot["label_count"] > 0
+        has_comments = snapshot["comment_count"] > 0
+
+        cls._update_bucket(bucket, "all", num_words, num_chars)
+        cls._update_bucket(bucket, "fuzzy", num_words, num_chars, state in FUZZY_STATES)
+        cls._update_bucket(
+            bucket, "readonly", num_words, num_chars, state == STATE_READONLY
+        )
+        cls._update_bucket(
+            bucket, "translated", num_words, num_chars, state >= STATE_TRANSLATED
+        )
+        cls._update_bucket(
+            bucket, "todo", num_words, num_chars, state < STATE_TRANSLATED
+        )
+        cls._update_bucket(
+            bucket, "nottranslated", num_words, num_chars, state == STATE_EMPTY
+        )
+        cls._update_bucket(
+            bucket, "approved", num_words, num_chars, state == STATE_APPROVED
+        )
+        cls._update_bucket(
+            bucket, "unapproved", num_words, num_chars, state == STATE_TRANSLATED
+        )
+        cls._update_bucket(bucket, "unlabeled", num_words, num_chars, not has_labels)
+        cls._update_bucket(bucket, "allchecks", num_words, num_chars, has_active_checks)
+        cls._update_bucket(
+            bucket,
+            "translated_checks",
+            num_words,
+            num_chars,
+            has_active_checks and state in {STATE_TRANSLATED, STATE_APPROVED},
+        )
+        cls._update_bucket(
+            bucket, "dismissed_checks", num_words, num_chars, has_dismissed_checks
+        )
+        cls._update_bucket(bucket, "suggestions", num_words, num_chars, has_suggestions)
+        cls._update_bucket(
+            bucket,
+            "nosuggestions",
+            num_words,
+            num_chars,
+            not has_suggestions and state < STATE_TRANSLATED,
+        )
+        cls._update_bucket(
+            bucket,
+            "approved_suggestions",
+            num_words,
+            num_chars,
+            has_suggestions and state == STATE_APPROVED,
+        )
+        cls._update_bucket(bucket, "comments", num_words, num_chars, has_comments)
+        return bucket
+
+    def can_apply_delta(self) -> bool:
+        self.ensure_loaded()
+        return bool(self._data) and all(key in self._data for key in self.basic_keys)
+
+    def get_data_copy(self) -> StatDict:
+        self.ensure_loaded()
+        return self._data.copy()
+
+    def apply_source_delta(
+        self, base_stats_timestamp: StatItem, delta: dict[str, int]
+    ) -> bool:
+        with self.lock:
+            self.set_data(self.load())
+            if (
+                not self.can_apply_delta()
+                or self.stats_timestamp != base_stats_timestamp
+            ):
+                return False
+            for key in tuple(self._data):
+                if key.startswith(("check:", "label:")):
+                    del self._data[key]
+            for key, value in delta.items():
+                self.store(key, cast("int", self.aggregate_get(key)) + value)
+            self.last_change_cache = None
+            self.fetch_last_change()
+            self.count_changes()
+            self.save(update_parents=False)
+            return True
 
     def _calculate_basic(self) -> None:  # noqa: PLR0914
         values = (


### PR DESCRIPTION
This avoids possibly expensive full stats update on large components and only applies delta that can be inferred from the current edit. The scope of delta handling is intentionally narrow to handle only the simple cases and avoid code complexity. If delta approach cannot be used, it falls back to standard stats calculation.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
