### PR TITLE
feat(search): allow to search for change events without an author

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Weblate 2026.6
 
 .. rubric:: Bug fixes
 
+* Searching for strings with content changes without a recorded author now supports ``changed_by:""``.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -81,6 +81,7 @@ Fields
    Path to the object to limit searching inside component, category, project, or translation.
 ``changed_by:TEXT``
    String was changed by author with given username.
+   Use ``changed_by:""`` to search for strings with at least one content change without a recorded author.
 ``changed:DATETIME``
    String content was changed on date, supports :ref:`search-operators` and :ref:`date-search`.
 ``change_time:DATETIME``

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -565,6 +565,26 @@ class UnitTermExpr(BaseTermExpr):
         "comment_author": "comment__user__username",
     }
 
+    def as_query(self, context: dict) -> Q:
+        if (
+            self.field == "changed_by"
+            and not self.match
+            and self.operator in {":", ":="}
+        ):
+            from weblate.trans.models import Change  # noqa: PLC0415
+
+            return Q(
+                Exists(
+                    Change.objects.filter(
+                        action__in=Change.ACTIONS_CONTENT,
+                        author__isnull=True,
+                        unit_id=OuterRef("pk"),
+                    )
+                )
+            )
+
+        return super().as_query(context)
+
     def is_field(self, text: str, context: dict) -> Q:
         if text in {"read-only", "readonly"}:
             return Q(state=STATE_READONLY)

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -411,11 +411,33 @@ class UnitQueryParserTest(SearchTestCase):
         self.assert_query("is:fuzzy", Q(state__in=FUZZY_STATES))
 
     def test_changed_by(self) -> None:
+        action_change = Q(change__action__in=Change.ACTIONS_CONTENT)
+
         self.assert_query(
             "changed_by:nijel",
-            Q(change__author__username__iexact="nijel")
-            & Q(change__action__in=Change.ACTIONS_CONTENT),
+            Q(change__author__username__iexact="nijel") & action_change,
         )
+        self.assert_query(
+            "changed_by:none",
+            Q(change__author__username__iexact="none") & action_change,
+        )
+
+        def get_query_parts(query: str):
+            filters, annotations = parse_query(query)
+            self.assertEqual(annotations, {})
+            return Unit.objects.filter(filters).query.sql_with_params()
+
+        sql, _params = get_query_parts('changed_by:""')
+        self.assertEqual(sql.count("EXISTS"), 1)
+        self.assertIn('"action" IN', sql)
+        self.assertIn('"author_id" IS NULL', sql)
+        self.assertNotIn('"weblate_auth_user"', sql)
+
+        sql, _params = get_query_parts('NOT changed_by:""')
+        self.assertEqual(sql.count("EXISTS"), 1)
+        self.assertIn("NOT (EXISTS", sql)
+        self.assertIn('"action" IN', sql)
+        self.assertIn('"author_id" IS NULL', sql)
 
     def test_explanation(self) -> None:
         self.assert_query(


### PR DESCRIPTION
We're trying to get rid of these, but they will exist in the history, so it might be useful for users to search for these.

Fixes #19214

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
