### PR TITLE
fix(tests): freeze alert timestamps before screenshot

### DIFF
--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -20,6 +20,7 @@ from django.core import mail
 from django.core.files import File
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.functional import cached_property
 from selenium import webdriver
 from selenium.common.exceptions import (
@@ -1531,7 +1532,7 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
 
     def test_alerts(self) -> None:
         project = Project.objects.create(name="WeblateOrg", slug="weblateorg")
-        Component.objects.create(
+        duplicates = Component.objects.create(
             name="Duplicates",
             slug="duplicates",
             project=project,
@@ -1541,6 +1542,8 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
             new_base="po-duplicates/hello.pot",
             file_format="po",
         )
+        alert_timestamp = timezone.now() - timedelta(minutes=1)
+        duplicates.alert_set.update(timestamp=alert_timestamp, updated=alert_timestamp)
         self.do_login(superuser=True)
         self.click(htmlid="projects-menu")
         with self.wait_for_page_load():


### PR DESCRIPTION
This avoids seconds-level changes in the screenshots.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
