### PR TITLE
fix(api): handle invalid workspace UUID in project create

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -2679,6 +2679,19 @@ class ProjectAPITest(APIBaseTest):
                 },
             )
 
+    def test_create_with_invalid_workspace_uuid(self) -> None:
+        self.do_request(
+            "api:project-list",
+            method="post",
+            code=400,
+            request={
+                "name": "API project",
+                "slug": "api-project",
+                "web": "https://weblate.org/",
+                "workspace": "not-a-uuid",
+            },
+        )
+
     def test_create_with_billing(self) -> None:
         with modify_settings(INSTALLED_APPS={"remove": "weblate.billing"}):
             response = self.do_request(

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1755,7 +1755,10 @@ class ProjectViewSet(
         """Create a new project."""
         workspace_id = request.data.get("workspace")
         if workspace_id:
-            workspace = get_object_or_404(Workspace, pk=workspace_id)
+            try:
+                workspace = get_object_or_404(Workspace, pk=workspace_id)
+            except (DjangoValidationError, ValueError) as error:
+                raise ValidationError({"workspace": error.messages}) from error
             if not request.user.has_perm("workspace.add_project", workspace):
                 self.permission_denied(request, "Can not create projects")
             if "weblate.billing" in settings.INSTALLED_APPS and hasattr(


### PR DESCRIPTION
### Motivation
- The `ProjectViewSet.create` handler read `request.data['workspace']` and called `get_object_or_404(Workspace, pk=workspace_id)` before serializer validation, which caused malformed UUIDs (e.g. `"not-a-uuid"`) to raise a `django.core.exceptions.ValidationError` and return a 500 instead of a 400 client error.
- The change aims to convert such server-side failures into proper DRF validation errors so clients receive a `400` and the server remains robust.

### Description
- Wrap the raw workspace lookup in `ProjectViewSet.create` (`weblate/api/views.py`) with a `try`/`except` that catches `DjangoValidationError` and `ValueError` and raises a DRF `ValidationError` with the workspace error mapped to the `workspace` field.
- Add a regression test `test_create_with_invalid_workspace_uuid` in `weblate/api/tests.py` that posts `"workspace": "not-a-uuid"` to the project create endpoint and asserts an HTTP `400` response.
- Commit message used: `fix(api): handle invalid workspace UUID in project create`.

### Testing
- Ran the targeted test: `uv run pytest weblate/api/tests.py -k invalid_workspace_uuid` and it passed (`1 passed, 450 deselected`).
- No other automated tests were changed or executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1664046e988329aae01bb3305e164b)