### PR TITLE
fix(glossary): avoid duplicate source-language term rendering

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,7 @@ Weblate 2026.7
 * Scoped team assignments can no longer be expanded through the API.
 * Empty component lists are no longer exposed to users without component list management permission.
 * TBX glossary files no longer duplicate terms when repeated pending add operations are saved.
+* Glossary terms are no longer shown in both columns when translating the glossary source language.
 * :ref:`code-hosting-gerrit` review pushes can again include Gerrit push options in the target branch.
 * Webhook target fallback matching is now stricter and reported in component diagnostics.
 * Creating components linked with ``weblate://`` no longer waits on the shared repository lock during the request.

--- a/weblate/templates/snippets/glossary.html
+++ b/weblate/templates/snippets/glossary.html
@@ -3,16 +3,28 @@
 {% for item in glossary %}
   <tr class="glossary-embed {% if "forbidden" in item.all_flags %}unclickable-row danger{% elif "read-only" in item.all_flags %}clickable-row warning{% else %}clickable-row{% endif %}"
       title=" {% if "forbidden" in item.all_flags %} {% translate "This translation is forbidden." %} {% elif "read-only" in item.all_flags %} {% translate "This term should not be translated." %} {% elif item.fuzzy %} {% translate "This translation needs editing." %}  {% else %} {% translate "Copy word into translation" %} {% endif %} ">
-    <td class="source">{{ item.source }}</td>
-    <td class="target">
-      {% if "forbidden" in item.all_flags %}
-        <span class="red forbidden-term">{% icon "cancel.svg" %}</span>
-      {% endif %}
-      {% if item.fuzzy %}
-        <span class="red forbidden-term">{% icon "alert.svg" %}</span>
-      {% endif %}
-      {% format_unit_target unit value=item.target simple=True %}
-    </td>
+    {% if item.is_source %}
+      <td class="source target" colspan="2">
+        {% if "forbidden" in item.all_flags %}
+          <span class="red forbidden-term">{% icon "cancel.svg" %}</span>
+        {% endif %}
+        {% if item.fuzzy %}
+          <span class="red forbidden-term">{% icon "alert.svg" %}</span>
+        {% endif %}
+        {% format_unit_target unit value=item.target simple=True %}
+      </td>
+    {% else %}
+      <td class="source">{{ item.source }}</td>
+      <td class="target">
+        {% if "forbidden" in item.all_flags %}
+          <span class="red forbidden-term">{% icon "cancel.svg" %}</span>
+        {% endif %}
+        {% if item.fuzzy %}
+          <span class="red forbidden-term">{% icon "alert.svg" %}</span>
+        {% endif %}
+        {% format_unit_target unit value=item.target simple=True %}
+      </td>
+    {% endif %}
     <td>{% include "snippets/glossary-badge.html" with glossary=item.translation %}</td>
     <td>
       <a href="{{ item.get_absolute_url }}"

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -781,8 +781,12 @@
                 <table class="table table-sm table-simple">
                   <thead>
                     <tr>
-                      <th>{{ unit.translation.component.source_language }}</th>
-                      <th>{{ unit.translation.language }}</th>
+                      {% if unit.translation.is_source %}
+                        <th colspan="2">{{ unit.translation.language }}</th>
+                      {% else %}
+                        <th>{{ unit.translation.component.source_language }}</th>
+                        <th>{{ unit.translation.language }}</th>
+                      {% endif %}
                       <th></th>
                       <th></th>
                     </tr>

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -1848,6 +1848,38 @@ class EditComplexTest(ViewTestCase):
         self.assertIsNotNone(response.context["addterm_form"])
         self.assertContains(response, "Add term to glossary")
 
+    def test_translate_source_language_renders_glossary_term_once(self) -> None:
+        glossary = self.create_po(
+            name="Glossary",
+            project=self.project,
+            is_glossary=True,
+            manage_units=True,
+        )
+        glossary.source_translation.unit_set.create(
+            source="Hello",
+            target="Hello",
+            context="",
+            id_hash=calculate_hash("Hello", ""),
+            position=glossary.source_translation.unit_set.count() + 1,
+            state=STATE_TRANSLATED,
+        )
+        glossary.invalidate_glossary_cache()
+
+        response = self.client.get(
+            self.component.source_translation.get_translate_url()
+        )
+
+        self.assertEqual(response.context["glossary"][0].source, "Hello")
+        self.assertTrue(response.context["glossary"][0].is_source)
+        content = response.content.decode()
+        glossary_start = content.index('<tbody id="glossary-terms">')
+        glossary_end = content.index("</tbody>", glossary_start)
+        glossary_body = content[glossary_start:glossary_end]
+        self.assertIn('class="source target" colspan="2"', glossary_body)
+        self.assertIn("Hello", glossary_body)
+        self.assertNotIn('class="source">', glossary_body)
+        self.assertNotIn('class="target">', glossary_body)
+
     def test_translate_skips_glossary_fetch_without_glossaries(self) -> None:
         with patch("weblate.trans.views.edit.fetch_glossary_terms") as fetch_terms:
             response = self.client.get(self.translate_url)


### PR DESCRIPTION
Render glossary source-language matches once while preserving glossary row copy behavior.

Fixes #20276

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
