### PR TITLE
fix(github): bound pending installation storage

### DIFF
--- a/weblate/trans/views/hooks.py
+++ b/weblate/trans/views/hooks.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Mapping
+from datetime import timedelta
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar, NotRequired, TypedDict, cast
 from urllib.parse import quote, urlparse
 
 from django.conf import settings
 from django.db.models import Q
+from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import parsers, serializers
 from rest_framework.exceptions import (
@@ -73,6 +75,9 @@ BITBUCKET_HG_REPOS = (
     "hg::ssh://hg@{server}/{full_name}",
     "hg::https://{server}/{full_name}",
 )
+
+PENDING_GITHUB_INSTALLATION_RETENTION = timedelta(days=1)
+PENDING_GITHUB_INSTALLATION_HOST_LIMIT = 1000
 
 GITHUB_REPOS = (
     "git://github.com/%(owner)s/%(slug)s.git",
@@ -507,15 +512,64 @@ def _github_repository_entries(repositories, hostname: str) -> list[dict]:
     return [_github_repository_entry(repo, hostname) for repo in repositories or []]
 
 
+def _pending_github_installation_payload(data: dict, hostname: str) -> dict:
+    """Return the minimal webhook metadata needed to complete delayed setup."""
+    payload = data.get("installation") or {}
+    account = payload.get("account") if isinstance(payload, Mapping) else None
+    return {
+        "action": data.get("action"),
+        "installation": {
+            "id": payload.get("id"),
+            "app_id": payload.get("app_id"),
+            "account": {
+                "login": account.get("login"),
+                "type": account.get("type"),
+            }
+            if isinstance(account, Mapping)
+            else {},
+        },
+        "repositories": _github_repository_entries(data.get("repositories"), hostname),
+    }
+
+
+def _prune_pending_github_installation_events(hostname: str) -> None:
+    """Remove stale unauthorised GitHub installation webhook payloads."""
+    PendingInstallation.objects.filter(
+        provider=InstallationProvider.GITHUB,
+        hostname=hostname,
+        updated__lt=timezone.now() - PENDING_GITHUB_INSTALLATION_RETENTION,
+    ).delete()
+
+
 def _store_pending_github_installation_event(
     data: dict, hostname: str, installation_id: str
 ) -> None:
     """Persist a signed installation event until setup validates a workspace."""
+    _prune_pending_github_installation_events(hostname)
+    pending = PendingInstallation.objects.filter(
+        provider=InstallationProvider.GITHUB,
+        hostname=hostname,
+        installation_id=installation_id,
+    )
+    if (
+        not pending.exists()
+        and PendingInstallation.objects.filter(
+            provider=InstallationProvider.GITHUB, hostname=hostname
+        ).count()
+        >= PENDING_GITHUB_INSTALLATION_HOST_LIMIT
+    ):
+        LOGGER.warning(
+            "Skipped pending GitHub account %s/%s webhook; host limit reached",
+            hostname,
+            installation_id,
+        )
+        return
+
     PendingInstallation.objects.update_or_create(
         provider=InstallationProvider.GITHUB,
         hostname=hostname,
         installation_id=installation_id,
-        defaults={"payload": data},
+        defaults={"payload": _pending_github_installation_payload(data, hostname)},
     )
     LOGGER.info(
         "Stored pending GitHub account %s/%s webhook until setup completes",

--- a/weblate/vcs/tests/test_github_hooks.py
+++ b/weblate/vcs/tests/test_github_hooks.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import responses
 from django.core.cache import cache
@@ -173,8 +174,22 @@ class TestGitHubAppHooks(ViewTestCase):
             "installation": {
                 "id": 12345,
                 "app_id": 99999,
-                "account": {"login": "test-org", "type": "Organization"},
+                "account": {
+                    "login": "test-org",
+                    "type": "Organization",
+                    "avatar_url": "https://avatars.example/test-org",
+                },
             },
+            "repositories": [
+                {
+                    "name": "repo",
+                    "full_name": "test-org/repo",
+                    "private": False,
+                    "description": "A repo",
+                    "owner": {"login": "test-org"},
+                }
+            ],
+            "sender": {"login": "octocat"},
         }
         response = self._post("installation", data)
         self.assertEqual(response.status_code, 201)
@@ -187,6 +202,41 @@ class TestGitHubAppHooks(ViewTestCase):
             installation_id="12345",
         )
         self.assertEqual(pending.payload["action"], "created")
+        self.assertEqual(pending.payload["installation"]["id"], 12345)
+        self.assertEqual(
+            pending.payload["installation"]["account"],
+            {"login": "test-org", "type": "Organization"},
+        )
+        self.assertEqual(
+            pending.payload["repositories"][0]["full_name"], "test-org/repo"
+        )
+        self.assertNotIn("sender", pending.payload)
+        self.assertNotIn("owner", pending.payload["repositories"][0])
+        self.assertNotIn("avatar_url", pending.payload["installation"]["account"])
+
+    @patch("weblate.trans.views.hooks.PENDING_GITHUB_INSTALLATION_HOST_LIMIT", 1)
+    def test_installation_created_pending_host_limit(self):
+        PendingInstallation.objects.create(
+            provider=InstallationProvider.GITHUB,
+            hostname="github.com",
+            installation_id="existing",
+            payload={"action": "created"},
+        )
+        data = {
+            "action": "created",
+            "installation": {
+                "id": 12345,
+                "app_id": 99999,
+                "account": {"login": "test-org", "type": "Organization"},
+            },
+        }
+
+        response = self._post("installation", data)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertFalse(
+            PendingInstallation.objects.filter(installation_id="12345").exists()
+        )
 
     def test_unknown_integration_token_is_rejected(self):
         """A delivery to an unknown integration token cannot be authenticated."""


### PR DESCRIPTION
### Motivation
- Prevent unbounded persistent storage of full GitHub App installation webhooks that can be triggered by public app installations and lead to database growth/DoS.  

### Description
- Add a one-day retention window (`PENDING_GITHUB_INSTALLATION_RETENTION`) and a per-host pending-row cap (`PENDING_GITHUB_INSTALLATION_HOST_LIMIT`) to limit stored unauthorised installation payloads.  
- Replace storing the full signed webhook JSON with a minimized payload via `_pending_github_installation_payload` that keeps only the installation id, app id, account login/type, action, and cached repository entries.  
- Prune stale pending rows in `_prune_pending_github_installation_events` and skip creating new pending rows when the per-host limit is reached.  
- Add regression tests to verify payload minimization and host-limit behavior in `weblate/vcs/tests/test_github_hooks.py` and keep existing setup-apply coverage in `weblate/vcs/tests/test_github_views.py`.  

### Testing
- Ran the focused pytest scenarios: `uv run pytest weblate/vcs/tests/test_github_hooks.py::TestGitHubAppHooks::test_installation_created_without_row_is_pending weblate/vcs/tests/test_github_hooks.py::TestGitHubAppHooks::test_installation_created_pending_host_limit weblate/vcs/tests/test_github_views.py::GitHubInstallationViewTest::test_setup_applies_pending_installation_webhook`, and all tests passed.  
- Ran the repository formatting/lint hooks with `uv run prek run --files weblate/trans/views/hooks.py weblate/vcs/tests/test_github_hooks.py` and the checks passed after formatting fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e781f064083298f8199eb8b047b99)