### PR TITLE
fix(vcs): manually build refspec for fetching remote

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,7 @@ Weblate 2026.6
 * Project and category language translation sessions now keep strings grouped by component priority and show component switch warnings reliably.
 * Engage page task links now stay centered and show the target translation language.
 * Gettext POT update add-ons now rescan translations after committing updated POT and PO files.
+* Git repositories now update branches correctly when the remote also has a tag with the same name.
 
 .. rubric:: Compatibility
 

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -827,9 +827,10 @@ class GitRepository(Repository):
     def update_remote(self) -> None:
         """Update remote repository."""
         branch = self.validate_branch_name(self.branch)
+        refspec = f"+refs/heads/{branch}:refs/remotes/origin/{branch}"
         # Update existing branch only, not changing depth
         self.execute(
-            [*self.get_auth_args(), "fetch", "origin", branch],
+            [*self.get_auth_args(), "fetch", "--no-tags", "origin", refspec],
             remote_op="pull",
         )
         self.clean_revision_cache()

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -927,6 +927,45 @@ class VCSGitTest(TestCase, RepoTestMixin, TempDirMixin):
         with self.repo.lock:
             self.repo.update_remote()
 
+    def test_update_remote_fetches_branch_over_same_named_tag(self) -> None:
+        if self._class is not GitRepository:
+            self.skipTest("GitRepository-specific regression test")
+
+        branch = self._remote_branch
+        with tempfile.TemporaryDirectory() as tempdir:
+            remote_repo = self.clone_repo(tempdir)
+            with remote_repo.lock:
+                old_revision = remote_repo.last_revision
+                remote_repo.execute(["tag", branch, old_revision], remote_op="none")
+                remote_repo.execute(
+                    ["push", "origin", f"refs/tags/{branch}:refs/tags/{branch}"],
+                    remote_op="push",
+                )
+
+                filename = "same-name-tag"
+                Path(os.path.join(tempdir, filename)).write_text(
+                    "SECOND TEST FILE\n", encoding="utf-8"
+                )
+                remote_repo.commit(
+                    "Test commit", "Foo Bar <foo@bar.com>", timezone.now(), [filename]
+                )
+                new_revision = remote_repo.last_revision
+                remote_repo.execute(
+                    ["push", "origin", f"refs/heads/{branch}:refs/heads/{branch}"],
+                    remote_op="push",
+                )
+
+        with self.repo.lock:
+            self.assertEqual(old_revision, self.repo.last_remote_revision)
+            self.repo.update_remote()
+            self.assertEqual(new_revision, self.repo.last_remote_revision)
+            self.assertEqual(
+                "",
+                self.repo.execute(
+                    ["tag", "--list", branch], remote_op="none", merge_err=False
+                ),
+            )
+
     def test_list_remote_branches_runtime_private_url_rejected(self) -> None:
         if self._class in {SubversionRepository, HgRepository, LocalRepository}:
             self.skipTest("Covered by backend-specific behavior")


### PR DESCRIPTION
There might be a tag with same name as the branch in the repository and git would then pick the tag (which Weblate does not use) over the branch. Manually writing the refspec tells Git exactly what we want to do and avoids ambiguity.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
