### PR TITLE
docs: Cleanup duplicate changelog bullets

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2189,6 +2189,8 @@ Weblate 5.0.1
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
+* The database upgrade can take considerable time on larger sites due to indexing changes.
+
 `All changes in detail <https://github.com/WeblateOrg/weblate/milestone/103?closed=1>`__.
 
 Weblate 5.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -787,7 +787,6 @@ Weblate 5.13
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
 * The distributed locking now uses a different implementation and that introduced several changes in :file:`settings_example.py`, most notably ``BACKEND`` in ``CACHES`` needs to be changed.
-* There are several changes in :file:`settings_example.py`, most notable are changed settings ``CRISPY_ALLOWED_TEMPLATE_PACKS`` and ``INSTALLED_APPS``; please adjust your settings accordingly.
 * The Docker container is now using :program:`granian`. This now requires explicit configuration of proxy trusted headers, including client protocol.
   :envvar:`WEBLATE_SECURE_PROXY_SSL_HEADER` typically needs to be added to avoid redirect loop, for example:
 
@@ -1399,7 +1398,6 @@ Weblate 5.8.2
 * Reduced number of database queries when updating multiple strings.
 * Leading problematic characters in :ref:`glossary` terms are now properly stripped in uploaded files.
 * Improved :ref:`workflow-customization` performance.
-* Fixed XML escaped output in some machine translation integrations.
 
 .. rubric:: Upgrading
 
@@ -1883,7 +1881,6 @@ Weblate 5.4.1
 .. rubric:: Bug fixes
 
 * Possible crash on Weblate upgrade check when cached from the previous versions.
-* Gracefully handle migration with duplicate built-in teams.
 
 .. rubric:: Upgrading
 
@@ -2191,8 +2188,6 @@ Weblate 5.0.1
 .. rubric:: Upgrading
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
-
-* The database upgrade can take considerable time on larger sites due to indexing changes.
 
 `All changes in detail <https://github.com/WeblateOrg/weblate/milestone/103?closed=1>`__.
 


### PR DESCRIPTION
Some bullet points in `changes.rst` are duplicate, probably due to a merge/rebase error after a new version was released.
This PR just cleans them out, assuming that the later is the valid one (i.e a change initally planned to be include in vX.X was eventually included in vX.X+1).
