### PR TITLE
fix(upload): show placeholders on unsupported levels

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -70,6 +70,7 @@ Weblate 2026.7
 * :ref:`check-max-size` now checks source strings and refreshes rendered previews after source edits.
 * Watched translations on the dashboard now include category path segments.
 * Restricted component changes are no longer exposed through nested project, component, or translation API change endpoints.
+* Unsupported upload levels now show an upload placeholder pointing to individual translations.
 
 .. rubric:: Compatibility
 

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from django.conf import settings
+from django.db.models import Q
 from django.utils.translation import gettext
 
 from weblate.formats.base import BilingualUpdateMixin
@@ -16,6 +17,7 @@ from weblate.trans.models import (
     Announcement,
     Category,
     Component,
+    ComponentLink,
     ComponentList,
     ContributorAgreement,
     Project,
@@ -28,7 +30,7 @@ from weblate.workspaces.models import Workspace
 from .results import Allowed, Denied
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from django.db.models import Model, QuerySet
 
@@ -41,6 +43,7 @@ if TYPE_CHECKING:
     from .results import PermissionResult
 
 SPECIALS: dict[str, Callable[[User, str, Model], bool | PermissionResult]] = {}
+UPLOAD_SCOPE_PERMISSIONS = frozenset({"glossary.upload", "upload.perform"})
 
 
 @dataclass(frozen=True)
@@ -328,6 +331,7 @@ def check_can_edit(
     | Project,
     *,
     is_vote: bool = False,
+    allow_limited_without_language: bool | None = None,
 ) -> bool | PermissionResult:
     translation = component = None
 
@@ -383,9 +387,10 @@ def check_can_edit(
             )
 
     # Perform usual permission check
-    allow_limited_without_language = isinstance(
-        obj, (Translation, ProjectLanguage, CategoryLanguage)
-    )
+    if allow_limited_without_language is None:
+        allow_limited_without_language = isinstance(
+            obj, (Translation, ProjectLanguage, CategoryLanguage)
+        )
     if not check_permission(
         user,
         permission,
@@ -493,7 +498,16 @@ def check_unit_review(
 def check_edit_approved(
     user: User,
     permission: str,
-    obj: Unit | Translation | Component | Project | ProjectLanguage | Workspace,
+    obj: Unit
+    | Translation
+    | Component
+    | Project
+    | ProjectLanguage
+    | CategoryLanguage
+    | Category
+    | Workspace,
+    *,
+    allow_limited_without_language: bool | None = None,
 ) -> bool | PermissionResult:
     component = None
     if isinstance(obj, Unit):
@@ -530,7 +544,12 @@ def check_edit_approved(
         component = obj
     if component is not None and component.is_glossary:
         permission = "glossary.edit"
-    return check_can_edit(user, permission, obj)
+    return check_can_edit(
+        user,
+        permission,
+        obj,
+        allow_limited_without_language=allow_limited_without_language,
+    )
 
 
 def check_manage_units(
@@ -659,7 +678,9 @@ def check_suggestion_vote(
 
 @register_perm("suggestion.add")
 def check_suggestion_add(
-    user: User, permission: str, obj: Unit | Translation | ProjectLanguage
+    user: User,
+    permission: str,
+    obj: Unit | Translation | ProjectLanguage | CategoryLanguage,
 ) -> bool | PermissionResult:
     if isinstance(obj, Unit):
         obj = obj.translation
@@ -676,9 +697,202 @@ def check_suggestion_add(
     return check_permission(user, permission, obj)
 
 
+def _category_component_filter(category: Category) -> Q:
+    return (
+        Q(category=category)
+        | Q(category__category=category)
+        | Q(category__category__category=category)
+    )
+
+
+def _category_translation_component_filter(category: Category) -> Q:
+    return (
+        Q(component__category=category)
+        | Q(component__category__category=category)
+        | Q(component__category__category__category=category)
+    )
+
+
+def _category_link_filter(category: Category) -> Q:
+    return (
+        Q(category=category)
+        | Q(category__category=category)
+        | Q(category__category__category=category)
+    )
+
+
+def _category_translation_filter(category: Category) -> Q:
+    shared_component_ids = ComponentLink.objects.filter(
+        _category_link_filter(category)
+    ).values("component_id")
+    return _category_translation_component_filter(category) | Q(
+        component_id__in=shared_component_ids
+    )
+
+
+def _has_upload_scope_permission(
+    scoped_permissions: Iterable[tuple[set[str], PermissionLanguageScope | None]],
+    language_id: int | None = None,
+) -> bool:
+    return any(
+        _has_scoped_permission(
+            permission,
+            permissions,
+            langs,
+            language_id,
+            allow_limited_without_language=True,
+        )
+        for permissions, langs in scoped_permissions
+        for permission in UPLOAD_SCOPE_PERMISSIONS
+    )
+
+
+def _get_upload_child_translations(
+    obj: Component | ProjectLanguage | CategoryLanguage | Category | Project,
+) -> Iterable[Translation]:
+    if isinstance(obj, Component):
+        return obj.translation_set.select_related(
+            "component", "component__project", "language"
+        )
+    if isinstance(obj, ProjectLanguage | CategoryLanguage):
+        return obj.translation_set
+    if isinstance(obj, Category):
+        return (
+            Translation.objects.filter(_category_translation_filter(obj))
+            .distinct()
+            .select_related("component", "component__project", "language")
+        )
+    return (
+        Translation.objects.filter(Q(component__project=obj) | Q(component__links=obj))
+        .distinct()
+        .select_related("component", "component__project", "language")
+    )
+
+
+def _get_user_upload_component_ids(user: User, language_id: int | None) -> set[int]:
+    return {
+        component_id
+        for component_id, scoped_permissions in user.component_permissions.items()
+        if _has_upload_scope_permission(scoped_permissions, language_id)
+    }
+
+
+def _has_upload_component_scope(
+    user: User,
+    obj: Component | ProjectLanguage | CategoryLanguage | Category | Project,
+    language_id: int | None,
+) -> bool:
+    component_ids = _get_user_upload_component_ids(user, language_id)
+    if not component_ids:
+        return False
+
+    if isinstance(obj, Component):
+        return obj.pk in component_ids
+
+    if isinstance(obj, Project | ProjectLanguage):
+        project = obj if isinstance(obj, Project) else obj.project
+        components = Component.objects.filter(pk__in=component_ids).filter(
+            Q(project=project) | Q(links=project)
+        )
+        if language_id is not None:
+            components = components.filter(translation__language_id=language_id)
+        return components.exists()
+
+    category = obj if isinstance(obj, Category) else obj.category
+    own_components = Component.objects.filter(pk__in=component_ids).filter(
+        _category_component_filter(category)
+    )
+    if language_id is not None:
+        own_components = own_components.filter(translation__language_id=language_id)
+    if own_components.exists():
+        return True
+
+    shared_links = ComponentLink.objects.filter(
+        _category_link_filter(category), component_id__in=component_ids
+    )
+    if language_id is not None:
+        shared_links = shared_links.filter(
+            component__translation__language_id=language_id
+        )
+    return shared_links.exists()
+
+
+def _has_upload_scope(
+    user: User,
+    obj: Component | ProjectLanguage | CategoryLanguage | Category | Project,
+) -> bool:
+    if user.is_superuser:
+        return True
+
+    if isinstance(obj, Component):
+        language_id = None
+        project = obj.project
+    elif isinstance(obj, ProjectLanguage | CategoryLanguage):
+        language_id = obj.language.id
+        project = obj.project
+    elif isinstance(obj, Category):
+        language_id = None
+        project = obj.project
+    else:
+        language_id = None
+        project = obj
+
+    return _has_upload_scope_permission(
+        user.get_project_permissions(project), language_id
+    ) or _has_upload_component_scope(user, obj, language_id)
+
+
+def _bind_upload_child_scope(
+    obj: Component | ProjectLanguage | CategoryLanguage | Category | Project,
+    translation: Translation,
+) -> None:
+    if isinstance(obj, Component):
+        if translation.component_id == obj.pk:
+            translation.component = obj
+            _bind_upload_child_workflow_settings(obj.project, translation)
+        return
+
+    project = obj if isinstance(obj, Project) else obj.project
+    if translation.component.project_id == project.pk:
+        translation.component.project = project
+        _bind_upload_child_workflow_settings(project, translation)
+
+
+def _bind_upload_child_workflow_settings(
+    project: Project, translation: Translation
+) -> None:
+    project_language = project.project_languages.data.get(translation.language_id)
+    if (
+        project_language is not None
+        and "workflow_settings" in project_language.__dict__
+    ):
+        translation.__dict__["workflow_settings"] = project_language.workflow_settings
+
+
+def _has_upload_child(
+    user: User,
+    obj: Component | ProjectLanguage | CategoryLanguage | Category | Project,
+) -> bool:
+    if not _has_upload_scope(user, obj):
+        return False
+
+    for translation in _get_upload_child_translations(obj):
+        _bind_upload_child_scope(obj, translation)
+        if user.has_perm("upload.perform", translation):
+            return True
+    return False
+
+
 @register_perm("upload.perform")
 def check_upload(
-    user: User, permission: str, obj: Translation | ProjectLanguage
+    user: User,
+    permission: str,
+    obj: Translation
+    | Component
+    | ProjectLanguage
+    | CategoryLanguage
+    | Category
+    | Project,
 ) -> bool | PermissionResult:
     """
     Check whether user can perform any upload operation.
@@ -703,17 +917,18 @@ def check_upload(
             )
         if obj.component.is_glossary:
             permission = "glossary.upload"
+        return check_can_edit(user, permission, obj) and (
+            # Normal upload
+            check_edit_approved(user, "unit.edit", obj)
+            # Suggestion upload
+            or check_suggestion_add(user, "suggestion.add", obj)
+            # Add upload
+            or check_suggestion_add(user, "unit.add", obj)
+            # Source upload
+            or obj.is_source
+        )
 
-    return check_can_edit(user, permission, obj) and (
-        # Normal upload
-        check_edit_approved(user, "unit.edit", obj)
-        # Suggestion upload
-        or check_suggestion_add(user, "suggestion.add", obj)
-        # Add upload
-        or check_suggestion_add(user, "unit.add", obj)
-        # Source upload
-        or (isinstance(obj, Translation) and obj.is_source)
-    )
+    return _has_upload_child(user, obj)
 
 
 @register_perm("machinery.view")

--- a/weblate/templates/category-language.html
+++ b/weblate/templates/category-language.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 
-{% load crispy_forms_tags i18n metrics translations %}
+{% load crispy_forms_tags i18n metrics permissions translations %}
 
 {% block nav_pills %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
+
   <ul class="nav nav-pills">
     <li class="nav-item">
       <a class="nav-link active"
@@ -38,6 +40,11 @@
              href="{% url 'download' path=object.get_url_path %}?format=zip"
              title="{% translate "Download for offline translation." %}">{% blocktranslate %}Download original translation files as ZIP file{% endblocktranslate %}</a>
         </li>
+        {% if user_can_upload_translation %}
+          <li>
+            <a class="dropdown-item" data-bs-target="#upload" data-bs-toggle="tab" href="#">{% translate "Upload translation" %}</a>
+          </li>
+        {% endif %}
       </ul>
     </li>
     <li class="nav-item dropdown">
@@ -76,6 +83,7 @@
 {% block content %}
 
   {% get_translate_url object as translate_url %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
 
   <div class="tab-content">
 
@@ -146,6 +154,12 @@
             </div>
           </div>
         </form>
+      </div>
+    {% endif %}
+
+    {% if user_can_upload_translation %}
+      <div class="tab-pane" id="upload">
+        {% include "snippets/upload-placeholder.html" with upload_translation_tab="#components" upload_translation_label=_("Browse components") %}
       </div>
     {% endif %}
 

--- a/weblate/templates/category.html
+++ b/weblate/templates/category.html
@@ -5,6 +5,7 @@
 {% block nav_pills %}
   {% perm 'project.edit' object as user_can_edit_project %}
   {% perm 'reports.view' object as user_can_view_reports %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
 
   <ul class="nav nav-pills">
     <li class="nav-item">
@@ -69,6 +70,11 @@
              href="{% url 'download' path=object.get_url_path %}?format=zip:xlsx"
              title="{% translate "Download for offline translation." %}">{% blocktranslate %}Download translations as XLSX in a ZIP file{% endblocktranslate %}</a>
         </li>
+        {% if user_can_upload_translation %}
+          <li>
+            <a class="dropdown-item" data-bs-target="#upload" data-bs-toggle="tab" href="#">{% translate "Upload translation" %}</a>
+          </li>
+        {% endif %}
       </ul>
     </li>
     <li class="nav-item dropdown">
@@ -164,6 +170,7 @@
 
   {% perm 'project.edit' object as user_can_edit_project %}
   {% perm 'reports.view' object as user_can_view_reports %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
 
   <div class="tab-content">
     <div class="tab-pane" id="components">
@@ -253,6 +260,12 @@
       </div>
     {% endif %}
 
+
+    {% if user_can_upload_translation %}
+      <div class="tab-pane" id="upload">
+        {% include "snippets/upload-placeholder.html" with upload_translation_tab="#languages" upload_translation_label=_("Browse translations") %}
+      </div>
+    {% endif %}
 
 
     {% if user_can_edit_project and add_form %}

--- a/weblate/templates/component.html
+++ b/weblate/templates/component.html
@@ -8,6 +8,7 @@
   {% perm 'reports.view' object as user_can_view_reports %}
   {% perm 'translation.add' object as user_can_add_translation %}
   {% perm 'component.edit' object as user_can_edit_component %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
 
   <ul class="nav nav-pills">
     <li class="nav-item">
@@ -88,6 +89,11 @@
              href="{% url 'download' path=object.get_url_path %}?format=zip:xlsx"
              title="{% translate "Download for offline translation." %}">{% blocktranslate %}Download translations as XLSX in a ZIP file{% endblocktranslate %}</a>
         </li>
+        {% if user_can_upload_translation %}
+          <li>
+            <a class="dropdown-item" data-bs-target="#upload" data-bs-toggle="tab" href="#">{% translate "Upload translation" %}</a>
+          </li>
+        {% endif %}
       </ul>
     </li>
     <li class="nav-item dropdown">
@@ -206,6 +212,7 @@
   {% perm 'reports.view' object as user_can_view_reports %}
   {% perm 'translation.add' object as user_can_add_translation %}
   {% perm 'component.edit' object as user_can_edit_component %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
 
   <div class="tab-content">
     <div class="tab-pane active" id="translations">
@@ -312,6 +319,12 @@
             </div>
           </div>
         </form>
+      </div>
+    {% endif %}
+
+    {% if user_can_upload_translation %}
+      <div class="tab-pane" id="upload">
+        {% include "snippets/upload-placeholder.html" with upload_translation_tab="#translations" upload_translation_label=_("Browse translations") %}
       </div>
     {% endif %}
 

--- a/weblate/templates/language-project.html
+++ b/weblate/templates/language-project.html
@@ -227,24 +227,7 @@
 
     {% if user_can_upload_translation %}
       <div class="tab-pane" id="upload">
-        <div class="card">
-          <div class="card-header">
-            <h4 class="card-title">
-              {% documentation_icon 'user/files' 'upload' right=True %}
-              {% translate "Upload" %}
-            </h4>
-          </div>
-          <div class="card-body">
-            <p>
-              {% blocktranslate trimmed %}
-                Project-wide uploads are currently not supported. Translation
-                files need to be uploaded on the individual translations. Switch
-                to the "Components" tab above, open the desired component, and
-                perform the upload there.
-              {% endblocktranslate %}
-            </p>
-          </div>
-        </div>
+        {% include "snippets/upload-placeholder.html" with upload_translation_tab="#components" upload_translation_label=_("Browse components") %}
       </div>
     {% endif %}
 

--- a/weblate/templates/project.html
+++ b/weblate/templates/project.html
@@ -7,6 +7,7 @@
   {% perm 'project.permissions' object as user_can_manage_acl %}
   {% perm 'project.edit' object as user_can_edit_project %}
   {% perm 'reports.view' object as user_can_view_reports %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
 
   <ul class="nav nav-pills">
     <li class="nav-item">
@@ -82,6 +83,11 @@
              href="{% url 'download' path=object.get_url_path %}?format=zip:xlsx"
              title="{% translate "Download for offline translation." %}">{% blocktranslate %}Download translations as XLSX in a ZIP file{% endblocktranslate %}</a>
         </li>
+        {% if user_can_upload_translation %}
+          <li>
+            <a class="dropdown-item" data-bs-target="#upload" data-bs-toggle="tab" href="#">{% translate "Upload translation" %}</a>
+          </li>
+        {% endif %}
       </ul>
     </li>
     <li class="nav-item dropdown">
@@ -235,6 +241,7 @@
   {% perm 'project.permissions' object as user_can_manage_acl %}
   {% perm 'project.edit' object as user_can_edit_project %}
   {% perm 'reports.view' object as user_can_view_reports %}
+  {% perm 'upload.perform' object as user_can_upload_translation %}
 
   <div class="tab-content">
     <div class="tab-pane" id="components">
@@ -317,6 +324,12 @@
             </div>
           </div>
         </form>
+      </div>
+    {% endif %}
+
+    {% if user_can_upload_translation %}
+      <div class="tab-pane" id="upload">
+        {% include "snippets/upload-placeholder.html" with upload_translation_tab="#languages" upload_translation_label=_("Browse translations") %}
       </div>
     {% endif %}
 

--- a/weblate/templates/snippets/upload-placeholder.html
+++ b/weblate/templates/snippets/upload-placeholder.html
@@ -1,0 +1,22 @@
+{% load i18n translations %}
+
+<div class="card">
+  <div class="card-header">
+    <h4 class="card-title">
+      {% documentation_icon 'user/files' 'upload' right=True %}
+      {% translate "Upload" %}
+    </h4>
+  </div>
+  <div class="card-body">
+    <p>
+      {% blocktranslate trimmed %}
+        Uploading translations at this level is not supported. Open an individual
+        translation and upload the file there.
+      {% endblocktranslate %}
+    </p>
+    <a class="btn btn-primary"
+       data-bs-target="{{ upload_translation_tab }}"
+       data-bs-toggle="tab"
+       href="#">{{ upload_translation_label }}</a>
+  </div>
+</div>

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -109,6 +109,8 @@ class ProjectLanguageFactory(UserDict):
         from weblate.trans.models.workflow import WorkflowSetting
 
         instances = self.preload() if instances is None else list(instances)
+        for instance in instances:
+            self.data[instance.language.id] = instance
 
         pending = {instance.language.id: instance for instance in instances}
 

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, cast
 from unittest import TestCase
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse, urlsplit
 from zipfile import ZipFile
 
@@ -31,7 +32,13 @@ from openpyxl import load_workbook
 from PIL import Image
 
 from weblate.auth.data import SELECTION_ALL
-from weblate.auth.models import Group, Permission, Role, setup_project_groups
+from weblate.auth.models import (
+    Group,
+    Permission,
+    Role,
+    TeamMembership,
+    setup_project_groups,
+)
 from weblate.lang.models import Language
 from weblate.trans.models import (
     Category,
@@ -50,6 +57,7 @@ from weblate.trans.tests.utils import (
 )
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.state import STATE_TRANSLATED
+from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.utils.views import zip_download
 from weblate.utils.xml import parse_xml
 
@@ -846,10 +854,177 @@ class CategoryLanguageAdditionTest(ProjectLanguageAdditionTest):
 
 
 class BasicViewTest(ViewTestCase):
+    def assert_upload_placeholder(self, response, tab: str) -> None:
+        self.assertContains(response, "Upload translation")
+        self.assertContains(
+            response, "Uploading translations at this level is not supported."
+        )
+        self.assertContains(response, f'data-bs-target="{tab}"')
+
+    def assert_no_upload_placeholder(self, response) -> None:
+        self.assertNotContains(response, "Upload translation")
+
     def test_view_project(self) -> None:
         response = self.client.get(self.project.get_absolute_url())
         self.assertContains(response, "test/test")
         self.assertNotContains(response, "Spanish")
+
+    def test_view_project_upload_placeholder(self) -> None:
+        response = self.client.get(self.project.get_absolute_url())
+
+        self.assert_upload_placeholder(response, "#languages")
+
+    def test_upload_placeholder_for_membership_limited_translator(self) -> None:
+        category = self.create_category(self.project)
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Limited upload", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        group.roles.add(Role.objects.get(name="Power user"))
+        self.user.groups.add(group)
+        membership = TeamMembership.objects.get(user=self.user, group=group)
+        membership.limit_languages.set([self.translation.language])
+        self.user.clear_cache()
+
+        for url, tab in (
+            (self.project.get_absolute_url(), "#languages"),
+            (self.component.get_absolute_url(), "#translations"),
+            (category.get_absolute_url(), "#languages"),
+        ):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+
+                self.assert_upload_placeholder(response, tab)
+
+    def test_upload_placeholder_skips_children_without_upload_scope(self) -> None:
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Project access only", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        self.user.groups.add(group)
+        self.user.clear_cache()
+
+        with patch(
+            "weblate.auth.permissions._get_upload_child_translations"
+        ) as get_upload_child_translations:
+            response = self.client.get(self.project.get_absolute_url())
+
+        self.assert_no_upload_placeholder(response)
+        get_upload_child_translations.assert_not_called()
+
+    def test_upload_placeholder_requires_uploadable_child_translation(self) -> None:
+        project = self.create_project(
+            name="Restricted upload", slug="restricted-upload"
+        )
+        category = self.create_category(project)
+        self.create_po(
+            project=project,
+            category=category,
+            name="restricted-upload",
+            restricted=True,
+        )
+
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Restricted project upload", language_selection=SELECTION_ALL
+        )
+        group.projects.add(project)
+        group.roles.add(Role.objects.get(name="Power user"))
+        self.user.groups.add(group)
+        self.user.clear_cache()
+
+        for url in (project.get_absolute_url(), category.get_absolute_url()):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+
+                self.assert_no_upload_placeholder(response)
+
+    def test_upload_placeholder_uses_component_scoped_permissions(self) -> None:
+        project = self.create_project(
+            name="Component scoped upload", slug="component-scoped-upload"
+        )
+        category = self.create_category(project)
+        component = self.create_po(
+            project=project,
+            category=category,
+            name="restricted-component-upload",
+            restricted=True,
+        )
+        translation = component.translation_set.get(language=self.translation.language)
+
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Component scoped upload", language_selection=SELECTION_ALL
+        )
+        group.components.add(component)
+        group.roles.add(Role.objects.get(name="Power user"))
+        self.user.groups.add(group)
+        self.user.clear_cache()
+
+        for url, tab in (
+            (project.get_absolute_url(), "#languages"),
+            (
+                ProjectLanguage(project, translation.language).get_absolute_url(),
+                "#components",
+            ),
+            (category.get_absolute_url(), "#languages"),
+            (
+                CategoryLanguage(category, translation.language).get_absolute_url(),
+                "#components",
+            ),
+            (component.get_absolute_url(), "#translations"),
+        ):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+
+                self.assert_upload_placeholder(response, tab)
+
+    def test_upload_placeholder_uses_component_link_category(self) -> None:
+        source_project = self.create_project(
+            name="Shared upload source", slug="shared-upload-source"
+        )
+        shared_component = self.create_po(
+            project=source_project, name="shared-category-upload"
+        )
+        linked_category = Category.objects.create(
+            name="Linked category",
+            slug="linked-category",
+            project=self.project,
+        )
+        unrelated_category = Category.objects.create(
+            name="Unrelated category",
+            slug="unrelated-category",
+            project=self.project,
+        )
+        ComponentLink.objects.create(
+            component=shared_component,
+            project=self.project,
+            category=linked_category,
+        )
+
+        self.user.groups.clear()
+        access_group = Group.objects.create(
+            name="Shared target access", language_selection=SELECTION_ALL
+        )
+        access_group.projects.add(self.project)
+        upload_group = Group.objects.create(
+            name="Shared component upload", language_selection=SELECTION_ALL
+        )
+        upload_group.components.add(shared_component)
+        upload_group.roles.add(Role.objects.get(name="Power user"))
+        self.user.groups.add(access_group, upload_group)
+        self.user.clear_cache()
+
+        response = self.client.get(linked_category.get_absolute_url())
+        self.assert_upload_placeholder(response, "#languages")
+
+        response = self.client.get(unrelated_category.get_absolute_url())
+        self.assert_no_upload_placeholder(response)
 
     def test_view_project_preloads_workflow_settings(self) -> None:
         self.project.translation_review = True
@@ -909,6 +1084,53 @@ class BasicViewTest(ViewTestCase):
         self.assertContains(response, "Test/Test")
         self.assertNotContains(response, "Spanish")
 
+    def test_view_component_upload_placeholder(self) -> None:
+        response = self.client.get(self.component.get_absolute_url())
+
+        self.assert_upload_placeholder(response, "#translations")
+
+    def test_glossary_component_upload_placeholder(self) -> None:
+        category = self.create_category(self.project)
+        self.component.create_glossary()
+        glossary = Component.objects.get(project=self.project, is_glossary=True)
+        glossary.category = category
+        glossary.save(update_fields=["category"])
+        glossary_translation = glossary.translation_set.exclude(
+            language=glossary.source_language
+        ).first()
+        if glossary_translation is None:
+            glossary_translation = glossary.translation_set.first()
+        self.assertIsNotNone(glossary_translation)
+        assert glossary_translation is not None
+        language = glossary_translation.language
+
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Glossary upload", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        group.roles.add(Role.objects.get(name="Manage glossary"))
+        self.user.groups.add(group)
+        self.user.clear_cache()
+
+        for url, tab in (
+            (self.project.get_absolute_url(), "#languages"),
+            (
+                ProjectLanguage(self.project, language).get_absolute_url(),
+                "#components",
+            ),
+            (category.get_absolute_url(), "#languages"),
+            (
+                CategoryLanguage(category, language).get_absolute_url(),
+                "#components",
+            ),
+            (glossary.get_absolute_url(), "#translations"),
+        ):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+
+                self.assert_upload_placeholder(response, tab)
+
     def test_view_component_ghost(self) -> None:
         self.user.profile.languages.add(Language.objects.get(code="es"))
         response = self.client.get(self.component.get_absolute_url())
@@ -967,6 +1189,13 @@ class BasicViewTest(ViewTestCase):
     def test_view_translation(self) -> None:
         response = self.client.get(self.translation.get_absolute_url())
         self.assertContains(response, "Test/Test")
+
+    def test_view_project_language_upload_placeholder(self) -> None:
+        project_language = ProjectLanguage(self.project, self.translation.language)
+
+        response = self.client.get(project_language.get_absolute_url())
+
+        self.assert_upload_placeholder(response, "#components")
 
     def test_view_translation_others(self) -> None:
         with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
@@ -1122,6 +1351,74 @@ class BasicViewTest(ViewTestCase):
         self.assertContains(response, category.name)
         self.assertContains(response, cat_component.name)
         self.assertContains(response, "Spanish")
+
+    def test_view_category_upload_placeholder(self) -> None:
+        category = self.create_category(self.project)
+        self.create_po(
+            project=self.project, category=category, name="Category Component"
+        )
+
+        response = self.client.get(category.get_absolute_url())
+
+        self.assert_upload_placeholder(response, "#languages")
+
+    def test_view_category_language_upload_placeholder(self) -> None:
+        category = self.create_category(self.project)
+        self.create_po(
+            project=self.project, category=category, name="Category Component"
+        )
+        category_language = CategoryLanguage(category, self.translation.language)
+
+        response = self.client.get(category_language.get_absolute_url())
+
+        self.assert_upload_placeholder(response, "#components")
+
+    def test_category_language_upload_placeholder_respects_suggestions(self) -> None:
+        category = self.create_category(self.project)
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+
+        self.user.groups.clear()
+        role = Role.objects.create(name="Upload suggestions")
+        role.permissions.add(
+            Permission.objects.get(codename="suggestion.add"),
+            Permission.objects.get(codename="upload.perform"),
+        )
+        group = Group.objects.create(
+            name="Upload suggestions", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        group.roles.add(role)
+        self.user.groups.add(group)
+        self.user.clear_cache()
+        category_language = CategoryLanguage(category, self.translation.language)
+
+        response = self.client.get(category_language.get_absolute_url())
+
+        self.assert_upload_placeholder(response, "#components")
+
+        self.component.enable_suggestions = False
+        self.component.save(update_fields=["enable_suggestions"])
+        self.user.clear_cache()
+        category_language = CategoryLanguage(category, self.translation.language)
+
+        response = self.client.get(category_language.get_absolute_url())
+
+        self.assert_no_upload_placeholder(response)
+
+        self.component.enable_suggestions = True
+        self.component.save(update_fields=["enable_suggestions"])
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=self.translation.language,
+            enable_suggestions=False,
+        )
+        self.user.clear_cache()
+        category_language = CategoryLanguage(category, self.translation.language)
+
+        response = self.client.get(category_language.get_absolute_url())
+
+        self.assertNotContains(response, "Upload translation")
 
 
 class BasicMonolingualViewTest(BasicViewTest):

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -1270,6 +1270,8 @@ class ProjectLanguage(BaseURLMixin, TranslationChecklistMixin):
 
     @property
     def enable_suggestions(self) -> bool:
+        if self.workflow_settings is not None:
+            return self.workflow_settings.enable_suggestions
         return True
 
     @property
@@ -1444,6 +1446,12 @@ class CategoryLanguage(BaseURLMixin, TranslationChecklistMixin):
         return self.project.enable_review
 
     @property
+    def enable_suggestions(self) -> bool:
+        return any(
+            translation.enable_suggestions for translation in self.translation_set
+        )
+
+    @property
     def is_readonly(self) -> bool:
         return False
 
@@ -1520,6 +1528,20 @@ class CategoryLanguage(BaseURLMixin, TranslationChecklistMixin):
     @cached_property
     def is_source(self):
         return self.language.id in self.category.source_language_ids
+
+    @cached_property
+    def workflow_settings(self):
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models.workflow import WorkflowSetting
+
+        workflow_settings = WorkflowSetting.objects.filter(
+            Q(project=None) | Q(project=self.project),
+            language=self.language,
+        ).order_by(F("project").desc(nulls_last=True))
+        if len(workflow_settings) == 0:
+            return None
+        # Project specific is first, project NULL is last
+        return workflow_settings[0]
 
     @cached_property
     def change_set(self):


### PR DESCRIPTION
Expose the upload placeholder from project, category, component, project-language, and category-language pages when uploads must happen on individual translations.

Fixes #20206

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
