### PR TITLE
docs(api): align param name for category statistics

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3081,8 +3081,8 @@ Categories
 
     Returns statistics for a category.
 
-    :param project: Category ID
-    :type project: int
+    :param id: Category ID
+    :type id: int
 
     .. seealso::
 


### PR DESCRIPTION
Just a tiny copy-paste fix.