### PR TITLE
fix(search): limit clause expansion in change query parser

### DIFF
--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -81,7 +81,7 @@ OPERATOR_MAP = {
     ":>=": "gte",
 }
 
-MAX_PARSED_QUERY_CLAUSES = 4096
+MAX_PARSED_QUERY_CLAUSES = 64
 
 
 @dataclass(slots=True)

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -81,6 +81,8 @@ OPERATOR_MAP = {
     ":>=": "gte",
 }
 
+MAX_PARSED_QUERY_CLAUSES = 4096
+
 
 @dataclass(slots=True)
 class ParsedQueryClause:
@@ -137,6 +139,11 @@ class ParsedQuery:
         if not self.has_change_query() and not other.has_change_query():
             return ParsedQuery.from_query(self.materialize() & other.materialize())
 
+        new_clause_count = len(self.clauses) * len(other.clauses)
+        if new_clause_count > MAX_PARSED_QUERY_CLAUSES:
+            msg = gettext("Search query is too complex.")
+            raise SearchQueryError(msg)
+
         return ParsedQuery(
             [
                 left.combine_and(right)
@@ -148,6 +155,11 @@ class ParsedQuery:
     def combine_or(self, other: ParsedQuery) -> ParsedQuery:
         if not self.has_change_query() and not other.has_change_query():
             return ParsedQuery.from_query(self.materialize() | other.materialize())
+
+        new_clause_count = len(self.clauses) + len(other.clauses)
+        if new_clause_count > MAX_PARSED_QUERY_CLAUSES:
+            msg = gettext("Search query is too complex.")
+            raise SearchQueryError(msg)
 
         return ParsedQuery([*self.clauses, *other.clauses])
 

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -503,9 +503,7 @@ class UnitQueryParserTest(SearchTestCase):
         self.assertEqual(params.count(end_2026), 2)
 
     def test_changed_query_complexity_limit(self) -> None:
-        query = " AND ".join(
-            "(changed_by:nijel OR changed_by:none)" for _ in range(13)
-        )
+        query = " AND ".join("(changed_by:nijel OR changed_by:none)" for _ in range(13))
         with self.assertRaises(SearchQueryError):
             parse_query(query)
 

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -502,6 +502,13 @@ class UnitQueryParserTest(SearchTestCase):
         self.assertEqual(params.count(start_2026), 2)
         self.assertEqual(params.count(end_2026), 2)
 
+    def test_changed_query_complexity_limit(self) -> None:
+        query = " AND ".join(
+            "(changed_by:nijel OR changed_by:none)" for _ in range(13)
+        )
+        with self.assertRaises(SearchQueryError):
+            parse_query(query)
+
     def test_explanation(self) -> None:
         self.assert_query(
             "explanation:text", Q(source_unit__explanation__substring="text")


### PR DESCRIPTION
### Motivation
- The change-query parser could materialize an exponential number of `ParsedQueryClause` objects when combining OR groups with AND, allowing a short crafted query to exhaust worker memory and CPU. 
- A lightweight parser-side cap is needed to fail early and avoid the Cartesian-product expansion while preserving existing query semantics for reasonable inputs.

### Description
- Add a constant `MAX_PARSED_QUERY_CLAUSES = 4096` and enforce it in `ParsedQuery.combine_and` and `ParsedQuery.combine_or` to guard clause-list growth. 
- When a combination would exceed the cap, raise `SearchQueryError` with a user-facing message (`gettext("Search query is too complex.")`) to abort parsing early. 
- Add a regression test `test_changed_query_complexity_limit` that builds repeated `(changed_by:... OR changed_by:...)` groups joined by `AND` and asserts `parse_query(...)` raises `SearchQueryError`. 
- Changes touch `weblate/utils/search.py` and `weblate/utils/tests/test_search.py` only.

### Testing
- Ran `uv run pytest weblate/utils/tests/test_search.py -k "changed_by or complexity_limit"` and the selected tests passed (`2 passed, 76 deselected`).
- The new test verifies the complexity limit triggers before exponential clause expansion and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ffc19a6548329be29d3745a01a416)