### PR TITLE
feat(create): honor file format parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ dependencies = [
   # Pin for translate-toolkit extra
   "tomlkit==0.14.0",
   "translate-toolkit[chardet,fluent,ini,markdown,toml,php,rc,subtitles,yaml]==3.19.8",
-  "translation-finder==2.24",
+  "translation-finder==3.0",
   "twisted==25.5.0",
   # Pin for translate-toolkit extra
   "unicode-segmentation-rs==0.2.4",

--- a/uv.lock
+++ b/uv.lock
@@ -4664,16 +4664,16 @@ yaml = [
 
 [[package]]
 name = "translation-finder"
-version = "2.24"
+version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "ruamel-yaml" },
     { name = "weblate-language-data" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/f0/f6bb9c07d6e59ed4516e73213da63d1b5036585c708d2c436f36cd9728e6/translation_finder-2.24.tar.gz", hash = "sha256:13612ae1dc0697f3e92f608f592d466173f391a404e9a93116498d2d54f49175", size = 80928, upload-time = "2026-01-26T06:59:11.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/f8/a314ddb5fc0ba0b1e48049f7fd0a795cc7ed70520b3b4b7f73057d54b7f4/translation_finder-3.0.tar.gz", hash = "sha256:30caf465b76fdcf60f19a7294cdae5c06a39e23ee6f2499b4350e9babcedd0e4", size = 85213, upload-time = "2026-05-06T14:12:57.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/f8/873c4ad9b54780cc204013f6f7ef452599159edad9b2d99d61a503163269/translation_finder-2.24-py3-none-any.whl", hash = "sha256:038a3b71a8c4e8141e5130a4f67e6ec89b8a1420df1c012a7d10bedda94ffe74", size = 91977, upload-time = "2026-01-26T06:59:12.458Z" },
+    { url = "https://files.pythonhosted.org/packages/52/79/d84230accee2ae4c956ceba80211942e49b22fbdf54427f229488a971dbc/translation_finder-3.0-py3-none-any.whl", hash = "sha256:f882c71fb5124889771f28b97b6083ec6302023c22a538c823c08768541eb42a", size = 95820, upload-time = "2026-05-06T14:12:58.707Z" },
 ]
 
 [[package]]
@@ -5453,7 +5453,7 @@ requires-dist = [
     { name = "tesserocr", specifier = "==2.10.0" },
     { name = "tomlkit", specifier = "==0.14.0" },
     { name = "translate-toolkit", extras = ["chardet", "fluent", "ini", "markdown", "toml", "php", "rc", "subtitles", "yaml"], specifier = "==3.19.8" },
-    { name = "translation-finder", specifier = "==2.24" },
+    { name = "translation-finder", specifier = "==3.0" },
     { name = "twisted", specifier = "==25.5.0" },
     { name = "unicode-segmentation-rs", specifier = "==0.2.4" },
     { name = "unidecode", specifier = "==1.4.0" },

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -121,6 +121,7 @@ if TYPE_CHECKING:
 
     from weblate.accounts.models import Profile
     from weblate.auth.models import AuthenticatedHttpRequest
+    from weblate.trans.file_format_params import FileFormatParams
     from weblate.trans.mixins import URLMixin
     from weblate.trans.models import (
         Translation,
@@ -2020,16 +2021,25 @@ class ComponentCreateForm(SettingsBaseForm, ComponentDocsMixin, ComponentAntispa
         ) and "file_format" in kwargs["initial"]:
             source_component = Component.objects.get(pk=int(source_component_text))
             if source_component.file_format_params:
-                kwargs["initial"]["file_format_params"] = {
+                supported_params = {
+                    param.get_identifier()
+                    for param in get_params_for_file_format(
+                        kwargs["initial"]["file_format"]
+                    )
+                }
+                source_file_format_params = {
                     k: v
                     for k, v in source_component.file_format_params.items()
-                    if k
-                    in [
-                        param.get_identifier()
-                        for param in get_params_for_file_format(
-                            kwargs["initial"]["file_format"]
-                        )
-                    ]
+                    if k in supported_params
+                }
+                initial_file_format_params = kwargs["initial"].get(
+                    "file_format_params", {}
+                )
+                if not isinstance(initial_file_format_params, dict):
+                    initial_file_format_params = {}
+                kwargs["initial"]["file_format_params"] = {
+                    **source_file_format_params,
+                    **initial_file_format_params,
                 }
         super().__init__(request, *args, **kwargs)
 
@@ -2361,11 +2371,29 @@ class ComponentDiscoverForm(ComponentInitCreateForm):
             hint=self.instance.filemask,
         )
 
+    @staticmethod
+    def get_discovery_data(value: DiscoveryResult) -> dict[str, Any]:
+        data = cast("dict[str, Any]", value.match)
+        file_format = data.get("file_format")
+        file_format_params = data.get("file_format_params")
+        if file_format_params is None:
+            return data
+        if not isinstance(file_format, str) or not isinstance(file_format_params, dict):
+            data.pop("file_format_params", None)
+            return data
+        data["file_format_params"] = strip_unused_file_format_params(
+            file_format,
+            cast("FileFormatParams", file_format_params.copy()),
+        )
+        return data
+
     def clean(self) -> None:
         super().clean()
         discovery = self.cleaned_data.get("discovery")
         if discovery and discovery != "manual":
-            self.cleaned_data.update(self.discovered[int(discovery)])
+            self.cleaned_data.update(
+                self.get_discovery_data(self.discovered[int(discovery)])
+            )
 
 
 class ComponentRenameForm(SettingsBaseForm, ComponentDocsMixin):

--- a/weblate/trans/tests/test_create.py
+++ b/weblate/trans/tests/test_create.py
@@ -4,16 +4,24 @@
 
 """Test for creating projects and models."""
 
+from typing import TYPE_CHECKING, cast
+from unittest.mock import patch
+
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
+from translation_finder import DiscoveryResult
 
 from weblate.lang.models import Language, get_default_lang
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Component
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import create_test_billing, get_test_file
+from weblate.utils.views import get_form_data
 from weblate.vcs.git import GitRepository
+
+if TYPE_CHECKING:
+    from translation_finder.discovery.result import ResultDict
 
 TEST_ZIP = get_test_file("translations.zip")
 TEST_HTML = get_test_file("cs.html")
@@ -179,6 +187,83 @@ class CreateTest(ViewTestCase):
             response = self.client.post(reverse("create-component-vcs"), params)
         self.assertContains(response, self.component.get_repo_link_url())
         self.assertContains(response, "po/*.po")
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_create_component_wizard_discovery_file_format_params(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+        source_component = self.create_java(name="source-java", project=self.project)
+
+        discovery = DiscoveryResult(
+            cast(
+                "ResultDict",
+                {
+                    "file_format": "properties",
+                    "filemask": "java/swing_messages_*.properties",
+                    "template": "java/swing_messages.properties",
+                    "file_format_params": {
+                        "properties_encoding": "utf-8",
+                        "strings_encoding": "utf-16",
+                    },
+                },
+            )
+        )
+        discovery.meta = {"priority": 1000, "origin": None}
+        create_url = (
+            f"{reverse('create-component-vcs')}?source_component={source_component.pk}"
+        )
+        params = {
+            "name": "Create Component With Discovery Params",
+            "slug": "create-component-with-discovery-params",
+            "project": self.project.pk,
+            "vcs": "git",
+            "repo": self.component.repo,
+            "source_language": get_default_lang(),
+        }
+
+        with (
+            patch("weblate.trans.forms.discover", return_value=[discovery]),
+            override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES),
+        ):
+            response = self.client.post(create_url, params)
+        self.assertContains(response, "Choose translation files to import")
+        self.assertContains(response, "java/swing_messages_*.properties")
+        self.assertNotContains(response, "properties_encoding")
+        self.assertNotContains(response, "strings_encoding")
+
+        params["discovery"] = "0"
+        with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
+            response = self.client.post(create_url, params)
+        self.assertContains(
+            response,
+            "You will be able to edit more options in the component settings after creating it.",
+        )
+        data = get_form_data(response.context["form"].initial)
+        self.assertEqual(data["file_format"], "properties")
+        self.assertEqual(
+            data["file_format_params"],
+            {"properties_encoding": "utf-8"},
+        )
+
+        file_format_params = data.pop("file_format_params")
+        data.update(
+            {
+                f"file_format_params_{key}": value
+                for key, value in file_format_params.items()
+            }
+        )
+        data["project"] = self.project.pk
+        data["source_language"] = get_default_lang()
+        data["language_regex"] = "^[^.]+$"
+        data["new_base"] = ""
+        data["new_lang"] = "contact"
+        with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
+            response = self.client.post(create_url, data)
+        self.assertEqual(response.status_code, 302)
+
+        component = Component.objects.get(slug="create-component-with-discovery-params")
+        self.assertEqual(component.file_format_params["properties_encoding"], "utf-8")
+        self.assertNotIn("strings_encoding", component.file_format_params)
 
     @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
     def test_create_component_existing(self) -> None:


### PR DESCRIPTION
    
    
The file encoding now lands as a file format parameter from the finder.


<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
