### PR TITLE
Add ClassVar typing to font models and form to silence mutable-default warnings

### DIFF
--- a/weblate/fonts/forms.py
+++ b/weblate/fonts/forms.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import ClassVar, cast
 
 from django import forms
 
@@ -16,8 +16,7 @@ class FontForm(forms.ModelForm):
     class Meta:
         model = Font
         fields = ("font",)
-        # ruff: ignore[mutable-class-default]
-        field_classes = {"font": AssetFileField}
+        field_classes: ClassVar[dict[str, type[forms.Field]]] = {"font": AssetFileField}
 
 
 class FontGroupForm(forms.ModelForm):

--- a/weblate/fonts/models.py
+++ b/weblate/fonts/models.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import ClassVar
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.storage import FileSystemStorage
@@ -45,7 +47,9 @@ class Font(models.Model, UserDisplayMixin):
     )
 
     class Meta:
-        unique_together = [("family", "style", "project")]  # ruff: ignore[mutable-class-default]
+        unique_together: ClassVar[list[tuple[str, str, str]]] = [
+            ("family", "style", "project")
+        ]
         verbose_name = "Font"
         verbose_name_plural = "Fonts"
 
@@ -126,7 +130,7 @@ class FontGroup(models.Model):
     objects = FontGroupQuerySet.as_manager()
 
     class Meta:
-        unique_together = [("project", "name")]  # ruff: ignore[mutable-class-default]
+        unique_together: ClassVar[list[tuple[str, str]]] = [("project", "name")]
         verbose_name = "Font group"
         verbose_name_plural = "Font groups"
 
@@ -153,7 +157,7 @@ class FontOverride(models.Model):
     )
 
     class Meta:
-        unique_together = [("group", "language")]  # ruff: ignore[mutable-class-default]
+        unique_together: ClassVar[list[tuple[str, str]]] = [("group", "language")]
         verbose_name = "Font override"
         verbose_name_plural = "Font overrides"
 


### PR DESCRIPTION
### Motivation
- Address typing and linter warnings about mutable class defaults by explicitly annotating class-level attributes with `ClassVar`.
- Improve static typing for the `field_classes` mapping in forms and the `unique_together` tuples in models to make intent explicit.

### Description
- Import `ClassVar` into `weblate/fonts/forms.py` and `weblate/fonts/models.py`.
- Annotate `FontForm.Meta.field_classes` as `ClassVar[dict[str, type[forms.Field]]]` and assign `{"font": AssetFileField}`.
- Annotate `unique_together` in `Font.Meta`, `FontGroup.Meta`, and `FontOverride.Meta` as `ClassVar[...]` with the appropriate list of tuples.
- Remove the `ruff: ignore[mutable-class-default]` comments now that the attributes are properly typed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a358484ad248329a1b5016f2ac28f90)