### PR TITLE
fix(client): avoid generating HTML from DOM attributes

### DIFF
--- a/weblate/static/js/widgets.js
+++ b/weblate/static/js/widgets.js
@@ -21,9 +21,13 @@ $(document).ready(() => {
     translationStatus,
   ) {
     if (codeLanguage === "html") {
-      return `<a href="${engageUrl}">
-<img src="${widgetUrl}" alt="${translationStatus}" />
-</a>`;
+      const link = document.createElement("a");
+      link.href = engageUrl;
+      const image = document.createElement("img");
+      image.src = widgetUrl;
+      image.alt = translationStatus;
+      link.append(image);
+      return link.outerHTML;
     }
     if (codeLanguage === "bb-code") {
       return `[url=${engageUrl}][img alt="${translationStatus}"]${widgetUrl}[/img][/url]`;

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -578,12 +578,11 @@ $(function () {
       $content.load($target.data("href"), (_responseText, status, xhr) => {
         if (status !== "success") {
           const msg = gettext("Error while loading page:");
-          $content.html(
-            `<div class="alert alert-danger" role="alert">
-                ${msg} ${xhr.statusText} (${xhr.status})
-              </div>
-            `,
-          );
+          const $alert = $("<div/>", {
+            class: "alert alert-danger",
+            role: "alert",
+          }).text(`${msg} ${xhr.statusText} (${xhr.status})`);
+          $content.empty().append($alert);
         }
         $target.data("loaded", 1);
         loadTableSorting();


### PR DESCRIPTION
Build elements by setting attributes instead of injecting DOM content as attribute value. The existing values are safe for the purpose, but this adds additional hardening.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
