### PR TITLE
fix(docs): correct Spanish screenshot path markup

### DIFF
--- a/docs/locales/es/LC_MESSAGES/docs.po
+++ b/docs/locales/es/LC_MESSAGES/docs.po
@@ -21202,7 +21202,7 @@ msgid ""
 "metadata/android/en-US/images/phoneScreenshots/`."
 msgstr ""
 "Almacénalos en una ruta de repositorio estable, por ejemplo debajo de "
-":file:`fastlane/metadata/android/es/images/phoneScreenshots/`.`"
+":file:`fastlane/metadata/android/en-US/images/phoneScreenshots/`."
 
 #: admin/translating.rst:203
 msgid "Configure :ref:`component-screenshot_filemask` for that path."


### PR DESCRIPTION
### Motivation
- Fix an active Spanish translation in `docs/locales/es/LC_MESSAGES/docs.po` that contained malformed reStructuredText (a stray trailing backtick in a `:file:` role) and an incorrect localized example path (`es` instead of `en-US`) which caused a visible rendering defect in localized documentation.

### Description
- Updated the Spanish `msgstr` for `admin/translating.rst:201` to restore the source-language example path to `fastlane/metadata/android/en-US/images/phoneScreenshots/` and removed the extra trailing backtick so the `:file:` role is well-formed.

### Testing
- Ran `msgfmt -c -o /tmp/docs-es.mo docs/locales/es/LC_MESSAGES/docs.po` which succeeded, ran `uv run sphinx-build -b html -q -D language=es docs /tmp/weblate-doc-es docs/admin/translating.rst` which completed (with unrelated intersphinx/prolog warnings), verified the generated HTML contains the `en-US` path using `rg -n "fastlane/metadata/android/(es|en-US)/images/phoneScreenshots" /tmp/weblate-doc-es/admin/translating.html`, and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa13d497083299cb6b027ec9393b5)