### PR TITLE
Restore default encoding fallback for file formats and fix encoding parameter resolution

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,7 @@ Weblate 5.17
 * Improved API access control for pending tasks.
 * Faster category and project removals.
 * Project backup restore no longer trusts repository-local VCS configuration and hooks from the uploaded archive.
+* Restored documented default encoding fallback for :doc:`/formats/apple` and :doc:`/formats/java` when file format parameters are not explicitly set.
 
 .. rubric:: Compatibility
 

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -70,6 +70,7 @@ from weblate.formats.ttkit import (
 )
 from weblate.lang.data import PLURAL_UNKNOWN
 from weblate.lang.models import Language, Plural
+from weblate.trans.file_format_params import get_encoding_param
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.tests.utils import TempDirMixin, get_test_file
 from weblate.utils.state import STATE_APPROVED, STATE_FUZZY, STATE_TRANSLATED
@@ -194,6 +195,19 @@ class AutoLoadTest(SimpleTestCase):
         for format_class in FILE_FORMATS.values():
             if issubclass(format_class, TTKitFormat):
                 format_class.get_class()
+
+    def test_encoding_loader_defaults(self) -> None:
+        """Encoding fallback should come from parameter defaults, not loader order."""
+        self.assertEqual(get_encoding_param("strings", {}), "utf-8")
+        self.assertEqual(get_encoding_param("properties", {}), "iso-8859-1")
+        self.assertEqual(get_encoding_param("gwt", {}), "utf-8")
+        self.assertEqual(
+            get_encoding_param("properties", {"strings_encoding": "utf-16"}),
+            "iso-8859-1",
+        )
+        self.assertIsNone(
+            get_encoding_param("xwiki-full-page", {"strings_encoding": "utf-16"})
+        )
 
 
 class BaseFormatTest(FixtureTestCase, TempDirMixin, ABC):

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -291,7 +291,7 @@ class BaseTTKitFormat[S: TranslationStore, U: TranslateToolkitUnit, T: TTKitUnit
             store.setsourcelanguage(self.source_language)
 
     def get_encoding(self) -> str | None:
-        return get_encoding_param(self.file_format_params)
+        return get_encoding_param(self.format_id, self.file_format_params)
 
     def load(
         self,
@@ -473,7 +473,9 @@ class BaseTTKitFormat[S: TranslationStore, U: TranslateToolkitUnit, T: TTKitUnit
             store.store.savefile(filename)
         elif cls.empty_file_template is not None:
             Path(filename).write_bytes(
-                cls.get_new_file_content(get_encoding_param(file_format_params))
+                cls.get_new_file_content(
+                    get_encoding_param(cls.format_id, file_format_params)
+                )
             )
         else:
             msg = "Not supported"
@@ -533,6 +535,7 @@ class TTKitFormat[S: TranslationStore, U: TranslateToolkitUnit, T: TTKitUnit](
             if encoding in cls.loader:
                 module_name, class_name = cls.loader[encoding]
             else:
+                # Defensive fallback for missing/unknown encoding values.
                 module_name, class_name = next(iter(cls.loader.values()))
         elif isinstance(cls.loader, tuple):
             # Tuple style loader, import from translate toolkit
@@ -549,7 +552,7 @@ class TTKitFormat[S: TranslationStore, U: TranslateToolkitUnit, T: TTKitUnit](
 
     def get_store_instance(self, **kwargs) -> S:
         kwargs.update(self.get_format_class_kwargs())
-        store = self.get_class(get_encoding_param(self.file_format_params))(**kwargs)
+        store = self.get_class(self.get_encoding())(**kwargs)
 
         # Apply possible fixups
         self.fixup(store)

--- a/weblate/trans/file_format_params.py
+++ b/weblate/trans/file_format_params.py
@@ -174,16 +174,16 @@ def get_param_for_name(name: str) -> type[BaseFileFormatParam]:
     raise ValueError(msg)
 
 
-def get_encoding_param(file_format_params: FileFormatParams | None) -> str | None:
+def get_encoding_param(
+    file_format: str, file_format_params: FileFormatParams | None
+) -> str | None:
     """Get encoding parameter from file format parameters."""
-    if file_format_params is None:
-        file_format_params = {}
-    for param_name, value in file_format_params.items():
-        try:
-            if get_param_for_name(param_name).is_encoding():
-                return cast("str", value)
-        except ValueError:
-            continue
+    file_format_params = get_default_params_for_file_format(file_format) | (
+        {} if file_format_params is None else file_format_params
+    )
+    for param in get_params_for_file_format(file_format):
+        if param.is_encoding():
+            return cast("str", param.get_value(file_format_params))
     return None
 
 
@@ -474,10 +474,10 @@ class StringsEncoding(BaseFileFormatParam):
     label = gettext_lazy("File encoding")
     field_class = forms.ChoiceField
     choices: ClassVar[list[tuple[str | int, StrOrPromise]] | None] = [
-        ("utf-16", gettext_lazy("UTF-16")),
         ("utf-8", gettext_lazy("UTF-8")),
+        ("utf-16", gettext_lazy("UTF-16")),
     ]
-    default = "utf-16"
+    default = "utf-8"
     help_text = gettext_lazy("Encoding used for iOS strings files")
 
 

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1826,7 +1826,7 @@ class Component(
                 ) or (
                     self.template
                     and self.file_format_cls.get_new_file_content(
-                        get_encoding_param(self.file_format_params)
+                        get_encoding_param(self.file_format, self.file_format_params)
                     )
                     is None
                 ):
@@ -1835,7 +1835,7 @@ class Component(
                     self.full_path,
                     {
                         self.template: self.file_format_cls.get_new_file_content(
-                            get_encoding_param(self.file_format_params)
+                            get_encoding_param(self.file_format, self.file_format_params)
                         )
                     }
                     if self.template


### PR DESCRIPTION
### Motivation

* Restore the documented default encoding behavior for formats like `apple` and `java` so fallback encoding comes from format parameter defaults rather than loader order or missing params.
* Make encoding resolution deterministic and format-aware so creation/parsing of new files and Translate Toolkit store initialization use the correct encoding.

### Description

* Change `get_encoding_param` to accept the `file_format` and merge provided params with format defaults from `get_default_params_for_file_format` so encoding parameters are resolved from format-specific defaults.
* Update callers to pass `file_format` where appropriate, including `BaseTTKitFormat.get_encoding`, `BaseTTKitFormat.create_new_file`, and component repository initialization in `Component.configure_repo`.
* Improve `TTKitFormat.get_class` with a defensive fallback when an unknown or missing encoding key is used, and make `get_store_instance` use `self.get_encoding()` for instantiation.
* Add a unit test `test_encoding_loader_defaults` in `weblate.formats.tests.test_formats` and update the changelog `docs/changes.rst` to reflect the restored default encoding fallback.

### Testing

* Added `test_encoding_loader_defaults` in `weblate.formats.tests.test_formats` and ran the formats unit tests covering encoding resolution and file creation, which succeeded.
* Ran the format-related test suite locally to validate `create_new_file`, `get_store_instance`, and component repo initialization, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a89354b48329beb6dee7d1ba56e7)