### PR TITLE
fix(search): use is:needs-editing when searching for all fuzzy states

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,7 @@ Weblate 2026.7
 * Document and translation-memory uploads now enforce :setting:`TRANSLATION_UPLOAD_MAX_SIZE`, and API document uploads validate file extensions.
 * :ref:`check-rst-syntax` now detects inline roles wrapped in stray backticks.
 * :ref:`auto-translation` no longer validates hidden component fields when using machine translation.
+* :guilabel:`Strings marked for edit` links now include all strings needing editing, checking, or rewriting.
 
 .. rubric:: Compatibility
 

--- a/weblate/templates/mail/snippets/stats.html
+++ b/weblate/templates/mail/snippets/stats.html
@@ -51,12 +51,12 @@
 <tr>
   <td>{% get_filter_name "fuzzy" %}</td>
   <td>
-    {% if url %}<a href="{{ url }}?q=state:needs-editing">{% endif %}
+    {% if url %}<a href="{{ url }}?q=is:needs-editing">{% endif %}
       {{ stats.fuzzy|intcomma }}
       {% if url %}</a>{% endif %}
   </td>
   <td>
-    {% if url %}<a href="{{ url }}?q=state:needs-editing">{% endif %}
+    {% if url %}<a href="{{ url }}?q=is:needs-editing">{% endif %}
       {{ stats.fuzzy_percent|percent_format }}
       {% if url %}</a>{% endif %}
   </td>

--- a/weblate/trans/filter.py
+++ b/weblate/trans/filter.py
@@ -25,7 +25,7 @@ class FilterRegistry:
             ("nottranslated", gettext_lazy("Untranslated strings"), "state:empty"),
             ("todo", gettext_lazy("Unfinished strings"), "state:<translated"),
             ("translated", gettext_lazy("Translated strings"), "state:>=translated"),
-            ("fuzzy", gettext_lazy("Strings marked for edit"), "state:needs-editing"),
+            ("fuzzy", gettext_lazy("Strings marked for edit"), "is:needs-editing"),
             ("suggestions", gettext_lazy("Strings with suggestions"), "has:suggestion"),
             ("variants", gettext_lazy("Strings with variants"), "has:variant"),
             ("screenshots", gettext_lazy("Strings with screenshots"), "has:screenshot"),

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -24,6 +24,8 @@ from weblate.utils.ratelimit import reset_rate_limit
 from weblate.utils.state import (
     STATE_APPROVED,
     STATE_FUZZY,
+    STATE_NEEDS_CHECKING,
+    STATE_NEEDS_REWRITING,
     STATE_READONLY,
     STATE_TRANSLATED,
 )
@@ -655,6 +657,37 @@ class BulkEditTest(ViewTestCase):
                 },
             )
         )
+
+    def test_bulk_edit_fuzzy_alias_includes_substates(self) -> None:
+        self.unit.state = STATE_NEEDS_REWRITING
+        self.unit.save(update_fields=["state"])
+
+        response = self.client.post(
+            reverse("bulk-edit", kwargs=self.kw_translation),
+            {"q": "is:needs-editing", "state": STATE_TRANSLATED},
+            follow=True,
+        )
+
+        self.assertContains(response, "Bulk edit completed, 1 string was updated.")
+        self.unit.refresh_from_db()
+        self.assertEqual(self.unit.state, STATE_TRANSLATED)
+
+    def test_bulk_edit_or_query_includes_substates(self) -> None:
+        self.unit.state = STATE_NEEDS_CHECKING
+        self.unit.save(update_fields=["state"])
+
+        response = self.client.post(
+            reverse("bulk-edit", kwargs=self.kw_translation),
+            {
+                "q": "state:needs-checking OR state:needs-rewriting",
+                "state": STATE_TRANSLATED,
+            },
+            follow=True,
+        )
+
+        self.assertContains(response, "Bulk edit completed, 1 string was updated.")
+        self.unit.refresh_from_db()
+        self.assertEqual(self.unit.state, STATE_TRANSLATED)
 
     def test_bulk_edit_requires_bulk_permission_per_unit(self) -> None:
         limited_user = User.objects.create_user(

--- a/weblate/trans/tests/test_widgets.py
+++ b/weblate/trans/tests/test_widgets.py
@@ -13,6 +13,7 @@ from django.test import SimpleTestCase
 from django.urls import reverse
 
 from weblate.trans.checklists import TranslationChecklistMixin
+from weblate.trans.filter import FILTERS
 from weblate.trans.models import Translation
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.views.widgets import WIDGETS
@@ -54,9 +55,12 @@ class EngageTaskChecklistTest(SimpleTestCase):
             [(task.url, task.total) for task in tasks],
             [
                 ("/translate/?q=state:empty", 1),
-                ("/translate/?q=state:needs-editing", 2),
+                ("/translate/?q=is:needs-editing", 2),
             ],
         )
+
+    def test_fuzzy_filter_query_matches_fuzzy_states(self) -> None:
+        self.assertEqual(FILTERS.get_filter_query("fuzzy"), "is:needs-editing")
 
     def test_engage_tasks_hide_empty_review(self) -> None:
         tasks = self.get_engage_tasks(enable_review=True)
@@ -135,7 +139,7 @@ class WidgetsTest(FixtureTestCase):
         )
         self.assertContains(response, "row engage-task-list justify-content-center")
         self.assertContains(response, "?q=state:empty")
-        self.assertNotContains(response, "?q=state:needs-editing")
+        self.assertNotContains(response, "?q=is:needs-editing")
         self.assertNotContains(response, "?q=has:check%20AND%20state:%3E=translated")
         self.assertNotContains(response, '?q=has:check"')
         self.assertNotContains(response, "?q=has:suggestion#suggestions")

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -22,6 +22,8 @@ from weblate.utils.state import (
     STATE_APPROVED,
     STATE_EMPTY,
     STATE_FUZZY,
+    STATE_NEEDS_CHECKING,
+    STATE_NEEDS_REWRITING,
     STATE_READONLY,
     STATE_TRANSLATED,
 )
@@ -433,6 +435,12 @@ class UnitQueryParserTest(SearchTestCase):
         self.assert_query("is:approved", Q(state=STATE_APPROVED))
         self.assert_query("is:read-only", Q(state=STATE_READONLY))
         self.assert_query("is:fuzzy", Q(state__in=FUZZY_STATES))
+        self.assert_query("is:needs-editing", Q(state__in=FUZZY_STATES))
+
+    def test_fuzzy_state_aliases(self) -> None:
+        self.assert_query("state:needs-editing", Q(state=STATE_FUZZY))
+        self.assert_query("state:needs-rewriting", Q(state=STATE_NEEDS_REWRITING))
+        self.assert_query("state:needs-checking", Q(state=STATE_NEEDS_CHECKING))
 
     def test_changed_by(self) -> None:
         self.assert_query_sql(


### PR DESCRIPTION
When broadening the fuzzy states, the stats were updated, but the search links still use the specific state instead of broad is queries.

Fixes #19969

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
