### PR TITLE
fix(ci): move pre-commit-ci/lite-action outside the composite

### DIFF
--- a/.github/actions/auto-commit/action.yml
+++ b/.github/actions/auto-commit/action.yml
@@ -5,17 +5,9 @@
 name: Prepare Auto Commit Changes
 description: Prepares generated changes for trusted maintenance commits
 
-inputs:
-  message:
-    description: Commit message to use for pull request formatting updates
-    required: true
-
 runs:
   using: composite
   steps:
-    # pre-commit-ci/lite-action identifies workflows by the caller step name.
-    # Keep the magic text in top-level workflow steps using this action.
-
   - name: pre-commit format the code
     run: uv run --frozen --only-group pre-commit prek run --all-files
     continue-on-error: true
@@ -24,14 +16,6 @@ runs:
   - name: Display changes
     run: git diff
     shell: bash
-
-    # PRs from forks / outside collaborators. This action receives no
-    # repository secret and is intentionally limited to pull request runs.
-  - name: Commit changes (external PR, pre-commit-ci-lite)
-    if: github.event_name == 'pull_request' && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]'
-    uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
-    with:
-      msg: ${{ inputs.message }}
 
   - name: Prepare maintenance patch
     if: github.event_name != 'pull_request' && github.repository_owner == 'WeblateOrg'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,10 +76,17 @@ jobs:
       run: uv run --frozen ./manage.py migrate --noinput --traceback
     - run: make -C docs update-docs
 
-    - name: Prepare maintenance patch (pre-commit-ci-lite)
+    - name: Prepare maintenance patch
       uses: ./.github/actions/auto-commit
+
+    # Keep this outside the composite action; pre-commit.ci lite detects the
+    # top-level post step, and composites expose nested post hooks.
+    # The condition mirrors pre-commit-ci/lite-action's main.mjs user-PR check.
+    - name: Commit changes (external PR, pre-commit-ci-lite)
+      if: github.event_name == 'pull_request' && github.event.sender.type == 'User'
+      uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       with:
-        message: 'docs: Documentation snippets update'
+        msg: 'docs: Documentation snippets update'
 
   list-languages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -30,7 +30,5 @@ jobs:
     - uses: ./.github/actions/pre-commit-setup
     - run: ./scripts/generate-license-data.py
 
-    - name: Prepare maintenance patch (pre-commit-ci-lite)
+    - name: Prepare maintenance patch
       uses: ./.github/actions/auto-commit
-      with:
-        message: 'utils: Update SPDX license data'

--- a/.github/workflows/schema-update.yml
+++ b/.github/workflows/schema-update.yml
@@ -39,7 +39,5 @@ jobs:
         uv sync --only-group schemas --only-group pre-commit
     - run: make -C docs update-schemas
 
-    - name: Prepare maintenance patch (pre-commit-ci-lite)
+    - name: Prepare maintenance patch
       uses: ./.github/actions/auto-commit
-      with:
-        message: 'docs: Update JSON schemas'

--- a/.github/workflows/unicodechars.yml
+++ b/.github/workflows/unicodechars.yml
@@ -42,7 +42,14 @@ jobs:
       run: uv sync --only-group pre-commit
     - run: ./scripts/generate-unicodechars.py > weblate/utils/unicodechars.py
 
-    - name: Prepare maintenance patch (pre-commit-ci-lite)
+    - name: Prepare maintenance patch
       uses: ./.github/actions/auto-commit
+
+    # Keep this outside the composite action; pre-commit.ci lite detects the
+    # top-level post step, and composites expose nested post hooks.
+    # The condition mirrors pre-commit-ci/lite-action's main.mjs user-PR check.
+    - name: Commit changes (external PR, pre-commit-ci-lite)
+      if: github.event_name == 'pull_request' && github.event.sender.type == 'User'
+      uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       with:
-        message: 'chore: update unicode characters data'
+        msg: 'chore: update unicode characters data'

--- a/.github/workflows/uv-upgrade.yml
+++ b/.github/workflows/uv-upgrade.yml
@@ -45,7 +45,14 @@ jobs:
     - run: uv sync --all-extras
       name: Update lock file
 
-    - name: Prepare maintenance patch (pre-commit-ci-lite)
+    - name: Prepare maintenance patch
       uses: ./.github/actions/auto-commit
+
+    # Keep this outside the composite action; pre-commit.ci lite detects the
+    # top-level post step, and composites expose nested post hooks.
+    # The condition mirrors pre-commit-ci/lite-action's main.mjs user-PR check.
+    - name: Commit changes (external PR, pre-commit-ci-lite)
+      if: github.event_name == 'pull_request' && github.event.sender.type == 'User'
+      uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       with:
-        message: 'chore(deps): update lockfile'
+        msg: 'chore(deps): update lockfile'

--- a/.github/workflows/yarn-update.yml
+++ b/.github/workflows/yarn-update.yml
@@ -55,7 +55,14 @@ jobs:
         yarn install
         yarn build
 
-    - name: Prepare maintenance patch (pre-commit-ci-lite)
+    - name: Prepare maintenance patch
       uses: ./.github/actions/auto-commit
+
+    # Keep this outside the composite action; pre-commit.ci lite detects the
+    # top-level post step, and composites expose nested post hooks.
+    # The condition mirrors pre-commit-ci/lite-action's main.mjs user-PR check.
+    - name: Commit changes (external PR, pre-commit-ci-lite)
+      if: github.event_name == 'pull_request' && github.event.sender.type == 'User'
+      uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       with:
-        message: 'chore(js): update vendored libraries'
+        msg: 'chore(js): update vendored libraries'


### PR DESCRIPTION
The composite action always exposes post if any action in it might trigger post. This breaks pre-commit-ci/lite-action logic as it uses option post step as a signal to look for the artifact.

Fixes #19582

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
