### PR TITLE
chore: split out base test classes to avoid not needed initializations

### DIFF
--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -31,7 +31,11 @@ from weblate.auth.models import User
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Announcement, Change, Comment, Suggestion
-from weblate.trans.tests.test_views import RegistrationTestMixin, ViewTestCase
+from weblate.trans.tests.test_views import (
+    FixtureComponentTestCase,
+    RegistrationTestMixin,
+    ViewTestCase,
+)
 
 TEMPLATES_RAISE = deepcopy(settings.TEMPLATES)
 TEMPLATES_RAISE[0]["OPTIONS"]["string_if_invalid"] = "TEMPLATE_BUG[%s]"
@@ -581,7 +585,7 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
         )
 
 
-class SubscriptionTest(ViewTestCase):
+class SubscriptionTest(FixtureComponentTestCase):
     notification = MergeFailureNotification
 
     def get_users(self, frequency):

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -49,7 +49,7 @@ from weblate.trans.models import (
     Unit,
     Vote,
 )
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import ComponentTestCase, ViewTestCase
 from weblate.utils.site import get_site_url
 from weblate.utils.state import (
     FUZZY_STATES,
@@ -168,7 +168,7 @@ class TestAddonMixin:
         del ADDONS.data[ExamplePreAddon.name]
 
 
-class AddonBaseTest(TestAddonMixin, ViewTestCase):
+class AddonBaseTest(TestAddonMixin, ComponentTestCase):
     def test_can_install(self) -> None:
         self.assertTrue(NoOpAddon.can_install(component=self.component))
 
@@ -3003,7 +3003,7 @@ class GettextAddonTest(ViewTestCase):
         self.assertEqual(fetch_strings.call_args.args[0].pk, source_translation.pk)
 
 
-class AppStoreAddonTest(ViewTestCase):
+class AppStoreAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_appstore()
 
@@ -3020,7 +3020,7 @@ class AppStoreAddonTest(ViewTestCase):
         self.assertIn("cs/changelogs/100000.txt", commit)
 
 
-class AndroidAddonTest(ViewTestCase):
+class AndroidAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_android(suffix="-not-synced", new_lang="add")
 
@@ -3038,7 +3038,7 @@ class AndroidAddonTest(ViewTestCase):
         self.assertIn('\n-    <string name="hello">Ahoj svete</string>', commit)
 
 
-class WindowsRCAddonTest(ViewTestCase):
+class WindowsRCAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_winrc()
 
@@ -3056,7 +3056,7 @@ class WindowsRCAddonTest(ViewTestCase):
         self.assertIn("\n-IDS_MSG5", commit)
 
 
-class IntermediateAddonTest(ViewTestCase):
+class IntermediateAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_json_intermediate(new_lang="add")
 
@@ -3075,7 +3075,7 @@ class IntermediateAddonTest(ViewTestCase):
         self.assertIn('-    "orangutan"', commit)
 
 
-class ResxAddonTest(ViewTestCase):
+class ResxAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_resx()
 
@@ -3108,7 +3108,7 @@ class ResxAddonTest(ViewTestCase):
         self.assertIn("resx/cs.resx", commit)
 
 
-class CSVAddonTest(ViewTestCase):
+class CSVAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_csv_mono()
 
@@ -3135,7 +3135,7 @@ class CSVAddonTest(ViewTestCase):
         self.assertIn("csv-mono/cs.csv", commit)
 
 
-class JsonAddonTest(ViewTestCase):
+class JsonAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_json_mono(suffix="mono-sync")
 
@@ -3495,7 +3495,7 @@ class PropertiesAddonTest(ViewTestCase):
         self.assertIn("-state=Stale", commit)
 
 
-class ResetAddonTest(ViewTestCase):
+class ResetAddonTest(ComponentTestCase):
     def create_component(self):
         project = self.create_project(name="Sandbox", slug="sandbox")
         return self.create_po_new_base(project=project)
@@ -3516,7 +3516,7 @@ class ResetAddonTest(ViewTestCase):
         mocked_reset.assert_called_once_with(self.component)
 
 
-class CommandTest(ViewTestCase):
+class CommandTest(ComponentTestCase):
     """Test for management commands."""
 
     def test_list_addons(self) -> None:
@@ -3808,7 +3808,7 @@ class DiscoveryTest(ViewTestCase):
         self.assertContains(response, "Installed 1 add-on")
 
 
-class ScriptsTest(TestAddonMixin, ViewTestCase):
+class ScriptsTest(TestAddonMixin, ComponentTestCase):
     def test_example_pre(self) -> None:
         self.assertTrue(ExamplePreAddon.can_install(component=self.component))
         translation = self.get_translation()
@@ -3822,7 +3822,7 @@ class ScriptsTest(TestAddonMixin, ViewTestCase):
         )
 
 
-class LanguageConsistencyTest(ViewTestCase):
+class LanguageConsistencyTest(ComponentTestCase):
     CREATE_GLOSSARIES: bool = True
 
     def test_consistency_cannot_install_on_component(self) -> None:
@@ -4176,7 +4176,7 @@ class GitSquashAddonTest(ViewTestCase):
         self.assertEqual(self.component.repository.count_outgoing(), 1)
 
 
-class TestRemoval(ViewTestCase):
+class TestRemoval(ComponentTestCase):
     def install(
         self,
         sitewide: bool = False,
@@ -4308,7 +4308,7 @@ class TestRemoval(ViewTestCase):
         self.assert_count()
 
 
-class AutoTranslateAddonTest(ViewTestCase):
+class AutoTranslateAddonTest(ComponentTestCase):
     def test_auto(self) -> None:
         self.assertTrue(AutoTranslateAddon.can_install(component=self.component))
         addon = AutoTranslateAddon.create(
@@ -4730,7 +4730,7 @@ class SiteWideAddonsTest(ViewTestCase):
         self.assertNotEqual(rev, self.component.repository.last_revision)
 
 
-class TargetChangeAddonTest(ViewTestCase):
+class TargetChangeAddonTest(ComponentTestCase):
     def create_component(self):
         return self.create_json_mono(suffix="mono-sync")
 
@@ -5415,7 +5415,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         self.assertContains(response, "Installed 1 add-on")
 
 
-class TestCommand(ViewTestCase):
+class TestCommand(ComponentTestCase):
     def test_list_addons(self) -> None:
         output = StringIO()
         call_command("list_addons", stdout=output)

--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -8,10 +8,10 @@ from weblate.auth.data import SELECTION_ALL, SELECTION_MANUAL
 from weblate.auth.models import Group, Role, User
 from weblate.lang.models import Language
 from weblate.trans.models import ComponentList, Project
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 
 
-class ModelTest(FixtureTestCase):
+class ModelTest(FixtureComponentTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project.access_control = Project.ACCESS_PRIVATE

--- a/weblate/auth/tests/test_permissions.py
+++ b/weblate/auth/tests/test_permissions.py
@@ -15,11 +15,11 @@ from weblate.auth.data import (
 )
 from weblate.auth.models import Group, Permission, Role, User
 from weblate.trans.models import Comment, Project
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.trans.tests.utils import create_test_billing
 
 
-class PermissionsTest(FixtureTestCase):
+class PermissionsTest(FixtureComponentTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.user = User.objects.create_user("user", "test@example.com")

--- a/weblate/auth/tests/test_views.py
+++ b/weblate/auth/tests/test_views.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from weblate.auth.models import Group
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase
 
 
-class TeamsTest(ViewTestCase):
+class TeamsTest(FixtureTestCase):
     def make_superuser(self, superuser: bool = True) -> None:
         self.user.is_superuser = superuser
         self.user.save()

--- a/weblate/checks/tests/test_consistency_checks.py
+++ b/weblate/checks/tests/test_consistency_checks.py
@@ -18,7 +18,10 @@ from weblate.checks.tests.test_checks import MockUnit
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Unit
-from weblate.trans.tests.test_views import ComponentTestCase, ViewTestCase
+from weblate.trans.tests.test_views import (
+    ComponentTestCase,
+    FixtureTestCase,
+)
 from weblate.utils.state import STATE_TRANSLATED
 
 
@@ -69,7 +72,7 @@ class SamePluralsCheckTest(PluralsCheckTest):
         )
 
 
-class TranslatedCheckTest(ViewTestCase):
+class TranslatedCheckTest(FixtureTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.check = TranslatedCheck()

--- a/weblate/checks/tests/test_consistency_checks.py
+++ b/weblate/checks/tests/test_consistency_checks.py
@@ -18,7 +18,7 @@ from weblate.checks.tests.test_checks import MockUnit
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Unit
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import ComponentTestCase, ViewTestCase
 from weblate.utils.state import STATE_TRANSLATED
 
 
@@ -108,7 +108,7 @@ class TranslatedCheckTest(ViewTestCase):
         )
 
 
-class ConsistencyCheckTest(ViewTestCase):
+class ConsistencyCheckTest(ComponentTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.other = self.create_link_existing()

--- a/weblate/checks/tests/test_format_checks.py
+++ b/weblate/checks/tests/test_format_checks.py
@@ -38,7 +38,7 @@ from weblate.checks.ruby import RubyFormatCheck
 from weblate.checks.tests.test_checks import CheckTestCase, MockUnit
 from weblate.lang.models import Language
 from weblate.trans.models import Component, Project, Translation, Unit
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.trans.util import join_plural
 
 if TYPE_CHECKING:
@@ -1352,7 +1352,7 @@ class RubyFormatCheckTest(CheckTestCase):
         )
 
 
-class PluralTest(FixtureTestCase):
+class PluralTest(FixtureComponentTestCase):
     check = PythonFormatCheck()
 
     def do_check(

--- a/weblate/checks/tests/test_glossary_checks.py
+++ b/weblate/checks/tests/test_glossary_checks.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from weblate.checks.glossary import GlossaryCheck, ProhibitedInitialCharacterCheck
 from weblate.checks.models import Check
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import ComponentTestCase
 from weblate.utils.csv import PROHIBITED_INITIAL_CHARS
 from weblate.utils.state import STATE_TRANSLATED
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from weblate.trans.models import Unit
 
 
-class GlossaryCheckTest(ViewTestCase):
+class GlossaryCheckTest(ComponentTestCase):
     check = GlossaryCheck()
     CREATE_GLOSSARIES = True
 
@@ -106,7 +106,7 @@ class GlossaryCheckTest(ViewTestCase):
         )
 
 
-class ProhibitedInitialCharacterCheckTest(ViewTestCase):
+class ProhibitedInitialCharacterCheckTest(ComponentTestCase):
     check = ProhibitedInitialCharacterCheck()
     CREATE_GLOSSARIES = True
 

--- a/weblate/checks/tests/test_placeholders.py
+++ b/weblate/checks/tests/test_placeholders.py
@@ -10,7 +10,7 @@ from weblate.checks.placeholders import PlaceholderCheck, RegexCheck
 from weblate.checks.tests.test_checks import CheckTestCase, MockUnit
 from weblate.lang.models import Language, Plural
 from weblate.trans.models import Component, Project, Translation, Unit
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 
 
 class PlaceholdersTest(CheckTestCase):
@@ -173,7 +173,7 @@ class PlaceholdersTest(CheckTestCase):
         )
 
 
-class PluralPlaceholdersTest(FixtureTestCase):
+class PluralPlaceholdersTest(FixtureComponentTestCase):
     def test_plural(self) -> None:
         check = PlaceholderCheck()
         lang = "cs"

--- a/weblate/checks/tests/test_source_checks.py
+++ b/weblate/checks/tests/test_source_checks.py
@@ -18,7 +18,7 @@ from weblate.checks.source import (
 )
 from weblate.checks.tests.test_checks import MockUnit
 from weblate.trans.models import Unit
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase, FixtureTestCase
 from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
 
 
@@ -50,7 +50,7 @@ class EllipsisCheckTest(TestCase):
         self.assertTrue(self.check.check_source(["text..."], MockUnit()))
 
 
-class LongUntranslatedCheckTestCase(FixtureTestCase):
+class LongUntranslatedCheckTestCase(FixtureComponentTestCase):
     check = LongUntranslatedCheck()
 
     def test_recent(self) -> None:

--- a/weblate/checks/tests/test_views.py
+++ b/weblate/checks/tests/test_views.py
@@ -6,10 +6,10 @@
 
 from django.urls import reverse
 
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase
 
 
-class ChecksViewTest(ViewTestCase):
+class ChecksViewTest(FixtureTestCase):
     """Testing of check views."""
 
     def test_browse(self) -> None:

--- a/weblate/fonts/tests/test_models.py
+++ b/weblate/fonts/tests/test_models.py
@@ -4,11 +4,11 @@
 
 from weblate.fonts.models import FONT_STORAGE
 from weblate.fonts.tasks import cleanup_font_files
-from weblate.fonts.tests.utils import FontTestCase
+from weblate.fonts.tests.utils import FontComponentTestCase
 from weblate.fonts.utils import configure_fontconfig
 
 
-class FontModelTest(FontTestCase):
+class FontModelTest(FontComponentTestCase):
     def test_save(self) -> None:
         font = self.add_font()
         self.assertEqual(font.family, "Kurinto Sans")

--- a/weblate/fonts/tests/test_utils.py
+++ b/weblate/fonts/tests/test_utils.py
@@ -13,7 +13,7 @@ from django.core.files.base import File
 from django.test import SimpleTestCase
 from PIL import Image
 
-from weblate.fonts.tests.utils import FONT, FONT_NAME, FontTestCase
+from weblate.fonts.tests.utils import FONT, FONT_NAME, FontComponentTestCase
 from weblate.fonts.utils import (
     _render_size,
     check_render_size,
@@ -119,7 +119,7 @@ class RenderTest(SimpleTestCase):
         self.assertGreater(image.size[1], 10)
 
 
-class FontNameTest(FontTestCase):
+class FontNameTest(FontComponentTestCase):
     def test_get_font_name_repeated_for_uploaded_file(self) -> None:
         with FONT.open("rb") as handle:
             uploaded = File(handle, name=FONT_NAME)

--- a/weblate/fonts/tests/utils.py
+++ b/weblate/fonts/tests/utils.py
@@ -3,12 +3,19 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
+from __future__ import annotations
+
 from importlib import resources
+from typing import TYPE_CHECKING
 
 import weblate_fonts
 
 from weblate.fonts.models import FONT_STORAGE, Font
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase, FixtureTestCase
+
+if TYPE_CHECKING:
+    from weblate.auth.models import User
+    from weblate.trans.models import Project
 
 PACKAGE_PATH = resources.files(weblate_fonts)
 FONT_DIR = PACKAGE_PATH / "static" / "weblate_fonts" / "kurinto" / "ttf"
@@ -26,8 +33,19 @@ FONT_SOURCE = (
 )
 
 
-class FontTestCase(FixtureTestCase):
+class FontTestMixin:
+    project: Project
+    user: User
+
     def add_font(self):
         with FONT.open("rb") as handle:
             fontfile = FONT_STORAGE.save(FONT_NAME, handle)
         return Font.objects.create(font=fontfile, project=self.project, user=self.user)
+
+
+class FontComponentTestCase(FontTestMixin, FixtureComponentTestCase):
+    pass
+
+
+class FontTestCase(FontTestMixin, FixtureTestCase):
+    pass

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -75,7 +75,7 @@ from weblate.formats.ttkit import (
 from weblate.lang.data import PLURAL_UNKNOWN
 from weblate.lang.models import Language, Plural
 from weblate.trans.file_format_params import get_encoding_param
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_models import BaseTestCase
 from weblate.trans.tests.utils import TempDirMixin, get_test_file
 from weblate.utils.files import REPO_TEMP_DIRNAME
 from weblate.utils.state import STATE_APPROVED, STATE_FUZZY, STATE_TRANSLATED
@@ -327,7 +327,17 @@ class AutoLoadTest(SimpleTestCase):
         )
 
 
-class BaseFormatTest(FixtureTestCase, TempDirMixin, ABC):
+class FormatTestCase(BaseTestCase, TempDirMixin):
+    def setUp(self) -> None:
+        super().setUp()
+        self.create_temp()
+
+    def tearDown(self) -> None:
+        self.remove_temp()
+        super().tearDown()
+
+
+class BaseFormatTest(FormatTestCase, ABC):
     FILE = TEST_PO
     BASE = TEST_POT
     TEMPLATE: str | None = None
@@ -352,14 +362,6 @@ class BaseFormatTest(FixtureTestCase, TempDirMixin, ABC):
     EDIT_TARGET: ClassVar[str | list[str]] = "Nazdar, svete!\n"
     MONOLINGUAL = False
     FILE_FORMAT_PARAMS: ClassVar[FileFormatParams] = {}
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.create_temp()
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        self.remove_temp()
 
     @property
     @abstractmethod

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -23,7 +23,11 @@ from weblate.lang import data
 from weblate.lang.models import Language, Plural, PluralMapper, get_plural_type
 from weblate.trans.models import Unit
 from weblate.trans.tests.test_models import BaseTestCase
-from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
+from weblate.trans.tests.test_views import (
+    FixtureComponentTestCase,
+    FixtureTestCase,
+    ViewTestCase,
+)
 from weblate.trans.util import join_plural
 from weblate.utils.state import STATE_TRANSLATED
 
@@ -740,7 +744,7 @@ class PluralTest(BaseTestCase):
         self.assertTrue(language.plural_set.filter(source=Plural.SOURCE_CLDR))
 
 
-class PluralMapperTestCase(FixtureTestCase):
+class PluralMapperTestCase(FixtureComponentTestCase):
     def test_english_czech(self) -> None:
         english = Language.objects.get(code="en")
         czech = Language.objects.get(code="cs")

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -71,7 +71,11 @@ from weblate.machinery.yandex import YandexTranslation
 from weblate.machinery.yandexv2 import YandexV2Translation
 from weblate.machinery.youdao import YoudaoTranslation
 from weblate.trans.models import Project, Unit
-from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
+from weblate.trans.tests.test_views import (
+    FixtureComponentTestCase,
+    FixtureTestCase,
+    ViewTestCase,
+)
 from weblate.trans.tests.utils import get_test_file
 from weblate.utils.classloader import load_class
 from weblate.utils.state import STATE_TRANSLATED
@@ -3081,7 +3085,7 @@ class AnthropicCustomModelTranslationTest(AnthropicTranslationTest):
         self.assertFalse(form.is_valid())
 
 
-class WeblateTranslationTest(FixtureTestCase):
+class WeblateTranslationTest(FixtureComponentTestCase):
     def test_empty(self) -> None:
         machine = WeblateTranslation({})
         results = machine.translate(self.get_unit(), self.user)
@@ -3918,7 +3922,7 @@ class MachineryValidationTest(TestCase):
         self.assertIn("Allowlisted provider error.", str(raised.exception))
 
 
-class CommandTest(FixtureTestCase):
+class CommandTest(FixtureComponentTestCase):
     """Test for management commands."""
 
     def test_list_machinery(self) -> None:

--- a/weblate/metrics/tests.py
+++ b/weblate/metrics/tests.py
@@ -5,10 +5,10 @@
 from weblate.metrics.models import Metric
 from weblate.metrics.tasks import cleanup_metrics, collect_metrics
 from weblate.trans.models import Project
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 
 
-class MetricTestCase(FixtureTestCase):
+class MetricTestCase(FixtureComponentTestCase):
     def test_collect(self) -> None:
         collect_metrics()
         self.assertNotEqual(Metric.objects.count(), 0)

--- a/weblate/trans/tests/test_agreement.py
+++ b/weblate/trans/tests/test_agreement.py
@@ -5,10 +5,10 @@
 """Test for contributor license agreement management."""
 
 from weblate.trans.models import ContributorAgreement
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 
 
-class AgreementTest(FixtureTestCase):
+class AgreementTest(FixtureComponentTestCase):
     def test_basic(self) -> None:
         self.assertFalse(
             ContributorAgreement.objects.has_agreed(self.user, self.component)

--- a/weblate/trans/tests/test_changes.py
+++ b/weblate/trans/tests/test_changes.py
@@ -13,10 +13,10 @@ from django.utils.http import urlencode
 
 from weblate.trans.feeds import TranslationChangesFeed
 from weblate.trans.models import Change, Unit
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
 
 
-class FeedQueriesTest(ViewTestCase):
+class FeedQueriesTest(FixtureTestCase):
     # Reverse managers populate different related objects up front, so the
     # fixed query budget differs between project/component/translation feeds.
     PROJECT_FEED_QUERIES = 12

--- a/weblate/trans/tests/test_commands.py
+++ b/weblate/trans/tests/test_commands.py
@@ -6,6 +6,7 @@
 
 import sys
 from io import StringIO
+from typing import cast
 
 import requests
 from django.core.management import call_command
@@ -22,7 +23,11 @@ from weblate.trans.file_format_params import (
 )
 from weblate.trans.models import Component, Translation
 from weblate.trans.tests.test_models import RepoTestCase
-from weblate.trans.tests.test_views import FixtureComponentTestCase, ViewTestCase
+from weblate.trans.tests.test_views import (
+    ComponentTestCase,
+    FixtureComponentTestCase,
+    ViewTestCase,
+)
 from weblate.trans.tests.utils import create_test_user, get_test_file
 from weblate.vcs.mercurial import HgRepository
 
@@ -336,19 +341,20 @@ class BasicCommandTest(FixtureComponentTestCase):
             call_command("check", "--deploy")
 
 
-class WeblateComponentCommandTestCase(ViewTestCase):
+class WeblateComponentCommandMixin:
     """Base class for handling tests of WeblateComponentCommand based commands."""
 
     command_name = "checkgit"
     expected_string = "On branch main"
 
     def do_test(self, *args, **kwargs) -> None:
+        test_case = cast("TestCase", self)
         output = StringIO()
         call_command(self.command_name, *args, stdout=output, **kwargs)
         if self.expected_string:
-            self.assertIn(self.expected_string, output.getvalue())
+            test_case.assertIn(self.expected_string, output.getvalue())
         else:
-            self.assertEqual("", output.getvalue())
+            test_case.assertEqual("", output.getvalue())
 
     def test_all(self) -> None:
         self.do_test(all=True)
@@ -360,15 +366,21 @@ class WeblateComponentCommandTestCase(ViewTestCase):
         self.do_test("test/test")
 
     def test_nonexisting_project(self) -> None:
-        with self.assertRaises(CommandError):
+        test_case = cast("TestCase", self)
+        with test_case.assertRaises(CommandError):
             self.do_test("notest")
 
     def test_nonexisting_component(self) -> None:
-        with self.assertRaises(CommandError):
+        test_case = cast("TestCase", self)
+        with test_case.assertRaises(CommandError):
             self.do_test("test/notest")
 
 
-class CommitPendingTest(WeblateComponentCommandTestCase):
+class WeblateComponentCommandTestCase(ComponentTestCase, WeblateComponentCommandMixin):
+    pass
+
+
+class CommitPendingCommandMixin(WeblateComponentCommandMixin):
     command_name = "commit_pending"
     expected_string = ""
 
@@ -376,7 +388,11 @@ class CommitPendingTest(WeblateComponentCommandTestCase):
         self.do_test("test", "--age", "1")
 
 
-class CommitPendingChangesTest(CommitPendingTest):
+class CommitPendingTest(ComponentTestCase, CommitPendingCommandMixin):
+    pass
+
+
+class CommitPendingChangesTest(ViewTestCase, CommitPendingCommandMixin):
     def setUp(self) -> None:
         super().setUp()
         self.edit_unit("Hello, world!\n", "Nazdar svete!\n")

--- a/weblate/trans/tests/test_commands.py
+++ b/weblate/trans/tests/test_commands.py
@@ -22,7 +22,7 @@ from weblate.trans.file_format_params import (
 )
 from weblate.trans.models import Component, Translation
 from weblate.trans.tests.test_models import RepoTestCase
-from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase, ViewTestCase
 from weblate.trans.tests.utils import create_test_user, get_test_file
 from weblate.vcs.mercurial import HgRepository
 
@@ -325,7 +325,7 @@ class ImportProjectTest(RepoTestCase):
             )
 
 
-class BasicCommandTest(FixtureTestCase):
+class BasicCommandTest(FixtureComponentTestCase):
     def test_versions(self) -> None:
         output = StringIO()
         call_command("list_versions", stdout=output)

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -9,18 +9,16 @@ from __future__ import annotations
 import os
 import pathlib
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import cast
 from unittest.mock import Mock, patch
 
 from django.contrib.messages import get_messages
-from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import ValidationError
 from django.db.models import F
 from django.test import SimpleTestCase
-from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from weblate.auth.models import Group, setup_project_groups
+from weblate.auth.models import setup_project_groups
 from weblate.checks.models import Check
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
@@ -33,18 +31,15 @@ from weblate.trans.models import (
     Unit,
 )
 from weblate.trans.tests.test_models import RepoTestCase
-from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
-from weblate.trans.tests.utils import clear_users_cache, create_test_user
+from weblate.trans.tests.test_views import (
+    ComponentTestCase,
+    FixtureTestCase,
+    ViewTestCase,
+)
 from weblate.utils.files import remove_tree
 from weblate.utils.state import STATE_EMPTY, STATE_READONLY, STATE_TRANSLATED
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.models import VCS_REGISTRY
-
-if TYPE_CHECKING:
-    from weblate.auth.models import User
-    from weblate.utils.state import (
-        StringState,
-    )
 
 HOST_KEY_MISMATCH_ERROR = """remote: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 remote: @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@ -1125,57 +1120,7 @@ class ComponentErrorTest(RepoTestCase):
             self.component.clean()
 
 
-class RepoViewLiteTestCase(RepoTestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        clear_users_cache()
-        super().setUpTestData()
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.factory = RequestFactory()
-        self.user = create_test_user()
-        self.user.groups.add(Group.objects.get(name="Users"))
-        self.component = self.create_component()
-        self.project = self.component.project
-        setup_project_groups(self, self.project)
-        self.translation = self.get_translation()
-
-    def get_request(self, user: User | None = None):
-        request = self.factory.get("/")
-        request.user = user or self.user
-        request.session = "session"
-        request._messages = FallbackStorage(request)  # noqa: SLF001
-        return request
-
-    def get_translation(self, language: str = "cs") -> Translation:
-        return self.component.translation_set.get(language__code=language)
-
-    def get_unit(
-        self,
-        source: str = "Hello, world!\n",
-        language: str = "cs",
-        translation: Translation | None = None,
-    ) -> Unit:
-        if translation is None:
-            translation = self.get_translation(language)
-        return translation.unit_set.get(source__startswith=source)
-
-    def change_unit(
-        self,
-        target: str,
-        source: str = "Hello, world!\n",
-        language: str = "cs",
-        translation: Translation | None = None,
-        user: User | None = None,
-        state: StringState = STATE_TRANSLATED,
-    ) -> Unit:
-        unit = self.get_unit(source, language, translation=translation)
-        unit.translate(user or self.user, target, state)
-        return unit
-
-
-class ResetReapplyMissingTranslationFileTest(RepoViewLiteTestCase):
+class ResetReapplyMissingTranslationFileTest(ComponentTestCase):
     def create_component(self):
         return self.create_po_new_base(new_lang="add")
 
@@ -1639,7 +1584,7 @@ class ResetReapplyMissingTranslationFileTest(RepoViewLiteTestCase):
         self.assertIn("Pending changes were kept", messages[0])
 
 
-class LinkedResetDiskStateTest(RepoViewLiteTestCase):
+class LinkedResetDiskStateTest(ComponentTestCase):
     def create_component(self):
         return self.create_link()
 

--- a/weblate/trans/tests/test_dashboard.py
+++ b/weblate/trans/tests/test_dashboard.py
@@ -8,10 +8,10 @@ from django.urls import reverse
 from weblate.accounts.models import Profile
 from weblate.lang.models import Language
 from weblate.trans.models import Announcement, ComponentList, Project
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase
 
 
-class DashboardTest(ViewTestCase):
+class DashboardTest(FixtureTestCase):
     """Test for home/index view."""
 
     def setUp(self) -> None:

--- a/weblate/trans/tests/test_labels.py
+++ b/weblate/trans/tests/test_labels.py
@@ -12,10 +12,10 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.trans.actions import ActionEvents
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
 
 
-class LabelTest(ViewTestCase):
+class LabelTest(FixtureTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.make_manager()

--- a/weblate/trans/tests/test_lock.py
+++ b/weblate/trans/tests/test_lock.py
@@ -7,10 +7,10 @@
 from django.urls import reverse
 
 from weblate.trans.models.component import Component
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase
 
 
-class LockTest(ViewTestCase):
+class LockTest(FixtureTestCase):
     def setUp(self) -> None:
         super().setUp()
 

--- a/weblate/trans/tests/test_projecttoken.py
+++ b/weblate/trans/tests/test_projecttoken.py
@@ -11,10 +11,11 @@ from rest_framework.authtoken.models import Token
 from weblate.auth.models import setup_project_groups
 from weblate.trans.models import Project
 from weblate.trans.tasks import actual_project_removal
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.utils.files import remove_tree
 
 
-class ProjectTokenTest(ViewTestCase):
+class ProjectTokenTest(FixtureTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project.access_control = Project.ACCESS_PRIVATE
@@ -47,6 +48,17 @@ class ProjectTokenTest(ViewTestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+
+    def create_additional_project(
+        self, name: str = "Other", slug: str = "other"
+    ) -> Project:
+        project = Project.objects.create(
+            name=name,
+            slug=slug,
+            web="https://nonexisting.weblate.org/",
+        )
+        self.addCleanup(remove_tree, project.full_path, True)
+        return project
 
     def test_create_token(self) -> None:
         """Managers should be able to create new tokens."""
@@ -161,7 +173,7 @@ class ProjectTokenTest(ViewTestCase):
         """Project removal should not delete tokens still used by another project."""
         token_key = self.create_token()
         token_user = self.get_token_user(token_key)
-        second_project = self.create_project(name="Other", slug="other")
+        second_project = self.create_additional_project(name="Other", slug="other")
         second_project.access_control = Project.ACCESS_PRIVATE
         second_project.save()
         if not second_project.defined_groups.exists():

--- a/weblate/trans/tests/test_remote.py
+++ b/weblate/trans/tests/test_remote.py
@@ -144,12 +144,10 @@ class MultiRepoTest(ViewTestCase):
 
     def test_failed_update(self) -> None:
         """Test failed remote update."""
-        if os.path.exists(self.git_repo_path):
-            remove_tree(self.git_repo_path)
-        if os.path.exists(self.mercurial_repo_path):
-            remove_tree(self.mercurial_repo_path)
-        if os.path.exists(self.subversion_repo_path):
-            remove_tree(self.subversion_repo_path)
+        for repo_name in ("test-repo.git", "test-repo.hg", "test-repo.svn"):
+            repo_path = self.get_repo_path(repo_name)
+            if os.path.exists(repo_path):
+                remove_tree(repo_path)
         translation = self.component.translation_set.get(language_code="cs")
         self.assertFalse(translation.do_update(self.request))
 

--- a/weblate/trans/tests/test_review.py
+++ b/weblate/trans/tests/test_review.py
@@ -4,11 +4,11 @@
 
 """Tests for review workflow."""
 
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.utils.state import STATE_APPROVED
 
 
-class ReviewTest(ViewTestCase):
+class ReviewTest(FixtureTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project.translation_review = True

--- a/weblate/trans/tests/test_tasks.py
+++ b/weblate/trans/tests/test_tasks.py
@@ -20,7 +20,7 @@ from weblate.trans.tasks import (
     daily_update_checks,
     update_remotes,
 )
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import ComponentTestCase
 from weblate.utils.state import STATE_FUZZY, STATE_TRANSLATED
 from weblate.utils.tasks import (
     update_language_stats_parents,
@@ -30,7 +30,7 @@ from weblate.utils.tasks import (
 from weblate.utils.version import GIT_VERSION
 
 
-class CleanupTest(ViewTestCase):
+class CleanupTest(ComponentTestCase):
     def test_cleanup_suggestions_case_sensitive(self) -> None:
         request = self.get_request()
         unit = self.get_unit()
@@ -100,7 +100,7 @@ class CleanupTest(ViewTestCase):
         self.test_cleanup_old_comments(1)
 
 
-class TasksTest(ViewTestCase):
+class TasksTest(ComponentTestCase):
     def test_daily_update_checks(self) -> None:
         daily_update_checks()
 

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -21,7 +21,7 @@ from weblate.trans.templatetags.translations import (
     translation_progress_render,
 )
 from weblate.trans.templatetags.upload_methods import get_upload_method_help
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.utils.files import FileUploadMethod
 
 
@@ -183,7 +183,7 @@ class LocationLinksTest(TestCase):
         )
 
 
-class TranslationFormatTestCase(FixtureTestCase):
+class TranslationFormatTestCase(FixtureComponentTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.translation = self.get_translation()

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -93,7 +93,7 @@ class RegistrationTestMixin(TestCase):
         )
 
 
-class ViewTestCase(RepoTestCase):
+class ComponentTestCase(RepoTestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         clear_users_cache()
@@ -107,18 +107,14 @@ class ViewTestCase(RepoTestCase):
         self.user = create_test_user()
         group = Group.objects.get(name="Users")
         self.user.groups.add(group)
-        # Create another user
-        self.anotheruser = create_another_user()
-        self.user.groups.add(group)
         # Create project to have some test base
         self.component = self.create_component()
         self.project = self.component.project
+        if not self.project.defined_groups.exists():
+            setup_project_groups(self, self.project)
         self.translation = self.get_translation()
         # Invalidate caches
         cache.clear()
-        # Login
-        self.client.login(username="testuser", password="testpassword")
-        # Prepopulate kwargs
 
     @property
     def kw_project(self):
@@ -163,6 +159,11 @@ class ViewTestCase(RepoTestCase):
         # Project privileges
         self.project.add_user(self.user, "Administration")
 
+    def set_up_authenticated_view(self) -> None:
+        self.anotheruser = create_another_user()
+        self.user.groups.add(Group.objects.get(name="Users"))
+        self.client.login(username="testuser", password="testpassword")
+
     def get_request(self, user=None):
         """Get fake request object."""
         request = self.factory.get("/")
@@ -197,29 +198,6 @@ class ViewTestCase(RepoTestCase):
         unit = self.get_unit(source, language, translation=translation)
         unit.translate(user or self.user, target, state)
         return unit
-
-    def edit_unit(
-        self,
-        source: str,
-        target: str,
-        language: str = "cs",
-        follow: bool = False,
-        translation: Translation | None = None,
-        **kwargs,
-    ):
-        """Do edit single unit using web interface."""
-        unit = self.get_unit(source, language, translation=translation)
-        params = {
-            "checksum": unit.checksum,
-            "contentsum": hash_to_checksum(unit.content_hash),
-            "translationsum": hash_to_checksum(unit.get_target_hash()),
-            "target_0": target,
-            "review": "20",
-        }
-        params.update(kwargs)
-        return self.client.post(
-            unit.translation.get_translate_url(), params, follow=follow
-        )
 
     def assert_redirects_offset(self, response, exp_path, exp_offset) -> None:
         """Assert that offset in response matches expected one."""
@@ -287,7 +265,7 @@ class ViewTestCase(RepoTestCase):
             None,
             file_format_params=translation.component.file_format_params,
         )
-        messages = set()
+        messages: set[int] = set()
         translated = 0
 
         for unit in store.content_units:
@@ -302,11 +280,40 @@ class ViewTestCase(RepoTestCase):
             f"Did not found expected number of translations ({translated} != {expected_translated}).",
         )
 
+    def edit_unit(
+        self,
+        source: str,
+        target: str,
+        language: str = "cs",
+        follow: bool = False,
+        translation: Translation | None = None,
+        **kwargs,
+    ):
+        """Do edit single unit using web interface."""
+        unit = self.get_unit(source, language, translation=translation)
+        params = {
+            "checksum": unit.checksum,
+            "contentsum": hash_to_checksum(unit.content_hash),
+            "translationsum": hash_to_checksum(unit.get_target_hash()),
+            "target_0": target,
+            "review": "20",
+        }
+        params.update(kwargs)
+        return self.client.post(
+            unit.translation.get_translate_url(), params, follow=follow
+        )
+
     def log_as_jane(self) -> None:
         self.client.login(username="jane", password="testpassword")
 
 
-class FixtureTestCase(ViewTestCase):
+class ViewTestCase(ComponentTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.set_up_authenticated_view()
+
+
+class FixtureComponentTestCase(ComponentTestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         """Manually load fixture."""
@@ -333,7 +340,7 @@ class FixtureTestCase(ViewTestCase):
         return
 
     # pylint: disable=arguments-differ
-    def create_project(self):
+    def create_project(self, name: str = "Test", slug: str = "test", **kwargs):
         project = Project.objects.all()[0]
         setup_project_groups(self, project)
         return project
@@ -342,6 +349,12 @@ class FixtureTestCase(ViewTestCase):
         component = self.create_project().component_set.all()[0]
         component.create_path()
         return component
+
+
+class FixtureTestCase(FixtureComponentTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.set_up_authenticated_view()
 
 
 class TranslationManipulationTest(ViewTestCase):

--- a/weblate/trans/tests/test_workflowsetting.py
+++ b/weblate/trans/tests/test_workflowsetting.py
@@ -6,10 +6,10 @@
 
 from weblate.lang.models import Language
 from weblate.trans.models import Translation, WorkflowSetting
-from weblate.trans.tests.test_views import ViewTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 
 
-class WorkflowSettingsTestCase(ViewTestCase):
+class WorkflowSettingsTestCase(FixtureComponentTestCase):
     def assert_workflow(self, **kwargs) -> None:
         self.assertFalse(self.translation.enable_review)
         self.assertTrue(self.translation.enable_suggestions)

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -132,9 +132,7 @@ class RepoTestMixin:
 
     @cached_property
     def git_repo_path(self) -> str:
-        path = self.get_repo_path("test-repo.git")
-        shutil.copytree(self.git_base_repo_path, path)
-        return path
+        return self._copy_test_repo("test-repo.git", self.git_base_repo_path)
 
     @property
     def mercurial_base_repo_path(self) -> str:
@@ -145,9 +143,7 @@ class RepoTestMixin:
 
     @cached_property
     def mercurial_repo_path(self) -> str:
-        path = self.get_repo_path("test-repo.hg")
-        shutil.copytree(self.mercurial_base_repo_path, path)
-        return path
+        return self._copy_test_repo("test-repo.hg", self.mercurial_base_repo_path)
 
     @property
     def subversion_base_repo_path(self) -> str:
@@ -158,19 +154,20 @@ class RepoTestMixin:
 
     @cached_property
     def subversion_repo_path(self) -> str:
-        path = self.get_repo_path("test-repo.svn")
-        shutil.copytree(self.subversion_base_repo_path, path)
+        return self._copy_test_repo("test-repo.svn", self.subversion_base_repo_path)
+
+    def _copy_test_repo(self, repo_name: str, base_repo_path: str) -> str:
+        path = self.get_repo_path(repo_name)
+        if os.path.exists(path):
+            remove_tree(path)
+        shutil.copytree(base_repo_path, path)
         return path
 
     def clone_test_repos(self) -> None:
-        dirs = ["test-repo.git", "test-repo.hg", "test-repo.svn"]
-        # Remove possibly existing directories
-        for name in dirs:
-            path = self.get_repo_path(name)
-            if os.path.exists(path):
-                remove_tree(path)
-
-        # Remove cached paths
+        # Repository copies are created lazily on access. Reset cached paths and
+        # project working directories so each test gets a fresh checkout without
+        # eagerly touching Mercurial/Subversion fixtures for the common git-only
+        # path.
         keys = ["git_repo_path", "mercurial_repo_path", "subversion_repo_path"]
         for key in keys:
             if key in self.__dict__:

--- a/weblate/utils/tests/test_db.py
+++ b/weblate/utils/tests/test_db.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from weblate.trans.models import Component, Project, Unit
-from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.utils.db import adjust_similarity_threshold, re_escape
 
 BASE_SQL = 'SELECT "trans_unit"."id" FROM "trans_unit" WHERE '
@@ -60,7 +60,7 @@ class PostgreSQLOperatorTest(TestCase):
         )
 
 
-class SearchSQLOperatorTest(FixtureTestCase):
+class SearchSQLOperatorTest(FixtureComponentTestCase):
     def test_search(self) -> None:
         # Verifies that even complex query with a fallback is built properly
         # This is essentially what bulk edit does with such search


### PR DESCRIPTION
This focuses on improving the test suite run times without changing what we test by removing unneeded initializations from test cases that do not need them.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
