### PR TITLE
feat(checks): optimize checks run

### DIFF
--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -123,6 +123,11 @@ class BaseCheck(ClassLoaderProtocol, DocVersionsMixin):
         self, sources: list[str], targets: list[str], unit: Unit
     ) -> Generator[bool | MissingExtraDict]:
         """Check single unit, handling plurals."""
+        # Singular units do not need plural metadata or PluralMapper.
+        if len(sources) == 1 and len(targets) == 1:
+            yield self.check_single(sources[0], targets[0], unit)
+            return
+
         from weblate.lang.models import PluralMapper  # noqa: PLC0415
 
         source_plural = unit.translation.component.source_language.plural
@@ -139,6 +144,9 @@ class BaseCheck(ClassLoaderProtocol, DocVersionsMixin):
         self, sources: list[str], targets: list[str], unit: Unit
     ) -> bool:
         """Check single unit, handling plurals."""
+        # Avoid creating a generator for the common singular case.
+        if len(sources) == 1 and len(targets) == 1:
+            return bool(self.check_single(sources[0], targets[0], unit))
         return any(self.check_target_generator(sources, targets, unit))
 
     def check_single(
@@ -152,6 +160,22 @@ class BaseCheck(ClassLoaderProtocol, DocVersionsMixin):
         if self.should_skip(unit):
             return False
         return self.check_source_unit(sources, unit)
+
+    def check_source_with_flags(
+        self, sources: list[str], unit: Unit, all_flags: Flags
+    ) -> bool:
+        """Check source strings with precomputed flags."""
+        # Only inline the base skip logic for checks that did not override it.
+        # Custom should_skip() methods can inspect arbitrary unit state.
+        if self.__class__.should_skip is BaseCheck.should_skip:
+            if self.is_ignored(all_flags):
+                return False
+            if self.default_disabled and not all_flags.has_any(
+                {self.enable_string, *self.extra_enable_strings}
+            ):
+                return False
+            return self.check_source_unit(sources, unit)
+        return self.check_source(sources, unit)
 
     def check_source_unit(self, sources: list[str], unit: Unit) -> bool:
         """Check source string."""

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -41,6 +41,10 @@ class ChecksLoader(ClassLoader[BaseCheck]):
         return {k: v for k, v in self.items() if v.target}
 
     @cached_property
+    def target_untranslated(self):
+        return {k: v for k, v in self.target.items() if not v.ignore_untranslated}
+
+    @cached_property
     def glossary(self):
         return {k: v for k, v in self.items() if v.glossary}
 

--- a/weblate/checks/source.py
+++ b/weblate/checks/source.py
@@ -84,7 +84,8 @@ class MultipleFailingCheck(SourceCheck, BatchCheckMixin):
             .values_list("unit__translation", flat=True)
             .distinct()
         )
-        return related.count() >= 2
+        # We only need to know whether two translations are affected.
+        return len(related[:2]) >= 2
 
     def check_component(self, component: Component) -> Iterable[Unit]:
         from weblate.trans.models import Unit  # noqa: PLC0415
@@ -165,17 +166,36 @@ class LongUntranslatedCheck(SourceCheck, BatchCheckMixin):
         if unit.timestamp > timezone.now() - timedelta(days=90):
             return False
 
+        component = unit.translation.component
+        component_stats = component.stats
+        if component_stats.is_loaded:
+            component_translated_percent = component_stats.translated_percent
+        else:
+            stats_data = component_stats.load()
+            if {"all", "translated"} <= stats_data.keys():
+                component_stats.set_data(stats_data)
+                component_translated_percent = component_stats.translated_percent
+            else:
+                # Avoid rebuilding full component stats just for this check.
+                component_data = self.get_component_translated_percent(component)
+                component_total = component_data["total"] or 0
+                component_translated_percent = (
+                    100
+                    * (component_total - (component_data["not_translated"] or 0))
+                    / component_total
+                    if component_total
+                    else 0
+                )
+        if component_translated_percent <= 0:
+            return False
+
         states = list(unit.unit_set.values_list("state", flat=True))
         total = len(states)
         not_translated = states.count(STATE_EMPTY) + sum(
             states.count(state) for state in FUZZY_STATES
         )
         translated_percent = 100 * (total - not_translated) / total
-        return (
-            total
-            and 2 * translated_percent
-            < unit.translation.component.stats.translated_percent
-        )
+        return total and 2 * translated_percent < component_translated_percent
 
     @staticmethod
     def get_component_translated_percent(component: Component):

--- a/weblate/checks/tests/test_consistency_checks.py
+++ b/weblate/checks/tests/test_consistency_checks.py
@@ -26,7 +26,7 @@ from weblate.trans.tests.test_views import (
     ComponentTestCase,
     FixtureTestCase,
 )
-from weblate.utils.state import STATE_TRANSLATED
+from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
 
 
 class PluralsCheckTest(TestCase):
@@ -113,6 +113,27 @@ class TranslatedCheckTest(FixtureTestCase):
             self.check.get_description(check),
             'Previous translation was "Nazdar svete!\n".',
         )
+
+    def test_run_checks_untranslated(self) -> None:
+        self.edit_unit("Hello, world!\n", "Nazdar svete!\n")
+        self.edit_unit("Hello, world!\n", "")
+        unit = self.get_unit()
+        Check.objects.filter(unit=unit).delete()
+        unit.clear_checks_cache()
+
+        unit.run_checks()
+
+        self.assertEqual(unit.state, STATE_EMPTY)
+        self.assertIn("translated", unit.all_checks_names)
+
+    def test_run_checks_untranslated_removes_stale_check(self) -> None:
+        unit = self.get_unit()
+        self.assertEqual(unit.state, STATE_EMPTY)
+        Check.objects.create(unit=unit, name="same")
+
+        unit.run_checks()
+
+        self.assertNotIn("same", unit.all_checks_names)
 
 
 class ReusedCheckGuardTest(SimpleTestCase):
@@ -272,6 +293,14 @@ class ConsistencyCheckTest(ComponentTestCase):
         self.add_unit(self.translation_2, "one", "One", "", increment=False)
 
         self.assertNotEqual(check.check_component(self.component), [])
+
+    def test_consistency_empty_target_run_checks(self) -> None:
+        self.add_unit(self.translation_1, "one", "One", "Jeden")
+        unit = self.add_unit(self.translation_2, "one", "One", "", increment=False)
+
+        unit.run_checks()
+
+        self.assertEqual(unit.all_checks_names, {"inconsistent"})
 
     def test_consistency_query_uses_min_max_targets(self) -> None:
         check = ConsistencyCheck()

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -1949,6 +1949,8 @@ class Unit(models.Model, LoggerMixin):
 
     @property
     def all_checks_names(self) -> set[str]:
+        if "all_checks" not in self.__dict__:
+            return set(self.check_set.values_list("name", flat=True))
         return {check.name for check in self.all_checks}
 
     @property
@@ -1992,29 +1994,32 @@ class Unit(models.Model, LoggerMixin):
             return len(self._prefetched_objects_cache["labels"])
         return self.labels.count()
 
-    def run_checks(  # noqa: C901
+    def run_checks(  # noqa: C901, PLR0912
         self, *, force_propagate: bool = False, skip_propagate: bool = False
     ) -> None:
         """Update checks for this unit."""
-        src = self.get_source_plurals()
-        tgt = self.get_target_plurals()
-
         old_checks = self.all_checks_names
         create = []
 
-        args: tuple[list[str], Unit] | tuple[list[str], list[str], Unit]
-        if self.is_source:
-            checks = CHECKS.source
-            meth = "check_source"
-            args = src, self
-        else:
-            checks = {} if self.readonly else CHECKS.target
-            meth = "check_target"
-            args = src, tgt, self
-        if self.translation.component.is_glossary:
+        component = self.translation.component
+        if component.is_glossary:
             checks = CHECKS.glossary
-            meth = "check_target"
-            args = src, tgt, self
+            target_checks = True
+        elif self.is_source:
+            checks = CHECKS.source
+            target_checks = False
+        elif self.readonly:
+            checks = {}
+            target_checks = False
+        elif self.state:
+            checks = CHECKS.target
+            target_checks = True
+        else:
+            # Most target checks ignore untranslated units in check_target().
+            # Keep checks that opt into untranslated handling so stale checks are
+            # removed and existing untranslated behavior is preserved.
+            checks = CHECKS.target_untranslated
+            target_checks = True
 
         # Initial propagation setup
         propagation: set[Literal["source", "target"]] = set()
@@ -2022,18 +2027,37 @@ class Unit(models.Model, LoggerMixin):
             propagation.add("source")
 
         # Run all checks
-        for check, check_obj in checks.items():
-            # Does the check fire?
-            if getattr(check_obj, meth)(*args):
-                if check in old_checks:
-                    # We already have this check
-                    old_checks.remove(check)
-                    # Propagation is handled later in this method
-                else:
-                    # Create new check
-                    create.append(Check(unit=self, dismissed=False, name=check))
-                    if check_obj.propagates and not skip_propagate:
-                        propagation.add(check_obj.propagates)
+        if checks:
+            src = self.get_source_plurals()
+            if target_checks:
+                tgt = self.get_target_plurals()
+                for check, check_obj in checks.items():
+                    # Does the check fire?
+                    if check_obj.check_target(src, tgt, self):
+                        if check in old_checks:
+                            # We already have this check
+                            old_checks.remove(check)
+                            # Propagation is handled later in this method
+                        else:
+                            # Create new check
+                            create.append(Check(unit=self, dismissed=False, name=check))
+                            if check_obj.propagates and not skip_propagate:
+                                propagation.add(check_obj.propagates)
+            else:
+                # Source checks mostly use the base skip logic; compute flags once.
+                all_flags = self.all_flags
+                for check, check_obj in checks.items():
+                    # Does the check fire?
+                    if check_obj.check_source_with_flags(src, self, all_flags):
+                        if check in old_checks:
+                            # We already have this check
+                            old_checks.remove(check)
+                            # Propagation is handled later in this method
+                        else:
+                            # Create new check
+                            create.append(Check(unit=self, dismissed=False, name=check))
+                            if check_obj.propagates and not skip_propagate:
+                                propagation.add(check_obj.propagates)
 
         if create:
             Check.objects.bulk_create(create, batch_size=500, ignore_conflicts=True)


### PR DESCRIPTION
- Optimized Unit.run_checks to avoid unnecessary target plural work and use a reduced target-check set for untranslated units.
- Avoided instantiating Check rows when only check names are needed.
- Added singular fast paths in check handling.
- Optimized source checks:
  - MultipleFailingCheck now stops after finding two related translations.
  - LongUntranslatedCheck avoids full stats rebuilds when cached stats are missing.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
