### PR TITLE
fix(forms): html escape help text

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -33,7 +33,7 @@ from django.forms.utils import from_current_timezone
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.html import format_html, format_html_join
+from django.utils.html import escape, format_html, format_html_join
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.text import normalize_newlines, slugify
@@ -502,9 +502,11 @@ class FuzzyField(forms.BooleanField):
 
     def __init__(self, *args, **kwargs) -> None:
         kwargs["label"] = gettext_lazy("Needs editing")
-        kwargs["help_text"] = gettext_lazy(
-            'Strings are usually marked as "Needs editing" after the source '
-            "string is updated, or when marked as such manually."
+        kwargs["help_text"] = escape(
+            gettext_lazy(
+                'Strings are usually marked as "Needs editing" after the source '
+                "string is updated, or when marked as such manually."
+            )
         )
         super().__init__(*args, **kwargs)
         self.widget.attrs["class"] = "fuzzy_checkbox"


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->

The help text for the 'needs editing' checkbox contains quotes that aren't escaped properly, making the text cutoff (see screenshot) and the generated HTML invalid.

This is my first contribution to weblate, and I'm not 100% sure this is the right place to escape.

I'm happy to add a test, but not sure where that would be.

| Before | After |
|---|---|
| <img width="497" height="136" alt="image" src="https://github.com/user-attachments/assets/cc0a8a98-4cfb-4980-ba62-9adcd969163d" /> | <img width="805" height="139" alt="image" src="https://github.com/user-attachments/assets/f93062a9-b093-4754-8fe6-8df5ea9a6bd0" /> |

Generated HTML after browser parsing (before fix):

```html
<span
  id="id_70ede8292633ed94_fuzzy_helptext" class="form-text"
  title="Strings are usually marked as " needs="" editing"="" after="" the="" source="" string="" is="" updated,="" or="" when="" marked="" as="" such="" manually."=""
>
  <svg ...><path>...</path> </svg>
</span>
```