### PR TITLE
fix(component): improve alerts prefetch

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -306,13 +306,7 @@ class ComponentQuerySet(models.QuerySet):
         else:
             linked_component = "linked_component"
         if alerts:
-            result = result.prefetch_related(
-                models.Prefetch(
-                    "alert_set",
-                    queryset=Alert.objects.filter(dismissed=False),
-                    to_attr="all_active_alerts",
-                ),
-            )
+            result = result.prefetch_related("alert_set")
 
         return result.prefetch_related(
             "project",
@@ -3005,14 +2999,16 @@ class Component(  # noqa: PLR0904
         return sorted(matches)
 
     @cached_property
-    def all_active_alerts(self):
-        result = self.alert_set.filter(dismissed=False)
-        list(result)
-        return result
+    def all_active_alerts(self) -> list[Alert]:
+        return [alert for alert in self.alert_set.all() if not alert.dismissed]
 
     @cached_property
-    def all_alerts(self):
+    def all_alerts(self) -> dict[str, Alert]:
         return {alert.name: alert for alert in self.alert_set.all()}
+
+    def clear_prefetched_alerts(self) -> None:
+        with suppress(AttributeError, KeyError):
+            self._prefetched_objects_cache.pop("alert_set")
 
     @property
     def lock_alerts(self):
@@ -3032,6 +3028,11 @@ class Component(  # noqa: PLR0904
         if alert in self.all_alerts:
             self.all_alerts[alert].delete()
             del self.all_alerts[alert]
+            if "all_active_alerts" in self.__dict__:
+                self.__dict__["all_active_alerts"] = [
+                    item for item in self.all_alerts.values() if not item.dismissed
+                ]
+            self.clear_prefetched_alerts()
             if (
                 self.locked
                 and self.auto_lock_error
@@ -3070,6 +3071,12 @@ class Component(  # noqa: PLR0904
         if not created and not noupdate:
             obj.details = details
             obj.save()
+
+        if "all_active_alerts" in self.__dict__:
+            self.__dict__["all_active_alerts"] = [
+                item for item in self.all_alerts.values() if not item.dismissed
+            ]
+        self.clear_prefetched_alerts()
 
         if ALERTS[alert].link_wide:
             for component in self.linked_children:

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -567,10 +567,12 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
     @cached_property
     def all_repo_components(self) -> list[Component]:
         """Return list of all unique VCS components."""
-        result = list(self.component_set.with_repo())
+        result = list(self.component_set.with_repo().prefetch_related("alert_set"))
         included = {component.id for component in result}
 
-        linked = self.component_set.filter(repo__startswith="weblate:")
+        linked = self.component_set.filter(
+            repo__startswith="weblate:"
+        ).prefetch_related("alert_set")
         for other in linked:
             if other.linked_component_id in included:
                 continue

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -147,7 +147,7 @@ class TranslationQuerySet(models.QuerySet):
         ).prefetch_meta()
 
     def prefetch_meta(self):
-        from weblate.trans.models import Alert, Component  # noqa: PLC0415
+        from weblate.trans.models import Component  # noqa: PLC0415
 
         return self.prefetch_related(
             "language",
@@ -155,11 +155,7 @@ class TranslationQuerySet(models.QuerySet):
                 "component__linked_component", queryset=Component.objects.defer_huge()
             ),
             "component__linked_component__project",
-            models.Prefetch(
-                "component__alert_set",
-                queryset=Alert.objects.filter(dismissed=False),
-                to_attr="all_active_alerts",
-            ),
+            "component__alert_set",
         )
 
     def prefetch_plurals(self):

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -18,7 +18,7 @@ from django.urls import reverse
 from weblate.addons.gettext import MsgmergeAddon, SphinxAddon, XgettextAddon
 from weblate.addons.models import Addon
 from weblate.lang.models import Language
-from weblate.trans.models import Component, Unit
+from weblate.trans.models import Component, Project, Unit
 from weblate.trans.models.alert import UpdateFailure, update_alerts
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.vcs.models import VCS_REGISTRY
@@ -246,6 +246,39 @@ class AlertTest(ViewTestCase):
 
         alert = self.component.alert_set.get(name="InexistantFiles")
         self.assertEqual(alert.details["files"], ["alert-base.pot"])
+
+
+class AlertQueryPrefetchTest(ViewTestCase):
+    def test_project_repo_components_prefetch_all_alerts(self) -> None:
+        self._create_component(
+            "po",
+            "po-link/*.po",
+            project=self.project,
+            name="LinkedRepo",
+        )
+        self.create_json(project=self.project, name="JSONRepo")
+
+        project = Project.objects.get(pk=self.project.pk)
+        components = project.all_repo_components
+
+        self.assertEqual(len(components), 3)
+        with self.assertNumQueries(0):
+            alert_maps = [component.all_alerts for component in components]
+
+        self.assertEqual(len(alert_maps), 3)
+
+    def test_linked_children_prefetch_all_alerts(self) -> None:
+        self.create_link_existing(name="Linked A", slug="linked-a")
+        self.create_link_existing(name="Linked B", slug="linked-b")
+
+        component = Component.objects.get(pk=self.component.pk)
+        children = list(component.linked_children)
+
+        self.assertEqual(len(children), 2)
+        with self.assertNumQueries(0):
+            alert_maps = [child.all_alerts for child in children]
+
+        self.assertEqual(len(alert_maps), 2)
 
 
 @override_settings(


### PR DESCRIPTION
Prefetch all alerts as filtering to not dismissed was over optimalization. Typically there are few dismissed alerts and we often need even those (especially in the update path).

Fixes WEBLATE-352Q

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
