### PR TITLE
fix(announcements): handle category-level announcements same as others

### DIFF
--- a/docs/admin/announcements.rst
+++ b/docs/admin/announcements.rst
@@ -5,7 +5,8 @@ Announcements
 
    In prior releases this feature was called whiteboard messages.
 
-Provide info to your translators by posting announcements, site-wide, per project, component, or language.
+Provide info to your translators by posting announcements, site-wide, per project,
+category, component, or language.
 
 Announce the purpose, deadlines, status, or specify targets for translation.
 
@@ -34,6 +35,10 @@ No context specified
 Project specified
 
     Shown within the project, including all its components and translations.
+
+Category specified
+
+    Shown within the category, including all its components and translations.
 
 Component specified
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 2026.5
 .. rubric:: Bug fixes
 
 * Database error details are no longer exposed in upload failure messages.
+* Category :doc:`/admin/announcements` no longer appear across the whole project.
 * Merge request pushes now refresh stale fork remotes after changing repository hosting.
 * :ref:`vcs-gerrit` now tracks the target branch on its Gerrit remote before invoking ``git-review``.
 * :ref:`vcs-gerrit` branch validation now suggests short branch names when full refs are supplied.

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -10323,7 +10323,6 @@ class AnnouncementAPITest(APIBaseTest):
             project=self.component.project, message="Test project announcement"
         )
         self.category_announcement = Announcement.objects.create(
-            project=self.component.project,
             category=self.category,
             message="Test category announcement",
         )
@@ -10585,7 +10584,7 @@ class AnnouncementAPITest(APIBaseTest):
             id=response.data["id"]
         )
         self.assertIsNotNone(announcement)
-        self.assertEqual(announcement.project, category.project)
+        self.assertIsNone(announcement.project)
         self.assertEqual(announcement.category, category)
         self.assertIsNone(announcement.component)
         self.assertIsNone(announcement.language)

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1281,7 +1281,6 @@ class AnnouncementsMixin:
         if isinstance(obj, Project):
             project = obj
         if isinstance(obj, Category):
-            project = obj.project
             category = obj
         if isinstance(obj, Component):
             project = obj.project
@@ -1295,6 +1294,12 @@ class AnnouncementsMixin:
 
     def get_announcements(self, obj):
         project, category, component, language = self.get_context(obj)
+        if category is not None:
+            return Announcement.objects.filter(
+                category=category,
+                component=component,
+                language=language,
+            )
 
         return Announcement.objects.filter(
             project=project,
@@ -1372,7 +1377,7 @@ class AnnouncementsMixin:
             msg = f"Announcement with ID {announcement_id} was not found"
             raise Http404(msg) from error
 
-        if not request.user.has_perm("announcement.delete", obj):
+        if not request.user.has_perm("announcement.delete", announcement):
             self.permission_denied(request, "Can not delete announcement")
 
         announcement.delete()

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext
 from weblate.formats.base import BilingualUpdateMixin
 from weblate.lang.models import Language
 from weblate.trans.models import (
+    Announcement,
     Category,
     Component,
     ComponentList,
@@ -630,8 +631,18 @@ def check_billing(user: User, permission: str, obj: Project) -> bool | Permissio
 
 @register_perm("announcement.delete")
 def check_announcement_delete(
-    user: User, permission: str, obj: Project | Component | None
+    user: User,
+    permission: str,
+    obj: Announcement | Project | Category | Component | None,
 ) -> bool | PermissionResult:
+    if isinstance(obj, Announcement):
+        if obj.component_id is not None:
+            obj = obj.component
+        elif obj.category_id is not None:
+            obj = obj.category
+        else:
+            obj = obj.project
+
     if obj is None:
         return check_global_permission(user, permission)
     return check_permission(user, permission, obj)

--- a/weblate/templates/category.html
+++ b/weblate/templates/category.html
@@ -145,7 +145,7 @@
 
 {% block content %}
 
-  {% announcements project=object.project %}
+  {% announcements category=object %}
 
   {% include "snippets/project/state.html" with object=object.project %}
 

--- a/weblate/trans/models/announcement.py
+++ b/weblate/trans/models/announcement.py
@@ -15,43 +15,84 @@ from weblate.trans.actions import ActionEvents
 
 
 class AnnouncementManager(models.Manager["Announcement"]):
-    def context_filter(self, project=None, component=None, language=None):
+    @staticmethod
+    def _category_filter(category):
+        category_ids = []
+        while category is not None:
+            category_ids.append(category.pk)
+            category = category.category
+        if not category_ids:
+            return Q(pk__in=[])
+        return Q(category_id__in=category_ids)
+
+    def context_filter(
+        self, project=None, component=None, language=None, category=None
+    ):
         """Filter announcements by context."""
         base = self.filter(
             Q(expiry__isnull=True) | Q(expiry__gte=timezone.now())
         ).order()
 
-        if language and project is None and component is None:
-            return base.filter(project=None, component=None, language=language)
+        if language and project is None and component is None and category is None:
+            return base.filter(
+                project=None, category=None, component=None, language=language
+            )
 
         if component:
+            category_filter = self._category_filter(component.category)
             if language:
                 return base.filter(
                     (Q(component=component) & Q(language=language))
-                    | (Q(project=None) & Q(component=None) & Q(language=language))
+                    | (
+                        Q(project=None)
+                        & Q(category=None)
+                        & Q(component=None)
+                        & Q(language=language)
+                    )
                     | (Q(component=component) & Q(language=None))
-                    | (Q(project=component.project) & Q(component=None))
+                    | (category_filter & Q(component=None))
+                    | (
+                        Q(project=component.project)
+                        & Q(category=None)
+                        & Q(component=None)
+                    )
                 )
 
             return base.filter(
                 (Q(component=component) & Q(language=None))
-                | (Q(project=component.project) & Q(component=None))
+                | (category_filter & Q(component=None))
+                | (Q(project=component.project) & Q(category=None) & Q(component=None))
+            )
+
+        if category:
+            category_filter = self._category_filter(category)
+            return base.filter(
+                (category_filter & Q(component=None))
+                | (Q(project=category.project) & Q(category=None) & Q(component=None))
             )
 
         if project:
-            return base.filter(Q(project=project) & Q(component=None))
+            return base.filter(
+                Q(project=project) & Q(category=None) & Q(component=None)
+            )
 
         # All are None
-        return base.filter(project=None, component=None, language=None)
+        return base.filter(project=None, category=None, component=None, language=None)
 
     def create(self, user=None, **kwargs):
         from weblate.trans.models.change import Change  # noqa: PLC0415
 
+        if kwargs.get("category") is not None and kwargs.get("component") is None:
+            kwargs["project"] = None
+
         result = super().create(**kwargs)
+        project = result.project
+        if project is None and result.category is not None:
+            project = result.category.project
 
         Change.objects.create(
             action=ActionEvents.ANNOUNCEMENT,
-            project=result.project,
+            project=project,
             category=result.category,
             component=result.component,
             language=result.language,
@@ -141,6 +182,16 @@ class Announcement(models.Model):
         return self.message
 
     def clean(self) -> None:
+        if self.category and self.component:
+            raise ValidationError(
+                gettext("Do not specify both component and category!")
+            )
+        if self.category:
+            if self.project and self.category.project != self.project:
+                raise ValidationError(
+                    gettext("The category does not belong to the selected project.")
+                )
+            self.project = None
         if self.project and self.component and self.component.project != self.project:
             raise ValidationError(gettext("Do not specify both component and project!"))
         if not self.project and self.component:

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -964,7 +964,9 @@ def get_location_links(user: User | None, unit):
 
 
 @register.simple_tag(takes_context=True)
-def announcements(context: Context, project=None, component=None, language=None):
+def announcements(
+    context: Context, project=None, component=None, language=None, category=None
+):
     """Display announcement messages for given context."""
     user = context["user"]
 
@@ -980,16 +982,16 @@ def announcements(context: Context, project=None, component=None, language=None)
                         "message": render_markdown(announcement.message),
                         "announcement": announcement,
                         "can_delete": user.has_perm(
-                            "announcement.delete",
-                            announcement.component
-                            if announcement.component is not None
-                            else announcement.project,
+                            "announcement.delete", announcement
                         ),
                     },
                 ),
             )
             for announcement in Announcement.objects.context_filter(
-                project, component, language
+                project=project,
+                component=component,
+                language=language,
+                category=category,
             )
         ),
     )

--- a/weblate/trans/tests/test_manage.py
+++ b/weblate/trans/tests/test_manage.py
@@ -407,6 +407,9 @@ class AnnouncementPermissionTestCase(ViewTestCase):
         category.save()
         url = reverse("announcement", kwargs={"path": category.get_url_path()})
         self.perform_test(url)
+        announcement = Announcement.objects.get(message=self.data["message"])
+        self.assertEqual(announcement.category, category)
+        self.assertIsNone(announcement.project)
 
     def test_delete_announcement(self) -> None:
         second_component = self.create_link_existing()
@@ -424,6 +427,13 @@ class AnnouncementPermissionTestCase(ViewTestCase):
         project_announcement = Announcement.objects.create(
             message="test project announcement",
             project=self.project,
+        )
+        category = Category.objects.create(
+            project=self.project, name="Test Category", slug="test-category"
+        )
+        category_announcement = Announcement.objects.create(
+            message="test category announcement",
+            category=category,
         )
 
         group = Group.objects.create(
@@ -458,6 +468,14 @@ class AnnouncementPermissionTestCase(ViewTestCase):
             Announcement.objects.filter(pk=project_announcement.pk).count(), 1
         )
 
+        response = self.client.post(
+            reverse("announcement-delete", kwargs={"pk": category_announcement.pk})
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            Announcement.objects.filter(pk=category_announcement.pk).count(), 1
+        )
+
         group.project_selection = SELECTION_ALL
         group.components.clear()
         group.save()
@@ -477,6 +495,14 @@ class AnnouncementPermissionTestCase(ViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             Announcement.objects.filter(pk=project_announcement.pk).count(), 0
+        )
+
+        response = self.client.post(
+            reverse("announcement-delete", kwargs={"pk": category_announcement.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            Announcement.objects.filter(pk=category_announcement.pk).count(), 0
         )
         self.assertEqual(Announcement.objects.count(), 0)
 

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -1167,6 +1167,53 @@ class AnnouncementTest(ModelTestCase):
             "test project",
         )
 
+    def test_contextfilter_category(self) -> None:
+        category = self.create_category(self.component.project)
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        other_component = self.create_po(project=self.component.project, name="Other")
+        Announcement.objects.create(
+            category=category,
+            message="test category",
+        )
+
+        self.assertCountEqual(
+            [
+                announcement.message
+                for announcement in Announcement.objects.context_filter(
+                    project=self.component.project
+                )
+            ],
+            ["test project"],
+        )
+        self.assertCountEqual(
+            [
+                announcement.message
+                for announcement in Announcement.objects.context_filter(
+                    category=category
+                )
+            ],
+            ["test project", "test category"],
+        )
+        self.assertCountEqual(
+            [
+                announcement.message
+                for announcement in Announcement.objects.context_filter(
+                    component=self.component
+                )
+            ],
+            ["test project", "test component", "test category"],
+        )
+        self.assertCountEqual(
+            [
+                announcement.message
+                for announcement in Announcement.objects.context_filter(
+                    component=other_component
+                )
+            ],
+            ["test project"],
+        )
+
     def test_contextfilter_component(self) -> None:
         self.verify_filter(
             Announcement.objects.context_filter(component=self.component), 2

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -613,7 +613,7 @@ def show_category(request: AuthenticatedHttpRequest, obj: Category) -> HttpRespo
                 obj=obj,
             ),
             "announcement_form": optional_form(
-                AnnouncementForm, user, "announcement.add", obj.project
+                AnnouncementForm, user, "announcement.add", obj
             ),
             "delete_form": optional_form(
                 CategoryDeleteForm, user, "project.edit", obj, obj=obj

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -399,7 +399,6 @@ def announcement(request: AuthenticatedHttpRequest, path):
         scope["project"] = obj.project
         scope["language"] = obj.language
     elif isinstance(obj, Category):
-        scope["project"] = obj.project
         scope["category"] = obj
     elif isinstance(obj, Translation):
         scope["project"] = obj.component.project
@@ -425,12 +424,7 @@ def announcement(request: AuthenticatedHttpRequest, path):
 def announcement_delete(request: AuthenticatedHttpRequest, pk):
     announcement = get_object_or_404(Announcement, pk=pk)
 
-    obj = (
-        announcement.component
-        if announcement.component is not None
-        else announcement.project
-    )
-    if not request.user.has_perm("announcement.delete", obj):
+    if not request.user.has_perm("announcement.delete", announcement):
         raise PermissionDenied
 
     announcement.delete()


### PR DESCRIPTION
Avoid setting project on category-level announcements to make the filtering consistent for all levels.

Followup for #11106

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
