### PR TITLE
feat(translate): show unit state when user has read-only access

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -551,6 +551,8 @@ class TranslationForm(UnitForm):
         }
         kwargs["auto_id"] = f"id_{unit.checksum}_%s"
         super().__init__(unit, *args, **kwargs)
+        user_can_edit = user.has_perm("unit.edit", unit)
+        user_can_review = user.has_perm("unit.review", translation)
         if unit.readonly:
             self.fields["target"].widget.attrs["readonly"] = 1
             # checkbox cannot be read-only, so hide it instead
@@ -577,6 +579,15 @@ class TranslationForm(UnitForm):
                 for state, label in StringState.choices
                 if state not in {STATE_READONLY, STATE_EMPTY} | states_to_hide
             ]
+        if not user_can_edit:
+            state = StringState(unit.state)
+            self.fields["review"].choices = [
+                (
+                    state,
+                    get_state_label(state, state.label, translation.enable_review),
+                )
+            ]
+            self.fields["review"].disabled = True
         self.user = user
         self.fields["target"].widget.profile = user.profile
         # Avoid failing validation on untranslated string
@@ -594,7 +605,7 @@ class TranslationForm(UnitForm):
             InlineRadios("review", css_class="review_radio"),
             Field("explanation"),
         )
-        if unit and user.has_perm("unit.review", translation):
+        if user_can_review or not user_can_edit:
             self.fields["fuzzy"].widget = forms.HiddenInput()
         else:
             self.fields["review"].widget = forms.HiddenInput()

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -27,6 +27,7 @@ from weblate.utils.docs import get_doc_url
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import (
+    STATE_APPROVED,
     STATE_EMPTY,
     STATE_FUZZY,
     STATE_NEEDS_CHECKING,
@@ -165,6 +166,26 @@ class EditTest(ViewTestCase):
         self.edit_unit(self.source, self.target, review=str(STATE_NEEDS_CHECKING))
         unit = self.get_unit(source=self.source)
         self.assertEqual(unit.state, STATE_NEEDS_CHECKING)
+
+    def test_approved_state_visible_without_edit_permission(self) -> None:
+        self.project.translation_review = True
+        self.project.save()
+        unit = self.change_unit(self.target, source=self.source, state=STATE_APPROVED)
+
+        self.assertFalse(self.user.has_perm("unit.edit", unit))
+
+        response = self.client.get(unit.get_absolute_url())
+
+        form = response.context["form"]
+        self.assertTrue(form.fields["fuzzy"].widget.is_hidden)
+        self.assertFalse(form.fields["review"].widget.is_hidden)
+        self.assertTrue(form.fields["review"].disabled)
+        self.assertEqual(
+            [choice[0] for choice in form.fields["review"].choices],
+            [STATE_APPROVED],
+        )
+        self.assertContains(response, "Approved")
+        self.assertNotContains(response, "fuzzy_checkbox")
 
     def add_unit(self, key, force_source: bool = False):
         if force_source or self.component.has_template():


### PR DESCRIPTION
Fixes #19546

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
