### PR TITLE
fix(api): allow project creating in default user workspace

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -915,9 +915,10 @@ Projects
     :type web: string
     :param workspace: Optional workspace UUID. Creating a project in a workspace
                        requires :guilabel:`Add projects to workspace` permission
-                       for that workspace. Creating a project without a
-                       workspace requires the site-wide :guilabel:`Add new
-                       projects` permission. See
+                       for that workspace. When omitted, Weblate can use the
+                       only eligible workspace. Creating a project without an
+                       eligible workspace requires the site-wide
+                       :guilabel:`Add new projects` permission. See
                        :ref:`workspace-project-creation`.
     :type workspace: string
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -51,6 +51,7 @@ Weblate 2026.7
 * :ref:`auto-translation` no longer validates hidden component fields when using machine translation.
 * :guilabel:`Strings marked for edit` links now include all strings needing editing, checking, or rewriting.
 * Anonymous permission checks no longer fail when loading teams scoped to projects or workspaces.
+* API project creation can again use the user's only eligible workspace when no explicit workspace is supplied.
 
 .. rubric:: Compatibility
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -3104,6 +3104,149 @@ class ProjectAPITest(APIBaseTest):
             },
         )
 
+    def test_create_with_project_add_permission(self) -> None:
+        self.grant_perm_to_user("project.add")
+
+        response = self.do_request(
+            "api:project-list",
+            method="post",
+            code=201,
+            request={
+                "name": "API project",
+                "slug": "api-project",
+                "web": "https://weblate.org/",
+            },
+        )
+        project = Project.objects.get(pk=response.data["id"])
+        self.assertIsNone(project.workspace)
+
+    def test_create_with_workspace_permission(self) -> None:
+        with modify_settings(INSTALLED_APPS={"prepend": "weblate.billing"}):
+            workspace = Workspace.objects.create(name="API workspace")
+            workspace.add_owner(self.user)
+
+            response = self.do_request(
+                "api:project-list",
+                method="post",
+                code=201,
+                request={
+                    "name": "API project",
+                    "slug": "api-project",
+                    "web": "https://weblate.org/",
+                    "workspace": str(workspace.pk),
+                },
+            )
+            project = Project.objects.get(pk=response.data["id"])
+            self.assertEqual(project.workspace_id, workspace.pk)
+
+    def test_create_with_workspace_permission_denied(self) -> None:
+        workspace = Workspace.objects.create(name="API workspace")
+
+        response = self.do_request(
+            "api:project-list",
+            method="post",
+            code=403,
+            request={
+                "name": "API project",
+                "slug": "api-project",
+                "web": "https://weblate.org/",
+                "workspace": str(workspace.pk),
+            },
+        )
+        self.assertEqual(
+            {
+                "errors": [
+                    {
+                        "attr": None,
+                        "code": "permission_denied",
+                        "detail": "Can not create projects",
+                    }
+                ],
+                "type": "client_error",
+            },
+            response.data,
+        )
+
+    def test_create_with_invalid_billing_workspace(self) -> None:
+        with modify_settings(INSTALLED_APPS={"prepend": "weblate.billing"}):
+            billing = create_test_billing(self.user, invoice=False)
+            billing.in_limits = False
+            billing.save(update_fields=["in_limits"])
+
+            response = self.do_request(
+                "api:project-list",
+                method="post",
+                code=403,
+                request={
+                    "name": "API project",
+                    "slug": "api-project",
+                    "web": "https://weblate.org/",
+                    "workspace": str(billing.workspace_id),
+                },
+            )
+            self.assertEqual(
+                {
+                    "errors": [
+                        {
+                            "attr": None,
+                            "code": "permission_denied",
+                            "detail": "No valid billing found or limit exceeded.",
+                        }
+                    ],
+                    "type": "client_error",
+                },
+                response.data,
+            )
+
+    def test_create_with_single_workspace(self) -> None:
+        with modify_settings(INSTALLED_APPS={"remove": "weblate.billing"}):
+            workspace = Workspace.objects.create(name="API workspace")
+            workspace.add_owner(self.user)
+
+            response = self.do_request(
+                "api:project-list",
+                method="post",
+                code=201,
+                request={
+                    "name": "API project",
+                    "slug": "api-project",
+                    "web": "https://weblate.org/",
+                },
+            )
+            project = Project.objects.get(pk=response.data["id"])
+            self.assertEqual(project.workspace_id, workspace.pk)
+
+    def test_create_with_multiple_workspaces_requires_workspace(self) -> None:
+        with modify_settings(INSTALLED_APPS={"remove": "weblate.billing"}):
+            first_workspace = Workspace.objects.create(name="First API workspace")
+            first_workspace.add_owner(self.user)
+            second_workspace = Workspace.objects.create(name="Second API workspace")
+            second_workspace.add_owner(self.user)
+
+            response = self.do_request(
+                "api:project-list",
+                method="post",
+                code=400,
+                request={
+                    "name": "API project",
+                    "slug": "api-project",
+                    "web": "https://weblate.org/",
+                },
+            )
+            self.assertEqual(
+                {
+                    "errors": [
+                        {
+                            "attr": "workspace",
+                            "code": "invalid",
+                            "detail": "Specify a workspace when multiple workspaces can be used.",
+                        }
+                    ],
+                    "type": "validation_error",
+                },
+                response.data,
+            )
+
     def test_create_with_billing(self) -> None:
         with modify_settings(INSTALLED_APPS={"remove": "weblate.billing"}):
             response = self.do_request(
@@ -3165,11 +3308,11 @@ class ProjectAPITest(APIBaseTest):
                     "name": "API project",
                     "slug": "api-project",
                     "web": "https://weblate.org/",
-                    "workspace": str(billing.workspace_id),
                 },
             )
             project = Project.objects.get(pk=response.data["id"])
             self.assertEqual(project.billing, billing)
+            self.assertEqual(project.workspace_id, billing.workspace_id)
 
             response = self.do_request(
                 "api:project-list",
@@ -3179,7 +3322,6 @@ class ProjectAPITest(APIBaseTest):
                     "name": "API project 2",
                     "slug": "api-project-2",
                     "web": "https://weblate.org/",
-                    "workspace": str(billing.workspace_id),
                 },
             )
             self.assertEqual(

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1570,6 +1570,20 @@ class ProjectViewSet(
     lookup_field = "slug"
     request: Request  # type: ignore[assignment]
 
+    def get_create_workspaces(self, request: Request):
+        workspaces = request.user.workspaces_with_perm("workspace.add_project")
+        if "weblate.billing" in settings.INSTALLED_APPS:
+            # ruff: ignore[import-outside-top-level]
+            from weblate.billing.models import Billing
+
+            valid_billing_workspaces = Billing.objects.for_user_within_limits(
+                request.user
+            ).values("workspace")
+            workspaces = workspaces.filter(
+                Q(billing__isnull=True) | Q(pk__in=valid_billing_workspaces)
+            )
+        return workspaces
+
     def get_queryset(self):
         return self.request.user.allowed_projects.prefetch_related(
             "addon_set"
@@ -1801,6 +1815,7 @@ class ProjectViewSet(
     def create(self, request: Request, *args, **kwargs):
         """Create a new project."""
         workspace_id = request.data.get("workspace")
+        data = request.data
         if workspace_id:
             try:
                 workspace = get_object_or_404(Workspace, pk=workspace_id)
@@ -1823,9 +1838,31 @@ class ProjectViewSet(
                         request, "No valid billing found or limit exceeded."
                     )
         elif not request.user.has_perm("project.add"):
-            self.permission_denied(request, "Can not create projects")
+            if not request.user.workspaces_with_perm("workspace.add_project").exists():
+                self.permission_denied(request, "Can not create projects")
+
+            try:
+                workspace = self.get_create_workspaces(request).get()
+            except Workspace.DoesNotExist:
+                self.permission_denied(
+                    request, "No valid billing found or limit exceeded."
+                )
+            except Workspace.MultipleObjectsReturned as error:
+                raise ValidationError(
+                    {
+                        "workspace": gettext(
+                            "Specify a workspace when multiple workspaces can be used."
+                        )
+                    }
+                ) from error
+            data = request.data.copy()
+            data["workspace"] = str(workspace.pk)
         self.request = request
-        return super().create(request, *args, **kwargs)
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=HTTP_201_CREATED, headers=headers)
 
     def perform_create(self, serializer) -> None:
         with transaction.atomic():


### PR DESCRIPTION
Restore the functionality present before introudction of workspaces. The user without a project.add permission and access to a single workspace will create the project within that workspace.

Fixes #20147

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
