### PR TITLE
fix(views): use ranking rather than subquery for matching othes

### DIFF
--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -14,7 +14,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.messages import get_messages
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.db.models import Count, Q, Value
+from django.db.models import Case, IntegerField, Q, Value, When
 from django.db.models.functions import MD5, Lower
 from django.http import (
     HttpResponse,
@@ -157,7 +157,13 @@ def get_other_units(unit):
                 translation__component__project=component.project,
                 translation__language=translation.language,
             )
-            .annotate(matches_current=Count("id", filter=match))
+            .alias(
+                matches_current=Case(
+                    When(match, then=Value(1)),
+                    default=Value(0),
+                    output_field=IntegerField(),
+                )
+            )
             .prefetch()
             .prefetch_source()
             .order_by("-matches_current")


### PR DESCRIPTION
This seems to be a more effective way to figure out whether the translation matches current term.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
