### PR TITLE
chore(add-ons): improve configuration type annotations

### DIFF
--- a/weblate/addons/autotranslate.py
+++ b/weblate/addons/autotranslate.py
@@ -15,6 +15,7 @@ from weblate.addons.base import BaseAddon
 from weblate.addons.events import AddonEvent
 from weblate.addons.forms import AutoAddonForm
 from weblate.trans.actions import ACTIONS_CONTENT, ActionEvents
+from weblate.trans.filter import FILTERS
 from weblate.trans.models import Component
 from weblate.trans.tasks import auto_translate, auto_translate_component
 
@@ -27,6 +28,22 @@ if TYPE_CHECKING:
 SKIP_ACTIONS = {ActionEvents.AUTO, ActionEvents.ENFORCED_CHECK}
 
 
+DEFAULT_AUTO_SOURCE: Literal["mt", "others"] = "others"
+DEFAULT_AUTO_TRANSLATE_MODE = "suggest"
+DEFAULT_AUTO_TRANSLATE_QUERY = "state:<translated"
+DEFAULT_AUTO_TRANSLATE_THRESHOLD = 80
+
+
+class AutoTranslateAddonStoredConfiguration(TypedDict, total=False):
+    auto_source: Literal["mt", "others"]
+    component: int | Literal[""] | None
+    engines: list[str]
+    filter_type: str
+    mode: str
+    q: str
+    threshold: int
+
+
 class AutoTranslateAddonConfiguration(TypedDict):
     auto_source: Literal["mt", "others"]
     component: int | None
@@ -36,7 +53,9 @@ class AutoTranslateAddonConfiguration(TypedDict):
     threshold: int
 
 
-class AutoTranslateAddon(BaseAddon):
+class AutoTranslateAddon(
+    BaseAddon[AutoTranslateAddonStoredConfiguration, AutoTranslateAddonConfiguration]
+):
     events: ClassVar[set[AddonEvent]] = {
         AddonEvent.EVENT_COMPONENT_UPDATE,
         AddonEvent.EVENT_DAILY,
@@ -57,27 +76,44 @@ class AutoTranslateAddon(BaseAddon):
     ) -> None:
         self.trigger_autotranslate(component=component)
 
-    def get_configuration(self) -> AutoTranslateAddonConfiguration:
-        configuration = self.instance.configuration
-        source_component_id = configuration["component"]
-        if not source_component_id:
+    def get_settings_form_data(
+        self,
+    ) -> AutoTranslateAddonStoredConfiguration | AutoTranslateAddonConfiguration:
+        return self.get_configuration()
+
+    def normalize_configuration(
+        self, configuration: AutoTranslateAddonStoredConfiguration
+    ) -> AutoTranslateAddonConfiguration:
+        auto_source = configuration.get("auto_source", DEFAULT_AUTO_SOURCE)
+        if auto_source == "others":
+            raw_component = configuration.get("component")
+            source_component_id = raw_component or None
+        else:
             source_component_id = None
-        elif source_component_id is not None and not isinstance(
-            source_component_id, int
-        ):
-            msg = (
-                "Automatic translation add-on component configuration must be an "
-                f"integer or None, got {source_component_id!r}"
-            )
-            raise ValueError(msg)
+
+        raw_query = configuration.get("q")
+        if raw_query is None:
+            raw_filter_type = configuration.get("filter_type")
+            if raw_filter_type is None:
+                query = DEFAULT_AUTO_TRANSLATE_QUERY
+            else:
+                query = FILTERS.get_filter_query(raw_filter_type)
+        else:
+            query = raw_query
+
+        threshold = (
+            configuration.get("threshold", DEFAULT_AUTO_TRANSLATE_THRESHOLD)
+            if auto_source == "mt"
+            else DEFAULT_AUTO_TRANSLATE_THRESHOLD
+        )
 
         return {
-            "auto_source": configuration["auto_source"],
+            "auto_source": auto_source,
             "component": source_component_id,
-            "engines": configuration["engines"],
-            "mode": configuration["mode"],
-            "q": configuration["q"],
-            "threshold": configuration["threshold"],
+            "engines": configuration.get("engines", []),
+            "mode": configuration.get("mode", DEFAULT_AUTO_TRANSLATE_MODE),
+            "q": query,
+            "threshold": threshold,
         }
 
     def trigger_autotranslate(
@@ -195,7 +231,18 @@ class AutoTranslateAddon(BaseAddon):
             )
 
     def show_setting_field(self, field: BoundField) -> bool:
-        auto_source = self.instance.configuration["auto_source"]
+        form = getattr(field, "form", None)
+        form_data = getattr(form, "data", None)
+        raw_auto_source = (
+            form_data.get("auto_source", DEFAULT_AUTO_SOURCE)
+            if form_data is not None
+            else DEFAULT_AUTO_SOURCE
+        )
+        auto_source = (
+            raw_auto_source
+            if raw_auto_source in {"mt", "others"}
+            else DEFAULT_AUTO_SOURCE
+        )
         # Do not show UI hidden fields
         if (auto_source == "mt" and field.name == "component") or (
             auto_source == "others" and field.name in {"engines", "threshold"}
@@ -206,5 +253,8 @@ class AutoTranslateAddon(BaseAddon):
     def get_setting_value(self, field: BoundField) -> StrOrPromise:
         if field.name == "component" and not hasattr(field.field, "choices"):
             # Manually handle char field
-            return str(Component.objects.get(pk=field.value()))
+            try:
+                return str(Component.objects.get(pk=field.value()))
+            except (Component.DoesNotExist, TypeError, ValueError):
+                return str(field.value())
         return super().get_setting_value(field)

--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -8,7 +8,7 @@ import os
 import subprocess  # noqa: S404
 from contextlib import suppress
 from itertools import chain
-from typing import TYPE_CHECKING, Any, ClassVar, Self, TypedDict, cast
+from typing import TYPE_CHECKING, ClassVar, Self, TypedDict, cast
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -31,7 +31,7 @@ from weblate.utils.render import render_template
 from weblate.utils.validators import validate_filename
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable
+    from collections.abc import Callable, Generator, Iterable, Mapping
 
     from django.forms.boundfield import BoundField
     from django_stubs_ext import StrOrPromise
@@ -48,11 +48,11 @@ class CompatDict(TypedDict, total=False):
     edit_template: set[bool]
 
 
-class BaseAddon(DocVersionsMixin):
+class BaseAddon[StoredConfigurationT, ConfigurationT](DocVersionsMixin):
     """Base class for Weblate add-ons."""
 
     events: ClassVar[set[AddonEvent]] = set()
-    settings_form: type[BaseAddonForm] | None = None
+    settings_form: type[BaseAddonForm[StoredConfigurationT, Self]] | None = None
     name = ""
     compat: ClassVar[CompatDict] = {}
     multiple = False
@@ -110,7 +110,7 @@ class BaseAddon(DocVersionsMixin):
             category=category,
             component=component,
             name=cls.name,
-            acting_user=acting_user,
+            acting_user=acting_user,  # type: ignore[misc]
             **kwargs,
         )
 
@@ -149,7 +149,7 @@ class BaseAddon(DocVersionsMixin):
         category: Category | None = None,
         project: Project | None = None,
         **kwargs,
-    ) -> BaseAddonForm | None:
+    ) -> BaseAddonForm[StoredConfigurationT, Self] | None:
         """Return configuration form for adding new add-on."""
         if cls.settings_form is None:
             return None
@@ -159,13 +159,34 @@ class BaseAddon(DocVersionsMixin):
         instance = cls(storage)
         return cls.settings_form(user, instance, **kwargs)
 
-    def get_settings_form(self, user: User | None, **kwargs) -> BaseAddonForm | None:
+    def get_settings_form(
+        self, user: User | None, **kwargs
+    ) -> BaseAddonForm[StoredConfigurationT, Self] | None:
         """Return configuration form for this add-on."""
         if self.settings_form is None:
             return None
         if "data" not in kwargs:
-            kwargs["data"] = self.instance.configuration
+            kwargs["data"] = self.get_settings_form_data()
         return self.settings_form(user, self, **kwargs)
+
+    def get_settings_form_data(self) -> Mapping[str, object]:
+        return cast("Mapping[str, object]", self.stored_configuration)
+
+    @property
+    def stored_configuration(self) -> StoredConfigurationT:
+        return cast("StoredConfigurationT", self.instance.configuration)
+
+    def normalize_configuration(
+        self, configuration: StoredConfigurationT
+    ) -> ConfigurationT:
+        return cast("ConfigurationT", configuration)
+
+    def get_configuration(self) -> ConfigurationT:
+        return self.normalize_configuration(self.stored_configuration)
+
+    @property
+    def configuration(self) -> ConfigurationT:
+        return self.get_configuration()
 
     def show_setting_field(self, field: BoundField) -> bool:
         return not field.is_hidden and field.value()
@@ -200,7 +221,7 @@ class BaseAddon(DocVersionsMixin):
             if self.show_setting_field(field)
         ]
 
-    def configure(self, configuration: dict[str, Any]) -> None:
+    def configure(self, configuration: StoredConfigurationT) -> None:
         """Save configuration."""
         self.instance.configuration = configuration
         self.instance.save()
@@ -523,11 +544,22 @@ class BaseAddon(DocVersionsMixin):
         Override this for project-level logic, or override daily_component()
         for per-component logic.
         """
+        results: dict[str, dict] = {}
         for comp in self.resolve_components(
             component=component, category=category, project=project
         ):
             if self.can_process(component=comp):
-                self.daily_component(comp, activity_log_id=activity_log_id)
+                result = cast(
+                    "dict | None",
+                    self.daily_component(comp, activity_log_id=activity_log_id),
+                )
+                if result is not None:
+                    results[comp.full_slug] = result
+        if not results:
+            return None
+        if component is not None and len(results) == 1:
+            return next(iter(results.values()))
+        return {"components": results}
 
     def daily_component(
         self,
@@ -535,12 +567,14 @@ class BaseAddon(DocVersionsMixin):
         activity_log_id: int | None = None,
     ) -> dict | None:
         """Per-component daily processing. Override this for component-level logic."""
+        return None
 
     def component_update(
         self, component: Component, activity_log_id: int | None = None
     ) -> dict | None:
         """Event handler for component update."""
         # To be implemented in a subclass
+        return None
 
     def check_change_action(self, change: Change) -> bool:
         """Early filtering of Change actions before triggering change_event callback."""
@@ -551,6 +585,7 @@ class BaseAddon(DocVersionsMixin):
     ) -> dict | None:
         """Event handler for change event."""
         # To be implemented in a subclass
+        return None
 
     def execute_process(
         self, component: Component, cmd: list[str], env: dict[str, str] | None = None

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -42,6 +42,10 @@ from weblate.utils.validators import (
 )
 
 if TYPE_CHECKING:
+    from weblate.addons.autotranslate import (
+        AutoTranslateAddon,
+        AutoTranslateAddonStoredConfiguration,
+    )
     from weblate.addons.cdn import CDNJSAddon  # noqa: F401
     from weblate.addons.gettext import MesonAddon
     from weblate.addons.models import Addon
@@ -49,7 +53,7 @@ if TYPE_CHECKING:
     from weblate.trans.models import Component, Project
 
 
-class BaseAddonForm[AddonT: BaseAddon](forms.Form):
+class BaseAddonForm[StoredConfigurationT, AddonT: BaseAddon[Any, Any]](forms.Form):
     def __init__(
         self,
         user: User | None,
@@ -62,11 +66,11 @@ class BaseAddonForm[AddonT: BaseAddon](forms.Form):
         self.user = user
         forms.Form.__init__(self, *args, **kwargs)
 
-    def serialize_form(self):
-        return self.cleaned_data
+    def serialize_form(self) -> StoredConfigurationT:
+        return cast("StoredConfigurationT", self.cleaned_data)
 
     def save(self):
-        self._addon.configure(self.serialize_form())
+        self._addon.configure(cast("Any", self.serialize_form()))
         return self._addon.instance
 
 
@@ -107,7 +111,7 @@ class GenerateMoForm(BaseAddonForm):
         return self.cleaned_data["path"]
 
 
-class BaseExtractPotForm(BaseAddonForm[BaseAddon]):
+class BaseExtractPotForm(BaseAddonForm):
     interval = forms.ChoiceField(
         label=gettext_lazy("Update frequency"),
         choices=(
@@ -760,12 +764,31 @@ class DiscoveryForm(BaseAddonForm):
         return self.template_clean("intermediate_template")
 
 
-class AutoAddonForm(BaseAddonForm, AutoForm):
-    def __init__(self, user: User, addon, instance=None, **kwargs) -> None:
+class AutoAddonForm(
+    BaseAddonForm["AutoTranslateAddonStoredConfiguration", "AutoTranslateAddon"],
+    AutoForm,
+):
+    def __init__(
+        self,
+        user: User | None,
+        addon: AutoTranslateAddon,
+        instance=None,
+        **kwargs,
+    ) -> None:
         BaseAddonForm.__init__(self, user, addon)
         AutoForm.__init__(
             self, obj=addon.instance.component or addon.instance.project, **kwargs
         )
+
+    def serialize_form(self) -> AutoTranslateAddonStoredConfiguration:
+        return {
+            "mode": self.cleaned_data["mode"],
+            "q": self.cleaned_data["q"],
+            "auto_source": self.cleaned_data["auto_source"],
+            "component": self.cleaned_data["component"],
+            "engines": self.cleaned_data["engines"],
+            "threshold": self.cleaned_data["threshold"],
+        }
 
 
 class BulkEditAddonForm(BaseAddonForm, BulkEditForm):
@@ -796,7 +819,7 @@ class BulkEditAddonForm(BaseAddonForm, BulkEditForm):
         return result
 
 
-class CDNJSForm(BaseAddonForm["CDNJSAddon"]):
+class CDNJSForm(BaseAddonForm):
     threshold = forms.IntegerField(
         label=gettext_lazy("Translation threshold"),
         initial=0,

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -16,7 +16,7 @@ from datetime import timedelta
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, TypedDict, cast
 from unittest.mock import patch
 
 import jsonschema.exceptions
@@ -62,7 +62,7 @@ from weblate.utils.state import (
 from weblate.utils.unittest import tempdir_setting
 from weblate.vcs.base import RepositoryError
 
-from .autotranslate import AutoTranslateAddon
+from .autotranslate import DEFAULT_AUTO_TRANSLATE_THRESHOLD, AutoTranslateAddon
 from .base import BaseAddon, UpdateBaseAddon
 from .cdn import CDNJSAddon
 from .cleanup import CleanupAddon, RemoveBlankAddon, ResetAddon
@@ -153,6 +153,45 @@ class CrashAddon(UpdateBaseAddon):
         return False
 
 
+class TypedConfigAddonStoredConfiguration(TypedDict, total=False):
+    count: int | str
+
+
+class TypedConfigAddonConfiguration(TypedDict):
+    count: int
+
+
+class TypedConfigAddon(
+    BaseAddon[TypedConfigAddonStoredConfiguration, TypedConfigAddonConfiguration]
+):
+    """Testing add-on with typed configuration normalization."""
+
+    name = "weblate.base.typed"
+    verbose = "Typed test add-on"
+    description = "Typed test add-on"
+
+    def normalize_configuration(
+        self, configuration: TypedConfigAddonStoredConfiguration
+    ) -> TypedConfigAddonConfiguration:
+        raw_count = configuration.get("count", 0)
+        if isinstance(raw_count, str):
+            raw_count = int(raw_count)
+        return {"count": raw_count}
+
+
+class DailyResultAddon(BaseAddon):
+    name = "weblate.base.daily-result"
+    verbose = "Daily result add-on"
+    description = "Daily result add-on"
+
+    def daily_component(
+        self,
+        component: Component,
+        activity_log_id: int | None = None,
+    ) -> dict | None:
+        return {"component": component.slug}
+
+
 class TestAddonMixin:
     def setUp(self) -> None:
         super().setUp()
@@ -160,6 +199,7 @@ class TestAddonMixin:
         ADDONS.data[ExampleAddon.name] = ExampleAddon
         ADDONS.data[CrashAddon.name] = CrashAddon
         ADDONS.data[ExamplePreAddon.name] = ExamplePreAddon
+        ADDONS.data[DailyResultAddon.name] = DailyResultAddon
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -167,6 +207,7 @@ class TestAddonMixin:
         del ADDONS.data[ExampleAddon.name]
         del ADDONS.data[CrashAddon.name]
         del ADDONS.data[ExamplePreAddon.name]
+        del ADDONS.data[DailyResultAddon.name]
 
 
 class AddonBaseTest(TestAddonMixin, ViewTestCase):
@@ -217,6 +258,29 @@ class AddonBaseTest(TestAddonMixin, ViewTestCase):
         addon_object = Addon.objects.filter(name="weblate.base.test")
         self.assertEqual(addon_object.count(), 1)
         self.assertEqual("Test add-on: site-wide", str(addon.instance))
+
+    def test_daily_returns_component_result(self) -> None:
+        addon = DailyResultAddon.create(component=self.component, run=False)
+
+        self.assertEqual(addon.daily(component=self.component), {"component": "test"})
+
+    def test_daily_aggregates_multiple_component_results(self) -> None:
+        component2 = self.create_po_new_base(
+            name="Test 2",
+            slug="test-2",
+            project=self.project,
+        )
+        addon = DailyResultAddon.create(project=self.project, run=False)
+
+        self.assertEqual(
+            addon.daily(project=self.project),
+            {
+                "components": {
+                    self.component.full_slug: {"component": "test"},
+                    component2.full_slug: {"component": component2.slug},
+                }
+            },
+        )
 
     def test_add_form(self) -> None:
         form = NoOpAddon.get_add_form(None, component=self.component, data={})
@@ -4426,6 +4490,20 @@ class AutoTranslateAddonTest(ViewTestCase):
 
 
 class AutoTranslateAddonUnitTest(SimpleTestCase):
+    def test_base_addon_configuration_normalizes_stored_values(self) -> None:
+        addon = TypedConfigAddon.__new__(TypedConfigAddon)
+        addon.instance = SimpleNamespace(configuration={"count": "5"})
+
+        self.assertEqual(addon.stored_configuration["count"], "5")
+        self.assertEqual(addon.get_configuration(), {"count": 5})
+        self.assertEqual(addon.configuration, {"count": 5})
+
+    def test_base_addon_configuration_defaults_missing_legacy_values(self) -> None:
+        addon = TypedConfigAddon.__new__(TypedConfigAddon)
+        addon.instance = SimpleNamespace(configuration={})
+
+        self.assertEqual(addon.get_configuration(), {"count": 0})
+
     def test_trigger_autotranslate_normalizes_blank_component_for_translation_task(
         self,
     ) -> None:
@@ -4486,6 +4564,101 @@ class AutoTranslateAddonUnitTest(SimpleTestCase):
             engines=[],
             threshold=80,
             source_component_id=None,
+        )
+
+    def test_get_configuration_normalizes_legacy_filter_configuration(self) -> None:
+        addon = AutoTranslateAddon.__new__(AutoTranslateAddon)
+        addon.instance = SimpleNamespace(
+            configuration={
+                "auto_source": "others",
+                "filter_type": "comments",
+                "mode": "translate",
+            }
+        )
+
+        self.assertEqual(
+            addon.get_configuration(),
+            {
+                "auto_source": "others",
+                "component": None,
+                "engines": [],
+                "mode": "translate",
+                "q": "has:comment",
+                "threshold": 80,
+            },
+        )
+
+    def test_get_settings_form_data_normalizes_legacy_filter_configuration(
+        self,
+    ) -> None:
+        addon = AutoTranslateAddon.__new__(AutoTranslateAddon)
+        addon.instance = SimpleNamespace(
+            configuration={
+                "auto_source": "others",
+                "filter_type": "comments",
+                "mode": "translate",
+            }
+        )
+
+        self.assertEqual(
+            addon.get_settings_form_data(),
+            {
+                "auto_source": "others",
+                "component": None,
+                "engines": [],
+                "mode": "translate",
+                "q": "has:comment",
+                "threshold": 80,
+            },
+        )
+
+    def test_get_configuration_ignores_component_for_mt(self) -> None:
+        addon = AutoTranslateAddon.__new__(AutoTranslateAddon)
+        addon.instance = SimpleNamespace(
+            configuration={
+                "component": 123,
+                "q": "state:<translated",
+                "auto_source": "mt",
+                "engines": ["weblate"],
+                "threshold": 80,
+                "mode": "translate",
+            }
+        )
+
+        self.assertEqual(
+            addon.get_configuration(),
+            {
+                "auto_source": "mt",
+                "component": None,
+                "engines": ["weblate"],
+                "mode": "translate",
+                "q": "state:<translated",
+                "threshold": 80,
+            },
+        )
+
+    def test_get_configuration_ignores_threshold_for_others(self) -> None:
+        addon = AutoTranslateAddon.__new__(AutoTranslateAddon)
+        addon.instance = SimpleNamespace(
+            configuration={
+                "component": "",
+                "q": "state:<translated",
+                "auto_source": "others",
+                "threshold": 50,
+                "mode": "translate",
+            }
+        )
+
+        self.assertEqual(
+            addon.get_configuration(),
+            {
+                "auto_source": "others",
+                "component": None,
+                "engines": [],
+                "mode": "translate",
+                "q": "state:<translated",
+                "threshold": DEFAULT_AUTO_TRANSLATE_THRESHOLD,
+            },
         )
 
 


### PR DESCRIPTION
Separate stored and runtime configurations and add sanitizing helper between. This moves the consolidation to a single place and makes type checking more usable here. Only autotranslate add-on is migrated at this point.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
