### PR TITLE
fix(reports): require reports.view for cost estimate endpoint

### DIFF
--- a/weblate/trans/tests/test_reports.py
+++ b/weblate/trans/tests/test_reports.py
@@ -577,6 +577,13 @@ class ReportsComponentTest(BaseReportsTest):
         self.assertContains(response, "New strings")
         self.assertContains(response, "Total")
 
+
+    def test_costs_requires_report_permission(self) -> None:
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        response = self.get_costs("json")
+        self.assertEqual(response.status_code, 403)
+
     def test_costs_invalid_threshold(self) -> None:
         response = self.get_costs("json", tm_threshold="200", follow=True)
         self.assertContains(

--- a/weblate/trans/tests/test_reports.py
+++ b/weblate/trans/tests/test_reports.py
@@ -577,7 +577,6 @@ class ReportsComponentTest(BaseReportsTest):
         self.assertContains(response, "New strings")
         self.assertContains(response, "Total")
 
-
     def test_costs_requires_report_permission(self) -> None:
         self.user.is_superuser = False
         self.user.save(update_fields=["is_superuser"])

--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
 from django.utils.html import conditional_escape, format_html, format_html_join
 from django.utils.translation import gettext
@@ -340,6 +341,9 @@ def get_costs(request: AuthenticatedHttpRequest, path=None):
         scope = {"category": obj}
     else:
         scope = {"component": obj}
+
+    if not request.user.has_perm("reports.view", obj):
+        raise PermissionDenied
 
     form = CostEstimateReportsForm(scope, request.POST)
 


### PR DESCRIPTION
### Motivation
- Close an authorization gap that allowed any authenticated user to run the expensive cost-estimate pipeline and access global/scoped cost reports without the `reports.view` permission, which undermines intended report-download and global-report controls.

### Description
- Enforce `reports.view` in `get_costs` by checking `request.user.has_perm("reports.view", obj)` and raising `PermissionDenied` when unauthorized, and import `PermissionDenied` from `django.core.exceptions`; add a regression test `test_costs_requires_report_permission` in `weblate/trans/tests/test_reports.py` to assert the endpoint returns HTTP 403 for users without the permission.

### Testing
- Ran the targeted test command `uv run pytest weblate/trans/tests/test_reports.py -k costs_requires_report_permission` and the test(s) passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c1739ae483299bdffd755ab93449)