### PR TITLE
feat #17666: Display icons for component priority

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -144,6 +144,12 @@ SPDX-FileCopyrightText = "Pictogrammers"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
+path = "weblate/static/priorities/**.svg"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Samuel Gomes <samuel.esteves.gomes@tecnico.ulisboa.pt>"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+[[annotations]]
 path = "weblate/static/vendor/prism/**"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Lea Verou"

--- a/weblate/static/priorities/double_arrow_down.svg
+++ b/weblate/static/priorities/double_arrow_down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="7 13 12 18 17 13"/><polyline points="7 6 12 11 17 6"/></svg>

--- a/weblate/static/priorities/double_arrow_up.svg
+++ b/weblate/static/priorities/double_arrow_up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg>

--- a/weblate/static/priorities/single_arrow_down.svg
+++ b/weblate/static/priorities/single_arrow_down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>

--- a/weblate/static/priorities/single_arrow_up.svg
+++ b/weblate/static/priorities/single_arrow_up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -47,6 +47,7 @@ from weblate.utils.diff import Differ
 from weblate.utils.docs import get_doc_url
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.html import format_html_join_comma, list_to_tuples
+from weblate.utils.icons import load_icon
 from weblate.utils.markdown import render_markdown
 from weblate.utils.messages import get_message_kind as get_message_kind_impl
 from weblate.utils.random import get_random_identifier
@@ -110,6 +111,13 @@ NAME_MAPPING = {
 }
 
 FLAG_TEMPLATE = '<span title="{0}" class="{1}">{2}</span>'
+
+PRIORITY_ICONS = {
+    60: ("double_arrow_up", "text-danger", gettext_lazy("Priority: Very high")),
+    80: ("single_arrow_up", "text-warning", gettext_lazy("Priority: High")),
+    120: ("single_arrow_down", "text-muted", gettext_lazy("Priority: Low")),
+    140: ("double_arrow_down", "text-secondary", gettext_lazy("Priority: Very low")),
+}
 
 SOURCE_LINK = (
     '<a href="{0}" target="_blank" rel="noopener noreferrer"'
@@ -1278,6 +1286,20 @@ def indicate_alerts(
     # GhostProjectLanguageStats and GhostCategoryLanguageStats as these would
     # be confusing (showing alert or admin icon on ghost containers).
 
+    priority_html = ""
+    if component and (priority := component.priority) in PRIORITY_ICONS:
+        selected_svg, css_class, title_text = PRIORITY_ICONS[priority]
+
+        priority_html = format_html(
+            '<span class="state-icon {}" data-bs-toggle="tooltip" title="{}" alt="{}" style="margin: 0">{}</span>',
+            css_class,
+            title_text,
+            title_text,
+            mark_safe(  # noqa: S308
+                load_icon(f"priorities/{selected_svg}.svg", auto_prefix=False).decode()
+            ),
+        )
+
     icons = format_html_join(
         "\n",
         '{}<span class="state-icon {}" title="{}" alt="{}">{}</span>{}',
@@ -1317,7 +1339,7 @@ def indicate_alerts(
             component.effective_license,
         )
 
-    return format_html("{}{}", icons, license_badge)
+    return format_html("{}{}{}", priority_html, icons, license_badge)
 
 
 @register.filter(is_safe=True)

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
+from django.template import Context
 from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
@@ -18,8 +19,10 @@ from weblate.checks.flags import Flags
 from weblate.lang.models import Language
 from weblate.trans.models import Component, Project, Translation, Unit
 from weblate.trans.templatetags.translations import (
+    PRIORITY_ICONS,
     format_translation,
     get_location_links,
+    indicate_alerts,
     naturaltime,
     same_naturaltime,
     translation_progress_render,
@@ -70,6 +73,53 @@ class NaturalTimeTest(SimpleTestCase):
                     timestamp - timedelta(seconds=125),
                 )
             )
+
+
+class IndicateAlertsPriorityTest(SimpleTestCase):
+    def test_priority_icons(self) -> None:
+        project = Project(slug="p", name="p")
+        context = Context({})
+
+        cases = [
+            (priority, svg, css, f'title="{title}"')
+            for priority, (svg, css, title) in PRIORITY_ICONS.items()
+        ]
+
+        def fake_load_icon(path: str, *, auto_prefix: bool = True) -> bytes:
+            return f'<svg data-icon="{path}"></svg>'.encode()
+
+        with (
+            patch(
+                "weblate.trans.templatetags.translations.get_alerts", return_value=[]
+            ),
+            patch(
+                "weblate.trans.templatetags.translations.load_icon",
+                side_effect=fake_load_icon,
+            ),
+        ):
+            for priority, svg, css_class, title in cases:
+                component = Component(
+                    project=project,
+                    slug="c",
+                    name="c",
+                    priority=priority,
+                    source_language=Language(),
+                )
+                html = str(indicate_alerts(context, component))
+                self.assertIn(f'data-icon="priorities/{svg}.svg"', html)
+                self.assertIn(f'class="state-icon {css_class}"', html)
+                self.assertIn(title, html)
+
+            # Default priority (100) should show no priority icon
+            default_component = Component(
+                project=project,
+                slug="c",
+                name="c",
+                priority=100,
+                source_language=Language(),
+            )
+            html = str(indicate_alerts(context, default_component))
+            self.assertNotIn('data-icon="priorities/', html)
 
 
 class LocationLinksTest(TestCase):


### PR DESCRIPTION
## Changes

- Adds 5 new svgs (1 for each priority)
- Add trumping logic to select the icon based on the component priority
- Display the priority along with the remaining icons related to the component
- Add a test to validate this logic checking each boundary

## Video of all this working

https://github.com/user-attachments/assets/6192b65b-6fa2-4083-bcfe-8f118f23bb8f


Closes #17666

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
