### PR TITLE
fix(translate): corrected string ordering

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.6
 
 * Hardened :http:post:`/api/screenshots/` access checks against private project enumeration.
 * Searching for strings with content changes without a recorded author now supports ``changed_by:""``.
+* Project and category language translation sessions now keep strings grouped by component priority and show component switch warnings reliably.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -76,6 +76,32 @@ if TYPE_CHECKING:
 
 
 NEWLINES = re.compile(r"\r\n|\r|\n")
+LOCKED_COMPONENT_ORDER_FIELD = "translation__component__locked"
+COMPONENT_ORDER_FIELDS = [
+    # Order by priority for custom ordering
+    "translation__component__priority",
+    # Show glossaries at the end
+    "translation__component__is_glossary",
+    "translation__component__name",
+]
+
+
+def orders_units_by_component(obj: object) -> bool:
+    """Return whether the object scope spans component-ordered units."""
+    if isinstance(obj, (Project, Category)):
+        return True
+
+    from weblate.utils.stats import CategoryLanguage, ProjectLanguage  # noqa: PLC0415
+
+    return isinstance(obj, (ProjectLanguage, CategoryLanguage))
+
+
+def get_component_order_fields(sign: str = "") -> list[str]:
+    return [
+        # Show locked components at the end, regardless of sort direction
+        LOCKED_COMPONENT_ORDER_FIELD,
+        *(f"{sign}{field}" for field in COMPONENT_ORDER_FIELDS),
+    ]
 
 
 def fill_in_source_translation(units: Iterable[Unit]) -> None:
@@ -254,6 +280,7 @@ class UnitQuerySet(models.QuerySet["Unit", "Unit"]):
             },
         }
         sort_list = []
+        component_sort = False
         for choice in sort_list_request:
             unsigned_choice = choice.replace("-", "")
             if unsigned_choice in countable_sort_choices:
@@ -266,33 +293,25 @@ class UnitQuerySet(models.QuerySet["Unit", "Unit"]):
                 )
             if unsigned_choice in available_sort_choices:
                 if unsigned_choice == "component":
+                    component_sort = True
                     sign = "-" if choice[0] == "-" else ""
-                    sort_list.extend(
-                        [
-                            f"{sign}translation__component__priority",
-                            f"{sign}translation__component__is_glossary",
-                            f"{sign}translation__component__name",
-                        ]
-                    )
+                    sort_list.extend(get_component_order_fields(sign))
                     continue
 
                 if unsigned_choice == "labels":
                     choice = choice.replace("labels", "max_labels_name")
                 sort_list.append(choice)
+        if (
+            component_sort
+            and orders_units_by_component(obj)
+            and "position" not in sort_list
+        ):
+            sort_list.append("position")
         if not sort_list:
             if hasattr(obj, "component") and obj.component.is_glossary:
                 sort_list = ["source"]
-            elif isinstance(obj, (Project, Category)):
-                sort_list = [
-                    # Show locked components at the end
-                    "translation__component__locked",
-                    # Order by priority for custom ordering
-                    "translation__component__priority",
-                    # Show glossaries at the end
-                    "translation__component__is_glossary",
-                    "translation__component__name",
-                    "-priority",
-                ]
+            elif orders_units_by_component(obj):
+                sort_list = [*get_component_order_fields(), "-priority", "position"]
             else:
                 sort_list = ["-priority", "position"]
         if "max_labels_name" in sort_list or "-max_labels_name" in sort_list:

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -33,7 +33,8 @@ from weblate.utils.state import (
     STATE_NEEDS_REWRITING,
     STATE_TRANSLATED,
 )
-from weblate.utils.stats import ProjectLanguage
+from weblate.utils.stats import CategoryLanguage, ProjectLanguage
+from weblate.utils.views import get_sort_name
 
 if TYPE_CHECKING:
     from weblate.checks.base import BaseCheck
@@ -1352,6 +1353,99 @@ class EditComplexTest(ViewTestCase):
         self.assertContains(
             response,
             f'href="{translate_url}?checksum={unit.checksum}&amp;revert={change.id}"',
+        )
+
+    def test_project_language_warns_when_switching_component(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(priority=120)
+        high_component = self.create_po(name="High", priority=80, project=self.project)
+        high_translation = high_component.translation_set.get(
+            language=self.translation.language
+        )
+        translate_url = ProjectLanguage(
+            self.project, self.translation.language
+        ).get_translate_url()
+        high_component_offset = high_translation.unit_set.count()
+
+        response = self.client.get(translate_url, {"offset": high_component_offset})
+        self.assertNotContains(response, "You have shifted from")
+        self.assertContains(response, 'value="component,-priority"')
+
+        response = self.client.get(translate_url, {"offset": high_component_offset + 1})
+        self.assertContains(response, "You have shifted from")
+
+    def test_language_scope_sort_defaults_to_component_priority(self) -> None:
+        request = SimpleNamespace(GET={})
+        category = self.create_category(self.project)
+
+        self.assertEqual(
+            get_sort_name(
+                request, ProjectLanguage(self.project, self.translation.language)
+            )["query"],
+            "component,-priority",
+        )
+        self.assertEqual(
+            get_sort_name(
+                request, CategoryLanguage(category, self.translation.language)
+            )["query"],
+            "component,-priority",
+        )
+
+    def test_project_language_submitted_search_keeps_component_order(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(priority=120)
+        high_component = self.create_po(
+            name="High", locked=True, priority=80, project=self.project
+        )
+        high_translation = high_component.translation_set.get(
+            language=self.translation.language
+        )
+        translate_url = ProjectLanguage(
+            self.project, self.translation.language
+        ).get_translate_url()
+
+        self.client.get(translate_url, {"sort_by": "component,-priority", "offset": 1})
+
+        session = self.client.session
+        session_keys = session.keys()
+        search_key = next(key for key in session_keys if key.startswith("search_"))
+        expected_ids = [
+            *self.translation.unit_set.order_by("position").values_list(
+                "pk", flat=True
+            ),
+            *high_translation.unit_set.order_by("position").values_list(
+                "pk", flat=True
+            ),
+        ]
+        self.assertEqual(session[search_key]["ids"], expected_ids)
+
+    def test_project_language_ignores_stale_component_shift_unit(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(priority=120)
+        high_component = self.create_po(name="High", priority=80, project=self.project)
+        high_translation = high_component.translation_set.get(
+            language=self.translation.language
+        )
+        translate_url = ProjectLanguage(
+            self.project, self.translation.language
+        ).get_translate_url()
+        high_component_offset = high_translation.unit_set.count()
+
+        response = self.client.get(translate_url, {"offset": high_component_offset})
+        self.assertEqual(response.status_code, 200)
+
+        last_unit_id = Unit.objects.order_by("-pk").values_list("pk", flat=True)[0]
+        stale_unit_id = last_unit_id + 1
+        session = self.client.session
+        session_keys = session.keys()
+        search_key = next(key for key in session_keys if key.startswith("search_"))
+        session_result = session[search_key]
+        session_result["last_viewed_unit_id"] = stale_unit_id
+        session[search_key] = session_result
+        session.save()
+
+        response = self.client.get(translate_url, {"offset": high_component_offset + 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "You have shifted from")
+        self.assertNotEqual(
+            self.client.session[search_key]["last_viewed_unit_id"], stale_unit_id
         )
 
     def test_revert_plural(self) -> None:

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -27,6 +27,7 @@ from weblate.trans.exceptions import SuggestionSimilarToTranslationError
 from weblate.trans.models import (
     Announcement,
     AutoComponentList,
+    Category,
     Change,
     Comment,
     Component,
@@ -57,7 +58,7 @@ from weblate.utils.state import (
     STATE_READONLY,
     STATE_TRANSLATED,
 )
-from weblate.utils.stats import GlobalStats
+from weblate.utils.stats import CategoryLanguage, GlobalStats, ProjectLanguage
 from weblate.utils.version import GIT_VERSION
 
 
@@ -1064,6 +1065,57 @@ class UnitTest(ModelTestCase):
             translation__language_code="cs"
         ).order_by_request({"sort_by": "position,timestamp"}, None)
         self.assertEqual(multiple_ordered_unit.count(), 4)
+
+    def test_order_by_request_language_scope_orders_by_component(self) -> None:
+        category = Category.objects.create(
+            name="Docs", slug="docs", project=self.component.project
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            category=category, priority=120
+        )
+        high_component = self.create_po(
+            category=category,
+            name="High",
+            locked=True,
+            priority=80,
+            project=self.component.project,
+        )
+        language = Language.objects.get(code="cs")
+        high_translation = high_component.translation_set.get(language=language)
+        high_units = list(high_translation.unit_set.order_by("position"))
+        low_units = list(
+            self.component.translation_set.get(language=language).unit_set.order_by(
+                "position"
+            )
+        )
+        high_priority_unit = high_units[-1]
+        Unit.objects.filter(pk=high_priority_unit.pk).update(priority=200)
+
+        expected_ids = [
+            *(unit.pk for unit in low_units),
+            high_priority_unit.pk,
+            *(unit.pk for unit in high_units if unit.pk != high_priority_unit.pk),
+        ]
+
+        scopes = [
+            ProjectLanguage(self.component.project, language),
+            CategoryLanguage(category, language),
+        ]
+        for scope in scopes:
+            for form_data in (
+                {},
+                {"sort_by": "component,-priority"},
+                {"sort_by": "-component,-priority"},
+            ):
+                ordered_ids = list(
+                    Unit.objects.filter(
+                        translation__component__in=(self.component, high_component),
+                        translation__language=language,
+                    )
+                    .order_by_request(form_data, scope)
+                    .values_list("pk", flat=True)
+                )
+                self.assertEqual(ordered_ids, expected_ids)
 
     def test_get_max_length_no_pk(self) -> None:
         unit = Unit.objects.filter(translation__language_code="cs")[0]

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -621,6 +621,37 @@ def handle_suggestions(
     return HttpResponseRedirect(redirect_url)
 
 
+def handle_component_shift_notice(
+    request: AuthenticatedHttpRequest, unit_set, search_result, unit
+) -> None:
+    """Show a warning when sequential navigation moves to another component."""
+    last_viewed_unit_id = search_result.get("last_viewed_unit_id")
+    if last_viewed_unit_id:
+        try:
+            previous_unit = unit_set.get(pk=last_viewed_unit_id)
+        except Unit.DoesNotExist:
+            previous_unit = None
+        if (
+            previous_unit is not None
+            and unit.translation.component != previous_unit.translation.component
+        ):
+            messages.warning(
+                request,
+                gettext("You have shifted from %(previous)s to %(current)s.")
+                % {
+                    "previous": previous_unit.translation.full_slug,
+                    "current": unit.translation.full_slug,
+                },
+            )
+
+    search_result["last_viewed_unit_id"] = unit.id
+    session_key = search_result["key"]
+    if session_key in request.session:
+        session_result = request.session[session_key]
+        session_result["last_viewed_unit_id"] = unit.id
+        request.session[session_key] = session_result
+
+
 @transaction.atomic
 def translate(request: AuthenticatedHttpRequest, path):
     """Translate, suggest and search view."""
@@ -675,19 +706,7 @@ def translate(request: AuthenticatedHttpRequest, path):
             messages.error(request, gettext("Invalid search string!"))
             return redirect(obj)
 
-    last_viewed_unit_id = search_result.get("last_viewed_unit_id")
-    if last_viewed_unit_id:
-        previous_unit = unit_set.get(pk=last_viewed_unit_id)
-        if unit.translation.component != previous_unit.translation.component:
-            messages.warning(
-                request,
-                gettext("You have shifted from %(previous)s to %(current)s.")
-                % {
-                    "previous": previous_unit.translation.full_slug,
-                    "current": unit.translation.full_slug,
-                },
-            )
-    search_result["last_viewed_unit_id"] = unit.id
+    handle_component_shift_notice(request, unit_set, search_result, unit)
 
     # Some URLs we will most likely use
     base_unit_url = f"{obj.get_translate_url()}?{search_result['url']}&offset="

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -239,7 +239,7 @@ SORT_LOOKUP = {key.replace("-", ""): value for key, value in SORT_CHOICES.items(
 
 def get_sort_name(request: AuthenticatedHttpRequest, obj=None):
     """Get sort name."""
-    if isinstance(obj, (Project, Category)):
+    if isinstance(obj, (Project, Category, ProjectLanguage, CategoryLanguage)):
         default = "component,-priority"
     elif hasattr(obj, "component") and obj.component.is_glossary:
         default = "source"


### PR DESCRIPTION
The project and category language views defaulted to wrong ordering and didn't show a component switch reliably.

Fixes #19613

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
