### PR TITLE
fix(autotranslate): avoid validating component when using mt

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,7 @@ Weblate 2026.7
 * Hardened HTML and AJAX object lookups against private project enumeration.
 * Document and translation-memory uploads now enforce :setting:`TRANSLATION_UPLOAD_MAX_SIZE`, and API document uploads validate file extensions.
 * :ref:`check-rst-syntax` now detects inline roles wrapped in stray backticks.
+* :ref:`auto-translation` no longer validates hidden component fields when using machine translation.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1128,6 +1128,13 @@ class AutoForm(forms.Form):
         """Generate choices for other components in the same project."""
         auto_id = kwargs.pop("auto_id", "id_auto_%s")
         super().__init__(*args, auto_id=auto_id, **kwargs)
+        if (
+            self.is_bound
+            and self.data.get("auto_source") == "mt"
+            and self.data.get("component")
+        ):
+            self.data = self.data.copy()
+            self.data["component"] = ""
         self.obj = obj
         self.project: Project | None = None
         machinery_settings = {}
@@ -1203,7 +1210,7 @@ class AutoForm(forms.Form):
             (engine.get_identifier(), engine.name) for engine in engines
         ]
         if "weblate" in engine_ids:
-            self.fields["engines"].initial = "weblate"
+            self.fields["engines"].initial = ["weblate"]
 
         if "q" not in self.initial:
             self.initial["q"] = "state:<translated"
@@ -1227,6 +1234,8 @@ class AutoForm(forms.Form):
         )
 
     def clean_component(self):
+        if self.cleaned_data.get("auto_source") == "mt":
+            return None
         component = self.cleaned_data["component"]
         if not component:
             return None

--- a/weblate/trans/tests/test_autotranslate.py
+++ b/weblate/trans/tests/test_autotranslate.py
@@ -19,6 +19,7 @@ from weblate.configuration.models import Setting, SettingCategory
 from weblate.lang.models import Language, Plural
 from weblate.machinery.dummy import DummyTranslation
 from weblate.trans.actions import ActionEvents
+from weblate.trans.forms import AutoForm
 from weblate.trans.models import Change, Component, PendingUnitChange, Project, Unit
 from weblate.trans.tasks import auto_translate, auto_translate_component
 from weblate.trans.tests.test_views import ViewTestCase
@@ -906,6 +907,66 @@ class AutoTranslationMtTest(ViewTestCase):
         translation = self.component3.translation_set.get(language_code="cs")
         translation.invalidate_cache()
         self.assertEqual(translation.stats.translated, expected)
+
+    def test_form_uses_list_initial_for_default_engine(self) -> None:
+        form = AutoForm(self.component3, self.user)
+
+        self.assertEqual(form.fields["engines"].initial, ["weblate"])
+
+    def test_form_ignores_component_in_machine_translation_mode(self) -> None:
+        form = AutoForm(
+            self.component3,
+            self.user,
+            {
+                "auto_source": "mt",
+                "component": "missing-component",
+                "engines": ["weblate"],
+                "threshold": "80",
+                "q": "state:empty",
+                "mode": "fuzzy",
+            },
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertIsNone(form.cleaned_data["component"])
+
+    def test_invalid_form_shows_field_errors(self) -> None:
+        path_params = {"path": [*self.component3.get_url_path(), "cs"]}
+        response = self.client.post(
+            reverse("auto_translation", kwargs=path_params),
+            {
+                "auto_source": "mt",
+                "engines": ["invalid"],
+                "threshold": "80",
+                "q": "state:empty",
+                "mode": "fuzzy",
+            },
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse("show", kwargs=path_params))
+        self.assertContains(response, "Error in parameter engines")
+        self.assertNotContains(response, "Could not process form!")
+
+    def test_locked_target_shows_specific_error(self) -> None:
+        self.component3.locked = True
+        self.component3.save(update_fields=["locked"])
+        path_params = {"path": [*self.component3.get_url_path(), "cs"]}
+        response = self.client.post(
+            reverse("auto_translation", kwargs=path_params),
+            {
+                "auto_source": "mt",
+                "engines": ["weblate"],
+                "threshold": "80",
+                "q": "state:empty",
+                "mode": "fuzzy",
+            },
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse("show", kwargs=path_params))
+        self.assertContains(response, "This translation is currently locked.")
+        self.assertNotContains(response, "Could not process form!")
 
     def test_different(self) -> None:
         """Test for automatic translation with different content."""

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -9,7 +9,7 @@ import math
 import os
 import time
 import warnings
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -806,6 +806,88 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
             ),
             "current replacement 2",
         )
+
+    @override_settings(
+        WEBLATE_MACHINERY=(
+            *settings.WEBLATE_MACHINERY,
+            "weblate.machinery.dummy.DummyTranslation",
+        )
+    )
+    def test_auto_translate_mt_ignores_persisted_component(self) -> None:
+        """Test MT auto-translation with persisted component form state."""
+        identifier = DummyTranslation.get_identifier()
+
+        def clear_auto_translation_storage() -> None:
+            with suppress(WebDriverException):
+                self.driver.execute_script(
+                    'window.localStorage.removeItem("auto-translation");'
+                )
+
+        self.addCleanup(clear_auto_translation_storage)
+
+        project = self.create_component()
+        project.machinery_settings = dict.fromkeys(
+            Setting.objects.get_settings_dict(SettingCategory.MT)
+        )
+        project.machinery_settings[identifier] = {}
+        project.save(update_fields=["machinery_settings"])
+
+        target_component = project.component_set.get(slug="django")
+        for index in range(28):
+            Component.objects.create(
+                name=f"Extra {index}",
+                slug=f"extra-{index}",
+                project=project,
+                repo="weblate://weblateorg/language-names",
+                filemask=f"extra/{index}/*.po",
+                new_base=f"extra/{index}/django.pot",
+                file_format="po",
+                source_language=target_component.source_language,
+            )
+
+        self.do_login(superuser=True)
+        self.driver.execute_script(
+            """
+            window.localStorage.setItem(
+                "auto-translation",
+                JSON.stringify({component: "missing-component"}),
+            );
+            """
+        )
+
+        self.open_component(component=target_component, project=project)
+        self.click("Operations")
+        self.click("Batch automatic translation")
+        self.click(htmlid="id_auto_auto_source_1")
+        WebDriverWait(self.driver, 10).until(
+            lambda driver: driver.execute_script(
+                """
+                const engines = document.getElementById("id_auto_engines");
+                return Boolean(engines && engines.tomselect);
+                """
+            )
+        )
+        self.driver.execute_script(
+            """
+            const engines = document.getElementById("id_auto_engines");
+            engines.tomselect.addItem(arguments[0]);
+            engines.dispatchEvent(new Event("change", {bubbles: true}));
+            """,
+            identifier,
+        )
+        query = self.driver.find_element(By.ID, "id_auto_q")
+        query.clear()
+        query.send_keys("state:empty")
+
+        with self.wait_for_page_load():
+            self.driver.find_element(
+                By.CSS_SELECTOR, 'form[data-persist="auto-translation"]'
+            ).submit()
+
+        body = self.driver.find_element(By.TAG_NAME, "body").text
+        self.assertIn("Automatic translation completed", body)
+        self.assertNotIn("Error in parameter component", body)
+        self.assertNotIn("Could not process form!", body)
 
     def test_login(self) -> None:
         # Do proper login with new user

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -1118,11 +1118,24 @@ def auto_translation(request: AuthenticatedHttpRequest, path):
             msg = "Unsupported object for auto translation"
             raise PermissionDenied(msg)
 
-    if not request.user.has_perm("translation.auto", obj):
+    permission = request.user.has_perm("translation.auto", obj)
+    if not permission:
+        reason = getattr(permission, "reason", "")
+        if update_locked and reason:
+            messages.error(request, reason)
+            return redirect(obj)
         raise PermissionDenied
 
-    if update_locked or not autoform.is_valid():
-        messages.error(request, gettext("Could not process form!"))
+    if update_locked:
+        messages.error(
+            request,
+            gettext(
+                "Automatic translation cannot be started because the target is locked."
+            ),
+        )
+        return redirect(obj)
+
+    if not autoform.is_valid():
         show_form_errors(request, autoform)
         return redirect(obj)
 


### PR DESCRIPTION
Avoid validating other component settings that are not applied in the mt mode.

Fixes #20034

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
