### PR TITLE
fix(vcs): require GitHub App installation admin proof

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -267,9 +267,9 @@ manifest with the correct permissions, events, and webhook URL pre-filled:
 The manifest requests the permissions and event subscriptions Weblate needs
 (``Contents`` and ``Pull requests`` read/write, ``Metadata`` read-only,
 ``Organization administration`` read-only, ``Workflows`` read/write, and the
-``Installation``, ``Meta`` and ``Push`` events), and sets the callback, setup 
-and per-integration webhook URLs automatically, so no manual GitHub App 
-configuration is required. GitHub delivers the ``Installation`` and 
+``Installation``, ``Meta`` and ``Push`` events), and sets the callback, setup
+and per-integration webhook URLs automatically, so no manual GitHub App
+configuration is required. GitHub delivers the ``Installation`` and
 ``Installation repositories`` events to all GitHub Apps by default.
 
 GitHub only offers accounts where the signed-in GitHub user can install or

--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -266,10 +266,10 @@ manifest with the correct permissions, events, and webhook URL pre-filled:
 
 The manifest requests the permissions and event subscriptions Weblate needs
 (``Contents`` and ``Pull requests`` read/write, ``Metadata`` read-only,
-``Workflows`` read/write, and the ``Installation``, ``Installation
-repositories``, ``Installation target``, ``Meta`` and ``Push`` events), and sets
-the callback, setup and per-integration webhook URLs automatically, so no manual
-GitHub App configuration is required.
+``Organization administration`` read-only, ``Workflows`` read/write, and the
+``Installation``, ``Installation repositories``, ``Installation target``,
+``Meta`` and ``Push`` events), and sets the callback, setup and per-integration
+webhook URLs automatically, so no manual GitHub App configuration is required.
 
 GitHub only offers accounts where the signed-in GitHub user can install or
 request the app. If an organization is not shown during the install flow, check
@@ -284,7 +284,8 @@ Connected GitHub accounts are bound to a Weblate :ref:`workspace <workspaces>`.
 A user with project administration rights for any project in a workspace can
 connect a GitHub account on that workspace. After connecting, every project in
 the workspace can import components from repositories the app installation has
-access to.
+access to. For organization installations, Weblate verifies that the install-time
+GitHub user can administer the organization installation.
 
 Projects that are not in a workspace cannot connect a GitHub App installation.
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -390,6 +390,14 @@ Input assumptions
      - Yes, where endpoint is reachable. *(documented)* (source: :ref:`hooks`)
      - Hook enablement only where needed, request limits, and monitoring.
        *(maintainer)*
+   * - GitHub App connection callbacks
+     - GitHub OAuth code, signed Weblate state, installation ID, account metadata
+     - Yes, from authenticated Weblate users and GitHub redirect query strings.
+       *(documented)* (source: :ref:`code-hosting-github-app-register`)
+     - Weblate requires workspace management rights and verifies that the
+       GitHub user owns the personal installation or can administer the
+       organization installation before saving it. *(documented)* (source:
+       :ref:`code-hosting-github-app-register`)
    * - Repository configuration
      - Repository URLs, branches, push URLs, credentials, Gerrit review push
        options, add-on settings

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -13,7 +13,7 @@ import logging
 import time
 import uuid
 from typing import TYPE_CHECKING, ClassVar
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 import jwt
 import requests
@@ -48,6 +48,7 @@ JWT_MAX_LIFETIME = 9 * 60
 GITHUB_APP_MANIFEST_PERMISSIONS: dict[str, str] = {
     "contents": "write",
     "metadata": "read",
+    "organization_administration": "read",
     "pull_requests": "write",
     "workflows": "write",
 }
@@ -464,27 +465,35 @@ def exchange_github_user_code(config: GitHubAppCredentials, code: str) -> str:
     return token
 
 
-def user_can_access_installation(
-    config: GitHubAppCredentials, user_token: str, installation_id: str | int
-) -> bool:
-    """Return whether the authenticated user can access ``installation_id``."""
-    return (
-        get_user_accessible_installation(config, user_token, installation_id)
-        is not None
+def get_authenticated_github_user(
+    config: GitHubAppCredentials, user_token: str
+) -> dict:
+    """Return metadata for the authenticated GitHub user."""
+    api_base = get_github_api_base(normalize_github_app_hostname(config.hostname))
+    response = requests.get(
+        f"{api_base}/user",
+        headers=_get_github_user_headers(user_token),
+        timeout=30,
     )
+    response.raise_for_status()
+    return response.json()
 
 
-def get_user_accessible_installation(
+def _get_github_user_headers(user_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {user_token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+
+def _get_user_accessible_installation(
     config: GitHubAppCredentials, user_token: str, installation_id: str | int
 ) -> dict | None:
     """Return the user-visible installation metadata for ``installation_id``."""
     installation_id = str(installation_id)
     api_base = get_github_api_base(normalize_github_app_hostname(config.hostname))
     url: str | None = f"{api_base}/user/installations?per_page=100"
-    headers = {
-        "Authorization": f"Bearer {user_token}",
-        "Accept": "application/vnd.github.v3+json",
-    }
+    headers = _get_github_user_headers(user_token)
     while url:
         response = requests.get(url, headers=headers, timeout=30)
         response.raise_for_status()
@@ -492,6 +501,68 @@ def get_user_accessible_installation(
             if str(installation.get("id")) == installation_id:
                 return installation
         url = response.links.get("next", {}).get("url")
+    return None
+
+
+def user_can_administer_org_installation(
+    config: GitHubAppCredentials,
+    user_token: str,
+    org: str,
+    installation_id: str | int,
+) -> bool:
+    """Return whether the authenticated user can administer an org installation."""
+    installation_id = str(installation_id)
+    api_base = get_github_api_base(normalize_github_app_hostname(config.hostname))
+    url: str | None = (
+        f"{api_base}/orgs/{quote(org, safe='')}/installations?per_page=100"
+    )
+    headers = _get_github_user_headers(user_token)
+    while url:
+        response = requests.get(url, headers=headers, timeout=30)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as error:
+            if error.response is not None and error.response.status_code in {403, 404}:
+                return False
+            raise
+        for installation in response.json().get("installations", []):
+            if str(installation.get("id")) == installation_id:
+                return True
+        url = response.links.get("next", {}).get("url")
+    return False
+
+
+def get_user_admin_installation(
+    config: GitHubAppCredentials, user_token: str, installation_id: str | int
+) -> dict | None:
+    """
+    Return installation metadata only when the user owns or administers it.
+
+    ``GET /user/installations`` is repository-access based, so organization
+    installations need an additional owner/admin check before Weblate can bind
+    the installation and mint installation tokens for all repositories.
+    """
+    installation = _get_user_accessible_installation(
+        config, user_token, installation_id
+    )
+    if installation is None:
+        return None
+
+    account = installation["account"]
+    target_login: str = account["login"]
+    target_type: str = account["type"].lower()
+
+    if target_type == "user":
+        user = get_authenticated_github_user(config, user_token)
+        if user.get("login") == target_login:
+            return installation
+        return None
+
+    if target_type == "organization" and user_can_administer_org_installation(
+        config, user_token, target_login, installation_id
+    ):
+        return installation
+
     return None
 
 

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -130,7 +130,9 @@ class GitHubInstallationViewTest(ViewTestCase):
         managed_ids = set(managed_installation_ids)
         org_rows: dict[str, list[dict]] = {}
         for installation in installation_rows:
-            account: dict[str, str] = cast(dict[str, str], installation.get("account")) or {}
+            account: dict[str, str] = (
+                cast(dict[str, str], installation.get("account")) or {}
+            )
             if account.get("type") != "Organization":
                 continue
             login = account.get("login")

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import responses

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -89,6 +89,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         *,
         hostname: str = "github.com",
         accessible_ids: tuple[str, ...] = ("12345",),
+        managed_installation_ids: tuple[str, ...] | None = None,
         installations: list[dict] | None = None,
         token: str = "ghu_user",  # noqa: S107
     ) -> None:
@@ -106,30 +107,59 @@ class GitHubInstallationViewTest(ViewTestCase):
             f"{oauth_base}/login/oauth/access_token",
             json={"access_token": token, "token_type": "bearer"},
         )
+        installation_rows = (
+            installations
+            if installations is not None
+            else [
+                {
+                    "id": int(i),
+                    "account": {"login": "test-org", "type": "Organization"},
+                }
+                for i in accessible_ids
+            ]
+        )
         responses.add(
             responses.GET,
             f"{api_base}/user/installations?per_page=100",
-            json={
-                "installations": installations
-                if installations is not None
-                else [{"id": int(i)} for i in accessible_ids]
-            },
+            json={"installations": installation_rows},
         )
+        if managed_installation_ids is None:
+            managed_installation_ids = tuple(
+                str(installation.get("id")) for installation in installation_rows
+            )
+        managed_ids = set(managed_installation_ids)
+        org_rows: dict[str, list[dict]] = {}
+        for installation in installation_rows:
+            account = installation.get("account") or {}
+            if account.get("type") != "Organization":
+                continue
+            login = account.get("login")
+            if not login:
+                continue
+            rows = org_rows.setdefault(str(login), [])
+            if str(installation.get("id")) in managed_ids:
+                rows.append(installation)
+        for org, rows in org_rows.items():
+            responses.add(
+                responses.GET,
+                f"{api_base}/orgs/{org}/installations?per_page=100",
+                json={"installations": rows},
+            )
 
     def _mock_setup_api(
         self,
         *,
         repositories: list[dict] | None = None,
+        account: dict | None = None,
     ) -> list[dict]:
         if repositories is None:
             repositories = [_repo_entry("test-org/repo1")]
+        if account is None:
+            account = {"login": "test-org", "type": "Organization"}
         responses.add(
             responses.GET,
             "https://api.github.com/app/installations/12345",
-            json={
-                "id": 12345,
-                "account": {"login": "test-org", "type": "Organization"},
-            },
+            json={"id": 12345, "account": account},
         )
         responses.add(
             responses.POST,
@@ -374,6 +404,61 @@ class GitHubInstallationViewTest(ViewTestCase):
             [
                 ("POST", "https://github.com/login/oauth/access_token"),
                 ("GET", "https://api.github.com/user/installations?per_page=100"),
+                (
+                    "GET",
+                    "https://api.github.com/orgs/test-org/installations?per_page=100",
+                ),
+                ("GET", "https://api.github.com/app/installations/12345"),
+                (
+                    "POST",
+                    "https://api.github.com/app/installations/12345/access_tokens",
+                ),
+                (
+                    "GET",
+                    "https://api.github.com/installation/repositories?per_page=100",
+                ),
+            ],
+        )
+
+    @responses.activate
+    def test_setup_connects_personal_installation_for_account_owner(self):
+        repositories = [_repo_entry("octocat/repo1", default_branch="stable")]
+        next_url = "/create/component/#github"
+        install_url = self._start_install(next_url)
+        state = parse_qs(urlparse(install_url).query)["state"][0]
+
+        self._mock_oauth(
+            installations=[
+                {"id": 12345, "account": {"login": "octocat", "type": "User"}}
+            ]
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/user",
+            json={"login": "octocat"},
+        )
+        self._mock_setup_api(
+            repositories=repositories,
+            account={"login": "octocat", "type": "User"},
+        )
+        response = self.client.get(
+            reverse("github-app-setup"),
+            {"installation_id": "12345", "state": state, "code": "oauth-code"},
+        )
+
+        self.assertRedirects(response, next_url)
+        connected = GitHubInstallation.objects.get(
+            installation_id="12345", workspace=self.workspace
+        )
+        self.assertEqual(connected.target_login, "octocat")
+        self.assertEqual(connected.target_type, "User")
+        self.assertEqual(connected.repositories, repositories)
+        self.assertEqual(
+            [(call.request.method, call.request.url) for call in responses.calls],
+            [
+                ("POST", "https://github.com/login/oauth/access_token"),
+                ("GET", "https://api.github.com/user/installations?per_page=100"),
+                ("GET", "https://api.github.com/user"),
                 ("GET", "https://api.github.com/app/installations/12345"),
                 (
                     "POST",
@@ -498,6 +583,69 @@ class GitHubInstallationViewTest(ViewTestCase):
             [
                 ("POST", "https://github.com/login/oauth/access_token"),
                 ("GET", "https://api.github.com/user/installations?per_page=100"),
+            ],
+        )
+
+    @responses.activate
+    def test_setup_rejects_personal_installation_for_non_owner(self):
+        install_url = self._start_install("/create/component/#github")
+        state = parse_qs(urlparse(install_url).query)["state"][0]
+
+        self._mock_oauth(
+            installations=[
+                {"id": 12345, "account": {"login": "octocat", "type": "User"}}
+            ]
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/user",
+            json={"login": "repo-collaborator"},
+        )
+        response = self.client.get(
+            reverse("github-app-setup"),
+            {"installation_id": "12345", "state": state, "code": "oauth-code"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(
+            GitHubInstallation.objects.filter(installation_id="12345").exists()
+        )
+        self.assertEqual(
+            [(call.request.method, call.request.url) for call in responses.calls],
+            [
+                ("POST", "https://github.com/login/oauth/access_token"),
+                ("GET", "https://api.github.com/user/installations?per_page=100"),
+                ("GET", "https://api.github.com/user"),
+            ],
+        )
+
+    @responses.activate
+    def test_setup_rejects_org_installation_without_admin_access(self):
+        # ``GET /user/installations`` can list organization installations where
+        # the user merely has repository access. Weblate must require the
+        # stronger organization-admin installation list before connecting it.
+        install_url = self._start_install("/create/component/#github")
+        state = parse_qs(urlparse(install_url).query)["state"][0]
+
+        self._mock_oauth(accessible_ids=("12345",), managed_installation_ids=())
+        response = self.client.get(
+            reverse("github-app-setup"),
+            {"installation_id": "12345", "state": state, "code": "oauth-code"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(
+            GitHubInstallation.objects.filter(installation_id="12345").exists()
+        )
+        self.assertEqual(
+            [(call.request.method, call.request.url) for call in responses.calls],
+            [
+                ("POST", "https://github.com/login/oauth/access_token"),
+                ("GET", "https://api.github.com/user/installations?per_page=100"),
+                (
+                    "GET",
+                    "https://api.github.com/orgs/test-org/installations?per_page=100",
+                ),
             ],
         )
 
@@ -842,7 +990,26 @@ class GitHubAppAccessControlTest(ViewTestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/user/installations?per_page=100",
-            json={"installations": [{"id": 12345}]},
+            json={
+                "installations": [
+                    {
+                        "id": 12345,
+                        "account": {"login": "test-org", "type": "Organization"},
+                    }
+                ]
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/orgs/test-org/installations?per_page=100",
+            json={
+                "installations": [
+                    {
+                        "id": 12345,
+                        "account": {"login": "test-org", "type": "Organization"},
+                    }
+                ]
+            },
         )
         responses.add(
             responses.GET,

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -130,7 +130,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         managed_ids = set(managed_installation_ids)
         org_rows: dict[str, list[dict]] = {}
         for installation in installation_rows:
-            account : dict[str, str] = installation.get("account") or {}
+            account: dict[str, str] = installation.get("account") or {}
             if account.get("type") != "Organization":
                 continue
             login = account.get("login")

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -132,7 +132,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         org_rows: dict[str, list[dict]] = {}
         for installation in installation_rows:
             account: dict[str, str] = (
-                cast(dict[str, str], installation.get("account")) or {}
+                cast("dict[str, str]", installation.get("account")) or {}
             )
             if account.get("type") != "Organization":
                 continue

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -130,7 +130,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         managed_ids = set(managed_installation_ids)
         org_rows: dict[str, list[dict]] = {}
         for installation in installation_rows:
-            account: dict[str, str] = installation.get("account") or {}
+            account: dict[str, str] = cast(dict[str, str], installation.get("account")) or {}
             if account.get("type") != "Organization":
                 continue
             login = account.get("login")

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -130,7 +130,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         managed_ids = set(managed_installation_ids)
         org_rows: dict[str, list[dict]] = {}
         for installation in installation_rows:
-            account = installation.get("account") or {}
+            account : dict[str, str] = installation.get("account") or {}
             if account.get("type") != "Organization":
                 continue
             login = account.get("login")

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -45,7 +45,7 @@ from weblate.vcs.github import (
     get_github_app_manifest_new_url,
     get_github_app_settings,
     get_github_repository_import_url,
-    get_user_accessible_installation,
+    get_user_admin_installation,
     github_app_is_configured,
     normalize_github_app_hostname,
 )
@@ -531,13 +531,13 @@ def _get_authorized_installation(request, config, code, installation_id) -> dict
     Return the installation when the current user controls it via OAuth.
 
     Exchanges the install-time ``code`` for a user-to-server token and checks
-    that the installation appears in the user's own installation list.
+    that the user owns or administers the selected installation.
     """
     if not code:
         return None
     try:
         user_token = exchange_github_user_code(config, code)
-        return get_user_accessible_installation(config, user_token, installation_id)
+        return get_user_admin_installation(config, user_token, installation_id)
     except Exception:
         report_error("Failed to verify GitHub installation ownership")
         return None
@@ -603,9 +603,9 @@ def github_app_setup(request):
         messages.error(
             request,
             gettext(
-                "Weblate could not confirm that you have access to this GitHub "
-                "installation. Start the installation again and approve the "
-                "authorization request."
+                "Weblate could not confirm that you can administer this GitHub "
+                "installation. Start the installation again with a GitHub user "
+                "who owns the account or can administer the organization."
             ),
         )
         return redirect(next_url)


### PR DESCRIPTION
Tighten the GitHub App setup callback so Weblate no longer accepts repository-level access as proof that a user can connect an installation to a workspace.

GitHub's /user/installations endpoint can list organization installations when the OAuth user only has access to repositories in that organization. Accepting that response lets a repository collaborator bind the whole installation to a Weblate workspace, after which Weblate can mint installation tokens for all repositories available to the App.

Replace the old access check with an admin-oriented verification step:

* keep /user/installations only as an internal lookup for the selected installation metadata
* require personal installations to match the authenticated GitHub user
* require organization installations to appear in /orgs/{org}/installations, which is gated by GitHub organization installation administration access
* request the GitHub App Organization administration read permission

Fixes #20291