### PR TITLE
fix(lang): annotate Meta.fields as ClassVar to remove ruff suppression

### DIFF
--- a/weblate/lang/forms.py
+++ b/weblate/lang/forms.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Field, Layout
@@ -99,8 +99,7 @@ class LimitLanguagesField(LanguageCodeMultipleChoiceField):
 class LanguageForm(forms.ModelForm):
     class Meta:
         model = Language
-        # ruff: ignore[mutable-class-default]
-        fields = [
+        fields: ClassVar[list[str]] = [
             "code",
             "name",
             "direction",
@@ -130,8 +129,7 @@ class LanguageForm(forms.ModelForm):
 class PluralForm(forms.ModelForm):
     class Meta:
         model = Plural
-        # ruff: ignore[mutable-class-default]
-        fields = [
+        fields: ClassVar[list[str]] = [
             "number",
             "formula",
         ]


### PR DESCRIPTION
### Motivation
- Silence the frequent fixable `ruff: ignore[mutable-class-default]` inline suppressions by making Django `Meta.fields` explicit non-mutable class variables so linting can validate them.

### Description
- Import `ClassVar` and annotate `LanguageForm.Meta.fields` and `PluralForm.Meta.fields` as `fields: ClassVar[list[str]]` and remove the targeted `# ruff: ignore[mutable-class-default]` comments in `weblate/lang/forms.py`.

### Testing
- Ran `uv run ruff check --select RUF012 weblate/lang/forms.py` which passed for the changed file.
- Ran `uv run mypy --show-column-numbers weblate/lang/forms.py | ./scripts/filter-mypy.sh` which reported no errors for the changed file while unrelated mypy issues remain elsewhere.
- Attempted `uv run prek run ruff --files weblate/lang/forms.py` but hook initialization failed due to an external network error (HTTP 403) when cloning a hook dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3630a22f608329bc28fd5ccbce54c0)