### PR TITLE
fix(add-ons): corrected create_translation invocations in POT update

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -341,7 +341,7 @@ class BaseAddon[StoredConfigurationT, ConfigurationT](DocVersionsMixin):
                 *(base_event_args),
                 AddonEvent.EVENT_POST_UPDATE,
                 "post_update",
-                (component, "", False),
+                (component, "", False, True),
             )
         if AddonEvent.EVENT_COMPONENT_UPDATE in self.events:
             component.log_debug("running component_update add-on: %s", self.name)
@@ -472,6 +472,7 @@ class BaseAddon[StoredConfigurationT, ConfigurationT](DocVersionsMixin):
         component: Component,
         previous_head: str,
         skip_push: bool,
+        parse_after_update: bool = False,
         activity_log_id: int | None = None,
     ) -> dict | None:
         """
@@ -690,6 +691,7 @@ class BaseAddon[StoredConfigurationT, ConfigurationT](DocVersionsMixin):
         component: Component,
         files: list[str] | None = None,
         skip_push: bool = False,
+        parse_after_update: bool = False,
     ) -> bool:
         if files is None:
             files = list(
@@ -879,13 +881,18 @@ class UpdateBaseAddon(BaseAddon):
         component: Component,
         previous_head: str,
         skip_push: bool,
+        parse_after_update: bool = False,
         activity_log_id: int | None = None,
     ) -> None:
         # Ignore file parse error, it will be properly tracked as an alert
         with component.repository.lock:
             with suppress(FileParseError):
                 self.update_translations(component, previous_head)
-            self.commit_and_push(component, skip_push=skip_push)
+            self.commit_and_push(
+                component,
+                skip_push=skip_push,
+                parse_after_update=parse_after_update,
+            )
 
 
 class ChangeBaseAddon(BaseAddon):

--- a/weblate/addons/cdn.py
+++ b/weblate/addons/cdn.py
@@ -246,6 +246,7 @@ class CDNJSAddon(CDNBaseAddon):
         component: Component,
         previous_head: str,
         skip_push: bool,
+        parse_after_update: bool = False,
         activity_log_id: int | None = None,
     ) -> None:
         self.daily_component(component)
@@ -346,6 +347,7 @@ class CDNFilesAddon(CDNBaseAddon):
         component: Component,
         previous_head: str,
         skip_push: bool,
+        parse_after_update: bool = False,
         activity_log_id: int | None = None,
     ) -> None:
         self.publish_files(component)

--- a/weblate/addons/discovery.py
+++ b/weblate/addons/discovery.py
@@ -41,6 +41,7 @@ class DiscoveryAddon(BaseAddon):
         component: Component,
         previous_head: str,
         skip_push: bool,
+        parse_after_update: bool = False,
         activity_log_id: int | None = None,
     ) -> None:
         discovery = self.get_discovery(component)

--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -454,9 +454,16 @@ class MsgmergeAddon(GettextBaseAddon, UpdateBaseAddon):
         component: Component,
         files: list[str] | None = None,
         skip_push: bool = False,
+        parse_after_update: bool = False,
     ) -> bool:
-        if super().commit_and_push(component, files=files, skip_push=skip_push):
-            component.create_translations()
+        if super().commit_and_push(
+            component,
+            files=files,
+            skip_push=skip_push,
+            parse_after_update=parse_after_update,
+        ):
+            if not parse_after_update:
+                component.create_translations()
             return True
         return False
 
@@ -934,14 +941,21 @@ class ExtractPotBaseAddon(GettextBaseAddon, UpdateBaseAddon):
         component: Component,
         files: list[str] | None = None,
         skip_push: bool = False,
+        parse_after_update: bool = False,
     ) -> bool:
-        committed = super().commit_and_push(component, files=files, skip_push=skip_push)
+        committed = super().commit_and_push(
+            component,
+            files=files,
+            skip_push=skip_push,
+            parse_after_update=parse_after_update,
+        )
         revision = self.pending_successful_revisions.pop(component.pk, None)
         if revision is None:
             return committed
         if committed:
             self.mark_successful_run(component, component.repository.last_revision)
-            component.create_translations()
+            if not parse_after_update:
+                component.create_translations()
         else:
             self.mark_successful_run(component, revision)
         return committed

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -302,7 +302,9 @@ class GitSquashAddon(
             if component.repo_needs_merge():
                 try:
                     branch_updated = component.update_branch(
-                        method="rebase", skip_push=True
+                        method="rebase",
+                        skip_push=True,
+                        parse_after_update=True,
                     )
                 except RepositoryError:
                     return

--- a/weblate/addons/models.py
+++ b/weblate/addons/models.py
@@ -691,12 +691,13 @@ def post_update(
     component: Component,
     previous_head: str,
     skip_push: bool = False,
+    parse_after_update: bool = False,
     **kwargs,
 ) -> None:
     handle_addon_event(
         AddonEvent.EVENT_POST_UPDATE,
         "post_update",
-        (component, previous_head, skip_push),
+        (component, previous_head, skip_push, parse_after_update),
         component=component,
     )
 

--- a/weblate/addons/scripts.py
+++ b/weblate/addons/scripts.py
@@ -60,6 +60,7 @@ class BaseScriptAddon(BaseAddon):
         component,
         previous_head: str,
         skip_push: bool,
+        parse_after_update: bool = False,
         activity_log_id: int | None = None,
     ) -> None:
         self.run_script(component, env={"WL_PREVIOUS_HEAD": previous_head})

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -2323,6 +2323,155 @@ class GettextAddonTest(ViewTestCase):
 
         mocked_commit.assert_called_once_with("add-on", None)
 
+    def test_extract_pot_commit_parses_without_followup_parse(self) -> None:
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+            },
+        )
+        addon.pending_successful_revisions[self.component.pk] = (
+            self.component.repository.last_revision
+        )
+
+        with (
+            patch.object(self.component.repository, "needs_commit", return_value=True),
+            patch.object(self.component, "commit_files") as mocked_commit,
+            patch.object(self.component, "create_translations") as mocked_parse,
+        ):
+            committed = addon.commit_and_push(
+                self.component, files=["po/hello.pot"], skip_push=True
+            )
+
+        self.assertTrue(committed)
+        mocked_commit.assert_called_once()
+        mocked_parse.assert_called_once_with()
+
+    def test_extract_pot_commit_uses_followup_parse(self) -> None:
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+            },
+        )
+        addon.pending_successful_revisions[self.component.pk] = (
+            self.component.repository.last_revision
+        )
+
+        with (
+            patch.object(self.component.repository, "needs_commit", return_value=True),
+            patch.object(self.component, "commit_files") as mocked_commit,
+            patch.object(self.component, "create_translations") as mocked_parse,
+        ):
+            committed = addon.commit_and_push(
+                self.component,
+                files=["po/hello.pot"],
+                skip_push=True,
+                parse_after_update=True,
+            )
+
+        self.assertTrue(committed)
+        mocked_commit.assert_called_once()
+        mocked_parse.assert_not_called()
+
+    def test_extract_pot_post_configure_parses_once_after_commit(self) -> None:
+        source = Path(self.component.full_path) / "src" / "messages.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(
+            'from gettext import gettext as _\n_("Thank you for using Weblate!")\n',
+            encoding="utf-8",
+        )
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+            },
+        )
+        template = Path(self.component.get_new_base_filename())
+        template_content = template.read_text(encoding="utf-8").replace(
+            "Thank you for using Weblate.",
+            "Thank you for using Weblate!",
+        )
+
+        def run_process(component: Component, command: list[str]) -> str:
+            template.write_text(template_content, encoding="utf-8")
+            return ""
+
+        with (
+            patch.object(XgettextAddon, "run_process", side_effect=run_process),
+            patch.object(self.component, "create_translations") as mocked_parse,
+        ):
+            addon.post_configure_run_component(self.component)
+
+        mocked_parse.assert_called_once_with()
+
+    def test_extract_pot_manual_parses_once_after_commit(self) -> None:
+        source = Path(self.component.full_path) / "src" / "messages.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(
+            'from gettext import gettext as _\n_("Thank you for using Weblate!")\n',
+            encoding="utf-8",
+        )
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+            },
+        )
+        template = Path(self.component.get_new_base_filename())
+        template_content = template.read_text(encoding="utf-8").replace(
+            "Thank you for using Weblate.",
+            "Thank you for using Weblate!",
+        )
+
+        def run_process(component: Component, command: list[str]) -> str:
+            template.write_text(template_content, encoding="utf-8")
+            return ""
+
+        with (
+            patch.object(XgettextAddon, "run_process", side_effect=run_process),
+            patch.object(self.component, "create_translations") as mocked_parse,
+        ):
+            addon.manual_component(self.component)
+
+        mocked_parse.assert_called_once_with()
+
+    def test_extract_pot_manual_does_not_parse_without_commit(self) -> None:
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+            },
+        )
+
+        with (
+            patch.object(XgettextAddon, "execute_update", return_value=False),
+            patch.object(self.component, "create_translations") as mocked_parse,
+        ):
+            addon.manual_component(self.component)
+
+        mocked_parse.assert_not_called()
+
     def test_xgettext_uses_last_successful_revision_for_change_detection(self) -> None:
         addon = XgettextAddon.create(
             component=self.component,

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -2219,7 +2219,12 @@ class Component(  # noqa: PLR0904
 
             # update local branch
             try:
-                result = self.update_branch(request, method=method, skip_push=True)
+                result = self.update_branch(
+                    request,
+                    method=method,
+                    skip_push=True,
+                    parse_after_update=True,
+                )
             except RepositoryError:
                 result = False
 
@@ -2452,6 +2457,7 @@ class Component(  # noqa: PLR0904
                     previous_head=previous_head,
                     skip_push=False,
                     user=user,
+                    parse_after_update=True,
                 )
 
                 # create translation objects for all files
@@ -3241,6 +3247,7 @@ class Component(  # noqa: PLR0904
         request: AuthenticatedHttpRequest | None = None,
         method: str | None = None,
         skip_push: bool = False,
+        parse_after_update: bool = False,
     ) -> bool:
         """Update current branch to match remote (if possible)."""
         if method is None:
@@ -3342,12 +3349,18 @@ class Component(  # noqa: PLR0904
                     previous_head=previous_head,
                     skip_push=skip_push,
                     user=user,
+                    parse_after_update=parse_after_update,
                 )
         return True
 
     @perform_on_link
     def trigger_post_update(
-        self, *, previous_head: str, skip_push: bool, user: User | None
+        self,
+        *,
+        previous_head: str,
+        skip_push: bool,
+        user: User | None,
+        parse_after_update: bool = False,
     ) -> None:
         vcs_post_update.send(
             sender=self.__class__,
@@ -3355,6 +3368,7 @@ class Component(  # noqa: PLR0904
             previous_head=previous_head,
             skip_push=skip_push,
             user=user,
+            parse_after_update=parse_after_update,
         )
         for component in self.linked_children:
             vcs_post_update.send(
@@ -3363,6 +3377,7 @@ class Component(  # noqa: PLR0904
                 previous_head=previous_head,
                 skip_push=skip_push,
                 user=user,
+                parse_after_update=parse_after_update,
             )
 
     def get_mask_matches(self, *, raise_on_timeout: bool = False) -> list[str]:
@@ -3946,6 +3961,7 @@ class Component(  # noqa: PLR0904
         validate: bool = False,
         skip_push: bool = False,
         skip_commit: bool = False,
+        parse_after_update: bool = False,
     ) -> None:
         """Bring VCS repo in sync with current model."""
         if self.is_repo_link:
@@ -3962,7 +3978,10 @@ class Component(  # noqa: PLR0904
         self.configure_branch()
         if self.id:
             # Update existing repo
-            self.update_branch(skip_push=skip_push)
+            self.update_branch(
+                skip_push=skip_push,
+                parse_after_update=parse_after_update,
+            )
         else:
             # Reset to upstream in case not yet saved model (this is called
             # from the clean method only)
@@ -4548,7 +4567,11 @@ class Component(  # noqa: PLR0904
         # Configure git repo if there were changes
         if changed_git and (not create or not self.is_repo_link):
             # Bring VCS repo in sync with current model
-            self.sync_git_repo(skip_push=skip_push, skip_commit=create)
+            self.sync_git_repo(
+                skip_push=skip_push,
+                skip_commit=create,
+                parse_after_update=True,
+            )
 
         # Create template in case intermediate file is present
         self.create_template_if_missing()

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -151,6 +151,7 @@ def perform_commit(
                 previous_head=previous_head,
                 skip_push=False,
                 user=user,
+                parse_after_update=True,
             )
             component.create_translations(force=True)
 


### PR DESCRIPTION
The explicit call is only needed via the manual trigger and not from the update trigher because that already does that anyway.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
