### PR TITLE
fix(trans): add explicit file cleanup actions

### DIFF
--- a/docs/admin/continuous.rst
+++ b/docs/admin/continuous.rst
@@ -187,6 +187,11 @@ Availability of individual actions depends on permissions, the configured
 version control system, whether pushing is configured, and whether the selected
 object can be locked.
 
+The :guilabel:`File management` actions are available only from
+:guilabel:`Repository maintenance` for an individual translation. These actions
+rewrite that translation file and commit the result; they are not project-wide
+or component-wide operations.
+
 Operations that read repository content, such as updating, resetting, or
 rescanning, also reconcile translation files in Weblate. Added or removed
 translation files are reflected after this processing finishes. Glossary
@@ -247,6 +252,14 @@ language synchronization and cleanup are described in
    * - :guilabel:`Rescan`
      - Re-reads translation files from the local repository into Weblate and removes translations whose files no longer match the component configuration.
      - Import file changes after manual repository work or file creation.
+
+   * - :guilabel:`Remove duplicates`
+     - Removes repeated strings with the same identifier from one translation file.
+     - Repair duplicate strings reported by Weblate when the file contains repeated units.
+
+   * - :guilabel:`Cleanup unused`
+     - Removes strings no longer present in the base file from one translation file. The :ref:`addon-weblate.cleanup.generic` add-on can perform this automatically.
+     - Run a one-time cleanup without installing the add-on.
 
 .. _manage-vcs-reset-reapply:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,6 +49,7 @@ Weblate 2026.7
 * Scoped team assignments can no longer be expanded through the API.
 * Empty component lists are no longer exposed to users without component list management permission.
 * TBX glossary files no longer duplicate terms when repeated pending add operations are saved.
+* Duplicate string alerts now offer a cleanup action to remove repeated strings from translation files.
 * Glossary terms are no longer shown in both columns when translating the glossary source language.
 * :ref:`code-hosting-gerrit` review pushes can again include Gerrit push options in the target branch.
 * Webhook target fallback matching is now stricter and reported in component diagnostics.

--- a/docs/snippets/addons-autogenerated.rst
+++ b/docs/snippets/addons-autogenerated.rst
@@ -186,6 +186,10 @@ For formats containing additional content besides translation strings (such as
 :ref:`html`, :ref:`winrc`, or :ref:`odf`) this also brings the translation file
 in sync with the base file.
 
+For a one-time cleanup of a single translation file, use
+:guilabel:`Cleanup unused` in :ref:`repository-maintenance` on that translation
+instead of installing the add-on.
+
 .. seealso::
 
    :ref:`faq-cleanup`

--- a/weblate/formats/base.py
+++ b/weblate/formats/base.py
@@ -572,6 +572,44 @@ class TranslationFormat[S: InnerStore, U: InnerUnit, T: TranslationUnit]:
     def ensure_index(self):
         return self._unit_index
 
+    def remove_duplicate_unit(self, unit: T) -> str | None:
+        """Remove a single duplicate unit from the underlying store."""
+        return self.delete_unit(unit.unit)
+
+    @classmethod
+    def supports_remove_duplicate_units(cls) -> bool:
+        """Check whether duplicate units can be removed from the underlying store."""
+        return cls.can_delete_unit and not cls.has_multiple_strings
+
+    def get_duplicate_cleanup_units(self) -> list[T]:
+        """Return actual store units used for duplicate cleanup."""
+        if not self.has_template:
+            return self._get_all_bilingual_units()
+        return [self.unit_class(self, unit, unit) for unit in self.all_store_units]
+
+    def remove_duplicate_units(self) -> list[str] | None:
+        """Remove duplicate units from the underlying store."""
+        if not self.supports_remove_duplicate_units():
+            return None
+        extra_files = []
+        seen: set[int] = set()
+        removed = False
+        for unit in self.get_duplicate_cleanup_units():
+            if not unit.has_unit() or not unit.has_content():
+                continue
+            id_hash = unit.id_hash
+            if id_hash not in seen:
+                seen.add(id_hash)
+                continue
+            extra_file = self.remove_duplicate_unit(unit)
+            if extra_file is not None:
+                extra_files.append(extra_file)
+            removed = True
+        if removed:
+            self._invalidate_units()
+            return extra_files
+        return None
+
     def add_unit(self, unit: T) -> None:
         """Add new unit to underlying store."""
         raise NotImplementedError

--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -2196,6 +2196,12 @@ class CSVFormatTest(BaseFormatTest):
             ["jeden soubor", "%(count)s soubory", "%(count)s souboru"],
         )
         self.assertTrue(all(row.isfuzzy() for row in storage.store.units))
+        self.assertIsNone(storage.remove_duplicate_units())
+        self.assertEqual(len(storage.store.units), 3)
+        self.assertEqual(
+            [row.target_plural_form for row in storage.store.units],
+            ["0", "1", "2"],
+        )
 
     def test_plural_metadata_missing_template_rows_are_materialized(self) -> None:
         if self.format_class is not CSVFormat:

--- a/weblate/formats/ttkit.py
+++ b/weblate/formats/ttkit.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import csv
 import importlib
 import inspect
@@ -457,6 +458,28 @@ class BaseTTKitFormat[S: TranslationStore, U: TranslateToolkitUnit, T: TTKitUnit
             self.store.addunit(unit.unit, new=True)
         else:
             self.store.addunit(unit.unit)
+
+    def remove_duplicate_unit(self, unit: T) -> str | None:
+        """Remove duplicate unit from Translate Toolkit store."""
+        ttkit_unit = unit.unit
+        xmlelement = getattr(ttkit_unit, "xmlelement", None)
+        if xmlelement is None:
+            return super().remove_duplicate_unit(unit)
+
+        for index, existing in enumerate(self.store.units):
+            if existing is ttkit_unit:
+                del self.store.units[index]
+                break
+        else:
+            return super().remove_duplicate_unit(unit)
+
+        with contextlib.suppress(AttributeError, KeyError, ValueError):
+            self.store.remove_unit_from_index(ttkit_unit)
+
+        parent = xmlelement.getparent()
+        if parent is not None:
+            parent.remove(xmlelement)
+        return None
 
     def save_content(self, handle: IO[bytes]) -> None:
         """Store content to file."""
@@ -2616,6 +2639,9 @@ class CSVFormat(TTKitFormat[WeblateCSVFile, WeblateCSVUnit, CSVUnit]):
         for row in plural_rows:
             self._remove_store_unit(row)
         return None
+
+    def get_duplicate_cleanup_units(self) -> list[CSVUnit]:
+        return self._get_all_bilingual_units()
 
     def _get_all_bilingual_units(self) -> list[CSVUnit]:
         return [

--- a/weblate/glossary/tests.py
+++ b/weblate/glossary/tests.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import csv
 import json
+from copy import deepcopy
 from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -15,6 +16,7 @@ from unittest.mock import patch
 
 from django.db import transaction
 from django.urls import reverse
+from lxml import etree
 
 from weblate.glossary.models import get_glossary_terms, get_glossary_tsv
 from weblate.glossary.tasks import (
@@ -30,6 +32,7 @@ from weblate.trans.tests.utils import get_test_file
 from weblate.utils.hash import calculate_hash
 from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import STATE_READONLY, STATE_TRANSLATED
+from weblate.utils.xml import PARSER
 
 if TYPE_CHECKING:
     from weblate.trans.models import Translation
@@ -94,6 +97,54 @@ more options)</p>
 
 def unit_sources_and_positions(units):
     return {(unit.source, unit.glossary_positions) for unit in units}
+
+
+def tbx_source_contexts(filename: str) -> list[tuple[str, str | None]]:
+    """Return stored TBX source terms grouped by termEntry id."""
+    root = etree.parse(filename, PARSER).getroot()
+    xml_lang = "{http://www.w3.org/XML/1998/namespace}lang"
+    result = []
+    for term_entry in root.findall(".//termEntry"):
+        context = term_entry.get("id") or ""
+        source = None
+        for lang_set in term_entry.findall("langSet"):
+            if lang_set.get(xml_lang) != "en":
+                continue
+            term = lang_set.find(".//term")
+            if term is not None:
+                source = term.text
+                break
+        result.append((context, source))
+    return result
+
+
+def duplicate_tbx_source_term(filename: str, source: str) -> None:
+    tree = etree.parse(filename, PARSER)
+    root = tree.getroot()
+    body = root.find("./text/body")
+    if body is None:
+        msg = "TBX body is missing"
+        raise AssertionError(msg)
+    xml_lang = "{http://www.w3.org/XML/1998/namespace}lang"
+    snippet = None
+    for term_entry in body.findall("termEntry"):
+        for lang_set in term_entry.findall("langSet"):
+            term = lang_set.find(".//term")
+            if (
+                lang_set.get(xml_lang) == "en"
+                and term is not None
+                and term.text == source
+            ):
+                snippet = term_entry
+                break
+        if snippet is not None:
+            break
+    if snippet is None:
+        msg = f"{source} term is missing"
+        raise AssertionError(msg)
+    for _unused in range(2):
+        body.insert(0, deepcopy(snippet))
+    tree.write(filename, encoding="utf-8", xml_declaration=True)
 
 
 class GlossaryTest(ViewTestCase):
@@ -453,6 +504,176 @@ class GlossaryTest(ViewTestCase):
     def test_add_duplicate(self) -> None:
         self.do_add_unit()
         self.do_add_unit()
+
+    def test_managed_tbx_remove_duplicate_terms_operation(self) -> None:
+        self.make_manager()
+        self.do_add_unit(
+            language="it",
+            context="",
+            source_0="Snippet",
+            target_0="Snippet",
+            terminology=1,
+        )
+        self.glossary_component.commit_pending("test", None)
+
+        filename = self.glossary.get_filename()
+        if filename is None:
+            self.fail("Glossary translation file is missing")
+        other_glossary = self.glossary_component.translation_set.get(
+            language__code="it"
+        )
+        other_filename = other_glossary.get_filename()
+        if other_filename is None:
+            self.fail("Italian glossary translation file is missing")
+
+        duplicate_tbx_source_term(filename, "Snippet")
+        duplicate_tbx_source_term(other_filename, "Snippet")
+
+        self.glossary_component.create_translations_immediate(
+            force=True, request=self.get_request()
+        )
+        alert = self.glossary_component.alert_set.get(name="DuplicateString")
+        rendered = alert.render(self.user)
+        cleanup_url = reverse(
+            "remove_duplicate_units", kwargs={"path": self.glossary.get_url_path()}
+        )
+        repository_response = self.client.get(
+            reverse("git_status", kwargs={"path": self.glossary.get_url_path()})
+        )
+        self.assertContains(repository_response, "File management")
+        self.assertContains(repository_response, cleanup_url)
+        self.assertIn(cleanup_url, rendered)
+
+        unit = self.glossary.unit_set.get(source="Snippet")
+        self.assertTrue(unit.translate(self.user, "Úryvek", STATE_TRANSLATED))
+        self.assertEqual(
+            PendingUnitChange.objects.for_translation(
+                self.glossary, apply_filters=False
+            ).count(),
+            1,
+        )
+        pending = PendingUnitChange.objects.for_translation(
+            self.glossary, apply_filters=False
+        ).get()
+        self.assertEqual(pending.target, "Úryvek")
+        self.assertEqual(
+            PendingUnitChange.objects.for_translation(
+                self.glossary, apply_filters=True
+            ).count(),
+            1,
+        )
+        self.do_add_unit(
+            context="",
+            source_0="Pending snippet",
+            target_0="Čekající",
+            terminology=1,
+        )
+        pending_add_unit = self.glossary.unit_set.get(source="Pending snippet")
+        self.assertTrue(
+            PendingUnitChange.objects.filter(
+                unit=pending_add_unit, add_unit=True
+            ).exists()
+        )
+        duplicate_language_occurrence = {
+            "language_code": self.glossary.language.code,
+            "codes": f"{self.glossary.language_code}, duplicate",
+            "filenames": f"{self.glossary.filename}, duplicate.tbx",
+        }
+        self.glossary_component.add_alert(
+            "DuplicateLanguage", occurrences=[duplicate_language_occurrence]
+        )
+
+        response = self.client.post(cleanup_url)
+        self.assertRedirects(response, f"{self.glossary.get_absolute_url()}#repository")
+        alert = self.glossary_component.alert_set.get(name="DuplicateString")
+        self.assertEqual(
+            {
+                occurrence["language_code"]
+                for occurrence in alert.details["occurrences"]
+            },
+            {other_glossary.language.code},
+        )
+        duplicate_language_alert = self.glossary_component.alert_set.get(
+            name="DuplicateLanguage"
+        )
+        self.assertEqual(
+            duplicate_language_alert.details["occurrences"],
+            [duplicate_language_occurrence],
+        )
+        self.assertEqual(
+            PendingUnitChange.objects.for_translation(
+                self.glossary, apply_filters=False
+            ).count(),
+            2,
+        )
+        self.assertTrue(Unit.objects.filter(pk=pending_add_unit.pk).exists())
+        self.assertTrue(
+            PendingUnitChange.objects.filter(
+                unit=pending_add_unit, add_unit=True
+            ).exists()
+        )
+        self.assertEqual(
+            [
+                context
+                for context, source in tbx_source_contexts(filename)
+                if source == "Snippet"
+            ],
+            [""],
+        )
+
+        self.glossary_component.commit_pending("test", self.user)
+        self.assertEqual(
+            PendingUnitChange.objects.for_translation(
+                self.glossary, apply_filters=False
+            ).count(),
+            0,
+        )
+
+        self.assertEqual(
+            [
+                context
+                for context, source in tbx_source_contexts(filename)
+                if source == "Snippet"
+            ],
+            [""],
+        )
+
+        file_content = Path(filename).read_text(encoding="utf-8")
+        self.assertEqual(file_content.count("<term>Snippet</term>"), 1)
+        self.assertEqual(file_content.count("<term>Úryvek</term>"), 1, file_content)
+        self.assertEqual(file_content.count("<term>Pending snippet</term>"), 1)
+        self.assertEqual(file_content.count("<term>Čekající</term>"), 1, file_content)
+
+    def test_file_cleanup_skips_alert_refresh_without_reparse(self) -> None:
+        store = self.glossary.store
+        with (
+            patch.object(store, "remove_duplicate_units", return_value=[]),
+            patch.object(store, "save"),
+            patch.object(self.glossary, "git_commit", return_value=True),
+            patch.object(self.glossary, "handle_store_change", return_value=False),
+            patch.object(self.glossary, "update_single_file_import_alerts") as update,
+        ):
+            self.assertTrue(self.glossary.do_remove_duplicate_units(self.get_request()))
+        update.assert_not_called()
+
+    def test_file_cleanup_keeps_parse_alert_after_failed_reparse(self) -> None:
+        store = self.glossary.store
+        occurrence = {
+            "language_code": self.glossary.language.code,
+            "error": "Broken file",
+            "filename": self.glossary.filename,
+        }
+        self.glossary_component.alerts_trigger = {"ParseError": [occurrence]}
+        with (
+            patch.object(store, "remove_duplicate_units", return_value=[]),
+            patch.object(store, "save"),
+            patch.object(self.glossary, "git_commit", return_value=True),
+            patch.object(self.glossary, "handle_store_change", return_value=False),
+        ):
+            self.assertTrue(self.glossary.do_remove_duplicate_units(self.get_request()))
+
+        alert = self.glossary_component.alert_set.get(name="ParseError")
+        self.assertEqual(alert.details["occurrences"], [occurrence])
 
     def test_duplicate_pending_add_entries_commit_once(self) -> None:
         self.do_add_unit(context="")

--- a/weblate/templates/js/git-status.html
+++ b/weblate/templates/js/git-status.html
@@ -221,6 +221,46 @@
     </div>
   {% endif %}
 
+  {% if user_can_reset_translation and file_management %}
+    <div class="card">
+      <div class="card-header text-bg-danger">
+        <h4 class="card-title">
+          {% documentation_icon 'admin/continuous' 'repository-maintenance' right=True %}
+          {% translate "File management" %}
+        </h4>
+      </div>
+      <ul class="list-group">
+        {% if supports_remove_duplicate_units %}
+          <li class="list-group-item">
+            <a href="#"
+               class="float-end link-post btn btn-danger"
+               data-href="{% url "remove_duplicate_units" path=object.get_url_path %}">{% translate "Remove duplicates" %}</a>
+            <h6 class="mb-1 fw-bold">{% translate "Remove duplicated strings from the translation file" %}</h6>
+            <p class="mb-0">
+              {% translate "Removes repeated strings with the same identifier from the translation file." %}
+              {% translate "Use when the translation file contains duplicate strings that are not present in Weblate." %}
+            </p>
+          </li>
+        {% endif %}
+        {% if supports_cleanup_unused %}
+          <li class="list-group-item">
+            <a href="#"
+               class="float-end link-post btn btn-danger"
+               data-href="{% url "cleanup_unused" path=object.get_url_path %}">{% translate "Cleanup unused" %}</a>
+            <h6 class="mb-1 fw-bold">{% translate "Remove unused strings from the translation file" %}</h6>
+            <p class="mb-0">
+              {% translate "Removes strings that are no longer present in the base file." %}
+              {% translate "The cleanup translation files add-on can perform this automatically." %}
+            </p>
+          </li>
+        {% endif %}
+      </ul>
+      <div class="card-footer">
+        <small>{% translate "Use these operations with caution, they rewrite the translation file." %}</small>
+      </div>
+    </div>
+  {% endif %}
+
   {% for component in repositories %}
     <div class="card">
       <div class="card-header">

--- a/weblate/templates/trans/alert/duplicatestring.html
+++ b/weblate/templates/trans/alert/duplicatestring.html
@@ -1,4 +1,4 @@
-{% load i18n translations %}
+{% load i18n permissions translations %}
 
 <p>{% translate "The component contains several duplicated translation strings." %}</p>
 
@@ -32,5 +32,16 @@
 <p>
   {% translate "Please fix this by removing duplicated strings with same identifier from the translation files." %}
 </p>
+
+{% for translation in analysis.cleanup_translations %}
+  {% perm "vcs.reset" translation as user_can_cleanup_translation %}
+  {% if user_can_cleanup_translation %}
+    <p>
+      <a href="#"
+         class="btn btn-danger link-post"
+         data-href="{% url "remove_duplicate_units" path=translation.get_url_path %}">{% translate "Remove duplicate strings" %}</a>
+    </p>
+  {% endif %}
+{% endfor %}
 
 {% include "trans/alert/occurrences-limit.html" %}

--- a/weblate/trans/alerts/files.py
+++ b/weblate/trans/alerts/files.py
@@ -29,6 +29,26 @@ class DuplicateString(MultiAlert):
 
     # Note: The removal of this alert can be also done in Translation.delete_unit
 
+    def get_analysis(self) -> dict[str, Any]:
+        translations = []
+        seen = set()
+        for occurrence in self.occurrences:
+            unit = occurrence.get("unit")
+            if unit is None:
+                continue
+            translation = unit.translation
+            if (
+                not translation.filename
+                or translation.pk in seen
+                or not translation.supports_remove_duplicate_units(
+                    translation.component
+                )
+            ):
+                continue
+            seen.add(translation.pk)
+            translations.append(translation)
+        return {"cleanup_translations": translations}
+
 
 @register
 class DuplicateLanguage(MultiAlert):

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -3960,6 +3960,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         changed_template: bool = False,
         from_link: bool = False,
         change: int | None = None,
+        preserve_pending_units: bool = False,
     ) -> bool:
         """Load translations from VCS."""
         if settings.CELERY_TASK_ALWAYS_EAGER:
@@ -3975,6 +3976,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 changed_template=changed_template,
                 from_link=from_link,
                 change=change,
+                preserve_pending_units=preserve_pending_units,
             )
 
         # When already in a Celery repository task, scan inline so the same
@@ -3990,6 +3992,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                     changed_template=changed_template,
                     from_link=from_link,
                     change=change,
+                    preserve_pending_units=preserve_pending_units,
                 )
             except WeblateLockTimeoutError:
                 self.log_info("scheduling update in background after lock timeout")
@@ -4009,6 +4012,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
             changed_template=changed_template,
             from_link=from_link,
             change=change,
+            preserve_pending_units=preserve_pending_units,
             user_id=load_user.id if load_user is not None else None,
         )
         return False
@@ -4024,6 +4028,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         changed_template: bool = False,
         from_link: bool = False,
         change: int | None = None,
+        preserve_pending_units: bool = False,
     ) -> bool:
         """
         Load translations from VCS synchronously.
@@ -4045,6 +4050,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 changed_template=changed_template,
                 from_link=from_link,
                 change=change,
+                preserve_pending_units=preserve_pending_units,
             )
 
     def check_template_valid(self) -> None:
@@ -4078,6 +4084,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         changed_template: bool = False,
         from_link: bool = False,
         change: int | None = None,
+        preserve_pending_units: bool = False,
     ) -> bool:
         """Load translations from VCS."""
         # ruff: ignore[import-outside-top-level]
@@ -4178,10 +4185,11 @@ class Component(  # ruff: ignore[too-many-public-methods]
                         lang,
                         code,
                         path,
-                        force,
+                        force=force,
                         request=request,
                         user=user,
                         change=change,
+                        preserve_pending_units=preserve_pending_units,
                     )
                 except InvalidTemplateError as error:
                     self.log_warning(
@@ -4261,6 +4269,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                     request=request,
                     user=user,
                     from_link=True,
+                    preserve_pending_units=preserve_pending_units,
                 )
             except FileParseError as error:
                 if not isinstance(error.__cause__, FileNotFoundError):

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -27,7 +27,7 @@ from translate.storage.fluent import FluentContentError
 
 from weblate.checks.flags import Flags
 from weblate.formats.auto import try_load
-from weblate.formats.base import UnitNotFoundError
+from weblate.formats.base import TranslationFormat, UnitNotFoundError
 from weblate.formats.helpers import CONTROLCHARS, NamedBytesIO
 from weblate.lang.models import Language, Plural
 from weblate.trans.actions import ActionEvents
@@ -78,16 +78,19 @@ from weblate.utils.stats import GhostStats, TranslationStats
 from weblate.utils.tracing import start_span
 from weblate.utils.version import GIT_VERSION
 
+SINGLE_FILE_IMPORT_ALERTS = {"DuplicateString", "ParseError"}
+
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
     from datetime import datetime
 
     from weblate.auth.models import AuthenticatedHttpRequest, User
-    from weblate.formats.base import TranslationFormat, TranslationUnit
+    from weblate.formats.base import TranslationUnit
     from weblate.utils.state import (
         StringState,
     )
 
+    from .component import Component
     from .project import Project
 
 UploadResult = tuple[int, int, int, int]
@@ -138,10 +141,12 @@ class TranslationManager(models.Manager):
         lang,
         code,
         path,
+        *,
         force=False,
         request: AuthenticatedHttpRequest | None = None,
         user: User | None = None,
         change=None,
+        preserve_pending_units: bool = False,
     ):
         """Parse translation meta info and updates translation object."""
         translation, _created = component.translation_set.get_or_create(
@@ -154,7 +159,13 @@ class TranslationManager(models.Manager):
             translation.language_code = code
             translation.save(update_fields=["filename", "language_code"])
         force |= translation.sync_readonly_check_flag()
-        translation.check_sync(force, request=request, change=change, author=user)
+        translation.check_sync(
+            force,
+            request=request,
+            change=change,
+            author=user,
+            preserve_pending_units=preserve_pending_units,
+        )
         return translation
 
 
@@ -694,7 +705,8 @@ class Translation(
         request: AuthenticatedHttpRequest | None = None,
         change: int | None = None,
         author: User | None = None,
-    ) -> None:
+        preserve_pending_units: bool = False,
+    ) -> bool:
         """Check whether database is in sync with git and possibly updates."""
         with start_span(op="translation.check_sync", name=self.full_slug):
             if change is None:
@@ -711,7 +723,7 @@ class Translation(
                 new_revision = self.get_git_blob_hash()
             except FileNotFoundError:
                 self.reason = ""
-                return
+                return False
             except Exception as exc:
                 report_error("Translation parse error", project=self.component.project)
                 self.component.handle_parse_error(exc, self)
@@ -736,7 +748,7 @@ class Translation(
                 self.reason = "check forced"
             else:
                 self.reason = ""
-                return
+                return False
             details["reason"] = self.reason
 
             self.component.check_template_valid()
@@ -753,10 +765,16 @@ class Translation(
                     )
                 self.log_warning("skipping update due to parse error: %s", error)
                 self.store_update_changes()
-                return
+                return False
 
             # Delete stale units
             stale = set(dbunits) - set(updated)
+            if stale and preserve_pending_units:
+                stale -= set(
+                    PendingUnitChange.objects.for_translation(self, apply_filters=False)
+                    .filter(add_unit=True, unit__id_hash__in=stale)
+                    .values_list("unit__id_hash", flat=True)
+                )
             if stale:
                 self.log_info("deleting %d stale strings", len(stale))
                 self.unit_set.filter(id_hash__in=stale).delete()
@@ -792,6 +810,7 @@ class Translation(
         # further consumers as no further consumer is expected after this and
         # we do not want to parse the file again.
         self.__dict__["store"] = None
+        return True
 
     def store_update_changes(self) -> None:
         # Save change
@@ -825,6 +844,142 @@ class Translation(
 
     def do_file_scan(self, request: AuthenticatedHttpRequest | None = None):
         return self.component.do_file_scan(request)
+
+    @staticmethod
+    def supports_remove_duplicate_units(component: Component) -> bool:
+        return component.file_format_cls.supports_remove_duplicate_units()
+
+    @staticmethod
+    def supports_cleanup_unused(component: Component) -> bool:
+        return component.has_template() and (
+            component.file_format_cls.can_delete_unit
+            or component.file_format_cls.cleanup_unused
+            != TranslationFormat.cleanup_unused
+        )
+
+    def _do_file_cleanup(
+        self,
+        request: AuthenticatedHttpRequest | None,
+        operation: Callable[[TranslationFormat], list[str] | None],
+        no_changes_message: str,
+    ) -> bool:
+        from weblate.auth.models import get_anonymous  # noqa: PLC0415
+
+        if not self.filename:
+            messages.info(request, no_changes_message)
+            return False
+
+        user = self.component.acting_user or (request.user if request else None)
+        if user is None:
+            user = get_anonymous()
+
+        component = self.component
+        with component.repository.lock:
+            store = self.store
+            extra_files = operation(store)
+            if extra_files is None:
+                messages.info(request, no_changes_message)
+                return False
+
+            previous_revision = component.repository.last_revision
+            self.addon_commit_files.extend(extra_files)
+            store.save()
+            self.drop_store_cache()
+            self.git_commit(
+                user,
+                user.get_author_name(),
+                store_hash=False,
+            )
+            reparsed = self.handle_store_change(
+                request, user, previous_revision, preserve_pending_units=True
+            )
+            if not self.is_source:
+                if reparsed:
+                    self.update_single_file_import_alerts()
+                elif "ParseError" in component.alerts_trigger:
+                    self.update_single_file_import_alerts({"ParseError"})
+                else:
+                    component.alerts_trigger = {}
+        return True
+
+    def _is_current_import_alert_occurrence(self, occurrence: dict) -> bool:
+        language_code = occurrence.get("language_code")
+        if language_code is not None:
+            return language_code == self.language.code
+        filename = occurrence.get("filename")
+        return filename is not None and filename == self.filename
+
+    def update_single_file_import_alerts(
+        self, alert_names: set[str] | None = None
+    ) -> None:
+        """Refresh import alerts after a single translation file was parsed."""
+        from weblate.trans.alerts.registry import get_import_alerts  # noqa: PLC0415
+
+        if alert_names is None:
+            alert_names = SINGLE_FILE_IMPORT_ALERTS
+        component = self.component
+        for alert_name in get_import_alerts() & alert_names:
+            occurrences = component.alerts_trigger.pop(alert_name, [])
+            try:
+                alert = component.alert_set.get(name=alert_name)
+            except ObjectDoesNotExist:
+                if occurrences:
+                    component.add_alert(alert_name, occurrences=occurrences)
+                continue
+
+            existing = alert.details.get("occurrences")
+            if not isinstance(existing, list):
+                if occurrences:
+                    component.add_alert(alert_name, occurrences=occurrences)
+                continue
+
+            updated = [
+                occurrence
+                for occurrence in existing
+                if not self._is_current_import_alert_occurrence(occurrence)
+            ]
+            updated.extend(occurrences)
+            if updated:
+                component.add_alert(alert_name, occurrences=updated)
+            else:
+                component.delete_alert(alert_name)
+        component.alerts_trigger = {}
+
+    @transaction.atomic
+    def do_remove_duplicate_units(
+        self, request: AuthenticatedHttpRequest | None = None
+    ) -> bool:
+        if not self.supports_remove_duplicate_units(self.component):
+            messages.info(
+                request,
+                gettext(
+                    "Removing duplicate strings is not supported for this file format."
+                ),
+            )
+            return False
+        return self._do_file_cleanup(
+            request,
+            lambda store: store.remove_duplicate_units(),
+            gettext("No duplicate strings were found in the translation file."),
+        )
+
+    @transaction.atomic
+    def do_cleanup_unused(
+        self, request: AuthenticatedHttpRequest | None = None
+    ) -> bool:
+        if not self.supports_cleanup_unused(self.component):
+            messages.info(
+                request,
+                gettext(
+                    "Cleanup of unused strings is not supported for this file format."
+                ),
+            )
+            return False
+        return self._do_file_cleanup(
+            request,
+            lambda store: store.cleanup_unused(),
+            gettext("No unused strings were found in the translation file."),
+        )
 
     def can_push(self) -> bool:
         return self.component.can_push()
@@ -2149,16 +2304,26 @@ class Translation(
         user: User,
         previous_revision: str,
         change=None,
-    ) -> None:
+        preserve_pending_units: bool = False,
+    ) -> bool:
         self.drop_store_cache()
         # Explicit stats invalidation is needed here as the unit removal in
         # delete_unit might do changes in the database only and not touch the files
         # for pending new units
         if self.is_source:
-            self.component.create_translations(request=request, change=change)
+            reparsed = self.component.create_translations(
+                request=request,
+                change=change,
+                preserve_pending_units=preserve_pending_units,
+            )
             self.component.invalidate_cache()
         else:
-            self.check_sync(request=request, change=change, author=user)
+            reparsed = self.check_sync(
+                request=request,
+                change=change,
+                author=user,
+                preserve_pending_units=preserve_pending_units,
+            )
             self.invalidate_cache()
         # Trigger post-update signal
         self.component.trigger_post_update(
@@ -2166,6 +2331,7 @@ class Translation(
             skip_push=False,
             user=user,
         )
+        return reparsed
 
     def get_store_change_translations(self) -> list[Translation]:
         component = self.component

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -150,6 +150,7 @@ def perform_load(
     changed_template: bool = False,
     from_link: bool = False,
     change: int | None = None,
+    preserve_pending_units: bool = False,
     user_id: int | None = None,
 ) -> None:
     request: AuthenticatedHttpRequest | None = None
@@ -170,6 +171,7 @@ def perform_load(
         changed_template=changed_template,
         from_link=from_link,
         change=change,
+        preserve_pending_units=preserve_pending_units,
         request=request,
         user=user,
     )

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -1746,6 +1746,7 @@ class ComponentErrorTest(RepoTestCase):
             changed_template=False,
             from_link=False,
             change=None,
+            preserve_pending_units=False,
         )
         queue_task.assert_not_called()
 

--- a/weblate/trans/views/git.py
+++ b/weblate/trans/views/git.py
@@ -207,6 +207,42 @@ def file_scan(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
 
 @login_required
 @require_repository_action_post
+def remove_duplicate_units(
+    request: AuthenticatedHttpRequest, path: list[str]
+) -> HttpResponseBase:
+    obj = parse_path(request, path, (Translation,))
+    if not request.user.has_perm("vcs.reset", obj):
+        raise PermissionDenied
+
+    return execute_locked(
+        request,
+        obj,
+        gettext("Duplicate strings have been removed from the translation file."),
+        obj.do_remove_duplicate_units,
+        request,
+    )
+
+
+@login_required
+@require_repository_action_post
+def cleanup_unused(
+    request: AuthenticatedHttpRequest, path: list[str]
+) -> HttpResponseBase:
+    obj = parse_path(request, path, (Translation,))
+    if not request.user.has_perm("vcs.reset", obj):
+        raise PermissionDenied
+
+    return execute_locked(
+        request,
+        obj,
+        gettext("Unused strings have been removed from the translation file."),
+        obj.do_cleanup_unused,
+        request,
+    )
+
+
+@login_required
+@require_repository_action_post
 def commit(request: AuthenticatedHttpRequest, path: list[str]) -> HttpResponseBase:
     obj = parse_path(request, path, (Project, Component, Translation))
     if not request.user.has_perm("vcs.commit", obj):

--- a/weblate/trans/views/js.py
+++ b/weblate/trans/views/js.py
@@ -145,6 +145,13 @@ def git_status(request: AuthenticatedHttpRequest, path):
         push_label = ""
 
     pending_units = PendingUnitChange.objects.detailed_count(obj)
+    is_translation = isinstance(obj, Translation)
+    supports_remove_duplicate_units = (
+        is_translation and obj.supports_remove_duplicate_units(obj.component)
+    )
+    supports_cleanup_unused = is_translation and obj.supports_cleanup_unused(
+        obj.component
+    )
 
     return render(
         request,
@@ -167,6 +174,11 @@ def git_status(request: AuthenticatedHttpRequest, path):
                 if repo.push_branch
             ),
             "missing_commits": sum(repo.count_repo_missing for repo in repo_components),
+            "file_management": is_translation
+            and bool(obj.filename)
+            and (supports_remove_duplicate_units or supports_cleanup_unused),
+            "supports_remove_duplicate_units": supports_remove_duplicate_units,
+            "supports_cleanup_unused": supports_cleanup_unused,
             "supports_push": any(
                 repo.repository_class.supports_push for repo in repo_components
             ),

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -431,6 +431,16 @@ real_patterns = [
         name="file_scan",
     ),
     path(
+        "remove-duplicate-units/<object_path:path>/",
+        weblate.trans.views.git.remove_duplicate_units,
+        name="remove_duplicate_units",
+    ),
+    path(
+        "cleanup-unused/<object_path:path>/",
+        weblate.trans.views.git.cleanup_unused,
+        name="cleanup_unused",
+    ),
+    path(
         "progress/<object_path:path>/",
         weblate.trans.views.settings.show_progress,
         name="show_progress",


### PR DESCRIPTION
Expose translation-level actions for removing duplicate units and unused strings, and make duplicate string alerts link to the cleanup.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
