### PR TITLE
fix(utils): reject NAT64-wrapped internal addresses

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,7 +26,7 @@ Weblate 2026.6
 
 .. rubric:: Bug fixes
 
-* Outbound URL validation now rejects NAT64-wrapped internal addresses.
+* Outbound URL validation now rejects additional non-public targets.
 * Hardened :http:post:`/api/screenshots/` access checks against private project enumeration.
 * Registration-attempt account activity e-mails now link to password reset to help users finish account setup.
 * :ref:`invite-user` links now work for signed-in users whose account owns the invited e-mail address.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,7 @@ Weblate 2026.6
 
 .. rubric:: Bug fixes
 
+* Outbound URL validation now rejects NAT64-wrapped internal addresses.
 * Hardened :http:post:`/api/screenshots/` access checks against private project enumeration.
 * Registration-attempt account activity e-mails now link to password reset to help users finish account setup.
 * :ref:`invite-user` links now work for signed-in users whose account owns the invited e-mail address.

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -26,6 +26,13 @@ _NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
 _NAT64_LOCAL_USE_PREFIX = ipaddress.IPv6Network("64:ff9b:1::/48")
 _SIXTOFOUR_PREFIX = ipaddress.IPv6Network("2002::/16")
 _IPV4_COMPAT = ipaddress.IPv6Network("::0.0.0.0/96")
+_NON_PUBLIC_SPECIAL_USE_PREFIXES: tuple[
+    ipaddress.IPv4Network | ipaddress.IPv6Network, ...
+] = (
+    ipaddress.IPv4Network("192.88.99.0/24"),  # 6to4 relay anycast
+    ipaddress.IPv6Network("5f00::/16"),  # IPv6 Segment Routing
+    ipaddress.IPv6Network("2001:20::/28"),  # ORCHIDv2
+)
 
 
 def _parse_ip(value: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
@@ -107,6 +114,11 @@ def _is_public_ip(value: str) -> bool:
 def _is_global_address(
     address: ipaddress.IPv4Address | ipaddress.IPv6Address,
 ) -> bool:
+    if address.is_multicast:
+        return False
+    for network in _NON_PUBLIC_SPECIAL_USE_PREFIXES:
+        if address.version == network.version and address in network:
+            return False
     if isinstance(address, ipaddress.IPv6Address) and address in _SIXTOFOUR_PREFIX:
         return False
     if (

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -129,7 +129,10 @@ def _is_global_address(
         # NAT64 prefix as global. TODO: remove once support for those Python
         # versions is dropped.
         return False
-    return _unwrap_ipv6_transition(address).is_global
+    unwrapped = _unwrap_ipv6_transition(address)
+    if unwrapped != address:
+        return _is_global_address(unwrapped)
+    return address.is_global
 
 
 def validate_runtime_ip(value: str, *, allow_private_targets: bool = True) -> None:

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -18,12 +18,13 @@ LOCAL_HOST_SUFFIXES = (
 )
 
 # IPv6 transition prefixes whose addresses encode an IPv4 destination.  On
-# hosts where 6to4 / NAT64 translation is configured, the kernel routes
-# packets sent to these addresses to the embedded IPv4 endpoint, so they
-# must be unwrapped before consulting ipaddress.is_global - which classifies
-# 2002::/16 and 64:ff9b::/96 as globally routable.
+# hosts where NAT64 translation is configured, the kernel routes packets sent
+# to these addresses to the embedded IPv4 endpoint, so they must be unwrapped
+# before consulting ipaddress.is_global - which classifies 64:ff9b::/96 as
+# globally routable.
 _NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
 _NAT64_LOCAL_USE_PREFIX = ipaddress.IPv6Network("64:ff9b:1::/48")
+_SIXTOFOUR_PREFIX = ipaddress.IPv6Network("2002::/16")
 _IPV4_COMPAT = ipaddress.IPv6Network("::0.0.0.0/96")
 
 
@@ -72,22 +73,19 @@ def _unwrap_ipv6_transition(
 
     Covers IPv4-mapped IPv6 (``::ffff:0:0/96``), IPv4-compatible IPv6
     (``::0.0.0.0/96``, deprecated by RFC 4291 but still routable on hosts
-    that have not removed the configuration), 6to4 (``2002::/16``,
-    RFC 3056) and the well-known NAT64 prefix (``64:ff9b::/96`` per
-    RFC 6052).  Returns the input unchanged when the address does not embed
-    an IPv4 destination.
+    that have not removed the configuration), and the well-known NAT64 prefix
+    (``64:ff9b::/96`` per RFC 6052).  Returns the input unchanged when the
+    address does not embed an IPv4 destination.
 
     Without this unwrap, ``ipaddress.IPv6Address.is_global`` classifies
-    ``2002::/16`` and ``64:ff9b::/96`` as globally routable and the
-    outbound-URL guard misses these forms when an attacker supplies a
-    hostname whose AAAA record points at a wrapped private IPv4.
+    ``64:ff9b::/96`` as globally routable and the outbound-URL guard misses
+    these forms when an attacker supplies a hostname whose AAAA record points
+    at a wrapped private IPv4.
     """
     if not isinstance(address, ipaddress.IPv6Address):
         return address
     if address.ipv4_mapped is not None:
         return address.ipv4_mapped
-    if address.sixtofour is not None:
-        return address.sixtofour
     if address in _NAT64_PREFIX:
         return ipaddress.IPv4Address(address.packed[-4:])
     if address in _IPV4_COMPAT:
@@ -109,6 +107,8 @@ def _is_public_ip(value: str) -> bool:
 def _is_global_address(
     address: ipaddress.IPv4Address | ipaddress.IPv6Address,
 ) -> bool:
+    if isinstance(address, ipaddress.IPv6Address) and address in _SIXTOFOUR_PREFIX:
+        return False
     if (
         isinstance(address, ipaddress.IPv6Address)
         and address in _NAT64_LOCAL_USE_PREFIX

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -17,6 +17,15 @@ LOCAL_HOST_SUFFIXES = (
     ".localhost",
 )
 
+# IPv6 transition prefixes whose addresses encode an IPv4 destination.  On
+# hosts where 6to4 / NAT64 translation is configured, the kernel routes
+# packets sent to these addresses to the embedded IPv4 endpoint, so they
+# must be unwrapped before consulting ipaddress.is_global - which classifies
+# 2002::/16 and 64:ff9b::/96 as globally routable.
+_NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
+_NAT64_DISCOVERY_PREFIX = ipaddress.IPv6Network("64:ff9b:1::/48")
+_IPV4_COMPAT = ipaddress.IPv6Network("::0.0.0.0/96")
+
 
 def _parse_ip(value: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
     try:
@@ -55,9 +64,46 @@ def _parse_hostname_ip(
     return ipaddress.IPv4Address(packed)
 
 
+def _unwrap_ipv6_transition(
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Return the embedded IPv4 destination for an IPv6 transition address.
+
+    Covers IPv4-mapped IPv6 (``::ffff:0:0/96``), IPv4-compatible IPv6
+    (``::0.0.0.0/96``, deprecated by RFC 4291 but still routable on hosts
+    that have not removed the configuration), 6to4 (``2002::/16``,
+    RFC 3056) and NAT64 (``64:ff9b::/96`` per RFC 6052 and
+    ``64:ff9b:1::/48`` per RFC 8215).  Returns the input unchanged when
+    the address does not embed an IPv4 destination.
+
+    Without this unwrap, ``ipaddress.IPv6Address.is_global`` classifies
+    ``2002::/16`` and ``64:ff9b::/96`` as globally routable and the
+    outbound-URL guard misses these forms when an attacker supplies a
+    hostname whose AAAA record points at a wrapped private IPv4.
+    """
+    if not isinstance(address, ipaddress.IPv6Address):
+        return address
+    if address.ipv4_mapped is not None:
+        return address.ipv4_mapped
+    if address.sixtofour is not None:
+        return address.sixtofour
+    if address in _NAT64_PREFIX or address in _NAT64_DISCOVERY_PREFIX:
+        return ipaddress.IPv4Address(address.packed[-4:])
+    if address in _IPV4_COMPAT:
+        # ::N.N.N.N - skip the unspecified address (::), which is also
+        # technically inside this /96 but is not an embedded IPv4 wrapper.
+        embedded = ipaddress.IPv4Address(address.packed[-4:])
+        if int(embedded) != 0:
+            return embedded
+    return address
+
+
 def _is_public_ip(value: str) -> bool:
     address = _parse_ip(value)
-    return address is not None and address.is_global
+    if address is None:
+        return False
+    address = _unwrap_ipv6_transition(address)
+    return address.is_global
 
 
 def validate_runtime_ip(value: str, *, allow_private_targets: bool = True) -> None:
@@ -99,7 +145,7 @@ def validate_untrusted_hostname(
         return
 
     if ip_address := _parse_hostname_ip(normalized):
-        if not ip_address.is_global:
+        if not _unwrap_ipv6_transition(ip_address).is_global:
             raise ValidationError(
                 gettext(
                     "This URL is prohibited because it points to an internal or non-public address."

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -67,7 +67,8 @@ def _parse_hostname_ip(
 def _unwrap_ipv6_transition(
     address: ipaddress.IPv4Address | ipaddress.IPv6Address,
 ) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
-    """Return the embedded IPv4 destination for an IPv6 transition address.
+    """
+    Return the embedded IPv4 destination for an IPv6 transition address.
 
     Covers IPv4-mapped IPv6 (``::ffff:0:0/96``), IPv4-compatible IPv6
     (``::0.0.0.0/96``, deprecated by RFC 4291 but still routable on hosts

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -23,6 +23,7 @@ LOCAL_HOST_SUFFIXES = (
 # must be unwrapped before consulting ipaddress.is_global - which classifies
 # 2002::/16 and 64:ff9b::/96 as globally routable.
 _NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
+_NAT64_LOCAL_USE_PREFIX = ipaddress.IPv6Network("64:ff9b:1::/48")
 _IPV4_COMPAT = ipaddress.IPv6Network("::0.0.0.0/96")
 
 
@@ -102,8 +103,21 @@ def _is_public_ip(value: str) -> bool:
     address = _parse_ip(value)
     if address is None:
         return False
-    address = _unwrap_ipv6_transition(address)
-    return address.is_global
+    return _is_global_address(address)
+
+
+def _is_global_address(
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    if (
+        isinstance(address, ipaddress.IPv6Address)
+        and address in _NAT64_LOCAL_USE_PREFIX
+    ):
+        # Legacy compatibility: Python before 3.12.4 classified this local-use
+        # NAT64 prefix as global. TODO: remove once support for those Python
+        # versions is dropped.
+        return False
+    return _unwrap_ipv6_transition(address).is_global
 
 
 def validate_runtime_ip(value: str, *, allow_private_targets: bool = True) -> None:
@@ -145,7 +159,7 @@ def validate_untrusted_hostname(
         return
 
     if ip_address := _parse_hostname_ip(normalized):
-        if not _unwrap_ipv6_transition(ip_address).is_global:
+        if not _is_global_address(ip_address):
             raise ValidationError(
                 gettext(
                     "This URL is prohibited because it points to an internal or non-public address."

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -23,7 +23,6 @@ LOCAL_HOST_SUFFIXES = (
 # must be unwrapped before consulting ipaddress.is_global - which classifies
 # 2002::/16 and 64:ff9b::/96 as globally routable.
 _NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
-_NAT64_DISCOVERY_PREFIX = ipaddress.IPv6Network("64:ff9b:1::/48")
 _IPV4_COMPAT = ipaddress.IPv6Network("::0.0.0.0/96")
 
 
@@ -73,9 +72,9 @@ def _unwrap_ipv6_transition(
     Covers IPv4-mapped IPv6 (``::ffff:0:0/96``), IPv4-compatible IPv6
     (``::0.0.0.0/96``, deprecated by RFC 4291 but still routable on hosts
     that have not removed the configuration), 6to4 (``2002::/16``,
-    RFC 3056) and NAT64 (``64:ff9b::/96`` per RFC 6052 and
-    ``64:ff9b:1::/48`` per RFC 8215).  Returns the input unchanged when
-    the address does not embed an IPv4 destination.
+    RFC 3056) and the well-known NAT64 prefix (``64:ff9b::/96`` per
+    RFC 6052).  Returns the input unchanged when the address does not embed
+    an IPv4 destination.
 
     Without this unwrap, ``ipaddress.IPv6Address.is_global`` classifies
     ``2002::/16`` and ``64:ff9b::/96`` as globally routable and the
@@ -88,7 +87,7 @@ def _unwrap_ipv6_transition(
         return address.ipv4_mapped
     if address.sixtofour is not None:
         return address.sixtofour
-    if address in _NAT64_PREFIX or address in _NAT64_DISCOVERY_PREFIX:
+    if address in _NAT64_PREFIX:
         return ipaddress.IPv4Address(address.packed[-4:])
     if address in _IPV4_COMPAT:
         # ::N.N.N.N - skip the unspecified address (::), which is also

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -681,6 +681,20 @@ class OutboundAddressValidationTest(SimpleTestCase):
             validate_runtime_ip("100.64.0.1", allow_private_targets=False)
         self.assertIn("internal or non-public address", str(error.exception))
 
+    def test_validate_runtime_ip_rejects_special_use_ranges(self) -> None:
+        for label, address in (
+            ("6to4 relay anycast", "192.88.99.1"),
+            ("IPv4 multicast", "224.0.0.1"),
+            ("IPv4 multicast documentation", "233.252.0.1"),
+            ("IPv6 Segment Routing", "5f00::1"),
+            ("ORCHIDv2", "2001:20::1"),
+            ("IPv6 multicast", "ff00::1"),
+        ):
+            with self.subTest(case=label, address=address):
+                with self.assertRaises(ValidationError) as error:
+                    validate_runtime_ip(address, allow_private_targets=False)
+                self.assertIn("internal or non-public address", str(error.exception))
+
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("100.64.0.1", 443))],
@@ -703,9 +717,8 @@ class OutboundAddressValidationTest(SimpleTestCase):
         """
         6to4, NAT64 and IPv4-compatible wrappers must be rejected.
 
-        Python's ``ipaddress.is_global`` classifies these wrappers as globally
-        routable; on hosts where the kernel has 6to4 or NAT64 translation
-        configured, traffic to them is forwarded to the embedded IPv4 endpoint.
+        On hosts where the kernel has NAT64 translation configured, traffic to
+        the NAT64 well-known prefix is forwarded to the embedded IPv4 endpoint.
         """
         for label, wrapped_address in (
             ("6to4 IMDS", "2002:a9fe:a9fe::"),

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -729,7 +729,11 @@ class OutboundAddressValidationTest(SimpleTestCase):
             ("NAT64 IMDS", "64:ff9b::a9fe:a9fe"),
             ("NAT64 loopback", "64:ff9b::7f00:1"),
             ("NAT64 RFC1918", "64:ff9b::a00:1"),
+            ("NAT64 multicast", "64:ff9b::e000:1"),
+            ("NAT64 6to4 relay anycast", "64:ff9b::c058:6301"),
             ("IPv4-compat", "::a00:1"),
+            ("IPv4-compat multicast", "::e000:1"),
+            ("IPv4-compat 6to4 relay anycast", "::c058:6301"),
         ):
             with self.subTest(case=label, address=wrapped_address):
                 with self.assertRaises(ValidationError) as error:

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -699,6 +699,59 @@ class OutboundAddressValidationTest(SimpleTestCase):
             "shared-address-space.example", None, type=1
         )
 
+    def test_validate_runtime_ip_rejects_ipv6_transition_wrappers(self) -> None:
+        """6to4, NAT64 and IPv4-compatible wrappers around private IPv4 must
+        be rejected.  Python's ``ipaddress.is_global`` classifies these
+        wrappers as globally routable; on hosts where the kernel has 6to4
+        or NAT64 translation configured, traffic to them is forwarded to
+        the embedded IPv4 endpoint.
+        """
+        for label, wrapped_address in (
+            ("6to4 IMDS",      "2002:a9fe:a9fe::"),
+            ("6to4 ECS",       "2002:a9fe:aa02::"),
+            ("6to4 loopback",  "2002:7f00:1::"),
+            ("6to4 RFC1918",   "2002:a00:1::"),
+            ("NAT64 IMDS",     "64:ff9b::a9fe:a9fe"),
+            ("NAT64 loopback", "64:ff9b::7f00:1"),
+            ("NAT64 RFC1918",  "64:ff9b::a00:1"),
+            ("IPv4-compat",    "::a00:1"),
+        ):
+            with self.subTest(case=label, address=wrapped_address):
+                with self.assertRaises(ValidationError) as error:
+                    validate_runtime_ip(
+                        wrapped_address, allow_private_targets=False
+                    )
+                self.assertIn(
+                    "internal or non-public address", str(error.exception)
+                )
+
+    def test_validate_runtime_ip_permits_public_ipv6(self) -> None:
+        """Legitimate public IPv6 must still be accepted - the unwrap
+        helper must not over-block."""
+        for address in (
+            "2606:4700:4700::1111",  # Cloudflare 1.1.1.1
+            "2001:4860:4860::8888",  # Google 8.8.8.8
+        ):
+            with self.subTest(address=address):
+                validate_runtime_ip(address, allow_private_targets=False)
+
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("2002:a9fe:a9fe::", 0, 0, 0))],
+    )
+    def test_validate_runtime_url_rejects_6to4_imds(
+        self, mocked_getaddrinfo
+    ) -> None:
+        """When a hostname's AAAA record resolves to a 6to4 wrapper of
+        the AWS / GCP / Azure / Oracle metadata IPv4, validate_runtime_url
+        must reject it.
+        """
+        with self.assertRaises(ValidationError) as error:
+            validate_runtime_url(
+                "https://attacker.example", allow_private_targets=False
+            )
+        self.assertIn("internal or non-public address", str(error.exception))
+
 
 class RepoURLValidationTestCase(SimpleTestCase):
     def test_file_rejected(self):

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -712,6 +712,7 @@ class OutboundAddressValidationTest(SimpleTestCase):
             ("6to4 ECS", "2002:a9fe:aa02::"),
             ("6to4 loopback", "2002:7f00:1::"),
             ("6to4 RFC1918", "2002:a00:1::"),
+            ("6to4 public IPv4", "2002:808:808::"),
             ("NAT64 IMDS", "64:ff9b::a9fe:a9fe"),
             ("NAT64 loopback", "64:ff9b::7f00:1"),
             ("NAT64 RFC1918", "64:ff9b::a00:1"),

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -700,34 +700,34 @@ class OutboundAddressValidationTest(SimpleTestCase):
         )
 
     def test_validate_runtime_ip_rejects_ipv6_transition_wrappers(self) -> None:
-        """6to4, NAT64 and IPv4-compatible wrappers around private IPv4 must
-        be rejected.  Python's ``ipaddress.is_global`` classifies these
-        wrappers as globally routable; on hosts where the kernel has 6to4
-        or NAT64 translation configured, traffic to them is forwarded to
-        the embedded IPv4 endpoint.
+        """
+        6to4, NAT64 and IPv4-compatible wrappers must be rejected.
+
+        Python's ``ipaddress.is_global`` classifies these wrappers as globally
+        routable; on hosts where the kernel has 6to4 or NAT64 translation
+        configured, traffic to them is forwarded to the embedded IPv4 endpoint.
         """
         for label, wrapped_address in (
-            ("6to4 IMDS",      "2002:a9fe:a9fe::"),
-            ("6to4 ECS",       "2002:a9fe:aa02::"),
-            ("6to4 loopback",  "2002:7f00:1::"),
-            ("6to4 RFC1918",   "2002:a00:1::"),
-            ("NAT64 IMDS",     "64:ff9b::a9fe:a9fe"),
+            ("6to4 IMDS", "2002:a9fe:a9fe::"),
+            ("6to4 ECS", "2002:a9fe:aa02::"),
+            ("6to4 loopback", "2002:7f00:1::"),
+            ("6to4 RFC1918", "2002:a00:1::"),
+            ("NAT64 IMDS", "64:ff9b::a9fe:a9fe"),
             ("NAT64 loopback", "64:ff9b::7f00:1"),
-            ("NAT64 RFC1918",  "64:ff9b::a00:1"),
-            ("IPv4-compat",    "::a00:1"),
+            ("NAT64 RFC1918", "64:ff9b::a00:1"),
+            ("IPv4-compat", "::a00:1"),
         ):
             with self.subTest(case=label, address=wrapped_address):
                 with self.assertRaises(ValidationError) as error:
-                    validate_runtime_ip(
-                        wrapped_address, allow_private_targets=False
-                    )
-                self.assertIn(
-                    "internal or non-public address", str(error.exception)
-                )
+                    validate_runtime_ip(wrapped_address, allow_private_targets=False)
+                self.assertIn("internal or non-public address", str(error.exception))
 
     def test_validate_runtime_ip_permits_public_ipv6(self) -> None:
-        """Legitimate public IPv6 must still be accepted - the unwrap
-        helper must not over-block."""
+        """
+        Legitimate public IPv6 must still be accepted.
+
+        The unwrap helper must not over-block.
+        """
         for address in (
             "2606:4700:4700::1111",  # Cloudflare 1.1.1.1
             "2001:4860:4860::8888",  # Google 8.8.8.8
@@ -739,12 +739,13 @@ class OutboundAddressValidationTest(SimpleTestCase):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("2002:a9fe:a9fe::", 0, 0, 0))],
     )
-    def test_validate_runtime_url_rejects_6to4_imds(
-        self, mocked_getaddrinfo
-    ) -> None:
-        """When a hostname's AAAA record resolves to a 6to4 wrapper of
-        the AWS / GCP / Azure / Oracle metadata IPv4, validate_runtime_url
-        must reject it.
+    def test_validate_runtime_url_rejects_6to4_imds(self, mocked_getaddrinfo) -> None:
+        """
+        Hostnames resolving to 6to4 metadata wrappers must be rejected.
+
+        When a hostname's AAAA record resolves to a 6to4 wrapper of the
+        AWS / GCP / Azure / Oracle metadata IPv4, validate_runtime_url must
+        reject it.
         """
         with self.assertRaises(ValidationError) as error:
             validate_runtime_url(

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -722,6 +722,11 @@ class OutboundAddressValidationTest(SimpleTestCase):
                     validate_runtime_ip(wrapped_address, allow_private_targets=False)
                 self.assertIn("internal or non-public address", str(error.exception))
 
+    def test_validate_runtime_ip_rejects_nat64_local_use_suffix(self) -> None:
+        with self.assertRaises(ValidationError) as error:
+            validate_runtime_ip("64:ff9b:1::808:808", allow_private_targets=False)
+        self.assertIn("internal or non-public address", str(error.exception))
+
     def test_validate_runtime_ip_permits_public_ipv6(self) -> None:
         """
         Legitimate public IPv6 must still be accepted.


### PR DESCRIPTION
Harden outbound URL validation by rejecting IPv6 transition, multicast, and special-use addresses that must not be treated as public targets, while unwrapping NAT64 well-known-prefix addresses to validate the embedded IPv4 destination. Adds regression coverage for the blocked address classes.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
