### PR TITLE
fix(views): embed access check into get_object_or_404 calls

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Weblate 2026.7
 * Creating components linked with ``weblate://`` no longer waits on the shared repository lock during the request.
 * Project and workspace translation license defaults now follow component and project licenses more closely.
 * Component and category API ``PATCH`` requests no longer remove the category when the field is omitted.
+* Hardened HTML and AJAX object lookups against private project enumeration.
 
 .. rubric:: Compatibility
 

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -977,6 +977,11 @@ class User(AbstractBaseUser):
     def needs_project_filter(self):
         if self.is_superuser:
             return False
+        if any(
+            key > 0 and permissions == [(None, None)]
+            for key, permissions in self.project_permissions.items()
+        ):
+            return True
         if self.project_permissions[-SELECTION_ALL]:
             return False
         return Project.objects.exclude(

--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -604,6 +604,19 @@ class ModelTest(FixtureComponentTestCase):
         with self.assertNumQueries(0):
             self.assertFalse(self.user.needs_project_filter)
 
+    def test_needs_project_filter_all_projects_with_block_query(self) -> None:
+        group = Group.objects.create(
+            name="All projects", project_selection=SELECTION_ALL
+        )
+        self.user.groups.add(group)
+        UserBlock.objects.create(user=self.user, project=self.project)
+        self.user.clear_cache()
+
+        self.assertIn(-SELECTION_ALL, self.user.project_permissions)
+        self.assertEqual(self.user.project_permissions[self.project.pk], [(None, None)])
+        with self.assertNumQueries(0):
+            self.assertTrue(self.user.needs_project_filter)
+
     def test_needs_project_filter_avoids_count_query(self) -> None:
         self.assertNotIn(-SELECTION_ALL, self.user.project_permissions)
 

--- a/weblate/trans/models/announcement.py
+++ b/weblate/trans/models/announcement.py
@@ -129,6 +129,31 @@ class AnnouncementManager(models.Manager["Announcement"]):
 
 
 class AnnouncementQuerySet(models.QuerySet["Announcement", "Announcement"]):
+    def filter_access(self, user):
+        if user.is_superuser:
+            return self
+
+        global_scope = Q(
+            project__isnull=True, category__isnull=True, component__isnull=True
+        )
+        project_scope = Q(category__isnull=True, component__isnull=True) & (
+            user.get_project_access_query("project")
+        )
+        category_scope = Q(category__isnull=False, component__isnull=True) & (
+            user.get_project_access_query("category__project")
+        )
+        component_scope = Q(component__isnull=False) & (
+            user.get_project_access_query("component__project")
+        )
+        if user.needs_component_restrictions_filter:
+            component_scope &= Q(component__restricted=False) | Q(
+                component_id__in=user.component_permissions
+            )
+
+        return self.filter(
+            global_scope | project_scope | category_scope | component_scope
+        )
+
     def order(self):
         return self.order_by("id")
 

--- a/weblate/trans/tests/test_changes.py
+++ b/weblate/trans/tests/test_changes.py
@@ -13,7 +13,7 @@ from django.utils.http import urlencode
 
 from weblate.trans.actions import ActionEvents
 from weblate.trans.feeds import TranslationChangesFeed
-from weblate.trans.models import Change, Unit
+from weblate.trans.models import Change, Project, Unit
 from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
 from weblate.utils.xml import parse_xml
 
@@ -141,6 +141,70 @@ class ChangesTest(ViewTestCase):
             reverse("changes", kwargs={"path": ["testx", "test", "cs"]})
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_show_change_hides_private_change(self) -> None:
+        private_project = self.create_project(
+            name="Private changes",
+            slug="private-changes",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_component = self.create_po(
+            project=private_project, name="private-changes"
+        )
+        hidden_change = Change.objects.create(
+            action=ActionEvents.LOCK,
+            project=private_project,
+            component=private_component,
+            user=self.anotheruser,
+        )
+
+        response = self.client.get(
+            reverse("show_change", kwargs={"pk": hidden_change.pk})
+        )
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get(reverse("show_change", kwargs={"pk": 999999}))
+        self.assertEqual(response.status_code, 404)
+
+    def test_show_change_ignores_private_other_changes(self) -> None:
+        visible_change = Change.objects.create(
+            action=ActionEvents.CREATE_PROJECT,
+            project=self.project,
+            user=self.user,
+        )
+        private_project = self.create_project(
+            name="Private other changes",
+            slug="private-other-changes",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_component = self.create_po(
+            project=private_project, name="private-other-changes"
+        )
+        hidden_change = Change.objects.create(
+            action=ActionEvents.LOCK,
+            project=private_project,
+            component=private_component,
+            user=self.anotheruser,
+        )
+
+        response = self.client.get(
+            reverse("show_change", kwargs={"pk": visible_change.pk}),
+            {"other": hidden_change.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_show_change_ignores_invalid_other_values(self) -> None:
+        visible_change = Change.objects.create(
+            action=ActionEvents.CREATE_PROJECT,
+            project=self.project,
+            user=self.user,
+        )
+
+        response = self.client.get(
+            reverse("show_change", kwargs={"pk": visible_change.pk}),
+            {"other": ["invalid", str(visible_change.pk)]},
+        )
+        self.assertEqual(response.status_code, 200)
 
     def test_string(self) -> None:
         response = self.client.get(

--- a/weblate/trans/tests/test_comment.py
+++ b/weblate/trans/tests/test_comment.py
@@ -8,7 +8,9 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
-from weblate.trans.models import Comment
+from weblate.auth.data import SELECTION_ALL
+from weblate.auth.models import Group, UserBlock
+from weblate.trans.models import Comment, Project
 from weblate.trans.tests.test_views import FixtureTestCase
 
 
@@ -157,6 +159,61 @@ class CommentViewTest(FixtureTestCase):
         comment.refresh_from_db()
         self.assertTrue(comment.resolved)
         self.assertFalse(comment.unit.has_comment)
+
+    def test_comment_views_hide_private_unit_and_comment(self) -> None:
+        self.project.access_control = Project.ACCESS_PRIVATE
+        self.project.save(update_fields=["access_control"])
+        self.user.clear_cache()
+
+        unit = self.get_unit()
+        comment = Comment.objects.create(
+            user=self.anotheruser, unit=unit, comment="Hidden comment"
+        )
+
+        response = self.client.post(
+            reverse("comment", kwargs={"pk": unit.pk}),
+            {"comment": "Probe comment", "scope": "translation"},
+        )
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.post(
+            reverse("delete-comment", kwargs={"pk": comment.pk})
+        )
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.post(
+            reverse("resolve-comment", kwargs={"pk": comment.pk})
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_comment_views_hide_blocked_project_for_all_projects_user(self) -> None:
+        group = Group.objects.create(
+            name="All projects comments", project_selection=SELECTION_ALL
+        )
+        self.user.groups.add(group)
+        UserBlock.objects.create(user=self.user, project=self.project)
+        self.user.clear_cache()
+
+        unit = self.get_unit()
+        comment = Comment.objects.create(
+            user=self.anotheruser, unit=unit, comment="Blocked comment"
+        )
+
+        response = self.client.post(
+            reverse("comment", kwargs={"pk": unit.pk}),
+            {"comment": "Probe comment", "scope": "translation"},
+        )
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.post(
+            reverse("delete-comment", kwargs={"pk": comment.pk})
+        )
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.post(
+            reverse("resolve-comment", kwargs={"pk": comment.pk})
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_translate_comment_queries_do_not_scale_with_comment_count(self) -> None:
         unit = self.get_unit()

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -15,7 +15,8 @@ from django.core.exceptions import ValidationError
 from django.urls import reverse
 
 from weblate.addons.resx import ResxUpdateAddon
-from weblate.auth.models import setup_project_groups
+from weblate.auth.data import SELECTION_ALL
+from weblate.auth.models import Group, UserBlock, setup_project_groups
 from weblate.checks.models import Check
 from weblate.trans.actions import ActionEvents
 from weblate.trans.exceptions import FileParseError
@@ -404,6 +405,51 @@ class EditTest(ViewTestCase):
 
         unit = self.get_unit(self.source)
         self.assertTrue(unit.automatically_translated)
+
+
+class EditAccessTest(ViewTestCase):
+    def assert_unit_action_urls_not_found(self, unit: Unit) -> None:
+        check = Check.objects.create(unit=unit, name="same")
+
+        urls = (
+            reverse("js-dismiss-automatically-translated", kwargs={"unit_id": unit.pk}),
+            reverse("delete-unit", kwargs={"unit_id": unit.source_unit.pk}),
+            reverse("js-ignore-check", kwargs={"check_id": check.pk}),
+            reverse("js-ignore-check-source", kwargs={"check_id": check.pk}),
+        )
+        for url in urls:
+            response = self.client.post(url)
+            self.assertEqual(response.status_code, 404)
+
+    def test_private_unit_actions_return_not_found(self) -> None:
+        private_project = self.create_project(
+            name="Private edit",
+            slug="private-edit",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_component = self.create_po(project=private_project, name="private-edit")
+        private_translation = private_component.translation_set.get(language_code="cs")
+        unit = self.get_unit("Hello, world!\n", translation=private_translation)
+
+        self.assert_unit_action_urls_not_found(unit)
+
+    def test_blocked_project_unit_actions_return_not_found(self) -> None:
+        group = Group.objects.create(
+            name="All projects edit", project_selection=SELECTION_ALL
+        )
+        self.user.groups.add(group)
+        private_project = self.create_project(
+            name="Blocked edit",
+            slug="blocked-edit",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_component = self.create_po(project=private_project, name="blocked-edit")
+        private_translation = private_component.translation_set.get(language_code="cs")
+        unit = self.get_unit("Hello, world!\n", translation=private_translation)
+        UserBlock.objects.create(user=self.user, project=private_project)
+        self.user.clear_cache()
+
+        self.assert_unit_action_urls_not_found(unit)
 
 
 class EditValidationTest(ViewTestCase):

--- a/weblate/trans/tests/test_js_views.py
+++ b/weblate/trans/tests/test_js_views.py
@@ -6,6 +6,7 @@
 
 from django.urls import reverse
 
+from weblate.trans.models import Project
 from weblate.trans.tests.test_views import FixtureTestCase
 
 
@@ -39,3 +40,14 @@ class JSViewsTest(FixtureTestCase):
         response = self.client.get(reverse("js-flag-choices"), {"lang": "cs"})
         self.assertEqual(response.status_code, 200)
         self.assertIn("private", response.get("Cache-Control", ""))
+
+    def test_get_unit_translations_hides_private_unit(self) -> None:
+        self.project.access_control = Project.ACCESS_PRIVATE
+        self.project.save(update_fields=["access_control"])
+        self.user.clear_cache()
+
+        unit = self.get_unit()
+        response = self.client.get(
+            reverse("js-unit-translations", kwargs={"unit_id": unit.id})
+        )
+        self.assertEqual(response.status_code, 404)

--- a/weblate/trans/tests/test_manage.py
+++ b/weblate/trans/tests/test_manage.py
@@ -603,7 +603,31 @@ class AnnouncementTest(AnnouncementPermissionTestCase):
 
     def test_delete_deny(self) -> None:
         message = Announcement.objects.create(message="test")
-        self.client.post(reverse("announcement-delete", kwargs={"pk": message.pk}))
+        response = self.client.post(
+            reverse("announcement-delete", kwargs={"pk": message.pk})
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Announcement.objects.count(), 1)
+
+    def test_delete_hides_private_announcement(self) -> None:
+        private_project = self.create_project(
+            name="Private announcement",
+            slug="private-announcement",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_component = self.create_po(
+            project=private_project, name="private-announcement"
+        )
+        announcement = Announcement.objects.create(
+            project=private_project,
+            component=private_component,
+            message="Hidden announcement",
+        )
+
+        response = self.client.post(
+            reverse("announcement-delete", kwargs={"pk": announcement.pk})
+        )
+        self.assertEqual(response.status_code, 404)
         self.assertEqual(Announcement.objects.count(), 1)
 
 

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -1061,6 +1061,24 @@ class SourceStringsTest(ViewTestCase):
         self.assertEqual(unit.context, "")
         self.assertEqual(unit.explanation, "Extra context")
 
+    def test_edit_context_hides_private_unit(self) -> None:
+        private_project = self.create_project(
+            name="Private source",
+            slug="private-source",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_component = self.create_po(
+            project=private_project, name="private-source"
+        )
+        private_translation = private_component.translation_set.get(language_code="cs")
+        unit = self.get_unit(translation=private_translation).source_unit
+
+        response = self.client.post(
+            reverse("edit_context", kwargs={"pk": unit.pk}),
+            {"explanation": "Extra context"},
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_edit_check_flags(self) -> None:
         # Need extra power
         self.user.is_superuser = True

--- a/weblate/trans/views/changes.py
+++ b/weblate/trans/views/changes.py
@@ -328,16 +328,26 @@ class ChangesRSSView(ChangesView):
 
 @login_required
 def show_change(request: AuthenticatedHttpRequest, pk: int):
-    change = get_object_or_404(Change, pk=pk)
+    accessible_changes = Change.objects.last_changes(request.user)
+    change = get_object_or_404(accessible_changes, pk=pk)
     acl_obj = change.translation or change.component or change.project
     if not request.user.has_perm("unit.edit", acl_obj):
         raise PermissionDenied
-    others = request.GET.getlist("other")
+    others = []
+    for other in request.GET.getlist("other"):
+        try:
+            others.append(int(other))
+        except ValueError:
+            continue
     changes = None
     if others:
-        changes = Change.objects.filter(pk__in=[*others, change.pk])
-        for change in changes:
-            acl_obj = change.translation or change.component or change.project
+        changes = accessible_changes.filter(pk__in=[*others, change.pk])
+        for related_change in changes:
+            acl_obj = (
+                related_change.translation
+                or related_change.component
+                or related_change.project
+            )
             if not request.user.has_perm("unit.edit", acl_obj):
                 raise PermissionDenied
     if change.action not in NOTIFICATIONS_ACTIONS:

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -930,7 +930,7 @@ def auto_translation(request: AuthenticatedHttpRequest, path):
 @session_ratelimit_post("comment", logout_user=False)
 def comment(request: AuthenticatedHttpRequest, pk):
     """Add new comment."""
-    unit = get_object_or_404(Unit, pk=pk)
+    unit = get_object_or_404(Unit.objects.filter_access(request.user), pk=pk)
 
     if not request.user.has_perm("comment.add", unit.translation):
         raise PermissionDenied
@@ -954,7 +954,10 @@ def comment(request: AuthenticatedHttpRequest, pk):
 @transaction.atomic
 def delete_comment(request: AuthenticatedHttpRequest, pk):
     """Delete comment."""
-    comment_obj = get_object_or_404(Comment, pk=pk)
+    comment_obj = get_object_or_404(
+        Comment.objects.filter(unit__in=Unit.objects.filter_access(request.user)),
+        pk=pk,
+    )
 
     if not request.user.has_perm("comment.delete", comment_obj):
         raise PermissionDenied
@@ -974,7 +977,10 @@ def delete_comment(request: AuthenticatedHttpRequest, pk):
 @transaction.atomic
 def resolve_comment(request: AuthenticatedHttpRequest, pk):
     """Resolve comment."""
-    comment_obj = get_object_or_404(Comment, pk=pk)
+    comment_obj = get_object_or_404(
+        Comment.objects.filter(unit__in=Unit.objects.filter_access(request.user)),
+        pk=pk,
+    )
 
     if not request.user.has_perm("comment.resolve", comment_obj):
         raise PermissionDenied
@@ -1181,7 +1187,7 @@ def new_unit(request: AuthenticatedHttpRequest, path):
 @transaction.atomic
 def delete_unit(request: AuthenticatedHttpRequest, unit_id):
     """Delete unit."""
-    unit = get_object_or_404(Unit, pk=unit_id)
+    unit = get_object_or_404(Unit.objects.filter_access(request.user), pk=unit_id)
 
     if not request.user.has_perm("unit.delete", unit):
         raise PermissionDenied

--- a/weblate/trans/views/js.py
+++ b/weblate/trans/views/js.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 def get_unit_translations(request: AuthenticatedHttpRequest, unit_id):
     """Return unit's other translations."""
-    unit = get_object_or_404(Unit, pk=int(unit_id))
+    unit = get_object_or_404(Unit.objects.filter_access(request.user), pk=int(unit_id))
     user = request.user
     user.check_access_component(unit.translation.component)
 
@@ -58,7 +58,9 @@ def get_unit_translations(request: AuthenticatedHttpRequest, unit_id):
 @login_required
 @transaction.atomic
 def ignore_check(request: AuthenticatedHttpRequest, check_id):
-    obj = get_object_or_404(Check.objects.select_for_update(), pk=int(check_id))
+    obj = get_object_or_404(
+        Check.objects.filter_access(request.user).select_for_update(), pk=int(check_id)
+    )
 
     if not request.user.has_perm("unit.check", obj):
         raise PermissionDenied
@@ -73,7 +75,7 @@ def ignore_check(request: AuthenticatedHttpRequest, check_id):
 @login_required
 @transaction.atomic
 def ignore_check_source(request: AuthenticatedHttpRequest, check_id):
-    obj = get_object_or_404(Check, pk=int(check_id))
+    obj = get_object_or_404(Check.objects.filter_access(request.user), pk=int(check_id))
     unit = obj.unit.source_unit
 
     if not request.user.has_perm("unit.check", obj) or not request.user.has_perm(
@@ -106,7 +108,7 @@ def ignore_check_source(request: AuthenticatedHttpRequest, check_id):
 @login_required
 @transaction.atomic
 def dismiss_automatically_translated(request: AuthenticatedHttpRequest, unit_id):
-    unit = get_object_or_404(Unit, pk=int(unit_id))
+    unit = get_object_or_404(Unit.objects.filter_access(request.user), pk=int(unit_id))
     if not request.user.has_perm("unit.edit", unit):
         raise PermissionDenied
 

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -481,7 +481,9 @@ def announcement(request: AuthenticatedHttpRequest, path):
 @login_required
 @require_POST
 def announcement_delete(request: AuthenticatedHttpRequest, pk):
-    announcement = get_object_or_404(Announcement, pk=pk)
+    announcement = get_object_or_404(
+        Announcement.objects.filter_access(request.user), pk=pk
+    )
 
     if not request.user.has_perm("announcement.delete", announcement):
         raise PermissionDenied

--- a/weblate/trans/views/source.py
+++ b/weblate/trans/views/source.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 @login_required
 @transaction.atomic
 def edit_context(request: AuthenticatedHttpRequest, pk):
-    unit = get_object_or_404(Unit, pk=pk)
+    unit = get_object_or_404(Unit.objects.filter_access(request.user), pk=pk)
     if not unit.is_source and not unit.translation.component.is_glossary:
         msg = "Non source unit!"
         raise Http404(msg)


### PR DESCRIPTION
This returns 404 for content user has not access to unlike 403 which allows probing for content presence.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
