### PR TITLE
feat(utils): check for CACHE_DIR allowing executables

### DIFF
--- a/dev-docker/docker-compose.yml
+++ b/dev-docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     restart: always
     user: $USER_ID:$GROUP_ID
     tmpfs:
-    - /app/cache:uid=$USER_ID,gid=$GROUP_ID
+    - /app/cache:exec,uid=$USER_ID,gid=$GROUP_ID
     - /tmp:uid=$USER_ID,gid=$GROUP_ID,exec
     - /run:uid=$USER_ID,gid=$GROUP_ID
     userns_mode: host

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -381,16 +381,16 @@ in :setting:`DATA_DIR`.
 Change this to local or temporary filesystem if :setting:`DATA_DIR` is on a
 network filesystem.
 
-Weblate also stores generated SSH wrapper scripts here, so :setting:`CACHE_DIR`
-needs to be on an executable filesystem if :setting:`DATA_DIR` is mounted with
-``noexec``.
+Weblate stores generated helper files here and executes some of them, so
+:setting:`CACHE_DIR` has to be writable and mounted on a filesystem that allows
+execution. Avoid using ``noexec`` mount options for this directory.
 
 The Docker container uses a separate volume for this, see :ref:`docker-volume`.
 
 The following subdirectories usually exist:
 
 :file:`ssh`
-   Generated SSH wrapper scripts used for VCS access.
+   Generated helper files used for VCS access.
 :file:`fonts`
    :program:`font-config` cache for :ref:`fonts`.
 :file:`avatar`

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -405,6 +405,10 @@ you might prefer to move these to a better location such as:
 Weblate tries to create these directories automatically, but it will fail
 when it does not have permissions to do so.
 
+The configured :setting:`CACHE_DIR` also has to be writable by the Weblate
+process and has to allow executing generated helper files. Do not mount
+:setting:`CACHE_DIR` with the ``noexec`` option.
+
 You should also take care when running :ref:`manage`, as they should be ran
 under the same user as Weblate itself is running, otherwise permissions on some
 files might be wrong.

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -2258,7 +2258,24 @@ consist of name of your docker-compose directory, container, and volume names).
 
 The :file:`cache` volume is mounted as :file:`/app/cache` and is used to store static
 files and :setting:`CACHE_DIR`. Its content is recreated on container startup
-and the volume can be mounted using ephemeral filesystem such as `tmpfs`.
+and the volume can be mounted using ephemeral filesystem such as `tmpfs`, but
+the mount has to allow execution because Weblate stores generated helper files
+there.
+
+When mounting :file:`/app/cache` explicitly as ``tmpfs`` in Docker Compose,
+enable execution:
+
+.. code-block:: yaml
+
+   tmpfs:
+     - /app/cache:exec
+
+When also setting ownership options, keep the ``exec`` option:
+
+.. code-block:: yaml
+
+   tmpfs:
+     - /app/cache:exec,uid=1000,gid=1000
 
 When creating the volumes manually, the directories should be owned by UID 1000
 as that is user used inside the container.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Weblate 2026.5
 * Improved :ref:`LLM translation context <llm-translation-context>` for automatic suggestions.
 * Audited project and component setting changes are now recorded in history.
 * :ref:`vcs-gerrit` now uses :ref:`component-push_branch` as the target branch for review pushes.
+* Weblate now checks whether :setting:`CACHE_DIR` allows executing generated helper files.
 * The :ref:`sbom` is now generated during release and published as a versioned release asset instead of being stored in the source repository.
 
 .. rubric:: Bug fixes

--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 
 import errno
 import os
+import subprocess  # noqa: S404
 import time
+from contextlib import suppress
 from datetime import timedelta
 from email.utils import parseaddr
 from itertools import chain
 from pathlib import Path
 from shutil import disk_usage
+from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, cast
 
 from celery.exceptions import TimeoutError as CeleryTimeoutError
@@ -63,6 +66,47 @@ DEFAULT_SECRET_KEYS = {
     "jm8fqjlg+5!#xu%e-oh#7!$aa7!6avf7ud*_v=chdrb9qdco6(",
     "secret key used for tests only",
 }
+CACHE_EXEC_CHECK_PREFIX = ".weblate-cache-exec-"
+
+
+def check_cache_dir_executable(cache_dir: Path) -> CheckMessage | None:
+    """Check whether Weblate can execute generated files from cache."""
+    probe: Path | None = None
+    message = (
+        "Cannot execute files from {}, check your CACHE_DIR settings and mount options."
+    )
+    try:
+        with NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=cache_dir,
+            prefix=CACHE_EXEC_CHECK_PREFIX,
+            delete=False,
+        ) as handle:
+            probe = Path(handle.name)
+            handle.write("#!/bin/sh\nexit 0\n")
+        probe.chmod(0o755)
+        result = subprocess.run(  # noqa: S603
+            [probe.as_posix()],
+            check=False,
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            timeout=5,
+        )
+        if result.returncode:
+            status = result.returncode
+            return weblate_check(
+                "weblate.C044",
+                f"{message.format(cache_dir)} The check exited with status {status}.",
+            )
+    except (OSError, subprocess.SubprocessError) as error:
+        return weblate_check("weblate.C044", f"{message.format(cache_dir)} {error}")
+    finally:
+        if probe is not None:
+            with suppress(OSError):
+                probe.unlink()
+
+    return None
 
 
 @register(deploy=True)
@@ -349,10 +393,16 @@ def check_data_writable(
         data_path("cache") / "fonts",
     ]
     message = "Path {} is not writable, check your DATA_DIR and CACHE_DIR settings."
+    cache_path = data_path("cache") / "ssh"
     for path in dirs:
         path.mkdir(parents=True, exist_ok=True)
         if not os.access(path, os.W_OK):
             errors.append(weblate_check("weblate.E002", message.format(path), Error))
+
+    if os.access(cache_path, os.W_OK) and (
+        executable_error := check_cache_dir_executable(cache_path)
+    ):
+        errors.append(executable_error)
 
     return errors
 

--- a/weblate/utils/checks.py
+++ b/weblate/utils/checks.py
@@ -81,6 +81,7 @@ DOC_LINKS: dict[str, str | tuple[str] | tuple[str, str]] = {
     "weblate.C041": "https://weblate.org/user/",
     "weblate.C042": ("admin/config", "std-setting-REGISTRATION_ALLOW_BACKENDS"),
     "weblate.E043": ("admin/install", "hardware"),
+    "weblate.C044": ("admin/config", "std-setting-CACHE_DIR"),
 }
 
 

--- a/weblate/utils/tests/test_checks.py
+++ b/weblate/utils/tests/test_checks.py
@@ -5,16 +5,24 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import Mock, patch
 
+from django.conf import settings
 from django.core.cache import cache
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
 from weblate.addons.base import BaseAddon
-from weblate.utils.apps import check_class_loader, check_settings
+from weblate.utils.apps import (
+    CACHE_EXEC_CHECK_PREFIX,
+    check_class_loader,
+    check_data_writable,
+    check_settings,
+)
 from weblate.utils.celery import is_celery_queue_long
 from weblate.utils.classloader import ClassLoader
+from weblate.utils.unittest import tempdir_setting
 
 
 class CeleryQueueTest(SimpleTestCase):
@@ -95,6 +103,46 @@ class ClassLoaderCheckTestCase(SimpleTestCase):
             self.assertIn("does not define a 'not_found' class", errors[0].msg)
         finally:
             ClassLoader.instances = old_instances
+
+
+class DataWritableCheckTestCase(SimpleTestCase):
+    @staticmethod
+    def get_cache_probes() -> list[Path]:
+        return list(
+            (Path(settings.CACHE_DIR) / "ssh").glob(f"{CACHE_EXEC_CHECK_PREFIX}*")
+        )
+
+    @tempdir_setting("CACHE_DIR")
+    @tempdir_setting("DATA_DIR")
+    def test_cache_dir_executable(self) -> None:
+        errors = list(check_data_writable(app_configs=None, databases=None))
+
+        self.assertFalse(any(error.id == "weblate.C044" for error in errors))
+        self.assertEqual(self.get_cache_probes(), [])
+
+    @tempdir_setting("CACHE_DIR")
+    @tempdir_setting("DATA_DIR")
+    def test_cache_dir_execution_permission_error(self) -> None:
+        with patch(
+            "weblate.utils.apps.subprocess.run",
+            side_effect=PermissionError("permission denied"),
+        ):
+            errors = list(check_data_writable(app_configs=None, databases=None))
+
+        self.assertTrue(any(error.id == "weblate.C044" for error in errors))
+        self.assertEqual(self.get_cache_probes(), [])
+
+    @tempdir_setting("CACHE_DIR")
+    @tempdir_setting("DATA_DIR")
+    def test_cache_dir_execution_failure(self) -> None:
+        with patch(
+            "weblate.utils.apps.subprocess.run",
+            return_value=Mock(returncode=126),
+        ):
+            errors = list(check_data_writable(app_configs=None, databases=None))
+
+        self.assertTrue(any(error.id == "weblate.C044" for error in errors))
+        self.assertEqual(self.get_cache_probes(), [])
 
 
 class SettingsCheckTestCase(SimpleTestCase):

--- a/weblate/wladmin/models.py
+++ b/weblate/wladmin/models.py
@@ -88,6 +88,7 @@ class ConfigurationErrorManager(models.Manager["ConfigurationError"]):
             "weblate.C040",
             "weblate.C041",
             "weblate.E006",
+            "weblate.C044",
         }
         removals = []
         existing = {error.name: error for error in self.all()}

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -404,12 +404,15 @@ class AdminTest(ViewTestCase):
             [
                 Critical(msg="Error", id="weblate.E001"),
                 Critical(msg="Test Error", id="weblate.E002"),
+                Critical(msg="Cache Error", id="weblate.C044"),
             ]
         )
         all_errors = ConfigurationError.objects.all()
-        self.assertEqual(len(all_errors), 1)
-        self.assertEqual(all_errors[0].name, "weblate.E002")
-        self.assertEqual(all_errors[0].message, "Test Error")
+        self.assertEqual(len(all_errors), 2)
+        self.assertEqual(
+            {error.name: error.message for error in all_errors},
+            {"weblate.E002": "Test Error", "weblate.C044": "Cache Error"},
+        )
         # No triggered checks
         ConfigurationError.objects.configuration_health_check([])
         self.assertEqual(ConfigurationError.objects.count(), 0)


### PR DESCRIPTION
The Docker tmpfs is noexec by default so this is quite easy to misconfigure and better to detect this early. Also updated documentation to cover this.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
