### PR TITLE
fix(checks): preserve MDX expression context in SafeMDX check

### DIFF
--- a/weblate/checks/mdx.py
+++ b/weblate/checks/mdx.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from weblate.trans.models import Unit
 
-_JSX_TAG_NAME_RE = re.compile(r"[A-Za-z][\w.:-]*")
+_JSX_TAG_NAME_RE = re.compile(r"[$_A-Za-z][\w.$:-]*")
 _ATTR_NAME_RE = re.compile(r"([A-Za-z_:][\w:.-]*)\s*=\s*$")
 
 # Various lexical contexts tracked while scanning a JSX expression.

--- a/weblate/checks/mdx.py
+++ b/weblate/checks/mdx.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext_lazy
@@ -14,6 +15,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from weblate.trans.models import Unit
+
+_JSX_TAG_RE = re.compile(r"<(/?)([A-Za-z][\w.:-]*)(?:\s[^<>]*)?(/?)>")
+_ATTR_NAME_RE = re.compile(r"([A-Za-z_:][\w:.-]*)\s*=\s*$")
 
 # Various lexical contexts tracked while scanning a JSX expression.
 _CODE = 0
@@ -173,11 +177,52 @@ class SafeMDXCheck(TargetCheck):
 
     def check_single(self, source: str, target: str, unit: Unit) -> bool:
         """Check the target has the same JSX expressions as the source."""
-        expected = list(self.get_jsx_expression_matches(source))
-        found = list(self.get_jsx_expression_matches(target))
-        return sorted(found) != sorted(expected)
+        expected = list(self.get_jsx_expression_signatures(source))
+        found = list(self.get_jsx_expression_signatures(target))
+        return found != expected
+
+    def get_jsx_expression_signatures(
+        self, text: str
+    ) -> Iterator[tuple[str, str, tuple[str, ...], str]]:
+        """Extract JSX expressions together with their syntactic context."""
+        for start, expression in self._iter_jsx_expressions(text):
+            yield (*self.get_jsx_expression_context(text, start), expression)
+
+    def get_jsx_expression_context(
+        self, text: str, start: int
+    ) -> tuple[str, str, tuple[str, ...]]:
+        """Return whether an expression appears in JSX text or an attribute."""
+        stack = self.get_jsx_element_stack(text[:start])
+        last_open = text.rfind("<", 0, start)
+        last_close = text.rfind(">", 0, start)
+        if last_open > last_close:
+            before_expression = text[last_open + 1 : start]
+            tag = before_expression.split(maxsplit=1)[0].lstrip("/")
+            if tag:
+                stack = (*stack, tag)
+            attr_match = _ATTR_NAME_RE.search(before_expression)
+            if attr_match:
+                return ("attribute", attr_match.group(1), stack)
+            return ("tag", "", stack)
+        return ("text", "", stack)
+
+    def get_jsx_element_stack(self, text: str) -> tuple[str, ...]:
+        """Return a best-effort stack of JSX elements open at the end of text."""
+        stack: list[str] = []
+        for match in _JSX_TAG_RE.finditer(text):
+            closing, tag, self_closing = match.groups()
+            if closing:
+                if tag in stack:
+                    del stack[stack.index(tag) :]
+            elif not self_closing:
+                stack.append(tag)
+        return tuple(stack)
 
     def get_jsx_expression_matches(self, text: str) -> Iterator[str]:
+        for _start, expression in self._iter_jsx_expressions(text):
+            yield expression
+
+    def _iter_jsx_expressions(self, text: str) -> Iterator[tuple[int, str]]:
         i = 0
         length = len(text)
         while i < length:
@@ -196,7 +241,7 @@ class SafeMDXCheck(TargetCheck):
                 # JSX expression
                 close = _scan_expression(text, i)
                 if close is not None:
-                    yield text[i : close + 1]
+                    yield i, text[i : close + 1]
                     i = close + 1
                     continue
             i += 1

--- a/weblate/checks/mdx.py
+++ b/weblate/checks/mdx.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from weblate.trans.models import Unit
 
-_JSX_TAG_RE = re.compile(r"<(/?)([A-Za-z][\w.:-]*)(?:\s[^<>]*)?(/?)>")
+_JSX_TAG_NAME_RE = re.compile(r"[A-Za-z][\w.:-]*")
 _ATTR_NAME_RE = re.compile(r"([A-Za-z_:][\w:.-]*)\s*=\s*$")
 
 # Various lexical contexts tracked while scanning a JSX expression.
@@ -164,6 +164,114 @@ def _skip_code_span(text: str, start: int) -> int | None:
     return None
 
 
+def _scan_jsx_tag(
+    text: str, start: int, limit: int | None = None
+) -> tuple[bool, str, bool, int | None] | None:
+    """Scan a JSX tag starting at ``start``."""
+    length = len(text) if limit is None else min(limit, len(text))
+    if text[start] != "<" or start + 1 >= len(text):
+        return None
+
+    i = start + 1
+    closing = text[i] == "/"
+    if closing:
+        i += 1
+
+    tag_match = _JSX_TAG_NAME_RE.match(text, i)
+    if tag_match is None:
+        return None
+
+    tag = tag_match.group()
+    quote = ""
+    i = tag_match.end()
+    while i < length:
+        char = text[i]
+        if quote:
+            if char == "\\":
+                i += 1
+            elif char == quote:
+                quote = ""
+        elif char in {'"', "'"}:
+            quote = char
+        elif char == "{":
+            close = _scan_expression(text, i)
+            if close is None or close >= length:
+                return (closing, tag, False, None)
+            i = close
+        elif char == ">":
+            self_closing = not closing and text[start + 1 : i].rstrip().endswith("/")
+            return (closing, tag, self_closing, i)
+        elif char == "<":
+            return None
+        i += 1
+
+    return (closing, tag, False, None)
+
+
+def _iter_jsx_tags(text: str) -> Iterator[tuple[bool, str, bool]]:
+    """Yield closed JSX tags while ignoring expressions and code spans."""
+    i = 0
+    length = len(text)
+    while i < length:
+        char = text[i]
+        if char == "\\":
+            i += 2
+            continue
+        if char == "`":
+            close = _skip_code_span(text, i)
+            if close is not None:
+                i = close + 1
+                continue
+        if char == "{":
+            close = _scan_expression(text, i)
+            if close is not None:
+                i = close + 1
+                continue
+        if char == "<":
+            tag = _scan_jsx_tag(text, i)
+            if tag is not None:
+                closing, tag_name, self_closing, end = tag
+                if end is None:
+                    break
+                yield closing, tag_name, self_closing
+                i = end + 1
+                continue
+        i += 1
+
+
+def _find_unclosed_jsx_tag(text: str, start: int) -> tuple[int, str] | None:
+    """Find an opening JSX tag containing ``start``."""
+    i = 0
+    while i < start:
+        char = text[i]
+        if char == "\\":
+            i += 2
+            continue
+        if char == "`":
+            close = _skip_code_span(text, i)
+            if close is not None and close < start:
+                i = close + 1
+                continue
+        if char == "{":
+            close = _scan_expression(text, i)
+            if close is not None and close < start:
+                i = close + 1
+                continue
+        if char == "<":
+            tag = _scan_jsx_tag(text, i, start)
+            if tag is not None:
+                closing, tag_name, _self_closing, end = tag
+                if end is None:
+                    if closing:
+                        return None
+                    return (i, tag_name)
+                i = end + 1
+                continue
+        i += 1
+
+    return None
+
+
 class SafeMDXCheck(TargetCheck):
     """Check for unsafe MDX content."""
 
@@ -193,13 +301,11 @@ class SafeMDXCheck(TargetCheck):
     ) -> tuple[str, str, tuple[str, ...]]:
         """Return whether an expression appears in JSX text or an attribute."""
         stack = self.get_jsx_element_stack(text[:start])
-        last_open = text.rfind("<", 0, start)
-        last_close = text.rfind(">", 0, start)
-        if last_open > last_close:
-            before_expression = text[last_open + 1 : start]
-            tag = before_expression.split(maxsplit=1)[0].lstrip("/")
-            if tag:
-                stack = (*stack, tag)
+        tag_context = _find_unclosed_jsx_tag(text, start)
+        if tag_context is not None:
+            tag_start, tag = tag_context
+            before_expression = text[tag_start + 1 : start]
+            stack = (*stack, tag)
             attr_match = _ATTR_NAME_RE.search(before_expression)
             if attr_match:
                 return ("attribute", attr_match.group(1), stack)
@@ -209,11 +315,12 @@ class SafeMDXCheck(TargetCheck):
     def get_jsx_element_stack(self, text: str) -> tuple[str, ...]:
         """Return a best-effort stack of JSX elements open at the end of text."""
         stack: list[str] = []
-        for match in _JSX_TAG_RE.finditer(text):
-            closing, tag, self_closing = match.groups()
+        for closing, tag, self_closing in _iter_jsx_tags(text):
             if closing:
-                if tag in stack:
-                    del stack[stack.index(tag) :]
+                for index in range(len(stack) - 1, -1, -1):
+                    if stack[index] == tag:
+                        del stack[index:]
+                        break
             elif not self_closing:
                 stack.append(tag)
         return tuple(stack)

--- a/weblate/checks/tests/test_mdx.py
+++ b/weblate/checks/tests/test_mdx.py
@@ -26,6 +26,16 @@ class SafeMDXCheckTest(CheckTestCase):
         )
         self.test_failure_2 = ("Test {Math.PI * 100}", "Test {Math.PI*100}", "safe-mdx")
         self.test_failure_3 = ("Hello, {props.name.toUpperCase()}", "Ahoj", "safe-mdx")
+        self.test_failure_4 = (
+            '<a href="/profile">{userName}</a>',
+            '<a href={userName}>View profile</a>',
+            "safe-mdx",
+        )
+        self.test_failure_5 = (
+            "<Card title={title}>{body}</Card>",
+            "<Card title={body}>{title}</Card>",
+            "safe-mdx",
+        )
         self.test_ignore_check = (
             "Hello, {test}",
             "Ahoj, {ignore}",
@@ -125,4 +135,22 @@ class SafeMDXCheckTest(CheckTestCase):
         self.assertEqual(
             list(self.check.get_jsx_expression_matches(text)),
             expected,
+        )
+
+    def test_expression_signatures_include_context(self) -> None:
+        self.assertEqual(
+            list(
+                self.check.get_jsx_expression_signatures(
+                    '<a href="/profile">{userName}</a>'
+                )
+            ),
+            [("text", "", ("a",), "{userName}")],
+        )
+        self.assertEqual(
+            list(
+                self.check.get_jsx_expression_signatures(
+                    '<a href={userName}>View profile</a>'
+                )
+            ),
+            [("attribute", "href", ("a",), "{userName}")],
         )

--- a/weblate/checks/tests/test_mdx.py
+++ b/weblate/checks/tests/test_mdx.py
@@ -28,7 +28,7 @@ class SafeMDXCheckTest(CheckTestCase):
         self.test_failure_3 = ("Hello, {props.name.toUpperCase()}", "Ahoj", "safe-mdx")
         self.test_failure_4 = (
             '<a href="/profile">{userName}</a>',
-            '<a href={userName}>View profile</a>',
+            "<a href={userName}>View profile</a>",
             "safe-mdx",
         )
         self.test_failure_5 = (
@@ -149,7 +149,7 @@ class SafeMDXCheckTest(CheckTestCase):
         self.assertEqual(
             list(
                 self.check.get_jsx_expression_signatures(
-                    '<a href={userName}>View profile</a>'
+                    "<a href={userName}>View profile</a>"
                 )
             ),
             [("attribute", "href", ("a",), "{userName}")],

--- a/weblate/checks/tests/test_mdx.py
+++ b/weblate/checks/tests/test_mdx.py
@@ -164,6 +164,17 @@ class SafeMDXCheckTest(CheckTestCase):
         )
         self.do_test(True, (source, target, "safe-mdx"))
 
+    def test_jsx_identifier_start_elements_set_context(self) -> None:
+        for tag in ("_Wrapper", "$Wrapper"):
+            with self.subTest(tag=tag):
+                source = f"<{tag}>{{x}}</{tag}>"
+                target = "{x}"
+                self.assertEqual(
+                    list(self.check.get_jsx_expression_signatures(source)),
+                    [("text", "", (tag,), "{x}")],
+                )
+                self.do_test(True, (source, target, "safe-mdx"))
+
     def test_attribute_context_ignores_expression_greater_than(self) -> None:
         source = "<a title={x > y} href={url}>"
         target = "<a title={x > y}>{url}</a>"

--- a/weblate/checks/tests/test_mdx.py
+++ b/weblate/checks/tests/test_mdx.py
@@ -154,3 +154,24 @@ class SafeMDXCheckTest(CheckTestCase):
             ),
             [("attribute", "href", ("a",), "{userName}")],
         )
+
+    def test_repeated_tags_close_innermost_element(self) -> None:
+        source = "<div><div></div>{x}</div>"
+        target = "<div><div></div></div>{x}"
+        self.assertEqual(
+            list(self.check.get_jsx_expression_signatures(source)),
+            [("text", "", ("div",), "{x}")],
+        )
+        self.do_test(True, (source, target, "safe-mdx"))
+
+    def test_attribute_context_ignores_expression_greater_than(self) -> None:
+        source = "<a title={x > y} href={url}>"
+        target = "<a title={x > y}>{url}</a>"
+        self.assertEqual(
+            list(self.check.get_jsx_expression_signatures(source)),
+            [
+                ("attribute", "title", ("a",), "{x > y}"),
+                ("attribute", "href", ("a",), "{url}"),
+            ],
+        )
+        self.do_test(True, (source, target, "safe-mdx"))


### PR DESCRIPTION
### Motivation
- The original `SafeMDX` check compared only the multiset of brace-delimited JSX expressions and ignored their JSX/MDX syntactic context, producing false negatives when expressions were moved between text and attribute contexts.
- This could allow translations to change runtime behavior (e.g., move an expression into an `href` attribute) without being detected by the safety check.

### Description
- Replace the multiset comparison with ordered expression signatures that include expression text, the surrounding context (`text`/`tag`/`attribute`), the attribute name when applicable, and a best-effort element stack.
- Add lightweight JSX context helpers: a tag/attribute regex, `get_jsx_expression_signatures`, `get_jsx_expression_context`, `get_jsx_element_stack`, and `_iter_jsx_expressions` while preserving the original expression scanner.
- Adjust `check_single` to compare ordered signatures (`found != expected`) instead of `sorted(found) != sorted(expected)`, so context or order changes fail the check.
- Add regression tests to `weblate/checks/tests/test_mdx.py` that cover moving an expression from element text into an attribute and swapping expressions between attribute/text contexts, and add an assertion that `get_jsx_expression_signatures` exposes the expected contexts.

### Testing
- Ran `uv run pytest weblate/checks/tests/test_mdx.py -q`, and the test file passed with all tests succeeding (16 passed, 4 skipped).
- Ran `uv run python -m compileall -q weblate/checks/mdx.py weblate/checks/tests/test_mdx.py`, which completed successfully.
- Attempted `uv run prek run ruff-format --files weblate/checks/mdx.py weblate/checks/tests/test_mdx.py`, but the pre-commit hook run was blocked by an external repo clone error (network/tunnel 403) and could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34d74e8ec88329a51c82dc4dfc1abc)