### PR TITLE
fix(translations): handle large pending commits asynchronously

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,7 @@ Weblate 2026.7
 * Added :wladmin:`analyze_translator_work` to estimate realistic daily translator throughput from change history.
 * :ref:`mt-deepl` now handles DeepL API versions internally, uses v3 for glossary management and language discovery, and no longer supports DeepL API v1.
 * :ref:`Bulk accepting suggestions <suggestions>` now confirms the number of affected suggestions, can approve them for reviewers, and processes the acceptance in the background.
+* Committing large numbers of pending translations now queues browser requests in the background and avoids duplicate repository commit tasks.
 
 .. rubric:: Bug fixes
 

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -17,7 +17,7 @@ from urllib.parse import quote as urlquote
 from urllib.parse import urlparse
 
 import regex
-from celery import current_task
+from celery import current_task, uuid
 from celery.result import AsyncResult
 from django.conf import settings
 from django.core.cache import cache
@@ -232,6 +232,7 @@ AZURE_REPOS_REGEXP = [
 REPOWEB_BRANCH = "{{branch}}"
 REPOWEB_FILENAME = "{{filename}}"
 REPOWEB_LINE = "{{line}}"
+BACKGROUND_TASK_TTL = 6 * 3600
 
 
 def perform_on_link(func):
@@ -269,6 +270,13 @@ class LocalHeadChange:
     def refresh_new_head(self) -> str:
         self.new_head = self.component.get_local_head_revision()
         return self.new_head
+
+
+class CommitTaskPayload(TypedDict):
+    reason: str
+    user_id: int | None
+    force_scan: bool
+    previous_head: str | None
 
 
 def prefetch_tasks(components):
@@ -1565,6 +1573,14 @@ class Component(  # ruff: ignore[too-many-public-methods]
     def update_key(self) -> str:
         return f"component-update-{self.pk}"
 
+    @cached_property
+    def commit_task_key(self) -> str:
+        return f"component-commit-{self.effective_repo_component.pk}"
+
+    @cached_property
+    def commit_task_reschedule_key(self) -> str:
+        return f"component-commit-reschedule-{self.effective_repo_component.pk}"
+
     def delete_background_task(self) -> None:
         delete_task_metadata(self.background_task_id)
         cache.delete(self.update_key)
@@ -1574,13 +1590,104 @@ class Component(  # ruff: ignore[too-many-public-methods]
             if not current_task:
                 return
             task = current_task.request
-        cache.set(self.update_key, task.id, 6 * 3600)
+        cache.set(self.update_key, task.id, BACKGROUND_TASK_TTL)
         store_task_metadata(task.id, component_id=self.pk)
 
     def queue_background_task(self, task, /, *args, **kwargs) -> None:
         transaction.on_commit(
             lambda: self.store_background_task(task.delay(*args, **kwargs))
         )
+
+    @staticmethod
+    def get_current_task_id() -> str | None:
+        if not current_task:
+            return None
+        return getattr(current_task.request, "id", None)
+
+    def delete_commit_task(
+        self, *, clear_reschedule: bool = True, require_match: bool = False
+    ) -> bool:
+        task_id = cache.get(self.commit_task_key)
+        if require_match and task_id != self.get_current_task_id():
+            return False
+        if task_id:
+            delete_task_metadata(task_id)
+        cache.delete(self.commit_task_key)
+        if clear_reschedule:
+            cache.delete(self.commit_task_reschedule_key)
+        return True
+
+    def finish_commit_task(self) -> CommitTaskPayload | None:
+        if not self.delete_commit_task(clear_reschedule=False, require_match=True):
+            return None
+        payload = cache.get(self.commit_task_reschedule_key)
+        cache.delete(self.commit_task_reschedule_key)
+        if isinstance(payload, dict):
+            return cast("CommitTaskPayload", payload)
+        return None
+
+    @perform_on_link
+    def queue_commit_pending(
+        self,
+        reason: str,
+        *,
+        user_id: int | None = None,
+        force_scan: bool = False,
+        previous_head: str | None = None,
+        deduplicate: bool = True,
+    ) -> None:
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.tasks import perform_commit
+
+        def schedule_commit() -> None:
+            payload: CommitTaskPayload = {
+                "reason": reason,
+                "user_id": user_id,
+                "force_scan": force_scan,
+                "previous_head": previous_head,
+            }
+            task_kwargs = {
+                "user_id": user_id,
+                "force_scan": force_scan,
+                "previous_head": previous_head,
+            }
+            if settings.CELERY_TASK_ALWAYS_EAGER:
+                self.log_info("scheduling commit")
+                perform_commit.delay(self.pk, reason, **task_kwargs)
+                return
+
+            task_id = uuid()
+            if deduplicate:
+                task_added = cache.add(
+                    self.commit_task_key, task_id, BACKGROUND_TASK_TTL
+                )
+                if not task_added:
+                    cache.set(
+                        self.commit_task_reschedule_key,
+                        payload,
+                        BACKGROUND_TASK_TTL,
+                    )
+                    self.log_info("skipped commit scheduling: commit already scheduled")
+                    return
+            else:
+                cache.set(self.commit_task_key, task_id, BACKGROUND_TASK_TTL)
+
+            self.log_info("scheduling commit")
+            store_task_metadata(task_id, component_id=self.pk)
+            try:
+                perform_commit.apply_async(
+                    args=(self.pk, reason),
+                    kwargs=task_kwargs,
+                    task_id=task_id,
+                )
+            except Exception:
+                self.delete_commit_task()
+                raise
+
+        if settings.CELERY_TASK_ALWAYS_EAGER:
+            schedule_commit()
+        else:
+            transaction.on_commit(schedule_commit)
 
     @cached_property
     def background_task_id(self):
@@ -3198,7 +3305,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         return translation
 
     @perform_on_link
-    def commit_pending(  # ruff: ignore[complex-structure]
+    def commit_pending(
         self, reason: str, user: User | None, skip_push: bool = False
     ) -> bool:
         """Check whether there is any translation to be committed."""
@@ -3210,24 +3317,13 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 scope="weblate", name="commit", verbose="Background commit"
             )
 
-        pending_changes = list(
-            PendingUnitChange.objects.for_component(
-                self, apply_filters=True, include_linked=True
-            ).values_list("pk", "unit__translation_id")
-        )
+        pending_translation_ids = PendingUnitChange.objects.for_component(
+            self, apply_filters=True, include_linked=True
+        ).values_list("unit__translation_id", flat=True)
 
-        # Short-circuit if no committable changes remain after all filters (including blocking check)
-        # This prevents unnecessary processing when blocking changes filter out all pending changes
-        if not pending_changes:
-            return True
-
-        changes_by_translation = defaultdict(list)
-        for pending_change_pk, translation_id in pending_changes:
-            changes_by_translation[translation_id].append(pending_change_pk)
-
-        # Get all translation with pending changes, source translation first
+        # Get all translations with committable changes, source translation first.
         translations = sorted(
-            Translation.objects.filter(pk__in=list(changes_by_translation.keys()))
+            Translation.objects.filter(pk__in=pending_translation_ids)
             .distinct()
             .prefetch_related("component"),
             key=lambda translation: not translation.is_source,
@@ -3272,9 +3368,8 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
                     components[component.pk] = component
                 with self.start_tracing_span("commit_pending"):
-                    pending_changes_pk = changes_by_translation[translation.pk]
                     translation_changed = translation._commit_pending(  # ruff: ignore[private-member-access]
-                        reason, user, pending_changes_pk
+                        reason, user
                     )
                 was_changed |= translation_changed
                 if translation_changed and component.has_template():
@@ -5603,9 +5698,6 @@ class Component(  # ruff: ignore[too-many-public-methods]
     def get_lock_change(
         self, *, user: User | None, lock: bool = True, auto: bool = False
     ) -> Change:
-        # ruff: ignore[import-outside-top-level]
-        from weblate.trans.tasks import perform_commit
-
         change = Change(
             component=self,
             user=user,
@@ -5613,9 +5705,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
             details={"auto": auto},
         )
         if lock and not auto:
-            self.queue_background_task(
-                perform_commit, self.pk, "lock", user_id=user.id if user else None
-            )
+            self.queue_commit_pending("lock", user_id=user.id if user else None)
         return change
 
     @cached_property

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 from contextlib import contextmanager, suppress
 from datetime import UTC
-from itertools import chain
+from itertools import batched, chain
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, Literal, NotRequired, TypedDict, overload
 
@@ -874,9 +874,7 @@ class Translation(
         return self.component.commit_pending(reason, user, skip_push=skip_push)
 
     @transaction.atomic
-    def _commit_pending(
-        self, reason: str, user: User | None, pending_changes_pk: list[int]
-    ) -> bool:
+    def _commit_pending(self, reason: str, user: User | None) -> bool:
         """
         Commit pending translation.
 
@@ -886,28 +884,27 @@ class Translation(
         - the source translation needs to be committed first
         - signals and alerts are updated by the caller
         - repository push is handled by the caller
-        - pending_changes_pk only has pending changes for units associated with this translation
         """
         if not self.filename:
-            return self._commit_pending_without_filename(pending_changes_pk)
-        return self._commit_pending_with_filename(reason, user, pending_changes_pk)
+            return self._commit_pending_without_filename()
+        return self._commit_pending_with_filename(reason, user)
 
-    def _commit_pending_without_filename(self, pending_changes_pk: list[int]) -> bool:
+    def _commit_pending_without_filename(self) -> bool:
         """Discard uncommittable pending changes for missing file translations."""
+        pending_changes_qs = PendingUnitChange.objects.for_translation(
+            self, apply_filters=True
+        )
+        pending_changes_count = pending_changes_qs.count()
         report_error(
             "Attempted to commit translation without filename",
             project=self.component.project,
             message=True,
-            extra_log=f"translation={self.full_slug}, pending_changes={len(pending_changes_pk)}",
+            extra_log=f"translation={self.full_slug}, pending_changes={pending_changes_count}",
         )
-        pending_changes = list(
-            PendingUnitChange.objects.filter(pk__in=pending_changes_pk).values_list(
-                "unit_id", flat=True
-            )
-        )
+        pending_changes = list(pending_changes_qs.values_list("unit_id", flat=True))
         if pending_changes:
             pending_unit_ids = set(pending_changes)
-            PendingUnitChange.objects.filter(pk__in=pending_changes_pk).delete()
+            pending_changes_qs.delete()
             remaining_pending_unit_ids = set(
                 PendingUnitChange.objects.filter(
                     unit_id__in=pending_unit_ids
@@ -923,9 +920,7 @@ class Translation(
         self.log_error("skipping commit due to missing filename")
         return False
 
-    def _commit_pending_with_filename(
-        self, reason: str, user: User | None, pending_changes_pk: list[int]
-    ) -> bool:
+    def _commit_pending_with_filename(self, reason: str, user: User | None) -> bool:
         """Commit pending changes when translation file exists."""
         try:
             store = self.store
@@ -946,9 +941,9 @@ class Translation(
             self.log_error("skipping commit due to error: %s", error)
             return False
 
-        pending_changes: list[PendingUnitChange] = list(
-            PendingUnitChange.objects.filter(pk__in=pending_changes_pk)
-            .prefetch_related("unit", "author")
+        pending_changes = list(
+            PendingUnitChange.objects.for_translation(self, apply_filters=True)
+            .select_related("unit", "author")
             .order_by("timestamp")
             .select_for_update()
         )
@@ -1004,24 +999,8 @@ class Translation(
                 if prev is None or change.timestamp > prev:
                     success_times[change.unit_id] = change.timestamp
 
-        for unit_id, ts in success_times.items():
-            PendingUnitChange.objects.filter(
-                unit_id=unit_id, timestamp__lte=ts
-            ).delete()
-
-        # Clear disk states for units that have no more pending changes
-        units_with_remaining_changes = set(
-            PendingUnitChange.objects.filter(
-                unit_id__in=units_to_clear_disk_state
-            ).values_list("unit_id", flat=True)
-        )
-
-        units_to_actually_clear = (
-            units_to_clear_disk_state - units_with_remaining_changes
-        )
-
-        if units_to_actually_clear:
-            Unit.objects.filter(id__in=units_to_actually_clear).clear_disk_state()
+        self.delete_successful_pending_changes(success_times)
+        self.clear_committed_disk_states(units_to_clear_disk_state)
 
         # Update stats (the translated flag might have changed)
         self.invalidate_cache()
@@ -1030,6 +1009,44 @@ class Translation(
         self.drop_store_cache()
 
         return True
+
+    @staticmethod
+    def delete_successful_pending_changes(success_times: dict[int, datetime]) -> None:
+        """Delete applied pending changes in bounded batches."""
+        pending_to_delete = []
+        for unit_ids in batched(success_times, 1000):
+            for pk, unit_id, timestamp in (
+                PendingUnitChange.objects.filter(unit_id__in=unit_ids)
+                .values_list("pk", "unit_id", "timestamp")
+                .iterator(chunk_size=1000)
+            ):
+                if timestamp <= success_times[unit_id]:
+                    pending_to_delete.append(pk)
+                    if len(pending_to_delete) >= 1000:
+                        PendingUnitChange.objects.filter(
+                            pk__in=pending_to_delete
+                        ).delete()
+                        pending_to_delete.clear()
+
+        if pending_to_delete:
+            PendingUnitChange.objects.filter(pk__in=pending_to_delete).delete()
+
+    @staticmethod
+    def clear_committed_disk_states(units_to_clear_disk_state: set[int]) -> None:
+        """Clear disk states for units that no longer have pending changes."""
+        units_with_remaining_changes = set()
+        for unit_ids in batched(units_to_clear_disk_state, 1000):
+            units_with_remaining_changes.update(
+                PendingUnitChange.objects.filter(unit_id__in=unit_ids).values_list(
+                    "unit_id", flat=True
+                )
+            )
+
+        units_to_actually_clear = (
+            units_to_clear_disk_state - units_with_remaining_changes
+        )
+        for unit_ids in batched(units_to_actually_clear, 1000):
+            Unit.objects.filter(id__in=unit_ids).clear_disk_state()
 
     @staticmethod
     def _group_changes_by_author(
@@ -1247,7 +1264,9 @@ class Translation(
         """Update backend file and unit."""
         changes_status = {}
         updated = False
-        for pending_change in pending_changes:
+        for index, pending_change in enumerate(pending_changes, start=1):
+            if index % 1000 == 0:
+                self.component.repository.lock.reacquire()
             unit = pending_change.unit
 
             # update the unit in memory so that get_target_plurals returns

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -63,6 +63,47 @@ if TYPE_CHECKING:
     from weblate.workspaces.models import Workspace
 
 
+def commit_lock_retries_exhausted() -> bool:
+    """Check whether a commit lock timeout will no longer be retried."""
+    if not current_task:
+        return True
+
+    if current_task.max_retries is None:
+        return False
+    return current_task.request.retries >= current_task.max_retries
+
+
+def schedule_deferred_commit(component: Component) -> None:
+    followup = component.finish_commit_task()
+    if followup:
+        component.queue_commit_pending(
+            followup["reason"],
+            user_id=followup["user_id"],
+            force_scan=followup["force_scan"],
+            previous_head=followup["previous_head"],
+        )
+
+
+def perform_component_commit(
+    component: Component,
+    reason: str,
+    user: User | None,
+    *,
+    force_scan: bool = False,
+    previous_head: str | None = None,
+) -> None:
+    with component.repository.lock:
+        component.commit_pending(reason, user=user)
+        if force_scan:
+            component.trigger_post_update(
+                previous_head=previous_head,
+                skip_push=False,
+                user=user,
+                parse_after_update=True,
+            )
+            component.create_translations(force=True)
+
+
 @app.task(
     trail=False,
     autoretry_for=(WeblateLockTimeoutError,),
@@ -148,18 +189,24 @@ def perform_commit(
     force_scan: bool = False,
     previous_head: str | None = None,
 ) -> None:
-    user = User.objects.get(pk=user_id) if user_id else None
     component = Component.objects.get(pk=pk)
-    with component.repository.lock:
-        component.commit_pending(reason, user=user)
-        if force_scan:
-            component.trigger_post_update(
-                previous_head=previous_head,
-                skip_push=False,
-                user=user,
-                parse_after_update=True,
-            )
-            component.create_translations(force=True)
+    try:
+        user = User.objects.get(pk=user_id) if user_id else None
+        perform_component_commit(
+            component,
+            reason,
+            user,
+            force_scan=force_scan,
+            previous_head=previous_head,
+        )
+    except WeblateLockTimeoutError:
+        if commit_lock_retries_exhausted():
+            schedule_deferred_commit(component)
+        raise
+    except Exception:
+        component.delete_commit_task(require_match=True)
+        raise
+    schedule_deferred_commit(component)
 
 
 @app.task(
@@ -192,7 +239,7 @@ def commit_pending(
         if logger:
             logger(f"Committing {component}")
 
-        perform_commit.delay(component.pk, "commit_pending")
+        component.queue_commit_pending("commit_pending")
 
 
 @app.task(trail=False)

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -13,10 +13,12 @@ from typing import cast
 from unittest.mock import Mock, patch
 
 from django.contrib.messages import get_messages
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db.models import F
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
+from django.utils import timezone
 from translate.storage.base import ParseError
 
 from weblate.auth.models import setup_project_groups
@@ -1561,6 +1563,88 @@ class ComponentErrorTest(RepoTestCase):
 
         immediate.assert_called_once()
         queue_task.assert_called_once()
+
+    def test_queue_commit_pending_deduplicates_repository_tasks(self) -> None:
+        cache.delete(self.component.commit_task_key)
+        cache.delete(self.component.commit_task_reschedule_key)
+
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch("weblate.trans.models.component.uuid", return_value="commit-task-id"),
+            patch("weblate.trans.tasks.perform_commit.apply_async") as apply_async,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self.component.queue_commit_pending("commit")
+            self.component.queue_commit_pending("commit")
+
+        apply_async.assert_called_once_with(
+            args=(self.component.pk, "commit"),
+            kwargs={
+                "user_id": None,
+                "force_scan": False,
+                "previous_head": None,
+            },
+            task_id="commit-task-id",
+        )
+        self.assertEqual(cache.get(self.component.commit_task_key), "commit-task-id")
+        self.assertEqual(
+            cache.get(self.component.commit_task_reschedule_key),
+            {
+                "reason": "commit",
+                "user_id": None,
+                "force_scan": False,
+                "previous_head": None,
+            },
+        )
+        self.component.delete_commit_task()
+        self.assertIsNone(cache.get(self.component.commit_task_reschedule_key))
+
+    def test_queue_commit_pending_does_not_reopen_finished_task(self) -> None:
+        cache.delete(self.component.commit_task_key)
+        cache.delete(self.component.commit_task_reschedule_key)
+
+        def delete_commit_task(*args, **kwargs) -> None:
+            self.component.delete_commit_task()
+
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch("weblate.trans.models.component.uuid", return_value="commit-task-id"),
+            patch(
+                "weblate.trans.tasks.perform_commit.apply_async",
+                side_effect=delete_commit_task,
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self.component.queue_commit_pending("commit")
+
+        self.assertIsNone(cache.get(self.component.commit_task_key))
+        self.assertIsNone(cache.get(self.component.commit_task_reschedule_key))
+
+
+class PendingChangeCleanupTest(SimpleTestCase):
+    def test_delete_successful_pending_changes_batches_lookup(self) -> None:
+        success_times = {unit_id: timezone.now() for unit_id in range(1001)}
+
+        def filter_pending_changes(**kwargs):
+            queryset = Mock()
+            queryset.values_list.return_value.iterator.return_value = iter(())
+            return queryset
+
+        with patch(
+            "weblate.trans.models.translation.PendingUnitChange.objects.filter",
+            side_effect=filter_pending_changes,
+        ) as pending_filter:
+            Translation.delete_successful_pending_changes(success_times)
+
+        self.assertEqual(pending_filter.call_count, 2)
+        self.assertEqual(
+            len(pending_filter.call_args_list[0].kwargs["unit_id__in"]),
+            1000,
+        )
+        self.assertEqual(
+            len(pending_filter.call_args_list[1].kwargs["unit_id__in"]),
+            1,
+        )
 
 
 class FileSyncPendingUnitOptimizationTest(ComponentTestCase):

--- a/weblate/trans/tests/test_git_views.py
+++ b/weblate/trans/tests/test_git_views.py
@@ -4,10 +4,13 @@
 
 """Test for Git manipulation views."""
 
+from unittest.mock import patch
+
 from django.contrib.messages import get_messages
+from django.test.utils import override_settings
 from django.urls import reverse
 
-from weblate.trans.models.pending import PendingUnitChange
+from weblate.trans.models import Component, PendingUnitChange
 from weblate.trans.tests.test_views import ViewTestCase
 
 
@@ -38,6 +41,23 @@ class GitNoChangeProjectTest(ViewTestCase):
     def test_commit(self) -> None:
         response = self.client.post(self.get_test_url("commit"))
         self.assertRedirects(response, self.get_expected_redirect())
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_commit_queues_background_task(self) -> None:
+        with patch.object(
+            Component, "queue_commit_pending", autospec=True
+        ) as queue_commit:
+            response = self.client.post(self.get_test_url("commit"))
+
+        self.assertRedirects(response, self.get_expected_redirect())
+        if self.TEST_TYPE == "translation" and not self.translation.needs_commit():
+            queue_commit.assert_not_called()
+            self.assertEqual(list(get_messages(response.wsgi_request)), [])
+        else:
+            self.assertGreaterEqual(queue_commit.call_count, 1)
+            for call in queue_commit.call_args_list:
+                self.assertEqual(call.args[1], "commit")
+                self.assertEqual(call.kwargs, {"user_id": self.user.id})
 
     def test_update(self) -> None:
         response = self.client.post(self.get_test_url("update"))
@@ -139,6 +159,23 @@ class GitNoChangeTranslationTest(GitNoChangeProjectTest):
     """Testing of translation git manipulations."""
 
     TEST_TYPE = "translation"
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_commit_clean_translation_does_not_queue_sibling_changes(self) -> None:
+        sibling = self.component.translation_set.exclude(pk=self.translation.pk).first()
+        self.assertIsNotNone(sibling)
+        self.change_unit("Hallo Welt!\n", translation=sibling)
+        self.assertFalse(self.translation.needs_commit())
+        self.assertTrue(sibling.needs_commit())
+
+        with patch.object(
+            Component, "queue_commit_pending", autospec=True
+        ) as queue_commit:
+            response = self.client.post(self.get_test_url("commit"))
+
+        self.assertRedirects(response, self.get_expected_redirect())
+        queue_commit.assert_not_called()
+        self.assertEqual(list(get_messages(response.wsgi_request)), [])
 
 
 class GitChangeProjectTest(GitNoChangeProjectTest):

--- a/weblate/trans/tests/test_tasks.py
+++ b/weblate/trans/tests/test_tasks.py
@@ -6,12 +6,15 @@ import os
 import time
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.db import connection
-from django.test.utils import CaptureQueriesContext
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils import timezone
 
+from weblate.auth.models import User
 from weblate.checks.tasks import finalize_component_checks
 from weblate.trans.models import Category, Component, PendingUnitChange, Suggestion
 from weblate.trans.models.project import CommitPolicyChoices
@@ -21,11 +24,13 @@ from weblate.trans.tasks import (
     cleanup_suggestions,
     commit_pending,
     daily_update_checks,
+    perform_commit,
     update_checks,
     update_remotes,
 )
 from weblate.trans.tests.test_views import ComponentTestCase
 from weblate.utils.files import remove_tree
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import STATE_FUZZY, STATE_TRANSLATED
 from weblate.utils.tasks import (
     update_language_stats_parents,
@@ -181,9 +186,215 @@ class TasksTest(ComponentTestCase):
         commit_pending(hours=1)
         self.assertEqual(component2.count_pending_units, 0)
 
+    def test_perform_commit_keeps_commit_task_on_pending_lock_retry(self) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        task = SimpleNamespace(
+            request=SimpleNamespace(id="commit-task-id", retries=2), max_retries=3
+        )
+
+        with (
+            patch("weblate.trans.models.component.current_task", task),
+            patch("weblate.trans.tasks.current_task", task),
+            patch.object(Component, "commit_pending", side_effect=lock_timeout),
+            self.assertRaises(WeblateLockTimeoutError),
+        ):
+            perform_commit.run(self.component.pk, "commit")
+
+        self.assertEqual(cache.get(self.component.commit_task_key), "commit-task-id")
+        cache.delete(self.component.commit_task_key)
+
+    def test_perform_commit_clears_commit_task_on_exhausted_lock_retry(self) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        task = SimpleNamespace(
+            request=SimpleNamespace(id="commit-task-id", retries=3), max_retries=3
+        )
+
+        with (
+            patch("weblate.trans.models.component.current_task", task),
+            patch("weblate.trans.tasks.current_task", task),
+            patch.object(Component, "commit_pending", side_effect=lock_timeout),
+            self.assertRaises(WeblateLockTimeoutError),
+        ):
+            perform_commit.run(self.component.pk, "commit")
+
+        self.assertIsNone(cache.get(self.component.commit_task_key))
+
+    def test_perform_commit_keeps_other_commit_task_on_exhausted_lock_retry(
+        self,
+    ) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        task = SimpleNamespace(
+            request=SimpleNamespace(id="background-task-id", retries=3), max_retries=3
+        )
+
+        with (
+            patch("weblate.trans.models.component.current_task", task),
+            patch("weblate.trans.tasks.current_task", task),
+            patch.object(Component, "commit_pending", side_effect=lock_timeout),
+            self.assertRaises(WeblateLockTimeoutError),
+        ):
+            perform_commit.run(self.component.pk, "commit")
+
+        self.assertEqual(cache.get(self.component.commit_task_key), "commit-task-id")
+        cache.delete(self.component.commit_task_key)
+
+    def test_perform_commit_schedules_deferred_commit_on_exhausted_lock_retry(
+        self,
+    ) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        cache.set(
+            self.component.commit_task_reschedule_key,
+            {
+                "reason": "commit",
+                "user_id": self.user.id,
+                "force_scan": False,
+                "previous_head": None,
+            },
+        )
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        task = SimpleNamespace(
+            request=SimpleNamespace(id="commit-task-id", retries=3), max_retries=3
+        )
+
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch("weblate.trans.models.component.current_task", task),
+            patch("weblate.trans.tasks.current_task", task),
+            patch.object(Component, "commit_pending", side_effect=lock_timeout),
+            patch("weblate.trans.models.component.uuid", return_value="next-task-id"),
+            patch.object(perform_commit, "apply_async") as apply_async,
+            self.captureOnCommitCallbacks(execute=True),
+            self.assertRaises(WeblateLockTimeoutError),
+        ):
+            perform_commit.run(self.component.pk, "commit")
+
+        apply_async.assert_called_once_with(
+            args=(self.component.pk, "commit"),
+            kwargs={
+                "user_id": self.user.id,
+                "force_scan": False,
+                "previous_head": None,
+            },
+            task_id="next-task-id",
+        )
+        self.assertEqual(cache.get(self.component.commit_task_key), "next-task-id")
+        self.assertIsNone(cache.get(self.component.commit_task_reschedule_key))
+        self.component.delete_commit_task()
+
+    def test_perform_commit_schedules_deferred_commit_request(self) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        cache.set(
+            self.component.commit_task_reschedule_key,
+            {
+                "reason": "commit",
+                "user_id": self.user.id,
+                "force_scan": False,
+                "previous_head": None,
+            },
+        )
+
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch(
+                "weblate.trans.models.component.current_task",
+                SimpleNamespace(request=SimpleNamespace(id="commit-task-id")),
+            ),
+            patch(
+                "weblate.trans.tasks.current_task",
+                SimpleNamespace(request=SimpleNamespace(id="commit-task-id")),
+            ),
+            patch.object(Component, "commit_pending", return_value=True),
+            patch("weblate.trans.models.component.uuid", return_value="next-task-id"),
+            patch.object(perform_commit, "apply_async") as apply_async,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            perform_commit.run(self.component.pk, "commit_pending")
+
+        apply_async.assert_called_once_with(
+            args=(self.component.pk, "commit"),
+            kwargs={
+                "user_id": self.user.id,
+                "force_scan": False,
+                "previous_head": None,
+            },
+            task_id="next-task-id",
+        )
+        self.assertEqual(cache.get(self.component.commit_task_key), "next-task-id")
+        self.assertIsNone(cache.get(self.component.commit_task_reschedule_key))
+        self.component.delete_commit_task()
+
+    def test_perform_commit_keeps_other_commit_task_on_success(self) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        cache.set(
+            self.component.commit_task_reschedule_key,
+            {
+                "reason": "commit",
+                "user_id": self.user.id,
+                "force_scan": False,
+                "previous_head": None,
+            },
+        )
+
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch(
+                "weblate.trans.models.component.current_task",
+                SimpleNamespace(request=SimpleNamespace(id="background-task-id")),
+            ),
+            patch(
+                "weblate.trans.tasks.current_task",
+                SimpleNamespace(request=SimpleNamespace(id="background-task-id")),
+            ),
+            patch.object(Component, "commit_pending", return_value=True),
+            patch.object(perform_commit, "apply_async") as apply_async,
+        ):
+            perform_commit.run(self.component.pk, "commit")
+
+        apply_async.assert_not_called()
+        self.assertEqual(cache.get(self.component.commit_task_key), "commit-task-id")
+        self.assertEqual(
+            cache.get(self.component.commit_task_reschedule_key),
+            {
+                "reason": "commit",
+                "user_id": self.user.id,
+                "force_scan": False,
+                "previous_head": None,
+            },
+        )
+        self.component.delete_commit_task()
+
+    def test_perform_commit_clears_commit_task_on_missing_user(self) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        cache.set(
+            self.component.commit_task_reschedule_key,
+            {
+                "reason": "commit",
+                "user_id": self.user.id,
+                "force_scan": False,
+                "previous_head": None,
+            },
+        )
+        task = SimpleNamespace(request=SimpleNamespace(id="commit-task-id"))
+
+        with (
+            patch("weblate.trans.models.component.current_task", task),
+            patch("weblate.trans.tasks.current_task", task),
+            patch.object(Component, "commit_pending") as commit_pending_mock,
+            self.assertRaises(User.DoesNotExist),
+        ):
+            perform_commit.run(self.component.pk, "commit", user_id=-1)
+
+        commit_pending_mock.assert_not_called()
+        self.assertIsNone(cache.get(self.component.commit_task_key))
+        self.assertIsNone(cache.get(self.component.commit_task_reschedule_key))
+
     @patch("weblate.trans.tasks.perform_commit")
     def test_commit_pending_with_ineligible_changes(self, mock_perform_commit) -> None:
         """Test that perform_commit is not called when all changes are ineligible."""
+        mock_perform_commit.delay.return_value.id = "commit-task-id"
         self.project.commit_policy = CommitPolicyChoices.WITHOUT_NEEDS_EDITING
         self.project.save()
 
@@ -266,7 +477,11 @@ class TasksTest(ComponentTestCase):
 
         commit_pending()
         mock_perform_commit.delay.assert_called_with(
-            self.component.pk, "commit_pending"
+            self.component.pk,
+            "commit_pending",
+            user_id=None,
+            force_scan=False,
+            previous_head=None,
         )
 
         # actually call commit_pending on the component to test count_pending_units is updated

--- a/weblate/trans/views/git.py
+++ b/weblate/trans/views/git.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
@@ -74,6 +75,21 @@ def execute_locked(
             report_error("Repository lock timeout", project=obj.component.project)
 
     return redirect_param(obj, "#repository")
+
+
+def queue_commit(request: AuthenticatedHttpRequest, obj) -> bool:
+    """Queue commit operation for browser requests."""
+    user_id = request.user.id
+    if isinstance(obj, Project):
+        for component in obj.all_repo_components:
+            component.queue_commit_pending("commit", user_id=user_id)
+    elif isinstance(obj, Translation):
+        if not obj.needs_commit():
+            return False
+        obj.component.queue_commit_pending("commit", user_id=user_id)
+    else:
+        obj.queue_commit_pending("commit", user_id=user_id)
+    return True
 
 
 @login_required
@@ -195,6 +211,14 @@ def commit(request: AuthenticatedHttpRequest, path: list[str]) -> HttpResponseBa
     obj = parse_path(request, path, (Project, Component, Translation))
     if not request.user.has_perm("vcs.commit", obj):
         raise PermissionDenied
+
+    if not settings.CELERY_TASK_ALWAYS_EAGER:
+        result = queue_commit(request, obj)
+        if result:
+            messages.success(
+                request, gettext("Pending translations are being committed.")
+            )
+        return redirect_param(obj, "#repository")
 
     return execute_locked(
         request,


### PR DESCRIPTION
- Deduplicate repository commit tasks per effective component.
- Process pending changes per translation and batch cleanup queries.
- Queue browser-triggered commits instead of blocking requests.

Fixes #20020

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
