### PR TITLE
fix(component): avoid waiting for shared lock on creating

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.7
 .. rubric:: Bug fixes
 
 * Webhook target fallback matching is now stricter and reported in component diagnostics.
+* Creating components linked with ``weblate://`` no longer waits on the shared repository lock during the request.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/tests/test_create.py
+++ b/weblate/trans/tests/test_create.py
@@ -15,7 +15,7 @@ from translation_finder import DiscoveryResult
 from weblate.lang.models import Language, get_default_lang
 from weblate.trans.actions import ActionEvents
 from weblate.trans.forms import ComponentCreateForm
-from weblate.trans.models import Component
+from weblate.trans.models import Component, Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import (
     create_another_user,
@@ -23,6 +23,7 @@ from weblate.trans.tests.utils import (
     get_test_file,
 )
 from weblate.utils.views import get_form_data
+from weblate.vcs.base import RepositoryLock
 from weblate.vcs.git import GitRepository
 from weblate.workspaces.models import WORKSPACE_PROJECT_CREATORS_GROUP, Workspace
 
@@ -182,6 +183,54 @@ class CreateTest(ViewTestCase):
         self.assert_create_component(True)
         self.client_create_component(True)
         self.client_create_component(True, name="c2", slug="c2")
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_create_linked_component_skips_repository_lock(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+
+        with patch.object(
+            RepositoryLock,
+            "__enter__",
+            autospec=True,
+            side_effect=AssertionError(
+                "Linked component creation should not lock the repository"
+            ),
+        ):
+            self.client_create_component(True)
+
+        component = Component.objects.get(slug="create-component")
+        self.assertTrue(component.is_repo_link)
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_create_git_component_keeps_repository_lock(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+        project = Project.objects.create(name="Other", slug="other")
+
+        original_lock_enter = RepositoryLock.__enter__
+
+        def record_lock_enter(lock):
+            return original_lock_enter(lock)
+
+        with patch.object(
+            RepositoryLock,
+            "__enter__",
+            autospec=True,
+            side_effect=record_lock_enter,
+        ) as lock_enter:
+            self.client_create_component(
+                True,
+                project=project.pk,
+                repo=self.component.repo,
+                branch=self.component.branch,
+            )
+
+        lock_enter.assert_called()
+        component = Component.objects.get(slug="create-component")
+        self.assertFalse(component.is_repo_link)
 
     @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
     def test_create_component_wizard(self) -> None:

--- a/weblate/trans/views/create.py
+++ b/weblate/trans/views/create.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import os
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 from zipfile import BadZipfile
@@ -333,7 +333,12 @@ class CreateComponent(BaseCreateView):
     @transaction.atomic
     def form_valid(self, form):
         if self.stage == "create":
-            with form.instance.repository.lock:
+            lock = (
+                nullcontext()
+                if form.instance.is_repo_link
+                else form.instance.repository.lock
+            )
+            with lock:
                 for field in INHERITABLE_COMPONENT_FLAGS:
                     setattr(form.instance, field, True)
                 for field in ("license", "new_lang", "language_code_style"):


### PR DESCRIPTION
The repository lock is needed here for the initial fetch, but this does not happen with sharing the repository via weblate:// links.

Fixes WEBLATE-3129

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
