### PR TITLE
Validate ZIP extraction in LocalRepository.from_zip to prevent path traversal and symlinks

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -42,7 +42,11 @@ from requests.exceptions import HTTPError
 
 from weblate.utils.data import data_dir, data_path
 from weblate.utils.errors import report_error
-from weblate.utils.files import is_excluded, remove_tree
+from weblate.utils.files import (
+    is_excluded,
+    is_path_within_resolved_directory,
+    remove_tree,
+)
 from weblate.utils.lock import WeblateLock, WeblateLockTimeoutError
 from weblate.utils.render import render_template
 from weblate.utils.xml import parse_xml
@@ -2199,8 +2203,21 @@ class LocalRepository(GitRepository):
             cls.build_local_repo(target, "ZIP file uploaded into Weblate") as repo,
             ZipFile(zipfile) as zipobj,
         ):
-            names = [name for name in zipobj.namelist() if not is_excluded(name)]
-            zipobj.extractall(path=target, members=names)
+            resolved_target = Path(target).resolve(strict=False)
+            for info in zipobj.infolist():
+                destination = (resolved_target / info.filename).resolve(strict=False)
+                if not is_path_within_resolved_directory(destination, resolved_target):
+                    msg = gettext("ZIP file contains invalid path: {path}").format(
+                        path=info.filename
+                    )
+                    raise RepositoryError(1, msg)
+                if is_excluded(info.filename):
+                    continue
+                mode = (info.external_attr >> 16) & 0o170000
+                if mode == 0o120000:
+                    msg = gettext("ZIP file contains unsupported symbolic links.")
+                    raise RepositoryError(1, msg)
+                zipobj.extract(info, path=target)
             return repo
 
     @classmethod

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -9,12 +9,14 @@ import os.path
 import re
 import shutil
 import tempfile
+from io import BytesIO
 from contextlib import ExitStack
 from os import utime
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NoReturn, Protocol
 from unittest.mock import patch
+from zipfile import ZipFile
 
 import responses
 from django.core.cache import cache
@@ -2888,6 +2890,30 @@ remove the file manually to continue.
             )
         finally:
             shutil.rmtree(tempdir)
+
+    def test_from_zip_rejects_symlink_entry(self) -> None:
+        archive = BytesIO()
+        with ZipFile(archive, "w") as zipfile:
+            zipfile.writestr("symlink", "ignored")
+            info = zipfile.getinfo("symlink")
+            info.external_attr = 0o120777 << 16
+        archive.seek(0)
+        target = os.path.join(self.tempdir, "from-zip-symlink")
+
+        with self.assertRaisesRegex(
+            RepositoryError, "ZIP file contains unsupported symbolic links"
+        ):
+            LocalRepository.from_zip(target, archive)
+
+    def test_from_zip_rejects_path_outside_target(self) -> None:
+        archive = BytesIO()
+        with ZipFile(archive, "w") as zipfile:
+            zipfile.writestr("../../outside.txt", "blocked")
+        archive.seek(0)
+        target = os.path.join(self.tempdir, "from-zip-path")
+
+        with self.assertRaisesRegex(RepositoryError, "ZIP file contains invalid path"):
+            LocalRepository.from_zip(target, archive)
 
 
 @override_settings(

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -9,8 +9,8 @@ import os.path
 import re
 import shutil
 import tempfile
-from io import BytesIO
 from contextlib import ExitStack
+from io import BytesIO
 from os import utime
 from pathlib import Path
 from time import time


### PR DESCRIPTION
### Motivation
- Prevent unsafe ZIP contents from being extracted into repository working trees by blocking path traversal and symbolic link entries.

### Description
- Add `is_path_within_resolved_directory` and use `Path.resolve` to ensure each ZIP entry resolves inside the target directory and raise `RepositoryError` for invalid paths.  
- Detect and reject ZIP entries that represent symbolic links by checking `info.external_attr` and raising `RepositoryError` with a clear message.  
- Replace bulk `extractall` with per-entry handling using `ZipFile.infolist()` to apply the above validations and skip excluded files.  
- Adjust imports in `weblate/vcs/git.py` and add unit tests to `weblate/vcs/tests/test_vcs.py` to cover the new validations.

### Testing
- Added `test_from_zip_rejects_symlink_entry` which asserts a `RepositoryError` is raised for symlink entries, and it passed.  
- Added `test_from_zip_rejects_path_outside_target` which asserts a `RepositoryError` is raised for path traversal entries, and it passed.  
- Ran the `weblate.vcs.tests.test_vcs` test class containing the new tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b3766608329915b165cdb17ac47)