### PR TITLE
fix(locale): correct Portuguese backup warning label

### DIFF
--- a/weblate/locale/pt/LC_MESSAGES/django.po
+++ b/weblate/locale/pt/LC_MESSAGES/django.po
@@ -12552,7 +12552,7 @@ msgstr "Falhou com um erro"
 
 #: weblate/templates/manage/backups.html:27
 msgid "Completed with warnings"
-msgstr "Completado sem avisos"
+msgstr "Completado com avisos"
 
 #: weblate/templates/manage/backups.html:30
 msgid "Turned off"


### PR DESCRIPTION
### Motivation
- Fix a Portuguese translation that incorrectly rendered the backup status `Completed with warnings` as “without warnings”, which could mislead administrators when `service.has_warnings` is true.

### Description
- Update `weblate/locale/pt/LC_MESSAGES/django.po` to change the `msgstr` for `msgid "Completed with warnings"` from `Completado sem avisos` to `Completado com avisos`.
- No other source or template changes were made and application behavior is unchanged.

### Testing
- Ran `msgfmt -c -o /tmp/django-pt.mo weblate/locale/pt/LC_MESSAGES/django.po` and it completed without errors.
- Ran `git diff --check` to verify there are no whitespace or diff issues and it reported no problems.
- Verified the `msgid`/`msgstr` mapping in the PO file shows the corrected translation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a352459aa588329a89bed35ee737bbf)