### PR TITLE
fix(settings): remove component.edit from announcement add path

### DIFF
--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -366,9 +366,7 @@ def announcement(request: AuthenticatedHttpRequest, path):
         request, path, (ProjectLanguage, Translation, Component, Project, Category)
     )
 
-    if not request.user.has_perm("component.edit", obj) and not request.user.has_perm(
-        "announcement.add", obj
-    ):
+    if not request.user.has_perm("announcement.add", obj):
         raise PermissionDenied
 
     form = AnnouncementForm(request.POST)


### PR DESCRIPTION
- the forms are not rendered in this case anyway, so nobody should use this path as there is no matching UI
- I believe this was missed when adding the announcement.add permission

This was introduced in #15005 and I don't think there was an actual reason for that.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
