### PR TITLE
fix(vcs): lock GitHub App component repositories

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -77,6 +77,7 @@ Weblate 2026.7
 * Restricted component changes are no longer exposed through nested project, component, or translation API change endpoints.
 * Unsupported upload levels now show an upload placeholder pointing to individual translations.
 * Repository update history keeps attribution and records remote update failures for easier hook debugging.
+* Existing :ref:`code-hosting-github-app-register` components can no longer be retargeted to another repository through the API.
 
 .. rubric:: Compatibility
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -88,6 +88,7 @@ from weblate.utils.state import (
 from weblate.utils.version import GIT_VERSION
 from weblate.utils.version_display import VERSION_DISPLAY_HIDE, VERSION_DISPLAY_SOFT
 from weblate.vcs.base import RepositoryError, RepositoryLock
+from weblate.vcs.github import GitHubInstallation
 from weblate.vcs.models import VCS_REGISTRY
 from weblate.workspaces.models import Workspace
 
@@ -5313,6 +5314,29 @@ class ComponentAPITest(APIBaseTest):
         with open(TEST_SCREENSHOT, "rb") as handle:
             shot.image.save("screenshot.png", File(handle))
 
+    def configure_github_app_component(self) -> None:
+        workspace = Workspace.objects.create(name="API GitHub App workspace")
+        self.project.workspace = workspace
+        self.project.save(update_fields=["workspace"])
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=workspace,
+            repositories=[
+                {"full_name": "test-org/repo"},
+                {"full_name": "test-org/other"},
+            ],
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="github-app",
+            repo="https://github.com/test-org/repo.git",
+            branch="main",
+            push="",
+            push_branch="",
+        )
+        self.component.refresh_from_db()
+
     def test_list_components(self) -> None:
         response = self.client.get(reverse("api:component-list"))
         self.assertEqual(response.data["count"], 2)
@@ -5802,6 +5826,48 @@ class ComponentAPITest(APIBaseTest):
             is_valid_index,
             "Component row should be locked before serializer validation runs",
         )
+
+    def test_patch_rejects_github_app_repository_change(self) -> None:
+        self.configure_github_app_component()
+
+        response = self.do_request(
+            "api:component-detail",
+            self.component_kwargs,
+            method="patch",
+            superuser=True,
+            code=400,
+            format="json",
+            request={"repo": "https://github.com/test-org/other.git"},
+        )
+
+        self.assertEqual(response.data["errors"][0]["attr"], "repo")
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "This field is managed by the repository integration and can not be changed.",
+        )
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.repo, "https://github.com/test-org/repo.git")
+
+    def test_patch_rejects_github_app_vcs_change(self) -> None:
+        self.configure_github_app_component()
+
+        response = self.do_request(
+            "api:component-detail",
+            self.component_kwargs,
+            method="patch",
+            superuser=True,
+            code=400,
+            format="json",
+            request={"vcs": "git"},
+        )
+
+        self.assertEqual(response.data["errors"][0]["attr"], "vcs")
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "This field is managed by the repository integration and can not be changed.",
+        )
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.vcs, "github-app")
 
     def test_patch_acquires_repository_lock_before_row_lock(self) -> None:
         events: list[tuple[str, int]] = []

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -532,6 +532,9 @@ class Component(  # ruff: ignore[too-many-public-methods]
     LINKED_REPOSITORY_SETTING_MESSAGE = gettext_lazy(
         "Option is not available for linked repositories. Setting from linked component will be used."
     )
+    INTEGRATION_LOCKED_FIELD_MESSAGE = gettext_lazy(
+        "This field is managed by the repository integration and can not be changed."
+    )
 
     name = models.CharField(
         verbose_name=gettext_lazy("Component name"),
@@ -4907,6 +4910,28 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 ) % {"param": param.name, "format": self.file_format}
                 raise ValidationError({"file_format_params": message})
 
+    def clean_integration_locked_fields(self, old: Component) -> None:
+        """Validate fields managed by an existing repository integration."""
+        vcs_backend = VCS_REGISTRY.get(old.vcs)
+        if vcs_backend is None:
+            return
+
+        errors: dict[str, Any] = {}
+        for field in vcs_backend.component_lock_fields:
+            old_value = getattr(old, field)
+            value = getattr(self, field)
+            if field in vcs_backend.component_clear_fields and not value:
+                setattr(self, field, "")
+                continue
+            if old_value == value:
+                if field in vcs_backend.component_clear_fields:
+                    setattr(self, field, "")
+                continue
+            errors[field] = self.INTEGRATION_LOCKED_FIELD_MESSAGE
+
+        if errors:
+            raise ValidationError(errors)
+
     def clean(self) -> None:
         """
         Validate component parameters.
@@ -4951,6 +4976,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         if self.id:
             old = Component.objects.get(pk=self.id)
+            self.clean_integration_locked_fields(old)
             self.check_rename(old, validate=True)
             if old.source_language != self.source_language:
                 # Might be implemented in future, but needs to handle:

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -1144,6 +1144,29 @@ class ComponentValidationTest(RepoTestCase):
         # Ensure we have correct component
         self.component.full_clean()
 
+    def configure_github_app_component(self, *, push: str = "") -> None:
+        workspace = Workspace.objects.create(name="GitHub App validation")
+        self.component.project.workspace = workspace
+        self.component.project.save(update_fields=["workspace"])
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=workspace,
+            repositories=[
+                {"full_name": "test-org/repo"},
+                {"full_name": "test-org/other"},
+            ],
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="github-app",
+            repo="https://github.com/test-org/repo.git",
+            branch="main",
+            push=push,
+            push_branch="translations" if push else "",
+        )
+        self.component.refresh_from_db()
+
     def test_commit_message(self) -> None:
         """Invalid commit message."""
         self.component.commit_message = "{% if %}"
@@ -1252,6 +1275,44 @@ class ComponentValidationTest(RepoTestCase):
         ):
             self.component.full_clean()
         self.assertIn("internal or non-public address", str(error.exception))
+
+    def test_github_app_rejects_locked_repository_field_changes(self) -> None:
+        self.configure_github_app_component()
+
+        for field, value in (
+            ("repo", "https://github.com/test-org/other.git"),
+            ("vcs", "git"),
+        ):
+            with self.subTest(field=field):
+                component = Component.objects.get(pk=self.component.pk)
+                setattr(component, field, value)
+
+                with self.assertRaises(ValidationError) as error:
+                    component.full_clean()
+
+                self.assertIn(field, error.exception.message_dict)
+                self.assertIn(
+                    "managed by the repository integration", str(error.exception)
+                )
+
+    def test_github_app_clears_locked_push_fields(self) -> None:
+        self.configure_github_app_component(push="https://example.com/other/repo.git")
+
+        with patch.object(Component, "validate_repository_access", return_value=None):
+            self.component.full_clean()
+
+        self.assertEqual(self.component.push, "")
+        self.assertEqual(self.component.push_branch, "")
+
+    def test_github_app_rejects_locked_push_field_changes(self) -> None:
+        self.configure_github_app_component()
+
+        self.component.push = "https://example.com/other/repo.git"
+        with self.assertRaises(ValidationError) as error:
+            self.component.full_clean()
+
+        self.assertIn("push", error.exception.message_dict)
+        self.assertIn("managed by the repository integration", str(error.exception))
 
     def create_unrelated_git_repo(self, branch: str) -> str:
         path = self.get_repo_path("unrelated-repo.git")


### PR DESCRIPTION
Prevent API and model updates from retargeting existing GitHub App components to another repository while preserving managed push-field cleanup.

Fixes #20303

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
