### PR TITLE
feat(formats): preserve markup escaping from the template

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -68,6 +68,7 @@ Weblate 5.17
 * Adding new languages now rescans only the newly added languages instead of forcing a full component scan.
 * :ref:`check-max-size` previews now keep the configured text box visible and render overflowing text in red.
 * Restored documented default encoding fallback for :doc:`/formats/apple` and :doc:`/formats/java` when file format parameters are not explicitly set.
+* :doc:`/formats/android` now preserves template-defined escaped markup formatting when saving translations.
 
 .. rubric:: Compatibility
 

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -988,6 +988,178 @@ class AndroidFormatTest(XMLMixin, BaseFormatTest):
         )
 
 
+class AndroidMarkupFormatTest(TempDirMixin, SimpleTestCase):
+    source = (
+        "To manage the existing work profile, navigate to the <b>Work</b> tab in "
+        "the launcher"
+    )
+    template_content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="existing_work_profile_help">To manage the existing work profile, navigate to the &lt;b&gt;Work&lt;/b&gt; tab in the launcher</string>
+</resources>
+"""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.create_temp()
+
+    def tearDown(self) -> None:
+        self.remove_temp()
+        super().tearDown()
+
+    def create_storage(self, translated_content: str):
+        template_file = Path(self.tempdir) / "template.xml"
+        translated_file = Path(self.tempdir) / "translated.xml"
+        template_file.write_text(self.template_content, encoding="utf-8")
+        translated_file.write_text(translated_content, encoding="utf-8")
+
+        template_storage = AndroidFormat(template_file.as_posix(), is_template=True)
+        target_storage = AndroidFormat(
+            translated_file.as_posix(), template_store=template_storage
+        )
+        return target_storage, translated_file
+
+    def test_add_uses_template_target_markup(self) -> None:
+        target_storage, translated_file = self.create_storage(
+            """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>
+"""
+        )
+        target = (
+            "To manage the active work profile, open the <b>Work</b> tab from the "
+            "launcher"
+        )
+
+        unit, add = target_storage.find_unit("existing_work_profile_help", self.source)
+
+        self.assertTrue(add)
+        self.assertTrue(unit.template.target_markup)
+        self.assertTrue(unit.unit.target_markup)
+        self.assertIn("safe-html", unit.flags)
+
+        target_storage.add_unit(unit)
+        unit.set_target(target)
+        target_storage.save()
+
+        saved = translated_file.read_text(encoding="utf-8")
+        self.assertIn("&lt;b&gt;Work&lt;/b&gt;", saved)
+        self.assertNotIn("<b>Work</b>", saved)
+
+    def test_edit_reapplies_template_target_markup(self) -> None:
+        target_storage, translated_file = self.create_storage(
+            """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="existing_work_profile_help">To manage the active work profile, open the <b>Work</b> tab from the launcher</string>
+</resources>
+"""
+        )
+        target = (
+            "To manage the active work profile, open the <b>Workspace</b> tab from "
+            "the launcher"
+        )
+
+        unit, add = target_storage.find_unit("existing_work_profile_help", self.source)
+
+        self.assertFalse(add)
+        self.assertTrue(unit.template.target_markup)
+        self.assertFalse(unit.unit.target_markup)
+        self.assertIn("safe-html", unit.flags)
+
+        unit.set_target(target)
+
+        self.assertTrue(unit.unit.target_markup)
+
+        target_storage.save()
+
+        saved = translated_file.read_text(encoding="utf-8")
+        self.assertIn("&lt;b&gt;Workspace&lt;/b&gt;", saved)
+        self.assertNotIn("<b>Workspace</b>", saved)
+
+    def test_units_with_real_xml_use_xml_text_flag(self) -> None:
+        template_file = Path(self.tempdir) / "template.xml"
+        translated_file = Path(self.tempdir) / "translated.xml"
+        template_file.write_text(
+            self.template_content.replace("&lt;b&gt;Work&lt;/b&gt;", "<b>Work</b>"),
+            encoding="utf-8",
+        )
+        translated_file.write_text(
+            """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>
+""",
+            encoding="utf-8",
+        )
+        template_storage = AndroidFormat(template_file.as_posix(), is_template=True)
+        target_storage = AndroidFormat(
+            translated_file.as_posix(),
+            template_store=template_storage,
+        )
+
+        unit, add = target_storage.find_unit("existing_work_profile_help", self.source)
+
+        self.assertTrue(add)
+        self.assertFalse(unit.template.target_markup)
+        self.assertIn("xml-text", unit.flags)
+        self.assertNotIn("safe-html", unit.flags)
+
+    def test_discard_safe_html_override_is_honored(self) -> None:
+        template_file = Path(self.tempdir) / "template.xml"
+        translated_file = Path(self.tempdir) / "translated.xml"
+        template_file.write_text(
+            self.template_content.replace(
+                'name="existing_work_profile_help"',
+                'name="existing_work_profile_help" weblate-flags="discard:safe-html"',
+            ),
+            encoding="utf-8",
+        )
+        translated_file.write_text(
+            """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>
+""",
+            encoding="utf-8",
+        )
+        template_storage = AndroidFormat(template_file.as_posix(), is_template=True)
+        target_storage = AndroidFormat(
+            translated_file.as_posix(),
+            template_store=template_storage,
+        )
+
+        unit, add = target_storage.find_unit("existing_work_profile_help", self.source)
+
+        self.assertTrue(add)
+        self.assertNotIn("safe-html", unit.flags)
+
+    def test_discard_xml_text_override_is_honored(self) -> None:
+        template_file = Path(self.tempdir) / "template.xml"
+        translated_file = Path(self.tempdir) / "translated.xml"
+        template_file.write_text(
+            self.template_content.replace(
+                'name="existing_work_profile_help"',
+                'name="existing_work_profile_help" weblate-flags="discard:xml-text"',
+            ).replace("&lt;b&gt;Work&lt;/b&gt;", "<b>Work</b>"),
+            encoding="utf-8",
+        )
+        translated_file.write_text(
+            """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>
+""",
+            encoding="utf-8",
+        )
+        template_storage = AndroidFormat(template_file.as_posix(), is_template=True)
+        target_storage = AndroidFormat(
+            translated_file.as_posix(),
+            template_store=template_storage,
+        )
+
+        unit, add = target_storage.find_unit("existing_work_profile_help", self.source)
+
+        self.assertTrue(add)
+        self.assertNotIn("xml-text", unit.flags)
+
+
 class XliffFormatTest(XMLMixin, BaseFormatTest):
     format_class = XliffFormat
     FILE = TEST_XLIFF

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -16,7 +16,7 @@ import subprocess  # noqa: S404
 from copy import copy
 from io import StringIO
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, ClassVar
+from typing import IO, TYPE_CHECKING, Any, ClassVar, cast
 
 from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
@@ -87,6 +87,7 @@ from weblate.utils.state import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
+    from translate.storage.aresource import AndroidResourceUnit
     from translate.storage.base import TranslationUnit as TranslateToolkitUnit
     from translate.storage.csvl10n import csvfile
     from translate.storage.ini import inifile, iniunit
@@ -1242,6 +1243,52 @@ class INIUnit(TTKitUnit):
 
 class AndroidUnit(MonolingualIDUnit):
     """Wrapper unit for Android Resource."""
+
+    def get_markup_reference_unit(self) -> AndroidResourceUnit:
+        """Use the template shape to derive markup behavior whenever possible."""
+        if self.template is not None:
+            return cast("AndroidResourceUnit", self.template)
+        return cast("AndroidResourceUnit", self.mainunit)
+
+    def has_target_markup(self) -> bool:
+        """Check whether Android string should preserve escaped HTML markup."""
+        return self.get_markup_reference_unit().target_markup
+
+    def has_xml_markup(self) -> bool:
+        """Check whether Android string contains real XML child elements."""
+        reference_unit = self.get_markup_reference_unit()
+        if reference_unit.xmlelement.tag == reference_unit.PLURAL_TAG:
+            return any(
+                len(entry) != 0
+                for entry in reference_unit.xmlelement.iterchildren("item")
+            )
+        return len(reference_unit.xmlelement) != 0
+
+    def apply_template_target_markup(self) -> None:
+        """Keep Android target serialization mode aligned with the template."""
+        if self.template is None or not self.has_unit():
+            return
+
+        target_unit = cast("AndroidResourceUnit", self.unit)
+        target_unit.target_markup = self.has_target_markup()
+
+    def clone_template(self) -> None:
+        super().clone_template()
+        self.apply_template_target_markup()
+
+    def set_target(self, target: str | list[str]) -> None:
+        self.apply_template_target_markup()
+        super().set_target(target)
+
+    def get_extra_flags(self) -> Generator[str | etree._Element | Flags]:
+        """Infer checks from template markup mode for Android-formatted strings."""
+        if self.has_target_markup():
+            # Escaped markup is consumed as HTML styling via Html.fromHtml().
+            yield "safe-html"
+        elif self.has_xml_markup():
+            # Real XML child nodes should stay valid XML in translations.
+            yield "xml-text"
+        yield from super().get_extra_flags()
 
     def set_state(self, state) -> None:
         """Tag unit as translatable/readonly aside from fuzzy and approved flags."""


### PR DESCRIPTION
The style of markup escaping is now preserved when saving translations.

Fixes #11995

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
