### PR TITLE
fix(memory): match bulk updates by exact MD5 source/target pairs

### DIFF
--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -8,6 +8,8 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, TypedDict
 
 from django.db import transaction
+from django.db.models import Q, Value
+from django.db.models.functions import MD5
 
 from weblate.machinery.base import get_machinery_language
 from weblate.memory.models import Memory
@@ -294,16 +296,18 @@ def get_group_matching_memory(
     statuses: dict[MemoryKey, int],
 ) -> tuple[dict[MemoryKey, set[MemoryCategory]], list[Memory]]:
     origin, source_language_id, target_language_id = group_key
-    sources = {entry["source"] for _, _, entry, _ in group_entries}
-    targets = {entry["target"] for _, _, entry, _ in group_entries}
     expected_keys = {key for _, key, _, _ in group_entries}
+    matching_pairs = Q()
+    for _, _, _, source, target in expected_keys:
+        matching_pairs |= Q(
+            source__md5=MD5(Value(source)), target__md5=MD5(Value(target))
+        )
     existing = defaultdict(set)
     to_update = []
 
     for matching in Memory.objects.filter(
+        matching_pairs,
         from_file=False,
-        source__in=sources,
-        target__in=targets,
         origin=origin,
         source_language_id=source_language_id,
         target_language_id=target_language_id,

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -8,12 +8,13 @@ import json
 import tempfile
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, call, patch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db.models import Q
+from django.db.models.functions import MD5
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -32,6 +33,7 @@ from weblate.memory.models import (
     load_memory_tmx_store,
 )
 from weblate.memory.tasks import (
+    get_group_matching_memory,
     handle_unit_translation_change,
     import_memory,
 )
@@ -40,6 +42,11 @@ from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.tests.utils import get_test_file
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.state import STATE_TRANSLATED
+
+if TYPE_CHECKING:
+    from weblate.memory.tasks import (
+        MemoryGroupEntry,
+    )
 
 
 def add_document(source: str = "Hello", target: str = "Ahoj") -> None:
@@ -95,6 +102,104 @@ class MemoryParserTest(SimpleTestCase):
                 ),
                 origin="missing-header.tmx",
             )
+
+    def test_bulk_matching_memory_uses_exact_md5_pairs(self) -> None:
+        entries: list[MemoryGroupEntry] = [
+            (
+                0,
+                ("origin", 1, 2, "source 1", "target 1"),
+                {
+                    "source_language_id": 1,
+                    "target_language_id": 2,
+                    "source": "source 1",
+                    "context": "",
+                    "target": "target 1",
+                    "origin": "origin",
+                    "add_shared": False,
+                    "add_project": True,
+                    "add_user": False,
+                    "user_id": None,
+                    "project_id": 1,
+                    "unit_state": STATE_TRANSLATED,
+                },
+                Memory.STATUS_ACTIVE,
+            ),
+            (
+                1,
+                ("origin", 1, 2, "source 2", "target 2"),
+                {
+                    "source_language_id": 1,
+                    "target_language_id": 2,
+                    "source": "source 2",
+                    "context": "",
+                    "target": "target 2",
+                    "origin": "origin",
+                    "add_shared": False,
+                    "add_project": True,
+                    "add_user": False,
+                    "user_id": None,
+                    "project_id": 1,
+                    "unit_state": STATE_TRANSLATED,
+                },
+                Memory.STATUS_ACTIVE,
+            ),
+        ]
+        statuses = {key: status for _, key, _, status in entries}
+        exact_match = MagicMock(
+            origin="origin",
+            source_language_id=1,
+            target_language_id=2,
+            source="source 1",
+            target="target 1",
+            status=Memory.STATUS_PENDING,
+            user_id=None,
+            project_id=1,
+            shared=False,
+        )
+
+        with patch.object(
+            Memory.objects, "filter", return_value=[exact_match]
+        ) as filter_mock:
+            existing, to_update = get_group_matching_memory(
+                ("origin", 1, 2), entries, statuses
+            )
+
+        args, kwargs = filter_mock.call_args
+        self.assertNotIn("source__in", kwargs)
+        self.assertNotIn("target__in", kwargs)
+        self.assertEqual(
+            kwargs,
+            {
+                "from_file": False,
+                "origin": "origin",
+                "source_language_id": 1,
+                "target_language_id": 2,
+            },
+        )
+        self.assertEqual(
+            self.get_query_pairs(args[0]),
+            {("source 1", "target 1"), ("source 2", "target 2")},
+        )
+        self.assertEqual(
+            existing["origin", 1, 2, "source 1", "target 1"], {("project", 1)}
+        )
+        self.assertEqual(to_update, [exact_match])
+
+    def get_query_pairs(self, query: Q) -> set[tuple[str, str]]:
+        children = query.children if query.connector == "OR" else [query]
+        pairs = set()
+        for child in children:
+            self.assertIsInstance(child, Q)
+            lookups = dict(cast("Any", child).children)
+            self.assertEqual(set(lookups), {"source__md5", "target__md5"})
+            source = lookups["source__md5"]
+            target = lookups["target__md5"]
+            self.assertIsInstance(source, MD5)
+            self.assertIsInstance(target, MD5)
+            pairs.add(
+                (source.source_expressions[0].value, target.source_expressions[0].value)
+            )
+        return pairs
 
 
 class MemoryModelTest(FixtureTestCase):


### PR DESCRIPTION
### Motivation
- The bulk memory updater previously used independent `source__in` and `target__in` filters which can match the cross-product of sources and targets and amplify DB work (N×N) before Python-side filtering.
- The change must preserve use of the existing MD5-based memory index so large memories continue to use the indexed lookup rather than scanning text fields.

### Description
- Replace the broad `source__in` / `target__in` filtering with an OR-chain of exact `(source, target)` predicates expressed as `source__md5=MD5(Value(source))` and `target__md5=MD5(Value(target))` combined in a `Q()` object so the `memory_md5_index` can be used.
- Add imports for `Q`, `Value`, and `MD5` in `weblate/memory/tasks.py` and use a `matching_pairs` predicate passed into `Memory.objects.filter(...)`.
- Add a regression test `test_bulk_matching_memory_uses_exact_md5_pairs` in `weblate/memory/tests.py` that patches `Memory.objects.filter`, asserts no `source__in`/`target__in` kwargs are passed, and verifies MD5 pair lookups are built and matching entries are updated.
- Files changed: `weblate/memory/tasks.py`, `weblate/memory/tests.py`.

### Testing
- Ran formatting/linting with `uv run ruff` on the modified files and fixed style issues; the checks passed for the updated files.
- Ran the new unit test with `uv run python -m pytest weblate/memory/tests.py::MemoryParserTest::test_bulk_matching_memory_uses_exact_md5_pairs -q`, which passed.
- Ran the full memory test module with `uv run python -m pytest weblate/memory/tests.py -q`, and all memory tests passed (`53 passed`).
- Ran a targeted `mypy` check for the modified files and resolved typing issues introduced by the test additions, yielding no remaining mypy failures in those files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e565be15883298baf3f51ddfb9806)