### PR TITLE
fix(checks): ignore malformed replacements flags

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,7 @@ Weblate 2026.7
 
 .. rubric:: Bug fixes
 
+* Malformed ``replacements`` flags no longer abort source length checks.
 * Scoped team assignments can no longer be expanded through the API.
 * Empty component lists are no longer exposed to users without component list management permission.
 * TBX glossary files no longer duplicate terms when repeated pending add operations are saved.

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -267,7 +267,10 @@ class BaseCheck(ClassLoaderProtocol, DocVersionsMixin):
             return replacement
 
         # Parse the flag
-        replacements = flags.get_value("replacements")
+        try:
+            replacements = flags.get_value("replacements")
+        except ValueError:
+            return replacement
         # Create dict from that
         replacements = dict(
             replacements[pos : pos + 2] for pos in range(0, len(replacements), 2)

--- a/weblate/checks/tests/test_source_checks.py
+++ b/weblate/checks/tests/test_source_checks.py
@@ -107,6 +107,12 @@ class SourceMaxLengthCheckTest(TestCase):
         self.assertFalse(self.check.check_source(["x" * 82], unit))
         self.assertTrue(self.check.check_source(["x" * 82 + "%s"], unit))
 
+    def test_invalid_replacements(self) -> None:
+        unit = self.get_unit("max-length:100, replacements:%s")
+
+        self.assertFalse(self.check.check_source(["x" * 85], unit))
+        self.assertTrue(self.check.check_source(["x" * 86], unit))
+
     def test_xml_text(self) -> None:
         unit = self.get_unit("max-length:100, xml-text")
 


### PR DESCRIPTION
### Motivation
- Prevent malformed `replacements` flag values provided by external repositories from raising `ValueError` and aborting source-check execution or background import/update tasks.

### Description
- Wrap `flags.get_value("replacements")` in a `try/except ValueError` in `get_replacement_function` and fall back to the XML/no-op replacement function when parsing fails instead of propagating the exception (`weblate/checks/base.py`).
- Add a unit test `test_invalid_replacements` to `SourceMaxLengthCheckTest` to cover a malformed `replacements` flag case and ensure length checks still behave as expected (`weblate/checks/tests/test_source_checks.py`).
- Add a short unreleased changelog entry noting that malformed `replacements` flags no longer abort source length checks (`docs/changes.rst`).

### Testing
- Ran `uv run pytest weblate/checks/tests/test_source_checks.py::SourceMaxLengthCheckTest`, which completed successfully (`10 passed`).
- Ran `uv run prek run --files weblate/checks/base.py weblate/checks/tests/test_source_checks.py docs/changes.rst`, which was blocked in this environment due to pre-commit hook repository cloning failing with an HTTP 403 error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0b6b6dcc832986936907ad2f5ead)