### PR TITLE
fix: gracefully handle mistletoe crashes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -61,6 +61,7 @@ Weblate 5.17.1
 * Project listings now show review progress columns when any listed project has reviews enabled.
 * The missing file-mask matches :ref:`alert <alerts>` is now restored after rescans that leave only the source translation.
 * Automatic translation from other components now ignores read-only source candidates with empty translations.
+* Markdown rendering now falls back to escaped plain text when the Markdown parser fails.
 
 .. rubric:: Compatibility
 

--- a/weblate/utils/markdown.py
+++ b/weblate/utils/markdown.py
@@ -8,10 +8,12 @@ from functools import reduce
 
 import mistletoe
 from django.db.models import Q
+from django.utils.html import linebreaks
 from django.utils.safestring import mark_safe
 from mistletoe import span_token
 
 from weblate.auth.models import User
+from weblate.utils.errors import report_error
 
 from .concurrency import MARKDOWN_LOCK
 
@@ -126,6 +128,7 @@ class SaferWeblateHtmlRenderer(mistletoe.HtmlRenderer):
 
 
 def render_markdown(text: str) -> str:
+    original_text = text
     users = {u.username.lower(): u for u in get_mention_users(text)}
     parts = MENTION_RE.split(text)
     for pos, part in enumerate(parts):
@@ -138,5 +141,9 @@ def render_markdown(text: str) -> str:
                 f'**[{part}]({user.get_absolute_url()} "{user.get_visible_name()}")**'
             )
     text = "".join(parts)
-    with MARKDOWN_LOCK, SaferWeblateHtmlRenderer() as renderer:
-        return mark_safe(renderer.render(mistletoe.Document(text)))  # noqa: S308
+    try:
+        with MARKDOWN_LOCK, SaferWeblateHtmlRenderer() as renderer:
+            return mark_safe(renderer.render(mistletoe.Document(text)))  # noqa: S308
+    except Exception:
+        report_error("Markdown rendering failed")
+        return mark_safe(linebreaks(original_text, autoescape=True))  # noqa: S308

--- a/weblate/utils/tests/test_markdown.py
+++ b/weblate/utils/tests/test_markdown.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from weblate.auth.models import User
@@ -47,6 +49,20 @@ class MarkdownTestCase(TestCase):
         self.assertEqual(
             "<p>foo<strong>bar</strong>baz</p>\n", render_markdown("foo**bar**baz")
         )
+
+    def test_parser_failure_fallback(self) -> None:
+        with (
+            patch(
+                "weblate.utils.markdown.mistletoe.Document",
+                side_effect=IndexError("string index out of range"),
+            ),
+            patch("weblate.utils.markdown.report_error") as report_error,
+        ):
+            self.assertEqual(
+                "<p>**markdown**<br>&lt;script&gt;</p>",
+                render_markdown("**markdown**\n<script>"),
+            )
+        report_error.assert_called_once_with("Markdown rendering failed")
 
     def test_autolink(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
When input is invalid markdown that crashes mistletoe, we should still render it reasonably.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
