### PR TITLE
fix(workspaces): filter workspace history by project access

### DIFF
--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -428,7 +428,9 @@ class ChangeManager(models.Manager["Change"]):
         elif workspace is not None:
             if not workspace.can_view(user):
                 return cast("ChangeQuerySet", self.none())
-            result = self.filter(workspace=workspace) | cast(
+            result = self.filter(workspace=workspace).filter_projects(
+                user
+            ).filter_components(user) | cast(
                 "ChangeQuerySet",
                 self.filter(
                     project__workspace=workspace,

--- a/weblate/workspaces/tests.py
+++ b/weblate/workspaces/tests.py
@@ -307,6 +307,28 @@ class WorkspaceViewTest(BaseTestCase):
         self.assertNotContains(response, hidden.name, status_code=200)
         self.assertNotContains(response, other.name, status_code=200)
 
+    def test_workspace_changes_exclude_hidden_project_move_events(self) -> None:
+        workspace = Workspace.objects.create(name="Shared history workspace")
+        self.create_project(
+            workspace,
+            name="Visible shared history project",
+            slug="visible-shared-history-project",
+        )
+        hidden = self.create_project(
+            workspace,
+            name="Hidden moved project",
+            slug="hidden-moved-project",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+
+        hidden.change_set.create(action=ActionEvents.MOVE_PROJECT, workspace=workspace)
+
+        response = self.client.get(
+            reverse("changes", kwargs={"path": workspace.get_url_path()})
+        )
+
+        self.assertNotContains(response, hidden.name, status_code=200)
+
     def test_workspace_changes_rss(self) -> None:
         workspace = Workspace.objects.create(name="RSS workspace")
         project = self.create_project(


### PR DESCRIPTION
### Motivation
- Prevent information disclosure where workspace-scoped history could include private project move events visible to users who can view any public/protected project in the same workspace.

### Description
- Apply `filter_projects(user)` and `filter_components(user)` to the `workspace=...` branch inside `ChangeManager.last_changes()` so workspace-scoped changes are permission-filtered before unioning querysets in `weblate/trans/models/change.py`.
- Add a regression test `test_workspace_changes_exclude_hidden_project_move_events` in `weblate/workspaces/tests.py` that creates a private project move event and asserts it is not shown on the workspace changes page for users without access.

### Testing
- Ran `uv run pytest weblate/workspaces/tests.py -k "workspace_changes_include_accessible_project_changes or workspace_changes_exclude_hidden_project_move_events"` and the selected tests passed (`2 passed, 23 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1736e0aa988329825e4b859cb5ae59)