### PR TITLE
fix(security): avoid reparsing sortable header text

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -451,7 +451,10 @@ function loadTableSorting() {
           th.setAttribute("title", gettext("Sort this column"));
           th.classList.add("sort-cell");
           if (th.classList.contains("number")) {
-            th.innerHTML = `<span·class="sort-icon">·</span>${th.textContent}`;
+            const icon = document.createElement("span");
+            icon.classList.add("sort-icon");
+            icon.textContent = " ";
+            th.prepend(icon);
           } else {
             th.insertAdjacentHTML(
               "beforeend",


### PR DESCRIPTION
### Motivation
- Prevent a DOM XSS regression introduced when numeric sortable column headers were refactored to assign `th.textContent` into `th.innerHTML`, which can reparse escaped header text as markup.

### Description
- Replace the unsafe `innerHTML` assignment in `weblate/static/loader-bootstrap.js` for `th.number` headers with explicit DOM creation of the sort icon (`document.createElement("span")`) and `th.prepend(icon)`, preserving existing header text as text instead of reparsing it as HTML and keeping sorting behavior intact.

### Testing
- Ran `node --check weblate/static/loader-bootstrap.js` which succeeded, ran `git diff --check` which reported no new issues, and attempted `uv run prek run biome-check --files weblate/static/loader-bootstrap.js` which was blocked due to a pre-commit dependency clone error (HTTP 403) preventing that check from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc0caa1608329bcf12d0853000b37)