### PR TITLE
fix(github): require management.configure for GitHub App credential management

### DIFF
--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -1190,7 +1190,7 @@ class GitHubAppManifestViewTest(TestCase):
         self._grant_global_permissions(user, "management.use")
         self.client.login(username=user.username, password="testpassword")
 
-        protected_urls = (
+        protected_urls: tuple[tuple[str, str, dict[str, str]], ...] = (
             ("get", reverse("github-app-register"), {}),
             ("post", reverse("github-app-register-submit"), {}),
             ("post", reverse("github-app-register-redirect"), {}),

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 
-from weblate.auth.models import User
+from weblate.auth.models import Group, Permission, Role, User
 from weblate.trans.models import Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.site import get_site_url
@@ -1004,6 +1004,19 @@ class GitHubAppManifestViewTest(TestCase):
         )
         self.client.login(username="admin", password="testpassword")
 
+    def _grant_global_permissions(self, user: User, *permissions: str) -> None:
+        role, _created = Role.objects.get_or_create(name="Test GitHub App role")
+        permission_objects = list(Permission.objects.filter(codename__in=permissions))
+        self.assertEqual(
+            {permission.codename for permission in permission_objects},
+            set(permissions),
+        )
+        role.permissions.add(*permission_objects)
+        group, _created = Group.objects.get_or_create(name="Test GitHub App team")
+        group.roles.add(role)
+        user.groups.add(group)
+        user.clear_cache()
+
     def _post_register(self, **fields):
         return self.client.post(reverse("github-app-register-submit"), fields)
 
@@ -1168,16 +1181,64 @@ class GitHubAppManifestViewTest(TestCase):
         self.assertRedirects(response, reverse("manage-github-accounts"))
         self.assertFalse(GitHubAppCredentials.objects.exists())
 
-    def test_register_requires_management_access(self):
-        non_admin = User.objects.create_user(
-            username="plain",
-            email="plain@example.org",
+    def test_register_requires_management_configure(self):
+        user = User.objects.create_user(
+            username="manager",
+            email="manager@example.org",
             password="testpassword",
         )
-        self.client.login(username=non_admin.username, password="testpassword")
+        self._grant_global_permissions(user, "management.use")
+        self.client.login(username=user.username, password="testpassword")
+
+        protected_urls = (
+            ("get", reverse("github-app-register"), {}),
+            ("post", reverse("github-app-register-submit"), {}),
+            ("post", reverse("github-app-register-redirect"), {}),
+            ("get", reverse("github-app-register-callback"), {}),
+        )
+        for method, url, data in protected_urls:
+            with self.subTest(url=url):
+                response = getattr(self.client, method)(url, data)
+                self.assertEqual(response.status_code, 403)
+
+        self._grant_global_permissions(user, "management.configure")
 
         response = self.client.get(reverse("github-app-register"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_remove_app_requires_management_configure(self):
+        user = User.objects.create_user(
+            username="manager",
+            email="manager@example.org",
+            password="testpassword",
+        )
+        self._grant_global_permissions(user, "management.use")
+        self.client.login(username=user.username, password="testpassword")
+        credentials = GitHubAppCredentials.objects.create(
+            hostname="github.com",
+            app_id="111",
+            app_slug="weblate",
+            private_key="pem",
+            webhook_secret="wh",
+        )
+
+        response = self.client.post(
+            reverse("manage-github-app-remove", kwargs={"pk": credentials.pk})
+        )
+
         self.assertEqual(response.status_code, 403)
+        self.assertTrue(GitHubAppCredentials.objects.filter(pk=credentials.pk).exists())
+
+        self._grant_global_permissions(user, "management.configure")
+
+        response = self.client.post(
+            reverse("manage-github-app-remove", kwargs={"pk": credentials.pk})
+        )
+
+        self.assertRedirects(response, reverse("manage-github-accounts"))
+        self.assertFalse(
+            GitHubAppCredentials.objects.filter(pk=credentials.pk).exists()
+        )
 
     def test_register_form_warns_about_existing_host(self):
         GitHubAppCredentials.objects.create(

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -24,7 +24,7 @@ from django.utils.text import slugify
 from django.utils.translation import gettext
 from django.views import View
 
-from weblate.auth.decorators import management_access
+from weblate.auth.decorators import management_access, management_permission_required
 from weblate.trans.models import Category, Project
 from weblate.trans.views.create import INTEGRATION_IMPORT_VCS_KEY, SESSION_CREATE_KEY
 from weblate.trans.views.hooks import apply_pending_github_installation_event
@@ -271,7 +271,10 @@ class GitHubInstallationListView(View):
                     "html_url": config.html_url,
                     "credentials_pk": config.pk,
                     "installations": host_installations,
-                    "can_remove": not host_installations,
+                    "can_remove": (
+                        request.user.has_perm("management.configure")
+                        and not host_installations
+                    ),
                     "install_url": _get_install_link(
                         request,
                         reverse("manage-github-accounts"),
@@ -288,7 +291,11 @@ class GitHubInstallationListView(View):
                 "github_app_install_url": _get_install_link(
                     request, reverse("manage-github-accounts")
                 ),
-                "github_app_register_url": reverse("github-app-register"),
+                "github_app_register_url": (
+                    reverse("github-app-register")
+                    if request.user.has_perm("management.configure")
+                    else None
+                ),
                 **_MENU_CONTEXT,
             },
         )
@@ -414,7 +421,7 @@ def remove_installation(request, pk):
     return redirect(next_url)
 
 
-@management_access
+@management_permission_required("management.configure")
 def remove_github_app(request, pk):
     """Delete the Weblate GitHub App credentials registered for one host."""
     if request.method != "POST":
@@ -887,7 +894,7 @@ def _read_register_fields(request) -> tuple[str, str, str, bool]:
     return hostname, org, name, public
 
 
-@management_access
+@management_permission_required("management.configure")
 def github_app_register(request):
     """Render the GitHub App registration form (editable host/org/name)."""
     hostname, org, name, public = _read_register_fields(request)
@@ -926,7 +933,7 @@ def github_app_register(request):
     )
 
 
-@management_access
+@management_permission_required("management.configure")
 def github_app_register_submit(request):
     """Render the intermediate page that posts the manifest to GitHub."""
     if request.method != "POST":
@@ -975,7 +982,7 @@ def github_app_register_submit(request):
     )
 
 
-@management_access
+@management_permission_required("management.configure")
 def github_app_register_redirect(request):
     """
     307-redirect the POSTed manifest to GitHub, preserving the body.
@@ -1003,7 +1010,7 @@ def github_app_register_redirect(request):
     return response
 
 
-@management_access
+@management_permission_required("management.configure")
 def github_app_register_callback(request):
     """Exchange a temporary manifest code for the App's credentials."""
     accounts_url = reverse("manage-github-accounts")


### PR DESCRIPTION
### Motivation

- Close an authorization gap that allowed users with only `management.use` to register, overwrite, or delete database-stored GitHub App credentials that take precedence over settings-based credentials.

### Description

- Require `management.configure` for the GitHub App registration, submit/redirect/callback, and removal endpoints by switching their decorators to `@management_permission_required("management.configure")` in `weblate/vcs/views.py`.
- Hide the registration UI and disallow the removal action for users who lack `management.configure` by gating `github_app_register_url` and `can_remove` on `request.user.has_perm("management.configure")` in `weblate/vcs/views.py`.
- Add regression tests to `weblate/vcs/tests/test_github_views.py` that assert `management.use` alone receives `403` for the protected endpoints and that `management.configure` allows the flows, and add a helper to grant global permissions in tests.

### Testing

- Ran the focused test suite `uv run pytest weblate/vcs/tests/test_github_views.py::GitHubAppManifestViewTest -q`, which passed (all tests in the target suite succeeded).
- Ran the repository pre-commit/format checks for the modified files with `uv run prek run --files weblate/vcs/views.py weblate/vcs/tests/test_github_views.py`, which passed formatting and lint hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e84c1626083298dc04bcb2360af94)