### PR TITLE
fix: use unicode-bidi CSS for rendering translation content

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.7
 * :ref:`addon-weblate.gettext.xgettext` can now leave the xgettext language blank to let xgettext guess it from source file extensions.
 * :envvar:`WEBLATE_ALLOWED_ASSET_SIZE` is now available in Docker container.
 * LLM automatic suggestions now use translated examples, language-specific instructions, and richer glossary context for more reliable output.
+* Improved bidirectional text handling for RTL translation display and editor previews.
 
 .. rubric:: Bug fixes
 

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -1158,6 +1158,10 @@ legend {
   width: 40px;
 }
 
+.bidi-isolate {
+  unicode-bidi: isolate;
+}
+
 .wrap-text {
   white-space: pre-wrap;
 }

--- a/weblate/templates/snippets/format-translation.html
+++ b/weblate/templates/snippets/format-translation.html
@@ -3,7 +3,7 @@
 {% if simple %}
   <span lang="{{ language.code }}"
         dir="{{ language.direction }}"
-        {% if wrap and items.0.content|length > 25 %}class="wrap-text"{% endif %}>{{ items.0.content }}</span>
+        class="bidi-isolate{% if wrap and items.0.content|length > 25 %} wrap-text{% endif %}">{{ items.0.content }}</span>
 {% elif has_content %}
   <div class="list-group">
     {% for item in items %}
@@ -13,7 +13,7 @@
             <strong>{{ item.title }}</strong>
           </h5>
         {% endif %}
-        <div class="list-group-item-text"
+        <div class="list-group-item-text bidi-isolate"
              lang="{{ language.code }}"
              dir="{{ language.direction }}">
           {% if unit and item.copy %}

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
@@ -181,6 +182,43 @@ class LocationLinksTest(TestCase):
             </a>
             """,
         )
+
+
+class FormatTranslationTemplateTest(SimpleTestCase):
+    def test_simple_bidi_isolate(self) -> None:
+        content = render_to_string(
+            "snippets/format-translation.html",
+            {
+                "simple": True,
+                "language": Language(code="fa", direction="rtl"),
+                "wrap": False,
+                "items": [{"content": "سلام test 123"}],
+            },
+        )
+        self.assertHTMLEqual(
+            content,
+            """
+            <span lang="fa" dir="rtl" class="bidi-isolate">
+              سلام test 123
+            </span>
+            """,
+        )
+
+    def test_list_bidi_isolate(self) -> None:
+        content = render_to_string(
+            "snippets/format-translation.html",
+            {
+                "simple": False,
+                "has_content": True,
+                "language": Language(code="fa", direction="rtl"),
+                "wrap": False,
+                "items": [{"content": "سلام test 123"}],
+            },
+        )
+        self.assertIn('class="list-group-item-text bidi-isolate"', content)
+        self.assertIn('lang="fa"', content)
+        self.assertIn('dir="rtl"', content)
+        self.assertIn("سلام test 123", content)
 
 
 class TranslationFormatTestCase(FixtureComponentTestCase):


### PR DESCRIPTION
This usually better aligns punctuation to the RTL content.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
