### PR TITLE
fix(add-ons): hide generic discovery presets for installed add-ons

### DIFF
--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -1069,6 +1069,8 @@ class DiscoveryForm(BaseAddonForm):
 
     @cached_property
     def generic_ui_presets(self) -> list[dict[str, object]]:
+        if self._addon.instance.pk is not None:
+            return []
         return self.get_builtin_ui_presets()
 
     @cached_property

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -5319,9 +5319,11 @@ class DiscoveryTest(ViewTestCase):
             "Generic preset: One folder per language [gettext PO file; no monolingual base]",
         )
 
-    def test_detected_ui_presets_are_not_shown_when_editing_existing_addon(
+    def test_ui_presets_are_not_shown_when_editing_existing_addon(
         self,
     ) -> None:
+        self.user.is_superuser = True
+        self.user.save()
         addon = DiscoveryAddon.create(
             component=self.component,
             configuration={
@@ -5346,7 +5348,17 @@ class DiscoveryTest(ViewTestCase):
             self.fail("Expected discovery form to be created")
         form = cast("DiscoveryForm", form)
         self.assertEqual(form.detected_ui_presets, [])
+        self.assertEqual(form.generic_ui_presets, [])
+        self.assertEqual(form.guided_presets, [])
+        self.assertEqual(form.guided_preset_sections, [])
         mocked.assert_not_called()
+
+        response = self.client.get(
+            reverse("addon-detail", kwargs={"pk": addon.instance.pk})
+        )
+        self.assertNotContains(response, "Guided presets")
+        self.assertNotContains(response, 'id="addon-discovery-presets"')
+        self.assertNotContains(response, "addon-ui-presets")
 
     def test_detected_ui_presets_skip_builtin_equivalent_matches(self) -> None:
         detected = [


### PR DESCRIPTION
These are not really useful once the discovery is configured.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
