### PR TITLE
fix(deepl): correctly handle Portugal languages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,7 @@ Weblate 5.17
 * Improved API access control for pending tasks.
 * Faster category and project removals.
 * Project backup restore no longer trusts repository-local VCS configuration and hooks from the uploaded archive.
+* :ref:`mt-deepl` maps plain Portuguese to European Portuguese.
 
 .. rubric:: Compatibility
 

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -410,6 +410,12 @@ class BatchMachineTranslation(DocVersionsMixin):
             code = code.rsplit("_", 1)[0]
             yield self.map_language_code(code)
 
+    def get_source_language_possibilities(self, language: Language) -> Iterator[str]:
+        return self.get_language_possibilities(language)
+
+    def get_target_language_possibilities(self, language: Language) -> Iterator[str]:
+        return self.get_language_possibilities(language)
+
     def get_languages(
         self, source_language: Language, target_language: Language
     ) -> tuple[str, str]:
@@ -417,8 +423,8 @@ class BatchMachineTranslation(DocVersionsMixin):
             msg = "Same languages"
             raise UnsupportedLanguageError(msg)
 
-        for source in self.get_language_possibilities(source_language):
-            for target in self.get_language_possibilities(target_language):
+        for source in self.get_source_language_possibilities(source_language):
+            for target in self.get_target_language_possibilities(target_language):
                 if self.is_supported(source, target):
                     return source, target
 

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -43,6 +43,9 @@ class DeepLTranslation(
         "pt@formal": "pt-pt@formal",
         "pt@informal": "pt-pt@informal",
     }
+    target_language_map: ClassVar[dict[str, str]] = {
+        "PT": "PT-PT",
+    }
     highlight_syntax = True
     settings_form = DeepLMachineryForm
     glossary_count_limit = 1000
@@ -68,6 +71,19 @@ class DeepLTranslation(
             # string side.
             if "-" in value:
                 yield value.split("-", 1)[0]
+
+    def get_target_language_possibilities(self, language: Language) -> Iterator[str]:
+        seen: set[str] = set()
+        base_code = self.map_language_code(language.code)
+
+        for value in super().get_language_possibilities(language):
+            if value not in seen:
+                seen.add(value)
+                yield value
+
+        mapped_value = self.target_language_map.get(base_code)
+        if mapped_value and mapped_value not in seen:
+            yield mapped_value
 
     def get_headers(self) -> dict[str, str]:
         return {"Authorization": f"DeepL-Auth-Key {self.settings['key']}"}

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -228,6 +228,7 @@ DEEPL_TARGET_LANG_RESPONSE = [
     {"language": "EN-GB", "name": "English (British)"},
     {"language": "DE", "name": "Deutsch", "supports_formality": True},
     {"language": "PT-BR", "name": "Portuguese (Brasilian)"},
+    {"language": "PT-PT", "name": "Portuguese (European)", "supports_formality": True},
 ]
 
 LIBRETRANSLATE_TRANS_RESPONSE = {"translatedText": "¡Hola, Mundo!"}
@@ -2121,9 +2122,12 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         self.mock_languages()
         lang_pt = Language.objects.get(code="pt")
         lang_pt_br = Language.objects.get(code="pt_BR")
+        lang_pt_pt = Language.objects.get(code="pt_PT")
         lang_en = Language.objects.get(code="en")
         self.assertEqual(machine.get_languages(lang_pt_br, lang_en), ("PT", "EN"))
         self.assertEqual(machine.get_languages(lang_pt, lang_pt_br), ("PT", "PT-BR"))
+        self.assertEqual(machine.get_languages(lang_en, lang_pt), ("EN", "PT-PT"))
+        self.assertEqual(machine.get_languages(lang_en, lang_pt_pt), ("EN", "PT-PT"))
 
 
 class LibreTranslateTranslationTest(BaseMachineTranslationTest):


### PR DESCRIPTION
The API have subtly changed by not exposing PT as supported target language (while it is actually supported), so map it to PT-PT.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
