### PR TITLE
fix(memory): match bulk entries by exact pairs

### DIFF
--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -8,6 +8,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, TypedDict
 
 from django.db import transaction
+from django.db.models import Q
 
 from weblate.machinery.base import get_machinery_language
 from weblate.memory.models import Memory
@@ -294,16 +295,16 @@ def get_group_matching_memory(
     statuses: dict[MemoryKey, int],
 ) -> tuple[dict[MemoryKey, set[MemoryCategory]], list[Memory]]:
     origin, source_language_id, target_language_id = group_key
-    sources = {entry["source"] for _, _, entry, _ in group_entries}
-    targets = {entry["target"] for _, _, entry, _ in group_entries}
     expected_keys = {key for _, key, _, _ in group_entries}
+    matching_pairs = Q()
+    for _, _, _, source, target in expected_keys:
+        matching_pairs |= Q(source=source, target=target)
     existing = defaultdict(set)
     to_update = []
 
     for matching in Memory.objects.filter(
+        matching_pairs,
         from_file=False,
-        source__in=sources,
-        target__in=targets,
         origin=origin,
         source_language_id=source_language_id,
         target_language_id=target_language_id,

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -32,6 +32,7 @@ from weblate.memory.models import (
     load_memory_tmx_store,
 )
 from weblate.memory.tasks import (
+    get_group_matching_memory,
     handle_unit_translation_change,
     import_memory,
 )
@@ -95,6 +96,66 @@ class MemoryParserTest(SimpleTestCase):
                 ),
                 origin="missing-header.tmx",
             )
+
+    def test_bulk_matching_memory_uses_exact_pairs(self) -> None:
+        entries = [
+            (
+                0,
+                ("origin", 1, 2, "source 1", "target 1"),
+                {"source": "source 1", "target": "target 1"},
+                Memory.STATUS_ACTIVE,
+            ),
+            (
+                1,
+                ("origin", 1, 2, "source 2", "target 2"),
+                {"source": "source 2", "target": "target 2"},
+                Memory.STATUS_ACTIVE,
+            ),
+        ]
+        statuses = {key: status for _, key, _, status in entries}
+        exact_match = MagicMock(
+            origin="origin",
+            source_language_id=1,
+            target_language_id=2,
+            source="source 1",
+            target="target 1",
+            status=Memory.STATUS_PENDING,
+            user_id=None,
+            project_id=1,
+            shared=False,
+        )
+
+        with patch.object(
+            Memory.objects, "filter", return_value=[exact_match]
+        ) as filter_mock:
+            existing, to_update = get_group_matching_memory(
+                ("origin", 1, 2), entries, statuses
+            )
+
+        args, kwargs = filter_mock.call_args
+        self.assertNotIn("source__in", kwargs)
+        self.assertNotIn("target__in", kwargs)
+        self.assertEqual(
+            kwargs,
+            {
+                "from_file": False,
+                "origin": "origin",
+                "source_language_id": 1,
+                "target_language_id": 2,
+            },
+        )
+        self.assertEqual(
+            self.get_query_pairs(args[0]),
+            {("source 1", "target 1"), ("source 2", "target 2")},
+        )
+        self.assertEqual(
+            existing["origin", 1, 2, "source 1", "target 1"], {("project", 1)}
+        )
+        self.assertEqual(to_update, [exact_match])
+
+    def get_query_pairs(self, query: Q) -> set[tuple[str, str]]:
+        children = query.children if query.connector == "OR" else [query]
+        return {tuple(value for _, value in child.children) for child in children}
 
 
 class MemoryModelTest(FixtureTestCase):


### PR DESCRIPTION
### Motivation
- Batched memory updates queried existing rows with independent `source__in` and `target__in` filters which can match the Cartesian product of sources and targets and cause large DB scans and Python-side filtering.  
- This introduces a resource-amplification vector when processing attacker-controlled or large import batches and regresses the previous per-entry exact-pair lookup behavior.

### Description
- Replace the broad `source__in` / `target__in` filter in `weblate/memory/tasks.py` with an exact-pairs predicate built as an OR of `Q(source=..., target=...)` clauses so the DB only returns submitted `(source, target)` pairs.  
- Import `Q` from `django.db.models` and apply the `matching_pairs` predicate in `get_group_matching_memory` to restrict the query.  
- Add a regression test `test_bulk_matching_memory_uses_exact_pairs` in `weblate/memory/tests.py` that asserts the bulk lookup does not use `source__in`/`target__in` and that the query contains only the exact submitted pairs.  
- Preserve existing behavior for creating/updating memories and the batch size (`MEMORY_UPDATE_BATCH_SIZE`) while reducing amplification risk.

### Testing
- Ran the new targeted test with `uv run pytest weblate/memory/tests.py -k bulk_matching_memory_uses_exact_pairs`, and it passed.  
- Ran the full memory test module with `uv run pytest weblate/memory/tests.py`, and the suite passed (`53 passed`).  
- Ran lint/format checks with `uv run ruff check --fix weblate/memory/tasks.py weblate/memory/tests.py` and `uv run ruff format weblate/memory/tasks.py weblate/memory/tests.py`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4fa603908329807385dcba999875)