### PR TITLE
refactor(forms): replace custom querystring logic with Django {% querystring %} tag

### DIFF
--- a/weblate/templates/paginator.html
+++ b/weblate/templates/paginator.html
@@ -3,7 +3,7 @@
 {% if page_obj.paginator.num_pages > 1 %}
   <ul class="pagination">
     <li class="page-item{% if page_obj.number == 1 %} disabled{% endif %}">
-      <a href="?page=1&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+      <a href="?{% querystring page=1 limit=page_obj.paginator.per_page %}{% if anchor %}#{{ anchor }}{% endif %}"
          class="page-link green">
         {% if LANGUAGE_BIDI %}
           {% icon "page-last.svg" %}
@@ -17,7 +17,7 @@
         {% if page_obj.has_previous %}
           rel="prev"
           {# djlint:off #}
-          href="?page={{ page_obj.previous_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+          href="?{% querystring page=page_obj.previous_page_number limit=page_obj.paginator.per_page %}{% if anchor %}#{{ anchor }}{% endif %}"
           {# djlint:on #}
         {% endif %}
         class="page-link green">
@@ -38,13 +38,6 @@
         {# djlint:off #}
         {% if not paginator_form %}<form method="get"{% if anchor %} action="#{{ anchor }}"{% endif %}>{% endif %}
         {# djlint:on #}
-        {% for key, value in search_items %}
-          <input {% if paginator_form %}form="{{ paginator_form }}"{% endif %}
-                 type="hidden"
-                 name="{{ key }}"
-                 value="{{ value }}"
-                 aria-label="{{ value }}" />
-        {% endfor %}
         <input {% if paginator_form %}form="{{ paginator_form }}"{% endif %}
                type="hidden"
                name="limit"
@@ -75,7 +68,7 @@
         {% if page_obj.has_next %}
           rel="next"
           {# djlint:off #}
-          href="?page={{ page_obj.next_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+          href="?{% querystring page=page_obj.next_page_number limit=page_obj.paginator.per_page %}{% if anchor %}#{{ anchor }}{% endif %}"
           {# djlint:on #}
         {% endif %}
         class="page-link green">
@@ -87,7 +80,7 @@
       </a>
     </li>
     <li class="page-item{% if page_obj.paginator.num_pages == page_obj.number %} disabled{% endif %}">
-      <a href="?page={{ page_obj.paginator.num_pages }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+      <a href="?{% querystring page=page_obj.paginator.num_pages limit=page_obj.paginator.per_page %}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
          class="page-link green">
         {% if not LANGUAGE_BIDI %}
           {% icon "page-last.svg" %}

--- a/weblate/templates/snippets/embed-units.html
+++ b/weblate/templates/snippets/embed-units.html
@@ -94,7 +94,7 @@
         {% if not hide_context and any_unit_has_context %}
           <td>
             {% if unit.context %}
-              <a href="{{ unit.get_absolute_url }}{% if include_search and search_url %}&amp;{{ search_url }}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
+              <a href="{{ unit.get_absolute_url }}{% if include_search %}{% querystring %}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
                 {% format_source_string unit.context unit wrap=True search_match=search_query %}
               </a>
             {% endif %}
@@ -102,13 +102,13 @@
         {% endif %}
         {% if force_source or not hide_source and not unit.is_source %}
           <td>
-            <a href="{{ unit.get_absolute_url }}{% if include_search and search_url %}&amp;{{ search_url }}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
+            <a href="{{ unit.get_absolute_url }}{% if include_search %}{% querystring %}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
               {% format_unit_source unit search_match=search_query %}
             </a>
           </td>
         {% endif %}
         <td>
-          <a href="{{ unit.get_absolute_url }}{% if include_search and search_url %}&amp;{{ search_url }}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
+          <a href="{{ unit.get_absolute_url }}{% if include_search %}{% querystring %}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
             {% format_unit_target unit search_match=search_query %}
           </a>
         </td>

--- a/weblate/templates/snippets/last-changes-content.html
+++ b/weblate/templates/snippets/last-changes-content.html
@@ -21,7 +21,7 @@
             <div class="btn-float">
               {% if item.permissions.can_revert %}
                 <a class="btn btn-link"
-                   href="{{ translate_url|default:item.change.translation.get_translate_url }}?{% if search_url %}{{ search_url }}&amp;offset={{ offset }}&amp;{% endif %}checksum={{ item.change.unit.checksum }}&amp;revert={{ item.change.id }}"
+                   href="{{ translate_url|default:item.change.translation.get_translate_url }}?{% if request.GET %}{% querystring %}&amp;offset={{ offset }}&amp;{% endif %}checksum={{ item.change.unit.checksum }}&amp;revert={{ item.change.id }}"
                    title="{% translate "Revert" %}">{% icon "undo.svg" %}</a>
               {% endif %}
               {% if item.permissions.can_block_user %}

--- a/weblate/templates/trans/change_list.html
+++ b/weblate/templates/trans/change_list.html
@@ -6,22 +6,22 @@
   {% if path_object %}
     {% path_object_breadcrumbs path_object %}
     <li class="breadcrumb-item">
-      <a href="{% url 'changes' path=path_object.get_url_path %}?{{ query_string }}">{% translate "Changes" %}</a>
+      <a href="{% url 'changes' path=path_object.get_url_path %}?{% querystring %}">{% translate "Changes" %}</a>
     </li>
   {% else %}
     <li class="breadcrumb-item">
-      <a href="{% url 'changes' %}?{{ query_string }}">{% translate "Changes" %}</a>
+      <a href="{% url 'changes' %}?{% querystring %}">{% translate "Changes" %}</a>
     </li>
   {% endif %}
 
   <div class="btn-group ms-auto btn-group-settings" role="group">
     {% if debug %}
       {% if path_object %}
-        <a href="{% url 'changes' path=path_object.get_url_path %}?{{ query_string }}&amp;digest=1"
+        <a href="{% url 'changes' path=path_object.get_url_path %}?{% querystring digest=1 %}"
            title="{% translate "View notification" %}"
            class="btn btn-link">{% icon "bell.svg" %}</a>
       {% else %}
-        <a href="{% url 'changes' %}?{{ query_string }}&amp;digest=1"
+        <a href="{% url 'changes' %}?{% querystring digest=1 %}"
            title="{% translate "View notification" %}"
            class="btn btn-link">{% icon "bell.svg" %}</a>
       {% endif %}
@@ -29,16 +29,16 @@
     {% perm 'change.download' path_object as user_can_download_changes %}
     {% if user_can_download_changes %}
       {% if path_object %}
-        <a href="{% url 'changes-csv' path=path_object.get_url_path %}?{{ query_string }}"
+        <a href="{% url 'changes-csv' path=path_object.get_url_path %}?{% querystring %}"
            title="{% translate "Download latest changes as CSV" %}"
            class="btn btn-link">{% icon "download.svg" %}</a>
       {% else %}
-        <a href="{% url 'changes-csv' %}?{{ query_string }}"
+        <a href="{% url 'changes-csv' %}?{% querystring %}"
            title="{% translate "Download latest changes as CSV" %}"
            class="btn btn-link">{% icon "download.svg" %}</a>
       {% endif %}
     {% endif %}
-    <a href="{{ changes_rss }}{% if query_string %}?{{ query_string }}{% endif %}"
+    <a href="{{ changes_rss }}?{% querystring %}"
        title="{% translate "Follow using RSS" %}"
        class="btn btn-link">{% icon "rss.svg" %}</a>
   </div>
@@ -48,19 +48,3 @@
   {% if form.is_valid %}
     {% include "paginator.html" %}
     {% format_last_changes_content last_changes=object_list user=user %}
-    {% include "paginator.html" %}
-  {% endif %}
-
-  <form method="get">
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title">{% translate "Search" %}</h4>
-      </div>
-      <div class="card-body">{{ form|crispy }}</div>
-      <div class="card-footer">
-        <input type="submit" value="{% translate "Search" %}" class="btn btn-primary" />
-      </div>
-    </div>
-  </form>
-
-{% endblock content %}

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -56,8 +56,8 @@
   {% perm 'unit.add' unit.translation as user_can_add_unit %}
 
   <div class="btn-group float-end btn-group-settings" role="group">
-    <a href="{% url 'zen' path=object.get_url_path %}?offset={{ offset }}&amp;{{ search_url }}"
-       data-params="{{ search_url }}"
+    <a href="{% url 'zen' path=object.get_url_path %}?{% querystring offset=offset %}"
+       data-params="{% querystring %}"
        title="{% translate "Open in Zen mode" %}"
        class="btn btn-link">{% icon "flash.svg" %} {% translate "Zen" %}</a>
 
@@ -410,7 +410,7 @@
                 <p class="help-block">{% translate "Showing only subset of the strings as there were too many matches." %}</p>
               {% endif %}
               <form method="post"
-                    action="{{ unit.translation.get_translate_url }}?{{ search_url }}&amp;offset={{ offset }}&amp;checksum={{ unit.checksum }}">
+                    action="{{ unit.translation.get_translate_url }}?{% querystring offset=offset checksum=unit.checksum %}">
                 {% csrf_token %}
                 <table class="table table-sm">
                   <thead>

--- a/weblate/templates/zen-units.html
+++ b/weblate/templates/zen-units.html
@@ -19,7 +19,7 @@
              title="{% translate "Copy permalink" %}"
              tabindex="-1">{% icon "link.svg" %}</a>
           <a class="btn btn-link btn-xs"
-             href="{% url 'translate' path=object.get_url_path %}?{{ search_url }}&amp;offset={{ item.offset }}"
+             href="{% url 'translate' path=object.get_url_path %}?{% querystring offset=item.offset %}"
              title="{% translate "Open in full editor" %}"
              tabindex="-1">{% icon "pencil-mini.svg" %}</a>
         </div>

--- a/weblate/templates/zen.html
+++ b/weblate/templates/zen.html
@@ -33,8 +33,8 @@
 
   <div class="btn-group float-end btn-group-settings" role="group">
 
-    <a href="{% url 'translate' path=object.get_url_path %}?{{ search_url }}"
-       data-params="{{ search_url }}"
+    <a href="{% url 'translate' path=object.get_url_path %}?{% querystring %}"
+       data-params="{% querystring %}"
        title="{% translate "Edit in single string mode" %}"
        class="btn btn-link">{% icon "close.svg" %} {% translate "Exit Zen" %}</a>
 
@@ -55,7 +55,7 @@
       <tr>
         <td colspan="3" class="loading-icon">
           {% loading_icon "next" %}
-          <a href="{% url 'load_zen' path=object.get_url_path %}?{{ search_url }}"
+          <a href="{% url 'load_zen' path=object.get_url_path %}?{% querystring %}"
              class="hidden"
              id="zen-load"
              data-offset="{{ offset }}"></a>

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -900,7 +900,6 @@ class SearchForm(forms.Form):
         return self.cleaned_data["offset"]
 
 
-
 class PositionSearchForm(SearchForm):
     offset = forms.IntegerField(min_value=-1, required=False)
     offset_kwargs: ClassVar[dict[str, str]] = {
@@ -3349,7 +3348,6 @@ class ChangesForm(forms.Form):
         label=gettext_lazy("Date range"),
         required=False,
     )
-
 
 
 class LabelForm(forms.ModelForm):

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -34,7 +34,6 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html, format_html_join
-from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.text import normalize_newlines, slugify
 from django.utils.translation import gettext, gettext_lazy
@@ -900,50 +899,6 @@ class SearchForm(forms.Form):
             self.cleaned_data["offset"] = 1
         return self.cleaned_data["offset"]
 
-    def items(self):
-        items = []
-        # Skip checksum and offset as these change
-        ignored = {"offset", "checksum"}
-        for param in sorted(self.cleaned_data):
-            value = self.cleaned_data[param]
-            # We don't care about empty values or ignored ones
-            if value is None or param in ignored:
-                continue
-            if isinstance(value, bool):
-                # Only store true values
-                if value:
-                    items.append((param, "1"))
-            elif isinstance(value, int):
-                # Avoid storing 0 values
-                if value > 0:
-                    items.append((param, str(value)))
-            elif isinstance(value, datetime):
-                # Convert date to string
-                items.append((param, value.date().isoformat()))
-            elif isinstance(value, list):
-                items.extend((param, val) for val in value)
-            elif isinstance(value, User):
-                items.append((param, value.username))
-            elif value:
-                # It should be a string here
-                items.append((param, value))
-        return items
-
-    def urlencode(self):
-        return urlencode(self.items())
-
-    def reset_offset(self):
-        """
-        Reset form offset.
-
-        This is needed to avoid issues when using the form as the default for
-        any new search.
-        """
-        data = copy.copy(self.data)  # pylint: disable=access-member-before-definition
-        data["offset"] = "1"
-        data["checksum"] = ""
-        self.data = data
-        return self
 
 
 class PositionSearchForm(SearchForm):
@@ -3395,33 +3350,6 @@ class ChangesForm(forms.Form):
         required=False,
     )
 
-    def items(self):
-        items = []
-        for param in sorted(self.cleaned_data):
-            value = self.cleaned_data[param]
-            # We don't care about empty values
-            if not value:
-                continue
-            if (
-                isinstance(value, dict)
-                and "start_date" in value
-                and "end_date" in value
-            ):
-                # Convert date to string
-                start_date = value["start_date"].strftime("%m/%d/%Y")
-                end_date = value["end_date"].strftime("%m/%d/%Y")
-                items.append((param, f"{start_date} - {end_date}"))
-            elif isinstance(value, User):
-                items.append((param, value.username))
-            elif isinstance(value, list):
-                items.extend((param, part) for part in value)
-            else:
-                # It should be a string here
-                items.append((param, value))
-        return items
-
-    def urlencode(self):
-        return urlencode(self.items())
 
 
 class LabelForm(forms.ModelForm):

--- a/weblate/trans/views/changes.py
+++ b/weblate/trans/views/changes.py
@@ -55,10 +55,8 @@ class ChangesView(PathViewMixin, ListView):
 
     def get_filtered_changes_url(self) -> str:
         url = self.get_changes_url()
-        if self.changes_form.is_valid() and (
-            query_string := self.changes_form.urlencode()
-        ):
-            return f"{url}?{query_string}"
+        if self.request.GET:
+            return f"{url}?{self.request.GET.urlencode()}"
         return url
 
     def get_title(self):
@@ -101,8 +99,6 @@ class ChangesView(PathViewMixin, ListView):
         context["changes_rss"] = self.get_changes_url("changes-rss")
 
         if self.changes_form.is_valid():
-            context["query_string"] = self.changes_form.urlencode()
-            context["search_items"] = self.changes_form.items()
             if period := self.changes_form.cleaned_data.get("period"):
                 self.changes_form.fields["period"].widget.attrs["data-start-date"] = (
                     period["start_date"].strftime("%m/%d/%Y")

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -270,19 +270,15 @@ def search(
     form_valid = form.is_valid()
     if form_valid:
         cleaned_data = form.cleaned_data
-        search_url = form.urlencode()
         search_query = form.cleaned_data["q"]
         name = form.get_name()
-        search_items = form.items()
     else:
         cleaned_data = {}
         show_form_errors(request, form)
-        search_url = ""
         search_query = ""
         name = ""
-        search_items = ()
 
-    with sentry_sdk.start_span(op="unit.search", name=search_url):
+    with sentry_sdk.start_span(op="unit.search", name=search_query):
         search_result = {
             "form": form,
             "offset": cleaned_data.get("offset", 1),
@@ -313,8 +309,6 @@ def search(
 
         store_result = {
             "query": search_query,
-            "url": search_url,
-            "items": search_items,
             "key": session_key,
             "name": str(name),
             "ids": unit_ids,
@@ -709,7 +703,7 @@ def translate(request: AuthenticatedHttpRequest, path):
     handle_component_shift_notice(request, unit_set, search_result, unit)
 
     # Some URLs we will most likely use
-    base_unit_url = f"{obj.get_translate_url()}?{search_result['url']}&offset="
+    base_unit_url = f"{obj.get_translate_url()}?{request.GET.urlencode()}&offset="
     this_unit_url = base_unit_url + str(offset)
     next_unit_url = base_unit_url + str(offset + 1)
 
@@ -777,8 +771,6 @@ def translate(request: AuthenticatedHttpRequest, path):
             "nearby_keys": unit.nearby_keys(user.profile.nearby_strings),
             "can_go_next_section": offset + user.profile.nearby_strings <= num_results,
             "others": get_other_units(unit) if user.is_authenticated else {"total": 0},
-            "search_url": search_result["url"],
-            "search_items": search_result["items"],
             "search_query": search_result["query"],
             "offset": offset,
             "filter_count": num_results,
@@ -789,7 +781,7 @@ def translate(request: AuthenticatedHttpRequest, path):
                 initial={"scope": "global" if unit.is_source else "translation"},
             ),
             "context_form": ContextForm(instance=unit.source_unit, user=user),
-            "search_form": search_result["form"].reset_offset(),
+            "search_form": search_result["form"],
             "secondary": secondary,
             "locked": unit.translation.component.locked,
             "glossary": get_glossary_terms(unit, full=True),
@@ -1034,9 +1026,8 @@ def zen(request: AuthenticatedHttpRequest, path):
             "filter_count": len(search_result["ids"]),
             "filter_pos": search_result["offset"],
             "last_section": search_result["last_section"],
-            "search_url": search_result["url"],
             "offset": search_result["offset"],
-            "search_form": search_result["form"].reset_offset(),
+            "search_form": search_result["form"],
             "is_zen": True,
         },
     )
@@ -1065,7 +1056,6 @@ def load_zen(request: AuthenticatedHttpRequest, path):
             "component": obj.component if isinstance(obj, Translation) else None,
             "unitdata": unitdata,
             "search_query": search_result["query"],
-            "search_url": search_result["url"],
             "last_section": search_result["last_section"],
         },
     )
@@ -1198,7 +1188,7 @@ def browse(request: AuthenticatedHttpRequest, path):
         search_result["ids"][(offset - 1) * page : (offset - 1) * page + page]
     )
 
-    base_unit_url = f"{reverse('browse', kwargs={'path': obj.get_url_path()})}?{search_result['url']}&offset="
+    base_unit_url = f"{reverse('browse', kwargs={'path': obj.get_url_path()})}?{request.GET.urlencode()}&offset="
     num_results = ceil(len(search_result["ids"]) / page)
 
     return render(
@@ -1211,8 +1201,7 @@ def browse(request: AuthenticatedHttpRequest, path):
             "component": obj.component if isinstance(obj, Translation) else None,
             "units": units,
             "search_query": search_result["query"],
-            "search_url": search_result["url"],
-            "search_form": search_result["form"].reset_offset(),
+            "search_form": search_result["form"],
             "filter_count": num_results,
             "filter_pos": offset,
             "first_unit_url": f"{base_unit_url}1",

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -183,10 +183,7 @@ def search(request: AuthenticatedHttpRequest, path=None):
                 "page_obj": units,
                 "path_object": obj,
                 "title": gettext("Search for %s") % (search_form.cleaned_data["q"]),
-                "query_string": search_form.urlencode(),
-                "search_url": search_form.urlencode(),
                 "search_query": search_form.cleaned_data["q"],
-                "search_items": search_form.items(),
                 "total_strings": total_strings,
                 "total_words": total_words,
             }


### PR DESCRIPTION
Replaces the manual querystring building in SearchForm.items(), urlencode(), and reset_offset() (and ChangesForm equivalents) with Django's built-in {% querystring %} template tag introduced in Django 5.1.

## Changes

### Python
- Removed `SearchForm.items()`, `SearchForm.urlencode()`, `SearchForm.reset_offset()` (weblate/trans/forms.py)
- Removed `ChangesForm.items()`, `ChangesForm.urlencode()` (weblate/trans/forms.py)
- Removed unused `from django.utils.http import urlencode` import
- Updated `search()` view in search.py to stop passing `query_string`/ `search_url`/ `search_items` to templates
- Updated `ChangesView` in changes.py: replaced `self.changes_form.urlencode()` with `self.request.GET.urlencode()`
- Updated `edit.py` views: removed `search_url`, `search_items`, `reset_offset()` references

### Templates
- Updated `paginator.html`: pagination links now use `{% querystring page=X limit=Y %}`
- Updated `change_list.html`: all `?{{ query_string }}` → `?{% querystring %}`
- Updated `translate.html`, `zen.html`, `zen-units.html`: `{{ search_url }}` → `{% querystring %}`
- Updated `embed-units.html`, `last-changes-content.html`: same pattern

This simplifies the codebase by removing ~140 lines of manual querystring manipulation in favor of Django's built-in solution.

Closes #13638