### PR TITLE
fix(machinery): avoid duplicate errors in Sentry

### DIFF
--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -28,7 +28,7 @@ from weblate.checks.utils import highlight_string
 from weblate.lang.models import Language, PluralMapper
 from weblate.machinery.forms import BaseMachineryForm
 from weblate.utils.docs import DocVersionsMixin
-from weblate.utils.errors import report_error
+from weblate.utils.errors import log_handled_exception, report_error
 from weblate.utils.forms import WeblateServiceURLField
 from weblate.utils.hash import calculate_dict_hash, calculate_hash, hash_to_checksum
 from weblate.utils.outbound import is_allowlisted_hostname
@@ -365,6 +365,10 @@ class BatchMachineTranslation(DocVersionsMixin):
         report_error(
             f"machinery[{self.name}]: {cause}", extra_log=extra_log, message=message
         )
+
+    def log_handled_error(self, cause: str, extra_log: str | None = None) -> None:
+        """Log a handled error without reporting it to external services."""
+        log_handled_exception(f"machinery[{self.name}]: {cause}", extra_log=extra_log)
 
     @cached_property
     def supported_languages(self):

--- a/weblate/machinery/llm.py
+++ b/weblate/machinery/llm.py
@@ -402,7 +402,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
         add_breadcrumb(self.name, "response", translations_string=translations_string)
         if translations_string is None or not translations_string:
             msg = "Blank assistant reply"
-            self.report_error(msg, extra_log=translations_string, message=True)
+            self.log_handled_error(msg, extra_log=translations_string)
             raise MachineTranslationError(msg)
 
         try:
@@ -413,14 +413,14 @@ class BaseLLMTranslation(BatchMachineTranslation):
             )
             if repaired_translations_string is None:
                 msg = "Could not parse assistant reply as JSON."
-                self.report_error(msg, extra_log=translations_string)
+                self.log_handled_error(msg, extra_log=translations_string)
                 raise MachineTranslationError(msg) from error
 
             try:
                 translations = json.loads(repaired_translations_string)
             except json.JSONDecodeError as repaired_error:
                 msg = "Could not parse assistant reply as JSON."
-                self.report_error(msg, extra_log=translations_string)
+                self.log_handled_error(msg, extra_log=translations_string)
                 raise MachineTranslationError(msg) from repaired_error
 
             add_breadcrumb(self.name, "response-repaired")
@@ -429,7 +429,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
             translations = self._validate_translations(translations, sources)
         except MachineTranslationError as error:
             msg = "Mismatching assistant reply."
-            self.report_error(msg, extra_log=translations_string, message=True)
+            self.log_handled_error(msg, extra_log=translations_string)
             raise MachineTranslationError(msg) from error
 
         for index, translation in enumerate(translations):

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -2831,6 +2831,54 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
     @responses.activate
     @respx.mock
+    def test_translate_blank_reply_reports_single_exception_event(self) -> None:
+        machine = self.get_machine()
+        handled_cause = f"machinery[{machine.name}]: Blank assistant reply"
+        report_cause = f"machinery[{machine.name}]: Could not fetch translations"
+
+        with (
+            patch("weblate.machinery.base.log_handled_exception") as mock_log_handled,
+            patch("weblate.machinery.base.report_error") as mock_report_error,
+            patch.object(machine, "fetch_llm_translations", return_value=""),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate("fr", "Hello", 1, machine=machine)
+
+        mock_log_handled.assert_called_once_with(handled_cause, extra_log="")
+        mock_report_error.assert_called_once_with(
+            report_cause, extra_log=None, message=False
+        )
+
+    @responses.activate
+    @respx.mock
+    def test_translate_parse_error_reports_single_exception_event(self) -> None:
+        machine = self.get_machine()
+        handled_cause = (
+            f"machinery[{machine.name}]: Could not parse assistant reply as JSON."
+        )
+        report_cause = f"machinery[{machine.name}]: Could not fetch translations"
+
+        with (
+            patch("weblate.machinery.base.log_handled_exception") as mock_log_handled,
+            patch("weblate.machinery.base.report_error") as mock_report_error,
+            patch.object(
+                machine, "fetch_llm_translations", return_value='["Ahoj "svete"]'
+            ),
+            patch.object(machine, "_repair_json_string_array", return_value=None),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate("fr", "Hello", 1, machine=machine)
+
+        mock_log_handled.assert_called_once_with(
+            handled_cause,
+            extra_log='["Ahoj "svete"]',
+        )
+        mock_report_error.assert_called_once_with(
+            report_cause, extra_log=None, message=False
+        )
+
+    @responses.activate
+    @respx.mock
     def test_translate_still_rejects_unrepairable_json(self) -> None:
         self.mock_response('["Ahoj světe"')
 


### PR DESCRIPTION
Avoid senting messages when we are already in the exception context.

Fixes WEBLATE-39DA

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
