### PR TITLE
fix(add-ons): use venv path to find commands

### DIFF
--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -53,6 +53,21 @@ class GettextBaseAddon(BaseAddon):
     compat: ClassVar[CompatDict] = {"file_format": {"po", "po-mono"}}
 
 
+def find_runtime_command(command: str) -> str | None:
+    """Find executable either on PATH or next to the active Python interpreter."""
+    if path := find_command(command):
+        return path
+    interpreter_dir = Path(sys.executable).parent
+    candidates = [
+        interpreter_dir / command,
+        interpreter_dir / f"{command}.exe",
+    ]
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return os.fspath(candidate)
+    return None
+
+
 class GenerateMoAddon(GettextBaseAddon):
     events: ClassVar[set[AddonEvent]] = {
         AddonEvent.EVENT_PRE_COMMIT,
@@ -335,7 +350,7 @@ class MsgmergeAddon(GettextBaseAddon, UpdateBaseAddon):
         category: Category | None = None,
         project: Project | None = None,
     ) -> bool:
-        if find_command("msgmerge") is None:
+        if find_runtime_command("msgmerge") is None:
             return False
         return super().can_install(
             component=component, category=category, project=project
@@ -827,7 +842,7 @@ class XgettextAddon(ExtractPotBaseAddon):
         category: Category | None = None,
         project: Project | None = None,
     ) -> bool:
-        return find_command("xgettext") is not None and super().can_install(
+        return find_runtime_command("xgettext") is not None and super().can_install(
             component=component, category=category, project=project
         )
 
@@ -1110,8 +1125,8 @@ class DjangoAddon(ExtractPotBaseAddon):
         project: Project | None = None,
     ) -> bool:
         if not (
-            find_command("xgettext") is not None
-            and find_command("msguniq") is not None
+            find_runtime_command("xgettext") is not None
+            and find_runtime_command("msguniq") is not None
             and super().can_install(
                 component=component, category=category, project=project
             )
@@ -1268,7 +1283,7 @@ class SphinxAddon(ExtractPotBaseAddon):
         project: Project | None = None,
     ) -> bool:
         if not (
-            find_command("sphinx-build") is not None
+            find_runtime_command("sphinx-build") is not None
             and super().can_install(
                 component=component, category=category, project=project
             )

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -744,6 +744,52 @@ class GettextAddonTest(ViewTestCase):
         self.component.new_base = "weblate/locale/django.pot"
         self.assertFalse(SphinxAddon.can_install(component=self.component))
 
+    def test_sphinx_can_install_uses_runtime_venv_bin(self) -> None:
+        self.component.new_base = "docs/locales/docs.pot"
+        docs_dir = Path(self.component.full_path) / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        (docs_dir / "conf.py").write_text("", encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="weblate-sphinx-venv-") as tempdir:
+            venv_bin = Path(tempdir) / "bin"
+            venv_bin.mkdir(parents=True, exist_ok=True)
+            fake_python = venv_bin / "python"
+            fake_python.write_text("", encoding="utf-8")
+            fake_python.chmod(0o755)
+            sphinx_build = venv_bin / "sphinx-build"
+            sphinx_build.write_text("", encoding="utf-8")
+            sphinx_build.chmod(0o755)
+
+            with (
+                patch("weblate.addons.gettext.find_command", return_value=None),
+                patch("weblate.addons.gettext.sys.executable", os.fspath(fake_python)),
+            ):
+                self.assertTrue(SphinxAddon.can_install(component=self.component))
+
+    def test_sphinx_can_install_uses_symlinked_runtime_venv_bin(self) -> None:
+        self.component.new_base = "docs/locales/docs.pot"
+        docs_dir = Path(self.component.full_path) / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        (docs_dir / "conf.py").write_text("", encoding="utf-8")
+        with tempfile.TemporaryDirectory(
+            prefix="weblate-sphinx-symlinked-venv-"
+        ) as tempdir:
+            venv_bin = Path(tempdir) / "bin"
+            venv_bin.mkdir(parents=True, exist_ok=True)
+            fake_python_target = Path(tempdir) / "python3"
+            fake_python_target.write_text("", encoding="utf-8")
+            fake_python_target.chmod(0o755)
+            fake_python = venv_bin / "python"
+            fake_python.symlink_to(fake_python_target)
+            sphinx_build = venv_bin / "sphinx-build"
+            sphinx_build.write_text("", encoding="utf-8")
+            sphinx_build.chmod(0o755)
+
+            with (
+                patch("weblate.addons.gettext.find_command", return_value=None),
+                patch("weblate.addons.gettext.sys.executable", os.fspath(fake_python)),
+            ):
+                self.assertTrue(SphinxAddon.can_install(component=self.component))
+
     def test_sphinx_form_missing_source_dir(self) -> None:
         self.component.new_base = "docs/locales/docs.pot"
         form = SphinxAddon.get_add_form(


### PR DESCRIPTION
At least the sphinx-build is installed in vevn and it would not be found on many installs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
