### PR TITLE
fix(stats): improve performance of counting project languages

### DIFF
--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -477,6 +477,21 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
             .order()
         )
 
+    def get_languages_count(self) -> int:
+        """Return count of all languages used in project."""
+        from weblate.trans.models import Translation
+
+        own = Translation.objects.filter(component__project=self).values_list(
+            "language_id", flat=True
+        )
+        shared = Translation.objects.filter(component__links=self).values_list(
+            "language_id", flat=True
+        )
+        # Keep the own/shared branches separate. PostgreSQL can plan this much
+        # better than the equivalent LEFT JOIN + OR predicate used by
+        # Project.languages.count() on large projects with shared components.
+        return own.union(shared).count()
+
     @property
     def count_pending_units(self) -> int:
         """Check whether there are any uncommitted changes."""

--- a/weblate/trans/tests/test_links.py
+++ b/weblate/trans/tests/test_links.py
@@ -102,6 +102,22 @@ class ComponentLinkTestCase(ViewTestCase):
         self.assertEqual(project.stats.get_data(), other.stats.get_data())
         self.assertNotEqual(start_data, other.stats.get_data())
 
+    def test_stats_languages_count_with_shared_components(self) -> None:
+        """Project stats should count distinct languages across own and shared components."""
+        own_component = self.create_po(project=self.other, name="Other")
+
+        shared_language_ids = set(
+            self.component.translation_set.values_list("language_id", flat=True)
+        )
+        own_language_ids = set(
+            own_component.translation_set.values_list("language_id", flat=True)
+        )
+        self.assertEqual(shared_language_ids, own_language_ids)
+
+        other = Project.objects.get(pk=self.other.pk)
+        self.assertEqual(other.get_languages_count(), len(shared_language_ids))
+        self.assertEqual(other.stats.languages, len(shared_language_ids))
+
     def test_labels(self) -> None:
         self.other.label_set.create(name="test other", color="navy")
         self.project.label_set.create(name="test project", color="navy")

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -1590,7 +1590,7 @@ class ProjectStats(ParentAggregatingStats):
 
     def _calculate_basic(self) -> None:
         super()._calculate_basic()
-        self.store("languages", self._object.languages.count())
+        self.store("languages", self._object.get_languages_count())
 
 
 class ComponentListStats(ParentAggregatingStats):


### PR DESCRIPTION
Counting the complex join is usually performing badly on the many linked components setup because PostgreSQL is not able to optimize the condition and doing full table scans on translations.

Fixes WEBLATE-39C8

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
