### PR TITLE
feat(widgets): add capitalize URL parameter to SVGBadgeWidget

### DIFF
--- a/weblate/trans/tests/test_widgets.py
+++ b/weblate/trans/tests/test_widgets.py
@@ -104,6 +104,51 @@ class WidgetsTest(FixtureTestCase):
         )
         self.assertContains(response, "Test")
 
+    def get_svg_badge_url(self) -> str:
+        return reverse(
+            "widget-image",
+            kwargs={
+                "path": self.project.get_url_path(),
+                "widget": "svg",
+                "color": "badge",
+                "extension": "svg",
+            },
+        )
+
+    def test_svg_badge_default_lowercase(self) -> None:
+        """The badge label is lowercase by default."""
+        response = self.client.get(self.get_svg_badge_url())
+        self.assert_svg(response)
+        self.assertContains(response, "translated")
+        self.assertNotContains(response, "Translated")
+
+    def test_svg_badge_capitalize(self) -> None:
+        """The capitalize parameter capitalizes the first letter of the label."""
+        response = self.client.get(self.get_svg_badge_url(), {"capitalize": "1"})
+        self.assert_svg(response)
+        self.assertContains(response, "Translated")
+
+    def test_svg_badge_capitalize_disabled(self) -> None:
+        """An explicit zero keeps the default lowercase label."""
+        response = self.client.get(self.get_svg_badge_url(), {"capitalize": "0"})
+        self.assert_svg(response)
+        self.assertContains(response, "translated")
+        self.assertNotContains(response, "Translated")
+
+    def test_svg_badge_capitalize_invalid(self) -> None:
+        """A non-integer value falls back to the default without breaking rendering."""
+        response = self.client.get(self.get_svg_badge_url(), {"capitalize": "invalid"})
+        self.assert_svg(response)
+        self.assertContains(response, "translated")
+        self.assertNotContains(response, "Translated")
+
+    def test_status_badge_capitalize(self) -> None:
+        """PNGBadgeWidget inherits the capitalize parameter from SVGBadgeWidget."""
+        self.assertEqual(
+            WIDGETS["status"].extra_parameters,
+            WIDGETS["svg"].extra_parameters,
+        )
+
     def test_view_engage(self) -> None:
         response = self.client.get(
             reverse("engage", kwargs={"path": self.project.get_url_path()})

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -433,9 +433,36 @@ class SVGBadgeWidget(BaseSVGBadgeWidget):
     order = 80
     # Translators: status widget name
     verbose = gettext_lazy("SVG status badge")
+    extra_parameters: ClassVar[list[ExtraParametersDict]] = [
+        {
+            "name": "capitalize",
+            "label": gettext("Capitalize first letter"),
+            "type": "number",
+            "default": 0,
+            "min": 0,
+            "max": 1,
+            "step": 1,
+        }
+    ]
 
     def render(self, request: HttpRequest, response: HttpResponse) -> None:
+        try:
+            capitalize = int(request.GET.get("capitalize", 0))
+        except ValueError as e:
+            messages.error(
+                request,
+                gettext("Error in parameter %(field)s: %(error)s")
+                % {
+                    "field": "capitalize",
+                    "error": str(e),
+                },
+            )
+            capitalize = 0
+
+        # Translators: Status badge label
         translated_text = gettext("translated")
+        if capitalize:
+            translated_text = translated_text.capitalize()
         percent_text = self.get_percent_text()
         if self.percent >= 90:
             color = "#4c1"


### PR DESCRIPTION
Closes #9850

## What this does?
Adds an optional `?capitalize=1` URL parameter to the SVG and PNG status badges. When set, the badge text renders as `Translated 76%` instead of the default `translated 76%`. Default behavior is unchanged.

## Why was this PR needed?
Some repositories like Flathub style all their badges with an uppercase first letter. Weblate badges showed inconsistently lowercase next to them with no option to change it.

## Approach:
Follows the existing `extra_parameters` pattern used by `LanguageBadgeWidget` for its `threshold` parameter, as suggested by @nijel. No new widget class needed — `PNGBadgeWidget` inherits the behavior automatically via `SVGBadgeWidget`.

## Changes:
- `weblate/trans/widgets.py` — added `extra_parameters` entry and capitalize logic to `SVGBadgeWidget.render()`
- `weblate/trans/tests/test_widgets.py` — added 5 tests covering default behavior, capitalize on/off, invalid input, and PNG badge inheritance

## Testing:
All 14 tests in `WidgetsTest` pass.