### PR TITLE
chore(utils): consolidate command execution and discovery

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -21,8 +21,8 @@ from weblate.addons.events import POST_CONFIGURE_EVENTS, AddonEvent
 from weblate.trans.exceptions import FileParseError
 from weblate.trans.models import Component
 from weblate.trans.templatetags.translations import format_json
-from weblate.trans.util import get_clean_env
 from weblate.utils import messages
+from weblate.utils.commands import get_clean_env
 from weblate.utils.docs import DocVersionsMixin
 from weblate.utils.errors import report_error
 from weblate.utils.files import cleanup_error_message

--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -16,7 +16,6 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, ClassVar, cast
 
 from django.core.exceptions import ValidationError
-from django.core.management.utils import find_command
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
@@ -31,7 +30,7 @@ from weblate.addons.forms import (
 )
 from weblate.formats.base import UpdateError
 from weblate.formats.exporters import MoExporter
-from weblate.trans.util import get_clean_env
+from weblate.utils.commands import find_runtime_command, get_clean_env
 from weblate.utils.errors import report_error
 from weblate.utils.files import cleanup_error_message
 from weblate.utils.site import get_site_url
@@ -52,21 +51,6 @@ if TYPE_CHECKING:
 
 class GettextBaseAddon(BaseAddon):
     compat: ClassVar[CompatDict] = {"file_format": {"po", "po-mono"}}
-
-
-def find_runtime_command(command: str) -> str | None:
-    """Find executable either on PATH or next to the active Python interpreter."""
-    if path := find_command(command):
-        return path
-    interpreter_dir = Path(sys.executable).parent
-    candidates = [
-        interpreter_dir / command,
-        interpreter_dir / f"{command}.exe",
-    ]
-    for candidate in candidates:
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            return os.fspath(candidate)
-    return None
 
 
 class GenerateMoAddon(GettextBaseAddon):

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -8,6 +8,7 @@ import base64
 import contextlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -761,8 +762,14 @@ class GettextAddonTest(ViewTestCase):
             sphinx_build.chmod(0o755)
 
             with (
-                patch("weblate.addons.gettext.find_command", return_value=None),
-                patch("weblate.addons.gettext.sys.executable", os.fspath(fake_python)),
+                patch(
+                    "weblate.utils.commands.find_command",
+                    side_effect=lambda command, path=None: shutil.which(
+                        command,
+                        path=None if path is None else os.pathsep.join(path),
+                    ),
+                ),
+                patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)),
             ):
                 self.assertTrue(SphinxAddon.can_install(component=self.component))
 
@@ -786,10 +793,28 @@ class GettextAddonTest(ViewTestCase):
             sphinx_build.chmod(0o755)
 
             with (
-                patch("weblate.addons.gettext.find_command", return_value=None),
-                patch("weblate.addons.gettext.sys.executable", os.fspath(fake_python)),
+                patch(
+                    "weblate.utils.commands.find_command",
+                    side_effect=lambda command, path=None: shutil.which(
+                        command,
+                        path=None if path is None else os.pathsep.join(path),
+                    ),
+                ),
+                patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)),
             ):
                 self.assertTrue(SphinxAddon.can_install(component=self.component))
+
+    def test_sphinx_can_install_ignores_relative_runtime_executable(self) -> None:
+        self.component.new_base = "docs/locales/docs.pot"
+        docs_dir = Path(self.component.full_path) / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        (docs_dir / "conf.py").write_text("", encoding="utf-8")
+
+        with (
+            patch("weblate.utils.commands.find_command", return_value=None),
+            patch("weblate.utils.commands.sys.executable", "python"),
+        ):
+            self.assertFalse(SphinxAddon.can_install(component=self.component))
 
     def test_sphinx_form_missing_source_dir(self) -> None:
         self.component.new_base = "docs/locales/docs.pot"
@@ -2345,11 +2370,45 @@ class GettextAddonTest(ViewTestCase):
         self.assertEqual(len(addon.alerts), 1)
         self.assertIn("timed out", addon.alerts[0]["error"].lower())
 
+    def test_extract_pot_uses_runtime_interpreter_path_for_commands(self) -> None:
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+            },
+        )
+
+        with tempfile.TemporaryDirectory(prefix="weblate-runtime-command-") as tempdir:
+            runtime_bin = Path(tempdir) / "runtime-bin"
+            runtime_bin.mkdir(parents=True, exist_ok=True)
+            fake_python = runtime_bin / "python"
+            fake_python.write_text("", encoding="utf-8")
+            fake_python.chmod(0o755)
+            xgettext = runtime_bin / "xgettext"
+            xgettext.write_text("#!/bin/sh\necho runtime-xgettext\n", encoding="utf-8")
+            xgettext.chmod(0o755)
+
+            with (
+                patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)),
+                patch(
+                    "weblate.utils.commands.sys.exec_prefix",
+                    os.fspath(Path(tempdir) / "other-prefix"),
+                ),
+                patch.dict(os.environ, {"PATH": "/usr/bin"}),
+            ):
+                output = addon.run_process(self.component, ["xgettext"])
+
+        self.assertEqual(output, "runtime-xgettext\n")
+
     def test_django_can_install_requires_msguniq(self) -> None:
         self.component.new_base = "locale/django.pot"
         self.component.save(update_fields=["new_base"])
 
-        def fake_find_command(name):
+        def fake_find_command(name, path=None):
             if name == "xgettext":
                 return "/usr/bin/xgettext"
             if name == "msguniq":
@@ -2357,7 +2416,7 @@ class GettextAddonTest(ViewTestCase):
             return "/usr/bin/other"
 
         with patch(
-            "weblate.addons.gettext.find_command", side_effect=fake_find_command
+            "weblate.utils.commands.find_command", side_effect=fake_find_command
         ):
             self.assertFalse(DjangoAddon.can_install(component=self.component))
 

--- a/weblate/fonts/tasks.py
+++ b/weblate/fonts/tasks.py
@@ -8,8 +8,8 @@ from celery.schedules import crontab
 
 from weblate.fonts.models import FONT_STORAGE, Font
 from weblate.fonts.utils import configure_fontconfig
-from weblate.trans.util import get_clean_env
 from weblate.utils.celery import app
+from weblate.utils.commands import get_clean_env
 
 
 @app.task(trail=False)

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -67,11 +67,11 @@ from weblate.lang.data import FORMULA_WITH_ZERO, ZERO_PLURAL_TYPES
 from weblate.lang.models import Plural
 from weblate.trans.file_format_params import get_encoding_param
 from weblate.trans.util import (
-    get_clean_env,
     get_string,
     rich_to_xliff_string,
     xliff_string_to_rich,
 )
+from weblate.utils.commands import get_clean_env
 from weblate.utils.errors import report_error
 from weblate.utils.files import cleanup_error_message
 from weblate.utils.state import (

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -8,7 +8,6 @@ import locale
 import os
 import platform
 import re
-import sys
 from operator import itemgetter
 from types import GeneratorType
 from typing import TYPE_CHECKING, Any, cast
@@ -26,7 +25,6 @@ from translate.misc.multistring import multistring
 from translate.storage.placeables.lisa import parse_xliff, strelem_to_xml
 
 from weblate.auth.results import Denied
-from weblate.utils.data import data_dir
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable
@@ -142,55 +140,6 @@ def translation_percent(
     if promile == 1000 and translated < total:
         return 99.9
     return promile / 10
-
-
-def get_clean_env(
-    extra: dict[str, str] | None = None, extra_path: str | None = None
-) -> dict[str, str]:
-    """Return cleaned up environment for subprocess execution."""
-    environ = {
-        "LANG": "C.UTF-8",
-        "LC_ALL": "C.UTF-8",
-        "HOME": data_dir("home"),
-        "PATH": "/bin:/usr/bin:/usr/local/bin",
-    }
-    if extra is not None:
-        environ.update(extra)
-    variables = (
-        # Keep PATH setup
-        "PATH",
-        # Keep Python search path
-        "PYTHONPATH",
-        # Keep linker configuration
-        "LD_LIBRARY_PATH",
-        "LD_PRELOAD",
-        # Fontconfig configuration by weblate.fonts
-        "FONTCONFIG_FILE",
-        # Needed by Git on Windows
-        "SystemRoot",
-        # Pass proxy configuration
-        "http_proxy",
-        "https_proxy",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-        # below two are needed for openshift3 deployment,
-        # where nss_wrapper is used
-        # more on the topic on below link:
-        # https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
-        "NSS_WRAPPER_GROUP",
-        "NSS_WRAPPER_PASSWD",
-    )
-    for var in variables:
-        if var in os.environ:
-            environ[var] = os.environ[var]
-    # Extend path to include Python environment, avoid inserting already existing ones to
-    # not break existing ordering (for example PATH injection used in tests)
-    venv_path = os.path.join(sys.exec_prefix, "bin")
-    if venv_path not in environ["PATH"]:
-        environ["PATH"] = f"{venv_path}:{environ['PATH']}"
-    if extra_path and extra_path not in environ["PATH"]:
-        environ["PATH"] = f"{extra_path}:{environ['PATH']}"
-    return environ
 
 
 def cleanup_repo_url(url: str, text: str | None = None) -> str:

--- a/weblate/utils/backup.py
+++ b/weblate/utils/backup.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 
-from weblate.trans.util import get_clean_env
+from weblate.utils.commands import get_clean_env
 from weblate.utils.data import data_dir
 from weblate.utils.errors import add_breadcrumb, report_error
 from weblate.utils.files import cleanup_error_message

--- a/weblate/utils/commands.py
+++ b/weblate/utils/commands.py
@@ -1,0 +1,121 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from django.core.management.utils import find_command
+
+from weblate.utils.data import data_dir
+
+DEFAULT_PATH = "/bin:/usr/bin:/usr/local/bin"
+
+
+def get_runtime_interpreter_dir() -> Path | None:
+    """Return the active interpreter directory when it is safely resolvable."""
+    executable = sys.executable
+    if not executable:
+        return None
+    executable_path = Path(executable)
+    if not executable_path.is_absolute():
+        return None
+    return executable_path.parent
+
+
+def build_runtime_path(
+    current_path: str,
+    *,
+    extra_path: str | None = None,
+) -> str:
+    """Build PATH for subprocesses."""
+    return os.pathsep.join(
+        build_runtime_path_entries(current_path, extra_path=extra_path)
+    )
+
+
+def build_runtime_path_entries(
+    current_path: str,
+    *,
+    extra_path: str | None = None,
+) -> list[str]:
+    """Build PATH entries for subprocesses and runtime command resolution."""
+    path_entries = current_path.split(os.pathsep) if current_path else []
+    interpreter_dir = get_runtime_interpreter_dir()
+    additional_paths = [
+        extra_path,
+        None if interpreter_dir is None else os.fspath(interpreter_dir),
+        os.path.join(sys.exec_prefix, "bin"),
+    ]
+    unique_additional_paths: list[str] = []
+    for candidate in additional_paths:
+        if not candidate or candidate in unique_additional_paths:
+            continue
+        unique_additional_paths.append(candidate)
+    merged_paths: list[str] = []
+    for candidate in path_entries:
+        if not candidate or candidate in merged_paths:
+            continue
+        merged_paths.append(candidate)
+    missing_paths = [
+        candidate
+        for candidate in unique_additional_paths
+        if candidate and candidate not in merged_paths
+    ]
+    return [*missing_paths, *merged_paths]
+
+
+def get_clean_env(
+    extra: dict[str, str] | None = None, extra_path: str | None = None
+) -> dict[str, str]:
+    """Return cleaned up environment for subprocess execution."""
+    environ = {
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "HOME": data_dir("home"),
+        "PATH": DEFAULT_PATH,
+    }
+    if extra is not None:
+        environ.update(extra)
+    variables = (
+        # Keep PATH setup
+        "PATH",
+        # Keep Python search path
+        "PYTHONPATH",
+        # Keep linker configuration
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+        # Fontconfig configuration by weblate.fonts
+        "FONTCONFIG_FILE",
+        # Needed by Git on Windows
+        "SystemRoot",
+        # Pass proxy configuration
+        "http_proxy",
+        "https_proxy",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        # below two are needed for openshift3 deployment,
+        # where nss_wrapper is used
+        # more on the topic on below link:
+        # https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
+        "NSS_WRAPPER_GROUP",
+        "NSS_WRAPPER_PASSWD",
+    )
+    for var in variables:
+        if var in os.environ:
+            environ[var] = os.environ[var]
+    environ["PATH"] = build_runtime_path(environ["PATH"], extra_path=extra_path)
+    return environ
+
+
+def find_runtime_command(command: str, *, extra_path: str | None = None) -> str | None:
+    """Find executable using the same PATH used for subprocess execution."""
+    return find_command(
+        command,
+        path=build_runtime_path_entries(
+            os.environ.get("PATH", DEFAULT_PATH), extra_path=extra_path
+        ),
+    )

--- a/weblate/utils/tasks.py
+++ b/weblate/utils/tasks.py
@@ -25,9 +25,9 @@ from weblate.formats.models import FILE_FORMATS
 from weblate.logger import LOGGER
 from weblate.machinery.models import MACHINERY
 from weblate.trans.models import Component, Project, Translation
-from weblate.trans.util import get_clean_env
 from weblate.utils.backup import backup_lock
 from weblate.utils.celery import app
+from weblate.utils.commands import get_clean_env
 from weblate.utils.data import data_dir
 from weblate.utils.errors import add_breadcrumb, report_error
 from weblate.utils.lock import WeblateLockTimeoutError

--- a/weblate/utils/tests/test_commands.py
+++ b/weblate/utils/tests/test_commands.py
@@ -2,12 +2,18 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import os
+import shutil
+import tempfile
 from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase
 
 from weblate.trans.tests.utils import TempDirMixin
+from weblate.utils.commands import find_runtime_command, get_clean_env
 
 
 class CommandTests(SimpleTestCase, TempDirMixin):
@@ -22,3 +28,150 @@ class DBCommandTests(TestCase):
         output = StringIO()
         call_command("ensure_stats", stdout=output)
         self.assertEqual("found 0 strings\n", output.getvalue())
+
+
+class RuntimeCommandTests(SimpleTestCase):
+    def test_get_clean_env_includes_runtime_and_venv_paths(self) -> None:
+        with (
+            patch("weblate.utils.commands.sys.executable", "/runtime/bin/python"),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(os.environ, {"PATH": "/usr/bin"}),
+        ):
+            env = get_clean_env(extra_path="/extra/bin")
+
+        self.assertEqual(
+            env["PATH"],
+            "/extra/bin:/runtime/bin:/venv-prefix/bin:/usr/bin",
+        )
+
+    def test_get_clean_env_skips_relative_runtime_path(self) -> None:
+        with (
+            patch("weblate.utils.commands.sys.executable", "python"),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(os.environ, {"PATH": "/usr/bin"}),
+        ):
+            env = get_clean_env(extra_path="/extra/bin")
+
+        self.assertEqual(
+            env["PATH"],
+            "/extra/bin:/venv-prefix/bin:/usr/bin",
+        )
+
+    def test_get_clean_env_skips_empty_runtime_path(self) -> None:
+        with (
+            patch("weblate.utils.commands.sys.executable", ""),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(os.environ, {"PATH": "/usr/bin"}),
+        ):
+            env = get_clean_env(extra_path="/extra/bin")
+
+        self.assertEqual(
+            env["PATH"],
+            "/extra/bin:/venv-prefix/bin:/usr/bin",
+        )
+
+    def test_find_runtime_command_uses_runtime_path(self) -> None:
+        with (
+            patch(
+                "weblate.utils.commands.find_command",
+                side_effect=lambda command, path=None: shutil.which(
+                    command,
+                    path=None if path is None else os.pathsep.join(path),
+                ),
+            ),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(os.environ, {"PATH": "/usr/bin"}),
+            tempfile.TemporaryDirectory(prefix="weblate-runtime-command-") as tempdir,
+        ):
+            runtime_bin = Path(tempdir) / "runtime-bin"
+            runtime_bin.mkdir(parents=True, exist_ok=True)
+            fake_python = runtime_bin / "python"
+            fake_python.write_text("", encoding="utf-8")
+            fake_python.chmod(0o755)
+            xgettext = runtime_bin / "xgettext"
+            xgettext.write_text("", encoding="utf-8")
+            xgettext.chmod(0o755)
+
+            with patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)):
+                self.assertEqual(
+                    find_runtime_command("xgettext"),
+                    os.fspath(xgettext),
+                )
+
+    def test_find_runtime_command_ignores_relative_runtime_path(self) -> None:
+        with (
+            patch("weblate.utils.commands.find_command", return_value=None),
+            patch("weblate.utils.commands.sys.executable", "python"),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(os.environ, {"PATH": "/usr/bin"}),
+        ):
+            self.assertIsNone(find_runtime_command("xgettext"))
+
+    def test_find_runtime_command_passes_split_path_entries(self) -> None:
+        with (
+            patch("weblate.utils.commands.sys.executable", "/runtime/bin/python"),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(os.environ, {"PATH": "/usr/bin:/usr/local/bin"}),
+            patch("weblate.utils.commands.find_command", return_value=None) as mocked,
+        ):
+            find_runtime_command("xgettext", extra_path="/extra/bin")
+
+        self.assertEqual(
+            mocked.call_args.kwargs["path"],
+            [
+                "/extra/bin",
+                "/runtime/bin",
+                "/venv-prefix/bin",
+                "/usr/bin",
+                "/usr/local/bin",
+            ],
+        )
+
+    def test_get_clean_env_preserves_existing_path_precedence(self) -> None:
+        with (
+            patch("weblate.utils.commands.sys.executable", "/runtime/bin/python"),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(
+                os.environ,
+                {
+                    "PATH": "/custom/bin:/extra/bin:/runtime/bin:/venv-prefix/bin:/usr/bin"
+                },
+            ),
+        ):
+            env = get_clean_env(extra_path="/extra/bin")
+
+        self.assertEqual(
+            env["PATH"],
+            "/custom/bin:/extra/bin:/runtime/bin:/venv-prefix/bin:/usr/bin",
+        )
+
+    def test_find_runtime_command_uses_default_path_when_unset(self) -> None:
+        with (
+            patch("weblate.utils.commands.sys.executable", "/runtime/bin/python"),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
+            patch.dict(os.environ, {}, clear=True),
+            patch("weblate.utils.commands.find_command", return_value=None) as mocked,
+        ):
+            find_runtime_command("xgettext", extra_path="/extra/bin")
+
+        self.assertEqual(
+            mocked.call_args.kwargs["path"],
+            [
+                "/extra/bin",
+                "/runtime/bin",
+                "/venv-prefix/bin",
+                "/bin",
+                "/usr/bin",
+                "/usr/local/bin",
+            ],
+        )
+
+    def test_get_clean_env_deduplicates_runtime_prefixes(self) -> None:
+        with (
+            patch("weblate.utils.commands.sys.executable", "/venv/bin/python"),
+            patch("weblate.utils.commands.sys.exec_prefix", "/venv"),
+            patch.dict(os.environ, {"PATH": "/usr/bin"}),
+        ):
+            env = get_clean_env()
+
+        self.assertEqual(env["PATH"], "/venv/bin:/usr/bin")

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -21,7 +21,8 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 from packaging.version import Version
 
-from weblate.trans.util import get_clean_env, path_separator
+from weblate.trans.util import path_separator
+from weblate.utils.commands import get_clean_env
 from weblate.utils.data import data_path
 from weblate.utils.errors import add_breadcrumb
 from weblate.utils.files import is_excluded

--- a/weblate/vcs/gpg.py
+++ b/weblate/vcs/gpg.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.cache import cache
 from siphashc import siphash
 
-from weblate.trans.util import get_clean_env
+from weblate.utils.commands import get_clean_env
 from weblate.utils.errors import report_error
 from weblate.utils.files import cleanup_error_message
 

--- a/weblate/vcs/ssh.py
+++ b/weblate/vcs/ssh.py
@@ -18,8 +18,8 @@ from django.core.management.utils import find_command
 from django.utils.functional import cached_property
 from django.utils.translation import gettext, pgettext_lazy
 
-from weblate.trans.util import get_clean_env
 from weblate.utils import messages
+from weblate.utils.commands import get_clean_env
 from weblate.utils.data import data_path
 from weblate.utils.files import cleanup_error_message
 from weblate.utils.hash import calculate_checksum


### PR DESCRIPTION
Use the same PATH for both and include current venv for that. In some context, the wsgi or celery process didn't have that present in PATH what made them silently use system tools instead of the ones Weblate depends on (or not finding them at all). This was uncovered by recent sphinx-build dependency, but applied to borg, git-review or mercurial as well.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
