### PR TITLE
fix(billing): add project owners to billing only for last project

### DIFF
--- a/weblate/billing/models.py
+++ b/weblate/billing/models.py
@@ -718,6 +718,10 @@ def record_project_bill(
     if isinstance(instance, Project):
         users = User.objects.having_perm("project.edit", instance)
         for billing in instance.billing_set.all():
+            # Do the owners sync only for the last project
+            if billing.projects.exclude(pk=instance.pk).exists():
+                continue
+            # Add project admins to the billing
             existing_owners = set(billing.owners.values_list("id", flat=True))
             for user in users:
                 if user.id in existing_owners:


### PR DESCRIPTION
This avoids escalation path when billing has multiple projects. What we really want to cover is that user removing the last project in the billing has permission to manage the billing.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
