### PR TITLE
fix(component): execute files processing in the same task if possible

### DIFF
--- a/docs/admin/continuous.rst
+++ b/docs/admin/continuous.rst
@@ -187,6 +187,12 @@ Availability of individual actions depends on permissions, the configured
 version control system, whether pushing is configured, and whether the selected
 object can be locked.
 
+Operations that read repository content, such as updating, resetting, or
+rescanning, also reconcile translation files in Weblate. Added or removed
+translation files are reflected after this processing finishes. Glossary
+translations are cleaned up only for Weblate-managed glossaries and only when no
+non-glossary component still uses the language.
+
 .. list-table::
    :header-rows: 1
 
@@ -203,7 +209,7 @@ object can be locked.
      - Send committed translations upstream when automatic push is disabled or delayed.
 
    * - :guilabel:`Update`
-     - Fetches upstream changes and integrates them using the component's configured :ref:`component-merge_style`.
+     - Fetches upstream changes, integrates them using the component's configured :ref:`component-merge_style`, and reconciles translation files.
      - Bring Weblate in sync with upstream using the default integration strategy.
 
    * - :guilabel:`Update with merge`
@@ -223,11 +229,11 @@ object can be locked.
      - Freeze translation changes while doing repository maintenance outside Weblate.
 
    * - :guilabel:`Reset and discard`
-     - Resets Weblate's local repository to upstream and discards pending Weblate changes.
+     - Resets Weblate's local repository to upstream, discards pending Weblate changes, and reconciles translation files.
      - Use when upstream should overwrite the local Weblate repository state.
 
    * - :guilabel:`Reset and reapply`
-     - Resets Weblate's local repository to upstream while preserving pending translations. See :ref:`manage-vcs-reset-reapply`.
+     - Resets Weblate's local repository to upstream, reconciles translation files, and reapplies pending translations. See :ref:`manage-vcs-reset-reapply`.
      - Recover from diverged history while keeping pending Weblate translations.
 
    * - :guilabel:`Cleanup`
@@ -239,7 +245,7 @@ object can be locked.
      - Repair cases where repository files became out of sync with the database state.
 
    * - :guilabel:`Rescan`
-     - Re-reads translation files from the local repository into Weblate.
+     - Re-reads translation files from the local repository into Weblate and removes translations whose files no longer match the component configuration.
      - Import file changes after manual repository work or file creation.
 
 .. _manage-vcs-reset-reapply:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,7 @@ Weblate 2026.7
 * Hardened HTML and AJAX object lookups against private project enumeration.
 * Document and translation-memory uploads now enforce :setting:`TRANSLATION_UPLOAD_MAX_SIZE`, and API document uploads validate file extensions.
 * :ref:`check-rst-syntax` now detects inline roles wrapped in stray backticks.
+* Repository reset and update progress now includes follow-up translation-file reconciliation.
 * :ref:`auto-translation` no longer validates hidden component fields when using machine translation.
 
 .. rubric:: Compatibility

--- a/weblate/templates/component-progress.html
+++ b/weblate/templates/component-progress.html
@@ -16,7 +16,7 @@
 
   <div class="card"
        data-progress-url="{% url 'api:task-detail' pk=object.background_task %}">
-    <div class="card-header">{% translate "Component is being updated…" %}</div>
+    <div class="card-header">{% translate "Repository changes are being processed…" %}</div>
     <div class="card-body">
 
       <div class="progress">

--- a/weblate/templates/multi-progress.html
+++ b/weblate/templates/multi-progress.html
@@ -13,7 +13,7 @@
 {% block content %}
 
   <div class="card">
-    <div class="card-header">{% translate "Components are being updated…" %}</div>
+    <div class="card-header">{% translate "Repository changes are being processed…" %}</div>
     <div class="card-body">
 
       {% for component in components %}

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -139,7 +139,7 @@ from weblate.utils.licenses import (
     get_license_url,
     is_libre,
 )
-from weblate.utils.lock import WeblateLock
+from weblate.utils.lock import WeblateLock, WeblateLockTimeoutError
 from weblate.utils.random import get_random_identifier
 from weblate.utils.regex import (
     compile_regex,
@@ -2385,10 +2385,16 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         if result:
             # create translation objects for all files
-            self.create_translations(request=request)
+            parse_error = None
+            try:
+                self.create_translations(request=request)
+            except FileParseError as error:
+                parse_error = error
 
             # Push after possible merge
             self.push_if_needed(do_update=False)
+            if parse_error is not None:
+                raise parse_error
 
         if not self.repo_needs_push():
             self.delete_alert("RepositoryChanges")
@@ -3792,10 +3798,27 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 change=change,
             )
 
+        # When already in a Celery repository task, scan inline so the same
+        # task tracks progress instead of finishing before a nested load task.
+        if current_task and current_task.request.id:
+            try:
+                return self.create_translations_immediate(
+                    force=force,
+                    force_scan=force_scan,
+                    langs=langs,
+                    request=request,
+                    changed_template=changed_template,
+                    from_link=from_link,
+                    change=change,
+                )
+            except WeblateLockTimeoutError:
+                self.log_info("scheduling update in background after lock timeout")
+        else:
+            self.log_info("scheduling update in background")
+
         # ruff: ignore[import-outside-top-level]
         from weblate.trans.tasks import perform_load
 
-        self.log_info("scheduling update in background")
         self.queue_background_task(
             perform_load,
             pk=self.pk,
@@ -4022,6 +4045,11 @@ class Component(  # ruff: ignore[too-many-public-methods]
                     Translation.objects.filter(
                         id__in=[translation.id for translation in todelete]
                     ).delete()
+                    if not self.is_glossary:
+                        # ruff: ignore[import-outside-top-level]
+                        from weblate.glossary.tasks import cleanup_stale_glossaries
+
+                        cleanup_stale_glossaries.delay_on_commit(self.project.id)
                     # Indicate a change to invalidate stats
                     was_change = True
 

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -40,6 +40,7 @@ from weblate.trans.tests.test_views import (
     ViewTestCase,
 )
 from weblate.utils.files import remove_tree
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import STATE_EMPTY, STATE_READONLY, STATE_TRANSLATED
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.models import VCS_REGISTRY
@@ -1380,6 +1381,25 @@ class ComponentErrorTest(RepoTestCase):
     def test_failed_update(self) -> None:
         self.assertFalse(self.component.do_update())
 
+    def test_update_pushes_before_reraising_parse_error(self) -> None:
+        error = FileParseError("parse failed")
+
+        with (
+            patch.object(self.component, "configure_repo"),
+            patch.object(self.component, "update_remote_branch", return_value=True),
+            patch.object(self.component, "configure_branch"),
+            patch.object(self.component, "repo_needs_merge", return_value=True),
+            patch.object(self.component, "needs_commit_upstream", return_value=False),
+            patch.object(self.component, "update_branch", return_value=True),
+            patch.object(self.component, "create_translations", side_effect=error),
+            patch.object(self.component, "push_if_needed") as push_if_needed,
+            self.assertRaises(FileParseError) as context,
+        ):
+            self.component.do_update()
+
+        self.assertIs(context.exception, error)
+        push_if_needed.assert_called_once_with(do_update=False)
+
     def test_failed_update_remote(self) -> None:
         self.assertFalse(self.component.update_remote_branch())
 
@@ -1483,6 +1503,63 @@ class ComponentErrorTest(RepoTestCase):
         self.component.source_language = Language.objects.get(code="cs")
         with self.assertRaises(ValidationError):
             self.component.clean()
+
+    def test_create_translations_queues_outside_celery_task(self) -> None:
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch("weblate.trans.models.component.current_task", None),
+            patch.object(self.component, "create_translations_immediate") as immediate,
+            patch.object(self.component, "queue_background_task") as queue_task,
+        ):
+            self.assertFalse(self.component.create_translations(force=True))
+
+        immediate.assert_not_called()
+        queue_task.assert_called_once()
+
+    def test_create_translations_runs_immediately_inside_celery_task(self) -> None:
+        task = SimpleNamespace(request=SimpleNamespace(id="task-id"))
+        request = SimpleNamespace(user=None)
+
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch("weblate.trans.models.component.current_task", task),
+            patch.object(
+                self.component, "create_translations_immediate", return_value=True
+            ) as immediate,
+            patch.object(self.component, "queue_background_task") as queue_task,
+        ):
+            self.assertTrue(
+                self.component.create_translations(force=True, request=request)
+            )
+
+        immediate.assert_called_once_with(
+            force=True,
+            force_scan=False,
+            langs=None,
+            request=request,
+            changed_template=False,
+            from_link=False,
+            change=None,
+        )
+        queue_task.assert_not_called()
+
+    def test_create_translations_queues_after_celery_lock_timeout(self) -> None:
+        task = SimpleNamespace(request=SimpleNamespace(id="task-id"))
+
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch("weblate.trans.models.component.current_task", task),
+            patch.object(
+                self.component,
+                "create_translations_immediate",
+                side_effect=WeblateLockTimeoutError("locked", lock=self.component.lock),
+            ) as immediate,
+            patch.object(self.component, "queue_background_task") as queue_task,
+        ):
+            self.assertFalse(self.component.create_translations(force=True))
+
+        immediate.assert_called_once()
+        queue_task.assert_called_once()
 
 
 class FileSyncPendingUnitOptimizationTest(ComponentTestCase):
@@ -2334,17 +2411,21 @@ class ResetDiscardRevisionTest(ComponentTestCase):
         filename = translation.filename
         pathlib.Path(cast("str", translation.get_filename())).unlink()
 
-        self.assertTrue(
-            self.component.create_translations_immediate(
-                force=True, request=self.get_request()
+        with patch(
+            "weblate.glossary.tasks.cleanup_stale_glossaries.delay_on_commit"
+        ) as cleanup_stale_glossaries:
+            self.assertTrue(
+                self.component.create_translations_immediate(
+                    force=True, request=self.get_request()
+                )
             )
-        )
 
         self.assertFalse(
             self.component.translation_set.filter(language_code="cs").exists()
         )
         self.assert_removed_translation_change(filename)
         self.assertFalse(self.project.has_language(Language.objects.get(code="cs")))
+        cleanup_stale_glossaries.assert_called_once_with(self.project.id)
 
     def test_reset_removes_upstream_deleted_translation_with_change(self) -> None:
         translation = self.component.translation_set.get(language_code="cs")


### PR DESCRIPTION
The git operations were moved to background tasks recently and they typically trigger create_translations task. Doing that as a separate task makes the progress confusing as the progress completes, but there is still additional task to process. We now inline the processing in the task if possible (no other update in progress).

Fixes #20088

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
