### PR TITLE
feat(memory): show migration progress on performance report

### DIFF
--- a/docs/admin/memory.rst
+++ b/docs/admin/memory.rst
@@ -35,7 +35,8 @@ Sharing of translations is also available.
    migrations. Until this backfill finishes, existing entries can be
    temporarily unavailable in suggestions and memory management views. Keep
    Celery workers and the broker running during the upgrade so the backfill can
-   complete.
+   complete. Site administrators can monitor the backfill and duplicate-entry
+   consolidation in :guilabel:`Administration` > :guilabel:`Performance report`.
 
 Imported translation memory
 +++++++++++++++++++++++++++

--- a/docs/admin/upgrade.rst
+++ b/docs/admin/upgrade.rst
@@ -114,6 +114,11 @@ releases should work, but is not as well tested as single version upgrades!
 
 #. Restart the Celery worker (see :ref:`celery`).
 
+   Some upgrades schedule translation-memory scope backfill and consolidation in
+   the background. Keep Celery workers running after the upgrade and monitor
+   progress in :guilabel:`Administration` > :guilabel:`Performance report`. See
+   :ref:`memory-scopes` for details.
+
 .. _version-specific-instructions:
 
 Version-specific instructions

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,8 +1,6 @@
 Weblate 2026.7
 --------------
 
-* Added translation-memory scope backfill and consolidation progress to the :guilabel:`Performance report`.
-
 *Not yet released.*
 
 .. rubric:: New features

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,8 @@
 Weblate 2026.7
 --------------
 
+* Added translation-memory scope backfill and consolidation progress to the :guilabel:`Performance report`.
+
 *Not yet released.*
 
 .. rubric:: New features

--- a/weblate/templates/manage/performance.html
+++ b/weblate/templates/manage/performance.html
@@ -123,6 +123,65 @@
         </table>
       </div>
 
+      <div class="card">
+        <div class="card-header">
+          <h4 class="card-title">
+            {% documentation_icon 'admin/memory' 'memory-scopes' right=True %}
+            {% translate "Translation memory migration" %}
+          </h4>
+        </div>
+        <table class="table table-striped">
+          <tbody>
+            <tr>
+              <td>{% translate "Scope backfill" %}</td>
+              <td>
+                <div class="progress">
+                  <div class="progress-bar {% if memory_migration_status.backfill_completed %}progress-bar-success{% else %}progress-bar-warning{% endif %}"
+                       role="progressbar"
+                       aria-valuenow="{{ memory_migration_status.backfill_percent }}"
+                       aria-valuemin="0"
+                       aria-valuemax="100"
+                       aria-label="{% translate "Translation memory scope backfill" %}"
+                       style="width: {{ memory_migration_status.backfill_percent }}%">
+                    {{ memory_migration_status.backfill_percent }}%
+                  </div>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>{% translate "Entries processed" %}</td>
+              <td class="number">{{ memory_migration_status.processed|intcomma }} / {{ memory_migration_status.total|intcomma }}</td>
+            </tr>
+            <tr>
+              <td>{% translate "Duplicate groups pending consolidation" %}</td>
+              <td class="number">{{ memory_migration_status.duplicate_groups|intcomma }}</td>
+            </tr>
+            <tr>
+              <td>{% translate "Last update" %}</td>
+              <td>
+                {% if memory_migration_status.updated %}
+                  {{ memory_migration_status.updated }}
+                {% else %}
+                  {% translate "Not yet started" %}
+                {% endif %}
+              </td>
+            </tr>
+            <tr>
+              <td>{% translate "Status" %}</td>
+              <td>
+                {% if memory_migration_status.completed %}
+                  {% translate "Completed" %}
+                {% elif memory_migration_status.backfill_completed %}
+                  {% translate "Consolidating duplicate entries" %}
+                {% else %}
+                  {% translate "Backfilling scopes" %}
+                {% endif %}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
       {% if disk_usage %}
         <div class="card">
           <div class="card-header">

--- a/weblate/templates/manage/performance.html
+++ b/weblate/templates/manage/performance.html
@@ -123,6 +123,7 @@
         </table>
       </div>
 
+      {# TODO(2028.1): Remove this migration status card once Weblate no longer supports direct upgrades from 2026 releases. #}
       <div class="card">
         <div class="card-header">
           <h4 class="card-title">
@@ -161,6 +162,8 @@
               <td>
                 {% if memory_migration_status.updated %}
                   {{ memory_migration_status.updated }}
+                {% elif memory_migration_status.backfill_completed %}
+                  {% translate "Not needed" %}
                 {% else %}
                   {% translate "Not yet started" %}
                 {% endif %}

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -28,7 +28,7 @@ from django.utils import timezone
 
 from weblate.accounts.models import AuditLog
 from weblate.auth.models import Group, Invitation, Permission, Role
-from weblate.memory.models import Memory, MemoryScopeMigrationState
+from weblate.memory.models import Memory, MemoryScope, MemoryScopeMigrationState
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Announcement, Change, Project
 from weblate.trans.tests.test_views import ViewTestCase
@@ -989,6 +989,57 @@ class AdminTest(ViewTestCase):
 
         self.assertContains(response, "Backfilling scopes")
         self.assertEqual(response.context["memory_migration_status"]["total"], 2)
+        self.assertEqual(
+            response.context["memory_migration_status"]["duplicate_groups"], 0
+        )
+        self.assertFalse(response.context["memory_migration_status"]["completed"])
+
+    def test_performance_memory_migration_status_without_state(self) -> None:
+        Memory.objects.all().delete()
+        MemoryScopeMigrationState.objects.all().delete()
+        memory = Memory.objects.create(
+            source="Hello",
+            target="Ahoj",
+            origin="project/component",
+            source_language_id=1,
+            target_language_id=2,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_GLOBAL_FILE,
+        )
+
+        response = self.client.get(reverse("manage-performance"))
+
+        self.assertContains(response, "Not needed")
+        self.assertContains(response, "Completed")
+        self.assertEqual(response.context["memory_migration_status"]["processed"], 1)
+        self.assertTrue(response.context["memory_migration_status"]["completed"])
+
+    def test_performance_memory_migration_status_with_duplicates(self) -> None:
+        Memory.objects.all().delete()
+        MemoryScopeMigrationState.objects.all().delete()
+        memory = Memory.objects.create(
+            source="Hello",
+            target="Ahoj",
+            origin="project/component",
+            source_language_id=1,
+            target_language_id=2,
+        )
+        Memory.objects.create(
+            source=memory.source,
+            target=memory.target,
+            origin=memory.origin,
+            source_language_id=memory.source_language_id,
+            target_language_id=memory.target_language_id,
+        )
+        MemoryScopeMigrationState.objects.create(
+            name="memory-scope-backfill", last_memory_id=memory.id, completed=True
+        )
+
+        response = self.client.get(reverse("manage-performance"))
+
+        self.assertContains(response, "Consolidating duplicate entries")
         self.assertEqual(
             response.context["memory_migration_status"]["duplicate_groups"], 1
         )

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -28,6 +28,7 @@ from django.utils import timezone
 
 from weblate.accounts.models import AuditLog
 from weblate.auth.models import Group, Invitation, Permission, Role
+from weblate.memory.models import Memory, MemoryScopeMigrationState
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Announcement, Change, Project
 from weblate.trans.tests.test_views import ViewTestCase
@@ -960,6 +961,38 @@ class AdminTest(ViewTestCase):
     def test_performance(self) -> None:
         response = self.client.get(reverse("manage-performance"))
         self.assertContains(response, "weblate.E005")
+        self.assertContains(response, "Translation memory migration")
+        self.assertIn("total", response.context["memory_migration_status"])
+
+    def test_performance_memory_migration_status(self) -> None:
+        Memory.objects.all().delete()
+        MemoryScopeMigrationState.objects.all().delete()
+        memory = Memory.objects.create(
+            source="Hello",
+            target="Ahoj",
+            origin="project/component",
+            source_language_id=1,
+            target_language_id=2,
+        )
+        Memory.objects.create(
+            source=memory.source,
+            target=memory.target,
+            origin=memory.origin,
+            source_language_id=memory.source_language_id,
+            target_language_id=memory.target_language_id,
+        )
+        MemoryScopeMigrationState.objects.create(
+            name="memory-scope-backfill", last_memory_id=memory.id
+        )
+
+        response = self.client.get(reverse("manage-performance"))
+
+        self.assertContains(response, "Backfilling scopes")
+        self.assertEqual(response.context["memory_migration_status"]["total"], 2)
+        self.assertEqual(
+            response.context["memory_migration_status"]["duplicate_groups"], 1
+        )
+        self.assertFalse(response.context["memory_migration_status"]["completed"])
 
     def test_performance_ordering(self) -> None:
         with (

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -47,6 +47,7 @@ from weblate.auth.models import (
 )
 from weblate.configuration.models import Setting, SettingCategory
 from weblate.configuration.views import CustomCSSView
+from weblate.memory.models import Memory, MemoryScopeMigrationState
 from weblate.trans.actions import ActionEvents
 from weblate.trans.alerts.base import AlertSeverity
 from weblate.trans.forms import AnnouncementForm
@@ -380,6 +381,51 @@ def backups(request: AuthenticatedHttpRequest) -> HttpResponse:
     return render(request, "manage/backups.html", context)
 
 
+def get_memory_migration_status() -> dict[str, Any]:
+    """Return translation memory background migration status."""
+    state = MemoryScopeMigrationState.objects.filter(
+        name="memory-scope-backfill"
+    ).first()
+    total = Memory.objects.count()
+    last_memory_id = state.last_memory_id if state is not None else 0
+    processed = Memory.objects.filter(id__lte=last_memory_id).count()
+
+    if total == 0 or (state is not None and state.completed):
+        backfill_percent = 100
+        processed = total
+    else:
+        backfill_percent = min(round(processed * 100 / total), 100)
+
+    duplicate_groups = (
+        Memory.objects.values(
+            "source_language_id",
+            "target_language_id",
+            "source",
+            "target",
+            "origin",
+            "context",
+            "status",
+            "legacy_from_file",
+        )
+        .annotate(count=Count("id"))
+        .filter(count__gt=1)
+        .count()
+    )
+
+    return {
+        "backfill_completed": total == 0 or (state is not None and state.completed),
+        "backfill_percent": backfill_percent,
+        "completed": total == 0
+        or (state is not None and state.completed and duplicate_groups == 0),
+        "duplicate_groups": duplicate_groups,
+        "last_memory_id": last_memory_id,
+        "processed": processed,
+        "state": state,
+        "total": total,
+        "updated": state.updated if state is not None else None,
+    }
+
+
 def handle_dismiss(request: AuthenticatedHttpRequest) -> HttpResponse:
     try:
         error = ConfigurationError.objects.get(pk=int(request.POST["pk"]))
@@ -433,6 +479,7 @@ def performance(request: AuthenticatedHttpRequest) -> HttpResponse:
         "cache_latency": measure_cache_latency(),
         "disk_usage": disk_usage_bytes,
         "disk_usage_percent": disk_usage_percent,
+        "memory_migration_status": get_memory_migration_status(),
     }
 
     return render(request, "manage/performance.html", context)

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -381,22 +381,11 @@ def backups(request: AuthenticatedHttpRequest) -> HttpResponse:
     return render(request, "manage/backups.html", context)
 
 
-def get_memory_migration_status() -> dict[str, Any]:
-    """Return translation memory background migration status."""
-    state = MemoryScopeMigrationState.objects.filter(
-        name="memory-scope-backfill"
-    ).first()
-    total = Memory.objects.count()
-    last_memory_id = state.last_memory_id if state is not None else 0
-    processed = Memory.objects.filter(id__lte=last_memory_id).count()
-
-    if total == 0 or (state is not None and state.completed):
-        backfill_percent = 100
-        processed = total
-    else:
-        backfill_percent = min(round(processed * 100 / total), 100)
-
-    duplicate_groups = (
+def get_memory_duplicate_group_count() -> int:
+    # TODO(2028.1): Remove this migration status helper once Weblate no longer
+    # supports direct upgrades from 2026 releases.
+    """Return translation memory duplicate group count."""
+    return (
         Memory.objects.values(
             "source_language_id",
             "target_language_id",
@@ -412,11 +401,42 @@ def get_memory_migration_status() -> dict[str, Any]:
         .count()
     )
 
+
+def get_memory_migration_status() -> dict[str, Any]:
+    # TODO(2028.1): Remove this migration status helper once Weblate no longer
+    # supports direct upgrades from 2026 releases.
+    """Return translation memory background migration status."""
+    state = MemoryScopeMigrationState.objects.filter(
+        name="memory-scope-backfill"
+    ).first()
+    total = Memory.objects.count()
+    last_memory_id = state.last_memory_id if state is not None else 0
+    needs_backfill = state is not None and not state.completed
+    if state is None and total:
+        needs_backfill = (
+            Memory.objects.alias(memory_has_scope=Memory.objects.get_has_scope_exists())
+            .filter(memory_has_scope=False)
+            .exists()
+        )
+    backfill_completed = total == 0 or not needs_backfill
+
+    if backfill_completed:
+        backfill_percent = 100
+        processed = total
+    else:
+        processed = Memory.objects.filter(id__lte=last_memory_id).count()
+        backfill_percent = min(round(processed * 100 / total), 100)
+
+    duplicate_groups = (
+        get_memory_duplicate_group_count()
+        if state is not None and state.completed
+        else 0
+    )
+
     return {
-        "backfill_completed": total == 0 or (state is not None and state.completed),
+        "backfill_completed": backfill_completed,
         "backfill_percent": backfill_percent,
-        "completed": total == 0
-        or (state is not None and state.completed and duplicate_groups == 0),
+        "completed": backfill_completed and duplicate_groups == 0,
         "duplicate_groups": duplicate_groups,
         "last_memory_id": last_memory_id,
         "processed": processed,


### PR DESCRIPTION
### Motivation
- Background translation-memory scope backfill and duplicate-entry consolidation run in Celery but had no site-visible progress indicator. 
- Site administrators need a quick way to monitor backfill/consolidation progress during upgrades without digging into the broker or task logs.

### Description
- Add `get_memory_migration_status()` in `weblate/wladmin/views.py` to aggregate `Memory` and `MemoryScopeMigrationState` and compute processed entries, backfill percent, duplicate groups, last update, and completion state, and expose it as `memory_migration_status` in the performance view context. 
- Add a new "Translation memory migration" card to `weblate/templates/manage/performance.html` that displays scope backfill progress, processed/total entries, pending duplicate groups, last update, and high-level status. 
- Update docs to mention monitoring the backfill/consolidation in `Administration -> Performance report` in `docs/admin/upgrade.rst`, `docs/admin/memory.rst`, and add a changelog note in `docs/changes.rst`. 
- Add/adjust tests in `weblate/wladmin/tests.py` to cover the new performance report memory migration status rendering.

### Testing
- Ran formatting and lint checks with `uv run prek run ruff-format --files weblate/wladmin/views.py weblate/wladmin/tests.py` and `uv run prek run ruff-check --files weblate/wladmin/views.py weblate/wladmin/tests.py`, which completed successfully after auto-fixes. 
- Executed the targeted test selection with `uv run pytest weblate/wladmin/tests.py -k 'performance'`, and the tests passed (`3 passed`). 
- Verified the performance page renders the new card and context variable by exercising the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e62ea808832993fbaa42e86067de)