### PR TITLE
fix(checks): avoid quadratic safe-html placeholder scan

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,7 +49,7 @@ Weblate 2026.7
 * Hardened HTML and AJAX object lookups against private project enumeration.
 * Document and translation-memory uploads now enforce :setting:`TRANSLATION_UPLOAD_MAX_SIZE`, and API document uploads validate file extensions.
 * :ref:`check-rst-syntax` now detects inline roles wrapped in stray backticks.
-* :ref:`check-safe-html` now detects changed placeholder-only HTML attribute values in translations.
+* :ref:`check-safe-html` now efficiently detects changed placeholder-only HTML attribute values in translations.
 * Repository reset and update progress now includes follow-up translation-file reconciliation.
 * :ref:`auto-translation` no longer validates hidden component fields when using machine translation.
 * :guilabel:`Strings marked for edit` links now include all strings needing editing, checking, or rewriting.

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -222,15 +222,18 @@ def get_wrapped_placeholder_attribute(value: str | None) -> str | None:
 
 
 def has_changed_placeholder_attributes(source: str, target: str) -> bool:
-    target_values: set[tuple[str, str, str]] = set()
-    for attribute in extract_html_attributes(target):
-        if placeholder := get_wrapped_placeholder_attribute(attribute.value):
-            target_values.add((attribute.tag, attribute.name, placeholder))
+    source_values: set[tuple[str, str, str]] = {
+        (attribute.tag, attribute.name, attribute.value)
+        for attribute in extract_html_attributes(source)
+        if is_html_attribute_placeholder(attribute.value)
+    }
+    if not source_values:
+        return False
 
-    for attribute in extract_html_attributes(source):
+    for attribute in extract_html_attributes(target):
         if (
-            is_html_attribute_placeholder(attribute.value)
-            and (attribute.tag, attribute.name, attribute.value) in target_values
+            (placeholder := get_wrapped_placeholder_attribute(attribute.value))
+            and (attribute.tag, attribute.name, placeholder) in source_values
         ):
             return True
     return False

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -231,10 +231,11 @@ def has_changed_placeholder_attributes(source: str, target: str) -> bool:
         return False
 
     for attribute in extract_html_attributes(target):
-        if (
-            (placeholder := get_wrapped_placeholder_attribute(attribute.value))
-            and (attribute.tag, attribute.name, placeholder) in source_values
-        ):
+        if (placeholder := get_wrapped_placeholder_attribute(attribute.value)) and (
+            attribute.tag,
+            attribute.name,
+            placeholder,
+        ) in source_values:
             return True
     return False
 

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -207,26 +207,30 @@ def strip_html_attribute_wrappers(value: str) -> str:
     return stripped
 
 
-def is_wrapped_html_attribute_placeholder(placeholder: str, value: str | None) -> bool:
-    return (
-        value is not None
-        and value != placeholder
+def get_wrapped_placeholder_attribute(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    placeholder = strip_html_attribute_wrappers(value)
+    if (
+        value != placeholder
         and placeholder in value
-        and strip_html_attribute_wrappers(value) == placeholder
-    )
+        and is_html_attribute_placeholder(placeholder)
+    ):
+        return placeholder
+    return None
 
 
 def has_changed_placeholder_attributes(source: str, target: str) -> bool:
-    target_values: dict[tuple[str, str], list[str | None]] = defaultdict(list)
+    target_values: set[tuple[str, str, str]] = set()
     for attribute in extract_html_attributes(target):
-        target_values[attribute.tag, attribute.name].append(attribute.value)
+        if placeholder := get_wrapped_placeholder_attribute(attribute.value):
+            target_values.add((attribute.tag, attribute.name, placeholder))
 
     for attribute in extract_html_attributes(source):
-        if not is_html_attribute_placeholder(attribute.value):
-            continue
-        if any(
-            is_wrapped_html_attribute_placeholder(attribute.value, target_value)
-            for target_value in target_values.get((attribute.tag, attribute.name), ())
+        if (
+            is_html_attribute_placeholder(attribute.value)
+            and (attribute.tag, attribute.name, attribute.value) in target_values
         ):
             return True
     return False

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -469,6 +469,11 @@ class SafeHTMLCheckTest(CheckTestCase):
             ),
         )
 
+    def test_repeated_placeholder_attributes(self) -> None:
+        source = '<a href="%(url)s">link</a>' * 1000
+        self.do_test(False, (source, source, "safe-html"))
+        self.do_test(True, (source, '<a href="„%(url)s“">link</a>', "safe-html"))
+
     def test_positional_printf_placeholder_attribute(self) -> None:
         source = '<a href="%1$s">terms</a>'
         self.do_test(False, (source, source, "safe-html"))

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -20,6 +20,7 @@ from weblate.checks.markup import (
     RSTReferencesCheck,
     RSTSyntaxCheck,
     SafeHTMLCheck,
+    has_changed_placeholder_attributes,
     URLCheck,
     XMLCharsAroundTagsCheck,
     XMLTagsCheck,
@@ -468,6 +469,14 @@ class SafeHTMLCheckTest(CheckTestCase):
                 "safe-html",
             ),
         )
+
+    def test_no_placeholder_attribute_skips_target_normalization(self) -> None:
+        target = f'<a title="{"„" * 1000}">link</a>'
+        with patch("weblate.checks.markup.get_wrapped_placeholder_attribute") as wrapped:
+            self.assertFalse(
+                has_changed_placeholder_attributes('<a title="plain">link</a>', target)
+            )
+        wrapped.assert_not_called()
 
     def test_repeated_placeholder_attributes(self) -> None:
         source = '<a href="%(url)s">link</a>' * 1000

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -20,12 +20,12 @@ from weblate.checks.markup import (
     RSTReferencesCheck,
     RSTSyntaxCheck,
     SafeHTMLCheck,
-    has_changed_placeholder_attributes,
     URLCheck,
     XMLCharsAroundTagsCheck,
     XMLTagsCheck,
     XMLValidityCheck,
     extract_rst_references,
+    has_changed_placeholder_attributes,
 )
 from weblate.checks.tests.test_checks import CheckTestCase
 from weblate.trans.tests.factories import make_check, make_unit
@@ -472,7 +472,9 @@ class SafeHTMLCheckTest(CheckTestCase):
 
     def test_no_placeholder_attribute_skips_target_normalization(self) -> None:
         target = f'<a title="{"„" * 1000}">link</a>'
-        with patch("weblate.checks.markup.get_wrapped_placeholder_attribute") as wrapped:
+        with patch(
+            "weblate.checks.markup.get_wrapped_placeholder_attribute"
+        ) as wrapped:
             self.assertFalse(
                 has_changed_placeholder_attributes('<a title="plain">link</a>', target)
             )


### PR DESCRIPTION
### Motivation

- A placeholder-attribute check in `safe-html` performed an O(source_attrs * target_attrs) nested scan which could be abused to cause CPU exhaustion for repeated attributes. 
- The intent is to detect wrapped/quoted placeholder-only HTML attribute values in translations without introducing a denial-of-service through quadratic behavior.

### Description

- Add `get_wrapped_placeholder_attribute` and normalize wrapped target attribute values instead of keeping duplicate target attribute lists. 
- Replace the nested per-pair scan in `has_changed_placeholder_attributes` with a precomputed `set` of `(tag, name, placeholder)` tuples and constant-time membership checks. 
- Add `test_repeated_placeholder_attributes` to `weblate/checks/tests/test_markup_checks.py` to cover many repeated placeholder attributes without regressions. 
- Update the unreleased changelog entry in `docs/changes.rst` to note the efficiency improvement.

### Testing

- Ran `uv run pytest weblate/checks/tests/test_markup_checks.py::SafeHTMLCheckTest` which completed successfully (`32 passed, 3 skipped`).
- Executed a micro-benchmark using the module-level function `has_changed_placeholder_attributes` for repeated attributes which showed near-linear timings (example runs: `1000 -> 0.0206s`, `5000 -> 0.1004s`, `10000 -> 0.2163s`).
- Attempted repository hook checks with `uv run prek run --files ...` but this was blocked by an external pre-commit hook clone failing with a network `CONNECT tunnel failed, response 403` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3584012e08832998fbea84a40f0a79)