### PR TITLE
fix(add-ons): do not set unsupported settings on discovered components

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -50,6 +50,7 @@ Weblate 5.17.1
 * Monolingual component validation now honors :ref:`component-source_language` when checking duplicate files alongside a separate :ref:`component-template`.
 * :ref:`Translation memory upload <memory-user>` and :wladmin:`import_memory` now report a validation error for TMX files missing the required header instead of failing the request.
 * The missing file-mask matches :ref:`alert <alerts>` is now restored after rescans that leave only the source translation.
+* :ref:`addon-weblate.discovery.discovery` now disables inherited string management for discovered formats that do not support adding or removing strings.
 * Automatic translation from other components now ignores read-only source candidates with empty translations.
 * Project component pagination now keeps the :guilabel:`Components` tab active when jumping to a typed page number.
 * Markdown rendering now falls back to escaped plain text when the parser fails and escapes image URLs before rendering.

--- a/weblate/trans/discovery.py
+++ b/weblate/trans/discovery.py
@@ -662,6 +662,28 @@ class ComponentDiscovery:
         else:
             LOGGER.info(*args)
 
+    def clean_inherited_file_format_options(
+        self, kwargs: dict[str, object], name: str
+    ) -> None:
+        """Drop inherited component options unsupported by the discovered format."""
+        if kwargs.get("edit_template", True) and not self.file_format_cls.can_edit_base:
+            self.log(
+                "Disabling template editing for %s because it is not supported",
+                name,
+            )
+            kwargs["edit_template"] = False
+
+        if (
+            kwargs.get("manage_units")
+            and not self.file_format_cls.can_add_unit
+            and not self.file_format_cls.can_delete_unit
+        ):
+            kwargs["manage_units"] = False
+            self.log(
+                "Disabling managing strings for %s because it is not supported",
+                name,
+            )
+
     def create_component(
         self,
         main: Component | None,
@@ -693,9 +715,7 @@ class ComponentDiscovery:
             kwargs.pop("enforced_checks", None)
             kwargs.pop("file_format_params", None)
 
-        # Disable template editing if not supported by format
-        if not self.file_format_cls.can_edit_base:
-            kwargs["edit_template"] = False
+        self.clean_inherited_file_format_options(kwargs, name)
 
         # Fill in repository
         if "repo" not in kwargs:

--- a/weblate/trans/tests/test_discovery.py
+++ b/weblate/trans/tests/test_discovery.py
@@ -302,6 +302,34 @@ class ComponentDiscoveryTest(RepoTestCase):
         self.assertEqual(len(deleted), 0)
         self.assertEqual(len(skipped), 1)
 
+    def test_perform_disables_unsupported_unit_management(self) -> None:
+        docs = pathlib.Path(self.component.full_path) / "docs"
+        docs.mkdir(exist_ok=True)
+        for language in ("cs", "en"):
+            (docs / f"news_{language}.md").write_text(
+                "# News\n\nContent\n", encoding="utf-8"
+            )
+
+        self.component.manage_units = True
+        discovery = ComponentDiscovery(
+            self.component,
+            file_format="markdown",
+            match=r"docs/(?P<component>.+?)_(?P<language>[^/.]+)\.md",
+            name_template="{{ component }}",
+            base_file_template="docs/{{ component }}_en.md",
+        )
+
+        created, matched, deleted, skipped = discovery.perform(preview=True)
+
+        self.assertEqual(skipped, [])
+        self.assertEqual(matched, [])
+        self.assertEqual(deleted, [])
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0][0]["mask"], "docs/news_*.md")
+        component = created[0][1]
+        self.assertIsNotNone(component)
+        self.assertFalse(component.manage_units)
+
     def test_create_component_tolerates_missing_copy_from_addons_source(self) -> None:
         source_component = self._create_component(
             "po",


### PR DESCRIPTION
Move the cleanup to separate method and apply it to manage_units as well.

Fixes #19229

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
