### PR TITLE
feat: Localize generic user agent strings

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -34,6 +34,7 @@ from django.utils.translation import (
     gettext_lazy,
     pgettext_lazy,
 )
+from django_stubs_ext import StrOrPromise
 from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from django_otp_webauthn.models import WebAuthnCredential
@@ -460,7 +461,7 @@ NOTIFY_ACTIVITY = {
 
 
 # Taken from https://github.com/selwin/python-user-agents/blob/master/user_agents/parsers.py
-USER_AGENT_DEVICE_TYPES: dict[str, str] = {
+USER_AGENT_DEVICE_TYPES: dict[str, StrOrPromise] = {
     # Translators: User agent device type
     "PC": pgettext_lazy("User agent device type", "PC"),
     # Translators: User agent device type

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -608,6 +608,21 @@ class AuditLog(models.Model):
             return EXTRA_MESSAGES[self.activity].format(**self.params)
         return None
 
+    def get_user_agent_display(self) -> str:
+        """Return a localized user agent string."""
+        ua_string = self.user_agent
+        if not ua_string:
+            return ""
+
+        parts = ua_string.split(" / ")
+        localized: list[str] = []
+        for part in parts:
+            part = part.strip()
+            if not part:
+                continue
+            localized.append(gettext(part))
+        return " / ".join(localized)
+
     def should_notify(self) -> bool:
         return (
             self.user is not None

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -468,7 +468,9 @@ USER_AGENT_DEVICE_TYPES: dict[str, str] = {
     # Translators: User agent device type
     "Generic Smartphone": pgettext_lazy("User agent platform", "Generic Smartphone"),
     # Translators: User agent device type
-    "Generic Feature Phone": pgettext_lazy("User agent platform", "Generic Feature Phone"),
+    "Generic Feature Phone": pgettext_lazy(
+        "User agent platform", "Generic Feature Phone"
+    ),
     # Translators: User agent device type
     "iOS-Device": pgettext_lazy("User agent platform", "iOS-Device"),
 }

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -466,9 +466,7 @@ USER_AGENT_DEVICE_TYPES: dict[str, str] = {
     # Translators: User agent device type
     "Other": pgettext_lazy("User agent device type", "Other"),
     # Translators: User agent device type
-    "Generic Smartphone": pgettext_lazy(
-        "User agent device type", "Generic Smartphone"
-    ),
+    "Generic Smartphone": pgettext_lazy("User agent device type", "Generic Smartphone"),
     # Translators: User agent device type
     "Generic Feature Phone": pgettext_lazy(
         "User agent device type", "Generic Feature Phone"

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -462,17 +462,19 @@ NOTIFY_ACTIVITY = {
 # Taken from https://github.com/selwin/python-user-agents/blob/master/user_agents/parsers.py
 USER_AGENT_DEVICE_TYPES: dict[str, str] = {
     # Translators: User agent device type
-    "PC": pgettext_lazy("User agent platform", "PC"),
+    "PC": pgettext_lazy("User agent device type", "PC"),
     # Translators: User agent device type
-    "Other": pgettext_lazy("User agent platform", "Other"),
+    "Other": pgettext_lazy("User agent device type", "Other"),
     # Translators: User agent device type
-    "Generic Smartphone": pgettext_lazy("User agent platform", "Generic Smartphone"),
-    # Translators: User agent device type
-    "Generic Feature Phone": pgettext_lazy(
-        "User agent platform", "Generic Feature Phone"
+    "Generic Smartphone": pgettext_lazy(
+        "User agent device type", "Generic Smartphone"
     ),
     # Translators: User agent device type
-    "iOS-Device": pgettext_lazy("User agent platform", "iOS-Device"),
+    "Generic Feature Phone": pgettext_lazy(
+        "User agent device type", "Generic Feature Phone"
+    ),
+    # Translators: User agent device type
+    "iOS-Device": pgettext_lazy("User agent device type", "iOS-Device"),
 }
 
 
@@ -631,7 +633,7 @@ class AuditLog(models.Model):
         return None
 
     def get_user_agent_display(self) -> str:
-        """Return a localized user agent string."""
+        """Return a user agent string with a localized device/platform segment."""
         ua_string = self.user_agent
         if not ua_string:
             return ""

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -638,9 +638,7 @@ class AuditLog(models.Model):
         localized = list(parts)
         if localized:
             device_type = localized[0].strip()
-            localized[0] = gettext(
-                USER_AGENT_DEVICE_TYPES.get(device_type, device_type)
-            )
+            localized[0] = USER_AGENT_DEVICE_TYPES.get(device_type, device_type)
 
         return " / ".join(localized)
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -615,12 +615,10 @@ class AuditLog(models.Model):
             return ""
 
         parts = ua_string.split(" / ")
-        localized: list[str] = []
-        for part in parts:
-            part = part.strip()
-            if not part:
-                continue
-            localized.append(gettext(part))
+        localized = list(parts)
+        if localized:
+            localized[0] = gettext(localized[0].strip())
+
         return " / ".join(localized)
 
     def should_notify(self) -> bool:

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -28,7 +28,12 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.timezone import now
-from django.utils.translation import get_language, gettext, gettext_lazy
+from django.utils.translation import (
+    get_language,
+    gettext,
+    gettext_lazy,
+    gettext_noop,
+)
 from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from django_otp_webauthn.models import WebAuthnCredential
@@ -454,6 +459,21 @@ NOTIFY_ACTIVITY = {
 }
 
 
+# Taken from https://github.com/selwin/python-user-agents/blob/master/user_agents/parsers.py
+USER_AGENT_DEVICE_TYPES: dict[str, str] = {
+    # Translators: User agent device type
+    "PC": gettext_noop("PC"),
+    # Translators: User agent device type
+    "Other": gettext_noop("Other"),
+    # Translators: User agent device type
+    "Generic Smartphone": gettext_noop("Generic Smartphone"),
+    # Translators: User agent device type
+    "Generic Feature Phone": gettext_noop("Generic Feature Phone"),
+    # Translators: User agent device type
+    "iOS-Device": gettext_noop("iOS-Device"),
+}
+
+
 class AuditLogManager(models.Manager):
     def is_new_login(self, user: User, address, user_agent) -> bool:
         """
@@ -617,7 +637,10 @@ class AuditLog(models.Model):
         parts = ua_string.split(" / ")
         localized = list(parts)
         if localized:
-            localized[0] = gettext(localized[0].strip())
+            device_type = localized[0].strip()
+            localized[0] = gettext(
+                USER_AGENT_DEVICE_TYPES.get(device_type, device_type)
+            )
 
         return " / ".join(localized)
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -32,7 +32,7 @@ from django.utils.translation import (
     get_language,
     gettext,
     gettext_lazy,
-    gettext_noop,
+    pgettext_lazy,
 )
 from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -462,15 +462,15 @@ NOTIFY_ACTIVITY = {
 # Taken from https://github.com/selwin/python-user-agents/blob/master/user_agents/parsers.py
 USER_AGENT_DEVICE_TYPES: dict[str, str] = {
     # Translators: User agent device type
-    "PC": gettext_lazy("PC"),
+    "PC": pgettext_lazy("PC"),
     # Translators: User agent device type
-    "Other": gettext_lazy("Other"),
+    "Other": pgettext_lazy("Other"),
     # Translators: User agent device type
-    "Generic Smartphone": gettext_lazy("Generic Smartphone"),
+    "Generic Smartphone": pgettext_lazy("Generic Smartphone"),
     # Translators: User agent device type
-    "Generic Feature Phone": gettext_lazy("Generic Feature Phone"),
+    "Generic Feature Phone": pgettext_lazy("Generic Feature Phone"),
     # Translators: User agent device type
-    "iOS-Device": gettext_lazy("iOS-Device"),
+    "iOS-Device": pgettext_lazy("iOS-Device"),
 }
 
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -462,15 +462,15 @@ NOTIFY_ACTIVITY = {
 # Taken from https://github.com/selwin/python-user-agents/blob/master/user_agents/parsers.py
 USER_AGENT_DEVICE_TYPES: dict[str, str] = {
     # Translators: User agent device type
-    "PC": pgettext_lazy("PC"),
+    "PC": pgettext_lazy("User agent platform", "PC"),
     # Translators: User agent device type
-    "Other": pgettext_lazy("Other"),
+    "Other": pgettext_lazy("User agent platform", "Other"),
     # Translators: User agent device type
-    "Generic Smartphone": pgettext_lazy("Generic Smartphone"),
+    "Generic Smartphone": pgettext_lazy("User agent platform", "Generic Smartphone"),
     # Translators: User agent device type
-    "Generic Feature Phone": pgettext_lazy("Generic Feature Phone"),
+    "Generic Feature Phone": pgettext_lazy("User agent platform", "Generic Feature Phone"),
     # Translators: User agent device type
-    "iOS-Device": pgettext_lazy("iOS-Device"),
+    "iOS-Device": pgettext_lazy("User agent platform", "iOS-Device"),
 }
 
 
@@ -638,7 +638,7 @@ class AuditLog(models.Model):
         localized = list(parts)
         if localized:
             device_type = localized[0].strip()
-            localized[0] = USER_AGENT_DEVICE_TYPES.get(device_type, device_type)
+            localized[0] = str(USER_AGENT_DEVICE_TYPES.get(device_type, device_type))
 
         return " / ".join(localized)
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -34,7 +34,6 @@ from django.utils.translation import (
     gettext_lazy,
     pgettext_lazy,
 )
-from django_stubs_ext import StrOrPromise
 from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from django_otp_webauthn.models import WebAuthnCredential
@@ -83,6 +82,7 @@ if TYPE_CHECKING:
 
     from django.http.request import HttpRequest
     from django_otp.models import Device
+    from django_stubs_ext import StrOrPromise
 
     from weblate.accounts.types import DeviceType
     from weblate.auth.models import AuthenticatedHttpRequest

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -462,15 +462,15 @@ NOTIFY_ACTIVITY = {
 # Taken from https://github.com/selwin/python-user-agents/blob/master/user_agents/parsers.py
 USER_AGENT_DEVICE_TYPES: dict[str, str] = {
     # Translators: User agent device type
-    "PC": gettext_noop("PC"),
+    "PC": gettext_lazy("PC"),
     # Translators: User agent device type
-    "Other": gettext_noop("Other"),
+    "Other": gettext_lazy("Other"),
     # Translators: User agent device type
-    "Generic Smartphone": gettext_noop("Generic Smartphone"),
+    "Generic Smartphone": gettext_lazy("Generic Smartphone"),
     # Translators: User agent device type
-    "Generic Feature Phone": gettext_noop("Generic Feature Phone"),
+    "Generic Feature Phone": gettext_lazy("Generic Feature Phone"),
     # Translators: User agent device type
-    "iOS-Device": gettext_noop("iOS-Device"),
+    "iOS-Device": gettext_lazy("iOS-Device"),
 }
 
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -632,18 +632,16 @@ class AuditLog(models.Model):
         return None
 
     def get_user_agent_display(self) -> str:
-        """Return a user agent string with a localized device/platform segment."""
+        """Return a user agent string with a localized first device-type segment."""
         ua_string = self.user_agent
         if not ua_string:
             return ""
 
         parts = ua_string.split(" / ")
-        localized = list(parts)
-        if localized:
-            device_type = localized[0].strip()
-            localized[0] = str(USER_AGENT_DEVICE_TYPES.get(device_type, device_type))
+        device_type = parts[0].strip()
+        parts[0] = str(USER_AGENT_DEVICE_TYPES.get(device_type, device_type))
 
-        return " / ".join(localized)
+        return " / ".join(parts)
 
     def should_notify(self) -> bool:
         return (

--- a/weblate/accounts/tests/test_models.py
+++ b/weblate/accounts/tests/test_models.py
@@ -44,21 +44,16 @@ class AuditLogTestCase(SimpleTestCase):
 
     def test_user_agent_display(self) -> None:
         audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
-        self.assertEqual(
-            audit.get_user_agent_display(), "PC / Linux / Chrome 120.0.0"
-        )
+        self.assertEqual(audit.get_user_agent_display(), "PC / Linux / Chrome 120.0.0")
 
-    def test_user_agent_display_calls_gettext_for_each_part(self) -> None:
+    def test_user_agent_display_calls_gettext_for_first_part_only(self) -> None:
         with mock.patch("weblate.accounts.models.gettext") as mocked_gettext:
             mocked_gettext.side_effect = lambda x: x
-            audit = AuditLog(
-                user_agent="PC / Linux / Chrome 120.0.0"
-            )
-            audit.get_user_agent_display()
-            self.assertEqual(mocked_gettext.call_count, 3)
+            audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
+            result = audit.get_user_agent_display()
+            self.assertEqual(mocked_gettext.call_count, 1)
             mocked_gettext.assert_any_call("PC")
-            mocked_gettext.assert_any_call("Linux")
-            mocked_gettext.assert_any_call("Chrome 120.0.0")
+            self.assertEqual(result, "PC / Linux / Chrome 120.0.0")
 
 
 class AuditLogLoggingTestCase(TestCase):

--- a/weblate/accounts/tests/test_models.py
+++ b/weblate/accounts/tests/test_models.py
@@ -47,13 +47,14 @@ class AuditLogTestCase(SimpleTestCase):
         self.assertEqual(audit.get_user_agent_display(), "PC / Linux / Chrome 120.0.0")
 
     def test_user_agent_display_calls_gettext_for_first_part_only(self) -> None:
-        with mock.patch("weblate.accounts.models.pgettext_lazy") as mocked_gettext:
-            mocked_gettext.side_effect = lambda x: x
+        with mock.patch.dict(
+            "weblate.accounts.models.USER_AGENT_DEVICE_TYPES",
+            {"PC": "Translated PC"},
+            clear=False,
+        ):
             audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
             result = audit.get_user_agent_display()
-            self.assertEqual(mocked_gettext.call_count, 1)
-            mocked_gettext.assert_any_call("PC")
-            self.assertEqual(result, "PC / Linux / Chrome 120.0.0")
+            self.assertEqual(result, "Translated PC / Linux / Chrome 120.0.0")
 
 
 class AuditLogLoggingTestCase(TestCase):

--- a/weblate/accounts/tests/test_models.py
+++ b/weblate/accounts/tests/test_models.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from unittest import mock
+
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
@@ -35,6 +37,28 @@ class AuditLogTestCase(SimpleTestCase):
         self.assertIn("superuser-revoked", AUDIT_WARNING)
         self.assertIn("superuser-granted", NOTIFY_ACTIVITY)
         self.assertIn("superuser-revoked", NOTIFY_ACTIVITY)
+
+    def test_user_agent_display_empty(self) -> None:
+        audit = AuditLog(user_agent="")
+        self.assertEqual(audit.get_user_agent_display(), "")
+
+    def test_user_agent_display(self) -> None:
+        audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
+        self.assertEqual(
+            audit.get_user_agent_display(), "PC / Linux / Chrome 120.0.0"
+        )
+
+    def test_user_agent_display_calls_gettext_for_each_part(self) -> None:
+        with mock.patch("weblate.accounts.models.gettext") as mocked_gettext:
+            mocked_gettext.side_effect = lambda x: x
+            audit = AuditLog(
+                user_agent="PC / Linux / Chrome 120.0.0"
+            )
+            audit.get_user_agent_display()
+            self.assertEqual(mocked_gettext.call_count, 3)
+            mocked_gettext.assert_any_call("PC")
+            mocked_gettext.assert_any_call("Linux")
+            mocked_gettext.assert_any_call("Chrome 120.0.0")
 
 
 class AuditLogLoggingTestCase(TestCase):

--- a/weblate/accounts/tests/test_models.py
+++ b/weblate/accounts/tests/test_models.py
@@ -47,7 +47,7 @@ class AuditLogTestCase(SimpleTestCase):
         self.assertEqual(audit.get_user_agent_display(), "PC / Linux / Chrome 120.0.0")
 
     def test_user_agent_display_calls_gettext_for_first_part_only(self) -> None:
-        with mock.patch("weblate.accounts.models.gettext") as mocked_gettext:
+        with mock.patch("weblate.accounts.models.gettext_lazy") as mocked_gettext:
             mocked_gettext.side_effect = lambda x: x
             audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
             result = audit.get_user_agent_display()

--- a/weblate/accounts/tests/test_models.py
+++ b/weblate/accounts/tests/test_models.py
@@ -47,7 +47,7 @@ class AuditLogTestCase(SimpleTestCase):
         self.assertEqual(audit.get_user_agent_display(), "PC / Linux / Chrome 120.0.0")
 
     def test_user_agent_display_calls_gettext_for_first_part_only(self) -> None:
-        with mock.patch("weblate.accounts.models.gettext_lazy") as mocked_gettext:
+        with mock.patch("weblate.accounts.models.pgettext_lazy") as mocked_gettext:
             mocked_gettext.side_effect = lambda x: x
             audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
             result = audit.get_user_agent_display()

--- a/weblate/accounts/tests/test_models.py
+++ b/weblate/accounts/tests/test_models.py
@@ -46,7 +46,7 @@ class AuditLogTestCase(SimpleTestCase):
         audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
         self.assertEqual(audit.get_user_agent_display(), "PC / Linux / Chrome 120.0.0")
 
-    def test_user_agent_display_calls_gettext_for_first_part_only(self) -> None:
+    def test_user_agent_display_localizes_first_part_via_mapping(self) -> None:
         with mock.patch.dict(
             "weblate.accounts.models.USER_AGENT_DEVICE_TYPES",
             {"PC": "Translated PC"},

--- a/weblate/templates/accounts/profile.html
+++ b/weblate/templates/accounts/profile.html
@@ -513,7 +513,7 @@
                   <td>{{ log.timestamp|naturaltime }}</td>
                   <td>{{ log.get_message }}</td>
                   <td>{{ log.address }}</td>
-                  <td>{{ log.user_agent }}</td>
+                  <td>{{ log.get_user_agent_display }}</td>
                 </tr>
               {% empty %}
                 <tr>

--- a/weblate/templates/accounts/user.html
+++ b/weblate/templates/accounts/user.html
@@ -319,7 +319,7 @@
                   <td>{{ log.timestamp|date:"DATETIME_FORMAT" }}</td>
                   <th>{{ log.get_message }}</th>
                   <td>{{ log.address }}</td>
-                  <td>{{ log.user_agent }}</td>
+                  <td>{{ log.get_user_agent_display }}</td>
                 </tr>
               {% endfor %}
             </tbody>


### PR DESCRIPTION
Fixes #12916

- This PR localizes the generic user agent strings when rendering in the audit log

We only localize the first part as the OS and the browser name + version probably don't need translating.

_I am unsure about the tests, I basically just mocked the localization method and then asserted the call - maybe there are better ways to do this_
