### PR TITLE
docs(config): improve allowed asset size configuration section

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -114,7 +114,7 @@ ALLOWED_ASSET_SIZE
 
 .. versionadded:: 5.14
 
-Configures size limit for fetching assets in Weblate. Defaults to 10 MB.
+Configures size limit for fetching or uploading assets into Weblate. Defaults to 10 MB.
 
 .. seealso::
 

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -118,6 +118,8 @@ Configures size limit for fetching or uploading assets into Weblate. Defaults to
 
 .. seealso::
 
+   * :ref:`screenshots`
+   * :ref:`fonts`
    * :setting:`ALLOWED_ASSET_DOMAINS`
 
 .. setting:: ASSET_PRIVATE_ALLOWLIST


### PR DESCRIPTION
It was only noted in the 5.17 changes so far.
