### PR TITLE
fix(about): avoid crash on empty stats

### DIFF
--- a/weblate/trans/tests/test_basic_views.py
+++ b/weblate/trans/tests/test_basic_views.py
@@ -37,6 +37,14 @@ class BasicViewTest(FixtureTestCase):
         response = self.client.get(reverse("stats"))
         self.assertContains(response, "Weblate statistics")
 
+    def test_stats_without_active_users(self) -> None:
+        self.client.logout()
+        User.objects.update(is_active=False)
+
+        response = self.client.get(reverse("stats"))
+
+        self.assertContains(response, "Weblate statistics")
+
     def test_donate(self) -> None:
         response = self.client.get(reverse("donate"))
         self.assertContains(response, "Support Weblate")

--- a/weblate/trans/views/about.py
+++ b/weblate/trans/views/about.py
@@ -78,7 +78,7 @@ class StatsView(AboutView):
             .filter(user__is_bot=False, user__is_active=True)[:10]
             .select_related("user")
         )
-        translated_max = max(user.translated for user in top_users)
+        translated_max = max((user.translated for user in top_users), default=0)
         for user in top_users:
             if translated_max:
                 user.translated_width = 100 * user.translated // translated_max


### PR DESCRIPTION
Calling max() on empty users list would crash.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
