### PR TITLE
fix(vcs): restrict GitHub installation management to workspace admins

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -45,6 +45,7 @@ Weblate 2026.7
 
 .. rubric:: Bug fixes
 
+* Restricted GitHub App installation management actions to workspace administrators.
 * Malformed ``replacements`` flags no longer abort source length checks.
 * Scoped team assignments can no longer be expanded through the API.
 * Empty component lists are no longer exposed to users without component list management permission.

--- a/weblate/templates/vcs/account_integrations.html
+++ b/weblate/templates/vcs/account_integrations.html
@@ -127,18 +127,20 @@
                   <td>
                     <a href="{% url 'github-app-repositories' %}?workspace={{ installation.workspace_id }}"
                        class="btn btn-outline-primary btn-sm">{% translate "Repositories" %}</a>
-                    <form method="post"
-                          action="{% url 'manage-github-account-refresh' installation.pk %}"
-                          class="d-inline">
-                      {% csrf_token %}
-                      <input type="hidden" name="next" value="{{ next_url }}" />
-                      <button type="submit" class="btn btn-outline-primary btn-sm">{% translate "Refresh" %}</button>
-                    </form>
-                    <button type="button"
-                            class="btn btn-outline-danger btn-sm"
-                            data-bs-toggle="modal"
-                            data-bs-target="#remove-github-account-{{ installation.pk }}">{% translate "Remove" %}</button>
-                    {% include "vcs/snippets/github_account_remove_modal.html" with installation=installation next_url=next_url csrf_token=csrf_token only %}
+                    {% if installation.pk in app.manageable_installations %}
+                      <form method="post"
+                            action="{% url 'manage-github-account-refresh' installation.pk %}"
+                            class="d-inline">
+                        {% csrf_token %}
+                        <input type="hidden" name="next" value="{{ next_url }}" />
+                        <button type="submit" class="btn btn-outline-primary btn-sm">{% translate "Refresh" %}</button>
+                      </form>
+                      <button type="button"
+                              class="btn btn-outline-danger btn-sm"
+                              data-bs-toggle="modal"
+                              data-bs-target="#remove-github-account-{{ installation.pk }}">{% translate "Remove" %}</button>
+                      {% include "vcs/snippets/github_account_remove_modal.html" with installation=installation next_url=next_url csrf_token=csrf_token only %}
+                    {% endif %}
                   </td>
                 </tr>
               {% endfor %}

--- a/weblate/templates/vcs/github_repository_list.html
+++ b/weblate/templates/vcs/github_repository_list.html
@@ -45,18 +45,20 @@
                 <td>{{ installation.workspace }}</td>
                 <td>{{ installation.repositories|length }}</td>
                 <td>
-                  <form method="post"
-                        action="{% url 'manage-github-account-refresh' installation.pk %}"
-                        class="d-inline">
-                    {% csrf_token %}
-                    <input type="hidden" name="next" value="{{ next_url }}" />
-                    <button type="submit" class="btn btn-outline-primary btn-sm">{% translate "Refresh" %}</button>
-                  </form>
-                  <button type="button"
-                          class="btn btn-outline-danger btn-sm"
-                          data-bs-toggle="modal"
-                          data-bs-target="#remove-github-account-{{ installation.pk }}">{% translate "Remove" %}</button>
-                  {% include "vcs/snippets/github_account_remove_modal.html" with installation=installation next_url=next_url csrf_token=csrf_token only %}
+                  {% if installation.can_manage %}
+                    <form method="post"
+                          action="{% url 'manage-github-account-refresh' installation.pk %}"
+                          class="d-inline">
+                      {% csrf_token %}
+                      <input type="hidden" name="next" value="{{ next_url }}" />
+                      <button type="submit" class="btn btn-outline-primary btn-sm">{% translate "Refresh" %}</button>
+                    </form>
+                    <button type="button"
+                            class="btn btn-outline-danger btn-sm"
+                            data-bs-toggle="modal"
+                            data-bs-target="#remove-github-account-{{ installation.pk }}">{% translate "Remove" %}</button>
+                    {% include "vcs/snippets/github_account_remove_modal.html" with installation=installation next_url=next_url csrf_token=csrf_token only %}
+                  {% endif %}
                 </td>
               </tr>
             {% endfor %}

--- a/weblate/templates/vcs/github_repository_list.html
+++ b/weblate/templates/vcs/github_repository_list.html
@@ -45,7 +45,7 @@
                 <td>{{ installation.workspace }}</td>
                 <td>{{ installation.repositories|length }}</td>
                 <td>
-                  {% if installation.can_manage %}
+                  {% if installation.pk in manageable_installations %}
                     <form method="post"
                           action="{% url 'manage-github-account-refresh' installation.pk %}"
                           class="d-inline">

--- a/weblate/trans/tests/test_create.py
+++ b/weblate/trans/tests/test_create.py
@@ -476,6 +476,30 @@ class CreateTest(ViewTestCase):
         self.assertEqual(response.context["github_app_repositories"], [])
         self.assertNotContains(response, "stale-org/repo1")
 
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_create_component_hides_github_app_install_link_for_project_admin(
+        self,
+    ) -> None:
+        self.project.workspace = Workspace.objects.create(name="GitHub App workspace")
+        self.project.save(update_fields=["workspace"])
+        self.project.add_user(self.user, "Administration")
+        GitHubAppCredentials.objects.create(
+            hostname="github.com",
+            app_id="99999",
+            app_slug="weblate-app",
+            private_key=generate_private_key(),
+            webhook_secret="secret",
+        )
+
+        response = self.client.get(
+            reverse("create-component"), {"project": self.project.pk}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["github_app_available"])
+        self.assertNotIn("github_app_install_url", response.context)
+        self.assertNotContains(response, "Add or configure account")
+
     def test_create_component_locks_github_app_integration_fields(self) -> None:
         form = ComponentCreateForm(
             self.get_request(),

--- a/weblate/trans/views/create.py
+++ b/weblate/trans/views/create.py
@@ -57,6 +57,7 @@ from weblate.vcs.github import (
     github_app_is_configured,
 )
 from weblate.vcs.models import VCS_REGISTRY
+from weblate.vcs.permissions import github_app_installation_workspaces
 from weblate.workspaces.models import Workspace
 
 if TYPE_CHECKING:
@@ -746,26 +747,33 @@ class CreateComponentSelection(CreateComponent):
                 )
                 repositories.append(entry)
         kwargs["github_app_repositories"] = repositories
-        if github_app_is_configured() and selected_project_obj is not None:
-            if selected_project_obj.workspace_id:
-                kwargs["github_app_install_url"] = (
-                    reverse("github-app-install")
-                    + "?"
-                    + urlencode(
-                        {
-                            "next": f"{self.request.get_full_path()}#github",
-                            "workspace": selected_project_obj.workspace_id,
-                        }
-                    )
-                )
-        elif github_app_is_configured() and len(workspace_ids) == 1:
+        install_workspace_id = None
+        installation_workspaces = github_app_installation_workspaces(self.request.user)
+        if (
+            github_app_is_configured()
+            and selected_project_obj is not None
+            and selected_project_obj.workspace_id
+            and installation_workspaces.filter(
+                pk=selected_project_obj.workspace_id
+            ).exists()
+        ):
+            install_workspace_id = selected_project_obj.workspace_id
+        elif (
+            github_app_is_configured()
+            and selected_project_obj is None
+            and len(workspace_ids) == 1
+            and installation_workspaces.filter(pk=workspace_ids[0]).exists()
+        ):
+            install_workspace_id = workspace_ids[0]
+
+        if install_workspace_id is not None:
             kwargs["github_app_install_url"] = (
                 reverse("github-app-install")
                 + "?"
                 + urlencode(
                     {
                         "next": f"{self.request.get_full_path()}#github",
-                        "workspace": workspace_ids[0],
+                        "workspace": install_workspace_id,
                     }
                 )
             )

--- a/weblate/vcs/permissions.py
+++ b/weblate/vcs/permissions.py
@@ -10,6 +10,7 @@ from weblate.workspaces.models import Workspace
 
 if TYPE_CHECKING:
     from weblate.auth.models import User
+    from weblate.auth.results import PermissionResult
 
 
 def github_app_installation_workspaces(user: User):
@@ -19,5 +20,7 @@ def github_app_installation_workspaces(user: User):
     return user.workspaces_with_perm("workspace.edit")
 
 
-def user_can_install_github_app_in_workspace(user: User, workspace: Workspace) -> bool:
+def user_can_install_github_app_in_workspace(
+    user: User, workspace: Workspace
+) -> PermissionResult | bool:
     return user.has_perm("management.use") or user.has_perm("workspace.edit", workspace)

--- a/weblate/vcs/permissions.py
+++ b/weblate/vcs/permissions.py
@@ -1,0 +1,23 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from weblate.workspaces.models import Workspace
+
+if TYPE_CHECKING:
+    from weblate.auth.models import User
+
+
+def github_app_installation_workspaces(user: User):
+    """Return workspaces where the user can connect GitHub accounts."""
+    if user.has_perm("management.use"):
+        return Workspace.objects.order()
+    return user.workspaces_with_perm("workspace.edit")
+
+
+def user_can_install_github_app_in_workspace(user: User, workspace: Workspace) -> bool:
+    return user.has_perm("management.use") or user.has_perm("workspace.edit", workspace)

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 
-from weblate.auth.models import User
+from weblate.auth.models import Group, Permission, Role, User
 from weblate.trans.models import Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.site import get_site_url
@@ -83,6 +83,14 @@ class GitHubInstallationViewTest(ViewTestCase):
         }
         defaults.update(overrides)
         return GitHubAppCredentials.objects.create(hostname=hostname, **defaults)
+
+    def _grant_management_permission(self, user: User) -> None:
+        role = Role.objects.create(name=f"GitHub management {user.pk}")
+        role.permissions.add(Permission.objects.get(codename="management.use"))
+        group = Group.objects.create(name=f"GitHub management {user.pk}")
+        group.roles.add(role)
+        user.groups.add(group)
+        user.clear_cache()
 
     def _mock_oauth(
         self,
@@ -279,6 +287,12 @@ class GitHubInstallationViewTest(ViewTestCase):
             response,
             f"{reverse('github-app-repositories')}?workspace={self.workspace.pk}",
         )
+        install_url = (
+            f"{reverse('github-app-install')}?"
+            f"{urlencode({'next': reverse('account-vcs'), 'host': 'github.com', 'workspace': self.workspace.pk})}"
+        )
+        self.assertNotContains(response, install_url.replace("&", "&amp;"))
+        self.assertNotContains(response, "Connect GitHub account")
         self.assertNotContains(
             response,
             reverse("manage-github-account-refresh", kwargs={"pk": installation.pk}),
@@ -287,6 +301,16 @@ class GitHubInstallationViewTest(ViewTestCase):
             response,
             reverse("manage-github-account-remove", kwargs={"pk": installation.pk}),
         )
+
+        install_response = self.client.get(
+            reverse("github-app-install"),
+            {
+                "next": reverse("account-vcs"),
+                "host": "github.com",
+                "workspace": str(self.workspace.pk),
+            },
+        )
+        self.assertEqual(install_response.status_code, 403)
 
     def test_project_admin_cannot_manage_github_installation(self):
         user = self.anotheruser
@@ -355,7 +379,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             f"{reverse('github-app-install')}?"
             f"{urlencode({'next': next_url, 'host': 'github.com', 'workspace': self.workspace.pk})}"
         )
-        self.assertContains(response, install_url.replace("&", "&amp;"))
+        self.assertNotContains(response, install_url.replace("&", "&amp;"))
 
     def test_account_vcs_integrations_accepts_workspace_owner(self):
         owner = User.objects.create_user(
@@ -707,6 +731,39 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertNotContains(response, _import_url(installation, repo))
         self.assertContains(response, "Unavailable")
 
+    def test_site_manager_can_import_from_installation_detail(self):
+        manager = User.objects.create_user(
+            username="site manager",
+            email="sitemanager@example.org",
+            password="testpassword",
+        )
+        self._grant_management_permission(manager)
+        repo = _repo_entry("test-org/repo1")
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[repo],
+        )
+        self.client.login(username=manager.username, password="testpassword")
+
+        response = self.client.get(
+            reverse("manage-github-account-detail", kwargs={"pk": installation.pk})
+        )
+
+        import_path = _import_url(installation, repo)
+        self.assertContains(response, import_path)
+        response = self.client.get(import_path)
+        self.assertRedirects(
+            response,
+            f"{reverse('create-component-vcs')}?session_component=1",
+            fetch_redirect_response=False,
+        )
+        self.assertEqual(
+            self.client.session["session_component"]["repo"], repo["clone_url"]
+        )
+
     def test_repository_import_link_preselects_github_app_vcs(self):
         repo = _repo_entry("test-org/repo1", default_branch="stable")
         installation = GitHubInstallation.objects.create(
@@ -906,6 +963,7 @@ class GitHubAppAccessControlTest(ViewTestCase):
             email="mainuser@example.org",
             password="testpassword",
         )
+        self.workspace.add_owner(self.user)
         self.project.add_user(self.user, "Administration")
 
         self.other_user = User.objects.create_user(
@@ -975,13 +1033,13 @@ class GitHubAppAccessControlTest(ViewTestCase):
         # A valid signed state for ``self.workspace`` produced by its admin.
         state = self._start_install(self.user)
 
-        # A user who manages an unrelated workspace must not be able to bind
+        # A user who owns an unrelated workspace must not be able to bind
         # GitHub to a workspace they don't manage.
         other_workspace = Workspace.objects.create(name="Other ACL Workspace")
-        other_project = self.create_project(
+        self.create_project(
             name="Other ACL", slug="other-acl", workspace=other_workspace
         )
-        other_project.add_user(self.other_user, "Administration")
+        other_workspace.add_owner(self.other_user)
         self.client.login(username=self.other_user.username, password="testpassword")
 
         response = self.client.get(

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -211,15 +211,15 @@ class GitHubInstallationViewTest(ViewTestCase):
 
     def test_account_vcs_integrations_uses_workspace_scope(self):
         user = self.anotheruser
-        self.project.add_user(user, "Administration")
+        self.workspace.add_owner(user)
         other_workspace = Workspace.objects.create(name="Other Workspace")
-        other_project = Project.objects.create(
+        Project.objects.create(
             name="Other GitHub Project",
             slug="other-github-project",
             web="https://example.com/",
             workspace=other_workspace,
         )
-        other_project.add_user(user, "Administration")
+        other_workspace.add_owner(user)
         hidden_workspace = Workspace.objects.create(name="Hidden Workspace")
         installation = GitHubInstallation.objects.create(
             installation_id="12345",
@@ -258,6 +258,61 @@ class GitHubInstallationViewTest(ViewTestCase):
                 f"{urlencode({'next': reverse('account-vcs'), 'host': 'github.com', 'workspace': workspace.pk})}"
             )
             self.assertContains(response, install_url.replace("&", "&amp;"))
+
+    def test_project_admin_cannot_manage_account_vcs_integrations(self):
+        user = self.anotheruser
+        self.project.add_user(user, "Administration")
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[_repo_entry("test-org/repo1")],
+        )
+        self.client.login(username=user.username, password="testpassword")
+
+        response = self.client.get(reverse("account-vcs"))
+
+        self.assertContains(response, "test-org")
+        self.assertContains(response, self.workspace.name)
+        self.assertContains(
+            response,
+            f"{reverse('github-app-repositories')}?workspace={self.workspace.pk}",
+        )
+        self.assertNotContains(
+            response,
+            reverse("manage-github-account-refresh", kwargs={"pk": installation.pk}),
+        )
+        self.assertNotContains(
+            response,
+            reverse("manage-github-account-remove", kwargs={"pk": installation.pk}),
+        )
+
+    def test_project_admin_cannot_manage_github_installation(self):
+        user = self.anotheruser
+        self.project.add_user(user, "Administration")
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[_repo_entry("test-org/repo1")],
+        )
+        self.client.login(username=user.username, password="testpassword")
+
+        detail_response = self.client.get(
+            reverse("manage-github-account-detail", kwargs={"pk": installation.pk})
+        )
+        self.assertEqual(detail_response.status_code, 403)
+        for view_name in (
+            "manage-github-account-refresh",
+            "manage-github-account-remove",
+        ):
+            response = self.client.post(
+                reverse(view_name, kwargs={"pk": installation.pk})
+            )
+            self.assertEqual(response.status_code, 403)
+        self.assertTrue(GitHubInstallation.objects.filter(pk=installation.pk).exists())
 
     def test_account_vcs_integrations_filters_selected_workspace(self):
         user = self.anotheruser

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -49,6 +49,10 @@ from weblate.vcs.github import (
     github_app_is_configured,
     normalize_github_app_hostname,
 )
+from weblate.vcs.permissions import (
+    github_app_installation_workspaces,
+    user_can_install_github_app_in_workspace,
+)
 from weblate.wladmin.views import MENU
 from weblate.workspaces.models import Workspace
 
@@ -70,10 +74,7 @@ def _managed_workspaces(user):
 
 
 def _installation_workspaces(user):
-    """Return workspaces where the user can connect GitHub accounts."""
-    if user.has_perm("management.use"):
-        return Workspace.objects.order()
-    return user.workspaces_with_perm("workspace.edit")
+    return github_app_installation_workspaces(user)
 
 
 def _user_can_install_github_app(user) -> bool:
@@ -142,7 +143,7 @@ def _get_install_workspace(request) -> Workspace | None:
 
 
 def _user_can_install_in_workspace(user, workspace: Workspace) -> bool:
-    return user.has_perm("management.use") or user.has_perm("workspace.edit", workspace)
+    return user_can_install_github_app_in_workspace(user, workspace)
 
 
 def _get_install_link(

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -69,8 +69,15 @@ def _managed_workspaces(user):
     ).distinct()
 
 
+def _installation_workspaces(user):
+    """Return workspaces where the user can connect GitHub accounts."""
+    if user.has_perm("management.use"):
+        return Workspace.objects.order()
+    return user.workspaces_with_perm("workspace.edit")
+
+
 def _user_can_install_github_app(user) -> bool:
-    return _managed_workspaces(user).exists()
+    return _installation_workspaces(user).exists()
 
 
 def _require_github_app_access(request) -> None:
@@ -101,21 +108,41 @@ def _get_next_url(request) -> str:
     return default_url
 
 
-def _get_managed_workspace(user, workspace_id) -> Workspace:
+def _get_workspace(workspaces, workspace_id) -> Workspace:
     try:
-        return _managed_workspaces(user).get(pk=workspace_id)
+        return workspaces.get(pk=workspace_id)
     except (Workspace.DoesNotExist, ValidationError, ValueError) as error:
         raise PermissionDenied from error
 
 
-def _get_install_workspace(request) -> Workspace | None:
+def _get_managed_workspace(user, workspace_id) -> Workspace:
+    return _get_workspace(_managed_workspaces(user), workspace_id)
+
+
+def _get_installation_workspace(user, workspace_id) -> Workspace:
+    return _get_workspace(_installation_workspaces(user), workspace_id)
+
+
+def _get_requested_workspace(request, workspaces) -> Workspace | None:
     workspace_id = request.GET.get("workspace", "").strip()
     if workspace_id:
-        return _get_managed_workspace(request.user, workspace_id)
-    workspaces = list(_managed_workspaces(request.user))
+        return _get_workspace(workspaces, workspace_id)
+    workspaces = list(workspaces)
     if len(workspaces) == 1:
         return workspaces[0]
     return None
+
+
+def _get_managed_request_workspace(request) -> Workspace | None:
+    return _get_requested_workspace(request, _managed_workspaces(request.user))
+
+
+def _get_install_workspace(request) -> Workspace | None:
+    return _get_requested_workspace(request, _installation_workspaces(request.user))
+
+
+def _user_can_install_in_workspace(user, workspace: Workspace) -> bool:
+    return user.has_perm("management.use") or user.has_perm("workspace.edit", workspace)
 
 
 def _get_install_link(
@@ -125,6 +152,8 @@ def _get_install_link(
         return None
     if workspace is None:
         workspace = _get_install_workspace(request)
+    elif not _user_can_install_in_workspace(request.user, workspace):
+        return None
     if workspace is None:
         return None
     target = next_url or request.get_full_path()
@@ -235,16 +264,14 @@ def _get_workspace_install_url(
 
 
 def _user_can_use_installation(user, installation: GitHubInstallation) -> bool:
-    return _managed_workspaces(user).filter(pk=installation.workspace_id).exists()
+    return (
+        user.has_perm("management.use")
+        or _managed_workspaces(user).filter(pk=installation.workspace_id).exists()
+    )
 
 
 def _user_can_manage_installation(user, installation: GitHubInstallation) -> bool:
-    return (
-        user.has_perm("management.use")
-        or user.workspaces_with_perm("workspace.edit")
-        .filter(pk=installation.workspace_id)
-        .exists()
-    )
+    return _installation_workspaces(user).filter(pk=installation.workspace_id).exists()
 
 
 def _require_installation_access(request, installation: GitHubInstallation) -> None:
@@ -347,6 +374,7 @@ class UserVCSIntegrationListView(View):
                         ),
                     }
                     for workspace in workspaces
+                    if _user_can_install_in_workspace(request.user, workspace)
                 ]
             apps.append(
                 {
@@ -572,7 +600,7 @@ def github_app_setup(request):
         state = _load_install_state(request, request.GET.get("state", ""))
         next_url = str(state["next"])
         hostname = str(state["host"])
-        workspace = _get_managed_workspace(request.user, state["workspace"])
+        workspace = _get_installation_workspace(request.user, state["workspace"])
     except (BadSignature, SignatureExpired):
         messages.error(
             request,
@@ -684,7 +712,7 @@ def github_app_repository_list(request):
     if not workspaces.exists():
         raise PermissionDenied
 
-    selected_workspace = _get_install_workspace(request)
+    selected_workspace = _get_managed_request_workspace(request)
     selected_project = None
     selected_project_without_workspace = False
     project_id = request.GET.get("project", "").strip()
@@ -710,11 +738,13 @@ def github_app_repository_list(request):
     installations = installations.order_by(
         "workspace__name", "target_login", "hostname"
     )
+    manageable_installations = {
+        installation.pk
+        for installation in installations
+        if _user_can_manage_installation(request.user, installation)
+    }
     all_repos = []
     for installation in installations:
-        installation.can_manage = _user_can_manage_installation(
-            request.user, installation
-        )
         for repo in installation.repositories:
             if repo.get("archived", False):
                 continue
@@ -737,6 +767,7 @@ def github_app_repository_list(request):
         {
             "repositories": all_repos,
             "installations": installations,
+            "manageable_installations": manageable_installations,
             "selected_workspace": selected_workspace,
             "selected_project": selected_project,
             "next_url": request.get_full_path(),

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -234,15 +234,26 @@ def _get_workspace_install_url(
     )
 
 
+def _user_can_use_installation(user, installation: GitHubInstallation) -> bool:
+    return _managed_workspaces(user).filter(pk=installation.workspace_id).exists()
+
+
 def _user_can_manage_installation(user, installation: GitHubInstallation) -> bool:
     return (
         user.has_perm("management.use")
-        or _managed_workspaces(user).filter(pk=installation.workspace_id).exists()
+        or user.workspaces_with_perm("workspace.edit")
+        .filter(pk=installation.workspace_id)
+        .exists()
     )
 
 
 def _require_installation_access(request, installation: GitHubInstallation) -> None:
     if not _user_can_manage_installation(request.user, installation):
+        raise PermissionDenied
+
+
+def _require_installation_use(request, installation: GitHubInstallation) -> None:
+    if not _user_can_use_installation(request.user, installation):
         raise PermissionDenied
 
 
@@ -311,6 +322,11 @@ class UserVCSIntegrationListView(View):
             .select_related("workspace")
             .order_by("hostname", "workspace__name", "target_login")
         )
+        manageable_installations = {
+            installation.pk
+            for installation in installations
+            if _user_can_manage_installation(request.user, installation)
+        }
         installations_by_host: defaultdict[str, list[GitHubInstallation]] = defaultdict(
             list
         )
@@ -339,6 +355,7 @@ class UserVCSIntegrationListView(View):
                     "html_url": config.html_url if config is not None else "",
                     "configured": config is not None,
                     "installations": installations_by_host.get(hostname, []),
+                    "manageable_installations": manageable_installations,
                     "workspace_links": workspace_links,
                 }
             )
@@ -695,6 +712,9 @@ def github_app_repository_list(request):
     )
     all_repos = []
     for installation in installations:
+        installation.can_manage = _user_can_manage_installation(
+            request.user, installation
+        )
         for repo in installation.repositories:
             if repo.get("archived", False):
                 continue
@@ -738,7 +758,7 @@ def github_app_import_repository(request, pk, repo_full_name):
         enabled=True,
         hostname__in=configured_hosts,
     )
-    _require_installation_access(request, installation)
+    _require_installation_use(request, installation)
 
     repository = None
     for entry in installation.repositories:

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -9,6 +9,7 @@ import logging
 import secrets
 import uuid
 from collections import defaultdict
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from django.contrib.auth.decorators import login_required
@@ -55,6 +56,9 @@ from weblate.vcs.permissions import (
 )
 from weblate.wladmin.views import MENU
 from weblate.workspaces.models import Workspace
+
+if TYPE_CHECKING:
+    from weblate.auth.results import PermissionResult
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +146,9 @@ def _get_install_workspace(request) -> Workspace | None:
     return _get_requested_workspace(request, _installation_workspaces(request.user))
 
 
-def _user_can_install_in_workspace(user, workspace: Workspace) -> bool:
+def _user_can_install_in_workspace(
+    user, workspace: Workspace
+) -> PermissionResult | bool:
     return user_can_install_github_app_in_workspace(user, workspace)
 
 


### PR DESCRIPTION
### Motivation
- Fix an authorization regression that allowed project-scoped administrators to manage (refresh/remove/view) workspace-wide GitHub App installations, which could delete workspace-wide integration state.
- Preserve project-admin ability to list and import repositories while requiring explicit workspace-level permission for management actions.

### Description
- Added a separate use-check ` _user_can_use_installation` and `_require_installation_use` to allow repository import/listing without granting management rights.
- Tightened ` _user_can_manage_installation` so management requires either site management permission (`management.use`) or an explicit workspace-level permission via `user.workspaces_with_perm("workspace.edit")`.
- Computed per-installation `manageable_installations` and `installation.can_manage` in the views and passed those flags to templates so UI controls are only shown to authorized users.
- Updated templates to hide `Refresh`/`Remove` actions unless the user can manage the installation, and switched the import endpoint to call the new use-only requirement.
- Added regression tests `test_project_admin_cannot_manage_account_vcs_integrations` and `test_project_admin_cannot_manage_github_installation` to verify project admins cannot view/invoke management endpoints, and added a brief changelog entry.

### Testing
- Ran the relevant test module with `uv run pytest weblate/vcs/tests/test_github_views.py` and observed all tests passing (`44 passed`).
- Ran repository formatting/lint checks with `uv run prek run --files weblate/vcs/views.py weblate/vcs/tests/test_github_views.py weblate/templates/vcs/account_integrations.html weblate/templates/vcs/github_repository_list.html docs/changes.rst` and the pre-commit checks passed.
- Verified `python -m py_compile weblate/vcs/views.py` succeeded (no syntax errors) during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e7fe92a0c8329b76c2809b26353d2)