### PR TITLE
fix(access): do not render all user edit forms

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -1128,21 +1128,60 @@ $(function () {
     selectAutoSource.trigger("change");
   }
 
-  /* Override all multiple selects */
-  document.querySelectorAll("select[multiple]").forEach((el) => {
-    if (el.tomselect) {
-      return;
+  const findElements = (root, selector) => {
+    const elements = [];
+    if (root instanceof Element && root.matches(selector)) {
+      elements.push(root);
     }
-    const options = {
-      plugins: ["remove_button", "checkbox_options"],
-      placeholder: el.dataset.placeholder || gettext("Search…"),
-      hidePlaceholder: el.dataset.hidePlaceholder === "true",
-      persist: false,
-      create: false,
-      allowEmptyOption: true,
-    };
-    new TomSelect(el, options);
-  });
+    elements.push(...root.querySelectorAll(selector));
+    return elements;
+  };
+
+  const initializeMultipleSelects = (root = document) => {
+    findElements(root, "select[multiple]").forEach((el) => {
+      if (el.tomselect) {
+        return;
+      }
+      const options = {
+        plugins: ["remove_button", "checkbox_options"],
+        placeholder: el.dataset.placeholder || gettext("Search…"),
+        hidePlaceholder: el.dataset.hidePlaceholder === "true",
+        persist: false,
+        create: false,
+        allowEmptyOption: true,
+      };
+      new TomSelect(el, options);
+    });
+  };
+
+  const initializeProjectMembershipControls = (root = document) => {
+    findElements(root, ".project-membership-team-toggle").forEach((el) => {
+      if (el.dataset.membershipToggleInitialized === "true") {
+        return;
+      }
+      el.dataset.membershipToggleInitialized = "true";
+      const limitField = document.getElementById(el.dataset.limitTarget);
+      const updateLimitField = () => {
+        if (!limitField) {
+          return;
+        }
+        limitField.disabled = !el.checked;
+        if (!limitField.tomselect) {
+          return;
+        }
+        if (el.checked) {
+          limitField.tomselect.enable();
+        } else {
+          limitField.tomselect.disable();
+        }
+      };
+      el.addEventListener("change", updateLimitField);
+      updateLimitField();
+    });
+  };
+
+  /* Override all multiple selects */
+  initializeMultipleSelects();
 
   /* Searchable single selects */
   document.querySelectorAll("select.searchable-select").forEach((el) => {
@@ -1241,25 +1280,76 @@ $(function () {
     updateInheritedSetting(false);
   });
 
-  document.querySelectorAll(".project-membership-team-toggle").forEach((el) => {
-    const limitField = document.getElementById(el.dataset.limitTarget);
-    const updateLimitField = () => {
-      if (!limitField) {
+  initializeProjectMembershipControls();
+
+  const projectUserGroupsModal = document.getElementById(
+    "project-user-groups-modal",
+  );
+  if (projectUserGroupsModal) {
+    const modalBody = projectUserGroupsModal.querySelector(".modal-body");
+    const modalTitle = projectUserGroupsModal.querySelector(".modal-title");
+    const submitButton = projectUserGroupsModal.querySelector(
+      "input[type='submit']",
+    );
+    const formCache = new Map();
+
+    const renderProjectUserGroupsForm = (url, html) => {
+      if (projectUserGroupsModal.dataset.activeUrl !== url) {
         return;
       }
-      limitField.disabled = !el.checked;
-      if (!limitField.tomselect) {
-        return;
-      }
-      if (el.checked) {
-        limitField.tomselect.enable();
-      } else {
-        limitField.tomselect.disable();
-      }
+      modalBody.innerHTML = html;
+      initializeMultipleSelects(modalBody);
+      initializeProjectMembershipControls(modalBody);
+      submitButton.disabled = false;
     };
-    el.addEventListener("change", updateLimitField);
-    updateLimitField();
-  });
+
+    projectUserGroupsModal.addEventListener("show.bs.modal", (event) => {
+      const trigger = event.relatedTarget;
+      const url = trigger?.dataset.href;
+      if (!url) {
+        return;
+      }
+      projectUserGroupsModal.dataset.activeUrl = url;
+      modalTitle.textContent = trigger.dataset.modalTitle || "";
+      submitButton.disabled = true;
+      modalBody.textContent =
+        modalBody.dataset.loadingText || gettext("Loading…");
+
+      if (formCache.has(url)) {
+        renderProjectUserGroupsForm(url, formCache.get(url));
+        return;
+      }
+
+      fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" } })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`${response.statusText} (${response.status})`);
+          }
+          return response.text();
+        })
+        .then((html) => {
+          formCache.set(url, html);
+          renderProjectUserGroupsForm(url, html);
+        })
+        .catch((error) => {
+          if (projectUserGroupsModal.dataset.activeUrl !== url) {
+            return;
+          }
+          const alert = document.createElement("div");
+          alert.className = "alert alert-danger";
+          alert.role = "alert";
+          const errorText =
+            modalBody.dataset.errorText || gettext("Error while loading form:");
+          alert.textContent = `${errorText} ${error.message}`;
+          modalBody.textContent = "";
+          modalBody.append(alert);
+        });
+    });
+
+    projectUserGroupsModal.addEventListener("hidden.bs.modal", () => {
+      delete projectUserGroupsModal.dataset.activeUrl;
+    });
+  }
 
   /* Slugify name */
   slugify.extend({ ".": "-" });

--- a/weblate/templates/trans/project-access-row.html
+++ b/weblate/templates/trans/project-access-row.html
@@ -32,7 +32,9 @@
   <td>
     <a href="#"
        data-bs-toggle="modal"
-       data-bs-target="#edit_user_{{ user.id }}"
+       data-bs-target="#project-user-groups-modal"
+       data-href="{% url "js-project-user-groups" project=object.slug user_id=user.id %}"
+       data-modal-title="{% blocktranslate with username=user.username %}Edit team membership for {{ username }}{% endblocktranslate %}"
        class="btn btn-link btn-xs"
        title="{% translate "Edit" %}">{% icon 'pencil.svg' %}</a>
     <a href="#"
@@ -69,32 +71,5 @@
       <!-- /.modal -->
     </form>
 
-    <form action="{% url "set-groups" project=object.slug %}"
-          method="post"
-          class="inlineform">
-      {% csrf_token %}
-      <div class="modal fade" tabindex="-1" role="dialog" id="edit_user_{{ user.id }}">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h4 class="modal-title">
-                {% blocktranslate with username=user.username %}Edit team membership for {{ username }}{% endblocktranslate %}
-              </h4>
-              <button type="button"
-                      class="btn-close"
-                      data-bs-dismiss="modal"
-                      aria-label="{% translate "Close" %}"></button>
-            </div>
-            <div class="modal-body">{% include "trans/project-access-team-form.html" with form=user.group_edit_form only %}</div>
-            <div class="modal-footer">
-              <input type="submit" class="btn btn-primary" value="{% translate "Save" %}" />
-            </div>
-          </div>
-          <!-- /.modal-content -->
-        </div>
-        <!-- /.modal-dialog -->
-      </div>
-      <!-- /.modal -->
-    </form>
   </td>
 </tr>

--- a/weblate/templates/trans/project-access.html
+++ b/weblate/templates/trans/project-access.html
@@ -459,6 +459,36 @@
       {% documentation_icon 'vcs' right=True %}
     </div>
   </div>
+
+  <form action="{% url "set-groups" project=object.slug %}"
+        method="post"
+        class="inlineform">
+    {% csrf_token %}
+    <div class="modal fade"
+         tabindex="-1"
+         role="dialog"
+         aria-labelledby="project-user-groups-modal-title"
+         id="project-user-groups-modal">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="project-user-groups-modal-title"></h4>
+            <button type="button"
+                    class="btn-close"
+                    data-bs-dismiss="modal"
+                    aria-label="{% translate "Close" %}"></button>
+          </div>
+          <div class="modal-body"
+               data-loading-text="{% translate "Loading…" %}"
+               data-error-text="{% translate "Error while loading form:" %}"></div>
+          <div class="modal-footer">
+            <input type="submit" class="btn btn-primary" value="{% translate "Save" %}" disabled />
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+
   <form method="get" id="paginator-form">
   </form>
 

--- a/weblate/trans/tests/test_acl.py
+++ b/weblate/trans/tests/test_acl.py
@@ -57,6 +57,12 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
         self.admin_group = self.project.defined_groups.get(name="Administration")
         self.translate_group = self.project.defined_groups.get(name="Translate")
 
+    def get_project_user_groups_url(self, user: User) -> str:
+        return reverse(
+            "js-project-user-groups",
+            kwargs={**self.kw_project, "user_id": user.id},
+        )
+
     def add_acl(self) -> None:
         """Add user to ACL."""
         self.project.add_user(self.user, "Translate")
@@ -112,6 +118,57 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
         self.project.add_user(self.user, "Administration")
         response = self.client.get(self.access_url)
         self.assertContains(response, "Users")
+
+    def test_edit_acl_user_group_form_is_lazy_loaded(self) -> None:
+        """Project user team forms are not rendered in every user row."""
+        self.project.add_user(self.user, "Administration")
+        self.project.add_user(self.second_user, "Translate")
+        form_url = self.get_project_user_groups_url(self.second_user)
+
+        response = self.client.get(self.access_url)
+
+        self.assertContains(response, form_url)
+        self.assertContains(response, 'id="project-user-groups-modal"')
+        self.assertNotContains(response, f'id="edit_user_{self.second_user.id}"')
+        self.assertNotContains(response, "project-membership-team-toggle")
+        self.assertNotContains(
+            response,
+            f"id_user_{self.second_user.id}_limit_languages_{self.translate_group.pk}",
+        )
+
+    def test_edit_acl_user_group_form_fragment(self) -> None:
+        """Project user team form is rendered by the JS endpoint."""
+        self.project.add_user(self.user, "Administration")
+        self.project.add_user(self.second_user, "Translate")
+
+        response = self.client.get(self.get_project_user_groups_url(self.second_user))
+
+        self.assertContains(response, self.second_user.username)
+        self.assertContains(response, "project-membership-team-toggle")
+        self.assertContains(
+            response,
+            f"id_user_{self.second_user.id}_limit_languages_{self.translate_group.pk}",
+        )
+
+    def test_edit_acl_user_group_form_fragment_denied(self) -> None:
+        """Regular project users can not load team management forms."""
+        self.add_acl()
+        self.project.add_user(self.second_user, "Translate")
+
+        response = self.client.get(self.get_project_user_groups_url(self.second_user))
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_edit_acl_user_group_form_fragment_project_scope(self) -> None:
+        """Team management form is available only for project users."""
+        self.project.add_user(self.user, "Administration")
+        outside_user = User.objects.create_user(
+            "outsideuser", "outside@example.org", "testpassword"
+        )
+
+        response = self.client.get(self.get_project_user_groups_url(outside_user))
+
+        self.assertEqual(response.status_code, 404)
 
     @override_settings(DEFAULT_PAGE_LIMIT=10)
     def test_edit_acl_users_pagination(self) -> None:
@@ -713,7 +770,10 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
 
         response = self.client.get(self.access_url)
         self.assertContains(response, str(self.translate_group))
-        self.assertContains(response, "(cs)")
+        self.assertInHTML(
+            f'<span class="badge text-bg-secondary">{self.translate_group} (cs)</span>',
+            response.content.decode(),
+        )
 
         self.client.post(
             reverse("set-groups", kwargs=self.kw_project),

--- a/weblate/trans/tests/test_projecttoken.py
+++ b/weblate/trans/tests/test_projecttoken.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from rest_framework.authtoken.models import Token
 
 from weblate.auth.models import setup_project_groups
+from weblate.lang.models import Language
 from weblate.trans.models import Project
 from weblate.trans.tasks import actual_project_removal
 from weblate.trans.tests.test_views import FixtureTestCase
@@ -160,6 +161,22 @@ class ProjectTokenTest(FixtureTestCase):
         # The token should still be visible on the access page
         response = self.client.get(reverse("manage-access", kwargs=self.kw_project))
         self.assertContains(response, token_user.username)
+
+    def test_limited_token_membership_badge(self) -> None:
+        """Project token memberships display language limits."""
+        token_key = self.create_token()
+        token_user = self.get_token_user(token_key)
+        czech = Language.objects.get(code="cs")
+        admin_group = self.project.defined_groups.get(name="Administration")
+        membership = token_user.team_memberships.get(group=admin_group)
+        membership.limit_languages.set([czech])
+
+        response = self.client.get(reverse("manage-access", kwargs=self.kw_project))
+
+        self.assertInHTML(
+            f'<span class="badge text-bg-secondary">{admin_group} (cs)</span>',
+            response.content.decode(),
+        )
 
     def test_project_removal_cleans_up_tokens(self) -> None:
         """Project removal should remove associated project tokens."""

--- a/weblate/trans/views/acl.py
+++ b/weblate/trans/views/acl.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Prefetch
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import gettext
@@ -193,14 +193,19 @@ def get_project_memberships_prefetch(groups):
     )
 
 
-def setup_project_group_edit_form(
-    user, project, groups, limit_language_choices
-) -> None:
-    initial = {"user": user.username, "groups": user.project_groups}
+def setup_project_membership_badges(user) -> None:
     for membership in user.project_group_memberships:
         membership.limit_language_codes = format_membership_limit_language_codes(
             membership
         )
+
+
+def setup_project_group_edit_form(
+    user, project, groups, limit_language_choices
+) -> None:
+    initial = {"user": user.username, "groups": user.project_groups}
+    setup_project_membership_badges(user)
+    for membership in user.project_group_memberships:
         initial[ProjectUserGroupForm.get_limit_languages_field(membership.group)] = (
             membership.limit_languages.all()
         )
@@ -210,6 +215,39 @@ def setup_project_group_edit_form(
         auto_id=f"id_user_{user.id}_%s",
         group_queryset=groups,
         limit_language_choices=limit_language_choices,
+    )
+
+
+@login_required
+def project_user_groups(request: AuthenticatedHttpRequest, project, user_id: int):
+    """Render team assignment form for a project user."""
+    obj = parse_path(request, [project], (Project,))
+
+    if not request.user.has_perm("project.permissions", obj):
+        raise PermissionDenied
+
+    groups = obj.defined_groups.order().prefetch_related("languages", "components")
+    user = get_object_or_404(
+        User.objects.filter(groups__in=groups, pk=user_id)
+        .distinct()
+        .prefetch_related(
+            Prefetch(
+                "groups",
+                queryset=groups,
+                to_attr="project_groups",
+            ),
+            get_project_memberships_prefetch(groups),
+        )
+    )
+
+    setup_project_group_edit_form(
+        user, obj, groups, get_language_code_choices(obj.languages)
+    )
+
+    return render(
+        request,
+        "trans/project-access-team-form.html",
+        {"form": user.group_edit_form},
     )
 
 
@@ -447,10 +485,8 @@ def manage_access(request: AuthenticatedHttpRequest, project):
         )
     )
 
-    limit_language_choices = get_language_code_choices(obj.languages)
-
     for user in chain(users, project_tokens):
-        setup_project_group_edit_form(user, obj, groups, limit_language_choices)
+        setup_project_membership_badges(user)
 
     invitations = list(
         Invitation.objects.filter(group__defining_project=obj)

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -818,6 +818,11 @@ real_patterns = [
         name="js-unit-translations",
     ),
     path(
+        "js/access/<name:project>/user/<int:user_id>/groups/",
+        weblate.trans.views.acl.project_user_groups,
+        name="js-project-user-groups",
+    ),
+    path(
         "js/git/<object_path:path>/",
         weblate.trans.views.js.git_status,
         name="git_status",


### PR DESCRIPTION
The user edit forms might get expensive on both server and client side if there is many of them. Instead add a dedicated endpoint to render form for single user and fetch the popup dynamically. This also needed refactoring of multi select loading to be able to attach it to AJAX loaded content.

Fixes #20137

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
