### PR TITLE
fix(add-ons): invalidate cache on add-on install

### DIFF
--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -460,14 +460,14 @@ class ExtractPotBaseAddon(GettextBaseAddon, UpdateBaseAddon):
             if arg in {"--no-location", "--no-wrap"}
         ]
 
-    def ensure_msgmerge_addon(self) -> None:
+    def ensure_msgmerge_addon(self) -> bool:
         from weblate.addons.models import Addon
 
         install_msgmerge = self.instance.configuration.get("_install_msgmerge", False)
         if not install_msgmerge:
-            return
+            return False
         if self.has_applicable_msgmerge_addon(Addon):
-            return
+            return False
         kwargs = self.get_msgmerge_addon_create_kwargs()
         if not MsgmergeAddon.can_install(**kwargs):
             self.warnings.append(
@@ -480,8 +480,9 @@ class ExtractPotBaseAddon(GettextBaseAddon, UpdateBaseAddon):
                     "error": "Could not install the msgmerge add-on for PO updates",
                 }
             )
-            return
+            return False
         MsgmergeAddon.create(run=False, **kwargs)
+        return True
 
     def has_applicable_msgmerge_addon(self, addon_model) -> bool:
         if self.instance.component is not None:
@@ -541,7 +542,8 @@ class ExtractPotBaseAddon(GettextBaseAddon, UpdateBaseAddon):
         return {}
 
     def post_configure_run(self) -> None:
-        self.ensure_msgmerge_addon()
+        if self.ensure_msgmerge_addon() and self.instance.component is not None:
+            self.instance.component.drop_addons_cache()
         super().post_configure_run()
         if self.instance.configuration.pop("_install_msgmerge", False):
             self.instance.save(update_fields=["configuration"])

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -2050,6 +2050,33 @@ class GettextAddonTest(ViewTestCase):
 
         mocked_create.assert_called_once()
 
+    def test_extract_pot_post_configure_triggers_newly_installed_msgmerge(self) -> None:
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "_install_msgmerge": True,
+                "interval": "weekly",
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+            },
+        )
+        source = Path(self.component.full_path) / "src" / "messages.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(
+            'from gettext import gettext as _\n_("Hello")\n', encoding="utf-8"
+        )
+        self.component.drop_addons_cache()
+        _ = self.component.addons_cache
+
+        with (
+            patch.object(XgettextAddon, "run_process", return_value=""),
+            patch.object(MsgmergeAddon, "update_translations", autospec=True) as mocked,
+        ):
+            addon.post_configure_run()
+
+        mocked.assert_called_once()
+
     def test_extract_pot_installs_msgmerge_for_project_scope(self) -> None:
         self.create_po_new_base(
             project=self.component.project,


### PR DESCRIPTION
The add-on cache would not contain the new add-on and it would not be triggered on this run.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
