### PR TITLE
fix: clear automatically_translated flag on state changes from repo

### DIFF
--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -918,11 +918,20 @@ class Unit(models.Model, LoggerMixin):
         self,
         unit,
         string_changed: bool,
+        state_changed: bool,
         disk_automatically_translated: bool | None = None,
     ) -> bool:
+        if not unit.is_translated():
+            return False
+
+        is_existing_automatically_translated = (
+            self.automatically_translated or disk_automatically_translated
+        )
+
         return unit.is_automatically_translated(
-            (self.automatically_translated or disk_automatically_translated)
+            is_existing_automatically_translated
             and not string_changed
+            and not state_changed
         )
 
     @staticmethod
@@ -1105,10 +1114,6 @@ class Unit(models.Model, LoggerMixin):
         )
         original_state = self.get_unit_state(unit, None, include_weblate_readonly=False)
 
-        automatically_translated = self.get_unit_automatically_translated(
-            unit, string_changed, comparison_state["automatically_translated"]
-        )
-
         # Monolingual files handling (without target change)
         if (
             not created
@@ -1145,6 +1150,14 @@ class Unit(models.Model, LoggerMixin):
 
         # Update checks on fuzzy update or on content change
         same_state = state == comparison_state["state"] and flags == Flags(self.flags)
+
+        automatically_translated = self.get_unit_automatically_translated(
+            unit,
+            string_changed=string_changed,
+            state_changed=not same_state,
+            disk_automatically_translated=comparison_state["automatically_translated"],
+        )
+
         same_metadata = (
             location == self.location
             and note == self.note

--- a/weblate/trans/tests/test_remote.py
+++ b/weblate/trans/tests/test_remote.py
@@ -13,6 +13,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.lang.models import Language
+from weblate.trans.actions import ActionEvents
 from weblate.trans.models import CommitPolicyChoices, Component, PendingUnitChange, Unit
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import REPOWEB_URL
@@ -882,6 +883,73 @@ class FileScanTest(ViewTestCase):
     def test_fuzzy_state_commit_policy_po(self) -> None:
         component = self.create_po(name="Po component", project=self.project)
         self._test_fuzzy_state_commit_policy(component)
+
+    def _test_auto_translated_cleared_on_state_change_from_repo(
+        self, component, expect_auto_translated: bool
+    ) -> None:
+        """Test that automatically_translated flag is cleared on any repo update."""
+        request = self.get_request()
+        translation = component.translation_set.get(language_code="cs")
+
+        unit = translation.unit_set.get(source="Hello, world!\n")
+        unit.translate(
+            self.user,
+            "Nazdar svete!\n",
+            STATE_TRANSLATED,
+            change_action=ActionEvents.AUTO,
+        )
+        unit.refresh_from_db()
+        self.assertTrue(unit.automatically_translated)
+
+        component.commit_pending("test", None)
+
+        # Directly edit the file on disk to mark the string as fuzzy
+        # (state change without content change)
+        ttk_unit, _ = translation.store.find_unit(unit.context, unit.source)
+        ttk_unit.unit.markfuzzy(True)
+        translation.store.save()
+        with transaction.atomic():
+            translation.git_commit(request.user, "TEST <test@example.net>")
+
+        component.do_file_scan(request)
+
+        unit = translation.unit_set.get(source="Hello, world!\n")
+        self.assertEqual(unit.state, STATE_FUZZY)
+        self.assertEqual(unit.automatically_translated, expect_auto_translated)
+
+    def test_auto_translated_cleared_on_state_change_from_repo_po(self) -> None:
+        component = self.create_po(name="Po component", project=self.project)
+        self._test_auto_translated_cleared_on_state_change_from_repo(component, False)
+
+    def test_auto_translated_cleared_on_state_change_from_repo_xliff(self) -> None:
+        component = self.create_xliff_mono(name="Xliff component", project=self.project)
+        # XLIFF stores auto-translated state in state-qualifier attribute,
+        # which is not cleared by markfuzzy - the file state is trusted
+        self._test_auto_translated_cleared_on_state_change_from_repo(component, True)
+
+    def test_auto_translated_ignored_on_empty_target_xliff(self) -> None:
+        """Test that state-qualifier is ignored when the unit target is empty."""
+        component = self.create_xliff_mono(name="Xliff component", project=self.project)
+        request = self.get_request()
+        translation = component.translation_set.get(language_code="cs")
+
+        unit = translation.unit_set.get(source="Hello, world!\n")
+        # Clear the target on disk while keeping state-qualifier="leveraged-mt"
+        ttk_unit, _ = translation.store.find_unit(unit.context, unit.source)
+        ttk_unit.set_target("t")
+        ttk_unit.unit.markfuzzy(False)
+        for node in ttk_unit.get_xliff_nodes():
+            if node is not None:
+                node.set("state-qualifier", "leveraged-mt")
+        translation.store.save()
+        with transaction.atomic():
+            translation.git_commit(request.user, "TEST <test@example.net>")
+
+        component.do_file_scan(request)
+
+        unit = translation.unit_set.get(source="Hello, world!\n")
+        self.assertEqual(unit.state, STATE_EMPTY)
+        self.assertFalse(unit.automatically_translated)
 
 
 class GitBranchMultiRepoTest(MultiRepoTest):

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -406,8 +406,10 @@ class RepoTestMixin:
     def create_xliff(self, name="default", **kwargs) -> Component:
         return self._create_component("xliff", f"xliff/*/{name}.xlf", **kwargs)
 
-    def create_xliff_mono(self) -> Component:
-        return self._create_component("xliff", "xliff-mono/*.xlf", "xliff-mono/en.xlf")
+    def create_xliff_mono(self, **kwargs) -> Component:
+        return self._create_component(
+            "xliff", "xliff-mono/*.xlf", "xliff-mono/en.xlf", **kwargs
+        )
 
     def create_xliff_auto(self) -> Component:
         return self._create_component("xliff", "xliff-auto/*.xlf")


### PR DESCRIPTION
When the state of a unit has changed in a file:
1. If the file format does not support writing automatically_translated, clear the automatically_translated flag.
2. If the file format supports writing automatically_translated status, then use the value of from the file.

Additionally, empty units are always marked as not automatically_translated.

Fix #18369