### PR TITLE
feat(add-ons): provide repository specific presets for discovery

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 5.17.1
 * Admins can now revert edits from blocked users in a project or from any user site-wide.
 * Clarified :ref:`generic-upgrade-instructions` to state that Celery queues should be empty before upgrading.
 * Admin user management search can now find users by audit log IP address.
+* Installing :ref:`addon-weblate.discovery.discovery` on a component now suggests additional guided presets detected from the component repository layout.
 
 .. rubric:: Bug fixes
 

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -20,7 +20,11 @@ from lxml.cssselect import CSSSelector
 from weblate.addons.base import BaseAddon
 from weblate.formats.models import FILE_FORMATS
 from weblate.trans.actions import ActionEvents
-from weblate.trans.discovery import ComponentDiscovery
+from weblate.trans.discovery import (
+    ComponentDiscovery,
+    get_component_detected_discovery_presets,
+    get_detected_discovery_preset_values_key,
+)
 from weblate.trans.forms import AutoForm, BulkEditForm
 from weblate.trans.models import Translation
 from weblate.utils.forms import (
@@ -29,7 +33,7 @@ from weblate.utils.forms import (
     SortedSelectMultiple,
     WeblateServiceURLField,
 )
-from weblate.utils.regex import compile_regex
+from weblate.utils.regex import compile_regex, regex_match, regex_sub
 from weblate.utils.render import validate_render, validate_render_translation
 from weblate.utils.validators import (
     DomainOrIPValidator,
@@ -47,13 +51,18 @@ if TYPE_CHECKING:
         AutoTranslateAddonStoredConfiguration,
     )
     from weblate.addons.cdn import CDNJSAddon  # noqa: F401
+    from weblate.addons.consistency import LanguageConsistencyAddon  # noqa: F401
     from weblate.addons.gettext import MesonAddon
     from weblate.addons.models import Addon
     from weblate.auth.models import User
+    from weblate.trans.discovery import (
+        DetectedDiscoveryPreset,
+        DetectedDiscoveryPresetValues,
+    )
     from weblate.trans.models import Component, Project
 
 
-class BaseAddonForm[StoredConfigurationT, AddonT: BaseAddon[Any, Any]](forms.Form):
+class BaseAddonForm[StoredConfigurationT, AddonT: BaseAddon](forms.Form):
     def __init__(
         self,
         user: User | None,
@@ -70,7 +79,7 @@ class BaseAddonForm[StoredConfigurationT, AddonT: BaseAddon[Any, Any]](forms.For
         return cast("StoredConfigurationT", self.cleaned_data)
 
     def save(self):
-        self._addon.configure(cast("Any", self.serialize_form()))
+        self._addon.configure(self.serialize_form())
         return self._addon.instance
 
 
@@ -572,7 +581,9 @@ class RemoveSuggestionForm(RemoveForm):
     )
 
 
-class LanguageConsistencyPreviewForm(BaseAddonForm):
+class LanguageConsistencyPreviewForm(
+    BaseAddonForm[dict[str, object], "LanguageConsistencyAddon"]
+):
     confirm = forms.BooleanField(
         label=gettext_lazy("I confirm the above actions look correct"),
         required=False,
@@ -612,6 +623,16 @@ class DiscoveryForm(BaseAddonForm):
         "charlie_xyz",
         "Q",
     )
+    DETECTED_PRESET_ID_PREFIX: ClassVar[str] = "detected-"
+    PRESET_VALUE_FIELDS: ClassVar[tuple[str, ...]] = (
+        "match",
+        "file_format",
+        "name_template",
+        "base_file_template",
+        "new_base_template",
+        "intermediate_template",
+        "language_regex",
+    )
     PRESET_FILENAME_LANGUAGE = "filename-language"
     PRESET_FOLDER_PER_LANGUAGE = "folder-per-language"
     PRESET_GETTEXT_LOCALES = "gettext-locales"
@@ -619,9 +640,10 @@ class DiscoveryForm(BaseAddonForm):
     PRESET_REPEATED_LANGUAGE = "repeated-language"
     PRESET_SPLIT_ANDROID = "split-android-strings"
     PRESET_MULTIPLE_PATHS = "multiple-paths"
-    PRESETS: ClassVar[dict[str, dict[str, str]]] = {
+    PRESETS: ClassVar[dict[str, DetectedDiscoveryPresetValues]] = {
         PRESET_FOLDER_PER_LANGUAGE: {
             "match": r"(?P<language>[^/.]*)/(?P<component>[^/]*)\.po",
+            "file_format": "po",
             "name_template": "{{ component }}",
             "base_file_template": "",
             "new_base_template": "",
@@ -630,6 +652,7 @@ class DiscoveryForm(BaseAddonForm):
         },
         PRESET_GETTEXT_LOCALES: {
             "match": r"locale/(?P<language>[^/.]*)/LC_MESSAGES/(?P<component>[^/]*)\.po",
+            "file_format": "po",
             "name_template": "{{ component }}",
             "base_file_template": "",
             "new_base_template": "",
@@ -638,6 +661,7 @@ class DiscoveryForm(BaseAddonForm):
         },
         PRESET_COMPLEX_FILENAMES: {
             "match": r"src/locale/(?P<component>[^/]*)\.(?P<language>[^/.]*)\.po",
+            "file_format": "po",
             "name_template": "{{ component }}",
             "base_file_template": "",
             "new_base_template": "",
@@ -646,6 +670,7 @@ class DiscoveryForm(BaseAddonForm):
         },
         PRESET_FILENAME_LANGUAGE: {
             "match": r"(?:(?P<path>.*/))?(?P<component>.+?)_(?P<language>[A-Za-z]{2,3}(?:[_-][A-Za-z0-9]+)*)\.(?P<extension>[^/.]+)",
+            "file_format": "",
             "name_template": "{{ component }}",
             "base_file_template": "",
             "new_base_template": "",
@@ -654,6 +679,7 @@ class DiscoveryForm(BaseAddonForm):
         },
         PRESET_REPEATED_LANGUAGE: {
             "match": r"locale/(?P<language>[^/.]*)/(?P<component>[^/]*)/(?P=language)\.po",
+            "file_format": "po",
             "name_template": "{{ component }}",
             "base_file_template": "",
             "new_base_template": "",
@@ -662,6 +688,7 @@ class DiscoveryForm(BaseAddonForm):
         },
         PRESET_SPLIT_ANDROID: {
             "match": r"res/values-(?P<language>[^/.]*)/strings-(?P<component>[^/]*)\.xml",
+            "file_format": "aresource",
             "name_template": "{{ component }}",
             "base_file_template": "",
             "new_base_template": "",
@@ -670,6 +697,7 @@ class DiscoveryForm(BaseAddonForm):
         },
         PRESET_MULTIPLE_PATHS: {
             "match": r"(?P<originalHierarchy>.+/)(?P<component>[^/]*)/src/main/resources/ApplicationResources_(?P<language>[^/.]*)\.properties",
+            "file_format": "properties",
             "name_template": "{{ originalHierarchy }}: {{ component }}",
             "base_file_template": "",
             "new_base_template": "",
@@ -767,6 +795,17 @@ class DiscoveryForm(BaseAddonForm):
             Field("copy_addons"),
             Field("remove"),
         )
+        if self.guided_preset_sections:
+            self.helper.layout.insert(
+                0,
+                ContextDiv(
+                    template="addons/discovery_presets.html",
+                    context={
+                        "guided_presets": self.guided_presets,
+                        "guided_preset_sections": self.guided_preset_sections,
+                    },
+                ),
+            )
         if self.is_bound:
             # Perform form validation
             self.full_clean()
@@ -799,61 +838,216 @@ class DiscoveryForm(BaseAddonForm):
         return result
 
     @classmethod
-    def get_ui_presets(cls) -> list[dict[str, object]]:
+    def render_builtin_ui_preset(
+        cls,
+        preset_id: str,
+        label: str,
+        description: str,
+    ) -> dict[str, object]:
+        values = cls.PRESETS[preset_id]
+        file_format_label = cls.render_preset_file_format_label(values)
+        base_file_label = cls.render_preset_base_file_label(values)
+        details = cls.render_preset_label_details(values)
+        return {
+            "id": preset_id,
+            "kind": "generic",
+            "title": label,
+            "details": details,
+            "file_format_label": file_format_label,
+            "base_file_label": base_file_label,
+            "examples": (),
+            "label": gettext("Generic preset: %(name)s [%(details)s]")
+            % {
+                "name": label,
+                "details": details,
+            },
+            "description": description,
+            "values": values,
+        }
+
+    @staticmethod
+    def render_preset_file_format_label(values: DetectedDiscoveryPresetValues) -> str:
+        file_format = values.get("file_format", "")
+        if not file_format:
+            return gettext("format not preset")
+        if file_format in FILE_FORMATS:
+            return str(FILE_FORMATS[file_format].name)
+        return file_format
+
+    @staticmethod
+    def render_preset_base_file_label(values: DetectedDiscoveryPresetValues) -> str:
+        if base_file_template := values.get("base_file_template", ""):
+            return gettext("monolingual base: %(base)s") % {
+                "base": DiscoveryForm.render_preset_template_label(base_file_template)
+            }
+        return gettext("no monolingual base")
+
+    @staticmethod
+    def render_preset_template_label(value: str) -> str:
+        return regex_sub(r"{{\s*component\s*}}", "*", value)
+
+    @classmethod
+    def render_preset_label_details(cls, values: DetectedDiscoveryPresetValues) -> str:
+        return gettext("%(format)s; %(base)s") % {
+            "format": cls.render_preset_file_format_label(values),
+            "base": cls.render_preset_base_file_label(values),
+        }
+
+    @classmethod
+    def get_builtin_ui_presets(cls) -> list[dict[str, object]]:
         return [
-            {
-                "id": cls.PRESET_FOLDER_PER_LANGUAGE,
-                "label": gettext("One folder per language"),
-                "description": gettext("Matches files like cs/application.po."),
-                "values": cls.PRESETS[cls.PRESET_FOLDER_PER_LANGUAGE],
-            },
-            {
-                "id": cls.PRESET_GETTEXT_LOCALES,
-                "label": gettext("Gettext locales layout"),
-                "description": gettext(
-                    "Matches files like locale/cs/LC_MESSAGES/application.po."
-                ),
-                "values": cls.PRESETS[cls.PRESET_GETTEXT_LOCALES],
-            },
-            {
-                "id": cls.PRESET_COMPLEX_FILENAMES,
-                "label": gettext("Complex filenames"),
-                "description": gettext(
-                    "Matches files like src/locale/application.cs.po."
-                ),
-                "values": cls.PRESETS[cls.PRESET_COMPLEX_FILENAMES],
-            },
-            {
-                "id": cls.PRESET_FILENAME_LANGUAGE,
-                "label": gettext("Filename-based language variants"),
-                "description": gettext("Matches files like news_en.md."),
-                "values": cls.PRESETS[cls.PRESET_FILENAME_LANGUAGE],
-            },
-            {
-                "id": cls.PRESET_REPEATED_LANGUAGE,
-                "label": gettext("Repeated language code"),
-                "description": gettext(
-                    "Matches files like locale/cs/application/cs.po."
-                ),
-                "values": cls.PRESETS[cls.PRESET_REPEATED_LANGUAGE],
-            },
-            {
-                "id": cls.PRESET_SPLIT_ANDROID,
-                "label": gettext("Split Android strings"),
-                "description": gettext(
-                    "Matches files like res/values-cs/strings-about.xml."
-                ),
-                "values": cls.PRESETS[cls.PRESET_SPLIT_ANDROID],
-            },
-            {
-                "id": cls.PRESET_MULTIPLE_PATHS,
-                "label": gettext("Matching multiple paths"),
-                "description": gettext(
+            cls.render_builtin_ui_preset(
+                cls.PRESET_FOLDER_PER_LANGUAGE,
+                gettext("One folder per language"),
+                gettext("Matches files like cs/application.po."),
+            ),
+            cls.render_builtin_ui_preset(
+                cls.PRESET_GETTEXT_LOCALES,
+                gettext("Gettext locales layout"),
+                gettext("Matches files like locale/cs/LC_MESSAGES/application.po."),
+            ),
+            cls.render_builtin_ui_preset(
+                cls.PRESET_COMPLEX_FILENAMES,
+                gettext("Complex filenames"),
+                gettext("Matches files like src/locale/application.cs.po."),
+            ),
+            cls.render_builtin_ui_preset(
+                cls.PRESET_FILENAME_LANGUAGE,
+                gettext("Filename-based language variants"),
+                gettext("Matches files like news_en.md."),
+            ),
+            cls.render_builtin_ui_preset(
+                cls.PRESET_REPEATED_LANGUAGE,
+                gettext("Repeated language code"),
+                gettext("Matches files like locale/cs/application/cs.po."),
+            ),
+            cls.render_builtin_ui_preset(
+                cls.PRESET_SPLIT_ANDROID,
+                gettext("Split Android strings"),
+                gettext("Matches files like res/values-cs/strings-about.xml."),
+            ),
+            cls.render_builtin_ui_preset(
+                cls.PRESET_MULTIPLE_PATHS,
+                gettext("Matching multiple paths"),
+                gettext(
                     "Matches nested Java properties layouts and also fills the component name template."
                 ),
-                "values": cls.PRESETS[cls.PRESET_MULTIPLE_PATHS],
-            },
+            ),
         ]
+
+    @classmethod
+    def get_preset_values_key(
+        cls, values: DetectedDiscoveryPresetValues
+    ) -> tuple[str, ...]:
+        return get_detected_discovery_preset_values_key(values)
+
+    def render_detected_ui_preset(
+        self, preset: DetectedDiscoveryPreset, index: int
+    ) -> dict[str, object]:
+        examples = self.render_detected_ui_examples(preset)
+        sample = examples[0]
+        values = preset["values"]
+        file_format_label = self.render_preset_file_format_label(values)
+        base_file_label = self.render_preset_base_file_label(values)
+        details = self.render_preset_label_details(values)
+        return {
+            "id": f"{self.DETECTED_PRESET_ID_PREFIX}{index}",
+            "kind": "detected",
+            "title": sample,
+            "details": details,
+            "file_format_label": file_format_label,
+            "base_file_label": base_file_label,
+            "examples": (),
+            "label": gettext("Detected: %(pattern)s [%(details)s]")
+            % {
+                "pattern": sample,
+                "details": details,
+            },
+            "description": "",
+            "values": values,
+        }
+
+    @staticmethod
+    def render_detected_ui_example(example: str, match: str) -> str:
+        detected = regex_match(f"^{match}$", example)
+        if detected is None or "component" not in detected.re.groupindex:
+            return example
+
+        start, end = detected.span("component")
+        if start < 0 or end < 0:
+            return example
+        return f"{example[:start]}*{example[end:]}"
+
+    @classmethod
+    def render_detected_ui_examples(
+        cls, preset: DetectedDiscoveryPreset
+    ) -> tuple[str, ...]:
+        match = preset["values"]["match"]
+        rendered: list[str] = []
+        seen: set[str] = set()
+        for example in preset["examples"]:
+            rendered_example = cls.render_detected_ui_example(example, match)
+            if rendered_example in seen:
+                continue
+            seen.add(rendered_example)
+            rendered.append(rendered_example)
+        return tuple(rendered) or preset["examples"]
+
+    @cached_property
+    def detected_ui_presets(self) -> list[dict[str, object]]:
+        component = self._addon.instance.component
+        if component is None or self._addon.instance.pk is not None:
+            return []
+
+        builtins = {
+            self.get_preset_values_key(values) for values in self.PRESETS.values()
+        }
+        detected: list[dict[str, object]] = []
+        seen: set[tuple[str, ...]] = set()
+        for preset in get_component_detected_discovery_presets(component):
+            key = self.get_preset_values_key(preset["values"])
+            if key in builtins or key in seen:
+                continue
+            seen.add(key)
+            detected.append(self.render_detected_ui_preset(preset, len(detected) + 1))
+        return detected
+
+    @cached_property
+    def generic_ui_presets(self) -> list[dict[str, object]]:
+        return self.get_builtin_ui_presets()
+
+    @cached_property
+    def guided_presets(self) -> list[dict[str, object]]:
+        return [*self.detected_ui_presets, *self.generic_ui_presets]
+
+    @cached_property
+    def guided_preset_sections(self) -> list[dict[str, object]]:
+        sections: list[dict[str, object]] = []
+        has_detected = bool(self.detected_ui_presets)
+        if has_detected:
+            sections.append(
+                {
+                    "id": "detected",
+                    "title": gettext("Detected from repository"),
+                    "kind": "detected",
+                    "expanded": True,
+                    "presets": self.detected_ui_presets,
+                }
+            )
+        if self.generic_ui_presets:
+            sections.append(
+                {
+                    "id": "generic",
+                    "title": gettext("Generic presets"),
+                    "kind": "generic",
+                    "expanded": not has_detected,
+                    "presets": self.generic_ui_presets,
+                }
+            )
+        return sections
+
+    def get_ui_presets(self) -> list[dict[str, object]]:
+        return self.guided_presets
 
     @cached_property
     def discovery(self):
@@ -1018,7 +1212,7 @@ class BulkEditAddonForm(BaseAddonForm, BulkEditForm):
         return result
 
 
-class CDNJSForm(BaseAddonForm):
+class CDNJSForm(BaseAddonForm[dict[str, object], "CDNJSAddon"]):
     threshold = forms.IntegerField(
         label=gettext_lazy("Translation threshold"),
         initial=0,

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -8,6 +8,7 @@ import base64
 import contextlib
 import json
 import os
+import re
 import shutil
 import subprocess  # noqa: S404
 import sys
@@ -4324,18 +4325,249 @@ class DiscoveryTest(ViewTestCase):
     def test_discovery_page_renders_ui_presets(self) -> None:
         self.user.is_superuser = True
         self.user.save()
-        response = self.client.post(
-            reverse("addons", kwargs=self.kw_component),
-            {"name": "weblate.discovery.discovery"},
-            follow=True,
+        with patch(
+            "weblate.addons.forms.get_component_detected_discovery_presets",
+            return_value=[],
+        ) as mocked:
+            response = self.client.post(
+                reverse("addons", kwargs=self.kw_component),
+                {"name": "weblate.discovery.discovery"},
+                follow=True,
+            )
+        self.assertNotContains(response, 'id="addon-ui-preset"')
+        self.assertContains(response, "Guided presets")
+        self.assertContains(response, "Generic presets")
+        self.assertContains(response, 'id="addon-discovery-presets"')
+        self.assertContains(response, "row row-cols-1 row-cols-lg-2 g-3")
+        self.assertContains(response, 'class="card h-100"')
+        self.assertContains(
+            response,
+            'data-bs-target="#addon-discovery-section-generic"',
         )
-        self.assertContains(response, 'id="addon-ui-preset"')
+        self.assertContains(response, 'data-addon-discovery-preset="filename-language"')
         self.assertContains(response, "Filename-based language variants")
-        self.assertContains(response, "Matching multiple paths")
+        self.assertContains(response, "format not preset")
+        self.assertContains(response, "Java Properties")
+        self.assertContains(response, "no monolingual base")
         self.assertContains(response, "addon-ui-presets")
+        self.assertNotContains(response, 'id="addon-discovery-feedback"')
+        content = response.content.decode()
+        self.assertRegex(
+            content,
+            re.compile(
+                r'id="addon-discovery-section-generic"\s+'
+                r'class="accordion-collapse collapse show"',
+            ),
+        )
+        self.assertNotContains(response, 'id="addon-discovery-section-detected"')
+        mocked.assert_called_once_with(self.component)
+
+    def test_discovery_page_renders_detected_ui_presets(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+        detected = [
+            {
+                "examples": (
+                    "weblate/locale/*/LC_MESSAGES/django.po",
+                    "weblate/locale/*/LC_MESSAGES/djangojs.po",
+                ),
+                "values": {
+                    "match": r"weblate/locale/(?P<language>[^/.]*)/LC_MESSAGES/(?P<component>[^/]*)\.po",
+                    "file_format": "po",
+                    "name_template": "{{ component }}",
+                    "language_regex": "^[^.]+$",
+                    "base_file_template": "",
+                    "new_base_template": "",
+                    "intermediate_template": "",
+                },
+            }
+        ]
+        with patch(
+            "weblate.addons.forms.get_component_detected_discovery_presets",
+            return_value=detected,
+        ) as mocked:
+            response = self.client.post(
+                reverse("addons", kwargs=self.kw_component),
+                {"name": "weblate.discovery.discovery"},
+                follow=True,
+            )
+
+        self.assertContains(response, "Detected from repository")
+        self.assertContains(
+            response,
+            'data-addon-discovery-preset="detected-1"',
+        )
+        self.assertContains(response, 'id="addon-discovery-presets"')
+        self.assertContains(
+            response,
+            'data-bs-target="#addon-discovery-section-detected"',
+        )
+        self.assertContains(
+            response,
+            'data-bs-target="#addon-discovery-section-generic"',
+        )
+        self.assertContains(
+            response,
+            "weblate/locale/*/LC_MESSAGES/*.po",
+        )
+        self.assertContains(response, "gettext PO file")
+        self.assertContains(response, "no monolingual base")
+        self.assertContains(
+            response,
+            "One folder per language",
+        )
+        content = response.content.decode()
+        self.assertLess(
+            content.index("Detected from repository"),
+            content.index("Generic presets"),
+        )
+        self.assertRegex(
+            content,
+            re.compile(
+                r'id="addon-discovery-section-detected"\s+'
+                r'class="accordion-collapse collapse show"',
+            ),
+        )
+        self.assertRegex(
+            content,
+            re.compile(
+                r'id="addon-discovery-section-generic"\s+'
+                r'class="accordion-collapse collapse"',
+            ),
+        )
+        self.assertNotContains(response, "Prefills component discovery")
+        mocked.assert_called_once_with(self.component)
+
+    def test_render_detected_ui_preset_uses_component_wildcard_in_filename(
+        self,
+    ) -> None:
+        form = DiscoveryAddon.get_add_form(self.user, component=self.component)
+        self.assertIsNotNone(form)
+        if form is None:
+            self.fail("Expected discovery form to be created")
+        form = cast("DiscoveryForm", form)
+
+        rendered = form.render_detected_ui_preset(
+            {
+                "examples": (
+                    "docs/news_*.md",
+                    "docs/guide_*.md",
+                ),
+                "values": {
+                    "match": r"docs/(?P<component>[^/]*)_(?P<language>[^/.]*)\.md",
+                    "file_format": "markdown",
+                    "name_template": "{{ component }}",
+                    "language_regex": "^[^.]+$",
+                    "base_file_template": "docs/{{ component }}.md",
+                    "new_base_template": "",
+                    "intermediate_template": "",
+                },
+            },
+            1,
+        )
+
+        self.assertEqual(
+            rendered["label"],
+            "Detected: docs/*_*.md [Markdown file; monolingual base: docs/*.md]",
+        )
+        self.assertEqual(rendered["file_format_label"], "Markdown file")
+        self.assertEqual(rendered["base_file_label"], "monolingual base: docs/*.md")
+        self.assertEqual(rendered["description"], "")
+        self.assertEqual(rendered["examples"], ())
+
+    def test_get_ui_presets_lists_detected_before_generic_presets(self) -> None:
+        with patch(
+            "weblate.addons.forms.get_component_detected_discovery_presets",
+            return_value=[
+                {
+                    "examples": ("docs/news_*.md", "docs/guide_*.md"),
+                    "values": {
+                        "match": r"docs/(?P<component>[^/]*)_(?P<language>[^/.]*)\.md",
+                        "file_format": "markdown",
+                        "name_template": "{{ component }}",
+                        "language_regex": "^[^.]+$",
+                        "base_file_template": "",
+                        "new_base_template": "",
+                        "intermediate_template": "",
+                    },
+                }
+            ],
+        ):
+            form = DiscoveryAddon.get_add_form(self.user, component=self.component)
+            self.assertIsNotNone(form)
+            if form is None:
+                self.fail("Expected discovery form to be created")
+            form = cast("DiscoveryForm", form)
+            presets = form.get_ui_presets()
+
+        self.assertEqual(
+            presets[0]["label"],
+            "Detected: docs/*_*.md [Markdown file; no monolingual base]",
+        )
+        self.assertEqual(
+            presets[1]["label"],
+            "Generic preset: One folder per language [gettext PO file; no monolingual base]",
+        )
+
+    def test_detected_ui_presets_are_not_shown_when_editing_existing_addon(
+        self,
+    ) -> None:
+        addon = DiscoveryAddon.create(
+            component=self.component,
+            configuration={
+                "file_format": "po",
+                "match": r"(?P<component>[^/]*)/(?P<language>[^/]*)\.po",
+                "name_template": "{{ component|title }}",
+                "language_regex": "^(?!xx).+$",
+                "base_file_template": "",
+                "new_base_template": "",
+                "intermediate_template": "",
+                "remove": True,
+            },
+            run=False,
+        )
+        with patch(
+            "weblate.addons.forms.get_component_detected_discovery_presets"
+        ) as mocked:
+            form = addon.get_settings_form(self.user)
+
+        self.assertIsNotNone(form)
+        if form is None:
+            self.fail("Expected discovery form to be created")
+        form = cast("DiscoveryForm", form)
+        self.assertEqual(form.detected_ui_presets, [])
+        mocked.assert_not_called()
+
+    def test_detected_ui_presets_skip_builtin_equivalent_matches(self) -> None:
+        detected = [
+            {
+                "examples": ("*/application.po", "*/other.po"),
+                "values": {
+                    "match": r"(?P<language>[^/.]*)/(?P<component>[^/]*)\.po",
+                    "file_format": "po",
+                    "name_template": "{{ component }}",
+                    "language_regex": "^[^.]+$",
+                    "base_file_template": "",
+                    "new_base_template": "",
+                    "intermediate_template": "",
+                },
+            }
+        ]
+        with patch(
+            "weblate.addons.forms.get_component_detected_discovery_presets",
+            return_value=detected,
+        ):
+            form = DiscoveryAddon.get_add_form(self.user, component=self.component)
+            self.assertIsNotNone(form)
+            if form is None:
+                self.fail("Expected discovery form to be created")
+            form = cast("DiscoveryForm", form)
+            presets = form.detected_ui_presets
+
+        self.assertEqual(presets, [])
 
     def test_discovery_ui_presets_include_multiple_paths_template(self) -> None:
-        presets = DiscoveryForm.get_ui_presets()
+        presets = DiscoveryForm.get_builtin_ui_presets()
         multiple_paths = next(
             preset for preset in presets if preset["id"] == "multiple-paths"
         )
@@ -4343,6 +4575,25 @@ class DiscoveryTest(ViewTestCase):
             multiple_paths["values"]["name_template"],
             "{{ originalHierarchy }}: {{ component }}",
         )
+
+    def test_discovery_ui_presets_include_filename_language_file_format_clear(
+        self,
+    ) -> None:
+        presets = DiscoveryForm.get_builtin_ui_presets()
+        folder = next(
+            preset for preset in presets if preset["id"] == "folder-per-language"
+        )
+        split_android = next(
+            preset for preset in presets if preset["id"] == "split-android-strings"
+        )
+        filename_language = next(
+            preset for preset in presets if preset["id"] == "filename-language"
+        )
+
+        self.assertEqual(folder["values"]["file_format"], "po")
+        self.assertEqual(split_android["values"]["file_format"], "aresource")
+        self.assertIn("file_format", filename_language["values"])
+        self.assertEqual(filename_language["values"]["file_format"], "")
 
 
 class ScriptsTest(TestAddonMixin, ComponentTestCase):

--- a/weblate/addons/views.py
+++ b/weblate/addons/views.py
@@ -181,15 +181,11 @@ class AddonList(PathViewMixin, ListView):
             return self.redirect_list()
 
         addon.pre_install(obj, request)
-        ui_presets = None
-        if form is not None and hasattr(form, "get_ui_presets"):
-            ui_presets = form.get_ui_presets()
         return self.response_class(
             request=self.request,
             template=["addons/addon_detail.html"],
             context={
                 "addon": addon(Addon()),
-                "addon_ui_presets": ui_presets,
                 "form": form,
                 "object": self.path_object,
             },
@@ -247,8 +243,6 @@ class AddonDetail(BaseAddonView, UpdateView):
         result["instance"] = self.object
         result["addon"] = self.object.addon if self.object.is_valid else None
         result["addon_name"] = self.object.addon_name
-        if (form := result.get("form")) and hasattr(form, "get_ui_presets"):
-            result["addon_ui_presets"] = form.get_ui_presets()
         return result
 
     def get_success_url(self):

--- a/weblate/static/js/addon-discovery.js
+++ b/weblate/static/js/addon-discovery.js
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 document.addEventListener("DOMContentLoaded", () => {
-  const presetSelect = document.querySelector("#addon-ui-preset");
+  const presetButtons = document.querySelectorAll(
+    "[data-addon-discovery-preset]",
+  );
   const presetData = document.querySelector("#addon-ui-presets");
 
-  if (!presetSelect || !presetData) {
+  if (!presetButtons.length || !presetData) {
     return;
   }
 
@@ -18,44 +20,54 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   const presetMap = new Map(presets.map((preset) => [preset.id, preset]));
-  const description = document.querySelector("#addon-ui-preset-description");
   const fieldNames = [
     "match",
+    "file_format",
     "name_template",
     "base_file_template",
     "new_base_template",
     "intermediate_template",
     "language_regex",
   ];
-
-  function updateDescription(preset) {
-    if (!description) {
-      return;
-    }
-    if (!preset?.description) {
-      description.textContent = "";
-      description.classList.add("d-none");
-      return;
-    }
-    description.textContent = preset.description;
-    description.classList.remove("d-none");
+  function flashChangedField(input) {
+    input.classList.remove("flags-updated");
+    void input.offsetWidth;
+    input.classList.add("flags-updated");
+    input.addEventListener(
+      "animationend",
+      (event) => {
+        if (event.target !== input || event.animationName !== "flags-updated") {
+          return;
+        }
+        input.classList.remove("flags-updated");
+      },
+      { once: true },
+    );
   }
 
-  presetSelect.addEventListener("change", () => {
-    const preset = presetMap.get(presetSelect.value);
-    updateDescription(preset);
-    if (!preset) {
-      return;
-    }
-
+  function applyPreset(preset) {
     fieldNames.forEach((name) => {
       const input = document.querySelector(`#id_${name}`);
       if (!input || !(name in preset.values)) {
         return;
       }
+      if (input.value === preset.values[name]) {
+        return;
+      }
       input.value = preset.values[name];
       input.dispatchEvent(new Event("input", { bubbles: true }));
       input.dispatchEvent(new Event("change", { bubbles: true }));
+      flashChangedField(input);
+    });
+  }
+
+  presetButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const preset = presetMap.get(button.dataset.addonDiscoveryPreset);
+      if (!preset) {
+        return;
+      }
+      applyPreset(preset);
     });
   });
 });

--- a/weblate/static/style-dark.css
+++ b/weblate/static/style-dark.css
@@ -1951,6 +1951,44 @@ button.list-group-item-danger.active:focus {
   background-color: #282b2c;
   border-color: #484d50;
 }
+
+.accordion {
+  --bs-accordion-btn-bg: #282b2c;
+  --bs-accordion-active-bg: #282b2c;
+  --bs-accordion-color: #dcd7cf;
+  --bs-accordion-active-color: #dcd7cf;
+  --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(22, 94, 150, 0.6);
+  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23dcd7cf' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3e%3cpath d='m3 6 5 5 5-5'/%3e%3c/svg%3e");
+  --bs-accordion-btn-active-icon: var(--bs-accordion-btn-icon);
+}
+
+.accordion .accordion-item {
+  background-color: #1a1d1e;
+  border-color: #484d50;
+}
+
+.accordion .accordion-button,
+.accordion .accordion-button:not(.collapsed) {
+  color: #dcd7cf;
+}
+
+.accordion .accordion-button:not(.collapsed) {
+  border-bottom: 1px solid #484d50;
+}
+
+.accordion .accordion-button:focus {
+  box-shadow: var(--bs-accordion-btn-focus-box-shadow);
+  z-index: 3;
+}
+
+.accordion .accordion-button:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.accordion .accordion-body {
+  background-color: #1a1d1e;
+}
+
 .card > .card-header .badge {
   color: #f1eee8;
   background-color: #2a2e2f;

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2212,7 +2212,7 @@ a.language:hover {
   display: inline-block;
 }
 
-#unit_all_flags.flags-updated {
+.flags-updated {
   animation: flags-updated ease-out 3000ms;
 }
 
@@ -2461,6 +2461,60 @@ tbody.warning {
 .card-footer {
   border-top: var(--border);
   background-color: inherit;
+}
+
+.accordion {
+  --bs-accordion-border-color: transparent;
+  --bs-accordion-border-radius: var(--border-radius);
+  --bs-accordion-inner-border-radius: calc(var(--border-radius) - 1px);
+  --bs-accordion-btn-bg: var(--bs-card-cap-bg);
+  --bs-accordion-active-bg: var(--bs-card-cap-bg);
+  --bs-accordion-color: var(--bs-body-color);
+  --bs-accordion-active-color: var(--bs-body-color);
+  --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(22, 94, 150, 0.25);
+  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%232a3744' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3e%3cpath d='m3 6 5 5 5-5'/%3e%3c/svg%3e");
+  --bs-accordion-btn-active-icon: var(--bs-accordion-btn-icon);
+}
+
+.accordion .accordion-item {
+  margin-bottom: 12px;
+  border: var(--border);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  background-color: var(--background-color);
+}
+
+.accordion .accordion-item:last-child {
+  margin-bottom: 0;
+}
+
+.accordion .accordion-button {
+  font-weight: 700;
+  gap: 0.75rem;
+}
+
+.accordion .accordion-button:hover,
+.accordion .accordion-button:not(.collapsed) {
+  box-shadow: none;
+  background-color: var(--bs-accordion-btn-bg);
+}
+
+.accordion .accordion-button:not(.collapsed) {
+  border-bottom: var(--border);
+}
+
+.accordion .accordion-button:focus {
+  box-shadow: var(--bs-accordion-btn-focus-box-shadow);
+  z-index: 3;
+}
+
+.accordion .accordion-button:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.accordion .accordion-body {
+  padding: 1rem;
+  background-color: var(--background-color);
 }
 
 .card {

--- a/weblate/templates/addons/addon_detail.html
+++ b/weblate/templates/addons/addon_detail.html
@@ -50,22 +50,6 @@
           <input type="hidden"
                  name="name"
                  value="{% if instance %}{{ instance.name }}{% else %}{{ addon.name }}{% endif %}" />
-          {% if addon_ui_presets %}
-            <div class="mb-3">
-              <label for="addon-ui-preset" class="form-label">{% translate "Guided preset" %}</label>
-              <select id="addon-ui-preset"
-                      class="form-select"
-                      aria-describedby="addon-ui-preset-help addon-ui-preset-description">
-                <option value="">{% translate "Manual configuration" %}</option>
-                {% for preset in addon_ui_presets %}<option value="{{ preset.id }}">{{ preset.label }}</option>{% endfor %}
-              </select>
-              <div id="addon-ui-preset-help" class="form-text">
-                {% translate "Populate one of the documented discovery layouts with ready-to-edit values. You can still edit the populated values." %}
-              </div>
-              <div id="addon-ui-preset-description" class="form-text d-none"></div>
-            </div>
-            {{ addon_ui_presets|json_script:"addon-ui-presets" }}
-          {% endif %}
           {% crispy form %}
         </div>
         <div class="card-footer">
@@ -90,7 +74,7 @@
 
 {% block extra_script %}
   {{ block.super }}
-  {% if addon_ui_presets %}
+  {% if form.guided_presets %}
     <script defer
             data-cfasync="false"
             src="{% static 'js/addon-discovery.js' %}{{ cache_param }}"></script>

--- a/weblate/templates/addons/discovery_presets.html
+++ b/weblate/templates/addons/discovery_presets.html
@@ -1,0 +1,64 @@
+{% load i18n %}
+
+<div class="mb-4">
+  <div class="mb-3">
+    <div class="fw-semibold">{% translate "Guided presets" %}</div>
+    <div class="form-text">
+      {% translate "Fill the form from a detected or generic repository layout, then edit the populated values as needed." %}
+    </div>
+  </div>
+  <div id="addon-discovery-presets" class="accordion">
+    {% for section in guided_preset_sections %}
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="addon-discovery-heading-{{ section.id }}">
+          <button type="button"
+                  class="accordion-button{% if not section.expanded %} collapsed{% endif %}"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#addon-discovery-section-{{ section.id }}"
+                  aria-expanded="{% if section.expanded %}true{% else %}false{% endif %}"
+                  aria-controls="addon-discovery-section-{{ section.id }}">{{ section.title }}</button>
+        </h2>
+        <div id="addon-discovery-section-{{ section.id }}"
+             class="accordion-collapse collapse{% if section.expanded %} show{% endif %}"
+             aria-labelledby="addon-discovery-heading-{{ section.id }}"
+             data-bs-parent="#addon-discovery-presets">
+          <div class="accordion-body">
+            <div class="row row-cols-1 row-cols-lg-2 g-3">
+              {% for preset in section.presets %}
+                <div class="col d-flex">
+                  <button type="button"
+                          class="btn p-0 border-0 text-start w-100 h-100"
+                          data-addon-discovery-preset="{{ preset.id }}">
+                    <div class="card h-100">
+                      <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start gap-3">
+                          <div class="flex-grow-1">
+                            <div class="fw-semibold text-break">{{ preset.title }}</div>
+                            <div class="small text-body-secondary mt-2">{{ preset.file_format_label }}</div>
+                            <div class="small text-body-secondary">{{ preset.base_file_label }}</div>
+                            {% if preset.description %}<div class="small mt-2">{{ preset.description }}</div>{% endif %}
+                            {% if preset.examples %}
+                              <div class="small text-body-secondary mt-2">
+                                {% translate "Examples:" %} {{ preset.examples|slice:":3"|join:", " }}
+                              </div>
+                            {% endif %}
+                          </div>
+                          {% if preset.kind == "detected" %}
+                            <span class="badge text-bg-success">{% translate "Detected" %}</span>
+                          {% else %}
+                            <span class="badge text-bg-secondary">{% translate "Generic" %}</span>
+                          {% endif %}
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</div>
+{{ guided_presets|json_script:"addon-ui-presets" }}

--- a/weblate/trans/discovery.py
+++ b/weblate/trans/discovery.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import os
+import re
 from itertools import chain
+from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, NotRequired, Required, TypedDict, cast
 
@@ -12,6 +14,7 @@ from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
 from django.utils.text import slugify
 from django.utils.translation import gettext
+from translation_finder import discover
 
 from weblate.formats.models import FILE_FORMATS
 from weblate.logger import LOGGER
@@ -28,11 +31,17 @@ from weblate.utils.regex import compile_regex, regex_match
 from weblate.utils.render import render_template
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
+
+    from translation_finder import DiscoveryResult
 
     from weblate.formats.base import TranslationFormat
 
 COPY_ATTRIBUTES = get_inherited_component_fields("project", "category_id")
+DISCOVERY_PRESET_COMPONENT_MARKER = "__COMPONENT__"
+DISCOVERY_PRESET_COMPONENT_TEMPLATE = "{{ component }}"
+DISCOVERY_PRESET_LANGUAGE_CAPTURE = r"(?P<language>[^/.]*)"
+DISCOVERY_PRESET_COMPONENT_CAPTURE = r"(?P<component>[^/]*)"
 
 
 class DiscoveryErrorMatch(TypedDict):
@@ -76,6 +85,368 @@ class DiscoveryMatch(TypedDict):
     mask: str
     name: str
     slug: str
+
+
+class DetectedDiscoveryPresetValues(TypedDict):
+    match: str
+    file_format: str
+    name_template: str
+    base_file_template: str
+    new_base_template: str
+    intermediate_template: str
+    language_regex: str
+
+
+class DetectedDiscoveryPreset(TypedDict):
+    examples: tuple[str, ...]
+    values: DetectedDiscoveryPresetValues
+
+
+get_detected_discovery_preset_values_key = cast(
+    "Callable[[DetectedDiscoveryPresetValues], tuple[str, ...]]",
+    itemgetter(
+        "match",
+        "file_format",
+        "name_template",
+        "base_file_template",
+        "new_base_template",
+        "intermediate_template",
+        "language_regex",
+    ),
+)
+
+
+def get_discovery_result_key(
+    result: DiscoveryResult,
+) -> tuple[str, str, str, str, str]:
+    return (
+        str(result.get("file_format", "")),
+        str(result.get("filemask", "")),
+        str(result.get("template", "")),
+        str(result.get("new_base", "")),
+        str(result.get("intermediate", "")),
+    )
+
+
+def split_discovery_path(value: str) -> list[str]:
+    return value.split("/") if value else []
+
+
+def common_string_prefix(values: list[str]) -> str:
+    shortest = min(len(value) for value in values)
+    result: list[str] = []
+    for offset in range(shortest):
+        char = values[0][offset]
+        if any(value[offset] != char for value in values[1:]):
+            break
+        result.append(char)
+    return "".join(result)
+
+
+def common_string_suffix(values: list[str], prefix_length: int) -> str:
+    smallest = min(len(value) for value in values)
+    result: list[str] = []
+    while prefix_length + len(result) < smallest:
+        offset = len(result) + 1
+        char = values[0][-offset]
+        if any(value[-offset] != char for value in values[1:]):
+            break
+        result.append(char)
+    result.reverse()
+    return "".join(result)
+
+
+def trim_common_prefix_to_separator(prefix: str) -> str:
+    while prefix and prefix[-1].isalnum():
+        prefix = prefix[:-1]
+    return prefix
+
+
+def trim_common_suffix_to_separator(suffix: str) -> str:
+    while suffix and suffix[0].isalnum():
+        suffix = suffix[1:]
+    return suffix
+
+
+def extract_component_variants(
+    values: list[str],
+    prefix: str,
+    suffix: str,
+) -> tuple[str, ...] | None:
+    prefix_length = len(prefix)
+    suffix_length = len(suffix)
+    components: list[str] = []
+
+    for value in values:
+        end = len(value) - suffix_length if suffix_length else len(value)
+        component = value[prefix_length:end]
+        if not component or "*" in component:
+            return None
+        components.append(component)
+
+    return tuple(components)
+
+
+def generalize_component_segment(
+    values: list[str],
+) -> tuple[str, tuple[str, ...]] | None:
+    if len(set(values)) < 2:
+        return None
+
+    prefix = common_string_prefix(values)
+    suffix = common_string_suffix(values, len(prefix))
+    prefix = trim_common_prefix_to_separator(prefix)
+    suffix = trim_common_suffix_to_separator(suffix)
+    attempts = (
+        (prefix, suffix),
+        ("", suffix),
+        (prefix, ""),
+        ("", ""),
+    )
+    for candidate_prefix, candidate_suffix in attempts:
+        components = extract_component_variants(
+            values,
+            candidate_prefix,
+            candidate_suffix,
+        )
+        if components is not None:
+            return (
+                f"{candidate_prefix}{DISCOVERY_PRESET_COMPONENT_MARKER}{candidate_suffix}",
+                components,
+            )
+
+    return None
+
+
+def render_discovery_match_segment(segment: str) -> str:
+    marker = "__WEBLATE_COMPONENT_MARKER__"
+    escaped = re.escape(segment.replace(DISCOVERY_PRESET_COMPONENT_MARKER, marker))
+    escaped = escaped.replace(r"\*", DISCOVERY_PRESET_LANGUAGE_CAPTURE)
+    return escaped.replace(
+        re.escape(marker),
+        DISCOVERY_PRESET_COMPONENT_CAPTURE,
+    )
+
+
+def generalize_discovery_template_field(
+    values: list[str],
+    *,
+    component_values: tuple[str, ...],
+) -> str | None:
+    if not any(values):
+        return ""
+    if any(not value for value in values):
+        return None
+    if len(set(values)) == 1:
+        return values[0]
+
+    segments = [split_discovery_path(value) for value in values]
+    segment_count = len(segments[0])
+    if any(len(current) != segment_count for current in segments[1:]):
+        return None
+
+    differing = [
+        index
+        for index, values_at_index in enumerate(zip(*segments, strict=False))
+        if len(set(values_at_index)) > 1
+    ]
+    if len(differing) != 1:
+        return None
+
+    component_index = differing[0]
+    generalized = generalize_component_segment(
+        [current[component_index] for current in segments]
+    )
+    if generalized is None:
+        return None
+
+    template_segment, extracted_components = generalized
+    if extracted_components != component_values:
+        return None
+
+    path = segments[0].copy()
+    path[component_index] = template_segment.replace(
+        DISCOVERY_PRESET_COMPONENT_MARKER,
+        DISCOVERY_PRESET_COMPONENT_TEMPLATE,
+    )
+    return "/".join(path)
+
+
+def detected_match_preserves_filemask_groups(
+    filemasks: list[str],
+    match: str,
+    component_values: tuple[str, ...],
+) -> bool:
+    compiled = compile_regex(f"^{match}$")
+    for filemask, component_value in zip(filemasks, component_values, strict=True):
+        detected = regex_match(compiled, filemask)
+        if (
+            detected is None
+            or detected.group("language") != "*"
+            or detected.group("component") != component_value
+        ):
+            return False
+    return True
+
+
+def build_detected_discovery_preset(
+    first: DiscoveryResult,
+    second: DiscoveryResult,
+) -> DetectedDiscoveryPreset | None:
+    if first.get("file_format") != second.get("file_format"):
+        return None
+
+    filemasks = [str(first.get("filemask", "")), str(second.get("filemask", ""))]
+    if any(not filemask or filemask.count("*") != 1 for filemask in filemasks):
+        return None
+
+    segments = [split_discovery_path(filemask) for filemask in filemasks]
+    segment_count = len(segments[0])
+    if any(len(current) != segment_count for current in segments[1:]):
+        return None
+
+    language_indexes = [
+        next(index for index, segment in enumerate(current) if "*" in segment)
+        for current in segments
+    ]
+    if language_indexes[0] != language_indexes[1]:
+        return None
+
+    differing = [
+        index
+        for index, values_at_index in enumerate(zip(*segments, strict=False))
+        if len(set(values_at_index)) > 1
+    ]
+    if len(differing) != 1:
+        return None
+
+    component_index = differing[0]
+    generalized = generalize_component_segment(
+        [current[component_index] for current in segments]
+    )
+    if generalized is None:
+        return None
+
+    generalized_segment, component_values = generalized
+    if component_index == language_indexes[0] and any(
+        "." in component_value for component_value in component_values
+    ):
+        return None
+
+    match_segments = segments[0].copy()
+    match_segments[component_index] = generalized_segment
+    match = "/".join(
+        render_discovery_match_segment(segment) for segment in match_segments
+    )
+    if not detected_match_preserves_filemask_groups(
+        filemasks,
+        match,
+        component_values,
+    ):
+        return None
+
+    base_file_template = generalize_discovery_template_field(
+        [str(first.get("template", "")), str(second.get("template", ""))],
+        component_values=component_values,
+    )
+    if base_file_template is None:
+        return None
+
+    new_base_template = generalize_discovery_template_field(
+        [str(first.get("new_base", "")), str(second.get("new_base", ""))],
+        component_values=component_values,
+    )
+    if new_base_template is None:
+        return None
+
+    intermediate_template = generalize_discovery_template_field(
+        [str(first.get("intermediate", "")), str(second.get("intermediate", ""))],
+        component_values=component_values,
+    )
+    if intermediate_template is None:
+        return None
+
+    values: DetectedDiscoveryPresetValues = {
+        "match": match,
+        "file_format": str(first["file_format"]),
+        "name_template": DISCOVERY_PRESET_COMPONENT_TEMPLATE,
+        "language_regex": "^[^.]+$",
+        "base_file_template": base_file_template,
+        "new_base_template": new_base_template,
+        "intermediate_template": intermediate_template,
+    }
+
+    return {
+        "examples": tuple(sorted({filemask for filemask in filemasks if filemask})),
+        "values": values,
+    }
+
+
+def get_detected_discovery_presets_from_results(
+    discovered: list[DiscoveryResult],
+) -> list[DetectedDiscoveryPreset]:
+    unique_results: dict[tuple[str, str, str, str, str], DiscoveryResult] = {}
+    for result in discovered:
+        key = get_discovery_result_key(result)
+        if key[0] and key[1]:
+            unique_results.setdefault(key, result)
+
+    candidates: dict[tuple[str, ...], dict[str, object]] = {}
+    values = list(unique_results.values())
+    for index, first in enumerate(values):
+        for second in values[index + 1 :]:
+            if detected := build_detected_discovery_preset(first, second):
+                preset_key = get_detected_discovery_preset_values_key(
+                    detected["values"]
+                )
+                if preset_key not in candidates:
+                    candidates[preset_key] = {
+                        "examples": set(detected["examples"]),
+                        "values": detected["values"],
+                    }
+                else:
+                    cast("set[str]", candidates[preset_key]["examples"]).update(
+                        detected["examples"]
+                    )
+
+    return [
+        {
+            "examples": tuple(sorted(cast("set[str]", candidate["examples"]))),
+            "values": cast("DetectedDiscoveryPresetValues", candidate["values"]),
+        }
+        for candidate in sorted(
+            candidates.values(),
+            key=lambda item: (
+                min(cast("set[str]", item["examples"])),
+                cast("DetectedDiscoveryPresetValues", item["values"])["match"],
+            ),
+        )
+    ]
+
+
+def get_component_detected_discovery_presets(
+    component: Component,
+) -> list[DetectedDiscoveryPreset]:
+    try:
+        discovered = discover(
+            component.full_path,
+            source_language=component.source_language.code,
+            hint=component.filemask,
+        )
+        if not discovered:
+            discovered = discover(
+                component.full_path,
+                source_language=component.source_language.code,
+                eager=True,
+                hint=component.filemask,
+            )
+        return get_detected_discovery_presets_from_results(discovered)
+    except Exception:  # pragma: no cover - defensive fallback
+        report_error(
+            "Component discovery preset detection failed",
+            project=component.project,
+        )
+        return []
 
 
 class ComponentDiscovery:

--- a/weblate/trans/tests/test_discovery.py
+++ b/weblate/trans/tests/test_discovery.py
@@ -5,14 +5,26 @@
 import os
 import pathlib
 import tempfile
-from unittest.mock import patch
+from typing import TYPE_CHECKING
+from unittest.mock import call, patch
 
+from django.test import SimpleTestCase
 from django.test.utils import override_settings
+from translation_finder import DiscoveryResult
 
-from weblate.trans.discovery import ComponentDiscovery
+from weblate.trans.discovery import (
+    ComponentDiscovery,
+    build_detected_discovery_preset,
+    get_component_detected_discovery_presets,
+    get_detected_discovery_preset_values_key,
+    get_detected_discovery_presets_from_results,
+)
 from weblate.trans.tasks import create_component
 from weblate.trans.tests.test_models import RepoTestCase
 from weblate.utils.files import remove_tree
+
+if TYPE_CHECKING:
+    from translation_finder.discovery.result import ResultDict
 
 
 class ComponentDiscoveryTest(RepoTestCase):
@@ -438,3 +450,263 @@ class ComponentDiscoveryTest(RepoTestCase):
         self.assertEqual(len(deleted), 0)
         self.assertEqual(len(deleted), 0)
         self.assertEqual(len(skipped), 0)
+
+
+class DetectedDiscoveryPresetTest(SimpleTestCase):
+    @staticmethod
+    def make_discovery_result(
+        *,
+        name: str = "",
+        filemask: str = "",
+        template: str = "",
+        file_format: str = "",
+        intermediate: str = "",
+        new_base: str = "",
+    ) -> DiscoveryResult:
+        data: ResultDict = {}
+        if name:
+            data["name"] = name
+        if filemask:
+            data["filemask"] = filemask
+        if template:
+            data["template"] = template
+        if file_format:
+            data["file_format"] = file_format
+        if intermediate:
+            data["intermediate"] = intermediate
+        if new_base:
+            data["new_base"] = new_base
+
+        result = DiscoveryResult(data)
+        result.meta = {"priority": 1000, "origin": None}
+        return result
+
+    def test_detected_presets_deduplicate_discovery_results(self) -> None:
+        first = self.make_discovery_result(
+            file_format="aresource",
+            filemask="android/values-*/strings.xml",
+            template="android/values/strings.xml",
+        )
+        second = self.make_discovery_result(
+            file_format="aresource",
+            filemask="android-not-synced/values-*/strings.xml",
+            template="android-not-synced/values/strings.xml",
+        )
+
+        presets = get_detected_discovery_presets_from_results(
+            [first, first.copy(), second, second.copy()]
+        )
+
+        self.assertEqual(len(presets), 1)
+        self.assertEqual(
+            presets[0]["values"]["match"],
+            r"(?P<component>[^/]*)/values\-(?P<language>[^/.]*)/strings\.xml",
+        )
+        self.assertEqual(
+            presets[0]["values"]["base_file_template"],
+            "{{ component }}/values/strings.xml",
+        )
+
+    def test_detected_presets_keep_filename_suffix_from_translation_finder_cases(
+        self,
+    ) -> None:
+        first = self.make_discovery_result(
+            file_format="po",
+            filemask="translations/manual/*/regexp.po",
+            new_base="translations/manual/regexp.pot",
+        )
+        second = self.make_discovery_result(
+            file_format="po",
+            filemask="translations/manual/*/regexp_quick_reference.po",
+            new_base="translations/manual/regexp_quick_reference.pot",
+        )
+
+        presets = get_detected_discovery_presets_from_results([first, second])
+
+        self.assertEqual(len(presets), 1)
+        self.assertEqual(
+            presets[0]["values"]["match"],
+            r"translations/manual/(?P<language>[^/.]*)/(?P<component>[^/]*)\.po",
+        )
+        self.assertEqual(
+            presets[0]["values"]["new_base_template"],
+            "translations/manual/{{ component }}.pot",
+        )
+
+    def test_detected_presets_cover_docs_filename_language_example(self) -> None:
+        first = self.make_discovery_result(
+            file_format="markdown",
+            filemask="docs/news_*.md",
+        )
+        second = self.make_discovery_result(
+            file_format="markdown",
+            filemask="docs/guide_*.md",
+        )
+
+        presets = get_detected_discovery_presets_from_results([first, second])
+
+        self.assertEqual(len(presets), 1)
+        self.assertEqual(
+            presets[0]["values"]["match"],
+            r"docs/(?P<component>[^/]*)_(?P<language>[^/.]*)\.md",
+        )
+        self.assertEqual(
+            presets[0]["values"]["name_template"],
+            "{{ component }}",
+        )
+
+    def test_detected_presets_cover_translation_finder_locales_examples(self) -> None:
+        first = self.make_discovery_result(
+            file_format="po",
+            filemask="locales/*/messages.po",
+            new_base="locales/messages.pot",
+        )
+        second = self.make_discovery_result(
+            file_format="po",
+            filemask="locales/*/other.po",
+            new_base="locales/other.pot",
+        )
+
+        presets = get_detected_discovery_presets_from_results([first, second])
+
+        self.assertEqual(len(presets), 1)
+        self.assertEqual(
+            presets[0]["values"]["match"],
+            r"locales/(?P<language>[^/.]*)/(?P<component>[^/]*)\.po",
+        )
+        self.assertEqual(
+            presets[0]["values"]["new_base_template"],
+            "locales/{{ component }}.pot",
+        )
+
+    def test_detected_presets_skip_ambiguous_generic_and_variant_pairs(self) -> None:
+        first = self.make_discovery_result(
+            file_format="csv",
+            filemask="weblate/trans/tests/data/*.csv",
+        )
+        second = self.make_discovery_result(
+            file_format="csv",
+            filemask="weblate/trans/tests/data/*-mono.csv",
+        )
+
+        preset = build_detected_discovery_preset(first, second)
+
+        self.assertIsNone(preset)
+
+    def test_detected_presets_trim_common_word_fragments_to_separators(self) -> None:
+        first = self.make_discovery_result(
+            file_format="po",
+            filemask="weblate/trans/tests/data/*-simple.po",
+            new_base="weblate/trans/tests/data/hello-charset.pot",
+        )
+        second = self.make_discovery_result(
+            file_format="po",
+            filemask="weblate/trans/tests/data/*-three.po",
+            new_base="weblate/trans/tests/data/hello-charset.pot",
+        )
+
+        preset = build_detected_discovery_preset(first, second)
+
+        self.assertIsNotNone(preset)
+        if preset is None:
+            self.fail("Expected a detected preset")
+        self.assertEqual(
+            preset["values"]["match"],
+            r"weblate/trans/tests/data/(?P<language>[^/.]*)\-(?P<component>[^/]*)\.po",
+        )
+
+    def test_detected_presets_skip_dot_suffix_variants_in_same_segment(self) -> None:
+        first = self.make_discovery_result(
+            file_format="ini",
+            filemask="weblate/trans/tests/data/*.ini",
+        )
+        second = self.make_discovery_result(
+            file_format="ini",
+            filemask="weblate/trans/tests/data/*.joomla.ini",
+        )
+
+        preset = build_detected_discovery_preset(first, second)
+
+        self.assertIsNone(preset)
+
+    def test_component_detected_presets_fallback_to_eager_scan(self) -> None:
+        component = self.make_mock_component()
+        discovered = [
+            self.make_discovery_result(
+                file_format="aresource",
+                filemask="android/values-*/strings.xml",
+                template="android/values/strings.xml",
+            ),
+            self.make_discovery_result(
+                file_format="aresource",
+                filemask="android-not-synced/values-*/strings.xml",
+                template="android-not-synced/values/strings.xml",
+            ),
+        ]
+
+        with patch(
+            "weblate.trans.discovery.discover",
+            side_effect=[[], discovered],
+        ) as mocked:
+            presets = get_component_detected_discovery_presets(component)
+
+        self.assertEqual(len(presets), 1)
+        self.assertEqual(presets[0]["values"]["file_format"], "aresource")
+        self.assertEqual(
+            mocked.call_args_list,
+            [
+                call(
+                    component.full_path,
+                    source_language=component.source_language.code,
+                    hint=component.filemask,
+                ),
+                call(
+                    component.full_path,
+                    source_language=component.source_language.code,
+                    eager=True,
+                    hint=component.filemask,
+                ),
+            ],
+        )
+
+    def test_detected_preset_key_matches_builtin_equivalent_po_layout(self) -> None:
+        first = self.make_discovery_result(
+            file_format="po",
+            filemask="*/application.po",
+        )
+        second = self.make_discovery_result(
+            file_format="po",
+            filemask="*/other.po",
+        )
+
+        presets = get_detected_discovery_presets_from_results([first, second])
+
+        self.assertEqual(len(presets), 1)
+        self.assertEqual(
+            get_detected_discovery_preset_values_key(presets[0]["values"]),
+            (
+                r"(?P<language>[^/.]*)/(?P<component>[^/]*)\.po",
+                "po",
+                "{{ component }}",
+                "",
+                "",
+                "",
+                "^[^.]+$",
+            ),
+        )
+
+    @staticmethod
+    def make_mock_component():
+        class MockSourceLanguage:
+            code = "en"
+
+        class MockProject:
+            pass
+
+        class MockComponent:
+            full_path = "mock-component"
+            filemask = "po/*.po"
+            source_language = MockSourceLanguage()
+            project = MockProject()
+
+        return MockComponent()


### PR DESCRIPTION
This makes the discovery add-on easier to configure as users might just need to tweak the presets and not invent them fully.

This is based on aggregating matches from the translation-finder.

Fixes #3967

<img width="1899" height="1089" alt="image" src="https://github.com/user-attachments/assets/3f1525c2-4357-420e-b625-a5c19ae8cac0" />



<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
