### PR TITLE
fix(checks): expose semantic highlight metadata

### DIFF
--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import re
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from django.http import Http404
@@ -35,6 +36,21 @@ if TYPE_CHECKING:
 FixupType = (
     tuple[Literal["regex"], str, str, str] | tuple[Literal["plurals"], list[str]]
 )
+type HighlightKind = Literal["grammar", "markup", "syntax"]
+
+
+@dataclass(frozen=True, slots=True)
+class Highlight:
+    """Highlighted source span and its translation semantics."""
+
+    start: int
+    end: int
+    text: str
+    kind: HighlightKind = "syntax"
+    group: str | None = None
+    role: str | None = None
+    translatable: bool = False
+    forbidden_text: tuple[str, ...] = ()
 
 
 class MissingExtraDict(TypedDict, total=False):
@@ -225,12 +241,13 @@ class BaseCheck(ClassLoaderProtocol, DocVersionsMixin):
         """Return link to documentation."""
         return get_doc_url("user/checks", self.doc_id, user=user)
 
-    def check_highlight(self, source: str, unit: Unit):
+    def check_highlight(self, source: str, unit: Unit) -> Iterable[Highlight]:
         """
         Return parts of the text that match to highlight them.
 
-        Result is list that contains lists of two elements with start position of the
-        match and the value of the match
+        Result contains highlighted spans with semantic information used by
+        formatting, automatic translation cleanup, and LLM structured
+        placeholders.
         """
         return []
 

--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -600,8 +600,8 @@ class PunctuationSpacingCheck(TargetCheck):
         # Enable syntax highlighting so RST inline literals/strong/emph spans
         # are also excluded (previously handled by RST_MATCH).
         highlighted_ranges = [
-            (start, end)
-            for start, end, _ in highlight_string(
+            (highlight.start, highlight.end)
+            for highlight in highlight_string(
                 target, unit, highlight_syntax="rst-text" in unit.all_flags
             )
         ]

--- a/weblate/checks/fluent/inner_html.py
+++ b/weblate/checks/fluent/inner_html.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext, gettext_lazy
 
-from weblate.checks.base import SourceCheck, TargetCheck
+from weblate.checks.base import Highlight, SourceCheck, TargetCheck
 from weblate.checks.fluent.utils import (
     FluentPatterns,
     FluentUnitConverter,
@@ -19,6 +19,7 @@ from weblate.checks.fluent.utils import (
     translation_from_check,
     variant_name,
 )
+from weblate.checks.utils import pair_markup_highlights
 from weblate.utils.html import format_html_join_comma, list_to_tuples
 
 if TYPE_CHECKING:
@@ -1296,7 +1297,10 @@ class FluentTargetInnerHTMLCheck(_FluentInnerHTMLCheck, TargetCheck):
 
         # We simply highlight all HTML tags that are valid tags according to our
         # parser, regardless of whether it matches a tag found in the source.
-        return [
-            (match.start(), match.end(), match.group())
-            for match in self.ALL_TAGS_REGEX.finditer(source)
-        ]
+        return pair_markup_highlights(
+            [
+                Highlight(match.start(), match.end(), match.group(), kind="markup")
+                for match in self.ALL_TAGS_REGEX.finditer(source)
+            ],
+            group_prefix="fluent-html",
+        )

--- a/weblate/checks/fluent/utils.py
+++ b/weblate/checks/fluent/utils.py
@@ -13,6 +13,8 @@ from translate.storage.fluent import (
     FluentUnit,
 )
 
+from weblate.checks.base import Highlight
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
@@ -26,7 +28,7 @@ if TYPE_CHECKING:
     from weblate.checks.models import Check as CheckModel
     from weblate.trans.models.unit import Unit as TransUnitModel
 
-HighlightsType = list[tuple[int, int, str]]
+HighlightsType = list[Highlight]
 
 
 def translation_from_check(
@@ -195,9 +197,7 @@ class FluentPatterns:
         Generate a list of highlights for the given source.
 
         Highlights all matches for the patterns in highlight_patterns, except
-        within a literal expression. Returns the highlights as a list of
-        3-tuples of the highlighted regions' starting positions, ending
-        positions and text.
+        within a literal expression.
         """
         unique_highlights = {p for p in highlight_patterns if p}
         if not unique_highlights:
@@ -207,7 +207,12 @@ class FluentPatterns:
         for start, text, _ in cls.split_literal_expressions(source):
             # NOTE: text may be empty if two literals touch.
             highlights.extend(
-                (start + match.start(), start + match.end(), match.group())
+                Highlight(
+                    start + match.start(),
+                    start + match.end(),
+                    match.group(),
+                    kind="grammar",
+                )
                 for match in regex.finditer(text)
             )
         return highlights

--- a/weblate/checks/format.py
+++ b/weblate/checks/format.py
@@ -13,7 +13,7 @@ from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext, gettext_lazy
 
-from weblate.checks.base import SourceCheck, TargetCheck
+from weblate.checks.base import Highlight, SourceCheck, TargetCheck
 from weblate.utils.html import format_html_join_comma, list_to_tuples
 
 if TYPE_CHECKING:
@@ -517,7 +517,7 @@ class BaseFormatCheck(TargetCheck):
             return
         match_objects = self.regexp.finditer(source)
         for match in match_objects:
-            yield match.start(), match.end(), match.group()
+            yield Highlight(match.start(), match.end(), match.group(), kind="grammar")
 
     def format_result(self, result: MissingExtraDict) -> Iterable[StrOrPromise]:
         if (

--- a/weblate/checks/icu.py
+++ b/weblate/checks/icu.py
@@ -11,7 +11,7 @@ from django.utils.html import format_html
 from django.utils.translation import gettext, gettext_lazy
 from pyicumessageformat import Parser
 
-from weblate.checks.base import SourceCheck
+from weblate.checks.base import Highlight, SourceCheck
 from weblate.checks.format import BaseFormatCheck
 from weblate.utils.html import format_html_join_comma, list_to_tuples
 
@@ -158,7 +158,7 @@ def extract_highlights(token, source: str):
         yield from extract_highlights(token["contents"], source)
 
     if usable:
-        yield (start, end, source[start:end])
+        yield Highlight(start, end, source[start:end], kind="grammar")
 
 
 def extract_placeholders(token, variables=None):

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -39,7 +39,7 @@ from docutils.parsers.rst.states import Inliner
 from docutils.readers.standalone import Reader
 from docutils.writers.null import Writer
 
-from weblate.checks.base import TargetCheck
+from weblate.checks.base import Highlight, TargetCheck
 from weblate.checks.format import (
     ES_TEMPLATE_MATCH,
     FLAG_RULES,
@@ -48,6 +48,7 @@ from weblate.checks.format import (
     PERCENT_MATCH,
     VUE_MATCH,
 )
+from weblate.checks.utils import pair_markup_highlights
 from weblate.utils.html import (
     MD_BROKEN_LINK,
     MD_LINK,
@@ -139,6 +140,18 @@ RST_TRANSLATABLE = {
     "index",
     "samp",
 }
+RST_LLM_TRANSLATABLE = {
+    "abbr",
+    "code",
+    "dfn",
+    "guilabel",
+    "index",
+    "kbd",
+    "menuselection",
+    "samp",
+    "sub",
+    "sup",
+}
 
 RST_ROLE_RE = [
     re.compile(r"""Unknown interpreted text role "([^"]*)"\."""),
@@ -157,7 +170,7 @@ RST_HIGHLIGHT_ROLE_TARGET = "role-target"
 
 
 type RSTHighlightKind = str
-type RSTHighlight = tuple[int, int, str]
+type RSTHighlight = Highlight
 
 
 class RSTRoleMatch(NamedTuple):
@@ -295,8 +308,17 @@ class BBCodeCheck(TargetCheck):
         if self.should_skip(unit):
             return
         for match in BBCODE_MATCH.finditer(source):
+            group = f"bbcode:{match.start()}:{match.end()}"
             for tag in ("start", "end"):
-                yield match.start(tag), match.end(tag), match.group(tag)
+                yield Highlight(
+                    match.start(tag),
+                    match.end(tag),
+                    match.group(tag),
+                    kind="markup",
+                    group=group,
+                    translatable=True,
+                    forbidden_text=("[", "]"),
+                )
 
 
 class BaseXMLCheck(TargetCheck):
@@ -408,11 +430,12 @@ class XMLTagsCheck(BaseXMLCheck):
             return []
         # Include XML markup
         ret = [
-            (match.start(), match.end(), match.group())
+            Highlight(match.start(), match.end(), match.group(), kind="markup")
             for match in XML_MATCH.finditer(source)
         ]
+        ret = pair_markup_highlights(ret, group_prefix="xml")
         # Add XML entities
-        skipranges = [x[:2] for x in ret]
+        skipranges = [(highlight.start, highlight.end) for highlight in ret]
         skipranges.append((len(source), len(source)))
         offset = 0
         for match in XML_ENTITY_MATCH.finditer(source):
@@ -423,7 +446,7 @@ class XMLTagsCheck(BaseXMLCheck):
             # Avoid including entities inside markup
             if start > skipranges[offset][0] and end < skipranges[offset][1]:
                 continue
-            ret.append((start, end, match.group()))
+            ret.append(Highlight(start, end, match.group(), kind="syntax"))
         return ret
 
 
@@ -573,8 +596,27 @@ class MarkdownSyntaxCheck(MarkdownBaseCheck):
                     break
             start = match.start()
             end = match.end()
-            yield (start, start + len(value), value)
-            yield (end - len(value), end, value if value != "<" else ">")
+            group = f"markdown:{start}:{end}"
+            translatable = value != "<"
+            forbidden_text = (value[0],) if translatable and len(value) > 1 else ()
+            yield Highlight(
+                start,
+                start + len(value),
+                value,
+                kind="markup",
+                group=group,
+                translatable=translatable,
+                forbidden_text=forbidden_text,
+            )
+            yield Highlight(
+                end - len(value),
+                end,
+                value if value != "<" else ">",
+                kind="markup",
+                group=group,
+                translatable=translatable,
+                forbidden_text=forbidden_text,
+            )
 
 
 class URLCheck(TargetCheck):
@@ -680,27 +722,60 @@ def get_rst_role_highlight(
     end: int,
 ) -> list[RSTHighlight]:
     if (matched_role := get_rst_role_match(rawsource)) is None:
-        return [(start, end, rawsource)]
+        return [Highlight(start, end, rawsource, kind="syntax")]
 
     prefix_end = start + len(matched_role.syntax_prefix)
+    group = f"rst-role:{start}:{end}"
     if matched_role.role in RST_TRANSLATABLE:
+        translatable = matched_role.role in RST_LLM_TRANSLATABLE
         return [
-            (start, prefix_end, matched_role.syntax_prefix),
-            (end - len(matched_role.syntax_suffix), end, matched_role.syntax_suffix),
+            Highlight(
+                start,
+                prefix_end,
+                matched_role.syntax_prefix,
+                kind="markup",
+                group=group,
+                role=matched_role.role,
+                translatable=translatable,
+            ),
+            Highlight(
+                end - len(matched_role.syntax_suffix),
+                end,
+                matched_role.syntax_suffix,
+                kind="markup",
+                group=group,
+                role=matched_role.role,
+                translatable=translatable,
+            ),
         ]
 
     if matched := RST_EXPLICIT_TITLE_RE.match(matched_role.inner):
         suffix_start = prefix_end + len(matched.group(1))
+        forbidden_text = ("`", "<", ">")
         return [
-            (start, prefix_end, matched_role.syntax_prefix),
-            (
+            Highlight(
+                start,
+                prefix_end,
+                matched_role.syntax_prefix,
+                kind="markup",
+                group=group,
+                role=matched_role.role,
+                translatable=True,
+                forbidden_text=forbidden_text,
+            ),
+            Highlight(
                 suffix_start,
                 end,
                 rawsource[len(matched_role.syntax_prefix) + len(matched.group(1)) :],
+                kind="markup",
+                group=group,
+                role=matched_role.role,
+                translatable=True,
+                forbidden_text=forbidden_text,
             ),
         ]
 
-    return [(start, end, rawsource)]
+    return [Highlight(start, end, rawsource, kind="syntax", role=matched_role.role)]
 
 
 def normalize_rst_node_token(token: str) -> str:
@@ -796,12 +871,12 @@ def extract_rst_references(
             name, highlight_type = role_reference
             result.append((name, token))
             if highlight_type == RST_HIGHLIGHT_WHOLE:
-                highlights.append((start, end, token))
+                highlights.append(Highlight(start, end, token, kind="syntax"))
             else:
                 highlights.extend(get_rst_role_highlight(token, start, end))
         elif isinstance(node, (footnote_reference, substitution_reference)):
             result.append((token, token))
-            highlights.append((start, end, token))
+            highlights.append(Highlight(start, end, token, kind="syntax"))
         elif isinstance(node, reference):
             # Ignore the content as it might be localized, just differentiate
             # references with a link and without
@@ -810,10 +885,11 @@ def extract_rst_references(
             if refuri and (target_start := token.find(f"<{refuri}>")) != -1:
                 target_end = target_start + len(refuri) + 2
                 highlights.append(
-                    (
+                    Highlight(
                         start + target_start,
                         start + target_end,
                         token[target_start:target_end],
+                        kind="syntax",
                     )
                 )
         elif isinstance(node, literal):

--- a/weblate/checks/placeholders.py
+++ b/weblate/checks/placeholders.py
@@ -12,9 +12,9 @@ from django.utils.html import escape, format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy
 
-from weblate.checks.base import TargetCheckParametrized
+from weblate.checks.base import Highlight, TargetCheckParametrized
 from weblate.checks.parser import multi_value_flag, single_value_flag
-from weblate.checks.utils import merge_highlight_spans
+from weblate.checks.utils import merge_highlight_spans, pair_markup_highlights
 from weblate.utils.errors import report_error
 from weblate.utils.regex import regex_findall, regex_finditer
 
@@ -154,7 +154,7 @@ class PlaceholderCheck(TargetCheckParametrized):
             return
 
         regex_flags = regex.IGNORECASE if "case-insensitive" in unit.all_flags else 0
-        spans: list[tuple[int, int, str]] = []
+        spans: list[Highlight] = []
 
         # get raw list of patterns from unit to run each independently                    continue
         for param in unit.all_flags.get_value_raw(self.enable_string):
@@ -169,7 +169,7 @@ class PlaceholderCheck(TargetCheckParametrized):
 
             try:
                 spans.extend(
-                    (match.start(), match.end(), match.group())
+                    Highlight(match.start(), match.end(), match.group(), kind="grammar")
                     for match in regex_finditer(pattern, source)
                 )
             except TimeoutError:
@@ -179,8 +179,10 @@ class PlaceholderCheck(TargetCheckParametrized):
         if not spans:
             return
 
-        spans.sort(key=lambda x: (x[0], -x[1]))
-        yield from merge_highlight_spans(source, spans)
+        spans.sort(key=lambda highlight: (highlight.start, -highlight.end))
+        yield from pair_markup_highlights(
+            merge_highlight_spans(source, spans), group_prefix="placeholder"
+        )
 
     def get_description(self, check_obj):
         unit = check_obj.unit

--- a/weblate/checks/tests/test_angularjs_checks.py
+++ b/weblate/checks/tests/test_angularjs_checks.py
@@ -84,7 +84,10 @@ class AngularJSInterpolationCheckTest(CheckTestCase):
         )
         self.assertEqual(
             [(0, 8, "{{name}}"), (9, 41, "{{ something.value | currency }}")],
-            highlights,
+            [
+                (highlight.start, highlight.end, highlight.text)
+                for highlight in highlights
+            ],
         )
 
     def test_check_highlight_ignored(self) -> None:

--- a/weblate/checks/tests/test_checks.py
+++ b/weblate/checks/tests/test_checks.py
@@ -12,6 +12,7 @@ from unittest import SkipTest
 
 from django.test import SimpleTestCase
 
+from weblate.checks.base import Highlight
 from weblate.checks.format import BaseFormatCheck
 from weblate.trans.tests.factories import make_unit
 
@@ -272,7 +273,14 @@ class CheckTestCase(SimpleTestCase, ABC):
             self.default_lang,
             source=self.test_highlight[1],
         )
+        highlights = list(self.check.check_highlight(self.test_highlight[1], unit))
+        self.assertTrue(
+            all(isinstance(highlight, Highlight) for highlight in highlights)
+        )
         self.assertEqual(
-            list(self.check.check_highlight(self.test_highlight[1], unit)),
+            [
+                (highlight.start, highlight.end, highlight.text)
+                for highlight in highlights
+            ],
             self.test_highlight[2],
         )

--- a/weblate/checks/tests/test_fluent_checks.py
+++ b/weblate/checks/tests/test_fluent_checks.py
@@ -207,8 +207,12 @@ class FluentCheckTestBase(SimpleTestCase):
         highlights: list[tuple[int, str]],
     ) -> None:
         unit = self._create_target_unit(source, "", fluent_type)
+        actual_highlights = check.check_highlight(source, unit)
         self.assertEqual(
-            check.check_highlight(source, unit),
+            [
+                (highlight.start, highlight.end, highlight.text)
+                for highlight in actual_highlights
+            ],
             [(start, start + len(string), string) for start, string in highlights],
             f"Highlights for {check.check_id} should match for {unit}",
         )
@@ -622,6 +626,18 @@ class FluentPartsCheckTest(FluentCheckTestBase):
 
 class TestFluentReferencesCheck(FluentCheckTestBase):
     check = FluentReferencesCheck()
+
+    def test_highlight_kind(self) -> None:
+        unit = self._create_target_unit(
+            "source { $num } and { message }",
+            "",
+            "Message",
+        )
+        highlights = self.check.check_highlight(unit.source, unit)
+        self.assertEqual(
+            [(highlight.text, highlight.kind) for highlight in highlights],
+            [("{ $num }", "grammar"), ("{ message }", "grammar")],
+        )
 
     def test_same_refs(self) -> None:
         for matching_sources in (

--- a/weblate/checks/tests/test_icu_checks.py
+++ b/weblate/checks/tests/test_icu_checks.py
@@ -265,7 +265,10 @@ class ICUMessageFormatCheckTest(CheckTestCase):
         )
 
         self.assertListEqual(
-            highlights,
+            [
+                (highlight.start, highlight.end, highlight.text)
+                for highlight in highlights
+            ],
             [
                 (14, 22, "{na<>me}"),
             ],
@@ -386,7 +389,10 @@ class ICUXMLFormatCheckTest(ICUMessageFormatCheckTest):
         )
 
         self.assertListEqual(
-            highlights,
+            [
+                (highlight.start, highlight.end, highlight.text)
+                for highlight in highlights
+            ],
             [
                 (14, 22, "{na<>me}"),
             ],

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -725,7 +725,13 @@ class RSTReferencesCheckTest(CheckTestCase):
             self.addCleanup(extract_rst_references.cache_clear)
             _references, _counter, highlights = extract_rst_references(text)
 
-        self.assertEqual(highlights, ((15, 20, "|foo|"),))
+        self.assertEqual(
+            tuple(
+                (highlight.start, highlight.end, highlight.text)
+                for highlight in highlights
+            ),
+            ((15, 20, "|foo|"),),
+        )
 
     def test_repeated_explicit_link_targets_keep_offset(self) -> None:
         text = (
@@ -760,7 +766,13 @@ class RSTReferencesCheckTest(CheckTestCase):
             offset = start + len(target)
 
         self.assertEqual(counter["`... <...>`_"], len(expected_targets))
-        self.assertEqual(highlights, tuple(expected_highlights))
+        self.assertEqual(
+            tuple(
+                (highlight.start, highlight.end, highlight.text)
+                for highlight in highlights
+            ),
+            tuple(expected_highlights),
+        )
 
     def test_option_space(self) -> None:
         self.do_test(

--- a/weblate/checks/tests/test_placeholders.py
+++ b/weblate/checks/tests/test_placeholders.py
@@ -13,6 +13,12 @@ from weblate.trans.tests.factories import make_check, make_unit
 from weblate.trans.tests.test_views import FixtureComponentTestCase
 
 
+def highlight_spans(highlights):
+    return [
+        (highlight.start, highlight.end, highlight.text) for highlight in highlights
+    ]
+
+
 class PlaceholdersTest(CheckTestCase):
     check = PlaceholderCheck()
 
@@ -128,13 +134,17 @@ class PlaceholdersTest(CheckTestCase):
             self.default_lang,
             "&lt;strong&gt;Not limit the amount of videos&lt;/strong&gt; new users can upload",
         )
+        highlights = list(self.check.check_highlight(unit.source, unit))
         self.assertEqual(
-            list(self.check.check_highlight(unit.source, unit)),
+            highlight_spans(highlights),
             [
                 (0, 14, "&lt;strong&gt;"),
                 (44, 59, "&lt;/strong&gt;"),
             ],
         )
+        self.assertEqual(highlights[0].kind, "markup")
+        self.assertEqual(highlights[0].group, highlights[1].group)
+        self.assertEqual(highlights[0].forbidden_text, ("&lt;", "&gt;", "<", ">"))
 
     def test_overlapping_non_nested(self) -> None:
         # The 2 flags match partially overlapping spans
@@ -146,10 +156,12 @@ class PlaceholdersTest(CheckTestCase):
             self.default_lang,
             "nested ${user.name} non-overlapping",
         )
+        highlights = list(self.check.check_highlight(unit.source, unit))
         self.assertEqual(
-            list(self.check.check_highlight(unit.source, unit)),
+            highlight_spans(highlights),
             [(7, 19, "${user.name}")],
         )
+        self.assertEqual(highlights[0].kind, "grammar")
 
     def test_empty_placeholder_flags_do_not_match(self) -> None:
         for flags in ("placeholders:", 'placeholders:""', 'placeholders:r""'):
@@ -176,8 +188,15 @@ class PlaceholdersTest(CheckTestCase):
             )
         )
         self.assertEqual(
-            list(self.check.check_highlight(unit.source, unit)),
+            highlight_spans(list(self.check.check_highlight(unit.source, unit))),
             [(7, 12, "$URL$"), (13, 16, "$2$")],
+        )
+        self.assertEqual(
+            [
+                highlight.kind
+                for highlight in self.check.check_highlight(unit.source, unit)
+            ],
+            ["grammar", "grammar"],
         )
 
     def test_regexp_timeout(self) -> None:

--- a/weblate/checks/tests/test_utils.py
+++ b/weblate/checks/tests/test_utils.py
@@ -2,10 +2,17 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.test import SimpleTestCase
 
 from weblate.checks.utils import highlight_string, replace_highlighted
 from weblate.trans.tests.factories import make_unit, set_unit_flags
+
+if TYPE_CHECKING:
+    from weblate.checks.base import Highlight
 
 REPLACEMENT_CALLS: list[int] = []
 
@@ -15,6 +22,12 @@ def marker_replacement(start: int) -> str:
     return f"marker-{start}"
 
 
+def highlight_spans(highlights: list[Highlight]) -> list[tuple[int, int, str]]:
+    return [
+        (highlight.start, highlight.end, highlight.text) for highlight in highlights
+    ]
+
+
 class HighlightTestCase(SimpleTestCase):
     def test_simple(self) -> None:
         unit = make_unit(
@@ -22,7 +35,7 @@ class HighlightTestCase(SimpleTestCase):
             flags="python-brace-format",
         )
         self.assertEqual(
-            highlight_string(unit.source, unit),
+            highlight_spans(highlight_string(unit.source, unit)),
             [(7, 15, "{format}")],
         )
 
@@ -32,7 +45,7 @@ class HighlightTestCase(SimpleTestCase):
             flags="python-brace-format, python-format",
         )
         self.assertEqual(
-            highlight_string(unit.source, unit),
+            highlight_spans(highlight_string(unit.source, unit)),
             [(7, 15, "{format}"), (16, 18, "%d")],
         )
 
@@ -42,7 +55,7 @@ class HighlightTestCase(SimpleTestCase):
             flags="python-brace-format",
         )
         self.assertEqual(
-            highlight_string(unit.source, unit),
+            highlight_spans(highlight_string(unit.source, unit)),
             [(7, 26, '<a href="{format}">'), (32, 36, "</a>")],
         )
 
@@ -54,10 +67,12 @@ class HighlightTestCase(SimpleTestCase):
             source="nested ${user.name} non-overlapping",
             flags=r'python-brace-format, placeholders:r"\$\{\w+"',
         )
+        highlights = highlight_string(unit.source, unit)
         self.assertEqual(
-            highlight_string(unit.source, unit),
+            highlight_spans(highlights),
             [(7, 19, "${user.name}")],
         )
+        self.assertEqual(highlights[0].kind, "grammar")
 
     def test_syntax(self) -> None:
         unit = make_unit(
@@ -65,69 +80,173 @@ class HighlightTestCase(SimpleTestCase):
             flags="rst-text",
         )
         self.assertEqual(
-            highlight_string(unit.source, unit, highlight_syntax=True),
+            highlight_spans(highlight_string(unit.source, unit, highlight_syntax=True)),
             [(12, 13, "`"), (18, 46, "<https://www.sphinx-doc.org>"), (46, 48, "`_")],
         )
         self.assertEqual(
-            highlight_string(
-                "Hello `world <https://weblate.org>`_", unit, highlight_syntax=True
+            highlight_spans(
+                highlight_string(
+                    "Hello `world <https://weblate.org>`_",
+                    unit,
+                    highlight_syntax=True,
+                )
             ),
             [(6, 7, "`"), (13, 34, "<https://weblate.org>"), (34, 36, "`_")],
         )
         self.assertEqual(
-            highlight_string("Hello **world**", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string("Hello **world**", unit, highlight_syntax=True)
+            ),
             [(6, 8, "**"), (13, 15, "**")],
         )
         self.assertEqual(
-            highlight_string("Hello *world*", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string("Hello *world*", unit, highlight_syntax=True)
+            ),
             [(6, 7, "*"), (12, 13, "*")],
         )
         self.assertEqual(
-            highlight_string(":guilabel:`Hello`", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string(":guilabel:`Hello`", unit, highlight_syntax=True)
+            ),
             [(0, 11, ":guilabel:`"), (16, 17, "`")],
         )
         self.assertEqual(
-            highlight_string(":Code:`printf()`", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string(":Code:`printf()`", unit, highlight_syntax=True)
+            ),
             [(0, 7, ":Code:`"), (15, 16, "`")],
         )
         self.assertEqual(
-            highlight_string("`printf()`:Code:", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string("`printf()`:Code:", unit, highlight_syntax=True)
+            ),
             [(0, 1, "`"), (9, 16, "`:Code:")],
         )
         self.assertEqual(
-            highlight_string(":file:`/tmp/example.txt`", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string(
+                    ":file:`/tmp/example.txt`", unit, highlight_syntax=True
+                )
+            ),
             [(0, 7, ":file:`"), (23, 24, "`")],
         )
         self.assertEqual(
-            highlight_string(":code:`printf()`", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string(":code:`printf()`", unit, highlight_syntax=True)
+            ),
             [(0, 7, ":code:`"), (15, 16, "`")],
         )
         self.assertEqual(
-            highlight_string(":math:`x + y`", unit, highlight_syntax=True),
+            highlight_spans(
+                highlight_string(":math:`x + y`", unit, highlight_syntax=True)
+            ),
             [(0, 7, ":math:`"), (12, 13, "`")],
         )
         self.assertEqual(
-            highlight_string(":sub:`2`", unit, highlight_syntax=True),
+            highlight_spans(highlight_string(":sub:`2`", unit, highlight_syntax=True)),
             [(0, 6, ":sub:`"), (7, 8, "`")],
         )
         self.assertEqual(
-            highlight_string(":sup:`2`", unit, highlight_syntax=True),
+            highlight_spans(highlight_string(":sup:`2`", unit, highlight_syntax=True)),
             [(0, 6, ":sup:`"), (7, 8, "`")],
         )
         self.assertEqual(
-            highlight_string(
-                ":ref:`review workflow <reviews>`", unit, highlight_syntax=True
+            highlight_spans(
+                highlight_string(
+                    ":ref:`review workflow <reviews>`",
+                    unit,
+                    highlight_syntax=True,
+                )
             ),
             [(0, 6, ":ref:`"), (21, 32, " <reviews>`")],
         )
         self.assertEqual(
-            highlight_string(
-                "`review workflow <reviews>`:ref:",
-                unit,
-                highlight_syntax=True,
+            highlight_spans(
+                highlight_string(
+                    "`review workflow <reviews>`:ref:",
+                    unit,
+                    highlight_syntax=True,
+                )
             ),
             [(0, 1, "`"), (16, 32, " <reviews>`:ref:")],
         )
+
+    def test_semantic_metadata(self) -> None:
+        unit = make_unit(
+            source="Use :guilabel:`Save` and %d.",
+            flags="rst-text, python-format",
+        )
+        highlights = highlight_string(unit.source, unit, highlight_syntax=True)
+        self.assertEqual(highlights[0].kind, "markup")
+        self.assertEqual(highlights[0].group, highlights[1].group)
+        self.assertEqual(highlights[0].role, "guilabel")
+        self.assertTrue(highlights[0].translatable)
+        self.assertEqual(highlights[2].kind, "grammar")
+
+    def test_rst_explicit_target_metadata(self) -> None:
+        unit = make_unit(
+            source="See :ref:`review workflow <reviews>`.",
+            flags="rst-text",
+        )
+        highlights = highlight_string(unit.source, unit, highlight_syntax=True)
+        self.assertEqual(highlights[0].kind, "markup")
+        self.assertEqual(highlights[0].group, highlights[1].group)
+        self.assertEqual(highlights[0].role, "ref")
+        self.assertTrue(highlights[0].translatable)
+        self.assertEqual(highlights[0].forbidden_text, ("`", "<", ">"))
+
+    def test_markdown_autolink_metadata(self) -> None:
+        unit = make_unit(
+            source="Use **Weblate** at <https://example.com> or <noreply@example.com>.",
+            flags="md-text",
+        )
+        highlights = highlight_string(unit.source, unit)
+        self.assertEqual(
+            highlight_spans(highlights),
+            [
+                (4, 6, "**"),
+                (13, 15, "**"),
+                (19, 20, "<"),
+                (39, 40, ">"),
+                (44, 45, "<"),
+                (64, 65, ">"),
+            ],
+        )
+        self.assertTrue(highlights[0].translatable)
+        self.assertEqual(highlights[0].group, highlights[1].group)
+        self.assertEqual(highlights[0].forbidden_text, ("*",))
+        self.assertFalse(highlights[2].translatable)
+        self.assertEqual(highlights[2].group, highlights[3].group)
+        self.assertFalse(highlights[4].translatable)
+        self.assertEqual(highlights[4].group, highlights[5].group)
+
+    def test_escaped_markup_metadata(self) -> None:
+        unit = make_unit(
+            source="&lt;strong&gt;Save&lt;/strong&gt;",
+            flags='placeholders:r"&lt;[a-z/]+&gt;", xml-text',
+        )
+        highlights = highlight_string(unit.source, unit, highlight_syntax=True)
+        self.assertEqual(
+            highlight_spans(highlights),
+            [(0, 14, "&lt;strong&gt;"), (18, 33, "&lt;/strong&gt;")],
+        )
+        self.assertEqual(highlights[0].kind, "markup")
+        self.assertEqual(highlights[0].group, highlights[1].group)
+        self.assertTrue(highlights[0].translatable)
+        self.assertEqual(highlights[0].forbidden_text, ("&lt;", "&gt;", "<", ">"))
+
+    def test_bbcode_markup_metadata(self) -> None:
+        unit = make_unit(
+            source="[b]Save[/b]",
+            flags="bbcode-text",
+        )
+        highlights = highlight_string(unit.source, unit, highlight_syntax=True)
+        self.assertEqual(highlight_spans(highlights), [(0, 3, "[b]"), (7, 11, "[/b]")])
+        self.assertEqual(highlights[0].kind, "markup")
+        self.assertEqual(highlights[0].group, highlights[1].group)
+        self.assertTrue(highlights[0].translatable)
+        self.assertEqual(highlights[0].forbidden_text, ("[", "]"))
 
     def test_rst_duplicate_fragment(self) -> None:
         unit = make_unit(
@@ -135,9 +254,11 @@ class HighlightTestCase(SimpleTestCase):
             flags="rst-text",
         )
         self.assertEqual(
-            highlight_string(
-                "Use ``:ref:`foo``` syntax, then see :ref:`foo`.",
-                unit,
+            highlight_spans(
+                highlight_string(
+                    "Use ``:ref:`foo``` syntax, then see :ref:`foo`.",
+                    unit,
+                )
             ),
             [(36, 46, ":ref:`foo`")],
         )
@@ -148,9 +269,11 @@ class HighlightTestCase(SimpleTestCase):
             flags="rst-text",
         )
         self.assertEqual(
-            highlight_string(
-                r"Use \:ref:`foo` literally, then see :ref:`foo`.",
-                unit,
+            highlight_spans(
+                highlight_string(
+                    r"Use \:ref:`foo` literally, then see :ref:`foo`.",
+                    unit,
+                )
             ),
             [(36, 46, ":ref:`foo`")],
         )
@@ -161,7 +284,7 @@ class HighlightTestCase(SimpleTestCase):
             flags='icu-message-format, placeholders:r"&lt;[a-z/]+&gt;", xml-text',
         )
         self.assertEqual(
-            highlight_string(unit.source, unit, highlight_syntax=True),
+            highlight_spans(highlight_string(unit.source, unit, highlight_syntax=True)),
             [
                 (0, 14, "&lt;strong&gt;"),
                 (44, 59, "&lt;/strong&gt;"),

--- a/weblate/checks/utils.py
+++ b/weblate/checks/utils.py
@@ -4,9 +4,13 @@
 
 from __future__ import annotations
 
+import re
+from collections import defaultdict
+from dataclasses import replace
 from types import FunctionType
 from typing import TYPE_CHECKING
 
+from weblate.checks.base import Highlight
 from weblate.checks.models import CHECKS
 
 if TYPE_CHECKING:
@@ -14,8 +18,77 @@ if TYPE_CHECKING:
 
     from weblate.trans.models import Unit
 
+MARKUP_TAG_RE = re.compile(
+    r"^(?:<|&lt;)\s*(?P<closing>/)?\s*"
+    r"(?P<tag>[A-Za-z][\w:.-]*)"
+    r"(?P<body>.*?)(?:>|&gt;)$"
+)
+BBCODE_TAG_RE = re.compile(
+    r"^\[\s*(?P<closing>/)?\s*(?P<tag>[A-Za-z][\w:.-]*)(?P<body>.*?)\]$"
+)
 
-def highlight_pygments(source: str, unit: Unit) -> Generator[tuple[int, int, str]]:
+
+def _get_markup_tag(highlight: Highlight) -> tuple[str, bool, bool] | None:
+    for regexp in (MARKUP_TAG_RE, BBCODE_TAG_RE):
+        match = regexp.match(highlight.text)
+        if match is None:
+            continue
+        body = match.group("body").strip()
+        return (
+            match.group("tag").lower(),
+            bool(match.group("closing")),
+            body.endswith("/"),
+        )
+    return None
+
+
+def pair_markup_highlights(
+    highlights: list[Highlight], *, group_prefix: str
+) -> list[Highlight]:
+    """Mark obvious open/close tag highlights as paired markup."""
+    result = list(highlights)
+    stacks: defaultdict[str, list[int]] = defaultdict(list)
+
+    for index, highlight in enumerate(tuple(result)):
+        tag = _get_markup_tag(highlight)
+        if tag is None:
+            continue
+
+        tag_name, closing, self_closing = tag
+        if self_closing:
+            continue
+        if closing:
+            if not stacks[tag_name]:
+                continue
+            opening_index = stacks[tag_name].pop()
+            group = f"{group_prefix}:{result[opening_index].start}:{highlight.end}"
+            if highlight.text.startswith("["):
+                forbidden_text = ("[", "]")
+            elif highlight.text.endswith("&gt;"):
+                forbidden_text = ("&lt;", "&gt;", "<", ">")
+            else:
+                forbidden_text = ("<", ">")
+            result[opening_index] = replace(
+                result[opening_index],
+                kind="markup",
+                group=group,
+                translatable=True,
+                forbidden_text=forbidden_text,
+            )
+            result[index] = replace(
+                highlight,
+                kind="markup",
+                group=group,
+                translatable=True,
+                forbidden_text=forbidden_text,
+            )
+        else:
+            stacks[tag_name].append(index)
+
+    return result
+
+
+def highlight_pygments(source: str, unit: Unit) -> Generator[Highlight]:
     """
     Highlight syntax characters using pygments.
 
@@ -34,40 +107,65 @@ def highlight_pygments(source: str, unit: Unit) -> Generator[tuple[int, int, str
         for token, text in lexer.get_tokens(source):
             if token == Token.Literal.String:
                 if text[0] == "`" and text != "`_":
-                    yield (start, start + 1, "`")
+                    yield Highlight(start, start + 1, "`", kind="syntax")
                 else:
-                    yield (start, start + len(text), text)
+                    yield Highlight(start, start + len(text), text, kind="syntax")
             elif token == Token.Literal.String.Interpol:
-                yield (start, start + len(text), text)
+                yield Highlight(start, start + len(text), text, kind="syntax")
             elif token == Token.Generic.Strong:
                 end = start + len(text)
-                yield (start, start + 2, "**")
-                yield (end - 2, end, "**")
+                group = f"rst-strong:{start}:{end}"
+                yield Highlight(start, start + 2, "**", kind="markup", group=group)
+                yield Highlight(end - 2, end, "**", kind="markup", group=group)
             elif token == Token.Generic.Emph:
                 end = start + len(text)
-                yield (start, start + 1, "*")
-                yield (end - 1, end, "*")
+                group = f"rst-emph:{start}:{end}"
+                yield Highlight(start, start + 1, "*", kind="markup", group=group)
+                yield Highlight(end - 1, end, "*", kind="markup", group=group)
             start += len(text)
 
 
-def merge_highlight_spans(
-    source: str, highlights: list[tuple[int, int, str]]
-) -> list[tuple[int, int, str]]:
+def _highlight_specificity(highlight: Highlight) -> tuple[bool, bool, bool, int]:
+    return (
+        highlight.group is not None,
+        highlight.translatable,
+        highlight.role is not None,
+        {"grammar": 0, "syntax": 1, "markup": 2}[highlight.kind],
+    )
+
+
+def merge_highlight_spans(source: str, highlights: list[Highlight]) -> list[Highlight]:
     """Merge overlapping highlight spans (nested or partial) into their union intervals."""
-    merged: list[tuple[int, int, str]] = []
-    for start, end, text in highlights:
-        if merged and start < merged[-1][1]:
-            prev_start, prev_end, _ = merged[-1]
-            new_end = max(prev_end, end)
-            merged[-1] = (prev_start, new_end, source[prev_start:new_end])
+    merged: list[Highlight] = []
+    for highlight in highlights:
+        if merged and highlight.start < merged[-1].end:
+            previous = merged[-1]
+            if previous.start == highlight.start and previous.end == highlight.end:
+                if _highlight_specificity(highlight) > _highlight_specificity(previous):
+                    merged[-1] = highlight
+                continue
+            if previous.start <= highlight.start and previous.end >= highlight.end:
+                continue
+            new_end = max(previous.end, highlight.end)
+            kind = (
+                "grammar"
+                if previous.kind == "grammar" and highlight.kind == "grammar"
+                else "syntax"
+            )
+            merged[-1] = Highlight(
+                previous.start,
+                new_end,
+                source[previous.start : new_end],
+                kind=kind,
+            )
         else:
-            merged.append((start, end, text))
+            merged.append(highlight)
     return merged
 
 
 def highlight_string(
     source: str, unit: Unit, *, highlight_syntax: bool = False
-) -> list[tuple[int, int, str]]:
+) -> list[Highlight]:
     """Return highlights for a string."""
     if unit is None:
         return []
@@ -81,10 +179,10 @@ def highlight_string(
         highlights.extend(highlight_pygments(source, unit))
 
     # Remove empty strings
-    highlights = [highlight for highlight in highlights if highlight[2]]
+    highlights = [highlight for highlight in highlights if highlight.text]
 
     # Sort by order in string, longest first
-    highlights.sort(key=lambda item: (item[0], -item[1]))
+    highlights.sort(key=lambda item: (item.start, -item.end))
 
     return merge_highlight_spans(source, highlights)
 
@@ -118,16 +216,16 @@ def replace_highlighted(
 
     result = []
     last_end = 0
-    for start, end, _text in highlights:
-        if start < last_end:
-            last_end = max(last_end, end)
+    for highlight in highlights:
+        if highlight.start < last_end:
+            last_end = max(last_end, highlight.end)
             continue
-        result.append(source[last_end:start])
+        result.append(source[last_end : highlight.start])
         if callable(replacement):
-            result.append(replacement(start))
+            result.append(replacement(highlight.start))
         else:
             result.append(replacement)
-        last_end = end
+        last_end = highlight.end
     result.append(source[last_end:])
     replaced = "".join(result)
     if use_cache:

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from requests.auth import AuthBase
 
     from weblate.auth.models import User
+    from weblate.checks.base import Highlight
     from weblate.trans.models import Translation, Unit
     from weblate.trans.models.unit import UnitQuerySet
 
@@ -463,18 +464,18 @@ class BatchMachineTranslation(DocVersionsMixin):
         return f"{re.escape(text[:-1])} *{re.escape(text[-1:])}"
 
     def format_replacement(
-        self, h_start: int, h_end: int, h_text: str, h_kind: Unit | None
+        self, h_start: int, h_end: int, h_text: str, h_kind: Highlight | Unit | None
     ) -> str:
         """Generate a single replacement."""
         return f"{self.replacement_start}{h_start}{self.replacement_end}"
 
     def get_highlights(
         self, text: str, unit
-    ) -> Iterable[tuple[int, int, str, Unit | None]]:
-        for h_start, h_end, h_text in highlight_string(
+    ) -> Iterable[tuple[int, int, str, Highlight | Unit | None]]:
+        for highlight in highlight_string(
             text, unit, highlight_syntax=self.highlight_syntax
         ):
-            yield h_start, h_end, h_text, None
+            yield highlight.start, highlight.end, highlight.text, highlight
 
     def cleanup_text(self, text: str, unit: Unit) -> tuple[str, dict[str, str]]:
         """Remove placeholder to avoid confusing the machine translation."""
@@ -1297,7 +1298,7 @@ class XMLMachineTranslationMixin(BatchMachineTranslation):
         return escape(text)
 
     def format_replacement(
-        self, h_start: int, h_end: int, h_text: str, h_kind: Unit | None
+        self, h_start: int, h_end: int, h_text: str, h_kind: Highlight | Unit | None
     ) -> str:
         """Generate a single replacement."""
         raise NotImplementedError

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from weblate.auth.models import User
+    from weblate.checks.base import Highlight
     from weblate.lang.models import Language
     from weblate.trans.models import Unit
 
@@ -225,7 +226,7 @@ class DeepLTranslation(
         return result
 
     def format_replacement(
-        self, h_start: int, h_end: int, h_text: str, h_kind: Unit | None
+        self, h_start: int, h_end: int, h_text: str, h_kind: Highlight | Unit | None
     ) -> str:
         """Generate a single replacement."""
         return f'<x id="{h_start}"></x>'

--- a/weblate/machinery/googlev3.py
+++ b/weblate/machinery/googlev3.py
@@ -32,6 +32,7 @@ from .forms import GoogleV3MachineryForm
 from .google import GoogleBaseTranslation
 
 if TYPE_CHECKING:
+    from weblate.checks.base import Highlight
     from weblate.trans.models import Unit
 
     from .base import (
@@ -136,7 +137,7 @@ class GoogleV3Translation(
         }
 
     def format_replacement(
-        self, h_start: int, h_end: int, h_text: str, h_kind: Unit | None
+        self, h_start: int, h_end: int, h_text: str, h_kind: Highlight | Unit | None
     ) -> str:
         """Generate a single replacement."""
         return f'<span translate="no" id="{h_start}">{self.escape_text(h_text)}</span>'

--- a/weblate/machinery/llm.py
+++ b/weblate/machinery/llm.py
@@ -37,6 +37,7 @@ from weblate.utils.translation import pgettext_noop
 if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
 
+    from weblate.checks.base import Highlight, HighlightKind
     from weblate.lang.models import Plural
     from weblate.trans.models import Component, Translation, Unit
 
@@ -84,6 +85,7 @@ Input is provided as JSON with the following schema:
                 {{
                     "type": "placeholder",
                     "id": "@@PH1@@",
+                    "kind": "syntax",
                     "text": "",
                     "translatable": false
                 }},
@@ -141,7 +143,7 @@ Rules:
 11. Output must be a single JSON array containing one item per input string. Prefer structured objects with a "parts" array when the input has "parts"; legacy JSON strings are accepted only if placeholders are preserved exactly.
 12. Do not include markdown code fences or any additional text.
 13. The number of output elements must exactly match the number of input strings. Do not emit empty extra strings, diagnostics, explanations, or metadata.
-14. For structured output, each item must be an object containing only "parts". The output parts array must have the same placeholder parts as the input. Text parts may be split or merged. Grammar placeholder parts may be reordered within the same surrounding markup if required by target language grammar; markup and syntax placeholder parts must keep source order. Placeholder part type, id, close_id, and translatable values must be preserved.
+14. For structured output, each item must be an object containing only "parts". The output parts array must have the same placeholder parts as the input. Text parts may be split or merged. Grammar placeholder parts may be reordered within the same surrounding markup if required by target language grammar; markup and syntax placeholder parts must keep source order. Placeholder part type, id, kind, role, close_id, and translatable values must be preserved.
 15. For structured text parts, translate the "text" value. For structured placeholder parts, preserve metadata and translate "text" only when "translatable" is true; when "translatable" is false, keep "text" unchanged.
 16. Ensure all output strings are properly JSON-escaped.
 17. Internally verify placeholder integrity and JSON validity before responding.
@@ -184,33 +186,6 @@ LLM_NEUTRAL_PREVIOUS_EXAMPLE_SOURCES = (
 LLM_JSON_ARRAY_STRING_TERMINATORS = frozenset({",", "]"})
 LLM_JSON_OBJECT_KEY_STRING_TERMINATORS = frozenset({":"})
 LLM_JSON_OBJECT_VALUE_STRING_TERMINATORS = frozenset({",", "}"})
-LLM_MARKUP_PLACEHOLDER_MARKERS = ("<", ">", "&lt;", "&gt;", "[", "]", "`", "*")
-LLM_CONTROL_PLACEHOLDER_MARKERS = (
-    *LLM_MARKUP_PLACEHOLDER_MARKERS,
-    "%",
-    "&",
-    "$",
-    "\\",
-    "[",
-    "]",
-    "{",
-    "}",
-)
-LLM_SINGLE_CHARACTER_MARKUP_DELIMITERS = frozenset({"`", "*"})
-LLM_TRANSLATABLE_RST_ROLES = frozenset(
-    {
-        "abbr",
-        "code",
-        "dfn",
-        "guilabel",
-        "index",
-        "kbd",
-        "menuselection",
-        "samp",
-        "sub",
-        "sup",
-    }
-)
 
 
 class LLMGlossaryEntry(TypedDict, total=False):
@@ -254,9 +229,11 @@ class LLMTextPart(TypedDict):
 class LLMPlaceholderPart(TypedDict):
     type: Literal["placeholder"]
     id: str
+    kind: HighlightKind
     text: str
     translatable: bool
     close_id: NotRequired[str]
+    role: NotRequired[str]
 
 
 type LLMStringPart = LLMTextPart | LLMPlaceholderPart
@@ -574,9 +551,9 @@ class BaseLLMTranslation(BatchMachineTranslation):
         return hash_to_checksum(calculate_hash(json.dumps(entries, sort_keys=True)))
 
     @classmethod
-    def _get_placeholder_context(
+    def _get_placeholder_specs(
         cls, source_text: str, unit: Unit | None, source_occurrence: int = 0
-    ) -> dict[str, str]:
+    ) -> dict[str, Highlight]:
         placeholder_specs = cls._iter_source_placeholder_specs(
             source_text, unit, source_occurrence
         )
@@ -584,49 +561,19 @@ class BaseLLMTranslation(BatchMachineTranslation):
             return {}
         return dict(placeholder_specs)
 
-    @staticmethod
-    def _get_rst_prefix_role(opening: str) -> str | None:
-        if opening.startswith(":") and opening.endswith(":`"):
-            role = opening[1:-2]
-            if role:
-                return role.lower()
-        return None
-
-    @staticmethod
-    def _get_rst_suffix_role(closing: str) -> str | None:
-        if closing.startswith("`:") and closing.endswith(":"):
-            role = closing[2:-1]
-            if role:
-                return role.lower()
-        return None
-
     @classmethod
-    def _is_rst_placeholder_wrapper(cls, opening: str, closing: str) -> bool:
-        return (
-            cls._get_rst_prefix_role(opening) is not None and closing.endswith("`")
-        ) or (opening == "`" and cls._get_rst_suffix_role(closing) is not None)
-
-    @staticmethod
-    def _is_angle_placeholder_wrapper(opening: str, closing: str) -> bool:
-        return (opening, closing) in {("<", ">"), ("&lt;", "&gt;")}
-
-    @classmethod
-    def _is_placeholder_wrapper(cls, opening: str, closing: str) -> bool:
-        return cls._is_rst_placeholder_wrapper(
-            opening, closing
-        ) or cls._is_angle_placeholder_wrapper(opening, closing)
-
-    @classmethod
-    def _is_translatable_placeholder_wrapper(cls, opening: str, closing: str) -> bool:
-        role = cls._get_rst_prefix_role(opening)
-        if role is not None:
-            return closing != "`" or role in LLM_TRANSLATABLE_RST_ROLES
-
-        role = cls._get_rst_suffix_role(closing)
-        if role is not None and opening == "`":
-            return role in LLM_TRANSLATABLE_RST_ROLES
-
-        return False
+    def _get_placeholder_context(
+        cls, source_text: str, unit: Unit | None, source_occurrence: int = 0
+    ) -> dict[str, str]:
+        placeholder_specs = cls._get_placeholder_specs(
+            source_text, unit, source_occurrence
+        )
+        if not placeholder_specs:
+            return {}
+        return {
+            placeholder: highlight.text
+            for placeholder, highlight in placeholder_specs.items()
+        }
 
     @staticmethod
     def _append_llm_text_part(parts: list[LLMStringPart], text: str) -> None:
@@ -637,58 +584,67 @@ class BaseLLMTranslation(BatchMachineTranslation):
             return
         parts.append({"type": "text", "text": text})
 
+    @staticmethod
+    def _get_placeholder_part(
+        token: str, highlight: Highlight | None
+    ) -> LLMPlaceholderPart:
+        part: LLMPlaceholderPart = {
+            "type": "placeholder",
+            "id": token,
+            "kind": highlight.kind if highlight is not None else "syntax",
+            "text": "",
+            "translatable": False,
+        }
+        if highlight is not None and highlight.role is not None:
+            part["role"] = highlight.role
+        return part
+
     @classmethod
     def _get_string_parts(
-        cls, source_text: str, unit: Unit | None, source_occurrence: int = 0
+        cls,
+        source_text: str,
+        unit: Unit | None,
+        source_occurrence: int = 0,
+        placeholder_specs: dict[str, Highlight] | None = None,
     ) -> list[LLMStringPart]:
         placeholder_matches = cls._iter_placeholder_matches(source_text)
         if not placeholder_matches:
             return [{"type": "text", "text": source_text}]
 
-        placeholders = cls._get_placeholder_context(
-            source_text, unit, source_occurrence
-        )
+        if placeholder_specs is None:
+            placeholder_specs = cls._get_placeholder_specs(
+                source_text, unit, source_occurrence
+            )
         parts: list[LLMStringPart] = []
         current = 0
         index = 0
         while index < len(placeholder_matches):
             start, end, token = placeholder_matches[index]
             cls._append_llm_text_part(parts, source_text[current:start])
+            highlight = placeholder_specs.get(token)
 
             if index + 1 < len(placeholder_matches):
                 next_start, next_end, next_token = placeholder_matches[index + 1]
                 inner_text = source_text[end:next_start]
-                opening = placeholders.get(token)
-                closing = placeholders.get(next_token)
+                opening = highlight
+                closing = placeholder_specs.get(next_token)
                 if (
                     inner_text
                     and opening is not None
                     and closing is not None
-                    and cls._is_placeholder_wrapper(opening, closing)
+                    and opening.group is not None
+                    and opening.group == closing.group
                 ):
-                    parts.append(
-                        {
-                            "type": "placeholder",
-                            "id": token,
-                            "close_id": next_token,
-                            "text": inner_text,
-                            "translatable": cls._is_translatable_placeholder_wrapper(
-                                opening, closing
-                            ),
-                        }
-                    )
+                    part = cls._get_placeholder_part(token, opening)
+                    part["close_id"] = next_token
+                    part["text"] = inner_text
+                    part["translatable"] = opening.translatable or closing.translatable
+                    parts.append(part)
                     current = next_end
                     index += 2
                     continue
 
-            parts.append(
-                {
-                    "type": "placeholder",
-                    "id": token,
-                    "text": "",
-                    "translatable": False,
-                }
-            )
+            parts.append(cls._get_placeholder_part(token, highlight))
             current = end
             index += 1
 
@@ -1548,26 +1504,26 @@ class BaseLLMTranslation(BatchMachineTranslation):
     @classmethod
     def _cleanup_source_variant(
         cls, source_variant: str, unit: Unit
-    ) -> tuple[str, list[tuple[str, str]]]:
+    ) -> tuple[str, list[tuple[str, Highlight]]]:
         parts: list[str] = []
-        specs: list[tuple[str, str]] = []
+        specs: list[tuple[str, Highlight]] = []
         start = 0
-        for highlight_start, highlight_end, highlight_text in highlight_string(
+        for highlight in highlight_string(
             source_variant,
             unit,
             highlight_syntax=cls.highlight_syntax,
         ):
-            token = f"{cls.replacement_start}{highlight_start}{cls.replacement_end}"
-            parts.extend((source_variant[start:highlight_start], token))
-            specs.append((token, highlight_text))
-            start = highlight_end
+            token = f"{cls.replacement_start}{highlight.start}{cls.replacement_end}"
+            parts.extend((source_variant[start : highlight.start], token))
+            specs.append((token, highlight))
+            start = highlight.end
         parts.append(source_variant[start:])
         return "".join(parts), specs
 
     @classmethod
     def _iter_source_placeholder_specs(
         cls, source_text: str, unit: Unit | None, source_occurrence: int = 0
-    ) -> list[tuple[str, str]] | None:
+    ) -> list[tuple[str, Highlight]] | None:
         source_placeholders = [
             token for token, _end in cls._iter_placeholders(source_text)
         ]
@@ -1577,7 +1533,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
         source_variants = dict.fromkeys(
             chain(getattr(unit, "plural_map", ()), unit.get_source_plurals())
         )
-        matching_specs: list[list[tuple[str, str]]] = []
+        matching_specs: list[list[tuple[str, Highlight]]] = []
         for source_variant in source_variants:
             cleaned_source, specs = cls._cleanup_source_variant(source_variant, unit)
             if cleaned_source == source_text:
@@ -1595,17 +1551,17 @@ class BaseLLMTranslation(BatchMachineTranslation):
         translation: str,
         unit: Unit,
         placeholder_matches: list[tuple[int, int, str]],
-    ) -> list[tuple[int, int, str]]:
-        highlights: list[tuple[int, int, str]] = []
-        for start, end, highlight_text in highlight_string(
+    ) -> list[Highlight]:
+        highlights: list[Highlight] = []
+        for highlight in highlight_string(
             translation, unit, highlight_syntax=cls.highlight_syntax
         ):
             if any(
-                start < placeholder_end and end > placeholder_start
+                highlight.start < placeholder_end and highlight.end > placeholder_start
                 for placeholder_start, placeholder_end, _token in placeholder_matches
             ):
                 continue
-            highlights.append((start, end, highlight_text))
+            highlights.append(highlight)
         return highlights
 
     @classmethod
@@ -1664,8 +1620,8 @@ class BaseLLMTranslation(BatchMachineTranslation):
             return None
 
         remaining_source_specs = [
-            (token, highlight_text)
-            for token, highlight_text in source_specs
+            (token, highlight.text)
+            for token, highlight in source_specs
             if token not in placeholder_tokens
         ]
         tokens_by_highlight_text: defaultdict[str, list[str]] = defaultdict(list)
@@ -1673,11 +1629,13 @@ class BaseLLMTranslation(BatchMachineTranslation):
             tokens_by_highlight_text[highlight_text].append(token)
 
         highlight_replacements: list[tuple[int, int, str]] = []
-        for start, end, highlight_text in translation_highlights:
-            tokens = tokens_by_highlight_text.get(highlight_text)
+        for highlight in translation_highlights:
+            tokens = tokens_by_highlight_text.get(highlight.text)
             if not tokens:
                 return None
-            highlight_replacements.append((start, end, tokens.pop(0)))
+            highlight_replacements.append(
+                (highlight.start, highlight.end, tokens.pop(0))
+            )
 
         replacements = [
             *placeholder_matches,
@@ -1700,7 +1658,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
         source_text: str,
         unit: Unit | None,
         placeholder_matches: list[tuple[int, int, str]],
-        translation_highlights: list[tuple[int, int, str]],
+        translation_highlights: list[Highlight],
     ) -> str | None:
         if unit is None:
             return None
@@ -1718,7 +1676,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
             return None
 
         extra_token = next(iter(extras))
-        source_highlights = dict(source_specs)
+        source_highlights = {token: highlight.text for token, highlight in source_specs}
         if extra_token not in source_highlights:
             return None
         extra_index = source_tokens.index(extra_token)
@@ -1741,7 +1699,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
         if len(matches_by_token) != expected_counts[extra_token] + 1:
             return None
 
-        highlight_starts = [start for start, _end, _text in translation_highlights]
+        highlight_starts = [highlight.start for highlight in translation_highlights]
         candidates = [
             (start, end)
             for start, end in matches_by_token
@@ -1828,63 +1786,81 @@ class BaseLLMTranslation(BatchMachineTranslation):
         return translations
 
     @staticmethod
-    def _is_protected_syntax_fragment(
-        text: str, include_single_character: bool
-    ) -> bool:
-        if text in LLM_SINGLE_CHARACTER_MARKUP_DELIMITERS:
-            return include_single_character
-        return any(marker in text for marker in LLM_CONTROL_PLACEHOLDER_MARKERS)
-
-    @staticmethod
-    def _is_markup_placeholder_text(text: str) -> bool:
-        return any(marker in text for marker in LLM_MARKUP_PLACEHOLDER_MARKERS)
-
-    @staticmethod
-    def _extract_single_character_syntax_counts(text: str) -> Counter[str]:
-        return Counter(
-            character
-            for character in text
-            if character in LLM_SINGLE_CHARACTER_MARKUP_DELIMITERS
-        )
+    def _is_protected_highlight(highlight: Highlight) -> bool:
+        return highlight.kind in {"markup", "syntax"}
 
     @classmethod
-    def _has_protected_syntax(
+    def _get_protected_highlight_texts(
+        cls, placeholder_specs: dict[str, Highlight]
+    ) -> frozenset[str]:
+        return frozenset(
+            highlight.text
+            for highlight in placeholder_specs.values()
+            if highlight.text and cls._is_protected_highlight(highlight)
+        )
+
+    @staticmethod
+    def _is_atomic_protected_highlight_text(text: str) -> bool:
+        return len(text) == 1
+
+    @classmethod
+    def _has_protected_highlight_text(
         cls,
         text: str,
-        source_text: str,
-        unit: Unit | None,
-        source_occurrence: int,
+        protected_texts: frozenset[str],
         *,
-        include_single_character: bool = False,
+        include_atomic: bool = False,
     ) -> bool:
         return any(
             protected in text
-            for protected in cls._get_placeholder_context(
-                source_text, unit, source_occurrence
-            ).values()
-            if cls._is_protected_syntax_fragment(protected, include_single_character)
+            for protected in protected_texts
+            if include_atomic or not cls._is_atomic_protected_highlight_text(protected)
+        )
+
+    @classmethod
+    def _extract_atomic_protected_highlight_counts(
+        cls, text: str, protected_texts: frozenset[str]
+    ) -> Counter[str]:
+        atomic_protected_texts = {
+            protected
+            for protected in protected_texts
+            if cls._is_atomic_protected_highlight_text(protected)
+        }
+        return Counter(
+            character for character in text if character in atomic_protected_texts
         )
 
     @classmethod
     def _is_structured_placeholder_reorderable(
-        cls, expected: LLMPlaceholderPart, placeholders: dict[str, str]
+        cls, expected: LLMPlaceholderPart
     ) -> bool:
-        placeholder_texts = [placeholders.get(expected["id"], "")]
-        if close_id := expected.get("close_id"):
-            placeholder_texts.append(placeholders.get(close_id, ""))
-        return not any(
-            cls._is_markup_placeholder_text(text) for text in placeholder_texts
-        )
+        return expected["kind"] == "grammar"
+
+    @classmethod
+    def _has_structured_placeholder_forbidden_text(
+        cls,
+        expected: LLMPlaceholderPart,
+        actual_text: str,
+        placeholder_specs: dict[str, Highlight],
+    ) -> bool:
+        for token in (expected["id"], expected.get("close_id")):
+            if token is None:
+                continue
+            highlight = placeholder_specs.get(token)
+            if highlight is None:
+                continue
+            for forbidden in highlight.forbidden_text:
+                if actual_text.count(forbidden) > expected["text"].count(forbidden):
+                    return True
+        return False
 
     @classmethod
     def _get_structured_part_text(
         cls,
         actual: JSONValue,
-        source_text: str,
-        unit: Unit | None,
-        source_occurrence: int,
+        protected_texts: frozenset[str],
         *,
-        include_single_character_protected_syntax: bool = False,
+        include_atomic: bool = False,
     ) -> str | None:
         if not isinstance(actual, dict):
             return None
@@ -1892,12 +1868,8 @@ class BaseLLMTranslation(BatchMachineTranslation):
         actual_text = actual.get("text")
         if not isinstance(actual_text, str):
             return None
-        if cls._extract_placeholders(actual_text) or cls._has_protected_syntax(
-            actual_text,
-            source_text,
-            unit,
-            source_occurrence,
-            include_single_character=include_single_character_protected_syntax,
+        if cls._extract_placeholders(actual_text) or cls._has_protected_highlight_text(
+            actual_text, protected_texts, include_atomic=include_atomic
         ):
             return None
         return actual_text
@@ -1908,14 +1880,24 @@ class BaseLLMTranslation(BatchMachineTranslation):
         actual: dict[str, JSONValue],
         expected: LLMPlaceholderPart,
         actual_text: str,
+        protected_texts: frozenset[str],
+        placeholder_specs: dict[str, Highlight],
     ) -> str | None:
         expected_keys = {"type", "id", "text", "translatable"}
+        expected_keys.add("kind")
         expected_close_id = expected.get("close_id")
         if expected_close_id is not None:
             expected_keys.add("close_id")
+        expected_role = expected.get("role")
+        if expected_role is not None:
+            expected_keys.add("role")
         if set(actual) != expected_keys:
             return None
         if actual.get("id") != expected["id"]:
+            return None
+        if actual.get("kind") != expected["kind"]:
+            return None
+        if expected_role is not None and actual.get("role") != expected_role:
             return None
         if actual.get("translatable") != expected["translatable"]:
             return None
@@ -1926,8 +1908,15 @@ class BaseLLMTranslation(BatchMachineTranslation):
             return None
 
         if expected["translatable"]:
-            if expected_close_id is None or cls._is_markup_placeholder_text(
-                actual_text
+            if (
+                expected_close_id is None
+                or (not actual_text and expected["text"])
+                or cls._has_protected_highlight_text(
+                    actual_text, protected_texts, include_atomic=True
+                )
+                or cls._has_structured_placeholder_forbidden_text(
+                    expected, actual_text, placeholder_specs
+                )
             ):
                 return None
             return f"{expected['id']}{actual_text}{expected_close_id}"
@@ -1944,11 +1933,17 @@ class BaseLLMTranslation(BatchMachineTranslation):
         actual: dict[str, JSONValue],
         expected_parts: list[tuple[LLMPlaceholderPart, int]],
         actual_text: str,
+        protected_texts: frozenset[str],
+        placeholder_specs: dict[str, Highlight],
         current_segment: int,
     ) -> tuple[str, int] | None:
         for index, (expected, expected_segment) in enumerate(expected_parts):
             normalized = cls._normalize_structured_placeholder_part(
-                actual, expected, actual_text
+                actual,
+                expected,
+                actual_text,
+                protected_texts,
+                placeholder_specs,
             )
             if normalized is None:
                 continue
@@ -1965,11 +1960,17 @@ class BaseLLMTranslation(BatchMachineTranslation):
         expected_ordered_parts: list[LLMPlaceholderPart],
         expected_reorderable_parts: list[tuple[LLMPlaceholderPart, int]],
         actual_text: str,
+        protected_texts: frozenset[str],
+        placeholder_specs: dict[str, Highlight],
         current_segment: int,
     ) -> tuple[str, int] | None:
         if expected_ordered_parts:
             normalized = cls._normalize_structured_placeholder_part(
-                actual, expected_ordered_parts[0], actual_text
+                actual,
+                expected_ordered_parts[0],
+                actual_text,
+                protected_texts,
+                placeholder_specs,
             )
             if normalized is not None:
                 del expected_ordered_parts[0]
@@ -1977,7 +1978,11 @@ class BaseLLMTranslation(BatchMachineTranslation):
 
             if any(
                 cls._normalize_structured_placeholder_part(
-                    actual, expected, actual_text
+                    actual,
+                    expected,
+                    actual_text,
+                    protected_texts,
+                    placeholder_specs,
                 )
                 is not None
                 for expected in expected_ordered_parts
@@ -1985,19 +1990,24 @@ class BaseLLMTranslation(BatchMachineTranslation):
                 return None
 
         return cls._normalize_reorderable_structured_placeholder_part(
-            actual, expected_reorderable_parts, actual_text, current_segment
+            actual,
+            expected_reorderable_parts,
+            actual_text,
+            protected_texts,
+            placeholder_specs,
+            current_segment,
         )
 
     @classmethod
     def _get_structured_expected_part_state(
-        cls, expected_parts: list[LLMStringPart], placeholders: dict[str, str]
+        cls, expected_parts: list[LLMStringPart], protected_texts: frozenset[str]
     ) -> tuple[
         Counter[str],
         list[LLMPlaceholderPart],
         list[tuple[LLMPlaceholderPart, int]],
         list[bool],
     ]:
-        text_syntax_counts: Counter[str] = Counter()
+        text_atomic_counts: Counter[str] = Counter()
         ordered_placeholder_parts: list[LLMPlaceholderPart] = []
         reorderable_placeholder_parts: list[tuple[LLMPlaceholderPart, int]] = []
         segment_has_text = [False]
@@ -2006,10 +2016,12 @@ class BaseLLMTranslation(BatchMachineTranslation):
             if expected["type"] == "text":
                 if expected["text"]:
                     segment_has_text[segment] = True
-                text_syntax_counts.update(
-                    cls._extract_single_character_syntax_counts(expected["text"])
+                text_atomic_counts.update(
+                    cls._extract_atomic_protected_highlight_counts(
+                        expected["text"], protected_texts
+                    )
                 )
-            elif cls._is_structured_placeholder_reorderable(expected, placeholders):
+            elif cls._is_structured_placeholder_reorderable(expected):
                 reorderable_placeholder_parts.append((expected, segment))
             else:
                 ordered_placeholder_parts.append(expected)
@@ -2017,7 +2029,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
                 segment_has_text.append(False)
 
         return (
-            text_syntax_counts,
+            text_atomic_counts,
             ordered_placeholder_parts,
             reorderable_placeholder_parts,
             segment_has_text,
@@ -2049,20 +2061,26 @@ class BaseLLMTranslation(BatchMachineTranslation):
         if not isinstance(parts, list):
             return None
 
-        expected_parts = cls._get_string_parts(source_text, unit, source_occurrence)
-        placeholders = cls._get_placeholder_context(
+        placeholder_specs = cls._get_placeholder_specs(
             source_text, unit, source_occurrence
         )
+        expected_parts = cls._get_string_parts(
+            source_text,
+            unit,
+            source_occurrence,
+            placeholder_specs=placeholder_specs,
+        )
+        protected_texts = cls._get_protected_highlight_texts(placeholder_specs)
         (
-            expected_text_syntax_counts,
+            expected_text_atomic_counts,
             expected_ordered_placeholder_parts,
             expected_reorderable_placeholder_parts,
             expected_segment_has_text,
-        ) = cls._get_structured_expected_part_state(expected_parts, placeholders)
+        ) = cls._get_structured_expected_part_state(expected_parts, protected_texts)
 
         current_segment = 0
         actual_segment_has_text = [False for _segment in expected_segment_has_text]
-        actual_text_syntax_counts: Counter[str] = Counter()
+        actual_text_atomic_counts: Counter[str] = Counter()
         result: list[str] = []
         for actual in parts:
             if not isinstance(actual, dict):
@@ -2070,10 +2088,8 @@ class BaseLLMTranslation(BatchMachineTranslation):
             actual_type = actual.get("type")
             actual_text = cls._get_structured_part_text(
                 actual,
-                source_text,
-                unit,
-                source_occurrence,
-                include_single_character_protected_syntax=actual_type == "placeholder",
+                protected_texts,
+                include_atomic=actual_type == "placeholder",
             )
             if actual_text is None:
                 return None
@@ -2085,8 +2101,10 @@ class BaseLLMTranslation(BatchMachineTranslation):
                     return None
                 if actual_text:
                     actual_segment_has_text[current_segment] = True
-                actual_text_syntax_counts.update(
-                    cls._extract_single_character_syntax_counts(actual_text)
+                actual_text_atomic_counts.update(
+                    cls._extract_atomic_protected_highlight_counts(
+                        actual_text, protected_texts
+                    )
                 )
                 result.append(actual_text)
                 continue
@@ -2098,6 +2116,8 @@ class BaseLLMTranslation(BatchMachineTranslation):
                 expected_ordered_placeholder_parts,
                 expected_reorderable_placeholder_parts,
                 actual_text,
+                protected_texts,
+                placeholder_specs,
                 current_segment,
             )
             if normalized_placeholder is None:
@@ -2108,7 +2128,7 @@ class BaseLLMTranslation(BatchMachineTranslation):
             result.append(normalized_text)
 
         if (
-            actual_text_syntax_counts - expected_text_syntax_counts
+            actual_text_atomic_counts - expected_text_atomic_counts
             or cls._has_structured_segment_text_mismatch(
                 actual_segment_has_text, expected_segment_has_text
             )

--- a/weblate/machinery/microsoft.py
+++ b/weblate/machinery/microsoft.py
@@ -23,6 +23,7 @@ from .forms import MicrosoftMachineryForm
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from weblate.checks.base import Highlight
     from weblate.trans.models import Unit
 
     from .base import (
@@ -179,10 +180,10 @@ class MicrosoftCognitiveTranslation(XMLMachineTranslationMixin, MachineTranslati
         }
 
     def format_replacement(
-        self, h_start: int, h_end: int, h_text: str, h_kind: Unit | None
+        self, h_start: int, h_end: int, h_text: str, h_kind: Highlight | Unit | None
     ):
         """Generate a single replacement."""
-        if h_kind is None:
+        if h_kind is None or not hasattr(h_kind, "all_flags"):
             return f'<span class="notranslate" id="{h_start}">{self.escape_text(h_text)}</span>'
         # Glossary
         flags = h_kind.all_flags

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -4817,6 +4817,19 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 placeholder_texts,
                 ["management interface", "Users", "Edit", "Contribution cleanup"],
             )
+            self.assertEqual(
+                [
+                    (part["kind"], part.get("role"))
+                    for part in parts
+                    if part["type"] == "placeholder" and part["translatable"]
+                ],
+                [
+                    ("markup", "ref"),
+                    ("markup", "guilabel"),
+                    ("markup", "guilabel"),
+                    ("markup", "guilabel"),
+                ],
+            )
 
             text_translations = iter(
                 [
@@ -4847,14 +4860,8 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                         {"type": "text", "text": next(text_translations)}
                     )
                 else:
-                    output_part = {
-                        "type": "placeholder",
-                        "id": part["id"],
-                        "text": placeholder_translations[part["text"]],
-                        "translatable": part["translatable"],
-                    }
-                    if "close_id" in part:
-                        output_part["close_id"] = part["close_id"]
+                    output_part = part.copy()
+                    output_part["text"] = placeholder_translations[part["text"]]
                     output_parts.append(output_part)
 
             return json.dumps([{"parts": output_parts}])
@@ -4877,6 +4884,125 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         self.assertIn(":guilabel:`Benutzer`", translation[0][0]["text"])
         self.assertIn(":guilabel:`Bearbeiten`", translation[0][0]["text"])
         self.assertIn(":guilabel:`Beitragsbereinigung`", translation[0][0]["text"])
+
+    def test_translate_rejects_structured_markdown_autolink_target_change(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+        source = "See <https://example.com> or <noreply@example.com>."
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            protected_parts = [
+                part
+                for part in parts
+                if part["type"] == "placeholder"
+                and part["text"] in {"https://example.com", "noreply@example.com"}
+            ]
+            self.assertEqual(
+                [(part["text"], part["translatable"]) for part in protected_parts],
+                [("https://example.com", False), ("noreply@example.com", False)],
+            )
+
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "text":
+                    output_part["text"] = {"See ": "Voir ", " or ": " ou ", ".": "."}[
+                        part["text"]
+                    ]
+                elif part["text"] == "https://example.com":
+                    output_part["text"] = "https://example.org"
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with (
+            patch.object(
+                machine, "fetch_llm_translations", side_effect=request_callback
+            ),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate(
+                "fr",
+                source,
+                1,
+                machine=machine,
+                unit_args={"flags": "md-text"},
+            )
+
+    def test_translate_rejects_structured_markdown_delimiter_in_wrapper_text(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "placeholder":
+                    output_part["text"] = "gras *"
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with (
+            patch.object(
+                machine, "fetch_llm_translations", side_effect=request_callback
+            ),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate(
+                "fr",
+                "Use **bold**.",
+                1,
+                machine=machine,
+                unit_args={"flags": "md-text"},
+            )
+
+    def test_translate_accepts_structured_markdown_existing_delimiter_in_wrapper_text(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            self.assertEqual(parts[1]["text"], "snake_case")
+            self.assertTrue(parts[1]["translatable"])
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "text":
+                    output_part["text"] = {"Use ": "Utiliser ", ".": "."}[part["text"]]
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with patch.object(
+            machine, "fetch_llm_translations", side_effect=request_callback
+        ):
+            translation = self.assert_translate(
+                "fr",
+                "Use __snake_case__.",
+                1,
+                machine=machine,
+                unit_args={"flags": "md-text"},
+            )
+
+        self.assertEqual(translation[0][0]["text"], "Utiliser __snake_case__.")
 
     def test_translate_accepts_mixed_structured_and_legacy_reply(self) -> None:
         machine = self.get_machine()
@@ -5014,6 +5140,174 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 1,
                 machine=machine,
                 unit_args={"flags": "rst-text"},
+            )
+
+    def test_translate_rejects_structured_rst_delimiter_in_wrapper_text(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "placeholder":
+                    output_part["text"] = "Premier `second"
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with (
+            patch.object(
+                machine, "fetch_llm_translations", side_effect=request_callback
+            ),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate(
+                "fr",
+                "See :ref:`First <first>`.",
+                1,
+                machine=machine,
+                unit_args={"flags": "rst-text"},
+            )
+
+    def test_translate_rejects_structured_xml_delimiter_in_wrapper_text(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "placeholder":
+                    output_part["text"] = "ici <"
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with (
+            patch.object(
+                machine, "fetch_llm_translations", side_effect=request_callback
+            ),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate(
+                "fr",
+                "Click <b>here</b>",
+                1,
+                machine=machine,
+                unit_args={"flags": "xml-text"},
+            )
+
+    def test_translate_rejects_structured_escaped_markup_raw_delimiter_in_wrapper_text(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "placeholder":
+                    output_part["text"] = "ici <"
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with (
+            patch.object(
+                machine, "fetch_llm_translations", side_effect=request_callback
+            ),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate(
+                "fr",
+                "&lt;strong&gt;Save&lt;/strong&gt;",
+                1,
+                machine=machine,
+                unit_args={"flags": 'placeholders:r"&lt;[a-z/]+&gt;", xml-text'},
+            )
+
+    def test_translate_rejects_structured_empty_wrapper_text(self) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "placeholder":
+                    output_part["text"] = ""
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with (
+            patch.object(
+                machine, "fetch_llm_translations", side_effect=request_callback
+            ),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate(
+                "fr",
+                "Click <b>here</b>",
+                1,
+                machine=machine,
+                unit_args={"flags": "xml-text"},
+            )
+
+    def test_translate_rejects_structured_bbcode_delimiter_in_wrapper_text(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            output_parts = []
+            for part in parts:
+                output_part = part.copy()
+                if part["type"] == "placeholder":
+                    output_part["text"] = "ici ["
+                output_parts.append(output_part)
+            return json.dumps([{"parts": output_parts}])
+
+        with (
+            patch.object(
+                machine, "fetch_llm_translations", side_effect=request_callback
+            ),
+            self.assertRaises(MachineTranslationError),
+        ):
+            self.assert_translate(
+                "fr",
+                "Click [b]here[/b]",
+                1,
+                machine=machine,
+                unit_args={"flags": "bbcode-text"},
             )
 
     def test_translate_rejects_structured_non_text_rst_role_translation(self) -> None:
@@ -5458,6 +5752,144 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         self.assertEqual(
             translation[0][0]["text"],
             "Deleted %s files",
+        )
+
+    def test_translate_accepts_reordered_structured_icu_placeholders(self) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            placeholders = [part for part in parts if part["type"] == "placeholder"]
+            self.assertEqual(
+                [part["kind"] for part in placeholders], ["grammar", "grammar"]
+            )
+            return json.dumps(
+                [
+                    {
+                        "parts": [
+                            {"type": "text", "text": "Entre "},
+                            placeholders[1],
+                            {"type": "text", "text": " et "},
+                            placeholders[0],
+                        ]
+                    }
+                ]
+            )
+
+        with patch.object(
+            machine, "fetch_llm_translations", side_effect=request_callback
+        ):
+            translation = self.assert_translate(
+                "fr",
+                "From {start} to {end}",
+                1,
+                machine=machine,
+                unit_args={"flags": "icu-message-format"},
+            )
+
+        self.assertEqual(
+            translation[0][0]["text"],
+            "Entre {end} et {start}",
+        )
+
+    def test_translate_accepts_reordered_structured_custom_placeholders(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            parts = json.loads(content)["strings"][0]["parts"]
+            placeholders = [part for part in parts if part["type"] == "placeholder"]
+            self.assertEqual(
+                [part["kind"] for part in placeholders], ["grammar", "grammar"]
+            )
+            return json.dumps(
+                [
+                    {
+                        "parts": [
+                            {"type": "text", "text": "Entre "},
+                            placeholders[1],
+                            {"type": "text", "text": " et "},
+                            placeholders[0],
+                        ]
+                    }
+                ]
+            )
+
+        with patch.object(
+            machine, "fetch_llm_translations", side_effect=request_callback
+        ):
+            translation = self.assert_translate(
+                "fr",
+                "From $1 to $2",
+                1,
+                machine=machine,
+                unit_args={"flags": r'placeholders:r"\$\d+"'},
+            )
+
+        self.assertEqual(
+            translation[0][0]["text"],
+            "Entre $2 et $1",
+        )
+
+    def test_translate_accepts_reordered_structured_overlapping_grammar_placeholders(
+        self,
+    ) -> None:
+        machine = self.get_machine()
+
+        def request_callback(
+            _prompt: str,
+            content: str,
+            _previous_content: str,
+            _previous_response: str,
+        ) -> str:
+            string = json.loads(content)["strings"][0]
+            parts = string["parts"]
+            placeholders = [part for part in parts if part["type"] == "placeholder"]
+            self.assertEqual(
+                [string["placeholders"][part["id"]] for part in placeholders],
+                ["${user.name}", "{other.name}"],
+            )
+            self.assertEqual(
+                [part["kind"] for part in placeholders], ["grammar", "grammar"]
+            )
+            return json.dumps(
+                [
+                    {
+                        "parts": [
+                            {"type": "text", "text": "Entre "},
+                            placeholders[1],
+                            {"type": "text", "text": " et "},
+                            placeholders[0],
+                        ]
+                    }
+                ]
+            )
+
+        with patch.object(
+            machine, "fetch_llm_translations", side_effect=request_callback
+        ):
+            translation = self.assert_translate(
+                "fr",
+                "From ${user.name} to {other.name}",
+                1,
+                machine=machine,
+                unit_args={"flags": r'python-brace-format, placeholders:r"\$\{\w+"'},
+            )
+
+        self.assertEqual(
+            translation[0][0]["text"],
+            "Entre {other.name} et ${user.name}",
         )
 
     @responses.activate

--- a/weblate/trans/autofixes/chars.py
+++ b/weblate/trans/autofixes/chars.py
@@ -115,7 +115,9 @@ class PunctuationSpacing(AutoFix):
             highlights = highlight_string(
                 target, unit, highlight_syntax="rst-text" in unit.all_flags
             )
-            highlight_ranges = sorted((start, end) for start, end, _ in highlights)
+            highlight_ranges = sorted(
+                (highlight.start, highlight.end) for highlight in highlights
+            )
 
             def make_replacer(replacement_char: str):
                 highlight_index = 0

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -449,7 +449,9 @@ class PluralTextarea(forms.Textarea):
         plural = translation.plural
         placeables_set: set[str] = set()
         for text in plurals:
-            placeables_set.update(hl[2] for hl in highlight_string(text, unit))
+            placeables_set.update(
+                highlight.text for highlight in highlight_string(text, unit)
+            )
         placeables = list(placeables_set)
         show_plural_labels = len(values) > 1 and not translation.component.is_multivalue
 

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -290,10 +290,12 @@ class Formatter:
         """Highlights unit placeables."""
         highlights = highlight_string(self.value, self.unit)
         cleaned_value = list(self.value)
-        for start, end, content in highlights:
-            self.tags[start].append(format_html(HLCHECK, content))
-            self.tags[end].insert(0, "</span>")
-            cleaned_value[start:end] = [" "] * (end - start)
+        for highlight in highlights:
+            self.tags[highlight.start].append(format_html(HLCHECK, highlight.text))
+            self.tags[highlight.end].insert(0, "</span>")
+            cleaned_value[highlight.start : highlight.end] = [" "] * (
+                highlight.end - highlight.start
+            )
 
         # Prepare cleaned up value for glossary terms (we do not want to extract those
         # from format strings)


### PR DESCRIPTION
Highlight spans were returned as positional tuples, which forced consumers to infer translation semantics from the highlighted text. The LLM machinery duplicated markup and RST wrapper parsing to decide which placeholders could be reordered, which wrapper text could be translated, and which syntax had to stay protected.

Introduce typed Highlight objects carrying kind, group, role, translatable, and forbidden text metadata. Convert existing highlighter callers to consume the new API, extend markup and Pygments/RST highlighting to expose wrapper semantics, and make machinery providers use the metadata directly.

This removes the LLM-specific marker and wrapper heuristics while keeping protected syntax validation, including preserving Markdown autolink and email targets in structured LLM output.

Fixes #20317

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
