### PR TITLE
feat(accounts): make failed registration mails actionable

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,7 @@ Weblate 2026.6
 .. rubric:: Bug fixes
 
 * Hardened :http:post:`/api/screenshots/` access checks against private project enumeration.
+* Registration-attempt account activity e-mails now link to password reset to help users finish account setup.
 * Searching for strings with content changes without a recorded author now supports ``changed_by:""``.
 * Project and category language translation sessions now keep strings grouped by component priority and show component switch warnings reliably.
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -406,11 +406,11 @@ EXTRA_MESSAGES = {
     ),
     # Translators: Audit log hint
     "register": gettext_lazy(
-        "If it was you, please use a password reset to regain access to your account."
+        "If it was you, reset your password to regain access to your account."
     ),
     # Translators: Audit log hint
     "connect": gettext_lazy(
-        "If it was you, please use a password reset to regain access to your account."
+        "If it was you, reset your password to regain access to your account."
     ),
 }
 

--- a/weblate/accounts/tasks.py
+++ b/weblate/accounts/tasks.py
@@ -17,6 +17,7 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.core.mail.backends.smtp import EmailBackend as DjangoSMTPEmailBackend
 from django.db import transaction
+from django.urls import reverse
 from django.utils.timezone import now
 from social_django.models import Code, Partial
 
@@ -43,6 +44,20 @@ class OutgoingEmail(TypedDict):
     subject: str
     body: str
     headers: dict[str, str]
+
+
+def get_registration_attempt_password_reset_url(activity: str) -> str | None:
+    """Return a password reset URL suitable for registration-attempt e-mails."""
+    if activity not in {"connect", "register"}:
+        return None
+    if settings.PASSWORD_RESET_URL:
+        return settings.PASSWORD_RESET_URL
+
+    from weblate.auth.utils import get_auth_keys  # noqa: PLC0415
+
+    if "email" in get_auth_keys():
+        return reverse("password_reset")
+    return None
 
 
 @app.task(trail=False)
@@ -166,6 +181,9 @@ def notify_auditlog(log_id: int, email: str) -> None:
             "extra_message": audit.get_extra_message,
             "address": audit.shortened_address,
             "user_agent": audit.user_agent,
+            "password_reset_url": get_registration_attempt_password_reset_url(
+                audit.activity
+            ),
         },
         info=f"{audit.activity} from {audit.address}",
         user=audit.user,

--- a/weblate/accounts/tests/test_registration.py
+++ b/weblate/accounts/tests/test_registration.py
@@ -17,7 +17,7 @@ import responses
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY
 from django.core import mail
-from django.test import Client, TestCase
+from django.test import Client, SimpleTestCase, TestCase
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -26,7 +26,10 @@ from rest_framework.authtoken.models import Token
 from weblate.accounts.captcha import solve_altcha
 from weblate.accounts.models import VerifiedEmail
 from weblate.accounts.pipeline import ensure_valid, handle_invite, store_email
-from weblate.accounts.tasks import cleanup_social_auth
+from weblate.accounts.tasks import (
+    cleanup_social_auth,
+    get_registration_attempt_password_reset_url,
+)
 from weblate.auth.models import (
     Group,
     Invitation,
@@ -72,6 +75,47 @@ REGISTRATION_SUCCESS = (
     "Click the confirmation link sent to your e-mail inbox "
     "and start using your account."
 )
+
+
+class RegistrationAttemptPasswordResetURLTest(SimpleTestCase):
+    def test_disabled_for_other_activity(self) -> None:
+        self.assertIsNone(get_registration_attempt_password_reset_url("password"))
+
+    @social_core_override_settings(
+        AUTHENTICATION_BACKENDS=(
+            "django.contrib.auth.backends.ModelBackend",
+            "weblate.accounts.auth.WeblateUserBackend",
+        ),
+        PASSWORD_RESET_URL=None,
+    )
+    def test_disabled_without_email_auth(self) -> None:
+        self.assertIsNone(get_registration_attempt_password_reset_url("connect"))
+
+    @social_core_override_settings(
+        AUTHENTICATION_BACKENDS=(
+            "django.contrib.auth.backends.ModelBackend",
+            "weblate.accounts.auth.WeblateUserBackend",
+        ),
+        PASSWORD_RESET_URL="https://id.example.net/password-reset",
+    )
+    def test_external_url_without_email_auth(self) -> None:
+        self.assertEqual(
+            get_registration_attempt_password_reset_url("connect"),
+            "https://id.example.net/password-reset",
+        )
+
+    @social_core_override_settings(
+        AUTHENTICATION_BACKENDS=(
+            "social_core.backends.email.EmailAuth",
+            "weblate.accounts.auth.WeblateUserBackend",
+        ),
+        PASSWORD_RESET_URL=None,
+    )
+    def test_internal_url_with_email_auth(self) -> None:
+        self.assertEqual(
+            get_registration_attempt_password_reset_url("register"),
+            reverse("password_reset"),
+        )
 
 
 class BaseRegistrationTest(TestCase, RegistrationTestMixin):
@@ -533,6 +577,41 @@ class RegistrationTest(BaseRegistrationTest):
     def test_double_register(self) -> None:
         """Test double registration from single browser without logout."""
         self.test_double_register_logout(False)
+
+    @override_settings(REGISTRATION_OPEN=True, REGISTRATION_CAPTCHA=False)
+    def test_verified_account_registration_attempt_links_password_reset(self) -> None:
+        """Test registration attempt notification guides to password reset."""
+        response = self.do_register()
+        self.assertContains(response, REGISTRATION_SUCCESS)
+        confirmation_url = self.assert_registration_mailbox()
+
+        response = self.client.get(confirmation_url, follow=True)
+        if "weblate.legal.pipeline.tos_confirm" in settings.SOCIAL_AUTH_PIPELINE:
+            response = self.confirm_tos(self.client, response)
+        self.assertRedirects(response, reverse("password"))
+        mail.outbox.clear()
+
+        self.client.post(reverse("logout"))
+
+        data = REGISTRATION_DATA.copy()
+        data["username"] = "second"
+        response = self.do_register(data)
+        self.assertContains(response, REGISTRATION_SUCCESS)
+
+        self.assertEqual(len(mail.outbox), 1)
+        notification = mail.outbox[0]
+        self.assert_notify_mailbox(notification)
+        self.assertEqual(notification.to, [REGISTRATION_DATA["email"]])
+        self.assertIn(
+            "If it was you, reset your password to regain access to your account.",
+            notification.body,
+        )
+        self.assertIn("Reset my password", notification.body)
+        content = notification.alternatives[0][0]
+        self.assertIn(
+            f'href="http://example.com{reverse("password_reset")}"',
+            content,
+        )
 
     @override_settings(REGISTRATION_OPEN=True, REGISTRATION_CAPTCHA=False)
     def test_register_missing(self) -> None:

--- a/weblate/templates/mail/account_activity.html
+++ b/weblate/templates/mail/account_activity.html
@@ -11,6 +11,12 @@
 
   {% if extra_message %}<p>{{ extra_message }}</p>{% endif %}
 
+  {% if password_reset_url %}
+    <div class="line buttons">
+      <a class="button" href="{{ password_reset_url }}">{% translate "Reset my password" %}</a>
+    </div>
+  {% endif %}
+
   {% include "mail/shared-activity.html" %}
 
 {% endblock content %}


### PR DESCRIPTION
Add password reset button to make the reset start directly rather then letting user figure out the way.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
