### PR TITLE
fix(csp): allow external static host for worker-src

### DIFF
--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -306,12 +306,10 @@ class RedirectMiddleware:
 
 class CSPBuilder:
     directives: CSP_TYPE
-    request: AuthenticatedHttpRequest
+    request: HttpRequest
     response: HttpResponse
 
-    def __init__(
-        self, request: AuthenticatedHttpRequest, response: HttpResponse
-    ) -> None:
+    def __init__(self, request: HttpRequest, response: HttpResponse) -> None:
         self.directives = deepcopy(CSP_DIRECTIVES)
         self.request = request
         self.response = response
@@ -402,7 +400,12 @@ class CSPBuilder:
         # External static URL
         if "://" in settings.STATIC_URL:
             self.add_csp_host(
-                settings.STATIC_URL, "script-src", "img-src", "style-src", "font-src"
+                settings.STATIC_URL,
+                "script-src",
+                "img-src",
+                "style-src",
+                "font-src",
+                "worker-src",
             )
 
     def build_csp_cdn(self) -> None:

--- a/weblate/utils/tests/test_middleware.py
+++ b/weblate/utils/tests/test_middleware.py
@@ -8,10 +8,12 @@ from typing import TYPE_CHECKING
 from unittest import TestCase
 from unittest.mock import patch
 
+from django.http import HttpResponse
 from django.http.request import HttpRequest
+from django.test import RequestFactory
 from django.test.utils import override_settings
 
-from weblate.middleware import ProxyMiddleware
+from weblate.middleware import CSPBuilder, ProxyMiddleware
 
 if TYPE_CHECKING:
     from weblate.auth.models import AuthenticatedHttpRequest
@@ -82,3 +84,17 @@ class ProxyTest(TestCase):
             middleware = ProxyMiddleware(self.get_response)
             self.assertEqual(middleware(request), "response")
             mock_report_error.assert_not_called()
+
+
+class CSPBuilderTest(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+
+    @override_settings(STATIC_URL="https://cdn.example.test/static/")
+    def test_external_static_url_added_to_worker_src(self) -> None:
+        request = self.factory.get("/")
+        request.resolver_match = None
+
+        builder = CSPBuilder(request, HttpResponse())
+
+        self.assertIn("cdn.example.test", builder.directives["worker-src"])


### PR DESCRIPTION
### Motivation
- Fix an availability regression where ALTCHA's Argon2id worker URL (served via `{% static %}`) is blocked by CSP when `STATIC_URL` points to an external CDN because `worker-src` did not include the external static host.

### Description
- Extend `CSPBuilder.build_csp_static_url()` to add the external `STATIC_URL` host to the `worker-src` directive in addition to `script-src`, `img-src`, `style-src`, and `font-src`.
- Add a focused regression test `CSPBuilderTest.test_external_static_url_added_to_worker_src` in `weblate/utils/tests/test_middleware.py` that sets `STATIC_URL` to an absolute CDN URL and asserts the host is present in `builder.directives['worker-src']`.
- Keep the existing CSP behavior for other directives unchanged while ensuring workers served from the configured static host are permitted.

### Testing
- Ran `uv run pytest weblate/utils/tests/test_middleware.py -q` and the test suite completed successfully with `6 passed`.
- The new regression test passes and verifies that an external CDN-style `STATIC_URL` is added to the `worker-src` directive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff80d15288329802f5e32000cd252)