### PR TITLE
docs: fix machinery api placeholders

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1311,7 +1311,7 @@ Projects
     :>json string change_count: Number of changes done in the time range
 
 
-.. http:get:: /api/projects/{string:project}/machinery_settings/
+.. http:get:: /api/projects/(string:project)/machinery_settings/
 
     .. versionadded:: 5.9
 
@@ -1322,7 +1322,7 @@ Projects
     :>json object suggestion_settings: Configuration for all installed services.
 
 
-.. http:post:: /api/projects/{string:project}/machinery_settings/
+.. http:post:: /api/projects/(string:project)/machinery_settings/
 
     .. versionadded:: 5.9
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1118,8 +1118,8 @@ Weblate 5.9
 
 * Per-project :ref:`machine-translation-setup` can now be configured via the Project :ref:`api`.
 
-  * Added :http:get:`/api/projects/{string:project}/machinery_settings/`.
-  * Added :http:post:`/api/projects/{string:project}/machinery_settings/`.
+  * Added :http:get:`/api/projects/(string:project)/machinery_settings/`.
+  * Added :http:post:`/api/projects/(string:project)/machinery_settings/`.
 
 * Translation memory import now supports files with XLIFF, PO and CSV formats, see :ref:`memory-user` and :wladmin:`import_memory` command in :ref:`manage`.
 * The registration CAPTCHA now includes proof-of-work mechanism ALTCHA.


### PR DESCRIPTION
Makes the placeholders stand out in the docs, like the others.