### PR TITLE
feat(settings): improve commit messages

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -707,6 +707,12 @@ DEFAULT_ADD_MESSAGE, DEFAULT_ADDON_MESSAGE, DEFAULT_COMMIT_MESSAGE, DEFAULT_DELE
 
 Default commit messages for different operations, please check :ref:`component` for details.
 
+The built-in defaults follow Conventional Commits and include
+Weblate links where available. Changing these settings affects newly created
+defaults; existing message templates can be reset in the settings forms with
+:guilabel:`Restore site default`. For inherited values, restoring the site
+default also disables inheritance for that message.
+
 
 .. seealso::
 
@@ -858,6 +864,9 @@ DEFAULT_PULL_MESSAGE
 --------------------
 
 Configures the default title and message for pull requests.
+
+The built-in default follows Conventional Commits and includes
+Weblate links and translation status.
 
 .. setting:: ENABLE_AVATARS
 

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -416,6 +416,11 @@ The default values can be changed by :setting:`DEFAULT_ADD_MESSAGE`,
 :setting:`DEFAULT_DELETE_MESSAGE`, :setting:`DEFAULT_MERGE_MESSAGE`,
 :setting:`DEFAULT_PULL_MESSAGE`.
 
+The built-in defaults follow Conventional Commits and include
+Weblate links where available. Use :guilabel:`Restore site default` next to a
+message editor to restore the current installation default for that message;
+for inherited values, this also disables inheritance for that message.
+
 .. seealso::
 
    * :ref:`workspace-inherited-settings`
@@ -1026,6 +1031,11 @@ The default value can be changed by :setting:`DEFAULT_ADD_MESSAGE`,
 :setting:`DEFAULT_ADDON_MESSAGE`, :setting:`DEFAULT_COMMIT_MESSAGE`,
 :setting:`DEFAULT_DELETE_MESSAGE`, :setting:`DEFAULT_MERGE_MESSAGE`,
 :setting:`DEFAULT_PULL_MESSAGE`.
+
+The built-in defaults follow Conventional Commits and include
+Weblate links where available. Use :guilabel:`Restore site default` next to a
+message editor to restore the current installation default for that message;
+for inherited values, this also disables inheritance for that message.
 
 .. seealso::
 

--- a/docs/admin/workspaces.rst
+++ b/docs/admin/workspaces.rst
@@ -150,6 +150,10 @@ Default commit and merge request message templates for projects and components
 in this workspace. These templates use the same markup as component message
 settings.
 
+The built-in defaults follow Conventional Commits and include
+Weblate links where available. Use :guilabel:`Restore site default` next to a
+message editor to restore the current installation default for that message.
+
 .. seealso::
 
    * :ref:`workspace-inherited-settings`

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Weblate 2026.7
 .. rubric:: Improvements
 
 * Management interface access control is now more fine-grained with dedicated site-wide permissions.
+* Default commit and merge request message templates now use Conventional Commits, and settings forms can restore installation defaults for individual message templates.
 
 .. rubric:: Bug fixes
 

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1152,6 +1152,52 @@ $(function () {
     });
   });
 
+  const getControlValue = (control) => {
+    if (control.tomselect) {
+      return control.tomselect.getValue();
+    }
+    return control.value;
+  };
+  const setControlValue = (control, value) => {
+    if (control.tomselect) {
+      control.tomselect.setValue(value, true);
+    } else {
+      control.value = value;
+    }
+    control.dispatchEvent(new Event("input", { bubbles: true }));
+    control.dispatchEvent(new Event("change", { bubbles: true }));
+  };
+  const setControlDisabled = (control, disabled) => {
+    control.disabled = disabled;
+    if (!control.tomselect) {
+      return;
+    }
+    if (disabled) {
+      control.tomselect.disable();
+    } else {
+      control.tomselect.enable();
+    }
+  };
+
+  document.querySelectorAll(".site-default-field-button").forEach((button) => {
+    const container = button.closest(".mb-3");
+    const control = container?.querySelector("[data-site-default-value]");
+    if (!control) {
+      return;
+    }
+    button.addEventListener("click", () => {
+      const inheritedSetting = button.closest("[data-inherited-setting]");
+      const inheritCheckbox = inheritedSetting?.querySelector(
+        ".inherited-setting-toggle input[type=checkbox]",
+      );
+      if (inheritCheckbox?.checked) {
+        inheritCheckbox.checked = false;
+        inheritCheckbox.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      setControlValue(control, control.dataset.siteDefaultValue || "");
+    });
+  });
+
   document.querySelectorAll("[data-inherited-setting]").forEach((el) => {
     const checkbox = el.querySelector(
       ".inherited-setting-toggle input[type=checkbox]",
@@ -1167,31 +1213,6 @@ $(function () {
     if (!checkbox) {
       return;
     }
-
-    const getControlValue = (control) => {
-      if (control.tomselect) {
-        return control.tomselect.getValue();
-      }
-      return control.value;
-    };
-    const setControlValue = (control, value) => {
-      if (control.tomselect) {
-        control.tomselect.setValue(value, true);
-      } else {
-        control.value = value;
-      }
-    };
-    const setControlDisabled = (control, disabled) => {
-      control.disabled = disabled;
-      if (!control.tomselect) {
-        return;
-      }
-      if (disabled) {
-        control.tomselect.disable();
-      } else {
-        control.tomselect.enable();
-      }
-    };
 
     const updateInheritedSetting = (syncValue) => {
       const disabled = checkbox.checked;

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2019,6 +2019,23 @@ input.color_edit:checked + label {
   margin-bottom: 0;
 }
 
+.form-label-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.form-label-actions .form-label {
+  margin-bottom: 0;
+}
+
+.form-label-actions .site-default-field-button {
+  flex: 0 0 auto;
+}
+
 .help-block {
   color: #2a3744;
 }

--- a/weblate/templates/bootstrap5/field.html
+++ b/weblate/templates/bootstrap5/field.html
@@ -1,4 +1,4 @@
-{% load crispy_forms_field translations %}
+{% load crispy_forms_field i18n icons translations %}
 
 {% comment %}Based on crispy original, just adds form_field_doc_link.{% endcomment %}
 
@@ -15,11 +15,23 @@
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="{% if field|is_checkbox and form_show_labels %}form-check{% else %}mb-3{% if 'form-horizontal' in form_class %} row{% endif %}{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
             {% if field.use_fieldset %}<fieldset{% if 'form-horizontal' in form_class %} class="row"{% endif %}{% if field.aria_describedby %} aria-describedby="{{ field.aria_describedby }}"{% endif %}>{% endif %}
-            <{% if field.use_fieldset %}legend{% else %}label{% endif %}
-                {% if field.id_for_label %}for="{{ field.id_for_label }}"{% endif %} class="{% if 'form-horizontal' in form_class %}col-form-label pt-0{% else %}form-label{% endif %}{% if label_class %} {{ label_class }}{% endif %}{% if field.field.required %} requiredField{% endif %}{% if field.use_fieldset %} fs-6{% endif %}">
-                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
-                {% form_field_doc_link field.form field %}
-            </{% if field.use_fieldset %}legend{% else %}label{% endif %}>
+            {% if field.field.site_default and not field.use_fieldset %}
+                <div class="form-label-actions">
+                    <label {% if field.id_for_label %}for="{{ field.id_for_label }}"{% endif %} class="{% if 'form-horizontal' in form_class %}col-form-label pt-0{% else %}form-label{% endif %}{% if label_class %} {{ label_class }}{% endif %}{% if field.field.required %} requiredField{% endif %}">
+                        {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                        {% form_field_doc_link field.form field %}
+                    </label>
+                    <button type="button" class="btn btn-outline-secondary btn-xs site-default-field-button" data-site-default-target="{{ field.html_name }}"{% if field.id_for_label %} aria-controls="{{ field.id_for_label }}"{% endif %} title="{% translate "Restore site default" %}">
+                        {% icon "undo.svg" %} {% translate "Restore site default" %}
+                    </button>
+                </div>
+            {% else %}
+                <{% if field.use_fieldset %}legend{% else %}label{% endif %}
+                    {% if field.id_for_label %}for="{{ field.id_for_label }}"{% endif %} class="{% if 'form-horizontal' in form_class %}col-form-label pt-0{% else %}form-label{% endif %}{% if label_class %} {{ label_class }}{% endif %}{% if field.field.required %} requiredField{% endif %}{% if field.use_fieldset %} fs-6{% endif %}">
+                    {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                    {% form_field_doc_link field.form field %}
+                </{% if field.use_fieldset %}legend{% else %}label{% endif %}>
+            {% endif %}
         {% endif %}
 
         {% if field|is_checkboxselectmultiple or field|is_radioselect %}

--- a/weblate/trans/defaults.py
+++ b/weblate/trans/defaults.py
@@ -57,38 +57,53 @@ DEFAULT_AUTO_LOCK_ERROR = True
 DEFAULT_VCS = "git"
 
 DEFAULT_COMMIT_MESSAGE = (
-    "Translated using Weblate ({{ language_name }})\n\n"
-    "Currently translated at {{ stats.translated_percent }}% "
-    "({{ stats.translated }} of {{ stats.all }} strings)\n\n"
+    "chore(l10n): update {{ language_name }} translation\n\n"
     "Translation: {{ project_name }}/{{ component_name }}\n"
+    "Language: {{ language_name }}\n"
+    "Progress: {{ stats.translated_percent }}% "
+    "({{ stats.translated }} of {{ stats.all }} strings)\n"
     "Translate-URL: {{ url }}"
 )
 
-DEFAULT_ADD_MESSAGE = "Added translation using Weblate ({{ language_name }})\n\n"
+DEFAULT_ADD_MESSAGE = (
+    "chore(l10n): add {{ language_name }} translation\n\n"
+    "Translation: {{ project_name }}/{{ component_name }}\n"
+    "Language: {{ language_name }}\n"
+    "Translate-URL: {{ url }}"
+)
 
-DEFAULT_DELETE_MESSAGE = "Deleted translation using Weblate ({{ language_name }})\n\n"
+DEFAULT_DELETE_MESSAGE = (
+    "chore(l10n): remove {{ language_name }} translation\n\n"
+    "Translation: {{ project_name }}/{{ component_name }}\n"
+    "Language: {{ language_name }}\n"
+    "Translate-URL: {{ url }}"
+)
 
-DEFAULT_MERGE_MESSAGE = "Merge branch '{{ component_remote_branch }}' into Weblate.\n\n"
+DEFAULT_MERGE_MESSAGE = (
+    "chore(l10n): merge remote changes\n\n"
+    "Translation: {{ project_name }}/{{ component_name }}\n"
+    "Remote-Branch: {{ component_remote_branch }}\n"
+    "Translate-URL: {{ url }}"
+)
 
-DEFAULT_ADDON_MESSAGE = """Update translation files
+DEFAULT_ADDON_MESSAGE = """chore(l10n): update translation files
 
-Updated by "{{ addon_name }}" add-on in Weblate.
-
+Add-on: {{ addon_name }}
 Translation: {{ project_name }}/{{ component_name }}
 Translate-URL: {{ url }}"""
 
-DEFAULT_PULL_MESSAGE = """Translations update from {{ site_title }}
+DEFAULT_PULL_MESSAGE = """chore(l10n): update translations
 
-Translations update from [{{ site_title }}]({{ site_url }}) for [{{ project_name }}/{{ component_name }}]({{url}}).
+Translations updated in [{{ site_title }}]({{ site_url }}) for [{{ project_name }}/{{ component_name }}]({{ url }}).
 
 {% if component_linked_children %}
-It also includes following components:
+Included components:
 {% for linked in component_linked_children %}
 * [{{ linked.project_name }}/{{ linked.name }}]({{ linked.url }})
 {% endfor %}
 {% endif %}
 
-Current translation status:
+Translation status:
 
 ![Weblate translation status]({{widget_url}})
 """

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from datetime import datetime
 from itertools import chain
 from secrets import token_hex
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, cast
 
 import jsonschema
 from crispy_forms.bootstrap import InlineCheckboxes, InlineRadios, Tab, TabHolder
@@ -72,6 +72,7 @@ from weblate.trans.file_format_params import (
 )
 from weblate.trans.filter import FILTERS
 from weblate.trans.inherited_settings import (
+    COMPONENT_MESSAGE_SETTINGS,
     INHERITABLE_COMPONENT_FLAGS,
     INHERITABLE_COMPONENT_SETTINGS,
     get_inherit_field_name,
@@ -150,6 +151,12 @@ if TYPE_CHECKING:
     )
     from weblate.trans.models.translation import NewUnitParams
     from weblate.utils.stats import CategoryLanguage, ProjectLanguage
+
+
+class SiteDefaultField(Protocol):
+    site_default: bool
+    widget: forms.Widget
+
 
 BUTTON_TEMPLATE = """
 <button type="button" class="btn btn-outline-primary {0}" title="{1}" {2}>{3}</button>
@@ -1821,6 +1828,7 @@ class InheritedSettingsFormMixin:
         )
 
     def setup_inherited_settings(self, parent_name: str, *, has_parent: bool) -> None:
+        setup_message_setting_site_defaults(self.fields)
         self._inherited_setting_fields = set()
         for field_name in INHERITABLE_COMPONENT_SETTINGS:
             inherit_field = get_inherit_field_name(field_name)
@@ -1882,6 +1890,16 @@ class InheritedSettingsFormMixin:
             super()._post_clean()
         finally:
             self.restore_inherited_values()
+
+
+def setup_message_setting_site_defaults(fields: dict[str, forms.Field]) -> None:
+    for field_name in COMPONENT_MESSAGE_SETTINGS:
+        if field_name not in fields:
+            continue
+        setting_name = f"DEFAULT_{field_name.upper()}"
+        field = cast("SiteDefaultField", fields[field_name])
+        field.site_default = True
+        field.widget.attrs["data-site-default-value"] = getattr(settings, setting_name)
 
 
 class SelectChecksWidget(SortedSelectMultiple):

--- a/weblate/trans/tests/test_file_format_params.py
+++ b/weblate/trans/tests/test_file_format_params.py
@@ -364,7 +364,7 @@ class TSParamsTest(BaseFileFormatsTest):
         new_revision = self.component.repository.last_revision
         self.assertNotEqual(rev, new_revision)
         new_commit = self.component.repository.show(new_revision)
-        self.assertIn("Added translation using Weblate (German)", new_commit)
+        self.assertIn("chore(l10n): add German translation", new_commit)
         if closing_tags_active:
             self.assertIn(
                 '<location filename="main.c" line="11"></location>', new_commit
@@ -552,7 +552,7 @@ class GettextParamsTest(BaseFileFormatsTest):
         rev3 = self.component.repository.last_revision
         commit3 = self.component.repository.show(rev3)
         self.assertNotEqual(rev2, rev3)
-        self.assertIn("Added translation using Weblate (Polish)", commit3)
+        self.assertIn("chore(l10n): add Polish translation", commit3)
         self.assertNotIn("Last-Translator: Automatically generated", commit3)
 
         # check header is present when a new language is added and parameter set to True
@@ -561,7 +561,7 @@ class GettextParamsTest(BaseFileFormatsTest):
         rev4 = self.component.repository.last_revision
         self.assertNotEqual(rev3, rev4)
         commit4 = self.component.repository.show(rev4)
-        self.assertIn("Added translation using Weblate (French)", commit4)
+        self.assertIn("chore(l10n): add French translation", commit4)
         self.assertIn("Last-Translator: Automatically generated", commit4)
 
     def test_x_generator_header(self):

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -15,8 +15,13 @@ from filelock import FileLock
 
 from weblate.auth.models import Group, Permission, Role
 from weblate.checks.models import Check
+from weblate.trans import defaults
 from weblate.trans.actions import ActionEvents
-from weblate.trans.forms import ComponentSettingsForm, ProjectSettingsForm
+from weblate.trans.forms import (
+    CategorySettingsForm,
+    ComponentSettingsForm,
+    ProjectSettingsForm,
+)
 from weblate.trans.models import (
     Category,
     CommitPolicyChoices,
@@ -29,12 +34,30 @@ from weblate.trans.models import (
 from weblate.trans.models.component import ComponentQuerySet
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import create_test_billing
+from weblate.utils.render import (
+    validate_render_addon,
+    validate_render_commit,
+    validate_render_component,
+)
 from weblate.utils.views import get_form_data
 from weblate.vcs.base import RepositoryLock
 from weblate.workspaces.models import Workspace
 
 
 class SettingsTest(ViewTestCase):
+    def test_default_message_templates_render(self) -> None:
+        validators = (
+            (defaults.DEFAULT_COMMIT_MESSAGE, validate_render_commit),
+            (defaults.DEFAULT_ADD_MESSAGE, validate_render_commit),
+            (defaults.DEFAULT_DELETE_MESSAGE, validate_render_commit),
+            (defaults.DEFAULT_MERGE_MESSAGE, validate_render_component),
+            (defaults.DEFAULT_ADDON_MESSAGE, validate_render_addon),
+            (defaults.DEFAULT_PULL_MESSAGE, validate_render_addon),
+        )
+        for template, validator in validators:
+            with self.subTest(template=template):
+                validator(template)
+
     def consolidate_inherited_settings(self) -> None:
         migration = import_module(
             "weblate.trans.migrations.0084_consolidate_inherited_settings"
@@ -173,6 +196,36 @@ class SettingsTest(ViewTestCase):
         self.assertContains(response, "Inherited value is shown")
         self.assertContains(response, 'name="license"')
         self.assertContains(response, "disabled")
+
+    @override_settings(DEFAULT_COMMIT_MESSAGE="Site default commit")
+    def test_message_setting_site_default_widget_state(self) -> None:
+        category = Category.objects.create(
+            name="Site defaults category",
+            slug="site-defaults-category",
+            project=self.project,
+        )
+
+        for form in (
+            ProjectSettingsForm(self.get_request(), instance=self.project),
+            CategorySettingsForm(self.get_request(), instance=category),
+            ComponentSettingsForm(self.get_request(), instance=self.component),
+        ):
+            with self.subTest(form=form.__class__.__name__):
+                self.assertEqual(
+                    form.fields["commit_message"].widget.attrs[
+                        "data-site-default-value"
+                    ],
+                    "Site default commit",
+                )
+
+    @override_settings(DEFAULT_COMMIT_MESSAGE="Site default commit")
+    def test_message_setting_site_default_form_rendering(self) -> None:
+        self.project.add_user(self.user, "Administration")
+
+        response = self.client.get(reverse("settings", kwargs=self.kw_component))
+
+        self.assertContains(response, 'data-site-default-value="Site default commit"')
+        self.assertContains(response, "Restore site default")
 
     def test_workspace_less_project_has_no_inheritance_wrapper(self) -> None:
         self.assertIsNone(self.project.workspace_id)

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -27,6 +27,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from responses import matchers
 
+from weblate.trans import defaults
 from weblate.trans.models import Component, Project
 from weblate.trans.tests.utils import RepoTestMixin, TempDirMixin
 from weblate.utils.files import REPO_TEMP_DIRNAME
@@ -774,6 +775,29 @@ class GitBranchValidationTest(SimpleTestCase):
             "origin/main",
         )
         self.assertIsInstance(component.repository, GitRepository)
+
+    def test_default_pull_message_title_ignores_multiline_names(self) -> None:
+        component = Component(
+            slug="test",
+            name="Test\ncomponent",
+            project=Project(name="Test\nproject", slug="test", pk=-1),
+            source_language_id=1,
+            branch="main",
+            vcs="git",
+            repo="https://example.invalid/repo.git",
+            pk=-1,
+        )
+        component.pull_message = defaults.DEFAULT_PULL_MESSAGE
+        component.inherit_pull_message = False
+
+        repo = GithubFakeRepository(".", branch="main", component=component, local=True)
+
+        with patch.object(
+            Component, "get_linked_children_for_template", return_value=[]
+        ):
+            title, body = repo.get_merge_message()
+        self.assertEqual(title, "chore(l10n): update translations")
+        self.assertIn("Test\nproject/Test\ncomponent", body)
 
 
 class RepositoryHostKeyErrorTest(SimpleTestCase):

--- a/weblate/workspaces/forms.py
+++ b/weblate/workspaces/forms.py
@@ -9,7 +9,7 @@ from crispy_forms.layout import Fieldset, Layout
 from django import forms
 from django.utils.translation import gettext
 
-from weblate.trans.forms import FieldDocsMixin
+from weblate.trans.forms import FieldDocsMixin, setup_message_setting_site_defaults
 from weblate.utils.forms import SearchableSelect, SortedSelect
 from weblate.workspaces.models import Workspace
 
@@ -40,6 +40,7 @@ class WorkspaceSettingsForm(FieldDocsMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        setup_message_setting_site_defaults(self.fields)
         self._missing_fields: set[str] = set()
         if self.is_bound and self.instance.pk:
             for field_name, field in self.fields.items():

--- a/weblate/workspaces/tests.py
+++ b/weblate/workspaces/tests.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.http import Http404
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.auth.models import Group
@@ -118,6 +119,20 @@ class WorkspaceViewTest(BaseTestCase):
 
         self.assertContains(response, 'data-bs-target="#settings"')
         self.assertContains(response, "Workspace settings")
+
+    @override_settings(DEFAULT_COMMIT_MESSAGE="Site default workspace commit")
+    def test_workspace_settings_show_site_default_message_control(self) -> None:
+        user = create_test_user()
+        workspace = Workspace.objects.create(name="Settings workspace")
+        workspace.add_owner(user)
+
+        self.client.login(username=user.username, password="testpassword")
+        response = self.client.get(workspace.get_absolute_url())
+
+        self.assertContains(
+            response, 'data-site-default-value="Site default workspace commit"'
+        )
+        self.assertContains(response, "Restore site default")
 
     def test_workspace_settings_are_hidden_without_workspace_edit(self) -> None:
         workspace = Workspace.objects.create(name="Public workspace")


### PR DESCRIPTION
- Follow Conventional Commits specification and make the content of the commit messages consistent.
- Add button to revert to the site defaults in case users wants to go back to the shipped/configured settings.

Fixes #19806

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
