### PR TITLE
docs(formats): remove empty translation in untranslateable term from tbx example

### DIFF
--- a/weblate/trans/tests/data/cs.tbx
+++ b/weblate/trans/tests/data/cs.tbx
@@ -56,11 +56,6 @@
                     <term>Weblate</term>
                   </tig>
                 </langSet>
-                <langSet xml:lang="cs">
-                  <tig>
-                    <term></term>
-                  </tig>
-                </langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en">


### PR DESCRIPTION
The untranslatable flag does not get applied on import when a translation langSet is present.