### PR TITLE
Make translation-memory scope backfill resumable and periodic; remove post-migrate scheduling

### DIFF
--- a/docs/admin/memory.rst
+++ b/docs/admin/memory.rst
@@ -33,9 +33,10 @@ Sharing of translations is also available.
    When upgrading from older Weblate releases, existing translation-memory
    entries are converted to scopes by a periodic Celery background task. Until
    this backfill finishes, existing entries can be temporarily unavailable in
-   suggestions and memory management views. Site administrators can monitor the
-   backfill and duplicate-entry consolidation in :guilabel:`Administration` >
-   :guilabel:`Performance report`.
+   suggestions and memory management views. Keep Celery running after the
+   upgrade so the periodic task can start or resume the migration. Site
+   administrators can monitor the backfill and duplicate-entry consolidation in
+   :guilabel:`Administration` > :guilabel:`Performance report`.
 
 Imported translation memory
 +++++++++++++++++++++++++++

--- a/docs/admin/memory.rst
+++ b/docs/admin/memory.rst
@@ -31,12 +31,11 @@ Sharing of translations is also available.
 .. note::
 
    When upgrading from older Weblate releases, existing translation-memory
-   entries are converted to scopes by a Celery background task after database
-   migrations. Until this backfill finishes, existing entries can be
-   temporarily unavailable in suggestions and memory management views. Keep
-   Celery workers and the broker running during the upgrade so the backfill can
-   complete. Site administrators can monitor the backfill and duplicate-entry
-   consolidation in :guilabel:`Administration` > :guilabel:`Performance report`.
+   entries are converted to scopes by a periodic Celery background task. Until
+   this backfill finishes, existing entries can be temporarily unavailable in
+   suggestions and memory management views. Site administrators can monitor the
+   backfill and duplicate-entry consolidation in :guilabel:`Administration` >
+   :guilabel:`Performance report`.
 
 Imported translation memory
 +++++++++++++++++++++++++++

--- a/docs/admin/upgrade.rst
+++ b/docs/admin/upgrade.rst
@@ -114,6 +114,11 @@ releases should work, but is not as well tested as single version upgrades!
 
 #. Restart the Celery worker (see :ref:`celery`).
 
+   Some upgrades run translation-memory scope backfill and consolidation in
+   the background using periodic Celery tasks. Keep Celery running after the
+   upgrade and monitor progress in :guilabel:`Administration` >
+   :guilabel:`Performance report`. See :ref:`memory-scopes` for details.
+
 .. _version-specific-instructions:
 
 Version-specific instructions

--- a/docs/admin/upgrade.rst
+++ b/docs/admin/upgrade.rst
@@ -114,11 +114,6 @@ releases should work, but is not as well tested as single version upgrades!
 
 #. Restart the Celery worker (see :ref:`celery`).
 
-   Some upgrades schedule translation-memory scope backfill and consolidation in
-   the background. Keep Celery workers running after the upgrade and monitor
-   progress in :guilabel:`Administration` > :guilabel:`Performance report`. See
-   :ref:`memory-scopes` for details.
-
 .. _version-specific-instructions:
 
 Version-specific instructions

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -93,7 +93,7 @@ Weblate 2026.7
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
 * There are changes in :file:`settings_example.py`, most notably in ``SOCIAL_AUTH_PIPELINE`` and ``SOCIAL_AUTH_DISCONNECT_PIPELINE``; please adjust your settings accordingly.
-* Existing translation-memory entries are moved to scoped storage by a periodic Celery background task. Keep Celery workers running after the upgrade; translation-memory suggestions can be incomplete until the backfill finishes.
+* Existing translation-memory entries are moved to scoped storage by a periodic Celery background task. Keep Celery running after the upgrade; translation-memory suggestions can be incomplete until the backfill finishes.
 
 .. rubric:: Contributors
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -93,7 +93,7 @@ Weblate 2026.7
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
 * There are changes in :file:`settings_example.py`, most notably in ``SOCIAL_AUTH_PIPELINE`` and ``SOCIAL_AUTH_DISCONNECT_PIPELINE``; please adjust your settings accordingly.
-* Existing translation-memory entries are moved to scoped storage by a Celery background task after database migrations. Keep Celery workers and the broker running during the upgrade; translation-memory suggestions can be incomplete until the backfill finishes.
+* Existing translation-memory entries are moved to scoped storage by a periodic Celery background task. Keep Celery workers running after the upgrade; translation-memory suggestions can be incomplete until the backfill finishes.
 
 .. rubric:: Contributors
 

--- a/weblate/memory/apps.py
+++ b/weblate/memory/apps.py
@@ -4,47 +4,9 @@
 from __future__ import annotations
 
 from django.apps import AppConfig
-from django.core.management.base import CommandError
-from django.db.models.signals import post_migrate
-from kombu.exceptions import OperationalError
 
 
 class MemoryConfig(AppConfig):
     name = "weblate.memory"
     label = "memory"
     verbose_name = "Translation Memory"
-
-    def ready(self) -> None:
-        super().ready()
-        post_migrate.connect(self.post_migrate, sender=self)
-
-    def post_migrate(self, sender: AppConfig, **kwargs) -> None:
-        # TODO(2028.1): Remove this background TM scope backfill scheduling once
-        # Weblate no longer supports direct upgrades from 2026 releases.
-        # ruff: ignore[import-outside-top-level]
-        from weblate.memory.models import (
-            Memory,
-            MemoryScopeMigrationState,
-        )
-        from weblate.memory.tasks import (  # noqa: PLC0415
-            backfill_memory_scopes,
-            compact_memory_scopes,
-        )
-
-        if Memory.objects.exists():
-            backfill_completed = MemoryScopeMigrationState.objects.filter(
-                name="memory-scope-backfill",
-                completed=True,
-            ).exists()
-            try:
-                if backfill_completed:
-                    compact_memory_scopes.delay()
-                else:
-                    backfill_memory_scopes.delay()
-            except OperationalError as error:
-                msg = (
-                    "Could not schedule translation memory scope migration task. "
-                    "Make sure the Celery broker is running during Weblate "
-                    "upgrade, then rerun migrations."
-                )
-                raise CommandError(msg) from error

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from datetime import timedelta
 from operator import itemgetter
 from typing import TYPE_CHECKING, TypedDict
 from uuid import UUID
@@ -256,12 +257,32 @@ def backfill_memory_scopes(batch_size: int = 5000) -> None:
         compact_memory_scopes.delay()
 
 
+def has_duplicate_memory_groups() -> bool:
+    # TODO(2028.1): Remove this helper once Weblate no longer supports direct
+    # upgrades from 2026 releases.
+    return (
+        Memory.objects.values(
+            "source_language_id",
+            "target_language_id",
+            "source",
+            "target",
+            "origin",
+            "context",
+            "status",
+            "legacy_from_file",
+        )
+        .annotate(count=Count("id"))
+        .filter(count__gt=1)
+        .exists()
+    )
+
+
 @app.task(trail=False)
 def resume_memory_scope_backfill() -> None:
     # TODO(2028.1): Remove this background TM scope backfill once Weblate no
     # longer supports direct upgrades from 2026 releases.
     state = MemoryScopeMigrationState.objects.filter(
-        name="memory-scope-backfill", completed=False
+        name="memory-scope-backfill",
     ).first()
     if state is None:
         needs_backfill = (
@@ -273,7 +294,12 @@ def resume_memory_scope_backfill() -> None:
             backfill_memory_scopes.delay()
         return
 
-    stale_before = timezone.now() - timezone.timedelta(
+    if state.completed:
+        if has_duplicate_memory_groups():
+            compact_memory_scopes.delay()
+        return
+
+    stale_before = timezone.now() - timedelta(
         seconds=MEMORY_SCOPE_BACKFILL_STALE_SECONDS
     )
     if state.updated <= stale_before:

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 MEMORY_UPDATE_BATCH_SIZE = 1000
 MEMORY_UPDATE_LOOKUP_CHUNK_SIZE = 50
 MEMORY_SCOPE_BACKFILL_STALE_SECONDS = 15 * 60
+MEMORY_SCOPE_BACKFILL_STATE = "memory-scope-backfill"
+MEMORY_SCOPE_COMPACTION_STATE = "memory-scope-compaction"
 
 
 class MemoryUpdatePayload(TypedDict):
@@ -218,7 +220,7 @@ def backfill_memory_scopes(batch_size: int = 5000) -> None:
 
     with transaction.atomic(using="default"):
         state, _created = migration_state_objects.select_for_update().get_or_create(
-            name="memory-scope-backfill"
+            name=MEMORY_SCOPE_BACKFILL_STATE
         )
         if state.completed:
             return
@@ -259,7 +261,33 @@ def backfill_memory_scopes(batch_size: int = 5000) -> None:
     if run_next:
         backfill_memory_scopes.delay(batch_size=batch_size)
     elif run_compact:
-        compact_memory_scopes.delay()
+        schedule_memory_scope_compaction()
+
+
+def set_memory_scope_compaction_completed(completed: bool) -> None:
+    # TODO(2028.1): Remove this helper once Weblate no longer supports direct
+    # upgrades from 2026 releases.
+    MemoryScopeMigrationState.objects.using("default").update_or_create(
+        name=MEMORY_SCOPE_COMPACTION_STATE,
+        defaults={"completed": completed, "updated": timezone.now()},
+    )
+
+
+def has_completed_memory_scope_compaction() -> bool:
+    # TODO(2028.1): Remove this helper once Weblate no longer supports direct
+    # upgrades from 2026 releases.
+    return (
+        MemoryScopeMigrationState.objects.using("default")
+        .filter(name=MEMORY_SCOPE_COMPACTION_STATE, completed=True)
+        .exists()
+    )
+
+
+def schedule_memory_scope_compaction() -> None:
+    # TODO(2028.1): Remove this helper once Weblate no longer supports direct
+    # upgrades from 2026 releases.
+    set_memory_scope_compaction_completed(False)
+    compact_memory_scopes.delay()
 
 
 def has_duplicate_memory_groups() -> bool:
@@ -290,7 +318,7 @@ def resume_memory_scope_backfill() -> None:
     state = (
         MemoryScopeMigrationState.objects.using("default")
         .filter(
-            name="memory-scope-backfill",
+            name=MEMORY_SCOPE_BACKFILL_STATE,
         )
         .first()
     )
@@ -306,8 +334,12 @@ def resume_memory_scope_backfill() -> None:
         return
 
     if state.completed:
+        if has_completed_memory_scope_compaction():
+            return
         if has_duplicate_memory_groups():
-            compact_memory_scopes.delay()
+            schedule_memory_scope_compaction()
+        else:
+            set_memory_scope_compaction_completed(True)
         return
 
     stale_before = timezone.now() - timedelta(
@@ -478,7 +510,7 @@ def compact_memory_scopes(batch_size: int = 100) -> None:
 
     state = (
         MemoryScopeMigrationState.objects.using("default")
-        .filter(name="memory-scope-backfill")
+        .filter(name=MEMORY_SCOPE_BACKFILL_STATE)
         .first()
     )
     if state is not None and not state.completed:
@@ -501,6 +533,7 @@ def compact_memory_scopes(batch_size: int = 100) -> None:
         .order_by("first_id")[:batch_size]
     )
     if not duplicate_groups:
+        set_memory_scope_compaction_completed(True)
         return
 
     for group in duplicate_groups:
@@ -569,6 +602,8 @@ def compact_memory_scopes(batch_size: int = 100) -> None:
 
     if len(duplicate_groups) == batch_size:
         compact_memory_scopes.delay(batch_size=batch_size)
+    else:
+        set_memory_scope_compaction_completed(True)
 
 
 @app.task(trail=False)

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -212,17 +212,19 @@ def set_scope_source_project_ids(memories: list[Memory]) -> None:
 def backfill_memory_scopes(batch_size: int = 5000) -> None:
     # TODO(2028.1): Remove this background TM scope backfill once Weblate no
     # longer supports direct upgrades from 2026 releases.
-    with transaction.atomic():
-        state, _created = (
-            MemoryScopeMigrationState.objects.select_for_update().get_or_create(
-                name="memory-scope-backfill"
-            )
+    memory_objects = Memory.objects.using("default")
+    memory_scope_objects = MemoryScope.objects.db_manager("default")
+    migration_state_objects = MemoryScopeMigrationState.objects.db_manager("default")
+
+    with transaction.atomic(using="default"):
+        state, _created = migration_state_objects.select_for_update().get_or_create(
+            name="memory-scope-backfill"
         )
         if state.completed:
             return
 
         memories = list(
-            Memory.objects.filter(id__gt=state.last_memory_id)
+            memory_objects.filter(id__gt=state.last_memory_id)
             .order_by("id")
             .select_related(
                 "legacy_project",
@@ -232,22 +234,25 @@ def backfill_memory_scopes(batch_size: int = 5000) -> None:
         if not memories:
             state.completed = True
             state.updated = timezone.now()
-            state.save(update_fields=["completed", "updated"])
+            state.save(using="default", update_fields=["completed", "updated"])
             run_compact = True
             run_next = False
         else:
             set_scope_source_project_ids(memories)
-            MemoryScope.objects.bulk_create_for_memories(memories)
+            memory_scope_objects.bulk_create_for_memories(memories)
             state.last_memory_id = memories[-1].id
             state.updated = timezone.now()
 
             if len(memories) == batch_size:
-                state.save(update_fields=["last_memory_id", "updated"])
+                state.save(using="default", update_fields=["last_memory_id", "updated"])
                 run_next = True
                 run_compact = False
             else:
                 state.completed = True
-                state.save(update_fields=["last_memory_id", "completed", "updated"])
+                state.save(
+                    using="default",
+                    update_fields=["last_memory_id", "completed", "updated"],
+                )
                 run_next = False
                 run_compact = True
 
@@ -261,7 +266,8 @@ def has_duplicate_memory_groups() -> bool:
     # TODO(2028.1): Remove this helper once Weblate no longer supports direct
     # upgrades from 2026 releases.
     return (
-        Memory.objects.values(
+        Memory.objects.using("default")
+        .values(
             "source_language_id",
             "target_language_id",
             "source",
@@ -281,12 +287,17 @@ def has_duplicate_memory_groups() -> bool:
 def resume_memory_scope_backfill() -> None:
     # TODO(2028.1): Remove this background TM scope backfill once Weblate no
     # longer supports direct upgrades from 2026 releases.
-    state = MemoryScopeMigrationState.objects.filter(
-        name="memory-scope-backfill",
-    ).first()
+    state = (
+        MemoryScopeMigrationState.objects.using("default")
+        .filter(
+            name="memory-scope-backfill",
+        )
+        .first()
+    )
     if state is None:
+        memory_objects = Memory.objects.using("default")
         needs_backfill = (
-            Memory.objects.alias(memory_has_scope=Memory.objects.get_has_scope_exists())
+            memory_objects.alias(memory_has_scope=memory_objects.get_has_scope_exists())
             .filter(memory_has_scope=False)
             .exists()
         )
@@ -462,15 +473,20 @@ def update_memory(  # noqa: PLR0913
 def compact_memory_scopes(batch_size: int = 100) -> None:
     # TODO(2028.1): Remove this background TM scope compaction once Weblate no
     # longer supports direct upgrades from 2026 releases.
-    state = MemoryScopeMigrationState.objects.filter(
-        name="memory-scope-backfill"
-    ).first()
+    memory_objects = Memory.objects.using("default")
+    memory_scope_objects = MemoryScope.objects.db_manager("default")
+
+    state = (
+        MemoryScopeMigrationState.objects.using("default")
+        .filter(name="memory-scope-backfill")
+        .first()
+    )
     if state is not None and not state.completed:
         backfill_memory_scopes.delay()
         return
 
     duplicate_groups = list(
-        Memory.objects.values(
+        memory_objects.values(
             "source_language_id",
             "target_language_id",
             "source",
@@ -502,7 +518,7 @@ def compact_memory_scopes(batch_size: int = 100) -> None:
             )
         }
         memories = list(
-            Memory.objects.filter(**filters)
+            memory_objects.filter(**filters)
             .order_by("id")
             .select_related(
                 "legacy_project",
@@ -512,18 +528,23 @@ def compact_memory_scopes(batch_size: int = 100) -> None:
         if len(memories) < 2:
             continue
         set_scope_source_project_ids(memories)
-        MemoryScope.objects.bulk_create_for_memories(memories)
+        memory_scope_objects.bulk_create_for_memories(memories)
         memories = list(
-            Memory.objects.filter(id__in=[memory.id for memory in memories])
-            .order_by("id")
-            .prefetch_related("scopes")
+            memory_objects.filter(id__in=[memory.id for memory in memories]).order_by(
+                "id"
+            )
         )
+        scopes_by_memory = defaultdict(list)
+        for scope in memory_scope_objects.filter(
+            memory_id__in=[memory.id for memory in memories]
+        ):
+            scopes_by_memory[scope.memory_id].append(scope)
         survivor = memories[0]
         duplicate_ids = [memory.id for memory in memories[1:]]
         scope_keys = {
             get_memory_scope_key(scope)
             for memory in memories
-            for scope in memory.scopes.all()
+            for scope in scopes_by_memory[memory.id]
         }
         scopes = []
         for memory in memories[1:]:
@@ -537,14 +558,14 @@ def compact_memory_scopes(batch_size: int = 100) -> None:
                         source_project_id=scope.source_project_id,
                         user_id=scope.user_id,
                     )
-                    for scope in memory.scopes.all()
+                    for scope in scopes_by_memory[memory.id]
                 ]
             )
         if scopes:
-            MemoryScope.objects.bulk_create(scopes, ignore_conflicts=True)
+            memory_scope_objects.bulk_create(scopes, ignore_conflicts=True)
         if len(scope_keys) >= 2:
             normalize_compacted_memory_owner(survivor)
-        Memory.objects.filter(id__in=duplicate_ids).delete()
+        memory_objects.filter(id__in=duplicate_ids).delete()
 
     if len(duplicate_groups) == batch_size:
         compact_memory_scopes.delay(batch_size=batch_size)

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 MEMORY_UPDATE_BATCH_SIZE = 1000
 MEMORY_UPDATE_LOOKUP_CHUNK_SIZE = 50
+MEMORY_SCOPE_BACKFILL_STALE_SECONDS = 15 * 60
 
 
 class MemoryUpdatePayload(TypedDict):
@@ -210,39 +211,82 @@ def set_scope_source_project_ids(memories: list[Memory]) -> None:
 def backfill_memory_scopes(batch_size: int = 5000) -> None:
     # TODO(2028.1): Remove this background TM scope backfill once Weblate no
     # longer supports direct upgrades from 2026 releases.
-    state, _created = MemoryScopeMigrationState.objects.get_or_create(
-        name="memory-scope-backfill"
-    )
-    if state.completed:
-        return
+    with transaction.atomic():
+        state, _created = (
+            MemoryScopeMigrationState.objects.select_for_update().get_or_create(
+                name="memory-scope-backfill"
+            )
+        )
+        if state.completed:
+            return
 
-    memories = list(
-        Memory.objects.filter(id__gt=state.last_memory_id)
-        .order_by("id")
-        .select_related(
-            "legacy_project",
-            "legacy_user",
-        )[:batch_size]
-    )
-    if not memories:
-        state.completed = True
-        state.updated = timezone.now()
-        state.save(update_fields=["completed", "updated"])
-        compact_memory_scopes.delay()
-        return
+        memories = list(
+            Memory.objects.filter(id__gt=state.last_memory_id)
+            .order_by("id")
+            .select_related(
+                "legacy_project",
+                "legacy_user",
+            )[:batch_size]
+        )
+        if not memories:
+            state.completed = True
+            state.updated = timezone.now()
+            state.save(update_fields=["completed", "updated"])
+            run_compact = True
+            run_next = False
+        else:
+            set_scope_source_project_ids(memories)
+            MemoryScope.objects.bulk_create_for_memories(memories)
+            state.last_memory_id = memories[-1].id
+            state.updated = timezone.now()
 
-    set_scope_source_project_ids(memories)
-    MemoryScope.objects.bulk_create_for_memories(memories)
-    state.last_memory_id = memories[-1].id
-    state.updated = timezone.now()
+            if len(memories) == batch_size:
+                state.save(update_fields=["last_memory_id", "updated"])
+                run_next = True
+                run_compact = False
+            else:
+                state.completed = True
+                state.save(update_fields=["last_memory_id", "completed", "updated"])
+                run_next = False
+                run_compact = True
 
-    if len(memories) == batch_size:
-        state.save(update_fields=["last_memory_id", "updated"])
+    if run_next:
         backfill_memory_scopes.delay(batch_size=batch_size)
-    else:
-        state.completed = True
-        state.save(update_fields=["last_memory_id", "completed", "updated"])
+    elif run_compact:
         compact_memory_scopes.delay()
+
+
+@app.task(trail=False)
+def resume_memory_scope_backfill() -> None:
+    # TODO(2028.1): Remove this background TM scope backfill once Weblate no
+    # longer supports direct upgrades from 2026 releases.
+    state = MemoryScopeMigrationState.objects.filter(
+        name="memory-scope-backfill", completed=False
+    ).first()
+    if state is None:
+        needs_backfill = (
+            Memory.objects.alias(memory_has_scope=Memory.objects.get_has_scope_exists())
+            .filter(memory_has_scope=False)
+            .exists()
+        )
+        if needs_backfill:
+            backfill_memory_scopes.delay()
+        return
+
+    stale_before = timezone.now() - timezone.timedelta(
+        seconds=MEMORY_SCOPE_BACKFILL_STALE_SECONDS
+    )
+    if state.updated <= stale_before:
+        backfill_memory_scopes.delay()
+
+
+@app.on_after_finalize.connect
+def setup_periodic_tasks(sender, **kwargs) -> None:
+    sender.add_periodic_task(
+        MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
+        resume_memory_scope_backfill.s(),
+        name="resume-memory-scope-backfill",
+    )
 
 
 @app.task(trail=False)

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 MEMORY_UPDATE_BATCH_SIZE = 1000
 MEMORY_UPDATE_LOOKUP_CHUNK_SIZE = 50
 MEMORY_SCOPE_BACKFILL_STALE_SECONDS = 15 * 60
+MEMORY_SCOPE_COMPACTION_STALE_SECONDS = 4 * MEMORY_SCOPE_BACKFILL_STALE_SECONDS
 MEMORY_SCOPE_BACKFILL_STATE = "memory-scope-backfill"
 MEMORY_SCOPE_COMPACTION_STATE = "memory-scope-compaction"
 
@@ -273,14 +274,42 @@ def set_memory_scope_compaction_completed(completed: bool) -> None:
     )
 
 
-def has_completed_memory_scope_compaction() -> bool:
+def set_memory_scope_backfill_completed() -> None:
+    # TODO(2028.1): Remove this helper once Weblate no longer supports direct
+    # upgrades from 2026 releases.
+    MemoryScopeMigrationState.objects.using("default").update_or_create(
+        name=MEMORY_SCOPE_BACKFILL_STATE,
+        defaults={"completed": True, "updated": timezone.now()},
+    )
+
+
+def get_memory_scope_compaction_state() -> MemoryScopeMigrationState | None:
     # TODO(2028.1): Remove this helper once Weblate no longer supports direct
     # upgrades from 2026 releases.
     return (
         MemoryScopeMigrationState.objects.using("default")
-        .filter(name=MEMORY_SCOPE_COMPACTION_STATE, completed=True)
-        .exists()
+        .filter(name=MEMORY_SCOPE_COMPACTION_STATE)
+        .first()
     )
+
+
+def resume_memory_scope_compaction() -> None:
+    # TODO(2028.1): Remove this helper once Weblate no longer supports direct
+    # upgrades from 2026 releases.
+    state = get_memory_scope_compaction_state()
+    if state is not None:
+        if state.completed:
+            return
+        stale_before = timezone.now() - timedelta(
+            seconds=MEMORY_SCOPE_COMPACTION_STALE_SECONDS
+        )
+        if state.updated > stale_before:
+            return
+
+    if has_duplicate_memory_groups():
+        schedule_memory_scope_compaction()
+    else:
+        set_memory_scope_compaction_completed(True)
 
 
 def schedule_memory_scope_compaction() -> None:
@@ -331,15 +360,13 @@ def resume_memory_scope_backfill() -> None:
         )
         if needs_backfill:
             backfill_memory_scopes.delay()
+        else:
+            set_memory_scope_backfill_completed()
+            resume_memory_scope_compaction()
         return
 
     if state.completed:
-        if has_completed_memory_scope_compaction():
-            return
-        if has_duplicate_memory_groups():
-            schedule_memory_scope_compaction()
-        else:
-            set_memory_scope_compaction_completed(True)
+        resume_memory_scope_compaction()
         return
 
     stale_before = timezone.now() - timedelta(
@@ -517,6 +544,7 @@ def compact_memory_scopes(batch_size: int = 100) -> None:
         backfill_memory_scopes.delay()
         return
 
+    set_memory_scope_compaction_completed(False)
     duplicate_groups = list(
         memory_objects.values(
             "source_language_id",

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+from datetime import timedelta
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Any, cast
@@ -1005,7 +1006,7 @@ msgstr "Nazdar svete!\n"
             name="memory-scope-backfill",
             last_memory_id=1,
             updated=timezone.now()
-            - timezone.timedelta(seconds=MEMORY_SCOPE_BACKFILL_STALE_SECONDS + 1),
+            - timedelta(seconds=MEMORY_SCOPE_BACKFILL_STALE_SECONDS + 1),
         )
 
         with patch("weblate.memory.tasks.backfill_memory_scopes.delay") as mocked_delay:
@@ -1043,6 +1044,52 @@ msgstr "Nazdar svete!\n"
             resume_memory_scope_backfill()
 
         mocked_delay.assert_called_once_with()
+
+    def test_resume_memory_scope_backfill_reschedules_completed_compaction(
+        self,
+    ) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "source": "Resumed duplicate source",
+            "target": "Obnoveny duplicitni cil",
+            "origin": self.component.full_slug,
+            "status": Memory.STATUS_ACTIVE,
+        }
+        Memory.objects.create(**values)
+        Memory.objects.create(**values)
+        MemoryScopeMigrationState.objects.create(
+            name="memory-scope-backfill",
+            completed=True,
+        )
+
+        with (
+            patch("weblate.memory.tasks.backfill_memory_scopes.delay") as backfill,
+            patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact,
+        ):
+            resume_memory_scope_backfill()
+
+        backfill.assert_not_called()
+        compact.assert_called_once_with()
+
+    def test_resume_memory_scope_backfill_keeps_completed_without_duplicates(
+        self,
+    ) -> None:
+        MemoryScopeMigrationState.objects.create(
+            name="memory-scope-backfill",
+            completed=True,
+        )
+
+        with (
+            patch("weblate.memory.tasks.backfill_memory_scopes.delay") as backfill,
+            patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact,
+        ):
+            resume_memory_scope_backfill()
+
+        backfill.assert_not_called()
+        compact.assert_not_called()
 
     def test_project_delete_removes_legacy_shared_scoped_memory(self) -> None:
         memory = Memory.objects.create(

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -41,6 +41,7 @@ from weblate.memory.models import (
 from weblate.memory.tasks import (
     MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
     MEMORY_SCOPE_BACKFILL_STATE,
+    MEMORY_SCOPE_COMPACTION_STALE_SECONDS,
     MEMORY_SCOPE_COMPACTION_STATE,
     MEMORY_UPDATE_LOOKUP_CHUNK_SIZE,
     MemoryGroupEntry,
@@ -1101,6 +1102,48 @@ msgstr "Nazdar svete!\n"
 
         mocked_delay.assert_called_once_with()
 
+    def test_resume_memory_scope_backfill_without_state_marks_scoped_rows_completed(
+        self,
+    ) -> None:
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Already scoped source",
+            target="Jiz rozsahovy cil",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(memory=memory, scope=MemoryScope.SCOPE_GLOBAL_FILE)
+
+        with (
+            patch("weblate.memory.tasks.backfill_memory_scopes.delay") as backfill,
+            patch(
+                "weblate.memory.tasks.has_duplicate_memory_groups",
+                return_value=False,
+            ) as has_duplicates,
+        ):
+            resume_memory_scope_backfill()
+
+        backfill.assert_not_called()
+        has_duplicates.assert_called_once_with()
+        backfill_state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_SCOPE_BACKFILL_STATE
+        )
+        self.assertTrue(backfill_state.completed)
+        compaction_state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_SCOPE_COMPACTION_STATE
+        )
+        self.assertTrue(compaction_state.completed)
+
+        with (
+            patch.object(MemoryQuerySet, "get_has_scope_exists") as has_scope,
+            patch("weblate.memory.tasks.has_duplicate_memory_groups") as has_duplicates,
+        ):
+            resume_memory_scope_backfill()
+
+        has_scope.assert_not_called()
+        has_duplicates.assert_not_called()
+
     def test_resume_memory_scope_backfill_reschedules_completed_compaction(
         self,
     ) -> None:
@@ -1175,6 +1218,59 @@ msgstr "Nazdar svete!\n"
 
         has_duplicates.assert_not_called()
         compact.assert_not_called()
+
+    def test_resume_memory_scope_backfill_skips_recent_compaction(
+        self,
+    ) -> None:
+        MemoryScopeMigrationState.objects.create(
+            name=MEMORY_SCOPE_BACKFILL_STATE,
+            completed=True,
+        )
+        MemoryScopeMigrationState.objects.create(
+            name=MEMORY_SCOPE_COMPACTION_STATE,
+            completed=False,
+            updated=timezone.now(),
+        )
+
+        with (
+            patch("weblate.memory.tasks.has_duplicate_memory_groups") as has_duplicates,
+            patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact,
+        ):
+            resume_memory_scope_backfill()
+
+        has_duplicates.assert_not_called()
+        compact.assert_not_called()
+
+    def test_resume_memory_scope_backfill_recovers_stale_compaction(
+        self,
+    ) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "source": "Stale compaction source",
+            "target": "Zastarala kompaktace cil",
+            "origin": self.component.full_slug,
+            "status": Memory.STATUS_ACTIVE,
+        }
+        Memory.objects.create(**values)
+        Memory.objects.create(**values)
+        MemoryScopeMigrationState.objects.create(
+            name=MEMORY_SCOPE_BACKFILL_STATE,
+            completed=True,
+        )
+        MemoryScopeMigrationState.objects.create(
+            name=MEMORY_SCOPE_COMPACTION_STATE,
+            completed=False,
+            updated=timezone.now()
+            - timedelta(seconds=MEMORY_SCOPE_COMPACTION_STALE_SECONDS + 1),
+        )
+
+        with patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact:
+            resume_memory_scope_backfill()
+
+        compact.assert_called_once_with()
 
     def test_project_delete_removes_legacy_shared_scoped_memory(self) -> None:
         memory = Memory.objects.create(

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -40,6 +40,8 @@ from weblate.memory.models import (
 )
 from weblate.memory.tasks import (
     MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
+    MEMORY_SCOPE_BACKFILL_STATE,
+    MEMORY_SCOPE_COMPACTION_STATE,
     MEMORY_UPDATE_LOOKUP_CHUNK_SIZE,
     MemoryGroupEntry,
     backfill_memory_scopes,
@@ -1034,7 +1036,7 @@ msgstr "Nazdar svete!\n"
         MemoryScopeMigrationState.objects.using("default").all().delete()
 
         with (
-            patch("weblate.memory.tasks.compact_memory_scopes.delay"),
+            patch("weblate.memory.tasks.schedule_memory_scope_compaction"),
             patch.object(
                 MemoryScope.objects,
                 "db_manager",
@@ -1057,7 +1059,7 @@ msgstr "Nazdar svete!\n"
 
     def test_resume_memory_scope_backfill_reschedules_stale_state(self) -> None:
         state = MemoryScopeMigrationState.objects.create(
-            name="memory-scope-backfill",
+            name=MEMORY_SCOPE_BACKFILL_STATE,
             last_memory_id=1,
             updated=timezone.now()
             - timedelta(seconds=MEMORY_SCOPE_BACKFILL_STALE_SECONDS + 1),
@@ -1072,7 +1074,7 @@ msgstr "Nazdar svete!\n"
 
     def test_resume_memory_scope_backfill_keeps_recent_state(self) -> None:
         MemoryScopeMigrationState.objects.create(
-            name="memory-scope-backfill", updated=timezone.now()
+            name=MEMORY_SCOPE_BACKFILL_STATE, updated=timezone.now()
         )
 
         with patch("weblate.memory.tasks.backfill_memory_scopes.delay") as mocked_delay:
@@ -1115,7 +1117,7 @@ msgstr "Nazdar svete!\n"
         Memory.objects.create(**values)
         Memory.objects.create(**values)
         MemoryScopeMigrationState.objects.create(
-            name="memory-scope-backfill",
+            name=MEMORY_SCOPE_BACKFILL_STATE,
             completed=True,
         )
 
@@ -1127,12 +1129,16 @@ msgstr "Nazdar svete!\n"
 
         backfill.assert_not_called()
         compact.assert_called_once_with()
+        state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_SCOPE_COMPACTION_STATE
+        )
+        self.assertFalse(state.completed)
 
     def test_resume_memory_scope_backfill_keeps_completed_without_duplicates(
         self,
     ) -> None:
         MemoryScopeMigrationState.objects.create(
-            name="memory-scope-backfill",
+            name=MEMORY_SCOPE_BACKFILL_STATE,
             completed=True,
         )
 
@@ -1143,6 +1149,31 @@ msgstr "Nazdar svete!\n"
             resume_memory_scope_backfill()
 
         backfill.assert_not_called()
+        compact.assert_not_called()
+        state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_SCOPE_COMPACTION_STATE
+        )
+        self.assertTrue(state.completed)
+
+    def test_resume_memory_scope_backfill_skips_completed_compaction(
+        self,
+    ) -> None:
+        MemoryScopeMigrationState.objects.create(
+            name=MEMORY_SCOPE_BACKFILL_STATE,
+            completed=True,
+        )
+        MemoryScopeMigrationState.objects.create(
+            name=MEMORY_SCOPE_COMPACTION_STATE,
+            completed=True,
+        )
+
+        with (
+            patch("weblate.memory.tasks.has_duplicate_memory_groups") as has_duplicates,
+            patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact,
+        ):
+            resume_memory_scope_backfill()
+
+        has_duplicates.assert_not_called()
         compact.assert_not_called()
 
     def test_project_delete_removes_legacy_shared_scoped_memory(self) -> None:
@@ -1841,6 +1872,25 @@ msgstr "Nazdar svete!\n"
             set(memory.scopes.values_list("scope", flat=True)),
             {MemoryScope.SCOPE_PROJECT, MemoryScope.SCOPE_SHARED},
         )
+        state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_SCOPE_COMPACTION_STATE
+        )
+        self.assertTrue(state.completed)
+
+    def test_compact_memory_scopes_marks_completion_without_duplicates(self) -> None:
+        MemoryScopeMigrationState.objects.create(
+            name=MEMORY_SCOPE_BACKFILL_STATE,
+            completed=True,
+        )
+
+        with patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact:
+            compact_memory_scopes()
+
+        compact.assert_not_called()
+        state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_SCOPE_COMPACTION_STATE
+        )
+        self.assertTrue(state.completed)
 
     @override_settings(
         DATABASE_ROUTERS=["weblate.memory.tests.MemoryReplicaWriteRouter"]

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -8,10 +8,9 @@ import json
 import tempfile
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 from unittest.mock import MagicMock, call, patch
 
-from django.apps import apps as django_apps
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -21,9 +20,9 @@ from django.db.models.functions import MD5
 from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
-from kombu.exceptions import OperationalError
 from weblate_schemas import load_schema
 
 from weblate.lang.data import FORMULA_WITH_ZERO
@@ -34,16 +33,20 @@ from weblate.memory.models import (
     MemoryImportError,
     MemoryQuerySet,
     MemoryScope,
+    MemoryScopeMigrationState,
     load_memory_json_data,
     load_memory_tmx_store,
 )
 from weblate.memory.tasks import (
+    MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
     MEMORY_UPDATE_LOOKUP_CHUNK_SIZE,
+    MemoryGroupEntry,
     cleanup_orphaned_memory,
     compact_memory_scopes,
     get_group_matching_memory,
     handle_unit_translation_change,
     import_memory,
+    resume_memory_scope_backfill,
     set_scope_source_project_ids,
     update_memory,
     update_memory_bulk,
@@ -60,10 +63,6 @@ from weblate.trans.tests.utils import create_another_user, get_test_file
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.state import STATE_TRANSLATED
 from weblate.workspaces.models import Workspace
-
-if TYPE_CHECKING:
-    from weblate.memory.apps import MemoryConfig
-    from weblate.memory.tasks import MemoryGroupEntry
 
 
 def add_document(source: str = "Hello", target: str = "Ahoj") -> None:
@@ -1001,23 +1000,49 @@ msgstr "Nazdar svete!\n"
 
         mocked_cleanup.assert_called_once_with()
 
-    def test_post_migrate_fails_on_celery_publish_failure(self) -> None:
-        add_document()
-        memory_config = cast("MemoryConfig", django_apps.get_app_config("memory"))
+    def test_resume_memory_scope_backfill_reschedules_stale_state(self) -> None:
+        state = MemoryScopeMigrationState.objects.create(
+            name="memory-scope-backfill",
+            last_memory_id=1,
+            updated=timezone.now()
+            - timezone.timedelta(seconds=MEMORY_SCOPE_BACKFILL_STALE_SECONDS + 1),
+        )
 
-        with (
-            patch(
-                "weblate.memory.tasks.backfill_memory_scopes.delay",
-                side_effect=OperationalError("broker unavailable"),
-            ) as mocked_backfill,
-            self.assertRaisesMessage(
-                CommandError,
-                "Could not schedule translation memory scope migration task",
-            ),
-        ):
-            memory_config.post_migrate(memory_config)
+        with patch("weblate.memory.tasks.backfill_memory_scopes.delay") as mocked_delay:
+            resume_memory_scope_backfill()
 
-        mocked_backfill.assert_called_once_with()
+        mocked_delay.assert_called_once_with()
+        state.refresh_from_db()
+        self.assertFalse(state.completed)
+
+    def test_resume_memory_scope_backfill_keeps_recent_state(self) -> None:
+        MemoryScopeMigrationState.objects.create(
+            name="memory-scope-backfill", updated=timezone.now()
+        )
+
+        with patch("weblate.memory.tasks.backfill_memory_scopes.delay") as mocked_delay:
+            resume_memory_scope_backfill()
+
+        mocked_delay.assert_not_called()
+
+    def test_resume_memory_scope_backfill_without_state_detects_unscoped_rows(
+        self,
+    ) -> None:
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Resumed unscoped source",
+            target="Obnoveny cil",
+            origin=self.component.full_slug,
+            legacy_project=self.project,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.filter(memory=memory).delete()
+
+        with patch("weblate.memory.tasks.backfill_memory_scopes.delay") as mocked_delay:
+            resume_memory_scope_backfill()
+
+        mocked_delay.assert_called_once_with()
 
     def test_project_delete_removes_legacy_shared_scoped_memory(self) -> None:
         memory = Memory.objects.create(

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -42,6 +42,7 @@ from weblate.memory.tasks import (
     MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
     MEMORY_UPDATE_LOOKUP_CHUNK_SIZE,
     MemoryGroupEntry,
+    backfill_memory_scopes,
     cleanup_orphaned_memory,
     compact_memory_scopes,
     get_group_matching_memory,
@@ -89,6 +90,21 @@ class MemoryReadReplicaRouter:
         if model._meta.app_label == "memory":  # noqa: SLF001
             return "default"
         return None
+
+
+class MemoryReplicaWriteRouter:
+    def db_for_read(self, model: type[models.Model], **_hints: object) -> str | None:
+        if model._meta.app_label == "memory":  # noqa: SLF001
+            return "memory_db"
+        return None
+
+    def db_for_write(self, model: type[models.Model], **_hints: object) -> str | None:
+        if model._meta.app_label == "memory":  # noqa: SLF001
+            return "memory_db"
+        return None
+
+    def allow_relation(self, obj1: models.Model, obj2: models.Model) -> bool | None:
+        return True
 
 
 class MemoryParserTest(SimpleTestCase):
@@ -1001,6 +1017,44 @@ msgstr "Nazdar svete!\n"
 
         mocked_cleanup.assert_called_once_with()
 
+    @override_settings(
+        DATABASE_ROUTERS=["weblate.memory.tests.MemoryReplicaWriteRouter"]
+    )
+    def test_backfill_memory_scopes_uses_default_database_alias(self) -> None:
+        memory = Memory.objects.using("default").create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Backfill routed source",
+            target="Doplneny smerovany cil",
+            origin=self.component.full_slug,
+            legacy_project=self.project,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.using("default").filter(memory=memory).delete()
+        MemoryScopeMigrationState.objects.using("default").all().delete()
+
+        with (
+            patch("weblate.memory.tasks.compact_memory_scopes.delay"),
+            patch.object(
+                MemoryScope.objects,
+                "db_manager",
+                wraps=MemoryScope.objects.db_manager,
+            ) as db_manager,
+        ):
+            backfill_memory_scopes()
+
+        db_manager.assert_any_call("default")
+        self.assertNotIn(call("memory_db"), db_manager.call_args_list)
+        self.assertTrue(
+            MemoryScope.objects.using("default")
+            .filter(
+                memory=memory,
+                scope=MemoryScope.SCOPE_PROJECT,
+                project=self.project,
+            )
+            .exists()
+        )
+
     def test_resume_memory_scope_backfill_reschedules_stale_state(self) -> None:
         state = MemoryScopeMigrationState.objects.create(
             name="memory-scope-backfill",
@@ -1786,6 +1840,39 @@ msgstr "Nazdar svete!\n"
         self.assertEqual(
             set(memory.scopes.values_list("scope", flat=True)),
             {MemoryScope.SCOPE_PROJECT, MemoryScope.SCOPE_SHARED},
+        )
+
+    @override_settings(
+        DATABASE_ROUTERS=["weblate.memory.tests.MemoryReplicaWriteRouter"]
+    )
+    def test_compact_memory_scopes_uses_default_database_alias(self) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "source": "Compacted routed source",
+            "target": "Kompaktni smerovany cil",
+            "origin": self.component.full_slug,
+            "status": Memory.STATUS_ACTIVE,
+        }
+        Memory.objects.using("default").create(legacy_project=self.project, **values)
+        Memory.objects.using("default").create(legacy_shared=True, **values)
+
+        with patch.object(
+            MemoryScope.objects,
+            "db_manager",
+            wraps=MemoryScope.objects.db_manager,
+        ) as db_manager:
+            compact_memory_scopes()
+
+        db_manager.assert_any_call("default")
+        self.assertNotIn(call("memory_db"), db_manager.call_args_list)
+        self.assertEqual(
+            Memory.objects.using("default")
+            .filter(source="Compacted routed source")
+            .count(),
+            1,
         )
 
     def test_compact_preserves_shared_source_projects(self) -> None:


### PR DESCRIPTION
### Motivation

- The translation-memory scope backfill previously tried to schedule work during `post_migrate`, which can fail if the Celery broker is unavailable and makes upgrades brittle. 
- The change makes the backfill robust and resumable by moving scheduling out of `post_migrate` and introducing a periodic resume mechanism.

### Description

- Remove `post_migrate` scheduling from `weblate.memory.apps.MemoryConfig` and stop attempting to publish Celery tasks during app migration time. 
- Rework `backfill_memory_scopes` to run inside a transaction with `select_for_update`, update `MemoryScopeMigrationState` atomically, and decide whether to schedule the next batch or run compaction based on progress. 
- Add `resume_memory_scope_backfill` task and a periodic Celery registration via `setup_periodic_tasks`, using `MEMORY_SCOPE_BACKFILL_STALE_SECONDS` to detect stale migration state and reschedule the backfill. 
- Update tests to remove the post-migrate publish-failure case and add tests covering resume behavior: rescheduling stale state, keeping recent state, and detecting unscoped rows when no state exists. 
- Update documentation strings in `docs/admin/memory.rst`, `docs/admin/upgrade.rst`, and `docs/changes.rst` to reflect the periodic Celery background task wording.

### Testing

- Ran the memory unit tests for the modified module, including the new `resume_memory_scope_backfill` tests (`test_resume_memory_scope_backfill_reschedules_stale_state`, `test_resume_memory_scope_backfill_keeps_recent_state`, `test_resume_memory_scope_backfill_without_state_detects_unscoped_rows`), and they passed. 
- Ran the existing `weblate.memory` test suite (`./manage.py test weblate.memory`) and observed no regressions in the modified areas. 
- No new integration tests were added for Celery broker behavior beyond task scheduling verification via mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4155bcaac88329b58f7a0ff878a0ab)