### PR TITLE
fix(locale): correct Slovak organize link href

### DIFF
--- a/weblate/locale/sk/LC_MESSAGES/django.po
+++ b/weblate/locale/sk/LC_MESSAGES/django.po
@@ -14065,7 +14065,7 @@ msgid ""
 "<a href=\"%(url)s\">Organize the project</a> to change its URL slug, move "
 "it, or remove it."
 msgstr ""
-"<a href=\"\\&quot;%(url)s\\&quot;\">Organizujte projekt</a> na zmenu jeho "
+"<a href=\"%(url)s\">Organizujte projekt</a> na zmenu jeho "
 "URL slugu, presunutie alebo odstránenie."
 
 #: weblate/templates/snippets/settings-organize.html:8


### PR DESCRIPTION
### Motivation
- Fix a Slovak translation that changed `href="%(url)s"` into `href="\&quot;%(url)s\&quot;"`, causing the rendered project "Organize" link to point to a malformed relative URL.

### Description
- Restore the placeholder to `href="%(url)s"` in `weblate/locale/sk/LC_MESSAGES/django.po` so the localized anchor uses the generated `object.get_absolute_url` as intended.

### Testing
- Ran `msgfmt --check --output-file=/tmp/django-sk.mo weblate/locale/sk/LC_MESSAGES/django.po` and a small Python check that asserted the malformed pattern was removed and the corrected placeholder present, and `git diff --check` showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18930b3df0832994a2f0821be9bf24)