### PR TITLE
fix(test): add test to avoid growing permissions queries

### DIFF
--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -25,6 +25,50 @@ class ModelTest(FixtureTestCase):
             self.assertEqual(len(self.user.component_permissions), 0)
             self.assertEqual(len(self.user.project_permissions), 2)
 
+    def test_num_queries_mixed_group_resolution(self) -> None:
+        self.group.projects.remove(self.project)
+
+        power_user = Role.objects.get(name="Power user")
+        cs = Language.objects.get(code="cs")
+        de = Language.objects.get(code="de")
+        other_component = self.create_link_existing(
+            slug="test-second", name="Test second"
+        )
+
+        component_group = Group.objects.create(
+            name="Components", language_selection=SELECTION_MANUAL
+        )
+        component_group.roles.add(power_user)
+        component_group.components.add(self.component)
+        component_group.languages.add(cs)
+
+        componentlist = ComponentList.objects.create(
+            name="Component list", slug="component-list"
+        )
+        componentlist.components.add(other_component)
+        componentlist_group = Group.objects.create(
+            name="Component lists", language_selection=SELECTION_MANUAL
+        )
+        componentlist_group.roles.add(power_user)
+        componentlist_group.componentlists.add(componentlist)
+        componentlist_group.languages.add(cs)
+
+        project_group = Group.objects.create(
+            name="Projects", language_selection=SELECTION_MANUAL
+        )
+        project_group.roles.add(power_user)
+        project_group.projects.add(self.project)
+        project_group.languages.add(cs, de)
+
+        self.user.groups.add(component_group, componentlist_group, project_group)
+        self.user.clear_cache()
+
+        with self.assertNumQueries(9):
+            self.assertEqual(len(self.user.component_permissions), 2)
+            self.assertIn(self.component.pk, self.user.component_permissions)
+            self.assertIn(other_component.pk, self.user.component_permissions)
+            self.assertIn(self.project.pk, self.user.project_permissions)
+
     def test_project(self) -> None:
         # No permissions
         self.assertFalse(self.user.can_access_project(self.project))

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1126,18 +1126,29 @@ class Component(
             import_memory.delay_on_commit(self.project.id, self.pk)
 
     def get_old_component_settings(self) -> OldComponentSettings:
+        """
+        Capture settings needed for change detection without loading deferred fields.
+
+        Some callers fetch Component objects using only a subset of fields. Reading
+        the attributes directly here would trigger additional queries while the
+        instance is being initialized or refreshed, so this intentionally prefers
+        values already present in __dict__ and falls back to previously captured
+        settings.
+        """
         current = getattr(self, "old_component_settings", {})
         return {
-            "check_flags": self.__dict__.get(
-                "check_flags", current.get("check_flags", "")
-            ),
-            "vcs": self.__dict__.get("vcs", current.get("vcs", "")),
-            "push": self.__dict__.get("push", current.get("push", "")),
-            "push_branch": self.__dict__.get(
-                "push_branch", current.get("push_branch", "")
-            ),
-            "repo": self.__dict__.get("repo", current.get("repo", "")),
+            "check_flags": self.get_old_component_setting("check_flags", current),
+            "vcs": self.get_old_component_setting("vcs", current),
+            "push": self.get_old_component_setting("push", current),
+            "push_branch": self.get_old_component_setting("push_branch", current),
+            "repo": self.get_old_component_setting("repo", current),
         }
+
+    def get_old_component_setting(
+        self, name: str, current: OldComponentSettings | dict[str, str]
+    ) -> str:
+        """Read a tracked setting without forcing deferred field evaluation."""
+        return self.__dict__.get(name, current.get(name, ""))
 
     def refresh_from_db(self, *args, **kwargs) -> None:
         super().refresh_from_db(*args, **kwargs)


### PR DESCRIPTION
We had a N+1 queries here for quote some time and it got fixed unintentionally in 97e7e94c6a6e2b6a305ddcef7fd71333e54f0701. Now there is dedicated test case for this and the magic in
Component.get_old_component_settings is properly documented.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
