### PR TITLE
fix(vcs): avoid duplicating git command on retry

### DIFF
--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -472,9 +472,8 @@ class Repository:
         """Execute the command using popen."""
         if args is None:
             raise RepositoryError(0, "Not supported functionality")
-        if not fullcmd:
-            args = [cls._cmd, *list(args)]
-        text_cmd = " ".join(args)
+        cmd = args if fullcmd else [cls._cmd, *args]
+        text_cmd = " ".join(cmd)
         # These are mutually exclusive, gevent actually checks
         # for their presence, not a value.
         kwargs: SubprocessArgs = {}
@@ -485,7 +484,7 @@ class Repository:
 
         try:
             process = subprocess.run(
-                args=args,
+                args=cmd,
                 cwd=cwd,
                 env=environment or {} if local else cls._getenv(environment, cwd=cwd),
                 stdout=subprocess.PIPE,

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -9,6 +9,7 @@ import json
 import os.path
 import re
 import shutil
+import subprocess
 import tempfile
 from contextlib import ExitStack
 from datetime import datetime
@@ -263,6 +264,36 @@ class RepositoryTest(SimpleTestCase):
         error = RepositoryError(-1, "Can not switch subversion URL")
 
         self.assertEqual(str(error), "Can not switch subversion URL (-1)")
+
+    def test_popen_retry_does_not_duplicate_command(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            args=["git", "reset", "--hard"],
+            returncode=1,
+            stdout="fatal: lock failed",
+            stderr=None,
+        )
+        successful_process = subprocess.CompletedProcess(
+            args=["git", "reset", "--hard"],
+            returncode=0,
+            stdout="",
+            stderr=None,
+        )
+
+        with (
+            patch.object(GitRepository, "should_retry_popen", return_value=True),
+            patch(
+                "weblate.vcs.base.subprocess.run",
+                side_effect=[failed_process, successful_process],
+            ) as run,
+        ):
+            # ruff: ignore[private-member-access]
+            GitRepository._popen(["reset", "--hard"], cwd="/tmp")
+
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["args"] for call in run.call_args_list],
+            [["git", "reset", "--hard"], ["git", "reset", "--hard"]],
+        )
 
     def test_popen_missing_working_tree_raises_repository_error(self) -> None:
         cwd = os.path.join(tempfile.gettempdir(), "missing-working-tree")

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -9,6 +9,7 @@ import json
 import os.path
 import re
 import shutil
+# ruff: ignore[suspicious-subprocess-import]
 import subprocess
 import tempfile
 from contextlib import ExitStack
@@ -286,7 +287,7 @@ class RepositoryTest(SimpleTestCase):
                 side_effect=[failed_process, successful_process],
             ) as run,
         ):
-            # ruff: ignore[private-member-access]
+            # ruff: ignore[private-member-access, hardcoded-temp-file]
             GitRepository._popen(["reset", "--hard"], cwd="/tmp")
 
         self.assertEqual(run.call_count, 2)

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -9,6 +9,7 @@ import json
 import os.path
 import re
 import shutil
+
 # ruff: ignore[suspicious-subprocess-import]
 import subprocess
 import tempfile

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -281,14 +281,15 @@ class RepositoryTest(SimpleTestCase):
         )
 
         with (
+            tempfile.TemporaryDirectory() as cwd,
             patch.object(GitRepository, "should_retry_popen", return_value=True),
             patch(
                 "weblate.vcs.base.subprocess.run",
                 side_effect=[failed_process, successful_process],
             ) as run,
         ):
-            # ruff: ignore[private-member-access, hardcoded-temp-file]
-            GitRepository._popen(["reset", "--hard"], cwd="/tmp")
+            # ruff: ignore[private-member-access]
+            GitRepository._popen(["reset", "--hard"], cwd=cwd)
 
         self.assertEqual(run.call_count, 2)
         self.assertEqual(


### PR DESCRIPTION
### Motivation

- A retry path in the VCS subprocess wrapper could prepend the VCS executable a second time, producing commands like `git git reset --hard` and triggering runtime errors observed in production.

### Description

- Change `_popen` in `weblate/vcs/base.py` to build a separate `cmd` list (`cmd = args if fullcmd else [cls._cmd, *args]`) and pass `cmd` to `subprocess.run` so the original `args` remains unchanged for retry logic.
- Add a regression test `test_popen_retry_does_not_duplicate_command` in `weblate/vcs/tests/test_vcs.py` that mocks `subprocess.run` and `should_retry_popen` to assert both attempts use `["git", "reset", "--hard"]` (no duplicated executable).
- Preserve existing behavior for breadcrumbs, environment handling, and retry decisions; only the subprocess argument construction was adjusted.

### Testing

- Ran the new regression test with `uv run pytest weblate/vcs/tests/test_vcs.py::RepositoryTest::test_popen_retry_does_not_duplicate_command` and it passed.
- Ran the test class with `uv run pytest weblate/vcs/tests/test_vcs.py::RepositoryTest` and all tests passed (`27 passed`).
- Performed a quick repository check (`git diff --check`) with no issues reported.
- Formatting/linting via the repository pre-commit hooks (`uv run prek run ruff-format && uv run prek run ruff`) could not complete in this environment because cloning pre-commit hooks from GitHub failed with a network/403 error, so those checks were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a327dc56b3c8329845f128673eabc9f)