### PR TITLE
fix(vcs): omit unsupported GitHub App manifest events

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -266,10 +266,11 @@ manifest with the correct permissions, events, and webhook URL pre-filled:
 
 The manifest requests the permissions and event subscriptions Weblate needs
 (``Contents`` and ``Pull requests`` read/write, ``Metadata`` read-only,
-``Workflows`` read/write, and the ``Installation``, ``Installation
-repositories``, ``Installation target``, ``Meta`` and ``Push`` events), and sets
-the callback, setup and per-integration webhook URLs automatically, so no manual
-GitHub App configuration is required.
+``Workflows`` read/write, and the ``Installation target``, ``Meta`` and ``Push``
+events), and sets the callback, setup and per-integration webhook URLs
+automatically, so no manual GitHub App configuration is required.
+GitHub delivers the ``Installation`` and ``Installation repositories`` events
+to all GitHub Apps by default.
 
 GitHub only offers accounts where the signed-in GitHub user can install or
 request the app. If an organization is not shown during the install flow, check

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -43,8 +43,11 @@ TOKEN_CACHE_TTL = 50 * 60
 # GitHub enforces a 10-minute maximum on App JWTs
 JWT_MAX_LIFETIME = 9 * 60
 
-# Permissions and events Weblate needs when registering a GitHub App via
-# the manifest flow. Keep aligned with the documented manual setup.
+# Permissions and manifest-selectable events Weblate needs when registering a
+# GitHub App via the manifest flow. GitHub delivers App lifecycle events such as
+# ``installation`` and ``installation_repositories`` to every App webhook
+# automatically, so requesting them in ``default_events`` makes GitHub reject the
+# manifest instead of enabling anything extra.
 GITHUB_APP_MANIFEST_PERMISSIONS: dict[str, str] = {
     "contents": "write",
     "metadata": "read",
@@ -52,8 +55,6 @@ GITHUB_APP_MANIFEST_PERMISSIONS: dict[str, str] = {
     "workflows": "write",
 }
 GITHUB_APP_MANIFEST_EVENTS: tuple[str, ...] = (
-    "installation",
-    "installation_repositories",
     "installation_target",
     "meta",
     "push",

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -1036,6 +1036,8 @@ class GitHubAppManifestViewTest(TestCase):
             manifest["default_permissions"], dict(GITHUB_APP_MANIFEST_PERMISSIONS)
         )
         self.assertEqual(manifest["default_events"], list(GITHUB_APP_MANIFEST_EVENTS))
+        self.assertNotIn("installation", manifest["default_events"])
+        self.assertNotIn("installation_repositories", manifest["default_events"])
 
         url, _manifest = self._capture_github_call(host="github.example.com")
 


### PR DESCRIPTION
Remove lifecycle webhook events from the manifest defaults because GitHub delivers them automatically and rejects explicit default subscriptions.

Fixes #20301

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
