### PR TITLE
fix: reduce default altcha memory cost

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -114,7 +114,7 @@ class WeblateAccountsConf(AppConf):
     REGISTRATION_CAPTCHA = True
 
     ALTCHA_COST = 3
-    ALTCHA_MEMORY_COST = 65536
+    ALTCHA_MEMORY_COST = 32768
     ALTCHA_PARALLELISM = 1
 
     REGISTRATION_HINTS: ClassVar[dict[str, str]] = {}


### PR DESCRIPTION
The altcha challenge would take a very long time to solve sometimes, worsening the user experience. Reducing the memory cost makes it much faster, hopefully without weakening the deterrence factor too much.
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
