### PR TITLE
Efficient detection of placeholder-only HTML attribute changes and improved wrapper stripping

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,7 +49,7 @@ Weblate 2026.7
 * Hardened HTML and AJAX object lookups against private project enumeration.
 * Document and translation-memory uploads now enforce :setting:`TRANSLATION_UPLOAD_MAX_SIZE`, and API document uploads validate file extensions.
 * :ref:`check-rst-syntax` now detects inline roles wrapped in stray backticks.
-* :ref:`check-safe-html` now detects changed placeholder-only HTML attribute values in translations.
+* :ref:`check-safe-html` now efficiently detects changed placeholder-only HTML attribute values in translations.
 * Repository reset and update progress now includes follow-up translation-file reconciliation.
 * :ref:`auto-translation` no longer validates hidden component fields when using machine translation.
 * :guilabel:`Strings marked for edit` links now include all strings needing editing, checking, or rewriting.

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -181,52 +181,80 @@ def is_html_attribute_placeholder(value: str | None) -> bool:
 
 def strip_html_attribute_wrappers(value: str) -> str:
     """Remove quote-like wrappers around a placeholder attribute."""
-    stripped = value.strip()
-    while stripped:
-        original = stripped
-        if stripped[0] in HTML_ATTRIBUTE_WRAPPER_CHARS:
-            stripped = stripped[1:].lstrip()
+    start = 0
+    end = len(value)
+
+    while True:
+        original = (start, end)
+
+        while start < end and value[start].isspace():
+            start += 1
+
+        if start < end and value[start] in HTML_ATTRIBUTE_WRAPPER_CHARS:
+            start += 1
+            while start < end and value[start].isspace():
+                start += 1
         elif (
-            len(stripped) > 1
-            and stripped[0] == "\\"
-            and stripped[1] in HTML_ATTRIBUTE_WRAPPER_CHARS
+            start + 1 < end
+            and value[start] == "\\"
+            and value[start + 1] in HTML_ATTRIBUTE_WRAPPER_CHARS
         ):
-            stripped = stripped[2:].lstrip()
+            start += 2
+            while start < end and value[start].isspace():
+                start += 1
+
+        while start < end and value[end - 1].isspace():
+            end -= 1
 
         if (
-            len(stripped) > 1
-            and stripped[-2] == "\\"
-            and stripped[-1] in HTML_ATTRIBUTE_WRAPPER_CHARS
+            start + 1 < end
+            and value[end - 2] == "\\"
+            and value[end - 1] in HTML_ATTRIBUTE_WRAPPER_CHARS
         ):
-            stripped = stripped[:-2].rstrip()
-        elif stripped and stripped[-1] in HTML_ATTRIBUTE_WRAPPER_CHARS:
-            stripped = stripped[:-1].rstrip()
+            end -= 2
+            while start < end and value[end - 1].isspace():
+                end -= 1
+        elif start < end and value[end - 1] in HTML_ATTRIBUTE_WRAPPER_CHARS:
+            end -= 1
+            while start < end and value[end - 1].isspace():
+                end -= 1
 
-        if stripped == original:
-            return stripped
-    return stripped
+        if (start, end) == original:
+            return value[start:end]
 
 
-def is_wrapped_html_attribute_placeholder(placeholder: str, value: str | None) -> bool:
-    return (
-        value is not None
-        and value != placeholder
+def get_wrapped_placeholder_attribute(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    placeholder = strip_html_attribute_wrappers(value)
+    if (
+        value != placeholder
         and placeholder in value
-        and strip_html_attribute_wrappers(value) == placeholder
-    )
+        and is_html_attribute_placeholder(placeholder)
+    ):
+        return placeholder
+    return None
 
 
 def has_changed_placeholder_attributes(source: str, target: str) -> bool:
-    target_values: dict[tuple[str, str], list[str | None]] = defaultdict(list)
-    for attribute in extract_html_attributes(target):
-        target_values[attribute.tag, attribute.name].append(attribute.value)
+    source_values: set[tuple[str, str, str]] = {
+        (attribute.tag, attribute.name, attribute.value)
+        for attribute in extract_html_attributes(source)
+        if is_html_attribute_placeholder(attribute.value)
+    }
+    source_attribute_names = {
+        (tag, name) for tag, name, _placeholder in source_values
+    }
+    if not source_attribute_names:
+        return False
 
-    for attribute in extract_html_attributes(source):
-        if not is_html_attribute_placeholder(attribute.value):
+    for attribute in extract_html_attributes(target):
+        if (attribute.tag, attribute.name) not in source_attribute_names:
             continue
-        if any(
-            is_wrapped_html_attribute_placeholder(attribute.value, target_value)
-            for target_value in target_values.get((attribute.tag, attribute.name), ())
+        if (
+            (placeholder := get_wrapped_placeholder_attribute(attribute.value))
+            and (attribute.tag, attribute.name, placeholder) in source_values
         ):
             return True
     return False

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -243,19 +243,18 @@ def has_changed_placeholder_attributes(source: str, target: str) -> bool:
         for attribute in extract_html_attributes(source)
         if is_html_attribute_placeholder(attribute.value)
     }
-    source_attribute_names = {
-        (tag, name) for tag, name, _placeholder in source_values
-    }
+    source_attribute_names = {(tag, name) for tag, name, _placeholder in source_values}
     if not source_attribute_names:
         return False
 
     for attribute in extract_html_attributes(target):
         if (attribute.tag, attribute.name) not in source_attribute_names:
             continue
-        if (
-            (placeholder := get_wrapped_placeholder_attribute(attribute.value))
-            and (attribute.tag, attribute.name, placeholder) in source_values
-        ):
+        if (placeholder := get_wrapped_placeholder_attribute(attribute.value)) and (
+            attribute.tag,
+            attribute.name,
+            placeholder,
+        ) in source_values:
             return True
     return False
 

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -20,12 +20,12 @@ from weblate.checks.markup import (
     RSTReferencesCheck,
     RSTSyntaxCheck,
     SafeHTMLCheck,
-    has_changed_placeholder_attributes,
     URLCheck,
     XMLCharsAroundTagsCheck,
     XMLTagsCheck,
     XMLValidityCheck,
     extract_rst_references,
+    has_changed_placeholder_attributes,
 )
 from weblate.checks.tests.test_checks import CheckTestCase
 from weblate.trans.tests.factories import make_check, make_unit
@@ -472,7 +472,9 @@ class SafeHTMLCheckTest(CheckTestCase):
 
     def test_no_placeholder_attribute_skips_target_normalization(self) -> None:
         target = f'<a title="{"„" * 1000}">link</a>'
-        with patch("weblate.checks.markup.get_wrapped_placeholder_attribute") as wrapped:
+        with patch(
+            "weblate.checks.markup.get_wrapped_placeholder_attribute"
+        ) as wrapped:
             self.assertFalse(
                 has_changed_placeholder_attributes('<a title="plain">link</a>', target)
             )

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -20,6 +20,7 @@ from weblate.checks.markup import (
     RSTReferencesCheck,
     RSTSyntaxCheck,
     SafeHTMLCheck,
+    has_changed_placeholder_attributes,
     URLCheck,
     XMLCharsAroundTagsCheck,
     XMLTagsCheck,
@@ -468,6 +469,19 @@ class SafeHTMLCheckTest(CheckTestCase):
                 "safe-html",
             ),
         )
+
+    def test_no_placeholder_attribute_skips_target_normalization(self) -> None:
+        target = f'<a title="{"„" * 1000}">link</a>'
+        with patch("weblate.checks.markup.get_wrapped_placeholder_attribute") as wrapped:
+            self.assertFalse(
+                has_changed_placeholder_attributes('<a title="plain">link</a>', target)
+            )
+        wrapped.assert_not_called()
+
+    def test_repeated_placeholder_attributes(self) -> None:
+        source = '<a href="%(url)s">link</a>' * 1000
+        self.do_test(False, (source, source, "safe-html"))
+        self.do_test(True, (source, '<a href="„%(url)s“">link</a>', "safe-html"))
 
     def test_positional_printf_placeholder_attribute(self) -> None:
         source = '<a href="%1$s">terms</a>'


### PR DESCRIPTION
### Motivation

* Fix correctness and performance in detecting changed placeholder-only HTML attribute values in translations by avoiding unnecessary normalization and repeated work. 
* Prevent slow behavior on large inputs caused by repeated string trimming and duplicate processing of attributes. 
* Reflect the behavioral improvement in the release notes.

### Description

* Rewrote `strip_html_attribute_wrappers` to use index-based trimming instead of repeated string slicing to avoid repeated allocations and ensure correct handling of escaped wrapper characters. 
* Introduced `get_wrapped_placeholder_attribute` to return a normalized placeholder only when the target contains a wrapped placeholder and it is a valid placeholder. 
* Reworked `has_changed_placeholder_attributes` to build a `source_values` set of placeholder attributes, short-circuit when the source contains no placeholder attributes, and compare normalized placeholders against the set for efficient detection. 
* Updated `docs/changes.rst` wording to indicate the `check-safe-html` improvement and added two unit tests to `weblate/checks/tests/test_markup_checks.py` (including `test_no_placeholder_attribute_skips_target_normalization` and `test_repeated_placeholder_attributes`).

### Testing

* Ran the markup checks unit tests in `weblate.checks.tests.test_markup_checks`, including the new `SafeHTMLCheckTest` cases, and they passed. 
* Executed the modified test module locally to verify `has_changed_placeholder_attributes` behavior and the new wrapper-handling code, and all assertions succeeded. 
* No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3584012e08832998fbea84a40f0a79)