### PR TITLE
Potential fix for code scanning alert no. 574: URL redirection from remote source

### DIFF
--- a/weblate/gitexport/views.py
+++ b/weblate/gitexport/views.py
@@ -119,8 +119,10 @@ def git_export(
                 "git_request": git_request,
             },
         )
+        query_string = request.GET.urlencode()
+        target = f"{url}?{query_string}" if query_string else url
         return redirect(
-            f"{url}?{request.META['QUERY_STRING']}",
+            target,
             permanent=True,
         )
 


### PR DESCRIPTION
Potential fix for [https://github.com/WeblateOrg/weblate/security/code-scanning/574](https://github.com/WeblateOrg/weblate/security/code-scanning/574)

To fix this without changing intended functionality, avoid direct string concatenation with `request.META["QUERY_STRING"]`. Instead, rebuild the redirect URL using encoded query parameters obtained from Django’s parsed `request.GET`. This preserves parameters while ensuring safe escaping and preventing malformed redirect targets due to raw untrusted query content.

In `weblate/gitexport/views.py`, update the `if obj.is_repo_link:` branch (around lines 122–125). Replace:

- `redirect(f"{url}?{request.META['QUERY_STRING']}", permanent=True)`

with logic that:

1. Reads query params from `request.GET.urlencode()` (safe, normalized encoding).
2. Appends them only when non-empty.
3. Redirects to `url` unchanged when there is no query string.

No new dependencies are required; no additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
