### PR TITLE
Improve screenshot upload workflow

### DIFF
--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -81,6 +81,40 @@ class ViewTest(FixtureTestCase):
         self.assertEqual(uploaded_changes.count(), 1)
         self.assertEqual(uploaded_changes[0].user, self.user)
 
+    def test_upload_redirect_next(self) -> None:
+        self.make_manager()
+        next_url = "/projects/weblate/weblate/cs/translate/"
+        with open(TEST_SCREENSHOT, "rb") as handle:
+            response = self.client.post(
+                reverse("screenshots", kwargs=self.kw_component),
+                {
+                    "image": handle,
+                    "name": "Obrazek",
+                    "translation": self.component.source_translation.pk,
+                    "next": next_url,
+                },
+            )
+        self.assertRedirects(response, next_url, fetch_redirect_response=False)
+        self.assertEqual(Screenshot.objects.count(), 1)
+
+    def test_upload_redirect_next_invalid(self) -> None:
+        self.make_manager()
+        with open(TEST_SCREENSHOT, "rb") as handle:
+            response = self.client.post(
+                reverse("screenshots", kwargs=self.kw_component),
+                {
+                    "image": handle,
+                    "name": "Obrazek",
+                    "translation": self.component.source_translation.pk,
+                    "next": "https://evil.com/redirect",
+                },
+            )
+        self.assertEqual(Screenshot.objects.count(), 1)
+        screenshot = Screenshot.objects.get()
+        self.assertRedirects(
+            response, screenshot.get_absolute_url(), fetch_redirect_response=False
+        )
+
     def test_upload_fail(self) -> None:
         self.make_manager()
         response = self.do_upload(name="")

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -407,8 +407,10 @@ class ScreenshotList(PathViewMixin, ListView):  # type: ignore[misc]
                 ),
             )
             next_url = request.POST.get("next") or request.GET.get("next")
-            if next_url and url_has_allowed_host_and_scheme(
-                url=next_url, allowed_hosts={request.get_host()}
+            if (
+                next_url
+                and next_url.startswith("/")
+                and url_has_allowed_host_and_scheme(url=next_url, allowed_hosts=None)
             ):
                 return redirect(next_url)
             return redirect(obj)

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -14,7 +14,7 @@ from django.db.models import Count
 from django.http import FileResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
-from django.utils.http import urlencode
+from django.utils.http import url_has_allowed_host_and_scheme, urlencode
 from django.utils.translation import gettext, ngettext
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, ListView
@@ -406,6 +406,11 @@ class ScreenshotList(PathViewMixin, ListView):  # type: ignore[misc]
                     "Search for source strings or find strings in the image."
                 ),
             )
+            next_url = request.POST.get("next") or request.GET.get("next")
+            if next_url and url_has_allowed_host_and_scheme(
+                url=next_url, allowed_hosts={request.get_host()}
+            ):
+                return redirect(next_url)
             return redirect(obj)
         messages.error(
             request, gettext("Could not upload screenshot, please fix errors below.")

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -31,6 +31,7 @@ from weblate.screenshots.forms import (
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Component, Unit
+from weblate.trans.util import redirect_next
 from weblate.utils import messages
 from weblate.utils.data import data_dir
 from weblate.utils.lock import WeblateLock
@@ -407,13 +408,7 @@ class ScreenshotList(PathViewMixin, ListView):  # type: ignore[misc]
                 ),
             )
             next_url = request.POST.get("next") or request.GET.get("next")
-            if (
-                next_url
-                and next_url.startswith("/")
-                and url_has_allowed_host_and_scheme(url=next_url, allowed_hosts=None)
-            ):
-                return redirect(next_url)
-            return redirect(obj)
+            return redirect_next(next_url, obj)
         messages.error(
             request, gettext("Could not upload screenshot, please fix errors below.")
         )

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -14,7 +14,7 @@ from django.db.models import Count
 from django.http import FileResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
-from django.utils.http import url_has_allowed_host_and_scheme, urlencode
+from django.utils.http import urlencode
 from django.utils.translation import gettext, ngettext
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, ListView

--- a/weblate/templates/screenshots/screenshot_list.html
+++ b/weblate/templates/screenshots/screenshot_list.html
@@ -226,7 +226,7 @@
               <div id="screenshot-form-container">{{ add_form|crispy }}</div>
             </div>
             <div class="card-footer">
-              <input type="submit" class="btn btn-primary" value="{% translate "Upload" %}" />
+              <input type="submit" class="btn btn-primary" value="{% translate "Save" %}" />
             </div>
           </div>
         </form>

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -1139,9 +1139,10 @@
             <div class="modal-body">
               <div id="screenshot-form-container">{{ screenshot_form|crispy }}</div>
               <input type="hidden" name="source" value="{{ unit.pk }}" />
+              <input type="hidden" name="next" value="{{ this_unit_url }}" />
             </div>
             <div class="modal-footer">
-              <input type="submit" class="btn btn-primary" value="{% translate "Upload" %}" />
+              <input type="submit" class="btn btn-primary" value="{% translate "Save" %}" />
             </div>
           </div>
           <!-- /.modal-content -->


### PR DESCRIPTION
## Summary

Uploading a screenshot from the translation view currently redirects users to the screenshot detail page after a successful upload.

Although the screenshot is already saved at that point, the screenshot detail page contains an "Edit screenshot" form with a "Save" button, which can make users believe that the upload has not yet been completed.

This change improves the workflow by preserving the translation context after upload.

## Changes

* Pass the current translation URL as a `next` parameter when uploading a screenshot from the translation view.
* Redirect users back to the translation page after a successful upload.
* Validate redirect targets using `url_has_allowed_host_and_scheme`.
* Keep the existing behavior unchanged when uploading screenshots from the screenshot list page.
* Rename the action button in the translation dialog from **Upload** to **Save** to better reflect the result.

## Testing

### Before

* Upload a screenshot from the translation page.
* User is redirected to the screenshot detail page.
* The additional "Save" button may imply that the upload is not yet complete.

### After

* Upload a screenshot from the translation page.
* User remains on the translation page.
* A success message is displayed.
* The screenshot is successfully attached to the source string.
* Uploads from the screenshot list page continue to behave as before.

## Screenshots

<img width="1853" height="928" alt="image" src="https://github.com/user-attachments/assets/95ce0327-096a-4b68-b7a9-26c0fc9937b7" />

<img width="1853" height="928" alt="image" src="https://github.com/user-attachments/assets/68bd76c6-3f4f-4b8a-b64d-9031c93f6e5b" />


Fixes #3817
