### PR TITLE
feat(vcs): allow push options for Gerrit

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -697,8 +697,10 @@ of pushing them directly to the repository.
 The optional :ref:`component-push_branch` setting selects the target branch for
 the Gerrit review. Leave it empty to use :ref:`component-branch`. Use the short
 branch name, such as ``main``; Weblate and ``git-review`` push the review to
-``refs/for/<branch>`` automatically. Do not include Gerrit push options such as
-``%submit`` or ``%l=Code-Review+2`` in the branch name.
+``refs/for/<branch>`` automatically. Gerrit push options can be appended after
+``%`` in either setting, for example ``main%topic=l10n``. Gerrit interprets
+these options as the configured Weblate Gerrit account and applies its own
+permissions.
 
 The Gerrit documentation has the details on the configuration necessary to set
 up such repositories. There is no separate code hosting credential setting for

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -579,8 +579,10 @@ Branch for pushing changes, leave empty to use :ref:`component-branch`.
 
    For Gerrit, this selects the target branch for the review request. Leave it
    empty to review against :ref:`component-branch`. Use the short branch name,
-   not ``refs/heads/<branch>``, ``refs/for/<branch>``, or Gerrit push options
-   such as ``%submit``.
+   not ``refs/heads/<branch>`` or ``refs/for/<branch>``. Gerrit push options
+   can be appended after ``%`` in either setting, for example
+   ``main%topic=l10n``; Gerrit interprets them as the configured Weblate Gerrit
+   account.
 
 .. seealso::
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Weblate 2026.7
 .. rubric:: Bug fixes
 
 * TBX glossary files no longer duplicate terms when repeated pending add operations are saved.
+* :ref:`code-hosting-gerrit` review pushes can again include Gerrit push options in the target branch.
 * Webhook target fallback matching is now stricter and reported in component diagnostics.
 * Creating components linked with ``weblate://`` no longer waits on the shared repository lock during the request.
 * Project and workspace translation license defaults now follow component and project licenses more closely.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -376,7 +376,8 @@ Input assumptions
      - Hook enablement only where needed, request limits, and monitoring.
        *(maintainer)*
    * - Repository configuration
-     - Repository URLs, branches, push URLs, credentials, add-on settings
+     - Repository URLs, branches, push URLs, credentials, Gerrit review push
+       options, add-on settings
      - Trusted to users with corresponding management permissions.
        *(documented)* (source: :doc:`/admin/access`, :doc:`/admin/continuous`)
      - Assign VCS and project management permissions only to trusted users.
@@ -684,6 +685,10 @@ Known non-findings
 * A report that a project manager can change repository settings, VCS
   credentials, or project configuration is not a vulnerability when the actor
   has the documented permission for that action. *(documented)* (source: :doc:`/admin/access`)
+* A report that a project manager can configure Gerrit review push options is
+  not a vulnerability by itself. Gerrit interprets these options as the
+  configured Weblate Gerrit account and enforces Gerrit-side permissions.
+  *(documented)* (source: :ref:`component-push_branch`)
 * A report against third-party add-on behavior is not a Weblate core
   vulnerability unless the report shows Weblate's permission or installation
   boundaries are bypassed. *(maintainer)*

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -756,6 +756,16 @@ class ComponentTest(RepoTestCase):
         self.assertIn("Invalid repository branch", error)
         self.assertIn("Use main instead of refs/heads/main", error)
 
+    def test_gerrit_branch_allows_push_options(self) -> None:
+        if "gerrit" not in VCS_REGISTRY:
+            self.skipTest("Gerrit not supported")
+        component = self.create_po()
+        component.vcs = "gerrit"
+        component.branch = "main%topic=l10n"
+
+        with patch("weblate.trans.models.Component.sync_git_repo", return_value=None):
+            component.clean()
+
     def test_invalid_gerrit_push_branch_full_ref_validation(self) -> None:
         if "gerrit" not in VCS_REGISTRY:
             self.skipTest("Gerrit not supported")
@@ -773,22 +783,15 @@ class ComponentTest(RepoTestCase):
         self.assertIn("Invalid push branch", error)
         self.assertIn("Use main instead of refs/for/main", error)
 
-    def test_invalid_gerrit_push_branch_magic_ref_option_validation(self) -> None:
+    def test_gerrit_push_branch_allows_push_options(self) -> None:
         if "gerrit" not in VCS_REGISTRY:
             self.skipTest("Gerrit not supported")
         component = self.create_po_push()
         component.vcs = "gerrit"
-        component.push_branch = "main%submit"
+        component.push_branch = "main%topic=l10n"
 
-        with (
-            patch("weblate.trans.models.Component.sync_git_repo", return_value=None),
-            self.assertRaises(ValidationError) as cm,
-        ):
+        with patch("weblate.trans.models.Component.sync_git_repo", return_value=None):
             component.clean()
-
-        error = str(cm.exception)
-        self.assertIn("Invalid push branch", error)
-        self.assertIn("review push options", error)
 
     def _test_maintenance(self, component: Component) -> None:
         self.verify_component(component, 4, "cs", 4)

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -795,8 +795,9 @@ class GitRepository(Repository):
                 remote_op="pull",
             )
         # Remove possible stale branches
+        local_branch = self.get_local_branch_name()
         for branch in self.list_branches():
-            if branch != self.branch:
+            if branch != local_branch:
                 self.execute(
                     ["branch", "--delete", "--force", branch], remote_op="none"
                 )
@@ -824,6 +825,9 @@ class GitRepository(Repository):
             line.split("\t", 1)[1].removeprefix("refs/heads/").strip()
             for line in branches.splitlines()
         ]
+
+    def get_local_branch_name(self) -> str:
+        return self.branch
 
     def update_remote(self) -> None:
         """Update remote repository."""
@@ -884,7 +888,6 @@ class GitWithGerritRepository(GitRepository):
         "This will push changes to Gerrit for a review."
     )
     pushes_to_different_location: ClassVar[bool] = True
-    BRANCH_OPTION_DELIMITERS: ClassVar[frozenset[str]] = frozenset({"%", ","})
 
     _version: ClassVar[str | None] = None
 
@@ -894,18 +897,22 @@ class GitWithGerritRepository(GitRepository):
         return cls._popen(["review", "--version"], merge_err=True).split()[-1]
 
     @classmethod
+    def validate_review_target(cls, branch: str) -> str:
+        """Validate Gerrit review target, including optional push options."""
+        review_target = super().validate_branch_name(branch)
+        super().validate_branch_name(review_target.split("%", 1)[0])
+        return review_target
+
+    @classmethod
     def validate_branch_name(cls, branch: str) -> str:
-        branch = super().validate_branch_name(branch)
-        if cls.BRANCH_OPTION_DELIMITERS.intersection(branch):
-            raise RepositoryError(
-                0,
-                gettext(
-                    "Gerrit branch names cannot contain %(chars)s because Gerrit "
-                    "interprets them as review push options."
-                )
-                % {"chars": "'%' or ','"},
-            )
-        return branch
+        """Validate Gerrit branch name without optional push options."""
+        review_target = cls.validate_review_target(branch)
+        return super().validate_branch_name(review_target.split("%", 1)[0])
+
+    @classmethod
+    def get_gerrit_branch_name(cls, branch: str) -> str:
+        """Return actual branch name from Gerrit review target."""
+        return cls.validate_branch_name(branch)
 
     def get_username_from_url(self, url) -> str:
         if url is not None:
@@ -919,11 +926,26 @@ class GitWithGerritRepository(GitRepository):
         return ""
 
     def get_gerrit_fetch_refspec(self, branch: str) -> str:
-        branch = self.validate_branch_name(branch)
+        branch = self.get_gerrit_branch_name(branch)
         return dumps(
             f"+refs/heads/{branch}:refs/remotes/gerrit/{branch}",
             ensure_ascii=False,
         )
+
+    def get_remote_branch_name(self, branch: str | None = None) -> str:
+        branch_name = self.get_gerrit_branch_name(branch or self.branch)
+        return f"origin/{branch_name}"
+
+    def get_local_branch_name(self) -> str:
+        return self.get_gerrit_branch_name(self.branch)
+
+    def checkout_with_temp_cleanup(self, branch: str) -> None:
+        super().checkout_with_temp_cleanup(self.get_gerrit_branch_name(branch))
+
+    def configure_branch(self, branch) -> None:
+        review_target = self.validate_review_target(branch)
+        super().configure_branch(branch)
+        self.branch = review_target
 
     def configure_gerrit_target_branch(self, branch: str) -> None:
         self.config_update(
@@ -932,7 +954,7 @@ class GitWithGerritRepository(GitRepository):
         )
 
     def push(self, branch) -> None:
-        target_branch = self.validate_branch_name(branch or self.branch)
+        target_branch = self.validate_review_target(branch or self.branch)
         if self.needs_push(branch):
             self.configure_gerrit_target_branch(target_branch)
             try:

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -17,7 +17,7 @@ from os import utime
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NoReturn, Protocol
-from unittest.mock import patch
+from unittest.mock import call, patch
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import responses
@@ -707,32 +707,59 @@ class GitBranchValidationTest(SimpleTestCase):
     def test_generic_git_branch_accepts_gerrit_option_delimiters(self) -> None:
         with patch.object(GitRepository, "_popen", return_value=""):
             self.assertEqual(
-                "main%submit", GitRepository.validate_branch_name("main%submit")
+                "main%topic=l10n", GitRepository.validate_branch_name("main%topic=l10n")
             )
 
-    def test_gerrit_branch_accepts_plain_name(self) -> None:
-        with patch.object(GitWithGerritRepository, "_popen", return_value=""):
-            self.assertEqual(
-                "review-branch",
-                GitWithGerritRepository.validate_branch_name("review-branch"),
-            )
-
-    def test_gerrit_branch_rejects_magic_ref_options(self) -> None:
+    def test_gerrit_branch_accepts_review_targets(self) -> None:
         branches = (
-            "main%submit",
-            "main%l=Code-Review+2",
-            "main%topic=evil,l=Code-Review+2",
-            "main,topic",
+            "review-branch",
+            "main%topic=l10n",
+            "main%hashtag=translations",
+            "main%topic=l10n,hashtag=translations",
         )
         with patch.object(GitWithGerritRepository, "_popen", return_value=""):
             for branch in branches:
-                with (
-                    self.subTest(branch=branch),
-                    self.assertRaises(RepositoryError) as cm,
-                ):
-                    GitWithGerritRepository.validate_branch_name(branch)
+                with self.subTest(branch=branch):
+                    self.assertEqual(
+                        branch,
+                        GitWithGerritRepository.validate_review_target(branch),
+                    )
 
-                self.assertIn("review push options", str(cm.exception))
+    def test_gerrit_branch_rejects_review_target_without_base_branch(self) -> None:
+        with (
+            patch.object(GitWithGerritRepository, "_popen", return_value=""),
+            self.assertRaises(RepositoryError) as cm,
+        ):
+            GitWithGerritRepository.validate_review_target("%topic=l10n")
+
+        self.assertEqual(str(cm.exception), "'' is not a valid branch name")
+
+    def test_gerrit_branch_extracts_fetch_branch_from_review_target(self) -> None:
+        with patch.object(GitWithGerritRepository, "_popen", return_value=""):
+            self.assertEqual(
+                "main",
+                GitWithGerritRepository.get_gerrit_branch_name(
+                    "main%topic=l10n,hashtag=translations"
+                ),
+            )
+
+    def test_gerrit_branch_validation_uses_base_review_target_branch(self) -> None:
+        with patch.object(GitWithGerritRepository, "_popen", return_value=""):
+            self.assertEqual(
+                "main",
+                GitWithGerritRepository.validate_branch_name(
+                    "main%topic=l10n,hashtag=translations"
+                ),
+            )
+
+    def test_gerrit_remote_branch_uses_base_review_target_branch(self) -> None:
+        repo = GitWithGerritRepository(".", branch="main", local=True)
+
+        with patch.object(GitWithGerritRepository, "_popen", return_value=""):
+            self.assertEqual(
+                "origin/main",
+                repo.get_remote_branch_name("main%topic=l10n,hashtag=translations"),
+            )
 
     def test_shorthand_branch_is_rejected(self) -> None:
         with self.assertRaises(RepositoryError) as cm:
@@ -2946,6 +2973,76 @@ class VCSGerritTest(VCSGitUpstreamTest):
         self.assertEqual(
             self.repo.get_config("remote.gerrit.fetch"),
             "+refs/heads/review-branch:refs/remotes/gerrit/review-branch",
+        )
+
+    def test_push_branch_targets_gerrit_review_branch_with_options(self) -> None:
+        with (
+            self.repo.lock,
+            patch.object(self.repo, "needs_push", return_value=True) as needs_push,
+            patch.object(self.repo, "execute") as execute,
+        ):
+            self.repo.push("review-branch%topic=l10n,hashtag=translations")
+
+        needs_push.assert_called_once_with(
+            "review-branch%topic=l10n,hashtag=translations"
+        )
+        execute.assert_called_once_with(
+            [
+                "review",
+                "--remote",
+                "gerrit",
+                "--yes",
+                "review-branch%topic=l10n,hashtag=translations",
+            ],
+            remote_op="push",
+        )
+        self.assertEqual(
+            self.repo.get_config("remote.gerrit.fetch"),
+            "+refs/heads/review-branch:refs/remotes/gerrit/review-branch",
+        )
+
+    def test_branch_targets_gerrit_review_branch_with_options(self) -> None:
+        self.repo.branch = "review-branch%topic=l10n,hashtag=translations"
+
+        with (
+            self.repo.lock,
+            patch.object(self.repo, "needs_push", return_value=True) as needs_push,
+            patch.object(self.repo, "execute") as execute,
+        ):
+            self.repo.push("")
+
+        needs_push.assert_called_once_with("")
+        execute.assert_called_once_with(
+            [
+                "review",
+                "--remote",
+                "gerrit",
+                "--yes",
+                "review-branch%topic=l10n,hashtag=translations",
+            ],
+            remote_op="push",
+        )
+        self.assertEqual(
+            self.repo.get_config("remote.gerrit.fetch"),
+            "+refs/heads/review-branch:refs/remotes/gerrit/review-branch",
+        )
+
+    def test_remove_stale_branches_keeps_gerrit_review_target_branch(self) -> None:
+        self.repo.branch = "main%topic=l10n,hashtag=translations"
+
+        with (
+            self.repo.lock,
+            patch.object(self.repo, "list_branches", return_value=["main", "stale"]),
+            patch.object(self.repo, "execute", return_value="") as execute,
+        ):
+            self.repo.remove_stale_branches()
+
+        execute.assert_any_call(
+            ["branch", "--delete", "--force", "stale"], remote_op="none"
+        )
+        self.assertNotIn(
+            call(["branch", "--delete", "--force", "main"], remote_op="none"),
+            execute.mock_calls,
         )
 
     def test_push_branch(self) -> None:


### PR DESCRIPTION
Restricting this was too tight. Instead we parse this when Git refspec is needed and pass as it is to Gerrit. Also updated the documentation to clarify the trust boundary here.

Fixes #19928

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
