### PR TITLE
fix(docs): correct German SAML settings link

### DIFF
--- a/docs/locales/de/LC_MESSAGES/docs.po
+++ b/docs/locales/de/LC_MESSAGES/docs.po
@@ -13735,8 +13735,8 @@ msgid ""
 "`python3-saml security settings <https://github.com/SAML-Toolkits/python3-"
 "saml#settings>`_"
 msgstr ""
-"`python3-saml-Sicherheitseinstellungen <https://pypi.org/project/python3-"
-"saml>`_"
+"`python3-saml-Sicherheitseinstellungen <https://github.com/SAML-Toolkits/python3-"
+"saml#settings>`_"
 
 #: admin/install/docker.rst:1794
 msgid "SAML attributes mapping."


### PR DESCRIPTION
### Motivation
- Fix an inaccurate German translation link in `docs/locales/de/LC_MESSAGES/docs.po` that pointed to the generic PyPI page instead of the upstream `python3-saml#settings` documentation.

### Description
- Update the German `msgstr` for the SAML settings reference to `https://github.com/SAML-Toolkits/python3-saml#settings` so the translated target matches the source `msgid`.

### Testing
- Ran `msgfmt -c -o /tmp/docs-de.mo docs/locales/de/LC_MESSAGES/docs.po`, a Python check validating `msgid`/`msgstr` link targets, and `git diff --check`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a290fcb0db48329aef54c6257383b04)