### PR TITLE
fix(machinery): reject unmapped LLM placeholders

### DIFF
--- a/weblate/machinery/llm.py
+++ b/weblate/machinery/llm.py
@@ -1055,6 +1055,8 @@ class BaseLLMTranslation(BatchMachineTranslation):
 
         extra_token = next(iter(extras))
         source_highlights = dict(source_specs)
+        if extra_token not in source_highlights:
+            return None
         extra_index = source_tokens.index(extra_token)
         missing_token = next(iter(missing), None)
         if missing_token is not None:

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -4114,6 +4114,18 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             )
 
     @responses.activate
+    def test_translate_rejects_literal_placeholder_repair_mismatch(self) -> None:
+        self.mock_response('["@@PH5@@"]')
+
+        with self.assertRaises(MachineTranslationError):
+            self.assert_translate(
+                "fr",
+                "Keep @@PH5@@ %s",
+                1,
+                unit_args={"flags": "python-format"},
+            )
+
+    @responses.activate
     def test_translate_recovers_spaced_placeholder_syntax(self) -> None:
         self.mock_response('["Bonjour @@PH7@ @! <<foo>>"]')
 


### PR DESCRIPTION
### Motivation
- Prevent a robustness regression where `_repair_duplicate_placeholder` could raise `ValueError` when the assistant reply contains a literal-looking `@@PHn@@` token that is not described by the source cleanup metadata.

### Description
- In `weblate/machinery/llm.py` update `_repair_duplicate_placeholder` to return `None` when the computed `extra_token` is not present in `source_highlights`, avoiding an unconditional `source_tokens.index(...)` lookup.
- Add a regression test `test_translate_rejects_literal_placeholder_repair_mismatch` in `weblate/machinery/tests.py` that verifies a source containing a literal `@@PH5@@` plus a generated placeholder and a malformed assistant reply `"@@PH5@@"` is rejected as a `MachineTranslationError`.
- Change preserves existing repair behavior for mapped placeholders while preventing unexpected exceptions for unmapped literal tokens.

### Testing
- Ran the new unit test: `uv run pytest weblate/machinery/tests.py::OpenAITranslationTest::test_translate_rejects_literal_placeholder_repair_mismatch` which passed.
- Ran a small test batch: `uv run pytest weblate/machinery/tests.py::OpenAITranslationTest::test_translate_recovers_extra_rst_closing_placeholder weblate/machinery/tests.py::OpenAITranslationTest::test_translate_rejects_literal_placeholder_repair_mismatch` which passed (`2 passed`).
- Ran linting with `uv run ruff check weblate/machinery/llm.py weblate/machinery/tests.py` and `git diff --check`, both succeeded with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19dd5c1cf483298744aafccf8068c1)