### PR TITLE
fix(checks): imporove inconsistent check performance

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.6
 
 * Docker containers can now adjust :setting:`WEBLATE_FORMATS`.
   Use :envvar:`WEBLATE_ADD_FORMATS` and :envvar:`WEBLATE_REMOVE_FORMATS`.
+* Improved performance of the :ref:`check-inconsistent` check on large projects.
 
 .. rubric:: Bug fixes
 

--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from functools import reduce
 from typing import TYPE_CHECKING, ClassVar, Literal
 
-from django.db.models import Count, Prefetch, Q, Value
+from django.db.models import Count, F, Max, Min, Prefetch, Q, Value
 from django.db.models.functions import MD5, Lower
 from django.utils.html import format_html
 from django.utils.translation import gettext, gettext_lazy, ngettext
@@ -121,8 +121,8 @@ class ConsistencyCheck(TargetCheck, BatchCheckMixin):
         # Limit this to 100 strings, otherwise the resulting query is way too complex
         matches = (
             units.values("id_hash", "translation__plural_id")
-            .annotate(Count("target", distinct=True))
-            .filter(target__count__gt=1)
+            .annotate(min_target=Min("target"), max_target=Max("target"))
+            .filter(min_target__lt=F("max_target"))
             .order_by("id_hash")[:100]
         )
 

--- a/weblate/checks/tests/test_consistency_checks.py
+++ b/weblate/checks/tests/test_consistency_checks.py
@@ -6,7 +6,9 @@
 
 from unittest.mock import patch
 
+from django.db import connection
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import CaptureQueriesContext
 
 from weblate.checks.consistency import (
     ConsistencyCheck,
@@ -262,3 +264,25 @@ class ConsistencyCheckTest(ComponentTestCase):
         self.assertTrue(check.check_target_unit([], [], unit))
 
         self.assertNotEqual(check.check_component(self.component), [])
+
+    def test_consistency_empty_target(self) -> None:
+        check = ConsistencyCheck()
+
+        self.add_unit(self.translation_1, "one", "One", "Jeden")
+        self.add_unit(self.translation_2, "one", "One", "", increment=False)
+
+        self.assertNotEqual(check.check_component(self.component), [])
+
+    def test_consistency_query_uses_min_max_targets(self) -> None:
+        check = ConsistencyCheck()
+
+        self.add_unit(self.translation_1, "one", "One", "Jeden")
+        self.add_unit(self.translation_2, "one", "One", "Jedna", increment=False)
+
+        with CaptureQueriesContext(connection) as queries:
+            list(check.check_component(self.component))
+
+        sql = "\n".join(query["sql"].upper() for query in queries)
+        self.assertNotIn("COUNT(DISTINCT", sql)
+        self.assertIn("MIN(", sql)
+        self.assertIn("MAX(", sql)


### PR DESCRIPTION
Avoid doing distict just to figure out there are at least two values, using min/max seems to achieve this faster.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
