### PR TITLE
Add WEBLATE_SAML_SECURITY_CONFIG Docker environment variable

### DIFF
--- a/docs/admin/auth.rst
+++ b/docs/admin/auth.rst
@@ -569,6 +569,18 @@ When configuring Weblate SP in your IdP, it is recommended to choose persistent
 
 .. hint::
 
+   Some identity providers (such as Microsoft Entra ID with multi-factor
+   authentication) require disabling the default ``requestedAuthnContext``
+   in the SAML security configuration:
+
+   .. code-block:: python
+
+      SOCIAL_AUTH_SAML_SECURITY_CONFIG = {"requestedAuthnContext": False}
+
+   In Docker, set :envvar:`WEBLATE_SAML_SECURITY_CONFIG` instead.
+
+.. hint::
+
    The example above and the Docker image define an IdP called ``weblate``.
    You might need to configure this string as :guilabel:`Relay` in your IdP.
 

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1731,6 +1731,24 @@ In case you want to use own keys, place the certificate and private key in
 
     SAML Identity Provider settings, see :ref:`saml-auth`.
 
+.. envvar:: WEBLATE_SAML_SECURITY_CONFIG
+
+    .. versionadded:: 2026.6
+
+    SAML security configuration as a JSON object, passed to
+    ``SOCIAL_AUTH_SAML_SECURITY_CONFIG``. For example, to disable the
+    ``requestedAuthnContext`` (needed for some identity providers such as
+    Microsoft Entra ID with multi-factor authentication):
+
+    .. code-block:: yaml
+
+        environment:
+          WEBLATE_SAML_SECURITY_CONFIG: '{"requestedAuthnContext": false}'
+
+    .. seealso::
+
+       `python3-saml security settings <https://github.com/SAML-Toolkits/python3-saml#settings>`_
+
 .. envvar:: WEBLATE_SAML_ID_ATTR_FULL_NAME
 .. envvar:: WEBLATE_SAML_ID_ATTR_FIRST_NAME
 .. envvar:: WEBLATE_SAML_ID_ATTR_LAST_NAME

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.6
 
 .. rubric:: Improvements
 
+* Docker containers can now configure :envvar:`WEBLATE_SAML_SECURITY_CONFIG` to customize SAML security settings such as disabling ``requestedAuthnContext``.
 * Docker containers can now adjust :setting:`WEBLATE_FORMATS`.
   Use :envvar:`WEBLATE_ADD_FORMATS` and :envvar:`WEBLATE_REMOVE_FORMATS`.
 * Improved performance of the :ref:`check-inconsistent` check on large projects.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -396,6 +396,7 @@ linkcheck_ignore = [
     "https://api.sap.com/api/translationhub/overview",
     # Anchor is not there for linkcheck
     "https://hub.docker.com/_/postgres#pgdata",
+    "https://github.com/SAML-Toolkits/python3-saml#settings",
     # Protected by Anubis
     "https://anubis.techaro.lol/",
     # Seems unstable

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -32,6 +32,7 @@ from weblate.utils.environment import (
     get_env_float,
     get_env_int,
     get_env_int_or_none,
+    get_env_json,
     get_env_list,
     get_env_list_or_none,
     get_env_map,
@@ -462,6 +463,7 @@ if WEBLATE_SAML_IDP:
     SOCIAL_AUTH_SAML_TITLE = get_env_str(
         "WEBLATE_SAML_IDP_TITLE", accounts_defaults.DEFAULT_SOCIAL_AUTH_SAML_TITLE
     )
+    SOCIAL_AUTH_SAML_SECURITY_CONFIG = get_env_json("WEBLATE_SAML_SECURITY_CONFIG", {})
 
 # Microsoft Entra ID
 SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = get_env_str("WEBLATE_SOCIAL_AUTH_AZUREAD_OAUTH2_KEY")

--- a/weblate/utils/environment.py
+++ b/weblate/utils/environment.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import os
 from pathlib import Path
 from typing import Any, Literal, cast, overload
@@ -117,6 +118,24 @@ def get_env_map(name: str, default: dict[str, str] | None = None) -> dict[str, s
     if env_map is not None:
         return env_map
     return default or {}
+
+
+@overload
+def get_env_json(name: str, default: dict[str, Any]) -> dict[str, Any]: ...
+@overload
+def get_env_json(name: str, default: None = None) -> dict[str, Any] | None: ...
+def get_env_json(
+    name: str, default: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
+    """Get JSON object from environment."""
+    string_value = get_env_str(name)
+    if not string_value:
+        return default
+    try:
+        return json.loads(string_value)
+    except json.JSONDecodeError as error:
+        msg = f"Could not parse {name}: {error}"
+        raise ImproperlyConfigured(msg) from error
 
 
 def get_env_int_or_none(name: str) -> int | None:

--- a/weblate/utils/tests/test_environment.py
+++ b/weblate/utils/tests/test_environment.py
@@ -16,6 +16,7 @@ from weblate.utils.environment import (
     get_env_credentials,
     get_env_int,
     get_env_int_or_none,
+    get_env_json,
     get_env_list,
     get_env_list_or_none,
     get_env_map,
@@ -190,6 +191,21 @@ class EnvTest(SimpleTestCase):
         self.assertEqual(get_env_map_or_none("TEST_DATA"), {})
         del os.environ["TEST_DATA"]
         self.assertIsNone(get_env_map_or_none("TEST_DATA"))
+
+    def test_get_env_json(self) -> None:
+        os.environ["TEST_DATA"] = '{"bool": true}'
+        self.assertEqual(get_env_json("TEST_DATA"), {"bool": True})
+        os.environ["TEST_DATA"] = '{"key": "value", "num": 123}'
+        self.assertEqual(get_env_json("TEST_DATA"), {"key": "value", "num": 123})
+        os.environ["TEST_DATA"] = "{invalid-syntax}"
+        with self.assertRaises(ImproperlyConfigured):
+            get_env_json("TEST_DATA")
+        os.environ["TEST_DATA"] = ""
+        self.assertIsNone(get_env_json("TEST_DATA"))
+        self.assertEqual(get_env_json("TEST_DATA", {}), {})
+        del os.environ["TEST_DATA"]
+        self.assertIsNone(get_env_json("TEST_DATA"))
+        self.assertEqual(get_env_json("TEST_DATA", {}), {})
 
     def test_bool(self) -> None:
         os.environ["TEST_DATA"] = "1"


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->

## Problem

When using SAML authentication with identity providers that enforce multi-factor authentication (e.g. Microsoft Entra ID), login fails with:

> AADSTS75011: Authentication method 'MultiFactor, PasswordlessPhoneSignIn' by which the user authenticated with the service doesn't match requested authentication method 'Password, ProtectedTransport'.

This happens because python3-saml sends a default requestedAuthnContext of urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport, which conflicts with the actual authentication method used.
https://github.com/SAML-Toolkits/python3-saml/blob/52d2ac8da3f35262755f6e1c32ba7c62a6011fe1/src/onelogin/saml2/authn_request.py#L100-L114


## Solution

Expose SOCIAL_AUTH_SAML_SECURITY_CONFIG as the Docker environment variable WEBLATE_SAML_SECURITY_CONFIG, accepting a JSON object. This allows users to customize SAML security settings, for example disabling requestedAuthnContext:

```yaml
WEBLATE_SAML_SECURITY_CONFIG: '{"requestedAuthnContext": false}'
```