### PR TITLE
perf(machinery): improve built-in machinery queries

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Weblate 5.17
 * Improved error messages in some of the :ref:`api` endpoints.
 * Improved performance of project and category search result pages with very large match sets.
 * :envvar:`WEBLATE_COMMIT_PENDING_HOURS` is now available in Docker container.
+* Improved performance of Weblate translation memory and built-in machinery lookups.
 
 .. rubric:: Bug fixes
 

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -2934,6 +2934,71 @@ class WeblateTranslationTest(FixtureTestCase):
         results = machine.translate(unit, self.user)
         self.assertNotEqual(results, [])
 
+    @patch("weblate.machinery.weblatetm.adjust_similarity_threshold")
+    def test_exact_matches_still_probe_fuzzy_fallback(self, adjust_threshold) -> None:
+        unit = Unit.objects.filter(translation__language_code="cs")[0]
+        other = unit.translation.unit_set.exclude(pk=unit.pk)[0]
+        other.source = unit.source
+        other.target = "Preklad"
+        other.state = STATE_TRANSLATED
+        other.save()
+
+        machine = WeblateTranslation({})
+        machine.translate(unit, self.user)
+
+        adjust_threshold.assert_called_once_with(0.98)
+
+    @patch("weblate.machinery.weblatetm.adjust_similarity_threshold")
+    def test_exact_matches_do_not_block_fuzzy_fallback(self, adjust_threshold) -> None:
+        machine = WeblateTranslation({})
+        exact_unit = MagicMock(pk=1)
+        fuzzy_unit = MagicMock(pk=2)
+        base = MagicMock()
+        exact_queryset = MagicMock(name="exact_queryset")
+        fuzzy_queryset = MagicMock(name="fuzzy_queryset")
+        deduped_queryset = MagicMock(name="deduped_queryset")
+        base.filter.side_effect = [exact_queryset, fuzzy_queryset]
+        fuzzy_queryset.exclude.return_value = deduped_queryset
+
+        with patch.object(
+            machine,
+            "prepare_queryset",
+            side_effect=([exact_unit], [fuzzy_unit]),
+        ):
+            results = machine.get_matching_units(base, "Hello", 75)
+
+        self.assertEqual(results, [exact_unit, fuzzy_unit])
+        fuzzy_queryset.exclude.assert_called_once_with(pk__in={1})
+        adjust_threshold.assert_called_once_with(0.98)
+
+    @patch("weblate.machinery.weblatetm.adjust_similarity_threshold")
+    def test_fuzzy_limit_applies_after_excluding_exact_ids(
+        self, adjust_threshold
+    ) -> None:
+        machine = WeblateTranslation({})
+        machine.candidate_limit = 2
+        exact_1 = MagicMock(pk=1)
+        exact_2 = MagicMock(pk=2)
+        fuzzy_3 = MagicMock(pk=3)
+        fuzzy_4 = MagicMock(pk=4)
+        base = MagicMock()
+        exact_queryset = MagicMock(name="exact_queryset")
+        fuzzy_queryset = MagicMock(name="fuzzy_queryset")
+        deduped_queryset = MagicMock(name="deduped_queryset")
+        base.filter.side_effect = [exact_queryset, fuzzy_queryset]
+        fuzzy_queryset.exclude.return_value = deduped_queryset
+
+        with patch.object(
+            machine,
+            "prepare_queryset",
+            side_effect=([exact_1, exact_2], [fuzzy_3, fuzzy_4]),
+        ):
+            results = machine.get_matching_units(base, "Hello", 75)
+
+        self.assertEqual(results, [exact_1, exact_2, fuzzy_3, fuzzy_4])
+        fuzzy_queryset.exclude.assert_called_once_with(pk__in={1, 2})
+        adjust_threshold.assert_called_once_with(0.98)
+
 
 class CyrTranslitTranslationTest(ViewTestCase, BaseMachineTranslationTest):
     ENGLISH = "sr@latin"

--- a/weblate/machinery/weblatetm.py
+++ b/weblate/machinery/weblatetm.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.db.models import Value
@@ -28,6 +28,7 @@ class WeblateTranslation(InternalMachineTranslation):
     cache_translations = True
     # Cache results for 1 hour to avoid frequent database hits
     cache_expiry = 3600
+    candidate_limit = 100
 
     def download_translations(
         self,
@@ -48,32 +49,15 @@ class WeblateTranslation(InternalMachineTranslation):
         if "memory_db" in settings.DATABASES:
             base = base.using("memory_db")
 
-        # Build search query
-        lookup: dict[str, Any] = {}
-        if threshold < 100:
-            # Full text search
-            lookup["source__trgm_search"] = text
-        else:
-            # Utilize PostgreSQL index
-            lookup["source__lower__md5"] = MD5(Lower(Value(text)))
-            lookup["source"] = text
-
-        matching_units = (
+        matching_units = self.get_matching_units(
             base.filter(
                 translation__component__source_language=source_language,
                 translation__language=target_language,
                 state__gte=STATE_TRANSLATED,
-                **lookup,
-            )
-            .exclude(
-                # The read-only strings can be possibly blank
-                target__lower__md5=MD5(Lower(Value("")))
-            )
-            .prefetch()
+            ),
+            text,
+            threshold,
         )
-
-        # We want only close matches here
-        adjust_similarity_threshold(0.98)
 
         for munit in matching_units:
             source = munit.source_string
@@ -91,3 +75,39 @@ class WeblateTranslation(InternalMachineTranslation):
                 "origin_url": munit.get_absolute_url(),
                 "source": source,
             }
+
+    def get_matching_units(self, base, text: str, threshold: int):
+        # Exact matches are common and are much cheaper than trigram search.
+        matching_units = list(
+            self.prepare_queryset(
+                base.filter(
+                    source__lower__md5=MD5(Lower(Value(text))),
+                    source=text,
+                )
+            )[: self.candidate_limit]
+        )
+        if threshold >= 100:
+            return matching_units.copy()
+
+        # We want only close matches here.
+        adjust_similarity_threshold(0.98)
+        exact_ids = {unit.pk for unit in matching_units}
+
+        fuzzy_queryset = base.filter(source__trgm_search=text)
+        if exact_ids:
+            fuzzy_queryset = fuzzy_queryset.exclude(pk__in=exact_ids)
+
+        matching_units.extend(
+            self.prepare_queryset(fuzzy_queryset)[: self.candidate_limit]
+        )
+
+        return matching_units
+
+    def prepare_queryset(self, queryset):
+        return queryset.exclude(target="").select_related(
+            "source_unit",
+            "translation__language",
+            "translation__plural",
+            "translation__component",
+            "translation__component__project",
+        )

--- a/weblate/memory/migrations/0005_memory_lookup_indexes.py
+++ b/weblate/memory/migrations/0005_memory_lookup_indexes.py
@@ -1,0 +1,53 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("memory", "0004_memory_status_and_context"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="memory",
+            index=models.Index(
+                "source_language",
+                "target_language",
+                condition=Q(from_file=True),
+                name="memory_file_lang_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="memory",
+            index=models.Index(
+                "project",
+                "source_language",
+                "target_language",
+                condition=Q(project__isnull=False, shared=False),
+                name="memory_project_lang_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="memory",
+            index=models.Index(
+                "user",
+                "source_language",
+                "target_language",
+                condition=Q(user__isnull=False, shared=False),
+                name="memory_user_lang_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="memory",
+            index=models.Index(
+                "source_language",
+                "target_language",
+                condition=Q(shared=True),
+                name="memory_shared_lang_idx",
+            ),
+        ),
+    ]

--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -79,6 +79,8 @@ def get_node_data(unit, node):
 
 
 class MemoryQuerySet(models.QuerySet):
+    lookup_limit = 50
+
     def filter_type(
         self,
         *,
@@ -168,38 +170,124 @@ class MemoryQuerySet(models.QuerySet):
         use_shared,
         threshold: int = 75,
     ):
+        results = self.lookup_scopes(
+            source_language=source_language,
+            target_language=target_language,
+            text=text,
+            user=user,
+            project=project,
+            use_shared=use_shared,
+            exact=True,
+            limit=self.lookup_limit,
+        )
+        exact_count = len(results)
+        remaining = self.lookup_limit - exact_count
+
         # Adjust similarity based on string length to get more relevant matches
         # for long strings
         similarity_threshold = self.threshold_to_similarity(text, threshold)
 
-        results = self.none()
-
-        while len(results) == 0 and similarity_threshold > MIN_SIMILARITY_THRESHOLD:
+        while (
+            remaining > 0
+            and len(results) == exact_count
+            and len(results) < self.lookup_limit
+            and similarity_threshold > MIN_SIMILARITY_THRESHOLD
+        ):
             # Change PostgreSQL similarity threshold configuration
             adjust_similarity_threshold(similarity_threshold)
 
             # Actual database query
-            results = (
-                self.prefetch_project()
-                .filter_type(
-                    # Type filtering
+            results = self.merge_lookup_results(
+                results,
+                self.lookup_scopes(
+                    source_language=source_language,
+                    target_language=target_language,
+                    text=text,
                     user=user,
                     project=project,
                     use_shared=use_shared,
-                    from_file=True,
-                )
-                .filter(
-                    # Full-text search on source
-                    source__trgm_search=text,
-                    # Language filtering
-                    source_language=source_language,
-                    target_language=target_language,
-                )[:50]
+                    limit=remaining,
+                ),
+                limit=self.lookup_limit,
             )
+            remaining = self.lookup_limit - len(results)
             # Decrease threshold in case no matches were found
             similarity_threshold -= 0.05
 
         return results
+
+    def lookup_scopes(
+        self,
+        *,
+        source_language,
+        target_language,
+        text: str,
+        user,
+        project,
+        use_shared: bool,
+        exact: bool = False,
+        limit: int = 50,
+    ) -> list[Memory]:
+        base = self
+        if "memory_db" in settings.DATABASES:
+            base = base.using("memory_db")
+        base = base.prefetch_project()
+        common_filters = {
+            "source_language": source_language,
+            "target_language": target_language,
+        }
+        if exact:
+            common_filters["source"] = text
+        else:
+            common_filters["source__trgm_search"] = text
+
+        results: list[Memory] = []
+        seen: set[int] = set()
+
+        for query in self.iter_lookup_scope_queries(
+            user=user,
+            project=project,
+            use_shared=use_shared,
+        ):
+            for memory in base.filter(query, **common_filters)[:limit]:
+                if memory.pk in seen:
+                    continue
+                seen.add(memory.pk)
+                results.append(memory)
+                if len(results) >= limit:
+                    return results
+
+        return results
+
+    def merge_lookup_results(
+        self,
+        existing: list[Memory],
+        additional: list[Memory],
+        *,
+        limit: int | None = None,
+    ) -> list[Memory]:
+        seen = {memory.pk for memory in existing}
+        results = [*existing]
+        for memory in additional:
+            if memory.pk in seen:
+                continue
+            seen.add(memory.pk)
+            results.append(memory)
+            if limit is not None and len(results) >= limit:
+                return results
+        return results
+
+    def iter_lookup_scope_queries(
+        self, *, user, project, use_shared: bool
+    ) -> tuple[Q, ...]:
+        queries: list[Q] = [Q(from_file=True)]
+        if project is not None:
+            queries.append(Q(project=project, shared=False))
+        if use_shared:
+            queries.append(Q(shared=True))
+        if user is not None:
+            queries.append(Q(user=user, shared=False))
+        return tuple(queries)
 
     def prefetch_lang(self):
         return self.prefetch_related("source_language", "target_language")
@@ -606,6 +694,32 @@ class Memory(models.Model):
                 models.F("target_language"),
                 models.F("source_language"),
                 name="memory_source_trgm",
+            ),
+            models.Index(
+                "source_language",
+                "target_language",
+                condition=Q(from_file=True),
+                name="memory_file_lang_idx",
+            ),
+            models.Index(
+                "project",
+                "source_language",
+                "target_language",
+                condition=Q(project__isnull=False, shared=False),
+                name="memory_project_lang_idx",
+            ),
+            models.Index(
+                "user",
+                "source_language",
+                "target_language",
+                condition=Q(user__isnull=False, shared=False),
+                name="memory_user_lang_idx",
+            ),
+            models.Index(
+                "source_language",
+                "target_language",
+                condition=Q(shared=True),
+                name="memory_shared_lang_idx",
             ),
         ]
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -8,7 +8,9 @@ import json
 import tempfile
 from io import StringIO
 from typing import Any
+from unittest.mock import MagicMock, patch
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import SimpleTestCase
@@ -19,7 +21,7 @@ from weblate_schemas import load_schema
 from weblate.lang.data import FORMULA_WITH_ZERO
 from weblate.lang.models import Language, Plural
 from weblate.memory.machine import WeblateMemory
-from weblate.memory.models import Memory
+from weblate.memory.models import Memory, MemoryQuerySet
 from weblate.memory.tasks import (
     handle_unit_translation_change,
     import_memory,
@@ -92,6 +94,109 @@ class MemoryModelTest(FixtureTestCase):
         machinery = unit.machinery
         del machinery["origin"]
         self.assertEqual(machinery, {"quality": [100], "translation": ["Ahoj"]})
+
+    @patch("weblate.memory.models.adjust_similarity_threshold")
+    def test_exact_matches_still_probe_fuzzy_lookup(self, adjust_threshold) -> None:
+        add_document()
+        unit = self.get_unit()
+
+        machine_translation = WeblateMemory({})
+        machine_translation.search(unit, "Hello", None)
+
+        self.assertGreater(adjust_threshold.call_count, 0)
+
+    @patch("weblate.memory.models.adjust_similarity_threshold")
+    def test_exact_matches_are_merged_with_fuzzy_results(
+        self, adjust_threshold
+    ) -> None:
+        exact = MagicMock(pk=1)
+        fuzzy = MagicMock(pk=2)
+
+        with (
+            patch.object(
+                MemoryQuerySet,
+                "lookup_scopes",
+                side_effect=([exact], [fuzzy]),
+            ),
+            patch.object(
+                MemoryQuerySet,
+                "threshold_to_similarity",
+                return_value=0.95,
+            ),
+        ):
+            results = Memory.objects.lookup(
+                Language.objects.get(code="en"),
+                Language.objects.get(code="cs"),
+                "Hello",
+                None,
+                None,
+                False,
+            )
+
+        self.assertEqual(results, [exact, fuzzy])
+        adjust_threshold.assert_called_once_with(0.95)
+
+    def test_lookup_scopes_uses_memory_db_when_configured(self) -> None:
+        with (
+            patch.dict(
+                settings.DATABASES,
+                {"memory_db": settings.DATABASES["default"]},
+                clear=False,
+            ),
+            patch.object(
+                MemoryQuerySet,
+                "using",
+                autospec=True,
+                side_effect=lambda queryset, _alias: queryset,
+            ) as using,
+            patch.object(
+                MemoryQuerySet,
+                "filter",
+                autospec=True,
+                return_value=Memory.objects.none(),
+            ),
+        ):
+            Memory.objects.lookup_scopes(
+                source_language=Language.objects.get(code="en"),
+                target_language=Language.objects.get(code="cs"),
+                text="Hello",
+                user=None,
+                project=None,
+                use_shared=False,
+            )
+
+        self.assertEqual(using.call_args.args[1], "memory_db")
+
+    @patch("weblate.memory.models.adjust_similarity_threshold")
+    def test_lookup_keeps_global_result_limit(self, adjust_threshold) -> None:
+        exact = [MagicMock(pk=index) for index in range(25)]
+        fuzzy = [MagicMock(pk=index) for index in range(25, 75)]
+
+        with (
+            patch.object(
+                MemoryQuerySet,
+                "lookup_scopes",
+                side_effect=(exact, fuzzy),
+            ),
+            patch.object(
+                MemoryQuerySet,
+                "threshold_to_similarity",
+                return_value=0.95,
+            ),
+        ):
+            results = Memory.objects.lookup(
+                Language.objects.get(code="en"),
+                Language.objects.get(code="cs"),
+                "Hello",
+                None,
+                None,
+                False,
+            )
+
+        self.assertEqual(len(results), MemoryQuerySet.lookup_limit)
+        self.assertEqual(results[:25], exact)
+        self.assertEqual(results[25:], fuzzy[:25])
+        adjust_threshold.assert_called_once_with(0.95)
 
     def test_machine_plurals(self) -> None:
         unit = self.get_unit("Orangutan has %d banana.\n")

--- a/weblate/trans/migrations/0067_unit_source_tm_index.py
+++ b/weblate/trans/migrations/0067_unit_source_tm_index.py
@@ -1,0 +1,24 @@
+# Copyright © Michal Cihar <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.contrib.postgres import indexes as postgres_indexes
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0066_alter_variant_key"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="unit",
+            index=postgres_indexes.GinIndex(
+                postgres_indexes.OpClass(models.F("source"), name="gin_trgm_ops"),
+                condition=Q(state__gte=20) & ~Q(target=""),
+                name="trans_unit_source_tm_idx",
+            ),
+        ),
+    ]

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -530,6 +530,11 @@ class Unit(models.Model, LoggerMixin):
                 models.F("translation"),
                 name="unit_explanation_fulltext",
             ),
+            postgres_indexes.GinIndex(
+                postgres_indexes.OpClass(models.F("source"), name="gin_trgm_ops"),
+                condition=Q(state__gte=STATE_TRANSLATED) & ~Q(target=""),
+                name="trans_unit_source_tm_idx",
+            ),
         ]
 
     def __str__(self) -> str:


### PR DESCRIPTION
This is AI-assisted approach:

- do an exact lookup first and skip trigram lookup in case some matches are found (is there problem with skipping other matches in this case?)
- create split indexes and split SQL query for translation memory, this seems to work better than forcing PostgreSQL to do the complex filtering on top of trigram

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
