### PR TITLE
fix(utils): update similarity treshold more tightly

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,6 +49,7 @@ Weblate 5.17.1
 * Screenshot OCR now skips corrupted or truncated image files instead of failing the request.
 * Monolingual component validation now honors :ref:`component-source_language` when checking duplicate files alongside a separate :ref:`component-template`.
 * :ref:`Translation memory upload <memory-user>` and :wladmin:`import_memory` now report a validation error for TMX files missing the required header instead of failing the request.
+* :ref:`mt-weblate-translation-memory` no longer misses boundary similarity matches after stricter lookups.
 * The missing file-mask matches :ref:`alert <alerts>` is now restored after rescans that leave only the source translation.
 * Automatic translation from other components now ignores read-only source candidates with empty translations.
 * Project component pagination now keeps the :guilabel:`Components` tab active when jumping to a typed page number.

--- a/weblate/utils/db.py
+++ b/weblate/utils/db.py
@@ -38,8 +38,10 @@ def adjust_similarity_threshold(value: float, *, alias: str | None = None) -> No
         connection = connections["default"]
 
     current_similarity = getattr(connection, "weblate_similarity", -1)
-    # Ignore small differences
-    if round(abs(current_similarity - value), 3) < 0.05:
+    # Ignore only values that are effectively identical at the precision used
+    # by callers. Nearby values can affect whether boundary matches pass the
+    # pg_trgm % operator.
+    if round(current_similarity, 3) == round(value, 3):
         return
 
     with connection.cursor() as cursor:

--- a/weblate/utils/tests/test_db.py
+++ b/weblate/utils/tests/test_db.py
@@ -33,6 +33,22 @@ class DbTest(TestCase):
 
         cursor.execute.assert_called_once_with("SELECT set_limit(%s)", [0.92])
 
+    @patch("weblate.utils.db.connections")
+    def test_adjust_similarity_threshold_applies_nearby_updates(
+        self, connections_mock
+    ) -> None:
+        cursor = MagicMock()
+        cursor.__enter__.return_value = cursor
+        connection = MagicMock()
+        connection.cursor.return_value = cursor
+        connection.weblate_similarity = 0.98
+        connections_mock.__contains__.return_value = False
+        connections_mock.__getitem__.return_value = connection
+
+        adjust_similarity_threshold(0.966)
+
+        cursor.execute.assert_called_once_with("SELECT set_limit(%s)", [0.966])
+
 
 class PostgreSQLOperatorTest(TestCase):
     def test_search(self) -> None:


### PR DESCRIPTION
The 0.05 step is too big for longer strings, compare it to three decimals.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
