### PR TITLE
fix(checks): changed rst highlighting for cleaner translatable scope

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -92,6 +92,7 @@ Weblate 5.17
 * SSH repository errors now distinguish changed host keys from missing host keys and avoid automatically trusting host key replacements.
 * Improved loading speed for comments on the translate page.
 * Reduced repeated metric queries when rendering activity charts on overview pages with cold caches.
+* :ref:`machine-translation` no longer treats translatable reStructuredText role content as :ref:`placeables-mt`.
 
 .. rubric:: Compatibility
 

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -10,7 +10,7 @@ from collections import Counter, defaultdict
 from functools import cache, lru_cache
 from itertools import chain
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 import regex
 from django.core.exceptions import ValidationError
@@ -23,13 +23,16 @@ from docutils import utils
 from docutils.core import Publisher
 from docutils.nodes import (
     Element,
+    Text,
     emphasis,
     footnote_reference,
     literal,
-    problematic,
     reference,
     strong,
     substitution_reference,
+)
+from docutils.nodes import (
+    target as docutils_target,
 )
 from docutils.parsers.rst import Parser, languages
 from docutils.parsers.rst.states import Inliner
@@ -125,6 +128,20 @@ RST_ROLE_RE = [
 ]
 
 RST_LIST_START = ("- ", "* ", "+ ")
+RST_HIGHLIGHT_WHOLE = "whole"
+RST_HIGHLIGHT_ROLE_SYNTAX = "role-syntax"
+RST_HIGHLIGHT_ROLE_TARGET = "role-target"
+
+
+type RSTHighlightKind = str
+type RSTHighlight = tuple[int, int, str]
+
+
+class RSTRoleMatch(NamedTuple):
+    role: str
+    inner: str
+    syntax_prefix: str
+    syntax_suffix: str
 
 
 def strip_entities(text):
@@ -500,8 +517,100 @@ class RSTBaseCheck(TargetCheck):
         self.enable_string = "rst-text"
 
 
+def get_rst_role_name(text: str) -> str | None:
+    if matched := get_rst_role_match(text):
+        return matched.role
+    return None
+
+
+def get_rst_role_match(text: str) -> RSTRoleMatch | None:
+    if text.startswith(":"):
+        separator = text.find(":`", 1)
+        if separator == -1 or not text.endswith("`"):
+            return None
+        role = text[1:separator]
+        if not role:
+            return None
+        return RSTRoleMatch(
+            role.lower(), text[separator + 2 : -1], text[: separator + 2], text[-1:]
+        )
+
+    if text.startswith("`") and text.endswith(":"):
+        separator = text.rfind("`:")
+        if separator <= 0:
+            return None
+        role = text[separator + 2 : -1]
+        if not role:
+            return None
+        return RSTRoleMatch(role.lower(), text[1:separator], text[:1], text[separator:])
+
+    return None
+
+
+def get_rst_role_reference(rawsource: str) -> tuple[str, RSTHighlightKind] | None:
+    if (matched_role := get_rst_role_match(rawsource)) is None:
+        return None
+
+    role = matched_role.role
+    if role in RST_TRANSLATABLE:
+        return f":{role}:", RST_HIGHLIGHT_ROLE_SYNTAX
+
+    if matched := RST_EXPLICIT_TITLE_RE.match(matched_role.inner):
+        return f":{role}:`{matched.group(2)}`", RST_HIGHLIGHT_ROLE_TARGET
+
+    return f":{role}:`{matched_role.inner}`", RST_HIGHLIGHT_WHOLE
+
+
+def get_rst_role_highlight(
+    rawsource: str,
+    start: int,
+    end: int,
+) -> list[RSTHighlight]:
+    if (matched_role := get_rst_role_match(rawsource)) is None:
+        return [(start, end, rawsource)]
+
+    prefix_end = start + len(matched_role.syntax_prefix)
+    if matched_role.role in RST_TRANSLATABLE:
+        return [
+            (start, prefix_end, matched_role.syntax_prefix),
+            (end - len(matched_role.syntax_suffix), end, matched_role.syntax_suffix),
+        ]
+
+    if matched := RST_EXPLICIT_TITLE_RE.match(matched_role.inner):
+        suffix_start = prefix_end + len(matched.group(1))
+        return [
+            (start, prefix_end, matched_role.syntax_prefix),
+            (
+                suffix_start,
+                end,
+                rawsource[len(matched_role.syntax_prefix) + len(matched.group(1)) :],
+            ),
+        ]
+
+    return [(start, end, rawsource)]
+
+
+def normalize_rst_node_token(token: str) -> str:
+    # Docutils uses a NUL placeholder for escaped markup in text nodes.
+    return token.replace("\x00", "\\")
+
+
+def get_rst_node_position(text: str, token: str, offset: int) -> tuple[int, int]:
+    normalized_token = normalize_rst_node_token(token)
+    start = text.find(normalized_token, offset)
+    if start == -1:
+        msg = (
+            "Could not locate parsed reStructuredText token "
+            f"{normalized_token!r} at offset {offset}"
+        )
+        raise ValueError(msg)
+    return start, start + len(normalized_token)
+
+
 @lru_cache(maxsize=512)
-def extract_rst_references(text: str) -> tuple[dict[str, str], Counter, list[str]]:
+def extract_rst_references(
+    text: str,
+) -> tuple[dict[str, str], Counter, tuple[RSTHighlight, ...]]:
     memo = SimpleNamespace()
     publisher = get_rst_publisher()
     document = utils.new_document("", publisher.settings)
@@ -515,51 +624,60 @@ def extract_rst_references(text: str) -> tuple[dict[str, str], Counter, list[str
     with DOCUTILS_PARSER_LOCK:
         nodes, system_messages = inliner.parse(text, 0, memo, document)
 
-    message_ids = {
-        message["ids"][0]: Element.astext(message)
-        for message in system_messages
-        if message["ids"]
-    }
+    del system_messages
     result: list[tuple[str, str]] = []
-    alltags: list[str] = []
+    highlights: list[RSTHighlight] = []
+    offset = 0
 
     for node in nodes:
-        if isinstance(node, problematic) and "refid" in node.attributes:
-            for rst_role_re in RST_ROLE_RE:
-                if match := rst_role_re.match(message_ids[node["refid"]]):
-                    alltags.append(node.rawsource)
-                    role = match.group(1)
-                    if role in RST_TRANSLATABLE:
-                        name = f":{role}:"
-                    elif matched := RST_EXPLICIT_TITLE_RE.match(
-                        node.rawsource[len(role) + 3 : -1]
-                    ):
-                        # Exclude title for checking translatable roles
-                        name = f":{role}:`{matched.group(2)}`"
-                    else:
-                        name = node.rawsource
+        token = str(node) if isinstance(node, Text) else getattr(node, "rawsource", "")
 
-                    result.append((name, node.rawsource))
-                    break
+        if not token:
+            continue
+
+        if isinstance(node, docutils_target):
+            normalized_token = normalize_rst_node_token(token)
+            if (start := text.find(normalized_token, offset)) != -1:
+                offset = start + len(normalized_token)
+            continue
+
+        start, end = get_rst_node_position(text, token, offset)
+        offset = end
+
+        if not isinstance(node, Text) and (
+            role_reference := get_rst_role_reference(token)
+        ):
+            name, highlight_type = role_reference
+            result.append((name, token))
+            if highlight_type == RST_HIGHLIGHT_WHOLE:
+                highlights.append((start, end, token))
+            else:
+                highlights.extend(get_rst_role_highlight(token, start, end))
         elif isinstance(node, (footnote_reference, substitution_reference)):
-            result.append((node.rawsource, node.rawsource))
-            alltags.append(node.rawsource)
+            result.append((token, token))
+            highlights.append((start, end, token))
         elif isinstance(node, reference):
             # Ignore the content as it might be localized, just differentiate
             # references with a link and without
             refuri = node.get("refuri")
-            name = "`... <...>`_" if refuri else "`...`_"
-            result.append((name, node.rawsource))
-            if refuri:
-                alltags.append(f"<{refuri}>")
+            result.append(("`... <...>`_" if refuri else "`...`_", token))
+            if refuri and (target_start := token.find(f"<{refuri}>")) != -1:
+                target_end = target_start + len(refuri) + 2
+                highlights.append(
+                    (
+                        start + target_start,
+                        start + target_end,
+                        token[target_start:target_end],
+                    )
+                )
         elif isinstance(node, literal):
-            result.append(("``...``", node.rawsource))
+            result.append(("``...``", token))
         elif isinstance(node, emphasis):
-            result.append(("*...*", node.rawsource))
+            result.append(("*...*", token))
         elif isinstance(node, strong):
-            result.append(("**...**", node.rawsource))
+            result.append(("**...**", token))
 
-    return dict(result), Counter(item[0] for item in result), alltags
+    return dict(result), Counter(item[0] for item in result), tuple(highlights)
 
 
 class RSTReferencesCheck(RSTBaseCheck):
@@ -633,12 +751,8 @@ class RSTReferencesCheck(RSTBaseCheck):
     def check_highlight(self, source: str, unit: Unit):
         if self.should_skip(unit):
             return
-        _references, _counter, alltags = extract_rst_references(source)
-        if not alltags:
-            return
-        match_exp = "|".join(re.escape(tag) for tag in alltags)
-        for match in re.finditer(match_exp, source):
-            yield match.start(0), match.end(0), match.group(0)
+        _references, _counter, highlights = extract_rst_references(source)
+        yield from highlights
 
 
 @cache

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -6,7 +6,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from django.contrib.admindocs.utils import docutils_is_available
+from docutils.nodes import Text, substitution_reference
+from docutils.nodes import target as docutils_target
 
 from weblate.checks.markup import (
     BBCodeCheck,
@@ -20,6 +24,7 @@ from weblate.checks.markup import (
     XMLCharsAroundTagsCheck,
     XMLTagsCheck,
     XMLValidityCheck,
+    extract_rst_references,
 )
 from weblate.checks.models import Check
 from weblate.checks.tests.test_checks import CheckTestCase
@@ -547,7 +552,7 @@ class RSTReferencesCheckTest(CheckTestCase):
         self.test_highlight = (
             "rst-text",
             ":ref:`bar` is :doc:`foo <baz>`",
-            [(0, 10, ":ref:`bar`"), (14, 30, ":doc:`foo <baz>`")],
+            [(0, 10, ":ref:`bar`"), (14, 20, ":doc:`"), (23, 30, " <baz>`")],
         )
 
     def test_description(self) -> None:
@@ -609,6 +614,26 @@ class RSTReferencesCheckTest(CheckTestCase):
                 "rst-text",
             ),
         )
+
+    def test_targets_advance_offset(self) -> None:
+        text = "Before _`|foo|`|foo|"
+
+        with patch(
+            "weblate.checks.markup.Inliner.parse",
+            return_value=(
+                [
+                    Text("Before "),
+                    docutils_target(rawsource="_`|foo|`"),
+                    substitution_reference(rawsource="|foo|"),
+                ],
+                [],
+            ),
+        ):
+            extract_rst_references.cache_clear()
+            self.addCleanup(extract_rst_references.cache_clear)
+            _references, _counter, highlights = extract_rst_references(text)
+
+        self.assertEqual(highlights, ((15, 20, "|foo|"),))
 
     def test_option_space(self) -> None:
         self.do_test(
@@ -703,6 +728,54 @@ class RSTReferencesCheckTest(CheckTestCase):
             (
                 ":kbd:`Ctrl+Home`",
                 ":kbd:`Ctrl+Inicio `",
+                "rst-text",
+            ),
+        )
+        self.do_test(
+            False,
+            (
+                ":code:`Save`",
+                ":code:`Ulozit`",
+                "rst-text",
+            ),
+        )
+        self.do_test(
+            False,
+            (
+                ":Code:`Save`",
+                ":Code:`Ulozit`",
+                "rst-text",
+            ),
+        )
+        self.do_test(
+            False,
+            (
+                "`Save`:guilabel:",
+                "`Ulozit`:guilabel:",
+                "rst-text",
+            ),
+        )
+        self.do_test(
+            False,
+            (
+                "`review workflow <reviews>`:ref:",
+                "`pracovni postup kontroly <reviews>`:ref:",
+                "rst-text",
+            ),
+        )
+        self.do_test(
+            True,
+            (
+                "`review workflow <reviews>`:ref:",
+                "`pracovni postup kontroly <other-reviews>`:ref:",
+                "rst-text",
+            ),
+        )
+        self.do_test(
+            True,
+            (
+                ":code:`Save`",
+                "``Ulozit``",
                 "rst-text",
             ),
         )

--- a/weblate/checks/tests/test_utils.py
+++ b/weblate/checks/tests/test_utils.py
@@ -62,6 +62,78 @@ class HighlightTestCase(SimpleTestCase):
             highlight_string("Hello *world*", unit, highlight_syntax=True),
             [(6, 7, "*"), (12, 13, "*")],
         )
+        self.assertEqual(
+            highlight_string(":guilabel:`Hello`", unit, highlight_syntax=True),
+            [(0, 11, ":guilabel:`"), (16, 17, "`")],
+        )
+        self.assertEqual(
+            highlight_string(":Code:`printf()`", unit, highlight_syntax=True),
+            [(0, 7, ":Code:`"), (15, 16, "`")],
+        )
+        self.assertEqual(
+            highlight_string("`printf()`:Code:", unit, highlight_syntax=True),
+            [(0, 1, "`"), (9, 16, "`:Code:")],
+        )
+        self.assertEqual(
+            highlight_string(":file:`/tmp/example.txt`", unit, highlight_syntax=True),
+            [(0, 7, ":file:`"), (23, 24, "`")],
+        )
+        self.assertEqual(
+            highlight_string(":code:`printf()`", unit, highlight_syntax=True),
+            [(0, 7, ":code:`"), (15, 16, "`")],
+        )
+        self.assertEqual(
+            highlight_string(":math:`x + y`", unit, highlight_syntax=True),
+            [(0, 7, ":math:`"), (12, 13, "`")],
+        )
+        self.assertEqual(
+            highlight_string(":sub:`2`", unit, highlight_syntax=True),
+            [(0, 6, ":sub:`"), (7, 8, "`")],
+        )
+        self.assertEqual(
+            highlight_string(":sup:`2`", unit, highlight_syntax=True),
+            [(0, 6, ":sup:`"), (7, 8, "`")],
+        )
+        self.assertEqual(
+            highlight_string(
+                ":ref:`review workflow <reviews>`", unit, highlight_syntax=True
+            ),
+            [(0, 6, ":ref:`"), (21, 32, " <reviews>`")],
+        )
+        self.assertEqual(
+            highlight_string(
+                "`review workflow <reviews>`:ref:",
+                unit,
+                highlight_syntax=True,
+            ),
+            [(0, 1, "`"), (16, 32, " <reviews>`:ref:")],
+        )
+
+    def test_rst_duplicate_fragment(self) -> None:
+        unit = MockUnit(
+            source="Use ``:ref:`foo``` syntax, then see :ref:`foo`.",
+            flags="rst-text",
+        )
+        self.assertEqual(
+            highlight_string(
+                "Use ``:ref:`foo``` syntax, then see :ref:`foo`.",
+                unit,
+            ),
+            [(36, 46, ":ref:`foo`")],
+        )
+
+    def test_rst_escaped_role_example(self) -> None:
+        unit = MockUnit(
+            source=r"Use \:ref:`foo` literally, then see :ref:`foo`.",
+            flags="rst-text",
+        )
+        self.assertEqual(
+            highlight_string(
+                r"Use \:ref:`foo` literally, then see :ref:`foo`.",
+                unit,
+            ),
+            [(36, 46, ":ref:`foo`")],
+        )
 
     def test_escaped_markup(self) -> None:
         unit = MockUnit(

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -480,30 +480,6 @@ class MachineTranslationTest(BaseMachineTranslationTest):
             ],
         )
 
-    def test_placeholders_rst(self) -> None:
-        machine_translation = self.get_machine()
-        unit = MockUnit(
-            code="cs", source=r"Hello, :file:`C:\Windows\System.exe`!", flags="rst-text"
-        )
-        self.assertEqual(
-            machine_translation.cleanup_text(unit.source, unit),
-            ("Hello, [X7X]!", {"[X7X]": r":file:`C:\Windows\System.exe`"}),
-        )
-        self.assertEqual(
-            machine_translation.translate(unit),
-            [
-                [
-                    {
-                        "quality": 100,
-                        "service": "Dummy",
-                        "source": r"Hello, :file:`C:\Windows\System.exe`!",
-                        "original_source": r"Hello, :file:`C:\Windows\System.exe`!",
-                        "text": r"Nazdar :file:`C:\Windows\System.exe`!",
-                    }
-                ]
-            ],
-        )
-
     def test_batch(self, machine=None) -> None:
         if machine is None:
             machine = self.get_machine()
@@ -520,6 +496,182 @@ class MachineTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(
             machine_translation.get_cache_key("test"),
             "mt:dummy:test:11364700946005001116",
+        )
+
+
+class MachineTranslationCleanupTest(SimpleTestCase):
+    def test_rst_reference_remains_placeholder(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs", source=r"Hello, :ref:`docker-volume`!", flags="rst-text"
+        )
+        self.assertEqual(
+            machine_translation.cleanup_text(unit.source, unit),
+            ("Hello, [X7X]!", {"[X7X]": r":ref:`docker-volume`"}),
+        )
+        self.assertEqual(
+            machine_translation.translate(unit),
+            [
+                [
+                    {
+                        "quality": 100,
+                        "service": "Dummy",
+                        "source": r"Hello, :ref:`docker-volume`!",
+                        "original_source": r"Hello, :ref:`docker-volume`!",
+                        "text": r"Nazdar :ref:`docker-volume`!",
+                    }
+                ]
+            ],
+        )
+
+    def test_rst_suffix_reference_remains_placeholder(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs", source=r"Hello, `docker-volume`:ref:!", flags="rst-text"
+        )
+        self.assertEqual(
+            machine_translation.cleanup_text(unit.source, unit),
+            ("Hello, [X7X]!", {"[X7X]": r"`docker-volume`:ref:"}),
+        )
+
+    def test_rst_file_role_roundtrip(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs",
+            source=r"Hello, :file:`C:\Windows\System.exe`!",
+            flags="rst-text",
+        )
+        replaced, replacements = machine_translation.cleanup_text(unit.source, unit)
+        self.assertEqual(
+            (replaced, replacements),
+            (
+                r"Hello, [X7X]C:\Windows\System.exe[X35X]!",
+                {
+                    "[X7X]": ":file:`",
+                    "[X35X]": "`",
+                },
+            ),
+        )
+        self.assertEqual(
+            machine_translation.uncleanup_text(
+                replacements,
+                r"Ahoj, [X7X]C:\Windows\System.exe[X35X]!",
+            ),
+            r"Ahoj, :file:`C:\Windows\System.exe`!",
+        )
+
+    def test_rst_builtin_translatable_role_roundtrip(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs",
+            source="Hello, :Code:`Save`!",
+            flags="rst-text",
+        )
+        replaced, replacements = machine_translation.cleanup_text(unit.source, unit)
+        self.assertEqual(
+            (replaced, replacements),
+            (
+                "Hello, [X7X]Save[X18X]!",
+                {
+                    "[X7X]": ":Code:`",
+                    "[X18X]": "`",
+                },
+            ),
+        )
+        self.assertEqual(
+            machine_translation.uncleanup_text(
+                replacements,
+                "Ahoj, [X7X]Ulozit[X18X]!",
+            ),
+            "Ahoj, :Code:`Ulozit`!",
+        )
+
+    def test_rst_suffix_translatable_role_roundtrip(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs",
+            source="Hello, `Save`:guilabel:!",
+            flags="rst-text",
+        )
+        replaced, replacements = machine_translation.cleanup_text(unit.source, unit)
+        self.assertEqual(
+            (replaced, replacements),
+            (
+                "Hello, [X7X]Save[X12X]!",
+                {
+                    "[X7X]": "`",
+                    "[X12X]": "`:guilabel:",
+                },
+            ),
+        )
+        self.assertEqual(
+            machine_translation.uncleanup_text(
+                replacements,
+                "Ahoj, [X7X]Ulozit[X12X]!",
+            ),
+            "Ahoj, `Ulozit`:guilabel:!",
+        )
+
+    def test_rst_translatable_role_roundtrip(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs",
+            source=(
+                "Hello, :guilabel:`Sign out` and :ref:`review workflow <reviews>`!"
+            ),
+            flags="rst-text",
+        )
+        replaced, replacements = machine_translation.cleanup_text(unit.source, unit)
+        self.assertEqual(
+            (replaced, replacements),
+            (
+                "Hello, [X7X]Sign out[X26X] and [X32X]review workflow[X53X]!",
+                {
+                    "[X7X]": ":guilabel:`",
+                    "[X26X]": "`",
+                    "[X32X]": ":ref:`",
+                    "[X53X]": " <reviews>`",
+                },
+            ),
+        )
+        self.assertEqual(
+            machine_translation.uncleanup_text(
+                replacements,
+                "Ahoj, [X7X]Odhlásit se[X26X] a [X32X]pracovní postup kontroly[X53X]!",
+            ),
+            "Ahoj, :guilabel:`Odhlásit se` a :ref:`pracovní postup kontroly <reviews>`!",
+        )
+
+    def test_rst_role_duplicate_fragment_roundtrip(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs",
+            source="Use ``:ref:`foo``` syntax, then see :ref:`foo`.",
+            flags="rst-text",
+        )
+        replaced, replacements = machine_translation.cleanup_text(unit.source, unit)
+        self.assertEqual(
+            (replaced, replacements),
+            (
+                "Use ``:ref:`foo``` syntax, then see [X36X].",
+                {"[X36X]": ":ref:`foo`"},
+            ),
+        )
+
+    def test_rst_escaped_role_example_roundtrip(self) -> None:
+        machine_translation = DummyTranslation({})
+        unit = MockUnit(
+            code="cs",
+            source=r"Use \:ref:`foo` literally, then see :ref:`foo`.",
+            flags="rst-text",
+        )
+        replaced, replacements = machine_translation.cleanup_text(unit.source, unit)
+        self.assertEqual(
+            (replaced, replacements),
+            (
+                r"Use \:ref:`foo` literally, then see [X36X].",
+                {"[X36X]": ":ref:`foo`"},
+            ),
         )
 
 


### PR DESCRIPTION
The transaltable parts are no longer highlighted to not treat them as non translatable in machinery.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
