### PR TITLE
test(selenium): wait for base JavaScript readiness

### DIFF
--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -191,7 +191,26 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
     @staticmethod
     def is_page_loaded(driver: WebDriver) -> bool:
         try:
-            return driver.execute_script("return document.readyState") == "complete"
+            return bool(
+                driver.execute_script(
+                    """
+                    if (document.readyState !== "complete") {
+                        return false;
+                    }
+                    if (!document.querySelector('meta[name="argon2id-worker-url"]')) {
+                        return true;
+                    }
+                    const status = {
+                        slugify: typeof window.slugify !== "undefined",
+                        DateRangePicker: typeof window.DateRangePicker !== "undefined",
+                        getNumber: typeof window.getNumber === "function",
+                        quoteSearch: typeof window.quoteSearch === "function",
+                        compareCells: typeof window.compareCells === "function",
+                    };
+                    return Object.values(status).every(Boolean);
+                    """
+                )
+            )
         except WebDriverException:
             return False
 
@@ -294,8 +313,9 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
     def setUp(self) -> None:
         super().setUp()
         self.driver.execute_cdp_cmd("Network.clearBrowserCache", {})
-        self.driver.get(f"{self.live_server_url}{reverse('home')}")
         self.driver.set_window_size(1200, 1024)
+        with self.wait_for_page_load():
+            self.driver.get(f"{self.live_server_url}{reverse('home')}")
         self.site_domain = settings.SITE_DOMAIN
         settings.SITE_DOMAIN = f"{self.host}:{self.server_thread.port}"
 
@@ -828,12 +848,19 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
         self.assertEqual(submit_button.get_attribute("type"), "submit")
         self.assertEqual(submit_button.get_attribute("value"), "Sign in")
 
-    def test_js_assets_are_loaded(self) -> None:
-        """Check that the main JS bundle is active and globals are available."""
-        self.assertTrue(
-            self.driver.execute_script(
-                "return typeof window.slugify !== 'undefined' && typeof window.DateRangePicker !== 'undefined';"
-            )
+    def test_slug_autofill(self) -> None:
+        """Check that base JavaScript initializes slug autogeneration."""
+        self.do_login(superuser=True)
+
+        with self.wait_for_page_load():
+            self.driver.get(f"{self.live_server_url}{reverse('create-project')}")
+
+        name_input = self.driver.find_element(By.ID, "id_name")
+        slug_input = self.driver.find_element(By.ID, "id_slug")
+        name_input.send_keys("Example.Project Name")
+
+        WebDriverWait(self.driver, 5).until(
+            lambda _driver: slug_input.get_attribute("value") == "example-project-name"
         )
 
     def test_js_unit_tests(self) -> None:


### PR DESCRIPTION
Fold base JavaScript readiness into page-load waits and cover slug autogeneration instead of asserting raw globals.

@KarenKonou Apparently jQuery removal made the loading a bit faster and now sometimes the tests fail because the scripts are not yet loaded. Instead of that test I folded the script loading assertion to the existing predicate and added test for slugify to test some JavaScript functionality.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
