### PR TITLE
fix(memory): use writable database for memory updates

### DIFF
--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, BinaryIO, NotRequired, Self, TypedDict, cast
 
 from django.conf import settings
 from django.contrib.postgres import indexes as postgres_indexes
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.db.models import Exists, F, OuterRef, Prefetch, Q, Value
 from django.db.models.functions import MD5
 from django.utils import timezone
@@ -99,6 +99,11 @@ def load_memory_tmx_store(fileobj: BinaryIO):
 
 
 class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
+    def using_write_db(self) -> Self:
+        if self.db != "memory_db":
+            return self
+        return self.using(router.db_for_write(self.model) or "default")
+
     def get_scope_exists(self, scope_query: Q) -> Exists:
         return Exists(
             MemoryScope.objects.using(self.db).filter(
@@ -206,28 +211,29 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         # TODO(2028.1): Remove legacy unscoped cleanup once Weblate no longer
         # supports direct upgrades from 2026 releases. Runtime visibility is
         # scope-only; this exists for the temporary migration/backfill window.
-        memory_query = self.order_by().values("pk")
+        queryset = self.using_write_db()
+        memory_query = queryset.order_by().values("pk")
         if delete_legacy:
-            self.alias(memory_has_scope=self.get_has_scope_exists()).filter(
+            queryset.alias(memory_has_scope=queryset.get_has_scope_exists()).filter(
                 memory_has_scope=False
             ).delete()
 
-        matching_scope = MemoryScope.objects.using(self.db).filter(
+        matching_scope = MemoryScope.objects.using(queryset.db).filter(
             scope_query, memory_id=OuterRef("pk")
         )
         remaining_scope = (
-            MemoryScope.objects.using(self.db)
+            MemoryScope.objects.using(queryset.db)
             .filter(memory_id=OuterRef("pk"))
             .exclude(scope_query)
         )
-        Memory.objects.using(self.db).filter(pk__in=memory_query).alias(
+        Memory.objects.using(queryset.db).filter(pk__in=memory_query).alias(
             has_matching_scope=Exists(matching_scope),
             has_remaining_scope=Exists(remaining_scope),
         ).filter(has_matching_scope=True, has_remaining_scope=False).delete()
 
-        MemoryScope.objects.using(self.db).filter(memory_id__in=memory_query).filter(
-            scope_query
-        ).delete()
+        MemoryScope.objects.using(queryset.db).filter(
+            memory_id__in=memory_query
+        ).filter(scope_query).delete()
 
     def filter(self, *args, **kwargs) -> Self:
         # Use MD5 for filtering to utilize MD5 index
@@ -987,6 +993,14 @@ class Memory(models.Model):
 
 
 class MemoryScopeManager(models.Manager["MemoryScope"]):
+    def get_write_db_for_memory(self, memory: Memory | None = None) -> str:
+        if self._db is not None and self._db != "memory_db":
+            return self._db
+        memory_db = None if memory is None else memory._state.db  # noqa: SLF001
+        if memory_db is not None and memory_db != "memory_db":
+            return memory_db
+        return router.db_for_write(self.model, instance=memory) or "default"
+
     def get_for_update_entry(
         self,
         *,
@@ -1095,14 +1109,20 @@ class MemoryScopeManager(models.Manager["MemoryScope"]):
     def create_for_memory(self, memory: Memory) -> None:
         scopes = self.get_for_memory(memory)
         if scopes:
-            self.bulk_create(scopes, ignore_conflicts=True)
+            self.db_manager(self.get_write_db_for_memory(memory)).bulk_create(
+                scopes, ignore_conflicts=True
+            )
 
     def bulk_create_for_memories(self, memories) -> None:
+        memories = list(memories)
         scopes = []
         for memory in memories:
             scopes.extend(self.get_for_memory(memory))
         if scopes:
-            self.bulk_create(scopes, ignore_conflicts=True)
+            memory = memories[0] if memories else None
+            self.db_manager(self.get_write_db_for_memory(memory)).bulk_create(
+                scopes, ignore_conflicts=True
+            )
 
 
 class MemoryScopeChoices(models.IntegerChoices):

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -267,12 +267,14 @@ def update_memory(  # noqa: PLR0913
     from weblate.trans.models import Project
 
     project = Project.objects.select_related("workspace").get(pk=project_id)
+    memory_objects = Memory.objects.using("default")
+    memory_scope_objects = MemoryScope.objects.db_manager("default")
     check_matching = True
     memory_status = get_memory_status(project, unit_state)
     if memory_status == Memory.STATUS_ACTIVE:
         if project.autoclean_tm:
             # delete old entries, including those with different targets
-            matching_memory = Memory.objects.filter(
+            matching_memory = memory_objects.filter(
                 source=source,
                 origin=origin,
                 context=context,
@@ -294,7 +296,7 @@ def update_memory(  # noqa: PLR0913
     if check_matching:
         # Check matching entries in memory
         for matching in (
-            Memory.objects.filter(
+            memory_objects.filter(
                 source=source,
                 target=target,
                 origin=origin,
@@ -378,12 +380,12 @@ def update_memory(  # noqa: PLR0913
         to_create.append(memory)
 
     if to_create:
-        with transaction.atomic():
-            Memory.objects.bulk_create(to_create)
-            MemoryScope.objects.bulk_create_for_memories(to_create)
+        with transaction.atomic(using="default"):
+            memory_objects.bulk_create(to_create)
+            memory_scope_objects.bulk_create_for_memories(to_create)
 
     if to_update:
-        Memory.objects.bulk_update(to_update, fields=["status"])
+        memory_objects.bulk_update(to_update, fields=["status"])
 
 
 @app.task(trail=False)
@@ -619,6 +621,7 @@ def get_group_matching_memory(
     expected_key_set = set(expected_keys)
     existing = defaultdict(set)
     to_update: list[Memory] = []
+    memory_objects = Memory.objects.using("default")
 
     for offset in range(0, len(expected_keys), MEMORY_UPDATE_LOOKUP_CHUNK_SIZE):
         matching_pairs = Q()
@@ -630,7 +633,7 @@ def get_group_matching_memory(
                 target__md5=MD5(Value(target)),
             )
 
-        matches = Memory.objects.filter(
+        matches = memory_objects.filter(
             matching_pairs,
             origin__md5=MD5(Value(origin)),
             source_language_id=source_language_id,
@@ -769,6 +772,8 @@ def update_memory_bulk(entries: list[MemoryUpdatePayload]) -> None:
     fallback = []
     grouped_entries = defaultdict(list)
     statuses = {}
+    memory_objects = Memory.objects.using("default")
+    memory_scope_objects = MemoryScope.objects.db_manager("default")
 
     for position, entry in enumerate(entries):
         project = projects[entry["project_id"]]
@@ -795,9 +800,9 @@ def update_memory_bulk(entries: list[MemoryUpdatePayload]) -> None:
         to_create.extend(create_missing_memory_entries(group_entries, existing))
 
     if to_create:
-        with transaction.atomic():
-            Memory.objects.bulk_create(to_create, batch_size=MEMORY_UPDATE_BATCH_SIZE)
-            MemoryScope.objects.bulk_create_for_memories(to_create)
+        with transaction.atomic(using="default"):
+            memory_objects.bulk_create(to_create, batch_size=MEMORY_UPDATE_BATCH_SIZE)
+            memory_scope_objects.bulk_create_for_memories(to_create)
 
     if to_update:
-        Memory.objects.bulk_update(to_update, fields=["status"])
+        memory_objects.bulk_update(to_update, fields=["status"])

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -15,7 +15,7 @@ from django.apps import apps as django_apps
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.db import connection
+from django.db import connection, models
 from django.db.models import Q
 from django.db.models.functions import MD5
 from django.test import SimpleTestCase
@@ -79,6 +79,18 @@ def add_document(source: str = "Hello", target: str = "Ahoj") -> None:
     )
 
 
+class MemoryReadReplicaRouter:
+    def db_for_read(self, model: type[models.Model], **_hints: object) -> str | None:
+        if model._meta.app_label == "memory":  # noqa: SLF001
+            return "memory_db"
+        return None
+
+    def db_for_write(self, model: type[models.Model], **_hints: object) -> str | None:
+        if model._meta.app_label == "memory":  # noqa: SLF001
+            return "default"
+        return None
+
+
 class MemoryParserTest(SimpleTestCase):
     def test_load_memory_json_data(self) -> None:
         data = load_memory_json_data(Path(get_test_file("memory.json")).read_bytes())
@@ -129,13 +141,17 @@ class MemoryParserTest(SimpleTestCase):
         exact_match = self.get_matching_memory("source 1", "target 1")
         cross_pair = self.get_matching_memory("source 1", "target 2")
 
+        memory_objects = MagicMock()
+        memory_objects.filter.return_value = [exact_match, cross_pair]
         with patch.object(
-            Memory.objects, "filter", return_value=[exact_match, cross_pair]
-        ) as filter_mock:
+            Memory.objects, "using", return_value=memory_objects
+        ) as using_mock:
             existing, to_update = get_group_matching_memory(
                 ("origin", 1, 2), entries, statuses
             )
 
+        using_mock.assert_called_once_with("default")
+        filter_mock = memory_objects.filter
         args, kwargs = filter_mock.call_args
         self.assertNotIn("source__in", kwargs)
         self.assertNotIn("target__in", kwargs)
@@ -169,9 +185,15 @@ class MemoryParserTest(SimpleTestCase):
         ]
         statuses = {key: status for _, key, _, status in entries}
 
-        with patch.object(Memory.objects, "filter", return_value=[]) as filter_mock:
+        memory_objects = MagicMock()
+        memory_objects.filter.return_value = []
+        with patch.object(
+            Memory.objects, "using", return_value=memory_objects
+        ) as using_mock:
             get_group_matching_memory(("origin", 1, 2), entries, statuses)
 
+        using_mock.assert_called_once_with("default")
+        filter_mock = memory_objects.filter
         self.assertEqual(filter_mock.call_count, 2)
         first_args, first_kwargs = filter_mock.call_args_list[0]
         second_args, second_kwargs = filter_mock.call_args_list[1]
@@ -1907,6 +1929,29 @@ msgstr "Nazdar svete!\n"
                 scope=MemoryScope.SCOPE_USER, user=self.user
             ).exists()
         )
+
+    @override_settings(
+        DATABASE_ROUTERS=["weblate.memory.tests.MemoryReadReplicaRouter"]
+    )
+    def test_delete_scope_uses_write_database_alias(self) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        memory = Memory.objects.create(
+            source_language=source_language,
+            target_language=target_language,
+            source="Delete scope routed source",
+            target="Smazat smerovany rozsah",
+            origin="delete-scope-routed",
+            legacy_project=self.project,
+            status=Memory.STATUS_ACTIVE,
+        )
+        queryset = Memory.objects.filter(origin="delete-scope-routed")
+
+        self.assertEqual(queryset.db, "memory_db")
+
+        queryset.delete_scope(Q(scope=MemoryScope.SCOPE_PROJECT, project=self.project))
+
+        self.assertFalse(Memory.objects.using("default").filter(pk=memory.pk).exists())
 
     def test_filter_type_skips_unbackfilled_legacy_entries(self) -> None:
         workspace = Workspace.objects.create(


### PR DESCRIPTION
Translation memory reads can be routed to memory_db, which is commonly configured as a read-only replica for expensive lookup traffic. The scoped memory update path reused queryset aliases from those reads while performing DELETE and bulk write operations, causing Celery updates to fail with read-only transaction errors when autoclean removed stale scopes.

Resolve mutating memory queryset helpers through the write router, pin the Celery memory update workflows to the default writable database, and ensure generated scope rows are written on the same writable database as their memory rows. Add regression coverage for read-routed memory querysets so future scope cleanup cannot target the replica.

Fixes WEBLATE-3AKF

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
