### PR TITLE
fix(edit): handle empty cached search snapshots

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,7 @@ Weblate 2026.7
 * Project and workspace translation license defaults now follow component and project licenses more closely.
 * Component and category API ``PATCH`` requests no longer remove the category when the field is omitted.
 * Hardened HTML and AJAX object lookups against private project enumeration.
+* Out-of-range cached search offsets no longer cause translate form submissions to fail.
 * Document and translation-memory uploads now enforce :setting:`TRANSLATION_UPLOAD_MAX_SIZE`, and API document uploads validate file extensions.
 * :ref:`check-rst-syntax` now detects inline roles wrapped in stray backticks.
 * :ref:`auto-translation` no longer validates hidden component fields when using machine translation.

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -102,6 +102,7 @@ class SearchSessionTest(TestCase):
                 {"partial_ids": [10, 11], "partial_offset": 3}, 2, 1
             )
         )
+        self.assertIsNone(get_search_session_snapshot({"ids": [1, 2, 3]}, 5, 1))
 
     def test_search_session_snapshot_rejects_malformed_ids(self) -> None:
         self.assertIsNone(get_search_session_snapshot({"ids": ["invalid"]}, 1, 1))

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -457,6 +457,8 @@ def get_search_session_snapshot(
             offset = max(len(unit_ids) - page_size + 1, 1)
         page_offset = offset - 1
         page_ids = unit_ids[page_offset : page_offset + page_size + 1]
+        if not page_ids:
+            return None
         return SearchSnapshot(
             ids=page_ids,
             offset=offset,


### PR DESCRIPTION
### Motivation
- A POST fast path for translate submissions could index `snapshot.ids[0]` when a cached full-search snapshot was sliced to an empty window, causing an `IndexError` and a 500 response.
- The root cause was that `get_search_session_snapshot` returned a non-null `SearchSnapshot` with `ids=[]` for out-of-range offsets on full cached `ids` lists.
- The change prevents availability issues triggered by a user-supplied offset against their own cached search session.

### Description
- In `weblate/trans/views/edit.py` update `get_search_session_snapshot` to return `None` when the computed `page_ids` for a full cached `ids` window is empty, matching the existing partial snapshot behavior. 
- Add a regression assertion in `weblate/trans/tests/test_edit.py` to ensure out-of-range full cached offsets produce `None` from `get_search_session_snapshot`.
- Add an unreleased changelog entry in `docs/changes.rst` noting the fix for translate form submissions.

### Testing
- Ran `uv run pytest weblate/trans/tests/test_edit.py::SearchSessionTest::test_search_session_snapshot_handles_full_and_partial_windows` which passed (1 test, 1 passed). 
- Ran `uv run pytest weblate/trans/tests/test_edit.py::SearchSessionTest` which passed (4 tests, 4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fff11addc832985d6e532afc08e67)