### PR TITLE
fix(memory): avoid douple import of translation memory

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,7 @@ Weblate 2026.7
 * Zen mode now loads large search results and glossary-heavy projects more efficiently.
 * Translate pages with filtered searches and nearby strings now load more efficiently.
 * Added :ref:`distribution-packaging` guidance for distribution maintainers.
+* Large component imports now avoid duplicate translation-memory processing.
 
 .. rubric:: Bug fixes
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -443,6 +443,32 @@ msgstr "Nazdar svete!\n"
         # 2 translations X 2 (project and shared memory) = total 7
         self.assertEqual(Memory.objects.count(), 7)
 
+    def test_component_project_tm_import_scheduled_only_when_reenabled(self) -> None:
+        with patch(
+            "weblate.trans.models.component.import_memory.delay_on_commit"
+        ) as mocked_import:
+            component = self._create_component(
+                "po", "po/*.po", name="memory", project=self.project
+            )
+
+        mocked_import.assert_not_called()
+
+        component.contribute_project_tm = False
+        with patch(
+            "weblate.trans.models.component.import_memory.delay_on_commit"
+        ) as mocked_import:
+            component.save()
+
+        mocked_import.assert_not_called()
+
+        component.contribute_project_tm = True
+        with patch(
+            "weblate.trans.models.component.import_memory.delay_on_commit"
+        ) as mocked_import:
+            component.save()
+
+        mocked_import.assert_called_once_with(self.project.id, component.pk)
+
     def test_import_unit(self) -> None:
         unit = self.get_unit()
         self.handle_unit_translation_change_with_callbacks(unit, self.user)

--- a/weblate/trans/management/commands/benchmark.py
+++ b/weblate/trans/management/commands/benchmark.py
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
 
 from django.test.utils import override_settings
 
+from weblate.lang.models import Language
 from weblate.trans.models import Component, Project
 from weblate.utils.management.base import BaseCommand
 from weblate.utils.views import create_component_from_zip
+from weblate.vcs.git import LocalRepository
 
 if TYPE_CHECKING:
     from django.core.management.base import CommandParser
@@ -29,14 +32,19 @@ class Command(BaseCommand):
         parser.add_argument("--repo", help="Test VCS repository URL")
         parser.add_argument("--filemask", help="File mask")
         parser.add_argument("--zipfile", help="Zip file")
+        parser.add_argument("--source-language", help="Source language code")
 
     def handle(self, *args, **options) -> None:
-        # Execute tasks in place
-        with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
+        # Execute tasks in place. Glossary auto-creation is disabled so the
+        # benchmark measures only the requested component import path.
+        with override_settings(
+            CELERY_TASK_ALWAYS_EAGER=True,
+            CREATE_GLOSSARIES=False,
+        ):
             project = Project.objects.get(slug=options["project"])
             # Delete any possible previous tests
             Component.objects.filter(project=project, slug="benchmark").delete()
-            params = {
+            params: dict[str, Any] = {
                 "name": "Benchmark",
                 "slug": "benchmark",
                 "repo": options["repo"],
@@ -45,11 +53,25 @@ class Command(BaseCommand):
                 "file_format": options["format"],
                 "project": project,
             }
+            if options["source_language"]:
+                params["source_language"] = Language.objects.get(
+                    code=options["source_language"]
+                )
             if options["zipfile"]:
                 params["vcs"] = "local"
                 params["repo"] = "local:"
                 params["branch"] = "main"
-                create_component_from_zip(params, options["zipfile"])
+                original_limits = LocalRepository.ZIP_IMPORT_LIMITS
+                # Benchmark archives are expected to be large; keep all ZIP
+                # member safety checks, but remove only the aggregate size cap
+                # while importing data for this command.
+                LocalRepository.ZIP_IMPORT_LIMITS = replace(
+                    original_limits, max_total_uncompressed_size=None
+                )
+                try:
+                    create_component_from_zip(params, options["zipfile"])
+                finally:
+                    LocalRepository.ZIP_IMPORT_LIMITS = original_limits
             component = Component.objects.create(**params)
             # Delete after testing
             if not options["keep"]:

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -1172,7 +1172,10 @@ class Component(  # noqa: PLR0904
         if self.key_filter and not self.has_template():
             self.key_filter = ""
 
-        update_tm = self.contribute_project_tm
+        # Newly imported units update translation memory as part of the import
+        # loop. A full component TM import is only needed when contribution is
+        # enabled later for units that already exist.
+        update_tm = False
 
         if self.id:
             old = Component.objects.get(pk=self.id)
@@ -1226,7 +1229,7 @@ class Component(  # noqa: PLR0904
 
             create = False
 
-            # detect if the component had TM contribution disabled but changed to enabled
+            # Detect if the component had TM contribution disabled but changed to enabled.
             update_tm = self.contribute_project_tm and not old.contribute_project_tm
         elif self.is_glossary:
             # Creating new glossary


### PR DESCRIPTION
- There is full import on initial load, so avoid doing that twice.
- Improve benchmarking code for easier use.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
