### PR TITLE
feat(project): add setting to control use of private urls in websites

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1681,6 +1681,7 @@ Default configuration:
 
    * :ref:`project-web`
    * :setting:`PROJECT_WEB_RESTRICT_NUMERIC`
+   * :setting:`PROJECT_WEB_RESTRICT_PRIVATE`
    * :setting:`PROJECT_WEB_RESTRICT_RE`
 
 
@@ -1697,6 +1698,25 @@ Reject using numeric IP address in project website. On by default.
 
    * :ref:`project-web`
    * :setting:`PROJECT_WEB_RESTRICT_HOST`
+   * :setting:`PROJECT_WEB_RESTRICT_PRIVATE`
+   * :setting:`PROJECT_WEB_RESTRICT_RE`
+
+.. setting:: PROJECT_WEB_RESTRICT_PRIVATE
+
+PROJECT_WEB_RESTRICT_PRIVATE
+----------------------------
+
+.. versionadded:: 5.17
+
+Reject using project website and repository browser URLs pointing to non-global
+IP ranges. On by default.
+
+.. seealso::
+
+   * :ref:`project-web`
+   * :ref:`component-repoweb`
+   * :setting:`PROJECT_WEB_RESTRICT_HOST`
+   * :setting:`PROJECT_WEB_RESTRICT_NUMERIC`
    * :setting:`PROJECT_WEB_RESTRICT_RE`
 
 .. setting:: PROJECT_WEB_RESTRICT_RE
@@ -1713,6 +1733,7 @@ Defines a regular expression to limit what can be entered as :ref:`project-web`.
    * :ref:`project-web`
    * :setting:`PROJECT_WEB_RESTRICT_HOST`
    * :setting:`PROJECT_WEB_RESTRICT_NUMERIC`
+   * :setting:`PROJECT_WEB_RESTRICT_PRIVATE`
 
 .. setting:: PUBLIC_ENGAGE
 

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -694,6 +694,14 @@ Generic settings
       environment:
         WEBLATE_REGISTRATION_ALLOW_DISPOSABLE_EMAILS: 1
 
+.. envvar:: WEBLATE_PROJECT_WEB_RESTRICT_PRIVATE
+
+   .. versionadded:: 5.17
+
+   Configures :setting:`PROJECT_WEB_RESTRICT_PRIVATE`.
+
+   Defaults to enabled.
+
 .. envvar:: WEBLATE_TIME_ZONE
 
     Configures the used time zone in Weblate, see :std:setting:`django:TIME_ZONE`.

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -149,6 +149,7 @@ This is a required parameter unless turned off by :setting:`WEBSITE_REQUIRED`.
 
    * :setting:`PROJECT_WEB_RESTRICT_HOST`
    * :setting:`PROJECT_WEB_RESTRICT_NUMERIC`
+   * :setting:`PROJECT_WEB_RESTRICT_PRIVATE`
    * :setting:`PROJECT_WEB_RESTRICT_RE`
 
 .. _project-instructions:
@@ -453,6 +454,10 @@ In case your paths are relative to different folder (path contains ``..``), you
 might want to strip leading directory by ``parentdir`` filter (see
 :ref:`markup`):
 ``https://github.com/WeblateOrg/hello/blob/{{branch}}/{{filename|parentdir}}#L{{line}}``
+
+.. seealso::
+
+   * :setting:`PROJECT_WEB_RESTRICT_PRIVATE`
 
 .. _component-git_export:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 5.17
 * Improved error messages in some of the :ref:`api` endpoints.
 * Improved performance of project and category search result pages with very large match sets.
 * :envvar:`WEBLATE_COMMIT_PENDING_HOURS` is now available in Docker container.
+* Added :setting:`PROJECT_WEB_RESTRICT_PRIVATE` to reject project website and repository browser URLs targeting non-global IP ranges, and exposed it in Docker as :envvar:`WEBLATE_PROJECT_WEB_RESTRICT_PRIVATE`.
 * Improved performance of :ref:`mt-weblate` lookups.
 * Screenshot and font upload forms now honor :setting:`ALLOWED_ASSET_SIZE` which now defaults to 10 MB.
 
@@ -61,6 +62,7 @@ Weblate 5.17
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
 * There are several changes in :file:`settings_example.py`, most notably :setting:`ADMINS` syntax has changed in Django and ``SOCIAL_AUTH_PIPELINE`` and ``INSTALLED_APPS`` need adjustments; please adjust your settings accordingly.
+* Project website and repository browser URLs pointing to private or other non-global IP ranges are now rejected by default. If your setup intentionally links to internal addresses, set :setting:`PROJECT_WEB_RESTRICT_PRIVATE` to ``False`` or :envvar:`WEBLATE_PROJECT_WEB_RESTRICT_PRIVATE` to ``0``.
 
 .. rubric:: Contributors
 

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -707,6 +707,9 @@ REGISTRATION_EMAIL_MATCH = get_env_str("WEBLATE_REGISTRATION_EMAIL_MATCH", ".*")
 REGISTRATION_ALLOW_DISPOSABLE_EMAILS = get_env_bool(
     "WEBLATE_REGISTRATION_ALLOW_DISPOSABLE_EMAILS", False
 )
+PROJECT_WEB_RESTRICT_PRIVATE = get_env_bool(
+    "WEBLATE_PROJECT_WEB_RESTRICT_PRIVATE", True
+)
 
 private_commit_email_template_str = get_env_str("WEBLATE_PRIVATE_COMMIT_EMAIL_TEMPLATE")
 if private_commit_email_template_str is not None:

--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -23,7 +23,11 @@ from weblate_language_data.countries import DEFAULT_LANGS
 
 from weblate.formats.models import FILE_FORMATS
 from weblate.trans.actions import ActionEvents
-from weblate.utils.requests import format_validation_error, get_uri_error
+from weblate.utils.requests import (
+    format_validation_error,
+    get_uri_error,
+    validate_request_url,
+)
 from weblate.utils.state import STATE_TRANSLATED
 from weblate.utils.validators import WeblateURLValidator, validate_project_web
 from weblate.vcs.models import VCS_REGISTRY
@@ -50,6 +54,12 @@ def _get_validated_uri_error(
             validator(uri)
         except ValidationError as error:
             return format_validation_error(error)
+    try:
+        validate_request_url(
+            uri, allow_private_targets=not settings.PROJECT_WEB_RESTRICT_PRIVATE
+        )
+    except ValidationError as error:
+        return format_validation_error(error)
     return get_uri_error(uri)
 
 

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+from django.core.exceptions import ValidationError
 from django.test import override_settings
 from django.urls import reverse
 
@@ -63,6 +64,31 @@ class WebsiteAlertSettingTest(ViewTestCase):
         self.assertEqual(
             self.component.alert_set.get(name="BrokenProjectURL").details["error"],
             "This URL is prohibited",
+        )
+        mocked_get_uri_error.assert_not_called()
+
+    @override_settings(WEBSITE_ALERTS_ENABLED=True)
+    @patch(
+        "weblate.trans.models.alert.validate_request_url",
+        side_effect=ValidationError("URL domain is not allowed."),
+    )
+    @patch("weblate.trans.models.alert.get_uri_error")
+    def test_website_alert_uses_runtime_validation_without_fetch(
+        self, mocked_get_uri_error, mocked_validate_request_url
+    ) -> None:
+        self.project.web = "https://public.example/project"
+
+        update_alerts(self.component, {"BrokenProjectURL"})
+
+        self.assertTrue(
+            self.component.alert_set.filter(name="BrokenProjectURL").exists()
+        )
+        self.assertEqual(
+            self.component.alert_set.get(name="BrokenProjectURL").details["error"],
+            "URL domain is not allowed.",
+        )
+        mocked_validate_request_url.assert_called_once_with(
+            "https://public.example/project", allow_private_targets=False
         )
         mocked_get_uri_error.assert_not_called()
 

--- a/weblate/utils/models.py
+++ b/weblate/utils/models.py
@@ -85,6 +85,7 @@ class WeblateConf(AppConf):
     PROJECT_WEB_RESTRICT_RE = None
     PROJECT_WEB_RESTRICT_HOST: ClassVar[set[str]] = {"localhost"}
     PROJECT_WEB_RESTRICT_NUMERIC = True
+    PROJECT_WEB_RESTRICT_PRIVATE = True
 
     LOCALE_FILTER_FILES = True
 

--- a/weblate/utils/render.py
+++ b/weblate/utils/render.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import gettext, override
 
+from weblate.utils.outbound import validate_runtime_url
 from weblate.utils.site import get_site_url
 from weblate.utils.validators import WeblateEditorURLValidator, WeblateURLValidator
 
@@ -178,8 +179,21 @@ def validate_repoweb(val: str, allow_editor: bool = False) -> None:
         and val.split("://", 1)[0].lower() in WeblateEditorURLValidator.schemes
     ):
         validator = WeblateEditorURLValidator()
+    elif allow_editor:
+        validator = WeblateURLValidator()
     else:
         validator = WeblateURLValidator()
+        try:
+            validate_runtime_url(
+                url, allow_private_targets=not settings.PROJECT_WEB_RESTRICT_PRIVATE
+            )
+        except ValidationError as error:
+            if not isinstance(error.__cause__, OSError):
+                raise
+        except UnicodeError as error:
+            raise ValidationError(
+                gettext("Could not resolve the URL domain: {}").format(error)
+            ) from error
     validator(url)
 
 

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -12,7 +12,7 @@ from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
 from weblate.utils.outbound import validate_runtime_ip, validate_runtime_url
-from weblate.utils.render import validate_editor
+from weblate.utils.render import validate_editor, validate_repoweb
 from weblate.utils.validators import (
     EmailValidator,
     WeblateServiceURLValidator,
@@ -237,7 +237,9 @@ class WebsiteTest(SimpleTestCase):
             validate_project_web("https://localhost")
         with self.assertRaises(ValidationError):
             validate_project_web("https://localHOST")
-        with override_settings(PROJECT_WEB_RESTRICT_HOST={}):
+        with override_settings(
+            PROJECT_WEB_RESTRICT_HOST={}, PROJECT_WEB_RESTRICT_PRIVATE=False
+        ):
             validate_project_web("https://localhost")
         with override_settings(PROJECT_WEB_RESTRICT_HOST={"example.com"}):
             with self.assertRaises(ValidationError):
@@ -250,9 +252,89 @@ class WebsiteTest(SimpleTestCase):
             validate_project_web("https://1.1.1.1")
         with self.assertRaises(ValidationError):
             validate_project_web("https://[2606:4700:4700::1111]")
-        with override_settings(PROJECT_WEB_RESTRICT_NUMERIC=False):
+        with override_settings(
+            PROJECT_WEB_RESTRICT_NUMERIC=False, PROJECT_WEB_RESTRICT_PRIVATE=False
+        ):
             validate_project_web("https://[2606:4700:4700::1111]")
             validate_project_web("https://1.1.1.1")
+
+    def test_private(self) -> None:
+        with (
+            self.assertRaises(ValidationError),
+            patch(
+                "weblate.utils.outbound.socket.getaddrinfo",
+                return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+            ),
+        ):
+            validate_project_web("https://private.example")
+        with (
+            self.assertRaises(ValidationError),
+            patch(
+                "weblate.utils.outbound.socket.getaddrinfo",
+                return_value=[(0, 0, 0, "", ("::1", 443))],
+            ),
+        ):
+            validate_project_web("https://private-v6.example")
+        with (
+            override_settings(PROJECT_WEB_RESTRICT_PRIVATE=False),
+            patch(
+                "weblate.utils.outbound.socket.getaddrinfo",
+                return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+            ),
+        ):
+            validate_project_web("https://private.example")
+
+    def test_repoweb_private(self) -> None:
+        with (
+            patch(
+                "weblate.utils.outbound.socket.getaddrinfo",
+                return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+            ),
+            self.assertRaises(ValidationError),
+        ):
+            validate_repoweb("https://private.example/{{ filename }}")
+        with (
+            patch(
+                "weblate.utils.outbound.socket.getaddrinfo",
+                return_value=[(0, 0, 0, "", ("::1", 443))],
+            ),
+            self.assertRaises(ValidationError),
+        ):
+            validate_repoweb("https://private-v6.example/{{ filename }}")
+        with (
+            override_settings(PROJECT_WEB_RESTRICT_PRIVATE=False),
+            patch(
+                "weblate.utils.outbound.socket.getaddrinfo",
+                return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+            ),
+        ):
+            validate_repoweb("https://private.example/{{ filename }}")
+
+    @patch(
+        "weblate.utils.validators.validate_runtime_url",
+        side_effect=UnicodeError("label empty or too long"),
+    )
+    def test_project_web_malformed_idna_is_validation_error(
+        self, mocked_validate_runtime_url
+    ) -> None:
+        with self.assertRaises(ValidationError) as error:
+            validate_project_web("https://a..b")
+
+        self.assertIn("Could not resolve the URL domain", str(error.exception))
+        mocked_validate_runtime_url.assert_called_once()
+
+    @patch(
+        "weblate.utils.render.validate_runtime_url",
+        side_effect=UnicodeError("label empty or too long"),
+    )
+    def test_repoweb_malformed_idna_is_validation_error(
+        self, mocked_validate_runtime_url
+    ) -> None:
+        with self.assertRaises(ValidationError) as error:
+            validate_repoweb("https://a..b/{{ filename }}")
+
+        self.assertIn("Could not resolve the URL domain", str(error.exception))
+        mocked_validate_runtime_url.assert_called_once()
 
     def verify_validator(self, validator) -> None:
         validator("https://1.1.1.1")

--- a/weblate/utils/validators.py
+++ b/weblate/utils/validators.py
@@ -39,7 +39,11 @@ from weblate.utils.const import WEBHOOKS_SECRET_PREFIX
 from weblate.utils.data import data_dir
 from weblate.utils.errors import report_error
 from weblate.utils.files import is_excluded, read_file_bytes
-from weblate.utils.outbound import validate_outbound_hostname, validate_outbound_url
+from weblate.utils.outbound import (
+    validate_outbound_hostname,
+    validate_outbound_url,
+    validate_runtime_url,
+)
 from weblate.utils.regex import REGEX_TIMEOUT, compile_regex
 
 if TYPE_CHECKING:
@@ -369,6 +373,18 @@ def validate_project_web(value) -> None:
             pass
         else:
             raise ValidationError(gettext("This URL is prohibited"))
+
+    try:
+        validate_runtime_url(
+            value, allow_private_targets=not settings.PROJECT_WEB_RESTRICT_PRIVATE
+        )
+    except ValidationError as error:
+        if not isinstance(error.__cause__, OSError):
+            raise
+    except UnicodeError as error:
+        raise ValidationError(
+            gettext("Could not resolve the URL domain: {}").format(error)
+        ) from error
 
 
 def validate_webhook_secret_string(value: str) -> None:


### PR DESCRIPTION
PROJECT_WEB_RESTRICT_PRIVATE now toggles whether the private range addresses can be used in website or repository browser URLs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
