### PR TITLE
fix(views): gracefully handle locking error on unit removal

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,7 @@ Weblate 5.17
 * Push branches are no longer updated with upstream-only commits in multi-branch workflows.
 * Improved :ref:`backup` status reporting while keeping maintenance after failed backup attempts.
 * POT update add-ons now fall back to the component URL for the ``Report-Msgid-Bugs-To`` header when the component setting is empty.
+* Improved repository lock error handling when deleting units.
 
 .. rubric:: Compatibility
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -9,6 +9,7 @@ from copy import copy
 from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import responses
@@ -54,6 +55,7 @@ from weblate.trans.tests.utils import (
 from weblate.utils.celery import get_task_metadata_key
 from weblate.utils.data import data_dir
 from weblate.utils.django_hacks import immediate_on_commit, immediate_on_commit_leave
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import (
     STATE_EMPTY,
     STATE_NEEDS_CHECKING,
@@ -6099,6 +6101,86 @@ class UnitAPITest(APIBaseTest):
         component = Component.objects.get(pk=component.pk)
         self.assertNotEqual(revision, component.repository.last_revision)
         self.assertEqual(component.stats.all, 12)
+
+    def test_delete_unit_locked(self) -> None:
+        component = self._create_component(
+            "po-mono",
+            "po-mono/*.po",
+            "po-mono/en.po",
+            project=self.component.project,
+            name="mono",
+        )
+        unit = Unit.objects.get(
+            translation__component=component,
+            translation__language_code="cs",
+            source="Hello, world!\n",
+        ).source_unit
+
+        with patch(
+            "weblate.trans.models.translation.Translation.delete_unit",
+            side_effect=WeblateLockTimeoutError(
+                "repository locked",
+                lock=SimpleNamespace(scope="repo", origin="test/component"),
+            ),
+        ):
+            self.do_request(
+                "api:unit-detail",
+                kwargs={"pk": unit.pk},
+                method="delete",
+                code=423,
+                superuser=True,
+                data={
+                    "type": "client_error",
+                    "errors": [
+                        {
+                            "code": "repository-locked",
+                            "detail": "Could not remove the string because another background operation is in progress. Please try again later.",
+                            "attr": None,
+                        }
+                    ],
+                },
+                format="json",
+            )
+
+    def test_delete_unit_component_locked(self) -> None:
+        component = self._create_component(
+            "po-mono",
+            "po-mono/*.po",
+            "po-mono/en.po",
+            project=self.component.project,
+            name="mono",
+        )
+        unit = Unit.objects.get(
+            translation__component=component,
+            translation__language_code="cs",
+            source="Hello, world!\n",
+        ).source_unit
+
+        with patch(
+            "weblate.trans.models.translation.Translation.delete_unit",
+            side_effect=WeblateLockTimeoutError(
+                "component locked",
+                lock=SimpleNamespace(scope="component-update", origin="test/component"),
+            ),
+        ):
+            self.do_request(
+                "api:unit-detail",
+                kwargs={"pk": unit.pk},
+                method="delete",
+                code=423,
+                superuser=True,
+                data={
+                    "type": "client_error",
+                    "errors": [
+                        {
+                            "code": "component-locked",
+                            "detail": "Could not obtain the update lock for component test/component to perform the operation.",
+                            "attr": None,
+                        }
+                    ],
+                },
+                format="json",
+            )
 
     def test_unit_translations(self) -> None:
         unit = Unit.objects.get(

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -167,6 +167,9 @@ DOC_TEXT = """
 <p>See <a href="{0}">the Weblate's Web API documentation</a> for detailed
 description of the API.</p>
 """
+DELETE_UNIT_LOCKED_DETAIL = gettext_lazy(
+    "Could not remove the string because another background operation is in progress. Please try again later."
+)
 
 
 class LockedError(APIException):
@@ -2398,6 +2401,13 @@ class UnitViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelM
             self.permission_denied(request, can_delete.reason)
         try:
             obj.translation.delete_unit(request, obj)
+        except WeblateLockTimeoutError as error:
+            if error.lock.scope == "repo":
+                raise LockedError(
+                    code="repository-locked",
+                    detail=DELETE_UNIT_LOCKED_DETAIL,
+                ) from None
+            raise
         except FileParseError as error:
             obj.translation.component.update_import_alerts(delete=False)
             return Response(

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -7,7 +7,9 @@
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
+from unittest.mock import patch
 
 from django.urls import reverse
 
@@ -19,6 +21,7 @@ from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.util import join_plural
 from weblate.trans.views.edit import format_newly_failing_checks_message
 from weblate.utils.hash import hash_to_checksum
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import (
     STATE_FUZZY,
     STATE_NEEDS_CHECKING,
@@ -616,6 +619,29 @@ class EditPoMonoTest(EditTest):
         component = Component.objects.get(pk=self.component.pk)
         self.assertEqual(component.stats.all, 12)
         self.assertEqual(unit_count - 4, Unit.objects.count())
+
+    def test_remove_unit_locked(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+        unit = self.get_unit().source_unit
+
+        with patch(
+            "weblate.trans.models.translation.Translation.delete_unit",
+            side_effect=WeblateLockTimeoutError(
+                "repository locked",
+                lock=SimpleNamespace(scope="repo", origin="test/component"),
+            ),
+        ):
+            response = self.client.post(
+                reverse("delete-unit", kwargs={"unit_id": unit.pk}),
+                follow=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "Could not remove the string because another background operation is in progress. Please try again later.",
+        )
 
 
 class EditIphoneTest(EditTest):

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -25,7 +25,7 @@ from django.http import (
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import gettext, ngettext
+from django.utils.translation import gettext, gettext_lazy, ngettext
 from django.views.decorators.http import require_POST
 
 from weblate.checks.models import CHECKS, get_display_checks
@@ -67,6 +67,7 @@ from weblate.utils import messages
 from weblate.utils.antispam import is_spam
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.html import format_html_join_comma, list_to_tuples
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.messages import get_message_kind
 from weblate.utils.ratelimit import revert_rate_limit, session_ratelimit_post
 from weblate.utils.state import (
@@ -84,6 +85,9 @@ if TYPE_CHECKING:
     )
 
 SESSION_SEARCH_CACHE_TTL = 1800
+DELETE_UNIT_LOCKED_MESSAGE = gettext_lazy(
+    "Could not remove the string because another background operation is in progress. Please try again later."
+)
 
 
 def display_fixups(request: AuthenticatedHttpRequest, fixups: list[str]) -> None:
@@ -1136,6 +1140,9 @@ def delete_unit(request: AuthenticatedHttpRequest, unit_id):
 
     try:
         unit.translation.delete_unit(request, unit)
+    except WeblateLockTimeoutError:
+        messages.error(request, DELETE_UNIT_LOCKED_MESSAGE)
+        return redirect(unit)
     except FileParseError as error:
         unit.translation.component.update_import_alerts(delete=False)
         messages.error(request, gettext("Could not remove the string: %s") % error)


### PR DESCRIPTION
There might be ongoing background task that holds the repository lock, so provide user a clear error message rather than error.

Fixes WEBLATE-30D4

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
