### PR TITLE
fix(docs): correct German setting role markup

### DIFF
--- a/docs/locales/de/LC_MESSAGES/docs.po
+++ b/docs/locales/de/LC_MESSAGES/docs.po
@@ -17987,7 +17987,7 @@ msgstr ""
 "Diese Klasse nummeriert automatisch ``h2``-Überschriften, Absätze mit den "
 "Klassen ``item``, ``subitem``, oder ``subsubitem`` sowie Elemente der "
 "obersten Ebene in geordneten Listen. Wenn Ihr Rechtsdokument bereits eine "
-"Nummerierung enthält, setzen Sie ` :setting:`LEGAL_DOCUMENT_CSS_CLASS` ` auf "
+"Nummerierung enthält, setzen Sie :setting:`LEGAL_DOCUMENT_CSS_CLASS` auf "
 "eine leere Zeichenkette, um diese Formatierung zu deaktivieren."
 
 #: admin/optionals.rst:228


### PR DESCRIPTION
### Motivation
- The German translation in `docs/locales/de/LC_MESSAGES/docs.po` contained stray literal backticks and spaces around the Sphinx `:setting:`LEGAL_DOCUMENT_CSS_CLASS`` role which renders incorrectly and may produce confusing output in documentation builds. 

### Description
- Remove the extra single backticks and surrounding spaces so the translation uses `:setting:`LEGAL_DOCUMENT_CSS_CLASS`` inline role correctly. 
- The change is a one-line edit to `docs/locales/de/LC_MESSAGES/docs.po` updating the `msgstr` for the related `msgid` from a backtick-wrapped form to the correct role usage. 
- The change preserves the original translated text and only adjusts RST markup.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff issues and it succeeded. 
- Ran `msgfmt --check --output-file=/tmp/docs.mo docs/locales/de/LC_MESSAGES/docs.po` to validate the PO file syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c1e2b82e48329a8a80f8d44394721)