### PR TITLE
chore(hooks): use rest framework to parse payload

### DIFF
--- a/weblate/trans/tests/test_hooks.py
+++ b/weblate/trans/tests/test_hooks.py
@@ -6,22 +6,33 @@
 
 import json
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 from urllib.parse import urlencode
 
+from django.http import QueryDict
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
+from rest_framework.exceptions import ParseError
 
 from weblate.trans.actions import ActionEvents
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.views.hooks import (
     HOOK_HANDLERS,
     HookPayloadError,
+    HookRequestSerializer,
+    extract_payload,
+    extract_request_data,
     normalize_branch_ref,
     require_mapping,
     validate_full_name,
 )
+
+if TYPE_CHECKING:
+    from weblate.trans.views.hooks import (
+        JSONDict,
+    )
 
 GITHUB_PAYLOAD = """
 {
@@ -1590,15 +1601,20 @@ class HooksViewTest(ViewTestCase):
         """Test for invalid payloads with github."""
         # missing
         response = self.client.post(reverse("webhook", kwargs={"service": "github"}))
-        self.assertContains(response, "Missing payload parameter!", status_code=400)
+        self.assertContains(response, "This field is required.", status_code=400)
         # wrong
         response = self.client.post(
             reverse("webhook", kwargs={"service": "github"}), {"payload": "XX"}
         )
-        self.assertContains(response, "JSON parse error", status_code=400)
+        self.assertContains(response, "Value must be valid JSON.", status_code=400)
         # missing data
         response = self.client.post(
             reverse("webhook", kwargs={"service": "github"}), {"payload": "{}"}
+        )
+        self.assertContains(response, "Invalid data in json payload!", status_code=400)
+        # wrong JSON type
+        response = self.client.post(
+            reverse("webhook", kwargs={"service": "github"}), {"payload": "[]"}
         )
         self.assertContains(response, "Invalid data in json payload!", status_code=400)
         # application/x-www-form-urlencoded
@@ -1614,12 +1630,12 @@ class HooksViewTest(ViewTestCase):
         """Test for invalid payloads with gitlab."""
         # missing
         response = self.client.post(reverse("webhook", kwargs={"service": "gitlab"}))
-        self.assertContains(response, "Missing payload parameter!", status_code=400)
+        self.assertContains(response, "This field is required.", status_code=400)
         # missing content-type header
         response = self.client.post(
             reverse("webhook", kwargs={"service": "gitlab"}), {"payload": "anything"}
         )
-        self.assertContains(response, "JSON parse error", status_code=400)
+        self.assertContains(response, "Value must be valid JSON.", status_code=400)
         # wrong
         response = self.client.post(
             reverse("webhook", kwargs={"service": "gitlab"}),
@@ -1627,6 +1643,13 @@ class HooksViewTest(ViewTestCase):
             content_type="application/json",
         )
         self.assertContains(response, "JSON parse error", status_code=400)
+        # wrong JSON type
+        response = self.client.post(
+            reverse("webhook", kwargs={"service": "gitlab"}),
+            "[42]",
+            content_type="application/json",
+        )
+        self.assertContains(response, "Invalid data in json payload!", status_code=400)
         # missing params
         response = self.client.post(
             reverse("webhook", kwargs={"service": "gitlab"}),
@@ -2066,12 +2089,66 @@ class NormalizeBranchRefTest(SimpleTestCase):
         self.assertIn("Missing ref in payload", str(cm.exception))
 
 
+class HookSerializerTest(SimpleTestCase):
+    """Test serializer-backed webhook payload validation."""
+
+    def test_extract_payload_parses_json_object(self) -> None:
+        payload = QueryDict("payload=%7B%22ref%22%3A+%22main%22%7D")
+        self.assertEqual(
+            extract_payload(payload),
+            {"ref": "main"},
+        )
+
+    def test_extract_payload_rejects_invalid_json(self) -> None:
+        payload = QueryDict("payload=%5B")
+        with self.assertRaises(ParseError) as cm:
+            extract_payload(payload)
+        self.assertIn("Value must be valid JSON.", str(cm.exception))
+
+    def test_extract_request_data_keeps_json_payload(self) -> None:
+        payload = {"ref": "refs/heads/main"}
+        self.assertEqual(
+            extract_request_data("application/json", payload),
+            payload,
+        )
+
+    def test_extract_request_data_keeps_json_payload_with_parameters(self) -> None:
+        payload = {"ref": "refs/heads/main"}
+        self.assertEqual(
+            extract_request_data("application/json; charset=utf-8", payload),
+            payload,
+        )
+
+    def test_extract_request_data_uses_payload_for_form(self) -> None:
+        payload = QueryDict("payload=%7B%22ref%22%3A+%22main%22%7D")
+        self.assertEqual(
+            extract_request_data("application/x-www-form-urlencoded", payload),
+            {"ref": "main"},
+        )
+
+    def test_request_serializer_rejects_non_mapping(self) -> None:
+        serializer = HookRequestSerializer(data=[42])
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["non_field_errors"][0],
+            "Invalid data in json payload!",
+        )
+
+    def test_request_serializer_rejects_empty_mapping(self) -> None:
+        serializer = HookRequestSerializer(data={})
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["non_field_errors"][0],
+            "Invalid data in json payload!",
+        )
+
+
 class RequireMappingTest(SimpleTestCase):
     """Test payload mapping validation."""
 
     def test_require_mapping(self) -> None:
         """Test valid mapping."""
-        payload = {"html_url": "https://example.invalid/repo"}
+        payload: JSONDict = {"html_url": "https://example.invalid/repo"}
         self.assertEqual(require_mapping(payload, "repository"), payload)
 
     def test_require_mapping_none(self) -> None:

--- a/weblate/trans/views/hooks.py
+++ b/weblate/trans/views/hooks.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-import json
 import re
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, ClassVar, TypedDict, cast
 from urllib.parse import quote, urlparse
 
 from django.conf import settings
@@ -22,6 +21,7 @@ from rest_framework.exceptions import (
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from weblate.api.serializers import MultiFieldHyperlinkedIdentityField
@@ -33,7 +33,7 @@ from weblate.trans.tasks import perform_update
 from weblate.utils.errors import report_error
 
 if TYPE_CHECKING:
-    from django.http import QueryDict
+    from django_stubs_ext import StrOrPromise
 
 BITBUCKET_GIT_REPOS = (
     "ssh://git@{server}/{full_name}.git",
@@ -75,6 +75,12 @@ AZURE_REPOS = (
     "{organization}@vs-ssh.visualstudio.com:v3/{organization}/{project}/{repository}",
 )
 
+type JSONScalar = str | int | float | bool | None
+type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
+type JSONDict = dict[str, JSONValue]
+type JSONMapping = Mapping[str, JSONValue]
+type FormData = Mapping[str, str | bytes]
+
 
 class HandlerResponse(TypedDict):
     service_long_name: str
@@ -113,7 +119,7 @@ def normalize_branch_ref(ref: str | None) -> str:
     return re.sub(r"^refs/heads/", "", ref)
 
 
-def require_mapping(value: object, field_name: str) -> Mapping[str, object]:
+def require_mapping(value: JSONValue, field_name: str) -> JSONMapping:
     """Validate that the payload field is a mapping."""
     if not isinstance(value, Mapping):
         msg = f"Invalid {field_name} in payload"
@@ -121,7 +127,7 @@ def require_mapping(value: object, field_name: str) -> Mapping[str, object]:
     return value
 
 
-def require_string(value: object, field_name: str) -> str:
+def require_string(value: JSONValue, field_name: str) -> str:
     """Validate that the payload field is a string."""
     if not isinstance(value, str):
         msg = f"Invalid {field_name} in payload"
@@ -129,7 +135,7 @@ def require_string(value: object, field_name: str) -> str:
     return value
 
 
-def optional_string(value: object, field_name: str) -> str | None:
+def optional_string(value: JSONValue, field_name: str) -> str | None:
     """Validate that the payload field is a string or null."""
     if value is None:
         return None
@@ -171,43 +177,46 @@ class HookResponseSerializer(serializers.Serializer):
 class HookRequestSerializer(serializers.Serializer):
     """Native webhook payload from the notifying service."""
 
+    default_error_messages: ClassVar[dict[str, StrOrPromise]] = {
+        "invalid": "Invalid data in json payload!",
+    }
 
-class PayloadMixin:
-    @staticmethod
-    def extract_payload(request_data: QueryDict | parsers.DataAndFiles | dict) -> dict:
-        data: QueryDict | dict
-        if isinstance(request_data, parsers.DataAndFiles):
-            data = request_data.data
-        else:
-            data = request_data
-        try:
-            payload = cast("str | bytes", data["payload"])
-        except KeyError as exc:
-            msg = "Missing payload parameter!"
-            raise ParseError(msg) from exc
-        try:
-            return json.loads(payload)
-        except ValueError as exc:
-            msg = f"JSON parse error - {exc!s}"
-            raise ParseError(msg) from exc
+    def to_internal_value(self, data: object) -> JSONDict:
+        if not isinstance(data, Mapping) or not data:
+            raise serializers.ValidationError(
+                {api_settings.NON_FIELD_ERRORS_KEY: [self.error_messages["invalid"]]}
+            )
+        return cast("JSONDict", dict(data))
 
 
-class PayloadMultiPartParser(parsers.MultiPartParser, PayloadMixin):
-    """Extract payload from application/x-www-form-urlencoded."""
-
-    def parse(self, stream, media_type=None, parser_context=None):
-        return self.extract_payload(
-            super().parse(stream, media_type=media_type, parser_context=parser_context)
-        )
+class HookPayloadSerializer(serializers.Serializer):
+    payload = serializers.JSONField()
 
 
-class PayloadFormParserParser(parsers.FormParser, PayloadMixin):
-    """Extract payload from multipart/form-data."""
+def extract_payload(request_data: FormData) -> JSONValue:
+    serializer = HookPayloadSerializer(data=request_data)
+    if not serializer.is_valid():
+        detail = serializer.errors.get(
+            "payload",
+            serializer.errors.get(
+                api_settings.NON_FIELD_ERRORS_KEY,
+                ["Invalid payload parameter!"],
+            ),
+        )[0]
+        raise ParseError(str(detail))
+    return cast("JSONValue", serializer.validated_data["payload"])
 
-    def parse(self, stream, media_type=None, parser_context=None):
-        return self.extract_payload(
-            super().parse(stream, media_type=media_type, parser_context=parser_context)
-        )
+
+def extract_request_data(
+    content_type: str | None,
+    request_data: JSONValue | FormData,
+) -> JSONValue:
+    media_type = (
+        content_type.partition(";")[0].strip().lower() if content_type else None
+    )
+    if media_type == parsers.JSONParser.media_type:
+        return cast("JSONValue", request_data)
+    return extract_payload(cast("FormData", request_data))
 
 
 def bitbucket_extract_changes(data: dict) -> list[dict]:
@@ -535,8 +544,8 @@ class ServiceHookView(APIView):
     http_method_names = ["post"]  # noqa: RUF012
     parser_classes = (
         parsers.JSONParser,
-        PayloadMultiPartParser,
-        PayloadFormParserParser,
+        parsers.MultiPartParser,
+        parsers.FormParser,
     )
 
     def hook_response(
@@ -572,11 +581,15 @@ class ServiceHookView(APIView):
             msg = f"Hook {service} not supported"
             raise NotFound(msg) from exc
 
-        # Check if we got payload
-        data = request.data
-        if not data:
-            msg = "Invalid data in json payload!"
-            raise ValidationError(msg)
+        request_data = extract_request_data(request.content_type, request.data)
+        request_serializer = HookRequestSerializer(data=request_data)
+        if not request_serializer.is_valid():
+            detail = request_serializer.errors.get(
+                api_settings.NON_FIELD_ERRORS_KEY,
+                ["Invalid data in json payload!"],
+            )[0]
+            raise ValidationError(str(detail))
+        data = cast("dict[str, object]", request_serializer.validated_data)
 
         # Send the request data to the service handler.
         try:


### PR DESCRIPTION
Remove custom parser and rely on rest framework to parse JSON. This slightly changes the error messages.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
