### PR TITLE
fix(memory): tighten initial similarity tresholds

### DIFF
--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -47,6 +47,7 @@ SUPPORTED_FORMATS = (
 )
 
 MIN_SIMILARITY_THRESHOLD = 0.3
+MEMORY_LOOKUP_LIMIT = 50
 
 
 class MemoryDict(TypedDict):
@@ -113,6 +114,9 @@ class MemoryQuerySet(models.QuerySet):
                 ]
         return super().filter(*args, **kwargs)
 
+    def get_lookup_length(self, text: str) -> int:
+        return len(NON_WORD_RE.sub("", text))
+
     def threshold_to_similarity(self, text: str, threshold: int) -> float:
         """
         Convert machinery threshold into PostgreSQL similarity threshold.
@@ -129,6 +133,9 @@ class MemoryQuerySet(models.QuerySet):
         We exclude non-word characters while calculating this as those are
         excluded in the trigram matching.
         """
+        if threshold >= 100:
+            return 1.0
+
         # Highest similarity we want to get
         high = 0.985
         # Limit the number of decimals to avoid too frequent flipping of the setting
@@ -149,14 +156,34 @@ class MemoryQuerySet(models.QuerySet):
 
         # Measure the length of alphanumeric characters in the text
         max_length = 2000
-        length = min(max(1, len(NON_WORD_RE.sub("", text))), max_length)
+        length = min(max(1, self.get_lookup_length(text)), max_length)
 
         # Apply boost based on square root of length so that it grows faster
         # for shorter strings
         boost = (maximum - base) * math.sqrt(length) / math.sqrt(max_length)
 
-        # Cap result into reasonable limits
-        return max(0.6, min(1.0, round(base + boost, decimals)))
+        similarity = max(0.6, min(1.0, round(base + boost, decimals)))
+
+        # Short, common strings tend to produce broad trigram matches. Start with
+        # a stricter threshold for those so that we avoid expensive fuzzy scans.
+        if threshold >= 75:
+            if length <= 8:
+                similarity = max(similarity, 0.97)
+            elif length <= 16:
+                similarity = max(similarity, 0.95)
+
+        return similarity
+
+    def minimum_similarity(self, text: str, threshold: int) -> float:
+        if threshold >= 100:
+            return 1.0
+        if threshold >= 75:
+            length = self.get_lookup_length(text)
+            if length <= 8:
+                return 0.92
+            if length <= 16:
+                return 0.90
+        return MIN_SIMILARITY_THRESHOLD
 
     def lookup(
         self,
@@ -168,36 +195,50 @@ class MemoryQuerySet(models.QuerySet):
         use_shared,
         threshold: int = 75,
     ):
+        base = self.prefetch_project().filter_type(
+            # Type filtering
+            user=user,
+            project=project,
+            use_shared=use_shared,
+            from_file=True,
+        )
+
+        if threshold >= 100:
+            return base.filter(
+                source=text,
+                source_language=source_language,
+                target_language=target_language,
+            )[:MEMORY_LOOKUP_LIMIT]
+
         # Adjust similarity based on string length to get more relevant matches
         # for long strings
         similarity_threshold = self.threshold_to_similarity(text, threshold)
+        minimum_similarity = self.minimum_similarity(text, threshold)
 
         results = self.none()
 
-        while len(results) == 0 and similarity_threshold > MIN_SIMILARITY_THRESHOLD:
+        while len(results) == 0 and similarity_threshold >= minimum_similarity:
             # Change PostgreSQL similarity threshold configuration
             adjust_similarity_threshold(similarity_threshold)
 
             # Actual database query
-            results = (
-                self.prefetch_project()
-                .filter_type(
-                    # Type filtering
-                    user=user,
-                    project=project,
-                    use_shared=use_shared,
-                    from_file=True,
-                )
-                .filter(
-                    # Full-text search on source
-                    source__trgm_search=text,
-                    # Language filtering
-                    source_language=source_language,
-                    target_language=target_language,
-                )[:50]
+            results = base.filter(
+                # Full-text search on source
+                source__trgm_search=text,
+                # Language filtering
+                source_language=source_language,
+                target_language=target_language,
             )
+            results = results[:MEMORY_LOOKUP_LIMIT]
             # Decrease threshold in case no matches were found
-            similarity_threshold -= 0.05
+            similarity_threshold = round(similarity_threshold - 0.05, 3)
+            if (
+                len(results) == 0
+                and similarity_threshold
+                < minimum_similarity
+                < similarity_threshold + 0.05
+            ):
+                similarity_threshold = minimum_similarity
 
         return results
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -8,6 +8,7 @@ import json
 import tempfile
 from io import StringIO
 from typing import Any
+from unittest.mock import MagicMock, call, patch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -19,7 +20,7 @@ from weblate_schemas import load_schema
 from weblate.lang.data import FORMULA_WITH_ZERO
 from weblate.lang.models import Language, Plural
 from weblate.memory.machine import WeblateMemory
-from weblate.memory.models import Memory
+from weblate.memory.models import Memory, MemoryQuerySet
 from weblate.memory.tasks import (
     handle_unit_translation_change,
     import_memory,
@@ -861,7 +862,7 @@ class ThresholdTestCase(SimpleTestCase):
 
     def test_auto(self) -> None:
         self.assertAlmostEqual(
-            Memory.objects.threshold_to_similarity("x", 80), 0.96, delta=0.01
+            Memory.objects.threshold_to_similarity("x", 80), 0.97, delta=0.01
         )
         self.assertAlmostEqual(
             Memory.objects.threshold_to_similarity("x" * 50, 80), 0.96, delta=0.01
@@ -877,7 +878,7 @@ class ThresholdTestCase(SimpleTestCase):
 
     def test_machine(self) -> None:
         self.assertAlmostEqual(
-            Memory.objects.threshold_to_similarity("x", 75), 0.95, delta=0.01
+            Memory.objects.threshold_to_similarity("x", 75), 0.97, delta=0.01
         )
         self.assertAlmostEqual(
             Memory.objects.threshold_to_similarity("x" * 50, 75), 0.96, delta=0.01
@@ -905,4 +906,47 @@ class ThresholdTestCase(SimpleTestCase):
             Memory.objects.threshold_to_similarity("<" * 50 + "x" * 50 + ">" * 50, 100),
             1.0,
             delta=0.01,
+        )
+
+    def test_minimum_similarity_short_strings(self) -> None:
+        self.assertEqual(Memory.objects.minimum_similarity("Username", 75), 0.92)
+        self.assertEqual(Memory.objects.minimum_similarity("Display name", 75), 0.9)
+        self.assertEqual(Memory.objects.minimum_similarity("x" * 50, 75), 0.3)
+        self.assertEqual(Memory.objects.minimum_similarity("x", 100), 1.0)
+
+
+class LookupPolicyTest(SimpleTestCase):
+    @patch("weblate.memory.models.adjust_similarity_threshold")
+    def test_lookup_short_strings_stop_backing_off_early(
+        self, adjust_threshold
+    ) -> None:
+        base = MagicMock()
+        base.filter_type.return_value = base
+        base.filter.return_value = []
+
+        with patch.object(MemoryQuerySet, "prefetch_project", return_value=base):
+            results = Memory.objects.lookup("en", "cs", "Username", None, None, False)
+
+        self.assertEqual(list(results), [])
+        self.assertEqual(adjust_threshold.call_args_list, [call(0.97), call(0.92)])
+
+    @patch("weblate.memory.models.adjust_similarity_threshold")
+    def test_lookup_exact_threshold_uses_single_exact_probe(
+        self, adjust_threshold
+    ) -> None:
+        base = MagicMock()
+        base.filter_type.return_value = base
+        base.filter.return_value = []
+
+        with patch.object(MemoryQuerySet, "prefetch_project", return_value=base):
+            results = Memory.objects.lookup(
+                "en", "cs", "Username", None, None, False, 100
+            )
+
+        self.assertEqual(list(results), [])
+        adjust_threshold.assert_not_called()
+        base.filter.assert_called_once_with(
+            source="Username",
+            source_language="en",
+            target_language="cs",
         )

--- a/weblate/utils/db.py
+++ b/weblate/utils/db.py
@@ -37,7 +37,7 @@ def adjust_similarity_threshold(value: float) -> None:
 
     current_similarity = getattr(connection, "weblate_similarity", -1)
     # Ignore small differences
-    if abs(current_similarity - value) < 0.05:
+    if round(abs(current_similarity - value), 3) < 0.05:
         return
 
     with connection.cursor() as cursor:

--- a/weblate/utils/tests/test_db.py
+++ b/weblate/utils/tests/test_db.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 from weblate.trans.models import Component, Project, Unit
 from weblate.trans.tests.test_views import FixtureTestCase
-from weblate.utils.db import re_escape
+from weblate.utils.db import adjust_similarity_threshold, re_escape
 
 BASE_SQL = 'SELECT "trans_unit"."id" FROM "trans_unit" WHERE '
 
@@ -15,6 +16,22 @@ class DbTest(TestCase):
     def test_re_escape(self) -> None:
         self.assertEqual(re_escape("[a-z]"), "\\[a\\-z\\]")
         self.assertEqual(re_escape("a{1,4}"), "a\\{1,4\\}")
+
+    @patch("weblate.utils.db.connections")
+    def test_adjust_similarity_threshold_applies_boundary_updates(
+        self, connections_mock
+    ) -> None:
+        cursor = MagicMock()
+        cursor.__enter__.return_value = cursor
+        connection = MagicMock()
+        connection.cursor.return_value = cursor
+        connection.weblate_similarity = 0.97
+        connections_mock.__contains__.return_value = False
+        connections_mock.__getitem__.return_value = connection
+
+        adjust_similarity_threshold(0.92)
+
+        cursor.execute.assert_called_once_with("SELECT set_limit(%s)", [0.92])
 
 
 class PostgreSQLOperatorTest(TestCase):


### PR DESCRIPTION
With the fallback in place, we no longer need broad matches by default, we can get to them if no actual matches are there.

This might be actually the solution for #18611.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
