### PR TITLE
feat(formats): support plurals round trip in CSV and XLSX

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Weblate 2026.5
 
 .. rubric:: New features
 
+* :ref:`CSV <csv>` and :ref:`XLSX <xlsx>` downloads in :ref:`download` now export plural strings as separate plural-form rows that can be imported back.
+
 .. rubric:: Improvements
 
 .. rubric:: Bug fixes

--- a/weblate/formats/auto.py
+++ b/weblate/formats/auto.py
@@ -16,13 +16,14 @@ from translate.storage.base import TranslationUnit as TranslateToolkitUnit
 
 from weblate.formats.helpers import NamedBytesIO
 from weblate.formats.models import FILE_FORMATS
-from weblate.formats.ttkit import BaseTTKitFormat, TTKitUnit
+from weblate.formats.ttkit import BaseTTKitFormat, CSVMetadataError, TTKitUnit
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator, Iterable
 
     from weblate.formats.base import TranslationFormat
     from weblate.trans.file_format_params import FileFormatParams
+    from weblate.trans.models import Unit
 
 
 def detect_filename(filename: str) -> type[TranslationFormat] | None:
@@ -86,13 +87,23 @@ def try_load(
     content: bytes,
     original_format: type[TranslationFormat] | None,
     template_store: TranslationFormat | None,
+    *,
     language_code: str | None = None,
     source_language: str | None = None,
     is_template: bool = False,
+    existing_units: Callable[[], Iterable[Unit]] | Iterable[Unit] | None = None,
     file_format_params: FileFormatParams | None = None,
 ) -> TranslationFormat:
     """Try to load file by guessing type."""
     failure = None
+
+    def get_existing_units() -> Iterable[Unit] | None:
+        if existing_units is None:
+            return None
+        if callable(existing_units):
+            return existing_units()
+        return existing_units
+
     for file_format in formats_iter(filename, original_format):
         for kwargs, validate in params_iter(file_format, template_store, is_template):
             handle = NamedBytesIO(filename, content)
@@ -103,10 +114,15 @@ def try_load(
                     source_language=language_code
                     if kwargs.get("is_template", False)
                     else source_language,
+                    existing_units=get_existing_units()
+                    if file_format.needs_existing_units
+                    else None,
                     file_format_params=file_format_params,
                     **kwargs,
                 )
                 result.check_valid()
+            except CSVMetadataError:
+                raise
             except Exception as error:
                 if failure is None:
                     failure = error

--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -406,6 +406,7 @@ class TranslationFormat[S: InnerStore, U: InnerUnit, T: TranslationUnit]:
     can_edit_base: bool = True
     strict_format_plurals: bool = False
     plural_preference: tuple[int, ...] | None = None
+    needs_existing_units: ClassVar[bool] = False
     store: S
 
     @classmethod
@@ -419,7 +420,7 @@ class TranslationFormat[S: InnerStore, U: InnerUnit, T: TranslationUnit]:
         language_code: str | None = None,
         source_language: str | None = None,
         is_template: bool = False,
-        existing_units: list[Unit] | None = None,
+        existing_units: Iterable[Unit] | None = None,
         file_format_params: FileFormatParams | None = None,
         repo_temp_dir: str | Path | None = None,
     ) -> None:
@@ -1127,6 +1128,10 @@ class BaseExporter:
 
     def add_unit(self, unit: Unit) -> None:
         output = self.build_unit(unit)
+        self.store_unit_metadata(output, unit)
+        self.storage.addunit(output)
+
+    def store_unit_metadata(self, output, unit: Unit) -> None:
         # Location needs to be set prior to ID to avoid overwrite
         # on some formats (for example xliff)
         for location in self.string_filter(unit.location).split(","):
@@ -1172,8 +1177,6 @@ class BaseExporter:
 
         # Store fuzzy flag
         self.store_unit_state(output, unit)
-
-        self.storage.addunit(output)
 
     def store_unit_state(self, output, unit) -> None:
         if unit.fuzzy:

--- a/weblate/formats/convert.py
+++ b/weblate/formats/convert.py
@@ -119,6 +119,7 @@ class ConvertFormat[S: TranslationStore, U: TranslateToolkitUnit, T: TTKitUnit](
     can_delete_unit = False
     can_edit_base: bool = False
     unit_class: type[TranslationUnit] = ConvertPoUnit  # type: ignore[assignment]
+    needs_existing_units = True
     autoaddon: ClassVar[dict[str, dict[str, Any]]] = {
         "weblate.flags.same_edit": {},
         "weblate.cleanup.generic": {},

--- a/weblate/formats/exporters.py
+++ b/weblate/formats/exporters.py
@@ -14,7 +14,6 @@ from django.utils.translation import gettext_lazy
 from lxml.etree import XMLSyntaxError
 from translate.misc.multistring import multistring
 from translate.storage.aresource import AndroidResourceFile
-from translate.storage.csvl10n import csvfile
 from translate.storage.jsonl10n import JsonFile, JsonNestedFile
 from translate.storage.mo import mofile
 from translate.storage.poxliff import PoXliffFile
@@ -26,6 +25,15 @@ from translate.storage.xliff import xlifffile
 
 import weblate.utils.version
 from weblate.formats.external import XlsxFormat
+from weblate.formats.helpers import (
+    CSV_ID_HASH,
+    CSV_PLURAL_FIELDNAMES,
+    CSV_SOURCE_PLURAL_FORM,
+    CSV_TARGET_PLURAL_FORM,
+    format_csv_id_hash,
+)
+from weblate.formats.ttkit import WeblateCSVFile
+from weblate.lang.models import PluralMapper
 from weblate.trans.util import split_plural, xliff_string_to_rich
 from weblate.utils.csv import PROHIBITED_INITIAL_CHARS
 
@@ -224,7 +232,7 @@ class MoExporter(PoExporter):
 
 
 class CVSBaseExporter(BaseExporter):
-    storage_class = csvfile
+    storage_class = WeblateCSVFile
 
     def get_storage(self):
         storage = self.storage_class(fieldnames=self.fieldnames)
@@ -235,7 +243,55 @@ class CVSBaseExporter(BaseExporter):
         return storage
 
 
-class CSVExporter(CVSBaseExporter):
+class PluralCSVExportMixin(BaseExporter):
+    def add_unit(self, unit) -> None:
+        if unit.is_plural and not unit.translation.component.is_multivalue:
+            self.add_plural_unit(unit)
+            return
+        super().add_unit(unit)
+
+    def add_plural_fieldnames(self) -> None:
+        for field in CSV_PLURAL_FIELDNAMES:
+            if field not in self.storage.fieldnames:
+                self.storage.fieldnames.append(field)
+
+    def get_source_plural_index(
+        self, unit, target_index: int, sources: list[str]
+    ) -> int:
+        if not sources:
+            return 0
+
+        source_plural = unit.translation.component.source_language.plural
+        target_plural = unit.translation.plural
+        if len(sources) == source_plural.number and target_index < target_plural.number:
+            mapper = PluralMapper(source_plural, target_plural)
+            if mapper.same_plurals and target_index < len(sources):
+                return target_index
+            if target_plural.number == 1:
+                return len(sources) - 1
+            source_index = mapper.target_map[target_index][0]
+            if source_index is not None and 0 <= source_index < len(sources):
+                return source_index
+            return len(sources) - 1
+
+        return min(target_index, len(sources) - 1)
+
+    def add_plural_unit(self, unit) -> None:
+        self.add_plural_fieldnames()
+        sources = unit.get_source_plurals()
+
+        for target_index, target in enumerate(unit.get_target_plurals()):
+            source_index = self.get_source_plural_index(unit, target_index, sources)
+            output = self.create_unit(self.string_filter(sources[source_index]))
+            self.add(output, self.string_filter(target))
+            setattr(output, CSV_SOURCE_PLURAL_FORM, str(source_index))
+            setattr(output, CSV_TARGET_PLURAL_FORM, str(target_index))
+            setattr(output, CSV_ID_HASH, format_csv_id_hash(unit.id_hash))
+            self.store_unit_metadata(output, unit)
+            self.storage.addunit(output)
+
+
+class CSVExporter(PluralCSVExportMixin, CVSBaseExporter):
     name = "csv"
     content_type = "text/csv"
     extension = "csv"
@@ -326,7 +382,7 @@ class MultiCSVExporter(CVSBaseExporter):
                 self.add_unit(unit)
 
 
-class XlsxExporter(XMLFilterMixin, CVSBaseExporter):
+class XlsxExporter(PluralCSVExportMixin, XMLFilterMixin, CVSBaseExporter):
     name = "xlsx"
     content_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     extension = "xlsx"

--- a/weblate/formats/helpers.py
+++ b/weblate/formats/helpers.py
@@ -4,6 +4,8 @@
 
 from io import BytesIO
 
+from weblate.utils.hash import hash_to_checksum
+
 CONTROLCHARS = {
     "\x00",
     "\x01",
@@ -38,6 +40,20 @@ CONTROLCHARS = {
     "\uffff",
 }
 CONTROLCHARS_TRANS = str.maketrans(dict.fromkeys(CONTROLCHARS))
+
+CSV_SOURCE_PLURAL_FORM = "source_plural_form"
+CSV_TARGET_PLURAL_FORM = "target_plural_form"
+CSV_ID_HASH = "id_hash"
+CSV_ID_HASH_PREFIX = "0x"
+CSV_PLURAL_FIELDNAMES = (
+    CSV_SOURCE_PLURAL_FORM,
+    CSV_TARGET_PLURAL_FORM,
+    CSV_ID_HASH,
+)
+
+
+def format_csv_id_hash(id_hash: int) -> str:
+    return f"{CSV_ID_HASH_PREFIX}{hash_to_checksum(id_hash)}"
 
 
 class NamedBytesIO(BytesIO):

--- a/weblate/formats/tests/test_exporters.py
+++ b/weblate/formats/tests/test_exporters.py
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import csv
 import os
 import shutil
 import subprocess  # noqa: S404
 import tempfile
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,7 +31,11 @@ from weblate.formats.exporters import (
     XliffExporter,
     XlsxExporter,
 )
-from weblate.formats.helpers import NamedBytesIO
+from weblate.formats.helpers import (
+    CSV_PLURAL_FIELDNAMES,
+    NamedBytesIO,
+    format_csv_id_hash,
+)
 from weblate.formats.multi import MultiCSVFormat
 from weblate.lang.models import Language, Plural
 from weblate.trans.models import (
@@ -81,6 +87,7 @@ class PoExporterTest(BaseTestCase):
         nplurals=3,
         template=None,
         source_info=None,
+        file_format="xliff",
         file_format_params=None,
         **kwargs,
     ):
@@ -91,7 +98,7 @@ class PoExporterTest(BaseTestCase):
         component = Component(
             slug="comp",
             project=project,
-            file_format="xliff",
+            file_format=file_format,
             file_format_params=file_format_params or {},
             template=template,
             source_language=Language.objects.get(code="en"),
@@ -329,6 +336,43 @@ class CSVExporterTest(PoExporterTest):
         # Doesn't support plurals
         pass
 
+    def test_plural_rows(self) -> None:
+        output = self.check_unit(
+            source="%(count)s file\x1e\x1e%(count)s files",
+            target="\x1e\x1e%(count)s soubory\x1e\x1e%(count)s souborů",
+            state=STATE_TRANSLATED,
+        ).decode()
+
+        self.assertNotIn("multistring", output)
+        self.assertNotIn("\x1e", output)
+
+        rows = list(csv.DictReader(StringIO(output)))
+        self.assertEqual(len(rows), 3)
+        self.assertEqual([row["target_plural_form"] for row in rows], ["0", "1", "2"])
+        self.assertEqual(
+            [row["target"] for row in rows],
+            ["", "'%(count)s soubory'", "'%(count)s souborů'"],
+        )
+        self.assertEqual(
+            [row["id_hash"] for row in rows],
+            [format_csv_id_hash(-1)] * 3,
+        )
+
+    def test_multivalue_units_are_not_exported_as_plural_rows(self) -> None:
+        output = self.check_unit(
+            nplurals=1,
+            file_format="csv-multi",
+            source="Source A\x1e\x1eSource B",
+            target="Target A\x1e\x1eTarget B",
+            state=STATE_TRANSLATED,
+        ).decode()
+
+        rows = list(csv.DictReader(StringIO(output)))
+        self.assertEqual(len(rows), 1)
+        for field in CSV_PLURAL_FIELDNAMES:
+            self.assertNotIn(field, rows[0])
+        self.assertIn("Target A", rows[0]["target"])
+
     def test_non_matching_encoding_params(self) -> None:
         exporter = self.get_exporter(
             translation=Translation(
@@ -365,6 +409,61 @@ class XlsxExporterTest(PoExporterTest):
     def check_plurals(self, result) -> None:
         # Doesn't support plurals
         pass
+
+    def test_plural_rows(self) -> None:
+        from openpyxl import load_workbook  # noqa: PLC0415
+
+        output = self.check_unit(
+            source="%(count)s file\x1e\x1e%(count)s files",
+            target="\x1e\x1e%(count)s soubory\x1e\x1e%(count)s souborů",
+            state=STATE_TRANSLATED,
+        )
+
+        workbook = load_workbook(BytesIO(output))
+        worksheet = workbook.active
+        if worksheet is None:
+            msg = "Workbook has no active worksheet."
+            raise AssertionError(msg)
+        rows = list(worksheet.iter_rows(values_only=True))
+        headers = rows[0]
+        data = [dict(zip(headers, row, strict=True)) for row in rows[1:]]
+
+        self.assertEqual(len(data), 3)
+        self.assertEqual([row["target_plural_form"] for row in data], ["0", "1", "2"])
+        self.assertEqual(data[0]["target"], None)
+        self.assertEqual(
+            [row["id_hash"] for row in data],
+            [format_csv_id_hash(-1)] * 3,
+        )
+
+    def test_multivalue_units_are_not_exported_as_plural_rows(self) -> None:
+        from openpyxl import load_workbook  # noqa: PLC0415
+
+        output = self.check_unit(
+            nplurals=1,
+            file_format="csv-multi",
+            source="Source A\x1e\x1eSource B",
+            target="Target A\x1e\x1eTarget B",
+            state=STATE_TRANSLATED,
+        )
+
+        workbook = load_workbook(BytesIO(output))
+        worksheet = workbook.active
+        if worksheet is None:
+            msg = "Workbook has no active worksheet."
+            raise AssertionError(msg)
+        rows = list(worksheet.iter_rows(values_only=True))
+        headers = rows[0]
+        data = [dict(zip(headers, row, strict=True)) for row in rows[1:]]
+
+        self.assertEqual(len(data), 1)
+        for field in CSV_PLURAL_FIELDNAMES:
+            self.assertNotIn(field, data[0])
+        target = data[0]["target"]
+        if not isinstance(target, str):
+            msg = f"Unexpected target cell value: {target!r}"
+            raise TypeError(msg)
+        self.assertIn("Target A", target)
 
 
 class AndroidResourceExporterTest(PoExporterTest):

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -26,6 +26,7 @@ from translate.storage.pypo import pofile
 from weblate.checks.flags import Flags
 from weblate.formats.auto import AutodetectFormat, detect_filename, try_load
 from weblate.formats.base import BilingualUpdateMixin, TranslationFormat, UpdateError
+from weblate.formats.helpers import NamedBytesIO, format_csv_id_hash
 from weblate.formats.models import FILE_FORMATS
 from weblate.formats.multi import MultiUnit
 from weblate.formats.ttkit import (
@@ -84,9 +85,12 @@ from weblate.utils.files import REPO_TEMP_DIRNAME
 from weblate.utils.state import STATE_APPROVED, STATE_FUZZY, STATE_TRANSLATED
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from lxml.etree import _Element
 
     from weblate.trans.file_format_params import FileFormatParams
+    from weblate.trans.models import Unit
 
 
 class DummyBilingualUpdate(BilingualUpdateMixin):
@@ -372,6 +376,11 @@ class HierarchicalContextValidationTest(SimpleTestCase):
 
 
 class AutoLoadTest(SimpleTestCase):
+    @staticmethod
+    def get_existing_units_probe() -> Iterable[Unit]:
+        msg = "existing units should not be loaded"
+        raise AssertionError(msg)
+
     def single_test(self, filename, fileclass) -> None:
         store = try_load(
             filename,
@@ -382,6 +391,28 @@ class AutoLoadTest(SimpleTestCase):
         )
         self.assertIsInstance(store, fileclass)
         self.assertEqual(fileclass, detect_filename(filename))
+
+    def test_existing_units_not_loaded_for_po(self) -> None:
+        store = try_load(
+            TEST_PO,
+            Path(TEST_PO).read_bytes(),
+            PoFormat,
+            None,
+            existing_units=self.get_existing_units_probe,
+        )
+
+        self.assertIsInstance(store, PoFormat)
+
+    def test_existing_units_not_loaded_for_csv(self) -> None:
+        store = try_load(
+            TEST_CSV,
+            Path(TEST_CSV).read_bytes(),
+            CSVFormat,
+            None,
+            existing_units=self.get_existing_units_probe,
+        )
+
+        self.assertIsInstance(store, CSVFormat)
 
     def test_detect_android(self) -> None:
         self.assertEqual(AndroidFormat, detect_filename("foo/bar/strings_baz.xml"))
@@ -1881,6 +1912,339 @@ class CSVFormatTest(BaseFormatTest):
     FIND_MATCH = "Hello, world!\r\n"
     NEW_UNIT_MATCH = b'"Source string",""\r\n'
     EXPECTED_FLAGS: ClassVar[str | list[str]] = ""
+
+    def test_plural_metadata_rows(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","context","source_plural_form",'
+                b'"target_plural_form","id_hash"\n'
+                b'"%(count)s file","","ctx","0","0","0x7fffffffffffff85"\n'
+                b'"%(count)s files","%(count)s soubory","ctx","1","1",'
+                b'"0x7fffffffffffff85"\n'
+                b'"%(count)s files","%(count)s souboru","ctx","1","2",'
+                b'"0x7fffffffffffff85"\n',
+            )
+        )
+
+        units = storage.content_units
+        self.assertEqual(len(units), 1)
+        self.assertEqual(
+            units[0].source,
+            "%(count)s file\x1e\x1e%(count)s files",
+        )
+        self.assertEqual(
+            units[0].target,
+            "\x1e\x1e%(count)s soubory\x1e\x1e%(count)s souboru",
+        )
+        self.assertEqual(units[0].context, "ctx")
+        self.assertEqual(units[0].import_id_hash, -123)
+        self.assertEqual(units[0].target_plural_forms, (0, 1, 2))
+
+        units[0].set_target(["jeden soubor", "%(count)s soubory", "%(count)s souboru"])
+        units[0].set_state(STATE_FUZZY)
+        self.assertEqual(
+            [row.target for row in storage.store.units],
+            ["jeden soubor", "%(count)s soubory", "%(count)s souboru"],
+        )
+        self.assertTrue(all(row.isfuzzy() for row in storage.store.units))
+
+        storage.delete_unit(units[0].unit)
+        self.assertEqual(storage.store.units, [])
+
+    def test_plural_metadata_rows_with_template_store(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        template_store = self.format_class(
+            NamedBytesIO(
+                "template.csv",
+                b'"source","target","context"\n'
+                b'"","%(count)s file\x1e\x1e%(count)s files","ctx"\n',
+            ),
+            is_template=True,
+        )
+        import_id_hash = template_store.template_units[0].id_hash
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                (
+                    '"source","target","context","source_plural_form",'
+                    '"target_plural_form","id_hash"\n'
+                    f'"%(count)s file","","ctx","0","0",'
+                    f'"{format_csv_id_hash(import_id_hash)}"\n'
+                    f'"%(count)s files","%(count)s soubory","ctx","1","1",'
+                    f'"{format_csv_id_hash(import_id_hash)}"\n'
+                    f'"%(count)s files","%(count)s souboru","ctx","1","2",'
+                    f'"{format_csv_id_hash(import_id_hash)}"\n'
+                ).encode(),
+            ),
+            template_store=template_store,
+        )
+
+        units = storage.content_units
+        self.assertEqual(len(units), 1)
+        self.assertEqual(
+            units[0].source,
+            "%(count)s file\x1e\x1e%(count)s files",
+        )
+        self.assertEqual(
+            units[0].target,
+            "\x1e\x1e%(count)s soubory\x1e\x1e%(count)s souboru",
+        )
+        self.assertEqual(units[0].context, "ctx")
+        self.assertEqual(units[0].import_id_hash, import_id_hash)
+        self.assertEqual(units[0].target_plural_forms, (0, 1, 2))
+
+        units[0].set_target(["jeden soubor", "%(count)s soubory", "%(count)s souboru"])
+        units[0].set_state(STATE_FUZZY)
+        self.assertEqual(
+            [row.target for row in storage.store.units],
+            ["jeden soubor", "%(count)s soubory", "%(count)s souboru"],
+        )
+        self.assertTrue(all(row.isfuzzy() for row in storage.store.units))
+
+    def test_plural_metadata_missing_template_rows_are_materialized(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        source = "%(count)s file\x1e\x1e%(count)s files"
+        import_id_hash = self.format_class.unit_class.calculate_id_hash(
+            True, source, "ctx"
+        )
+        template_store = self.format_class(
+            NamedBytesIO(
+                "template.csv",
+                (
+                    '"source","target","context","source_plural_form",'
+                    '"target_plural_form","id_hash"\n'
+                    f'"%(count)s file","%(count)s file","ctx","0","0",'
+                    f'"{format_csv_id_hash(import_id_hash)}"\n'
+                    f'"%(count)s files","%(count)s files","ctx","1","1",'
+                    f'"{format_csv_id_hash(import_id_hash)}"\n'
+                    f'"%(count)s files","%(count)s files","ctx","1","2",'
+                    f'"{format_csv_id_hash(import_id_hash)}"\n'
+                ).encode(),
+            ),
+            is_template=True,
+        )
+        storage = self.format_class(
+            NamedBytesIO(
+                "target.csv",
+                b'"source","target","context","source_plural_form",'
+                b'"target_plural_form","id_hash"\n',
+            ),
+            template_store=template_store,
+        )
+
+        unit, add = storage.find_unit("ctx", source)
+        self.assertTrue(add)
+        storage.add_unit(unit)
+        unit.set_target(["jeden soubor", "%(count)s soubory", "%(count)s souboru"])
+
+        self.assertEqual(len(storage.store.units), 3)
+        self.assertEqual(
+            [row.target for row in storage.store.units],
+            ["jeden soubor", "%(count)s soubory", "%(count)s souboru"],
+        )
+        self.assertEqual(
+            [row.target_plural_form for row in storage.store.units],
+            ["0", "1", "2"],
+        )
+        self.assertEqual(
+            [row.id_hash for row in storage.store.units],
+            [format_csv_id_hash(import_id_hash)] * 3,
+        )
+        self.assertTrue(
+            all(
+                any(stored is row for stored in storage.store.units)
+                for row in unit.unit.plural_rows
+            )
+        )
+
+    def test_plural_metadata_rows_without_id_hash_is_rejected(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","context","source_plural_form",'
+                b'"target_plural_form","id_hash"\n'
+                b'"%(count)s file","","ctx","0","0",""\n'
+                b'"%(count)s files","%(count)s soubory","ctx","1","1",""\n'
+                b'"%(count)s files","%(count)s souboru","ctx","1","2",""\n',
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires id_hash"):
+            _ = storage.content_units
+
+    def test_plural_metadata_decimal_id_hash_is_rejected(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","source_plural_form","target_plural_form",'
+                b'"id_hash"\n'
+                b'"%(count)s file","%(count)s soubor","0","0","-123"\n',
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "Invalid id_hash metadata"):
+            _ = storage.content_units
+
+    def test_check_valid_validates_plural_metadata(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","source_plural_form","target_plural_form",'
+                b'"id_hash"\n'
+                b'"%(count)s file","%(count)s soubor","0","0",""\n',
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires id_hash"):
+            storage.check_valid()
+
+    def test_non_plural_id_hash_column_is_not_metadata(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "id-hash.csv",
+                b'"source","target","id_hash"\n'
+                b'"External source","Imported target","external-id"\n',
+            )
+        )
+
+        units = storage.content_units
+        self.assertEqual(len(units), 1)
+        self.assertIsNone(units[0].import_id_hash)
+
+    def test_blank_plural_metadata_target_is_untranslated(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","source_plural_form","target_plural_form",'
+                b'"id_hash"\n'
+                b'"%(count)s file","","0","0","0x7fffffffffffff85"\n'
+                b'"%(count)s files","","1","1","0x7fffffffffffff85"\n',
+            )
+        )
+
+        units = storage.content_units
+        self.assertEqual(len(units), 1)
+        self.assertEqual(units[0].target, "")
+        self.assertFalse(units[0].is_translated())
+
+    def test_plural_metadata_missing_target_form_is_rejected(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","source_plural_form","target_plural_form",'
+                b'"id_hash"\n'
+                b'"%(count)s files","%(count)s soubory","1","1",'
+                b'"0x7fffffffffffff85"\n',
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing form 0"):
+            _ = storage.content_units
+
+    def test_source_plural_metadata_requires_target_form(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","source_plural_form","id_hash"\n'
+                b'"%(count)s files","%(count)s soubor","1","0x7fffffffffffff85"\n',
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires target_plural_form"):
+            _ = storage.content_units
+
+    def test_target_plural_metadata_requires_source_form(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","target_plural_form","id_hash"\n'
+                b'"%(count)s files","%(count)s soubor","0","0x7fffffffffffff85"\n',
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires source_plural_form"):
+            _ = storage.content_units
+
+    def test_plural_metadata_conflicting_source_form(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        storage = self.format_class(
+            NamedBytesIO(
+                "plural.csv",
+                b'"source","target","context","source_plural_form",'
+                b'"target_plural_form","id_hash"\n'
+                b'"%(count)s file","%(count)s soubor","ctx","0","0",'
+                b'"0x7fffffffffffff85"\n'
+                b'"%(count)s files","%(count)s soubory","ctx","0","1",'
+                b'"0x7fffffffffffff85"\n',
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "Conflicting source plural form"):
+            _ = storage.content_units
+
+    def test_plural_metadata_index_limit(self) -> None:
+        if self.format_class is not CSVFormat:
+            self.skipTest("Only full CSV preserves plural metadata fields")
+
+        for field, metadata in (
+            (
+                b"source_plural_form",
+                (
+                    b'"source","target","source_plural_form","target_plural_form",'
+                    b'"id_hash"\n'
+                    b'"%(count)s files","%(count)s soubory","1000000","0",'
+                    b'"0x7fffffffffffff85"\n'
+                ),
+            ),
+            (
+                b"target_plural_form",
+                (
+                    b'"source","target","target_plural_form","id_hash"\n'
+                    b'"%(count)s files","%(count)s soubory","1000000",'
+                    b'"0x7fffffffffffff85"\n'
+                ),
+            ),
+        ):
+            with (
+                self.subTest(field=field),
+                self.assertRaisesRegex(ValueError, "out of range"),
+            ):
+                storage = self.format_class(NamedBytesIO("plural.csv", metadata))
+                _ = storage.content_units
 
 
 class CSVFormatNoHeadTest(CSVFormatTest):

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -16,7 +16,7 @@ import subprocess  # noqa: S404
 from copy import copy
 from io import StringIO
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, ClassVar, cast
+from typing import IO, TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
@@ -29,7 +29,7 @@ from translate.misc.xml_helpers import setXMLspace
 from translate.storage.applestrings_xliff import AppleStringsXliffFile
 from translate.storage.base import TranslationStore
 from translate.storage.catkeys import CatkeysFile, CatkeysUnit
-from translate.storage.csvl10n import csvunit
+from translate.storage.csvl10n import csvfile, csvunit
 from translate.storage.jsonl10n import (
     ARBJsonFile,
     BaseJsonUnit,
@@ -64,17 +64,27 @@ from weblate.formats.base import (
     TranslationUnit,
     UpdateError,
 )
+from weblate.formats.helpers import (
+    CSV_ID_HASH,
+    CSV_ID_HASH_PREFIX,
+    CSV_PLURAL_FIELDNAMES,
+    CSV_SOURCE_PLURAL_FORM,
+    CSV_TARGET_PLURAL_FORM,
+    format_csv_id_hash,
+)
 from weblate.lang.data import FORMULA_WITH_ZERO, ZERO_PLURAL_TYPES
 from weblate.lang.models import Plural
 from weblate.trans.file_format_params import get_encoding_param
 from weblate.trans.util import (
     get_string,
+    join_plural,
     rich_to_xliff_string,
     xliff_string_to_rich,
 )
 from weblate.utils.commands import get_clean_env
 from weblate.utils.errors import report_error
 from weblate.utils.files import cleanup_error_message
+from weblate.utils.hash import checksum_to_hash
 from weblate.utils.state import (
     FUZZY_STATES,
     STATE_APPROVED,
@@ -89,7 +99,6 @@ if TYPE_CHECKING:
 
     from translate.storage.aresource import AndroidResourceUnit
     from translate.storage.base import TranslationUnit as TranslateToolkitUnit
-    from translate.storage.csvl10n import csvfile
     from translate.storage.ini import inifile, iniunit
     from translate.storage.php import phpfile, phpunit
     from translate.storage.placeables import StringElem
@@ -98,10 +107,115 @@ if TYPE_CHECKING:
     from weblate.checks.flags import Flags
     from weblate.lang.models import Language
     from weblate.trans.file_format_params import FileFormatParams
+    from weblate.trans.models import Unit
 
 LOCATIONS_RE = re.compile(r"^([+-]|.*, [+-]|.*:[+-])")
 PO_DOCSTRING_LOCATION = re.compile(r":docstring of [a-zA-Z0-9._]+:[0-9]+")
 XLIFF_FUZZY_STATES = {"new", "needs-translation", "needs-adaptation", "needs-l10n"}
+_CSV_MAX_PLURAL_FORMS = 100
+
+
+class CSVMetadataError(ValueError):
+    """Invalid Weblate CSV metadata."""
+
+
+def _parse_csv_int_metadata(
+    source: WeblateCSVUnit,
+    field_name: str,
+    *,
+    allow_negative: bool = False,
+    max_value: int | None = None,
+) -> int | None:
+    value = getattr(source, field_name, "")
+    if value is None:
+        return None
+    if isinstance(value, str) and not value:
+        return None
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as error:
+        raise CSVMetadataError(
+            gettext("Invalid plural form metadata in CSV file: %s") % value
+        ) from error
+    if result < 0 and not allow_negative:
+        raise CSVMetadataError(
+            gettext("Invalid plural form metadata in CSV file: %s") % value
+        )
+    if max_value is not None and result >= max_value:
+        raise CSVMetadataError(
+            gettext(
+                "Plural form metadata in CSV file is out of range: "
+                "%(value)s (maximum: %(maximum)s)"
+            )
+            % {"value": value, "maximum": max_value - 1}
+        )
+    return result
+
+
+def _has_csv_plural_metadata(source: WeblateCSVUnit) -> bool:
+    for field in (CSV_SOURCE_PLURAL_FORM, CSV_TARGET_PLURAL_FORM):
+        value = getattr(source, field, None)
+        if value is None:
+            continue
+        if isinstance(value, str) and not value:
+            continue
+        return True
+    return False
+
+
+def _parse_csv_id_hash_metadata(source: WeblateCSVUnit) -> int | None:
+    value = getattr(source, CSV_ID_HASH, "")
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise CSVMetadataError(
+            gettext("Invalid id_hash metadata in CSV file: %s") % value
+        )
+    if not value:
+        return None
+    if not value.lower().startswith(CSV_ID_HASH_PREFIX):
+        raise CSVMetadataError(
+            gettext("Invalid id_hash metadata in CSV file: %s") % value
+        )
+    checksum = value[len(CSV_ID_HASH_PREFIX) :]
+    if len(checksum) != 16:
+        raise CSVMetadataError(
+            gettext("Invalid id_hash metadata in CSV file: %s") % value
+        )
+    try:
+        return checksum_to_hash(checksum)
+    except ValueError as error:
+        raise CSVMetadataError(
+            gettext("Invalid id_hash metadata in CSV file: %s") % value
+        ) from error
+
+
+def _get_csv_import_id_hash(source: WeblateCSVUnit) -> int | None:
+    has_plural_metadata = _has_csv_plural_metadata(source) or bool(
+        getattr(source, "target_plural_forms", ())
+    )
+    if not has_plural_metadata:
+        return None
+    result = _parse_csv_id_hash_metadata(source)
+    if result is None:
+        raise CSVMetadataError(
+            gettext("Plural form metadata in CSV file requires id_hash.")
+        )
+    return result
+
+
+def _get_csv_target_plural_form(row: WeblateCSVUnit) -> int:
+    result = _parse_csv_int_metadata(
+        row,
+        CSV_TARGET_PLURAL_FORM,
+        max_value=_CSV_MAX_PLURAL_FORMS,
+    )
+    if result is None:
+        raise ValueError(
+            gettext("Invalid plural form metadata in CSV file: %s")
+            % row.target_plural_form
+        )
+    return result
 
 
 class TTKitUnit[U: TranslateToolkitUnit, F: "BaseTTKitFormat"](TranslationUnit[U, F]):
@@ -1102,7 +1216,80 @@ class PlaceholdersJSONUnit(JSONUnit):
         return flags
 
 
+class WeblateCSVUnit(csvunit):
+    """CSV unit preserving Weblate-specific import/export metadata."""
+
+    def __init__(self, source=None) -> None:
+        super().__init__(source)
+        self.source_plural_form = ""
+        self.target_plural_form = ""
+        self.target_plural_forms: tuple[int, ...] = ()
+        self.plural_rows: tuple[WeblateCSVUnit, ...] = ()
+        self.id_hash = ""
+
+    def fromdict(self, cedict, encoding="utf-8") -> None:
+        super().fromdict(cedict, encoding=encoding)
+        for field in (CSV_SOURCE_PLURAL_FORM, CSV_TARGET_PLURAL_FORM, CSV_ID_HASH):
+            value = cedict.get(field)
+            if value is not None:
+                setattr(self, field, value)
+
+    def todict(self, **kwargs):
+        result = super().todict(**kwargs)
+        for field in (CSV_SOURCE_PLURAL_FORM, CSV_TARGET_PLURAL_FORM, CSV_ID_HASH):
+            result[field] = str(getattr(self, field, "") or "")
+        return result
+
+
+class WeblateCSVFile(csvfile):
+    UnitClass = WeblateCSVUnit
+
+
+CSVPluralGroupKey = int
+
+
 class CSVUnit(MonolingualSimpleUnit):
+    def _get_int_metadata(
+        self,
+        field: str,
+        *,
+        allow_negative: bool = False,
+        max_value: int | None = None,
+    ) -> int | None:
+        return _parse_csv_int_metadata(
+            self.mainunit,
+            field,
+            allow_negative=allow_negative,
+            max_value=max_value,
+        )
+
+    @cached_property
+    def import_id_hash(self) -> int | None:
+        return _get_csv_import_id_hash(self.mainunit)
+
+    @cached_property
+    def id_hash(self) -> int:
+        import_id_hash = self.import_id_hash
+        if import_id_hash is not None:
+            return import_id_hash
+        return super().id_hash
+
+    @cached_property
+    def source_plural_form(self) -> int | None:
+        return self._get_int_metadata(
+            CSV_SOURCE_PLURAL_FORM, max_value=_CSV_MAX_PLURAL_FORMS
+        )
+
+    @cached_property
+    def target_plural_form(self) -> int | None:
+        return self._get_int_metadata(
+            CSV_TARGET_PLURAL_FORM, max_value=_CSV_MAX_PLURAL_FORMS
+        )
+
+    @cached_property
+    def target_plural_forms(self) -> tuple[int, ...]:
+        return tuple(getattr(self.mainunit, "target_plural_forms", ()))
+
     @staticmethod
     def unescape_csv(string):
         r"""
@@ -1165,6 +1352,24 @@ class CSVUnit(MonolingualSimpleUnit):
         return self.unescape_csv(target)
 
     def set_target(self, target: str | list[str]) -> None:
+        plural_rows = getattr(self.mainunit, "plural_rows", ())
+        if plural_rows:
+            self._invalidate_target()
+            if isinstance(target, multistring):
+                target_forms = [str(target), *target.extra_strings]
+            elif isinstance(target, list):
+                target_forms = target
+            else:
+                target_forms = [target]
+            self.unit.target = multistring(target_forms)
+            for row in plural_rows:
+                target_form = self._get_row_plural_form(row)
+                if target_form < len(target_forms):
+                    row.target = target_forms[target_form]
+                else:
+                    row.target = ""
+            return
+
         super().set_target(target)
         if (
             self.template is not None
@@ -1184,11 +1389,28 @@ class CSVUnit(MonolingualSimpleUnit):
             # which may be empty when "source" acts as the key column.
             self.unit.source = self.context
 
+    def set_state(self, state) -> None:
+        super().set_state(state)
+        for row in getattr(self.mainunit, "plural_rows", ()):
+            row.markfuzzy(state in FUZZY_STATES)
+
+    @staticmethod
+    def _get_row_plural_form(row: WeblateCSVUnit) -> int:
+        return _get_csv_target_plural_form(row)
+
     def is_fuzzy(self, fallback=False):
         # Report fuzzy state only if present in the fields
         if "fuzzy" not in self.parent.store.fieldnames:
             return fallback
         return super().is_fuzzy()
+
+
+class CSVPluralGroup(TypedDict):
+    first: WeblateCSVUnit
+    import_id_hash: int
+    rows: list[WeblateCSVUnit]
+    source_forms: dict[int, str]
+    target_forms: dict[int, str]
 
 
 class RESXUnit(TTKitUnit):
@@ -2026,12 +2248,12 @@ class GoI18nTOMLFormat(TOMLFormat):
     supports_plural: bool = True
 
 
-class CSVFormat[S: csvfile, U: csvunit, T: CSVUnit](TTKitFormat[S, U, T]):
+class CSVFormat(TTKitFormat[WeblateCSVFile, WeblateCSVUnit, CSVUnit]):
     # Translators: File format name
     name = gettext_lazy("CSV file")
     format_id = "csv"
-    loader = ("csvl10n", "csvfile")
-    unit_class = CSVUnit  # type: ignore[assignment]
+    loader = WeblateCSVFile
+    unit_class = CSVUnit
     autoload: tuple[str, ...] = ("*.csv",)
     supports_descriptions: bool = True
     supports_context: bool = True
@@ -2045,7 +2267,7 @@ class CSVFormat[S: csvfile, U: csvunit, T: CSVUnit](TTKitFormat[S, U, T]):
         language_code: str | None = None,
         source_language: str | None = None,
         is_template: bool = False,
-        existing_units: list[Any] | None = None,
+        existing_units: Iterable[Unit] | None = None,
         file_format_params: FileFormatParams | None = None,
         repo_temp_dir: str | Path | None = None,
     ) -> None:
@@ -2065,6 +2287,247 @@ class CSVFormat[S: csvfile, U: csvunit, T: CSVUnit](TTKitFormat[S, U, T]):
             template_store, CSVFormat
         ):
             self.template_store = None
+
+    def check_valid(self) -> None:
+        """Check store validity without treating plural metadata as format detection."""
+        if not isinstance(self.store, csvfile):
+            raise TypeError(
+                gettext(
+                    "Could not load strings from the file, try choosing other format."
+                )
+            )
+        super().check_valid()
+
+    @staticmethod
+    def _forms_to_list(
+        forms: dict[int, str], fallback: str, *, require_complete: bool = False
+    ) -> list[str]:
+        if not forms:
+            return [fallback]
+
+        plural_count = max(forms) + 1
+        if plural_count > _CSV_MAX_PLURAL_FORMS:
+            raise CSVMetadataError(
+                gettext(
+                    "Plural form metadata in CSV file is out of range: "
+                    "%(value)s (maximum: %(maximum)s)"
+                )
+                % {"value": plural_count - 1, "maximum": _CSV_MAX_PLURAL_FORMS - 1}
+            )
+        if require_complete:
+            missing = set(range(plural_count)) - set(forms)
+            if missing:
+                raise CSVMetadataError(
+                    gettext("Plural form metadata in CSV file is missing form %d.")
+                    % min(missing)
+                )
+
+        result = [""] * plural_count
+        for index, value in forms.items():
+            result[index] = value
+        return result
+
+    def _get_plural_group_source(self, group: CSVPluralGroup) -> str:
+        first = group["first"]
+        return join_plural(
+            self._forms_to_list(
+                group["source_forms"],
+                CSVUnit.unescape_csv(get_string(first.source)),
+            )
+        )
+
+    @staticmethod
+    def _plural_group_key(unit: WeblateCSVUnit) -> CSVPluralGroupKey:
+        import_id_hash = _get_csv_import_id_hash(unit)
+        if import_id_hash is None:
+            raise CSVMetadataError(
+                gettext("Plural form metadata in CSV file requires id_hash.")
+            )
+        return import_id_hash
+
+    def _build_plural_group(self, group: CSVPluralGroup) -> WeblateCSVUnit:
+        first = group["first"]
+        source = self._get_plural_group_source(group)
+        target_forms = self._forms_to_list(
+            group["target_forms"], "", require_complete=True
+        )
+        target = "" if not any(target_forms) else join_plural(target_forms)
+
+        unit = cast("WeblateCSVUnit", self.store.UnitClass(source))
+        unit.target = target
+        unit.target_plural_forms = tuple(sorted(group["target_forms"]))
+        unit.plural_rows = tuple(group["rows"])
+        for attr in (
+            "location",
+            "id",
+            "fuzzy",
+            "context",
+            "translator_comments",
+            "developer_comments",
+        ):
+            setattr(unit, attr, getattr(first, attr))
+        unit.id_hash = format_csv_id_hash(group["import_id_hash"])
+
+        return unit
+
+    def _group_csv_units(
+        self, source_units: Iterable[WeblateCSVUnit]
+    ) -> list[WeblateCSVUnit]:
+        units = list(source_units)
+        grouped: dict[CSVPluralGroupKey, CSVPluralGroup] = {}
+        result: list[WeblateCSVUnit | CSVPluralGroupKey] = []
+
+        for unit in units:
+            source_form = _parse_csv_int_metadata(
+                unit, CSV_SOURCE_PLURAL_FORM, max_value=_CSV_MAX_PLURAL_FORMS
+            )
+            target_form = _parse_csv_int_metadata(
+                unit, CSV_TARGET_PLURAL_FORM, max_value=_CSV_MAX_PLURAL_FORMS
+            )
+            if target_form is None:
+                if source_form is not None:
+                    raise CSVMetadataError(
+                        gettext(
+                            "Plural form metadata in CSV file requires "
+                            "target_plural_form."
+                        )
+                    )
+                result.append(unit)
+                continue
+            if source_form is None:
+                raise CSVMetadataError(
+                    gettext(
+                        "Plural form metadata in CSV file requires source_plural_form."
+                    )
+                )
+
+            key = self._plural_group_key(unit)
+
+            if key not in grouped:
+                grouped[key] = {
+                    "first": unit,
+                    "import_id_hash": key,
+                    "rows": [],
+                    "source_forms": {},
+                    "target_forms": {},
+                }
+                result.append(key)
+
+            group = grouped[key]
+            group["rows"].append(unit)
+            target_forms = group["target_forms"]
+            if target_form in target_forms:
+                raise CSVMetadataError(
+                    gettext("Duplicate target plural form in CSV file: %s")
+                    % target_form
+                )
+
+            source_forms = group["source_forms"]
+            source = CSVUnit.unescape_csv(get_string(unit.source))
+            if source_form in source_forms:
+                if source_forms[source_form] != source:
+                    raise CSVMetadataError(
+                        gettext("Conflicting source plural form in CSV file: %s")
+                        % source_form
+                    )
+            else:
+                source_forms[source_form] = source
+            target_forms[target_form] = CSVUnit.unescape_csv(get_string(unit.target))
+
+        if not grouped:
+            return units
+
+        return [
+            self._build_plural_group(grouped[item]) if isinstance(item, int) else item
+            for item in result
+        ]
+
+    def _build_monolingual_unit(self, unit: CSVUnit) -> CSVUnit:
+        store_unit = self.find_unit_template(unit.context, unit.source, unit.id_hash)
+        template = cast("WeblateCSVUnit", unit.template)
+        if store_unit is not None and store_unit.plural_rows:
+            template = copy(template)
+            template.id_hash = store_unit.id_hash
+            template.target_plural_forms = store_unit.target_plural_forms
+            template.plural_rows = store_unit.plural_rows
+        return self.unit_class(self, store_unit, template)
+
+    def _ensure_plural_fieldnames(self) -> None:
+        for field in CSV_PLURAL_FIELDNAMES:
+            if field not in self.store.fieldnames:
+                self.store.fieldnames.append(field)
+
+    def _copy_plural_row_for_target(self, source: WeblateCSVUnit) -> WeblateCSVUnit:
+        row = cast("WeblateCSVUnit", self.store.UnitClass(source.source))
+        for attr in (
+            "location",
+            "id",
+            "fuzzy",
+            "context",
+            "translator_comments",
+            "developer_comments",
+            CSV_SOURCE_PLURAL_FORM,
+            CSV_TARGET_PLURAL_FORM,
+            CSV_ID_HASH,
+        ):
+            setattr(row, attr, getattr(source, attr))
+        row.target = ""
+        return row
+
+    def _has_store_unit(self, unit: WeblateCSVUnit) -> bool:
+        return any(existing is unit for existing in self.store.units)
+
+    def _remove_store_unit(self, unit: WeblateCSVUnit) -> None:
+        for index, existing in enumerate(self.store.units):
+            if existing is unit:
+                del self.store.units[index]
+                return
+        self.store.removeunit(unit)
+
+    def add_unit(self, unit: TranslationUnit) -> None:
+        """Add new unit to underlying store."""
+        csv_unit = cast("WeblateCSVUnit", unit.unit)
+        plural_rows = getattr(csv_unit, "plural_rows", ())
+        if not plural_rows:
+            super().add_unit(unit)
+            return
+
+        self._ensure_plural_fieldnames()
+        target_rows: list[WeblateCSVUnit] = []
+        for row in plural_rows:
+            if self._has_store_unit(row):
+                target_row = row
+            else:
+                target_row = self._copy_plural_row_for_target(row)
+            if not self._has_store_unit(target_row):
+                self.store.addunit(target_row)
+            target_rows.append(target_row)
+        csv_unit.plural_rows = tuple(target_rows)
+        csv_unit.target_plural_forms = tuple(
+            _get_csv_target_plural_form(row) for row in target_rows
+        )
+
+    def delete_unit(self, ttkit_unit) -> str | None:
+        plural_rows = getattr(ttkit_unit, "plural_rows", ())
+        if not plural_rows:
+            return super().delete_unit(ttkit_unit)
+
+        for row in plural_rows:
+            self._remove_store_unit(row)
+        return None
+
+    def _get_all_bilingual_units(self) -> list[CSVUnit]:
+        return [
+            self.unit_class(self, unit)
+            for unit in self._group_csv_units(self.all_store_units)
+        ]
+
+    @cached_property
+    def template_units(self) -> list[CSVUnit]:
+        return [
+            self.unit_class(self, None, unit)
+            for unit in self._group_csv_units(self.all_store_units)
+        ]
 
     @staticmethod
     def mimetype() -> str:
@@ -2089,11 +2552,11 @@ class CSVFormat[S: csvfile, U: csvunit, T: CSVUnit](TTKitFormat[S, U, T]):
         return content, filename
 
     # pylint: disable-next=arguments-differ
-    def parse_store(self, storefile) -> S:
+    def parse_store(self, storefile) -> WeblateCSVFile:
         """Parse the store."""
         return self.parse_csv(storefile)
 
-    def parse_csv(self, storefile, *, dialect: str | None = None) -> S:
+    def parse_csv(self, storefile, *, dialect: str | None = None) -> WeblateCSVFile:
         """Parse CSV file with a dialect."""
         content, filename = self.get_content_and_filename(storefile)
 
@@ -2124,7 +2587,9 @@ class CSVFormat[S: csvfile, U: csvunit, T: CSVUnit](TTKitFormat[S, U, T]):
 
         return self.parse_simple_csv(content, filename, header=header)
 
-    def parse_simple_csv(self, content, filename, header: list[str] | None = None) -> S:
+    def parse_simple_csv(
+        self, content, filename, header: list[str] | None = None
+    ) -> WeblateCSVFile:
         fieldnames = ["source", "target"]
         # Prefer detected header if available (translate-toolkit PR #5830 adds
         # monolingual CSV support with proper handling of context/id/target columns)
@@ -2590,7 +3055,7 @@ class TBXFormat[S: tbxfile, U: tbxunit, T: TBXUnit](TTKitFormat[S, U, T]):
         language_code: str | None = None,
         source_language: str | None = None,
         is_template: bool = False,
-        existing_units: list[Any] | None = None,
+        existing_units: Iterable[Unit] | None = None,
         file_format_params: FileFormatParams | None = None,
         repo_temp_dir: str | Path | None = None,
     ) -> None:

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -73,6 +73,7 @@ from weblate.utils.stats import GhostStats, TranslationStats
 from weblate.utils.version import GIT_VERSION
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from datetime import datetime
 
     from weblate.auth.models import AuthenticatedHttpRequest, User
@@ -1326,6 +1327,40 @@ class Translation(
             ),
         )
 
+    def validate_upload_plural_forms(self, unit: TranslationUnit) -> None:
+        target_plural_forms = getattr(unit, "target_plural_forms", ())
+        if not target_plural_forms:
+            return
+
+        invalid = [form for form in target_plural_forms if form >= self.plural.number]
+        if invalid:
+            raise FileParseError(
+                gettext("Plural form %d in the uploaded file is out of range.")
+                % invalid[0]
+            )
+        missing = set(range(self.plural.number)) - set(target_plural_forms)
+        if missing:
+            raise FileParseError(
+                gettext("Plural form %d in the uploaded file is missing.")
+                % min(missing)
+            )
+
+    def validate_upload_unit_metadata(self, unit: TranslationUnit) -> None:
+        try:
+            _ = getattr(unit, "import_id_hash", None)
+        except ValueError as error:
+            raise FileParseError(str(error)) from error
+        self.validate_upload_plural_forms(unit)
+
+    def validate_upload_plural_store(self, store: TranslationFormat) -> None:
+        try:
+            units = store.content_units
+        except ValueError as error:
+            raise FileParseError(str(error)) from error
+
+        for unit in units:
+            self.validate_upload_unit_metadata(unit)
+
     def merge_translations(
         self,
         request: AuthenticatedHttpRequest,
@@ -1345,6 +1380,8 @@ class Translation(
         add_fuzzy = method == "fuzzy"
         add_approve = method == "approve"
         not_found_log: list[str] = []
+
+        self.validate_upload_plural_store(store2)
 
         # Are there any translations to propagate?
         # This is just an optimalization to avoid doing that for every unit.
@@ -1421,6 +1458,8 @@ class Translation(
         skipped = 0
         accepted = 0
         not_found_log: list[str] = []
+
+        self.validate_upload_plural_store(store)
 
         unit_set = self.unit_set.all()
 
@@ -1624,8 +1663,13 @@ class Translation(
         has_template = component.has_template()
         skipped = 0
         accepted = 0
-        component.start_batched_checks()
         existing: set[str] | set[tuple[str, str]]
+        existing_id_hashes: set[int] | None = None
+
+        self.validate_upload_plural_store(store)
+
+        component.start_batched_checks()
+
         if has_template:
             existing = set(self.unit_set.values_list("context", flat=True))
         else:
@@ -1637,6 +1681,15 @@ class Translation(
                     existing.add((ex_context, split_plural(ex_source)[0]))
 
         for _set_fuzzy, unit in store.iterate_merge(fuzzy, only_translated=False):
+            import_id_hash = getattr(unit, "import_id_hash", None)
+            if import_id_hash is not None:
+                if existing_id_hashes is None:
+                    existing_id_hashes = set(
+                        self.unit_set.values_list("id_hash", flat=True)
+                    )
+                if import_id_hash in existing_id_hashes:
+                    skipped += 1
+                    continue
             idkey = unit.context if has_template else (unit.context, unit.source)
             if idkey in existing:
                 skipped += 1
@@ -1697,6 +1750,14 @@ class Translation(
                     )
                 ) from error
 
+        existing_units_cache: Iterable[Unit] | None = None
+
+        def get_existing_units() -> Iterable[Unit]:
+            nonlocal existing_units_cache
+            if existing_units_cache is None:
+                existing_units_cache = self.unit_set.all()
+            return existing_units_cache
+
         def load_uploaded_store(
             template_store: TranslationFormat | None,
             *,
@@ -1711,6 +1772,7 @@ class Translation(
                     is_template=is_template,
                     language_code=self.language_code,
                     source_language=self.component.source_language.code,
+                    existing_units=get_existing_units,
                     file_format_params=self.component.file_format_params,
                 )
             except Exception as error:

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -315,12 +315,23 @@ class UnitQuerySet(models.QuerySet["Unit"]):
     def source_lookup(self) -> dict[str, Unit]:
         return {unit.source: unit for unit in self}
 
+    @cached_property
+    def id_hash_lookup(self) -> dict[int, Unit]:
+        return {unit.id_hash: unit for unit in self}
+
     def get_unit(self, ttunit: TranslationUnit) -> Unit:
         """
         Find unit matching translate-toolkit unit.
 
         This is used for import, so kind of fuzzy matching is expected.
         """
+        import_id_hash = getattr(ttunit, "import_id_hash", None)
+        if import_id_hash is not None:
+            try:
+                return self.id_hash_lookup[import_id_hash]
+            except KeyError:
+                pass
+
         source = ttunit.source
         context = ttunit.context
 

--- a/weblate/trans/tests/test_files.py
+++ b/weblate/trans/tests/test_files.py
@@ -6,9 +6,10 @@
 
 from __future__ import annotations
 
+import csv
 import os
 import tempfile
-from io import BytesIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -20,10 +21,11 @@ from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 from openpyxl import load_workbook
 
-from weblate.formats.helpers import NamedBytesIO
-from weblate.lang.models import Language
+from weblate.formats.helpers import NamedBytesIO, format_csv_id_hash
+from weblate.formats.ttkit import CSVFormat
+from weblate.lang.models import Language, Plural
 from weblate.trans.actions import ActionEvents
-from weblate.trans.exceptions import FailedCommitError
+from weblate.trans.exceptions import FailedCommitError, FileParseError
 from weblate.trans.forms import SimpleUploadForm
 from weblate.trans.models import Change, ComponentList, PendingUnitChange, Translation
 from weblate.trans.tests.test_views import ViewTestCase
@@ -280,6 +282,262 @@ class ImportErrorTest(ImportBaseTest):
         self.assertIn(
             "Plural forms in the uploaded file do not match", messages[0].message
         )
+
+
+class PluralMetadataUploadValidationTest(ImportBaseTest):
+    @staticmethod
+    def get_csv_id_hash(id_hash: int) -> str:
+        return format_csv_id_hash(id_hash)
+
+    @staticmethod
+    def get_csv_content(rows: list[dict[str, str]]) -> bytes:
+        output = StringIO()
+        fieldnames = [
+            "source",
+            "target",
+            "id_hash",
+            "source_plural_form",
+            "target_plural_form",
+        ]
+        writer = csv.DictWriter(output, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+        return output.getvalue().encode()
+
+    @classmethod
+    def get_csv_store(cls, rows: list[dict[str, str]]) -> CSVFormat:
+        return CSVFormat(NamedBytesIO("plural.csv", cls.get_csv_content(rows)))
+
+    def test_merge_plural_metadata_out_of_range_is_not_partially_applied(
+        self,
+    ) -> None:
+        translation = self.get_translation()
+        request = self.get_request()
+        hello_unit = self.get_unit()
+        plural_unit = self.get_unit("Orangutan has %d banana.\n")
+        original_hello_target = hello_unit.target
+        original_plural_target = plural_unit.target
+        source_plurals = plural_unit.get_source_plurals()
+
+        store = self.get_csv_store(
+            [
+                {
+                    "source": hello_unit.source,
+                    "target": "This should not be imported.\n",
+                    "id_hash": str(hello_unit.id_hash),
+                    "source_plural_form": "",
+                    "target_plural_form": "",
+                },
+                *(
+                    {
+                        "source": source_plurals[min(form, len(source_plurals) - 1)],
+                        "target": f"Plural form {form}.\n",
+                        "id_hash": self.get_csv_id_hash(plural_unit.id_hash),
+                        "source_plural_form": str(min(form, len(source_plurals) - 1)),
+                        "target_plural_form": str(form),
+                    }
+                    for form in range(translation.plural.number + 1)
+                ),
+            ]
+        )
+
+        with self.assertRaisesMessage(
+            FileParseError,
+            f"Plural form {translation.plural.number} in the uploaded file is out of range.",
+        ):
+            translation.merge_translations(
+                request, self.user, store, "", "translate", ""
+            )
+
+        hello_unit.refresh_from_db()
+        plural_unit.refresh_from_db()
+        self.assertEqual(hello_unit.target, original_hello_target)
+        self.assertEqual(plural_unit.target, original_plural_target)
+
+    def test_merge_incomplete_plural_metadata_is_not_partially_applied(self) -> None:
+        translation = self.get_translation()
+        request = self.get_request()
+        hello_unit = self.get_unit()
+        plural_unit = self.get_unit("Orangutan has %d banana.\n")
+        original_hello_target = hello_unit.target
+        original_plural_target = plural_unit.target
+        self.assertGreater(translation.plural.number, 1)
+        missing_form = translation.plural.number - 1
+        source_plurals = plural_unit.get_source_plurals()
+        plural_rows = [
+            {
+                "source": source_plurals[min(form, len(source_plurals) - 1)],
+                "target": f"Incomplete plural form {form}.\n",
+                "id_hash": self.get_csv_id_hash(plural_unit.id_hash),
+                "source_plural_form": str(min(form, len(source_plurals) - 1)),
+                "target_plural_form": str(form),
+            }
+            for form in range(missing_form)
+        ]
+        store = self.get_csv_store(
+            [
+                {
+                    "source": hello_unit.source,
+                    "target": "This should not be imported.\n",
+                    "id_hash": str(hello_unit.id_hash),
+                    "source_plural_form": "",
+                    "target_plural_form": "",
+                },
+                *plural_rows,
+            ]
+        )
+
+        with self.assertRaisesMessage(
+            FileParseError,
+            f"Plural form {missing_form} in the uploaded file is missing.",
+        ):
+            translation.merge_translations(
+                request, self.user, store, "", "translate", ""
+            )
+
+        hello_unit.refresh_from_db()
+        plural_unit.refresh_from_db()
+        self.assertEqual(hello_unit.target, original_hello_target)
+        self.assertEqual(plural_unit.target, original_plural_target)
+
+    def test_merge_malformed_id_hash_is_not_partially_applied(self) -> None:
+        translation = self.get_translation()
+        request = self.get_request()
+        hello_unit = self.get_unit()
+        plural_unit = self.get_unit("Orangutan has %d banana.\n")
+        original_target = hello_unit.target
+
+        store = self.get_csv_store(
+            [
+                {
+                    "source": hello_unit.source,
+                    "target": "This should not be imported.\n",
+                    "id_hash": str(hello_unit.id_hash),
+                    "source_plural_form": "",
+                    "target_plural_form": "",
+                },
+                {
+                    "source": plural_unit.get_source_plurals()[0],
+                    "target": "Invalid id hash.\n",
+                    "id_hash": "invalid",
+                    "source_plural_form": "0",
+                    "target_plural_form": "0",
+                },
+            ]
+        )
+
+        with self.assertRaisesMessage(
+            FileParseError, "Invalid id_hash metadata in CSV file: invalid"
+        ):
+            translation.merge_translations(
+                request, self.user, store, "", "translate", ""
+            )
+
+        hello_unit.refresh_from_db()
+        self.assertEqual(hello_unit.target, original_target)
+
+    def test_merge_non_plural_id_hash_column_is_ignored(self) -> None:
+        translation = self.get_translation()
+        hello_unit = self.get_unit()
+        target = "Imported despite external id_hash.\n"
+        store = self.get_csv_store(
+            [
+                {
+                    "source": hello_unit.source,
+                    "target": target,
+                    "id_hash": "external-id",
+                    "source_plural_form": "",
+                    "target_plural_form": "",
+                },
+            ]
+        )
+
+        result = translation.merge_translations(
+            self.get_request(), self.user, store, "replace-translated", "translate", ""
+        )
+
+        self.assertEqual(result, (0, 0, 1, 1))
+        hello_unit.refresh_from_db()
+        self.assertEqual(hello_unit.target, target)
+
+    def test_upload_plural_metadata_without_id_hash_is_rejected(self) -> None:
+        translation = self.get_translation()
+        translation.plural = Plural.objects.create(
+            language=translation.language, number=1, formula="0"
+        )
+        translation.save(update_fields=["plural"])
+
+        plural_unit = self.get_unit("Orangutan has %d banana.\n")
+        original_target = plural_unit.target
+
+        with self.assertRaisesMessage(
+            FileParseError, "Plural form metadata in CSV file requires id_hash."
+        ):
+            translation.handle_upload(
+                self.get_request(),
+                NamedBytesIO(
+                    "plural.csv",
+                    self.get_csv_content(
+                        [
+                            {
+                                "source": plural_unit.get_source_plurals()[1],
+                                "target": "Imported one plural form.\n",
+                                "id_hash": "",
+                                "source_plural_form": "1",
+                                "target_plural_form": "0",
+                            },
+                        ]
+                    ),
+                ),
+                "replace-translated",
+                method="translate",
+            )
+
+        plural_unit.refresh_from_db()
+        self.assertEqual(plural_unit.target, original_target)
+
+    def test_add_plural_metadata_with_id_hash_sparse_source_form_skips_existing(
+        self,
+    ) -> None:
+        translation = self.get_translation()
+        translation.plural = Plural.objects.create(
+            language=translation.language, number=1, formula="0"
+        )
+        translation.save(update_fields=["plural"])
+        plural_unit = self.get_unit("Orangutan has %d banana.\n")
+        translation.add_unit(
+            self.get_request(),
+            plural_unit.context,
+            [
+                "Ambiguous singular source.\n",
+                plural_unit.get_source_plurals()[1],
+            ],
+            ["Ambiguous one plural form.\n"],
+        )
+        initial_count = translation.unit_set.count()
+
+        result = translation.handle_upload(
+            self.get_request(),
+            NamedBytesIO(
+                "plural.csv",
+                self.get_csv_content(
+                    [
+                        {
+                            "source": plural_unit.get_source_plurals()[1],
+                            "target": "Existing one plural form.\n",
+                            "id_hash": self.get_csv_id_hash(plural_unit.id_hash),
+                            "source_plural_form": "1",
+                            "target_plural_form": "0",
+                        },
+                    ]
+                ),
+            ),
+            "",
+            method="add",
+        )
+
+        self.assertEqual(result, (0, 1, 0, 1))
+        self.assertEqual(translation.unit_set.count(), initial_count)
 
 
 class BOMImportTest(ImportTest):


### PR DESCRIPTION
The plurals were silently ignored in these, now they are exported into separate rows based on the PluralMapper.

Fixes WEBLATE-39MX
Fixes WEBLATE-39MY

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
