### PR TITLE
fix(change): add validation before trying revert

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1024,13 +1024,14 @@ class RevertForm(UnitForm):
         if "revert" not in self.cleaned_data:
             return None
         try:
-            self.cleaned_data["revert_change"] = Change.objects.get(
-                pk=self.cleaned_data["revert"], unit=self.unit
-            )
+            change = Change.objects.get(pk=self.cleaned_data["revert"], unit=self.unit)
         except Change.DoesNotExist as error:
             raise ValidationError(
                 gettext("Could not find the reverted change.")
             ) from error
+        if not change.can_revert():
+            raise ValidationError(gettext("Could not find the reverted change."))
+        self.cleaned_data["revert_change"] = change
         return self.cleaned_data
 
 

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, ClassVar, Self, TypedDict, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Self, TypedDict, cast, overload
 from uuid import uuid5
 
 from django.conf import settings
@@ -837,11 +837,18 @@ class Change(models.Model, UserDisplayMixin):
         return (
             self.unit is not None
             and self.action in ACTIONS_REVERTABLE
-            and "old_state" in self.details
+            and self.get_revert_state() is not None
         )
 
-    def get_revert_state(self) -> StringState:
-        return StringState(self.details["old_state"])
+    @staticmethod
+    def parse_revert_state(details: dict[str, Any]) -> StringState | None:
+        try:
+            return StringState(details["old_state"])
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def get_revert_state(self) -> StringState | None:
+        return self.parse_revert_state(self.details)
 
     def get_latest_user_revert_target(self) -> tuple[str, StringState] | None:
         if self.unit_id is None or self.user_id is None:
@@ -859,10 +866,10 @@ class Change(models.Model, UserDisplayMixin):
                 return None
             if user_id != self.user_id:
                 break
-            if "old_state" not in details:
+            boundary_state = self.parse_revert_state(details)
+            if boundary_state is None:
                 return None
             boundary_old = old
-            boundary_state = StringState(details["old_state"])
 
         if boundary_old is None or boundary_state is None:
             return None
@@ -914,13 +921,14 @@ class Change(models.Model, UserDisplayMixin):
 
         unit = cast("Unit", self.unit)
         locked_unit = unit.__class__.objects.select_for_update().get(pk=unit.pk)
-        if "old_state" not in self.details:
+        state = self.get_revert_state()
+        if state is None:
             return False
 
         return locked_unit.translate(
             user,
             split_plural(self.old),
-            self.get_revert_state(),
+            state,
             change_action=change_action,
             author=author,
             request=request,

--- a/weblate/trans/tests/test_acl.py
+++ b/weblate/trans/tests/test_acl.py
@@ -1153,6 +1153,39 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
         self.assertEqual(change.user, self.user)
         self.assertEqual(change.get_details_display(), self.second_user.username)
 
+    def test_revert_user_edits_task_invalid_old_state(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        unit = self.get_unit()
+        self.change_unit("Ahoj svete!\n", user=self.user)
+        self.change_unit("Nazdar svete!\n", user=self.second_user)
+        self.change_unit("Cus svete!\n", user=self.second_user)
+        change = Change.objects.filter(unit=unit, user=self.second_user).order_by(
+            "-timestamp", "-pk"
+        )[0]
+        change.details["old_state"] = -1
+        change.save(update_fields=["details"])
+
+        result = revert_user_edits_task(
+            target_user_id=self.second_user.id,
+            acting_user_id=self.user.id,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "reverted": 0,
+                "skipped": 1,
+                "skipped_newer": 0,
+                "skipped_failed": 1,
+            },
+        )
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "Cus svete!\n")
+        self.assertFalse(
+            Change.objects.filter(action=ActionEvents.USER_REVERT).exists()
+        )
+
     def test_block_user_revert_edits_skips_newer_changes(self) -> None:
         self.project.add_user(self.user, "Administration")
         unit = self.get_unit()

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -1514,6 +1514,30 @@ class EditComplexTest(ViewTestCase):
         self.assertEqual(unit.target, "")
         self.assertEqual(unit.state, STATE_EMPTY)
 
+    def test_revert_invalid_old_state(self) -> None:
+        source = "Hello, world!\n"
+        target = "Nazdar svete!\n"
+        self.edit_unit(source, target)
+        unit = self.get_unit(source)
+        change = Change.objects.content().filter(unit=unit).order()[0]
+        change.details["old_state"] = -1
+        change.save(update_fields=["details"])
+
+        self.assertFalse(change.can_revert())
+        self.assertIsNone(change.get_revert_state())
+        self.assertFalse(change.revert(self.user))
+
+        response = self.client.get(
+            self.translate_url,
+            {"checksum": unit.checksum, "revert": change.id},
+            follow=True,
+        )
+
+        self.assertContains(response, "Could not find the reverted change.")
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, target)
+        self.assertEqual(unit.state, STATE_TRANSLATED)
+
     def test_revert_restores_old_state(self) -> None:
         source = "Hello, world!\n"
         original = "Nazdar svete!\n"


### PR DESCRIPTION
The historical events might have state of -1 which then fails with a ValueError.

Fixes WEBLATE-39QZ

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
