### PR TITLE
fix(vcs): harden local zip import path handling

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -42,7 +42,11 @@ from requests.exceptions import HTTPError
 
 from weblate.utils.data import data_dir, data_path
 from weblate.utils.errors import report_error
-from weblate.utils.files import is_excluded, remove_tree
+from weblate.utils.files import (
+    is_excluded,
+    is_path_within_resolved_directory,
+    remove_tree,
+)
 from weblate.utils.lock import WeblateLock, WeblateLockTimeoutError
 from weblate.utils.render import render_template
 from weblate.utils.xml import parse_xml
@@ -2199,8 +2203,21 @@ class LocalRepository(GitRepository):
             cls.build_local_repo(target, "ZIP file uploaded into Weblate") as repo,
             ZipFile(zipfile) as zipobj,
         ):
-            names = [name for name in zipobj.namelist() if not is_excluded(name)]
-            zipobj.extractall(path=target, members=names)
+            resolved_target = Path(target).resolve(strict=False)
+            for info in zipobj.infolist():
+                if is_excluded(info.filename):
+                    continue
+                destination = (resolved_target / info.filename).resolve(strict=False)
+                if not is_path_within_resolved_directory(destination, resolved_target):
+                    msg = gettext("ZIP file contains invalid path: {path}").format(
+                        path=info.filename
+                    )
+                    raise RepositoryError(msg)
+                mode = (info.external_attr >> 16) & 0o170000
+                if mode == 0o120000:
+                    msg = gettext("ZIP file contains unsupported symbolic links.")
+                    raise RepositoryError(msg)
+                zipobj.extract(info, path=target)
             return repo
 
     @classmethod

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -9,12 +9,14 @@ import os.path
 import re
 import shutil
 import tempfile
+from io import BytesIO
 from contextlib import ExitStack
 from os import utime
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NoReturn, Protocol
 from unittest.mock import patch
+from zipfile import ZipFile
 
 import responses
 from django.core.cache import cache
@@ -2888,6 +2890,30 @@ remove the file manually to continue.
             )
         finally:
             shutil.rmtree(tempdir)
+
+    def test_from_zip_rejects_symlink_entry(self) -> None:
+        archive = BytesIO()
+        with ZipFile(archive, "w") as zipfile:
+            zipfile.writestr("symlink", "ignored")
+            info = zipfile.getinfo("symlink")
+            info.external_attr = 0o120777 << 16
+        archive.seek(0)
+        target = os.path.join(self.tempdir, "from-zip-symlink")
+
+        with self.assertRaisesRegex(
+            RepositoryError, "ZIP file contains unsupported symbolic links"
+        ):
+            LocalRepository.from_zip(target, archive)
+
+    def test_from_zip_rejects_path_outside_target(self) -> None:
+        archive = BytesIO()
+        with ZipFile(archive, "w") as zipfile:
+            zipfile.writestr("../../outside.txt", "blocked")
+        archive.seek(0)
+        target = os.path.join(self.tempdir, "from-zip-path")
+
+        with self.assertRaisesRegex(RepositoryError, "ZIP file contains invalid path"):
+            LocalRepository.from_zip(target, archive)
 
 
 @override_settings(

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -9,8 +9,8 @@ import os.path
 import re
 import shutil
 import tempfile
-from io import BytesIO
 from contextlib import ExitStack
+from io import BytesIO
 from os import utime
 from pathlib import Path
 from time import time


### PR DESCRIPTION
### Motivation
- Prevent path traversal and symlink abuse when importing uploaded ZIP archives into local repositories by validating each archive member prior to extraction.

### Description
- Replace bulk `ZipFile.extractall()` with per-entry extraction in `LocalRepository.from_zip()` and import `is_path_within_resolved_directory` from `weblate.utils.files` to verify targets stay within the repository directory.
- Skip existing excluded paths via `is_excluded()` and raise `RepositoryError` when an entry resolves outside the target directory or when a ZIP entry is a symbolic link (detected via `ZipInfo.external_attr`).
- Add regression tests in `weblate/vcs/tests/test_vcs.py` that construct in-memory ZIP archives and assert that symlink entries and `../../` traversal entries are rejected.
- Keep existing exclusion behavior and maintain atomic repo creation via the existing `build_local_repo()` context.

### Testing
- Ran `python -m py_compile weblate/vcs/git.py weblate/vcs/tests/test_vcs.py`, which succeeded.
- Attempted `pytest` for the new tests with `python -m pytest weblate/vcs/tests/test_vcs.py -k 'from_zip_rejects' -q`, but pytest startup failed in this environment due to a missing `gi` module referenced by warning filters (test execution not completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b3766608329915b165cdb17ac47)