### PR TITLE
fix(addons): tolerate missing xgettext language

### DIFF
--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -1018,7 +1018,7 @@ class XgettextAddon(ExtractPotBaseAddon):
         }
 
     def get_language(self) -> str | None:
-        return self.instance.configuration["language"]
+        return self.instance.configuration.get("language", "")
 
     def get_comment_mode(self) -> str:
         return str(self.instance.configuration.get("comment_mode", "off"))

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -1695,34 +1695,48 @@ class GettextAddonTest(ViewTestCase):
         )
 
     def test_xgettext_without_language_omits_language_argument(self) -> None:
-        source = Path(self.component.full_path) / "src" / "messages.py"
-        source.parent.mkdir(parents=True, exist_ok=True)
-        source.write_text(
-            'from gettext import gettext as _\n_("Hello")\n', encoding="utf-8"
-        )
-        addon = XgettextAddon.create(
-            component=self.component,
-            run=False,
-            configuration={
+        for configuration in (
+            {
                 "interval": "weekly",
                 "update_po_files": False,
                 "language": "",
                 "source_patterns": ["src/*.py"],
             },
-        )
-
-        with (
-            patch.object(XgettextAddon, "run_process", return_value="") as mocked,
-            patch.object(XgettextAddon, "validate_repository_tree", return_value=True),
+            {
+                "interval": "weekly",
+                "update_po_files": False,
+                "source_patterns": ["src/*.py"],
+            },
         ):
-            addon.update_translations(self.component, "")
+            with self.subTest(configuration=configuration):
+                source = Path(self.component.full_path) / "src" / "messages.py"
+                source.parent.mkdir(parents=True, exist_ok=True)
+                source.write_text(
+                    'from gettext import gettext as _\n_("Hello")\n', encoding="utf-8"
+                )
+                addon = XgettextAddon.create(
+                    component=self.component,
+                    run=False,
+                    configuration=configuration,
+                )
 
-        mocked.assert_called_once()
-        command = mocked.call_args.args[1]
-        self.assertEqual(command[:3], ["xgettext", "--output", "po/hello.pot"])
-        self.assertNotIn("--language", command)
-        self.assertIn("--from-code=UTF-8", command)
-        self.assertIn("src/messages.py", command)
+                with (
+                    patch.object(
+                        XgettextAddon, "run_process", return_value=""
+                    ) as mocked,
+                    patch.object(
+                        XgettextAddon, "validate_repository_tree", return_value=True
+                    ),
+                ):
+                    addon.update_translations(self.component, "")
+
+                mocked.assert_called_once()
+                command = mocked.call_args.args[1]
+                self.assertEqual(command[:3], ["xgettext", "--output", "po/hello.pot"])
+                self.assertNotIn("--language", command)
+                self.assertIn("--from-code=UTF-8", command)
+                self.assertIn("src/messages.py", command)
+                addon.instance.delete()
 
     def test_xgettext_uses_potfiles_manifest(self) -> None:
         source = Path(self.component.full_path) / "src" / "messages.py"


### PR DESCRIPTION
### Motivation
- The xgettext add-on form made `language` optional causing API submissions that omit the key to be stored without a `language` entry, which later raised `KeyError` at runtime when the add-on accessed `configuration["language"]`.
- The intent is to treat an omitted `language` the same as an explicit blank value so the add-on can omit the `--language` argument when appropriate.

### Description
- Change `XgettextAddon.get_language()` to use `self.instance.configuration.get("language", "")` so a missing key is treated as an empty string. (`weblate/addons/gettext.py`)
- Extend the existing test `test_xgettext_without_language_omits_language_argument` to exercise both an explicit blank `language` and a configuration that omits `language`, asserting that `--language` is not included in the generated command and cleaning up the created addon instance. (`weblate/addons/tests.py`)
- Run repository formatting on the modified test file to conform to project linting rules.

### Testing
- Ran formatter and linter: `uv run ruff format weblate/addons/tests.py` and `uv run ruff check weblate/addons/gettext.py weblate/addons/tests.py`, which completed successfully.
- Ran targeted tests: `uv run pytest weblate/addons/tests.py -k 'xgettext_without_language_omits_language_argument or xgettext_form_accepts_blank_language'`, yielding `2 passed, 355 deselected`.
- All automated checks in this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ad6785ac48329bd7cdba86ce04fec)