### PR TITLE
fix(workspaces): consolidate changes referencing workspace

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -50,6 +50,7 @@ Weblate 2026.6
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
 * There is a change in :setting:`django:INSTALLED_APPS`; ``weblate.workspaces`` should be added.
+* The database migrations might take longer on larger instances.
 
 .. rubric:: Contributors
 

--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -83,7 +83,8 @@ class LazyLanguageChange:
     def __init__(self) -> None:
         self.translation = LazyTranslation()
         self.component = SimpleNamespace(project=None, category=None)
-        self.project = object()
+        self.project = SimpleNamespace(workspace=None)
+        self.workspace = SimpleNamespace()
         self.category = object()
         self.language = SimpleNamespace()
 
@@ -98,6 +99,7 @@ class ChangePrefetchTest(SimpleTestCase):
         self.assertIs(change.translation.component, change.component)
         self.assertIs(change.component.project, change.project)
         self.assertIs(change.component.category, change.category)
+        self.assertIs(change.project.workspace, change.workspace)
 
     def test_preload_list_injects_change_language(self) -> None:
         change = LazyLanguageChange()
@@ -105,6 +107,7 @@ class ChangePrefetchTest(SimpleTestCase):
         Change.objects.preload_list([change])
 
         self.assertIs(change.translation.prefetched_language, change.language)
+        self.assertIs(change.project.workspace, change.workspace)
         self.assertIs(change.translation.component, change.component)
         self.assertIs(change.component.project, change.project)
 

--- a/weblate/trans/migrations/0088_change_workspace_backfill.py
+++ b/weblate/trans/migrations/0088_change_workspace_backfill.py
@@ -1,0 +1,32 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import migrations
+from django.db.models import OuterRef, Subquery
+
+
+def backfill_change_workspace(apps, schema_editor) -> None:
+    Change = apps.get_model("trans", "Change")
+    Project = apps.get_model("trans", "Project")
+    projects_with_workspace = Project.objects.filter(workspace__isnull=False)
+    project_workspace = projects_with_workspace.filter(
+        pk=OuterRef("project_id")
+    ).values("workspace_id")[:1]
+
+    Change.objects.filter(
+        workspace__isnull=True,
+        project_id__in=projects_with_workspace.values("pk"),
+    ).update(workspace_id=Subquery(project_workspace))
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("trans", "0087_consolidate_category_inherited_settings"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_change_workspace, migrations.RunPython.noop),
+    ]

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -209,6 +209,8 @@ class ChangeQuerySet(models.QuerySet["Change", "Change"]):
     def preload_list(self, results, skip=None):
         """Companion for prefetch to fill in nested references."""
         for item in results:
+            if item.project and skip != "project":
+                item.project.workspace = item.workspace
             if item.component and skip != "component":
                 item.component.project = item.project
             if item.translation and skip != "translation":
@@ -279,6 +281,10 @@ class ChangeQuerySet(models.QuerySet["Change", "Change"]):
         from weblate.accounts.notifications import (  # noqa: PLC0415
             dispatch_changes_notifications,
         )
+
+        objs = list(objs)
+        for change in objs:
+            change.fixup_references()
 
         changes: list[Change] = super().bulk_create(  # type: ignore[assignment]
             objs,  # type: ignore[arg-type]
@@ -428,12 +434,15 @@ class ChangeManager(models.Manager["Change"]):
         elif workspace is not None:
             if not workspace.can_view(user):
                 return cast("ChangeQuerySet", self.none())
-            result = self.filter(workspace=workspace) | cast(
-                "ChangeQuerySet",
-                self.filter(
-                    project__workspace=workspace,
-                ),
-            ).filter_projects(user).filter_components(user)
+            result = cast("ChangeQuerySet", self.filter(workspace=workspace))
+            if user.needs_project_filter:
+                result = cast(
+                    "ChangeQuerySet",
+                    result.filter(
+                        Q(project__isnull=True) | Q(project__in=user.allowed_projects)
+                    ),
+                )
+            result = result.filter_components(user)
         elif language is not None:
             result = language.change_set.filter_projects(user).filter_components(user)
         else:
@@ -796,6 +805,8 @@ class Change(models.Model, UserDisplayMixin):
         if self.component:
             self.project = self.component.project
             self.category = self.component.category
+        if self.project:
+            self.workspace = self.project.workspace
         if (self.user is None or not self.user.is_authenticated) and (
             ip_address := self.get_ip_address()
         ):
@@ -994,6 +1005,8 @@ class Change(models.Model, UserDisplayMixin):
         if self.component:
             self.component.project = cast("Project", self.project)
             self.component.category = cast("Category", self.category)
+        if self.project:
+            self.project.workspace = self.workspace
 
 
 @receiver(post_save, sender=Change)

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -4,12 +4,14 @@
 
 """Test for translation models."""
 
+import importlib
 import os
 from contextlib import ExitStack
 from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
+from django.apps import apps
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -59,6 +61,7 @@ from weblate.utils.state import (
 )
 from weblate.utils.stats import CategoryLanguage, GlobalStats, ProjectLanguage
 from weblate.utils.version import GIT_VERSION
+from weblate.workspaces.models import Workspace
 
 
 class BaseTestCase(TestCase):
@@ -1376,6 +1379,85 @@ class AnnouncementTest(ModelTestCase):
 
 class ChangeTest(ModelTestCase):
     """Test(s) for Change model."""
+
+    def test_fixup_references_inherits_project_workspace(self) -> None:
+        workspace = Workspace.objects.create(name="Change workspace")
+        Project.objects.filter(pk=self.component.project_id).update(workspace=workspace)
+
+        project = Project.objects.get(pk=self.component.project_id)
+        component = Component.objects.select_related("project__workspace").get(
+            pk=self.component.pk
+        )
+        translation = Translation.objects.select_related(
+            "component__project__workspace", "language"
+        ).get(component=component, language_code="cs")
+        unit = Unit.objects.select_related(
+            "translation__component__project__workspace",
+            "translation__language",
+        ).filter(translation=translation)[0]
+
+        for change in (
+            Change(project=project),
+            Change(component=component),
+            Change(translation=translation),
+            Change(unit=unit),
+        ):
+            self.assertEqual(change.workspace_id, workspace.pk)
+
+    def test_existing_change_keeps_workspace_after_project_move(self) -> None:
+        original = Workspace.objects.create(name="Original change workspace")
+        target = Workspace.objects.create(name="Target change workspace")
+        project = self.component.project
+        Project.objects.filter(pk=project.pk).update(workspace=original)
+        project.refresh_from_db()
+
+        change = Change.objects.create(
+            project=project, action=ActionEvents.CREATE_PROJECT
+        )
+
+        project.workspace = target
+        project.save(update_fields=["workspace"])
+        change.refresh_from_db()
+
+        self.assertEqual(change.workspace_id, original.pk)
+
+    def test_change_workspace_backfill_migration(self) -> None:
+        migration = importlib.import_module(
+            "weblate.trans.migrations.0088_change_workspace_backfill"
+        )
+        workspace = Workspace.objects.create(name="Backfilled change workspace")
+        existing = Workspace.objects.create(name="Existing change workspace")
+        project = self.component.project
+        Project.objects.filter(pk=project.pk).update(workspace=workspace)
+        project.refresh_from_db()
+        Change.objects.all().delete()
+
+        backfilled = Change.objects.create(
+            project=project, action=ActionEvents.CREATE_PROJECT
+        )
+        kept = Change.objects.create(project=project, action=ActionEvents.LOCK)
+        standalone = Change.objects.create(action=ActionEvents.CREATE_PROJECT)
+        standalone_project = self.create_project(
+            name="Standalone backfill project",
+            slug="standalone-backfill-project",
+        )
+        standalone_project_change = Change.objects.create(
+            project=standalone_project,
+            action=ActionEvents.CREATE_PROJECT,
+        )
+        Change.objects.filter(pk=backfilled.pk).update(workspace=None)
+        Change.objects.filter(pk=kept.pk).update(workspace=existing)
+
+        migration.backfill_change_workspace(apps, None)
+
+        backfilled.refresh_from_db()
+        kept.refresh_from_db()
+        standalone.refresh_from_db()
+        standalone_project_change.refresh_from_db()
+        self.assertEqual(backfilled.workspace_id, workspace.pk)
+        self.assertEqual(kept.workspace_id, existing.pk)
+        self.assertIsNone(standalone.workspace_id)
+        self.assertIsNone(standalone_project_change.workspace_id)
 
     def test_day_filtering(self) -> None:
         Change.objects.all().delete()

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -477,8 +477,10 @@ def show_project(request: AuthenticatedHttpRequest, obj: Project) -> HttpRespons
     user = request.user
 
     all_changes = obj.change_set.filter_components(request.user).prefetch()
-    last_changes = all_changes.recent()
-    last_announcements = all_changes.filter_announcements().recent()
+    last_changes = all_changes.recent(skip_preload="project")
+    last_announcements = all_changes.filter_announcements().recent(
+        skip_preload="project"
+    )
 
     all_components = obj.get_child_components_access(user, filter_no_category)
     all_components = get_paginator(


### PR DESCRIPTION
Use the same logic as on project or component level. The change object gets workspace attribute based on the project. This makes subsequent filters cheap because otherwise we end up with complex join where databsae does not use the field indexes.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
