### PR TITLE
feat: redesign contact page

### DIFF
--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -116,8 +116,17 @@ class ViewTest(RepoTestCase):
     )
     def test_contact(self) -> None:
         """Test for contact form."""
-        # Basic get
+        # Topic chooser is shown by default
         response = self.client.get(reverse("contact"))
+        self.assertNotContains(response, 'id="id_message"')
+        self.assertContains(response, "?topic=server")
+
+        # Form is shown after picking the server topic
+        response = self.client.get(reverse("contact"), {"topic": "server"})
+        self.assertContains(response, 'id="id_message"')
+
+        # Form is also shown for known subject deep-links
+        response = self.client.get(reverse("contact"), {"t": "trial"})
         self.assertContains(response, 'id="id_message"')
 
         # Sending message

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -246,7 +246,7 @@ class ViewTest(RepoTestCase):
         user = self.get_user()
         # Login
         self.client.login(username=user.username, password="testpassword")
-        response = self.client.get(reverse("contact"))
+        response = self.client.get(reverse("contact"), {"topic": "server"})
         self.assertContains(response, 'value="First Second"')
         self.assertContains(response, user.email)
 

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -600,7 +600,9 @@ def contact(request: AuthenticatedHttpRequest):
         msg = "Contact form is disabled."
         raise Http404(msg)
 
+    show_form = False
     if request.method == "POST":
+        show_form = True
         form = ContactForm(
             request=request,
             hide_captcha=request.user.is_authenticated,
@@ -625,6 +627,9 @@ def contact(request: AuthenticatedHttpRequest):
         initial = get_initial_contact(request)
         if request.GET.get("t") in CONTACT_SUBJECTS:
             initial["subject"] = CONTACT_SUBJECTS[request.GET["t"]]
+            show_form = True
+        if request.GET.get("topic") == "server":
+            show_form = True
         form = ContactForm(
             request=request, hide_captcha=request.user.is_authenticated, initial=initial
         )
@@ -632,7 +637,7 @@ def contact(request: AuthenticatedHttpRequest):
     return render(
         request,
         "accounts/contact.html",
-        {"form": form, "title": gettext("Contact")},
+        {"form": form, "title": gettext("Contact"), "show_form": show_form},
     )
 
 

--- a/weblate/legal/tests.py
+++ b/weblate/legal/tests.py
@@ -81,7 +81,7 @@ class LegalTest(TestCase, RegistrationTestMixin):
         )
         # Check that contact works even without TOS
         response = self.client.get(reverse("contact"), follow=True)
-        self.assertContains(response, "You can only contact administrators")
+        self.assertContains(response, "How can we help?")
         # Confirm current TOS
         request = HttpRequest()
         request.META["REMOTE_ADDR"] = "127.0.0.1"

--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -32,7 +32,7 @@
           </div>
           <div class="card-footer">
             <a href="{% url 'contact' %}" class="btn btn-primary">{% translate "Back" %}</a>
-            <input type="submit" value="{% translate "Send" %}" class="btn btn-primary" />
+            <input type="submit" value="{% translate "Send" %}" class="btn btn-warning" />
           </div>
         </div>
       </form>

--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load crispy_forms_tags i18n %}
+{% load crispy_forms_tags i18n translations %}
 
 {% block breadcrumbs %}
   <li class="breadcrumb-item">
@@ -12,43 +12,161 @@
 
   <div class="container">
 
-    <div class="alert alert-warning alert-contact-form">
-      <ul>
-        <li>
-          {% if site_title != "Weblate" %}
-            {% blocktranslate %}You can only contact administrators of {{ site_title }} server here.{% endblocktranslate %}
-          {% else %}
-            {% blocktranslate %}You can only contact administrators of the whole server here.{% endblocktranslate %}
-          {% endif %}
-        </li>
-        <li>
-          {% blocktranslate %}For questions about a specific translation project, don’t use this form. Refer to the project’s Info tab and contact its maintainers.{% endblocktranslate %}
-        </li>
-        {% if offer_hosting %}
-          <li>
-            {% blocktranslate %}If you seek support for any other Weblate deployment than {{ site_title }}, please check support offerings at {{ weblate_link }} or use this form on the correct server.{% endblocktranslate %}
-          </li>
-        {% endif %}
-        <li>
-          {% blocktranslate with link_start='<a href="https://github.com/WeblateOrg/weblate/issues/new/choose">' link_end='</a>' %}Weblate development ideas and questions can be sent to the {{ link_start }}Weblate issue tracker{{ link_end }}.{% endblocktranslate %}
-        </li>
-      </ul>
-    </div>
+    {% if show_form %}
 
-    <form method="post" action="{% url 'contact' %}">
-      <div class="card">
+      <p>
+        <a href="{% url 'contact' %}" class="btn btn-link p-0">
+          &larr; {% translate "Back to contact options" %}
+        </a>
+      </p>
+
+      <form method="post" action="{% url 'contact' %}">
+        <div class="card">
+          <div class="card-header">
+            <h4 class="card-title">{% translate "Contact server administrators" %}</h4>
+          </div>
+          <div class="card-body">
+            <p class="text-body-secondary">
+              {% if site_title != "Weblate" %}
+                {% blocktranslate %}Use this form to reach the administrators of {{ site_title }}.{% endblocktranslate %}
+              {% else %}
+                {% blocktranslate %}Use this form to reach the administrators of this server.{% endblocktranslate %}
+              {% endif %}
+            </p>
+            {% csrf_token %}
+            {{ form|crispy }}
+          </div>
+          <div class="card-footer">
+            <input type="submit" value="{% translate "Send" %}" class="btn btn-primary" />
+          </div>
+        </div>
+      </form>
+
+    {% else %}
+
+      <div class="card mb-3">
         <div class="card-header">
-          <h4 class="card-title">{% translate "Contact server administrators" %}</h4>
+          <h4 class="card-title">{% translate "How can we help?" %}</h4>
         </div>
         <div class="card-body">
-          {% csrf_token %}
-          {{ form|crispy }}
-        </div>
-        <div class="card-footer">
-          <input type="submit" value="{% translate "Send" %}" class="btn btn-primary" />
+          <p class="mb-0">
+            {% translate "Pick the topic that best matches your question to find the fastest way to get help." %}
+          </p>
         </div>
       </div>
-    </form>
+
+      <div class="row row-cols-1 row-cols-md-2 g-3">
+
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-header">
+              <h4 class="card-title">{% translate "Question about a translation project" %}</h4>
+            </div>
+            <div class="card-body">
+              <p>
+                {% blocktranslate %}For questions about a specific translation project, refer to the project's Info tab and contact its maintainers.{% endblocktranslate %}
+              </p>
+            </div>
+            <div class="card-footer">
+              <a class="btn btn-primary" href="{% url 'projects' %}">
+                {% translate "Browse projects" %}
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-header">
+              <h4 class="card-title">{% translate "Weblate product feedback" %}</h4>
+            </div>
+            <div class="card-body">
+              <p>
+                {% blocktranslate %}Share Weblate development ideas, feature requests, or report bugs in the upstream issue tracker.{% endblocktranslate %}
+              </p>
+            </div>
+            <div class="card-footer">
+              <a class="btn btn-primary"
+                 href="https://github.com/WeblateOrg/weblate/issues/new/choose"
+                 rel="noopener noreferrer"
+                 target="_blank">
+                {% translate "Open issue tracker" %}
+              </a>
+            </div>
+          </div>
+        </div>
+
+        {% if offer_hosting %}
+          <div class="col">
+            <div class="card h-100">
+              <div class="card-header">
+                <h4 class="card-title">{% translate "Support for another Weblate server" %}</h4>
+              </div>
+              <div class="card-body">
+                <p>
+                  {% blocktranslate %}If you seek support for any other Weblate deployment than {{ site_title }}, check the available support offerings, or use the contact form on the correct server.{% endblocktranslate %}
+                </p>
+              </div>
+              <div class="card-footer">
+                <a class="btn btn-primary"
+                   href="https://weblate.org/support/"
+                   rel="noopener noreferrer"
+                   target="_blank">
+                  {% translate "View support offerings" %}
+                </a>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-header">
+              <h4 class="card-title">{% translate "Documentation" %}</h4>
+            </div>
+            <div class="card-body">
+              <p>
+                {% translate "Browse the Weblate documentation for guides on translating, administration, and configuration." %}
+              </p>
+            </div>
+            <div class="card-footer">
+              <a class="btn btn-primary"
+                 href="{% documentation 'index' %}"
+                 rel="noopener noreferrer"
+                 target="_blank">
+                {% translate "Read the docs" %}
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100 border-primary">
+            <div class="card-header">
+              <h4 class="card-title">
+                {% if site_title != "Weblate" %}
+                  {% blocktranslate %}Question for {{ site_title }} administrators{% endblocktranslate %}
+                {% else %}
+                  {% translate "Question for the server administrators" %}
+                {% endif %}
+              </h4>
+            </div>
+            <div class="card-body">
+              <p>
+                {% blocktranslate %}Reach out to the administrators of this server about account, registration, or server-wide questions that don't fit the topics above.{% endblocktranslate %}
+              </p>
+            </div>
+            <div class="card-footer">
+              <a class="btn btn-primary" href="{% url 'contact' %}?topic=server">
+                {% translate "Open contact form" %}
+              </a>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+    {% endif %}
 
   </div>
 

--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -15,9 +15,7 @@
     {% if show_form %}
 
       <p>
-        <a href="{% url 'contact' %}" class="btn btn-link p-0">
-          &larr; {% translate "Back to contact options" %}
-        </a>
+        <a href="{% url 'contact' %}" class="btn btn-link p-0">{% translate "Back to contact options" %}</a>
       </p>
 
       <form method="post" action="{% url 'contact' %}">
@@ -68,9 +66,7 @@
               </p>
             </div>
             <div class="card-footer">
-              <a class="btn btn-primary" href="{% url 'projects' %}">
-                {% translate "Browse projects" %}
-              </a>
+              <a class="btn btn-primary" href="{% url 'projects' %}">{% translate "Browse projects" %}</a>
             </div>
           </div>
         </div>
@@ -89,9 +85,7 @@
               <a class="btn btn-primary"
                  href="https://github.com/WeblateOrg/weblate/issues/new/choose"
                  rel="noopener noreferrer"
-                 target="_blank">
-                {% translate "Open issue tracker" %}
-              </a>
+                 target="_blank">{% translate "Open issue tracker" %}</a>
             </div>
           </div>
         </div>
@@ -111,9 +105,7 @@
                 <a class="btn btn-primary"
                    href="https://weblate.org/support/"
                    rel="noopener noreferrer"
-                   target="_blank">
-                  {% translate "View support offerings" %}
-                </a>
+                   target="_blank">{% translate "View support offerings" %}</a>
               </div>
             </div>
           </div>
@@ -125,17 +117,13 @@
               <h4 class="card-title">{% translate "Documentation" %}</h4>
             </div>
             <div class="card-body">
-              <p>
-                {% translate "Browse the Weblate documentation for guides on translating, administration, and configuration." %}
-              </p>
+              <p>{% translate "Browse the Weblate documentation for guides on translating, administration, and configuration." %}</p>
             </div>
             <div class="card-footer">
               <a class="btn btn-primary"
                  href="{% documentation 'index' %}"
                  rel="noopener noreferrer"
-                 target="_blank">
-                {% translate "Read the docs" %}
-              </a>
+                 target="_blank">{% translate "Read the docs" %}</a>
             </div>
           </div>
         </div>
@@ -157,9 +145,7 @@
               </p>
             </div>
             <div class="card-footer">
-              <a class="btn btn-primary" href="{% url 'contact' %}?topic=server">
-                {% translate "Open contact form" %}
-              </a>
+              <a class="btn btn-primary" href="{% url 'contact' %}?topic=server">{% translate "Open contact form" %}</a>
             </div>
           </div>
         </div>

--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -44,9 +44,7 @@
           <h4 class="card-title">{% translate "How can we help?" %}</h4>
         </div>
         <div class="card-body">
-          <p class="mb-0">
-            {% translate "Select one of the options below to get help." %}
-          </p>
+          <p class="mb-0">{% translate "Select one of the options below to get help." %}</p>
         </div>
       </div>
 

--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -45,7 +45,7 @@
         </div>
         <div class="card-body">
           <p class="mb-0">
-            {% translate "Pick the topic that best matches your question to find the fastest way to get help." %}
+            {% translate "Select one of the options below to get help." %}
           </p>
         </div>
       </div>
@@ -59,7 +59,7 @@
             </div>
             <div class="card-body">
               <p>
-                {% blocktranslate %}For questions about a specific translation project, refer to the project's Info tab and contact its maintainers.{% endblocktranslate %}
+                {% blocktranslate %}Find a specific translation project, refer to the project's Overview tab and contact its maintainers directly.{% endblocktranslate %}
               </p>
             </div>
             <div class="card-footer">

--- a/weblate/templates/accounts/contact.html
+++ b/weblate/templates/accounts/contact.html
@@ -14,10 +14,6 @@
 
     {% if show_form %}
 
-      <p>
-        <a href="{% url 'contact' %}" class="btn btn-link p-0">{% translate "Back to contact options" %}</a>
-      </p>
-
       <form method="post" action="{% url 'contact' %}">
         <div class="card">
           <div class="card-header">
@@ -35,6 +31,7 @@
             {{ form|crispy }}
           </div>
           <div class="card-footer">
+            <a href="{% url 'contact' %}" class="btn btn-primary">{% translate "Back" %}</a>
             <input type="submit" value="{% translate "Send" %}" class="btn btn-primary" />
           </div>
         </div>


### PR DESCRIPTION
Replaces the contact page with a new topic based picker:
<img width="1914" height="861" alt="image" src="https://github.com/user-attachments/assets/dd2bd58b-39a0-4325-9a58-ca5230483023" />

The old contact form is preserved under the contact administration option:
<img width="1896" height="963" alt="image" src="https://github.com/user-attachments/assets/7860799c-577a-4779-81b7-15af5e7aa541" />



closes https://github.com/WeblateOrg/weblate/issues/16017
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
