### PR TITLE
fix(component): better handle stale dirs

### DIFF
--- a/weblate/trans/mixins.py
+++ b/weblate/trans/mixins.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext
 from weblate.accounts.avatar import get_user_display
 from weblate.logger import LOGGER
 from weblate.utils.data import data_dir
+from weblate.utils.files import remove_tree
 
 if TYPE_CHECKING:
     from weblate.auth.models import User
@@ -128,8 +129,12 @@ class PathMixin(LoggerMixin, URLMixin):
                 new_parent = os.path.dirname(new_path)
                 if not os.path.exists(new_parent):
                     os.makedirs(new_parent)
-                if os.path.isdir(new_path) and not os.listdir(new_path):
-                    os.rmdir(new_path)
+                if os.path.lexists(new_path):
+                    self.log_info('removing stale target "%s"', new_path)
+                    if os.path.isdir(new_path) and not os.path.islink(new_path):
+                        remove_tree(new_path)
+                    else:
+                        os.unlink(new_path)
                 os.rename(old_path, new_path)
             return True
         return False

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -427,6 +427,11 @@ def cleanup_stale_repos(root: Path | None = None) -> bool:
                 empty_dir = False
             continue
 
+        component = _get_component_by_vcs_path(relative_parts)
+        if component is not None and not component.is_repo_link:
+            empty_dir = False
+            continue
+
         if not git_dir.exists() and not mercurial_dir.exists():
             # Possible project/category dir not present in the database.
             if not cleanup_stale_repos(path):
@@ -438,7 +443,6 @@ def cleanup_stale_repos(root: Path | None = None) -> bool:
             empty_dir = False
             continue
 
-        component = _get_component_by_vcs_path(relative_parts)
         if component is None:
             LOGGER.info("removing stale VCS path (not found): %s", path)
             remove_tree(path)

--- a/weblate/trans/tests/test_manage.py
+++ b/weblate/trans/tests/test_manage.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os.path
+import pathlib
 from typing import ClassVar
 from unittest.mock import patch
 
@@ -205,6 +206,33 @@ class RenameTest(ViewTestCase):
         # Test rename redirect for the old name in middleware
         response = self.client.get(original_url)
         self.assertRedirects(response, component.get_absolute_url(), status_code=301)
+
+    def test_rename_component_replaces_stale_target_dir(self) -> None:
+        self.make_manager()
+        old_path = self.component.full_path
+        target = os.path.join(data_dir("vcs"), self.project.slug, "stale-target")
+        os.makedirs(os.path.join(target, ".git"))
+        pathlib.Path(os.path.join(target, ".git", "config")).write_text(
+            "[stale]\n", encoding="utf-8"
+        )
+        self.addCleanup(remove_tree, target, True)
+
+        response = self.client.post(
+            reverse("rename", kwargs=self.kw_component),
+            {
+                "project": self.project.pk,
+                "slug": "stale-target",
+                "name": self.component.name,
+            },
+        )
+
+        self.assertRedirects(response, "/projects/test/stale-target/")
+        component = Component.objects.get(pk=self.component.pk)
+        config = pathlib.Path(component.full_path) / ".git" / "config"
+        self.assertFalse(os.path.exists(old_path))
+        self.assertTrue(os.path.isdir(component.full_path))
+        self.assertTrue(config.is_file())
+        self.assertNotIn("[stale]", config.read_text(encoding="utf-8"))
 
     def test_rename_component_locks_component_before_binding_form(self) -> None:
         self.make_manager()

--- a/weblate/trans/tests/test_tasks.py
+++ b/weblate/trans/tests/test_tasks.py
@@ -22,6 +22,7 @@ from weblate.trans.tasks import (
     update_remotes,
 )
 from weblate.trans.tests.test_views import ComponentTestCase
+from weblate.utils.files import remove_tree
 from weblate.utils.state import STATE_FUZZY, STATE_TRANSLATED
 from weblate.utils.tasks import (
     update_language_stats_parents,
@@ -104,6 +105,23 @@ class TasksTest(ComponentTestCase):
         self.assertTrue(
             os.path.isfile(os.path.join(component.full_path, ".git", "config"))
         )
+
+    def test_cleanup_stale_repos_keeps_empty_component_dir(self) -> None:
+        component = self.create_po(project=self.project, name="empty", vcs="local")
+        component_path = Path(component.full_path)
+
+        for entry in component_path.iterdir():
+            if entry.is_dir():
+                remove_tree(entry)
+            else:
+                entry.unlink()
+
+        old_timestamp = time.time() - 2 * 86400
+        os.utime(component_path, (old_timestamp, old_timestamp))
+
+        cleanup_stale_repos()
+
+        self.assertTrue(component_path.is_dir())
 
     def test_update_remotes(self) -> None:
         update_remotes()

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -495,6 +495,12 @@ class Repository:
                 timeout=3600,
                 **kwargs,
             )
+        except OSError as error:
+            if cwd is None or error.filename != cwd:
+                raise
+            raise RepositoryCommandError(
+                error.errno or 1, cls.sanitize_error_message(str(error))
+            ) from error
         except subprocess.TimeoutExpired as error:
             stdout = (
                 error.stdout.decode()

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -261,6 +261,20 @@ class RepositoryTest(SimpleTestCase):
 
         self.assertEqual(str(error), "Can not switch subversion URL (-1)")
 
+    def test_popen_missing_working_tree_raises_repository_error(self) -> None:
+        cwd = os.path.join(tempfile.gettempdir(), "missing-working-tree")
+        error = FileNotFoundError(2, "No such file or directory", cwd)
+
+        with (
+            patch("weblate.vcs.base.subprocess.run", side_effect=error),
+            self.assertRaises(RepositoryCommandError) as context,
+        ):
+            GitRepository._popen(["status"], cwd=cwd)  # noqa: SLF001
+
+        self.assertIs(context.exception.__cause__, error)
+        self.assertEqual(context.exception.retcode, 2)
+        self.assertIn(cwd, str(context.exception))
+
     def test_mercurial_repository_uses_hg_temp_dir(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_path = Path(tempdir)


### PR DESCRIPTION
When user renames there and back and imports new components in between, there might be some stale directories, so deal with that gracefully.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
