### PR TITLE
fix(component): avoid lock errors on settings

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,7 @@ Weblate 5.17.1
 .. rubric:: Bug fixes
 
 * :ref:`check-rst-references` no longer crashes on repeated explicit-link targets.
+* Component updates no longer time out waiting on their own repository lock during validation.
 * :ref:`check-punctuation-spacing` check no longer triggers false positives for placeholders.
 * Client-side popup notifications triggered by JavaScript now use Bootstrap toasts.
 * Dark theme Bootstrap subtle and emphasis colors now use higher-contrast values, improving popup toasts and other semantic UI elements.

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -8397,7 +8397,7 @@ class UnitAPITest(APIBaseTest):
             "weblate.trans.models.translation.Translation.delete_unit",
             side_effect=WeblateLockTimeoutError(
                 "repository locked",
-                lock=SimpleNamespace(scope="repo", origin="test/component"),
+                lock=SimpleNamespace(scope="repository", origin="test/component"),
             ),
         ):
             self.do_request(
@@ -8437,7 +8437,7 @@ class UnitAPITest(APIBaseTest):
             "weblate.trans.models.translation.Translation.delete_unit",
             side_effect=WeblateLockTimeoutError(
                 "component locked",
-                lock=SimpleNamespace(scope="component-update", origin="test/component"),
+                lock=SimpleNamespace(scope="component:update", origin="test/component"),
             ),
         ):
             self.do_request(

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -205,7 +205,7 @@ class NotSourceUnit(APIException):
 class WeblateExceptionHandler(ExceptionHandler):
     def convert_known_exceptions(self, exc: Exception) -> Exception:
         if isinstance(exc, WeblateLockTimeoutError):
-            if exc.lock.scope == "repo":
+            if exc.lock.scope == "repository":
                 return LockedError(
                     code="repository-locked",
                     detail=gettext(
@@ -213,7 +213,7 @@ class WeblateExceptionHandler(ExceptionHandler):
                     )
                     % exc.lock.origin,
                 )
-            if exc.lock.scope == "component-update":
+            if exc.lock.scope == "component:update":
                 return LockedError(
                     code="component-locked",
                     detail=gettext(
@@ -2841,7 +2841,7 @@ class UnitViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelM
         try:
             obj.translation.delete_unit(request, obj)
         except WeblateLockTimeoutError as error:
-            if error.lock.scope == "repo":
+            if error.lock.scope == "repository":
                 raise LockedError(
                     code="repository-locked",
                     detail=DELETE_UNIT_LOCKED_DETAIL,

--- a/weblate/checks/tests/test_models.py
+++ b/weblate/checks/tests/test_models.py
@@ -73,31 +73,31 @@ class CheckModelTestCase(FixtureTestCase):
 
 class BatchCheckMixinTest(SimpleTestCase):
     def test_project_checks_lock_uses_unique_file_name(self) -> None:
-        project = Project(name="Shared", slug="shared")
+        project = Project(pk=1, name="Shared", slug="shared")
 
-        with TemporaryDirectory() as lock_path:
-            project.__dict__["full_path"] = lock_path
-            with patch("weblate.utils.lock.is_redis_cache", return_value=False):
-                project_lock = project.checks_lock
-                component_lock = WeblateLock(
-                    lock_path=lock_path,
-                    scope="component-checks",
-                    key=1,
-                    slug=project.slug,
-                    cache_template="{scope}-lock-{key}",
-                    file_template="{slug}-{scope}-{key}.lock",
-                    timeout=5,
-                    origin=project.full_slug,
-                )
+        with (
+            TemporaryDirectory() as temp_dir,
+            self.settings(DATA_DIR=temp_dir),
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+        ):
+            project_lock = project.checks_lock
+            component_lock = WeblateLock(
+                scope="component:checks",
+                key=1,
+                slug=project.slug,
+                timeout=5,
+                origin=project.full_slug,
+            )
 
         self.assertNotEqual(project_lock._name, component_lock._name)  # noqa: SLF001
+        self.assertEqual(Path(project_lock._name).parent, Path(temp_dir, "locks"))  # noqa: SLF001
         self.assertEqual(
             Path(project_lock._name).name,  # noqa: SLF001
-            "shared-project-checks.lock",
+            "project%3Achecks-1.lock",
         )
         self.assertEqual(
             Path(component_lock._name).name,  # noqa: SLF001
-            "shared-component-checks-1.lock",
+            "component%3Achecks-1.lock",
         )
 
     def test_project_checks_lock_uses_longer_timeout(self) -> None:
@@ -114,26 +114,21 @@ class BatchCheckMixinTest(SimpleTestCase):
 
     def test_component_checks_lock_uses_key_in_file_name(self) -> None:
         with (
-            TemporaryDirectory() as lock_path,
+            TemporaryDirectory() as temp_dir,
+            self.settings(DATA_DIR=temp_dir),
             patch("weblate.utils.lock.is_redis_cache", return_value=False),
         ):
             first_lock = WeblateLock(
-                lock_path=lock_path,
-                scope="component-checks",
+                scope="component:checks",
                 key=1,
                 slug="shared",
-                cache_template="{scope}-lock-{key}",
-                file_template="{slug}-{scope}-{key}.lock",
                 timeout=5,
                 origin="project/shared",
             )
             second_lock = WeblateLock(
-                lock_path=lock_path,
-                scope="component-checks",
+                scope="component:checks",
                 key=2,
                 slug="shared",
-                cache_template="{scope}-lock-{key}",
-                file_template="{slug}-{scope}-{key}.lock",
                 timeout=5,
                 origin="project/shared",
             )
@@ -141,11 +136,11 @@ class BatchCheckMixinTest(SimpleTestCase):
         self.assertNotEqual(first_lock._name, second_lock._name)  # noqa: SLF001
         self.assertEqual(
             Path(first_lock._name).name,  # noqa: SLF001
-            "shared-component-checks-1.lock",
+            "component%3Achecks-1.lock",
         )
         self.assertEqual(
             Path(second_lock._name).name,  # noqa: SLF001
-            "shared-component-checks-2.lock",
+            "component%3Achecks-2.lock",
         )
 
     def test_project_wide_batch_uses_project_lock(self) -> None:

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -161,10 +161,9 @@ def ensure_tesseract_language(lang: str) -> None:
     # Operate with a lock held to avoid concurrent downloads
     with (
         WeblateLock(
-            lock_path=data_dir("home"),
-            scope="screenshots:tesseract-download",
+            scope="screenshots:tesseract:download",
             key=0,
-            slug="screenshots:tesseract-download",
+            slug="screenshots:tesseract:download",
             timeout=600,
         ),
         sentry_sdk.start_span(op="ocr.models"),

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -167,7 +167,7 @@ if TYPE_CHECKING:
     from weblate.trans.models import Project
     from weblate.trans.models.unit import UnitAttributesDict
     from weblate.trans.removal import RemovalBatch
-    from weblate.vcs.base import Repository
+    from weblate.vcs.base import Repository, RepositoryLock
 
 NEW_LANG_CHOICES = (
     # Translators: Action when adding new translation
@@ -1180,14 +1180,19 @@ class Component(  # noqa: PLR0904
 
         Some write paths validate or save through repository-backed operations,
         while background revision updates already lock in repository -> row order.
-        Reuse the same ordering here to avoid deadlocks.
+        Reuse the same ordering here to avoid deadlocks while still validating on a
+        freshly loaded component instance.
         """
         if queryset is None:
             queryset = Component.objects.all()
-        with self.repository.lock, transaction.atomic():
+        repository = self.repository
+        with repository.lock, transaction.atomic():
             locked_component = queryset.get_for_update(pk=self.pk)
             if self.acting_user is not None:
                 locked_component.acting_user = self.acting_user
+            locked_component.__dict__["repository"] = locked_component.build_repository(
+                lock_override=repository.lock
+            )
             yield locked_component
 
     def get_old_component_settings(self) -> OldComponentSettings:
@@ -1217,6 +1222,14 @@ class Component(  # noqa: PLR0904
 
     def refresh_from_db(self, *args, **kwargs) -> None:
         super().refresh_from_db(*args, **kwargs)
+        self.__dict__.pop("full_slug", None)
+        self.invalidate_path_cache()
+        self.drop_repository_cache()
+        self.drop_template_store_cache()
+        self.drop_key_filter_cache()
+        self.drop_file_format_cache()
+        self.__dict__.pop("file_format_flags", None)
+        self._template_check_done = False
         self.old_component_settings = self.get_old_component_settings()
 
     def prepare_seed_from_component(
@@ -1330,12 +1343,9 @@ class Component(  # noqa: PLR0904
     @cached_property
     def lock(self):
         return WeblateLock(
-            lock_path=self.project.full_path,
-            scope="component-update",
+            scope="component:update",
             key=self.pk,
             slug=self.slug,
-            cache_template="{scope}-lock-{key}",
-            file_template="{slug}-{scope}-{key}.lock",
             timeout=5,
             origin=self.full_slug,
         )
@@ -1343,12 +1353,9 @@ class Component(  # noqa: PLR0904
     @cached_property
     def checks_lock(self):
         return WeblateLock(
-            lock_path=self.project.full_path,
-            scope="component-checks",
+            scope="component:checks",
             key=self.pk,
             slug=self.slug,
-            cache_template="{scope}-lock-{key}",
-            file_template="{slug}-{scope}-{key}.lock",
             timeout=5,
             origin=self.full_slug,
         )
@@ -1738,12 +1745,23 @@ class Component(  # noqa: PLR0904
             msg = f"Component using VCS {self.vcs}, but it is not configured"
             raise ImproperlyConfigured(msg) from error
 
+    def build_repository(
+        self, *, lock_override: RepositoryLock | None = None
+    ) -> Repository:
+        if self.linked_component is not None:
+            repository = self.linked_component.repository
+        else:
+            repository = self.repository_class(
+                self.full_path, branch=self.branch, component=self
+            )
+        if lock_override is not None:
+            repository.lock.replace_lock_if_matching(lock_override)
+        return repository
+
     @cached_property
     def repository(self) -> Repository:
         """Get VCS repository object."""
-        if self.linked_component is not None:
-            return self.linked_component.repository
-        return self.repository_class(self.full_path, branch=self.branch, component=self)
+        return self.build_repository()
 
     @perform_on_link
     def get_last_remote_commit(self):
@@ -4508,8 +4526,11 @@ class Component(  # noqa: PLR0904
             del self.__dict__["intermediate_store"]
 
     def drop_repository_cache(self) -> None:
-        if "repository" in self.__dict__:
-            del self.__dict__["repository"]
+        repository = self.__dict__.pop("repository", None)
+        if repository is not None and repository.lock.is_locked:
+            self.__dict__["repository"] = self.build_repository(
+                lock_override=repository.lock
+            )
 
     def drop_addons_cache(self) -> None:
         if "addons_cache" in self.__dict__:

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -400,12 +400,9 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
     @cached_property
     def checks_lock(self):
         return WeblateLock(
-            lock_path=self.full_path,
-            scope="project-checks",
+            scope="project:checks",
             key=self.pk,
             slug=self.slug,
-            cache_template="{scope}-lock-{key}",
-            file_template="{slug}-{scope}.lock",
             timeout=PROJECT_CHECKS_LOCK_TIMEOUT,
             origin=self.full_slug,
         )

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -714,7 +714,7 @@ class EditPoMonoTest(EditTest):
             "weblate.trans.models.translation.Translation.delete_unit",
             side_effect=WeblateLockTimeoutError(
                 "repository locked",
-                lock=SimpleNamespace(scope="repo", origin="test/component"),
+                lock=SimpleNamespace(scope="repository", origin="test/component"),
             ),
         ):
             response = self.client.post(

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
+from filelock import FileLock
 
 from weblate.checks.models import Check
 from weblate.trans.actions import ActionEvents
@@ -282,6 +283,43 @@ class SettingsTest(ViewTestCase):
             events.index(("repo_lock", self.component.pk)),
             events.index(("row_lock", self.component.pk)),
             "Component repository lock should be acquired before the row lock",
+        )
+
+    def test_component_post_reuses_repository_lock_during_validation(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        url = reverse("settings", kwargs=self.kw_component)
+        response = self.client.get(url)
+        data = get_form_data(response.context["form"].initial)
+        data["license"] = "MIT"
+
+        original_clean = Component.clean
+
+        def clean_with_fresh_repository_lock(instance):
+            instance.drop_repository_cache()
+            with instance.repository.lock:
+                return original_clean(instance)
+
+        with (
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+            patch.object(
+                Component,
+                "clean",
+                autospec=True,
+                side_effect=clean_with_fresh_repository_lock,
+            ),
+            patch.object(FileLock, "acquire", autospec=True) as acquire,
+            patch.object(FileLock, "release", autospec=True) as release,
+        ):
+            response = self.client.post(url, data)
+
+        self.assertRedirects(response, url, fetch_redirect_response=False)
+        acquire.assert_called_once()
+        self.assertEqual(
+            sum(
+                call.kwargs.get("force", False) is False
+                for call in release.call_args_list
+            ),
+            1,
         )
 
     def test_linked_component_repository_settings_show_effective_values(self) -> None:

--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -339,6 +339,7 @@ def check_data_writable(
         ]
     dirs: list[Path] = [
         Path(settings.DATA_DIR),
+        data_path("locks"),
         data_path("home"),
         data_path("ssh"),
         data_path("vcs"),

--- a/weblate/utils/backup.py
+++ b/weblate/utils/backup.py
@@ -39,14 +39,11 @@ def ensure_backup_dir():
 
 
 def backup_lock():
-    backup_dir = ensure_backup_dir()
+    ensure_backup_dir()
     return WeblateLock(
-        lock_path=backup_dir,
-        scope="backuplock",
+        scope="backup:run",
         key=0,
         slug="",
-        cache_template="lock:{scope}",
-        file_template=".{scope}",
         timeout=120,
         expiry_timeout=4 * 3600,
     )

--- a/weblate/utils/lock.py
+++ b/weblate/utils/lock.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 import os
 import threading
 from typing import TYPE_CHECKING, cast
+from urllib.parse import quote
 
 import sentry_sdk
 from django.core.cache import cache
 from filelock import FileLock, Timeout
 
 from weblate.utils.cache import is_redis_cache
+from weblate.utils.data import data_dir
 from weblate.utils.errors import add_breadcrumb
 
 if TYPE_CHECKING:
@@ -39,6 +41,7 @@ class WeblateLockNotLockedError(WeblateLockError):
 class WeblateLock:
     """Wrapper around Redis or file based lock."""
 
+    _cache_template = "lock:{scope}:{key}"
     _redis_lock: RedisLock
     _file_lock: FileLock
 
@@ -47,18 +50,17 @@ class WeblateLock:
     def __init__(
         self,
         *,
-        lock_path: str,
+        lock_path: str | None = None,
         scope: str,
         key: int | str,
         slug: str,
-        cache_template: str = "lock:{scope}:{key}",
-        file_template: str = "{slug}-{scope}.lock",
+        file_template: str = "{scope}-{key}.lock",
         timeout: int = 1,
         expiry_timeout: int = 3600,
         origin: str | None = None,
     ) -> None:
         self._timeout = timeout
-        self._lock_path = lock_path
+        self._lock_path = lock_path or data_dir("locks")
         self._scope = scope
         self._key = key
         self._slug = slug
@@ -69,7 +71,7 @@ class WeblateLock:
         self._redis_expiry_timeout = expiry_timeout
         if self._using_redis:
             # Prefer Redis locking as it works distributed
-            self._name = self._format_template(cache_template)
+            self._name = self._format_template(self._cache_template)
             self._redis_lock = cast("RedisCache", cache).lock(
                 key=self._name,
                 blocking=True,
@@ -79,7 +81,10 @@ class WeblateLock:
             )
         else:
             # Fall back to file based locking
-            self._name = os.path.join(lock_path, self._format_template(file_template))
+            os.makedirs(self._lock_path, exist_ok=True)
+            self._name = os.path.join(
+                self._lock_path, self._format_template(file_template, escape=True)
+            )
             self._file_lock = FileLock(
                 self._name,
                 timeout=self._timeout,
@@ -93,12 +98,28 @@ class WeblateLock:
     def origin(self) -> str | None:
         return self._origin
 
-    def _format_template(self, template: str) -> str:
-        return template.format(
-            scope=self._scope,
-            key=self._key,
-            slug=self._slug,
-        )
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def _format_template(self, template: str, *, escape: bool = False) -> str:
+        if escape:
+            values = {
+                "scope": self._escape_file_component(self._scope),
+                "key": self._escape_file_component(self._key),
+                "slug": self._escape_file_component(self._slug),
+            }
+        else:
+            values = {
+                "scope": str(self._scope),
+                "key": str(self._key),
+                "slug": str(self._slug),
+            }
+        return template.format(**values)
+
+    @staticmethod
+    def _escape_file_component(value: int | str) -> str:
+        return quote(str(value), safe="._-")
 
     def get_error_message(self) -> str:
         if self.origin:

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import os
 import time
 from datetime import datetime, timedelta
 from itertools import chain
@@ -28,7 +27,6 @@ from weblate.lang.models import Language
 from weblate.trans.checklists import TranslationChecklistMixin
 from weblate.trans.mixins import BaseURLMixin
 from weblate.trans.util import translation_percent
-from weblate.utils.data import data_dir
 from weblate.utils.lock import WeblateLock
 from weblate.utils.random import get_random_identifier
 from weblate.utils.site import get_site_url
@@ -288,15 +286,10 @@ class BaseStats:
 
     @cached_property
     def lock(self) -> WeblateLock:
-        lock_path = data_dir("cache", "stats-locks")
-        os.makedirs(lock_path, exist_ok=True)
         return WeblateLock(
-            lock_path=lock_path,
-            scope="stats-update",
+            scope="stats:update",
             key=self.cache_key,
             slug=self.cache_key,
-            cache_template="lock:{scope}:{key}",
-            file_template="{slug}.lock",
             timeout=5,
             expiry_timeout=300,
             origin=self.cache_key,

--- a/weblate/utils/tests/test_lock.py
+++ b/weblate/utils/tests/test_lock.py
@@ -1,0 +1,284 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+from filelock import FileLock
+
+from weblate.utils.lock import WeblateLock
+from weblate.vcs.base import Repository, RepositoryLock, get_repository_lock_key
+
+if TYPE_CHECKING:
+    from weblate.trans.models import Component
+
+
+class RepositoryLockTest(SimpleTestCase):
+    def test_default_redis_lock_uses_scope_and_key(self) -> None:
+        redis_lock_factory = MagicMock(return_value=SimpleNamespace())
+
+        with (
+            patch("weblate.utils.lock.is_redis_cache", return_value=True),
+            patch(
+                "weblate.utils.lock.cache",
+                SimpleNamespace(lock=redis_lock_factory),
+            ),
+        ):
+            lock = WeblateLock(
+                scope="vcs:api:throttle",
+                key="github",
+                slug="ignored",
+                timeout=5,
+                origin="project/component",
+            )
+
+        redis_lock_factory.assert_called_once_with(
+            key="lock:vcs:api:throttle:github",
+            blocking=True,
+            timeout=3600,
+            blocking_timeout=5,
+            thread_local=True,
+        )
+        self.assertEqual(lock.name, "lock:vcs:api:throttle:github")
+
+    def test_default_file_lock_uses_locks_dir(self) -> None:
+        with (
+            TemporaryDirectory() as temp_dir,
+            self.settings(DATA_DIR=temp_dir),
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+        ):
+            lock = WeblateLock(
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+
+        self.assertEqual(
+            lock.name, Path(temp_dir, "locks", "repository-1.lock").as_posix()
+        )
+
+    def test_default_file_lock_escapes_scope_and_key(self) -> None:
+        with (
+            TemporaryDirectory() as temp_dir,
+            self.settings(DATA_DIR=temp_dir),
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+        ):
+            lock = WeblateLock(
+                scope="vcs:api:throttle",
+                key="project/main",
+                slug="ignored",
+                timeout=5,
+                origin="project/component",
+            )
+
+        self.assertEqual(
+            lock.name,
+            Path(
+                temp_dir, "locks", "vcs%3Aapi%3Athrottle-project%2Fmain.lock"
+            ).as_posix(),
+        )
+
+    def test_reused_lock_stays_reentrant(self) -> None:
+        with (
+            TemporaryDirectory() as lock_path,
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+            patch.object(FileLock, "acquire", autospec=True) as acquire,
+            patch.object(FileLock, "release", autospec=True) as release,
+        ):
+            first_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+            second_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+            first_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=lambda: None),
+            )
+            second_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=lambda: None),
+            )
+            outer_lock = RepositoryLock(first_repository, first_lock)
+            inner_lock = RepositoryLock(second_repository, second_lock)
+            self.assertTrue(inner_lock.replace_lock_if_matching(outer_lock))
+
+            with outer_lock, inner_lock:
+                self.assertTrue(outer_lock.is_locked)
+                self.assertTrue(inner_lock.is_locked)
+
+        acquire.assert_called_once()
+        self.assertEqual(
+            sum(
+                call.kwargs.get("force", False) is False
+                for call in release.call_args_list
+            ),
+            1,
+        )
+
+    def test_lock_override_is_rejected_for_different_lock_name(self) -> None:
+        with (
+            TemporaryDirectory() as lock_path,
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+        ):
+            first_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+            second_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=2,
+                slug="other-component",
+                timeout=5,
+                origin="project/other-component",
+            )
+            first_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=lambda: None),
+            )
+            second_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=lambda: None),
+            )
+            outer_lock = RepositoryLock(first_repository, first_lock)
+            inner_lock = RepositoryLock(second_repository, second_lock)
+
+        self.assertFalse(inner_lock.replace_lock_if_matching(outer_lock))
+        self.assertIs(inner_lock.lock_object, second_lock)
+
+    def test_reused_lock_preserves_pending_recovery(self) -> None:
+        with (
+            TemporaryDirectory() as lock_path,
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+            patch.object(FileLock, "acquire", autospec=True),
+            patch.object(FileLock, "release", autospec=True),
+        ):
+            first_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+            second_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+            first_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=lambda: None),
+            )
+            second_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=lambda: None),
+            )
+            outer_lock = RepositoryLock(first_repository, first_lock)
+            inner_lock = RepositoryLock(second_repository, second_lock)
+
+            with outer_lock:
+                self.assertTrue(inner_lock.replace_lock_if_matching(outer_lock))
+                self.assertTrue(inner_lock.begin_recovery())
+                inner_lock.finish_recovery()
+
+    def test_component_repository_lock_name_is_stable_across_path_changes(self) -> None:
+        with (
+            TemporaryDirectory() as temp_dir,
+            self.settings(DATA_DIR=temp_dir),
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+        ):
+            Path(temp_dir, "home").mkdir()
+            first_path = Path(temp_dir, "vcs", "project", "component")
+            second_path = Path(temp_dir, "vcs", "renamed-project", "renamed-component")
+            first = Repository(
+                first_path.as_posix(),
+                branch="main",
+                component=cast(
+                    "Component",
+                    SimpleNamespace(pk=1, full_slug="project/component"),
+                ),
+                local=True,
+            )
+            second = Repository(
+                second_path.as_posix(),
+                branch="main",
+                component=cast(
+                    "Component",
+                    SimpleNamespace(pk=1, full_slug="renamed/project/component"),
+                ),
+                local=True,
+            )
+
+        self.assertEqual(first.lock.name, second.lock.name)
+
+    def test_unsaved_component_repository_lock_name_uses_checkout_path(self) -> None:
+        with (
+            TemporaryDirectory() as temp_dir,
+            self.settings(DATA_DIR=temp_dir),
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+        ):
+            Path(temp_dir, "home").mkdir()
+            first_path = Path(temp_dir, "vcs", "project", "component")
+            second_path = Path(temp_dir, "vcs", "other-project", "component")
+            first = Repository(
+                first_path.as_posix(),
+                branch="main",
+                component=cast(
+                    "Component",
+                    SimpleNamespace(pk=None, full_slug="project/component"),
+                ),
+                local=True,
+            )
+            second = Repository(
+                second_path.as_posix(),
+                branch="main",
+                component=cast(
+                    "Component",
+                    SimpleNamespace(pk=None, full_slug="other-project/component"),
+                ),
+                local=True,
+            )
+
+        self.assertEqual(
+            first.lock.name,
+            Path(
+                temp_dir,
+                "locks",
+                f"repository-{get_repository_lock_key(first_path.as_posix(), first.component)}.lock",
+            ).as_posix(),
+        )
+        self.assertEqual(
+            second.lock.name,
+            Path(
+                temp_dir,
+                "locks",
+                f"repository-{get_repository_lock_key(second_path.as_posix(), second.component)}.lock",
+            ).as_posix(),
+        )
+        self.assertNotEqual(first.lock.name, second.lock.name)

--- a/weblate/vcs/apps.py
+++ b/weblate/vcs/apps.py
@@ -119,12 +119,9 @@ class VCSConfig(AppConfig):
         # We need to do this behind lock to avoid errors when servers
         # start in parallel
         lockfile = WeblateLock(
-            lock_path=home,
-            scope="gitlock",
+            scope="vcs:setup",
             key=0,
             slug="",
-            cache_template="lock:{scope}",
-            file_template="{scope}",
             timeout=120,
         )
         with lockfile:

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -56,6 +56,13 @@ def get_config_check_cache_key(component_pk: int) -> str:
     return f"sp-config-check-{wrapper_hash}-{component_pk}"
 
 
+def get_repository_lock_key(base_path: str, component: Component | None) -> int | str:
+    """Build lock key for repository operations."""
+    if component is not None and component.pk is not None:
+        return component.pk
+    return hashlib.sha256(base_path.encode("utf-8")).hexdigest()
+
+
 class SubprocessArgs(TypedDict, total=False):
     stdin: int
     input: str
@@ -70,6 +77,21 @@ class RepositoryLock:
         self._lock = lock
         self._recovery_pending = False
         self._recovering = False
+
+    @property
+    def lock_object(self) -> WeblateLock:
+        return self._lock
+
+    def replace_lock(self, lock: Self) -> None:
+        self._lock = lock._lock
+        self._recovery_pending = lock._recovery_pending
+        self._recovering = lock._recovering
+
+    def replace_lock_if_matching(self, lock: Self) -> bool:
+        if self._lock.name != lock._lock.name:
+            return False
+        self.replace_lock(lock)
+        return True
 
     def __enter__(self) -> None:
         outermost_enter = not self._lock.is_locked
@@ -212,11 +234,9 @@ class Repository:
         self.last_output = ""
         base_path = self.path.rstrip("/").rstrip("\\")
         lock = WeblateLock(
-            lock_path=os.path.dirname(base_path),
-            scope="repo",
-            key=component.pk if component else os.path.basename(base_path),
+            scope="repository",
+            key=get_repository_lock_key(base_path, component),
             slug=os.path.basename(base_path),
-            file_template="{slug}.lock",
             timeout=120,
             origin=component.full_slug if component else base_path,
         )

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -1459,9 +1459,8 @@ class GitMergeRequestBase(GitForcePushRepository):
         self.log(f"HTTP {method} {url}")
         cache_id = self.request_time_cache_key
         lock = WeblateLock(
-            lock_path=data_dir("home"),
-            scope=f"vcs:api:{vcs_id}",
-            key=0,
+            scope="vcs:api:throttle",
+            key=vcs_id,
             slug=vcs_id,
             timeout=3 * max(settings.VCS_API_DELAY, 10),
         )


### PR DESCRIPTION
With the select for update and refresh, the already held lock was discarder and new could not be obtained.

Fixes WEBLATE-39G2

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
