### PR TITLE
ci: pin Argos CLI version in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,12 +138,16 @@ jobs:
         mv build/coverage/.coverage.* .
         uv run coverage combine
         uv run coverage xml
+    - name: Install client dependencies for Argos CI
+      if: matrix.python-version == '3.14' && matrix.requirements == 'latest' && github.repository_owner == 'WeblateOrg'
+      working-directory: ./client
+      run: yarn install --immutable
     - name: Argos CI upload
       if: matrix.python-version == '3.14' && matrix.requirements == 'latest' && github.repository_owner == 'WeblateOrg'
+      working-directory: ./client
       env:
         ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }} # zizmor: ignore[secrets-outside-env]
-      run: |
-        npx --package=@argos-ci/cli@3.0.6 -- argos upload ./test-images/
+      run: yarn argos upload ../test-images/
     - uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
       with:
         token: ${{secrets.CODECOV_TOKEN}} # zizmor: ignore[secrets-outside-env]

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "daterangepicker/jquery": "~3.7.1"
   },
   "devDependencies": {
+    "@argos-ci/cli": "3.0.6",
     "css-loader": "7.1.4",
     "mini-css-extract-plugin": "2.10.1",
     "terser-webpack-plugin": "5.4.0",


### PR DESCRIPTION
### Motivation
- The Argos CI upload step used `npx --package=@argos-ci/cli` without a version, allowing arbitrary npm-published code to execute in CI with access to secrets and creating a supply-chain risk.

### Description
- Pin `@argos-ci/cli` to `3.0.6` in `.github/workflows/test.yml` by changing the invocation to `npx --package=@argos-ci/cli@3.0.6 -- argos upload ./test-images/` to remove runtime "latest" resolution while preserving existing behavior.

### Testing
- Verified the updated line with `nl -ba .github/workflows/test.yml | sed -n '138,150p'` and observed the pinned invocation (succeeded).
- Ran `git diff --check` to ensure no diff issues (succeeded).
- Attempted YAML parsing with `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`, which failed because `PyYAML` is not installed in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2567fc5808329aa00c829a84937f6)