### PR TITLE
Show PostgreSQL disk usage in Performance page and add checks for database size/backup space

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -47,6 +47,7 @@ Weblate 2026.7
 * Change-event notification add-ons can now use presets for translation content events, all events, or selected individual events.
 * :ref:`addon-weblate.fedora_messaging.publish` now validates secure broker connections and exposes delivery timing settings.
 * Pull request messages now use a compact language progress matrix widget that scales better for projects with many languages.
+* :ref:`manage-performance` now shows PostgreSQL database disk usage next to server disk usage and warns when the database usage cannot be collected or there is not enough free space in the backup destination to store a database dump.
 
 .. rubric:: Bug fixes
 

--- a/weblate/templates/manage/performance.html
+++ b/weblate/templates/manage/performance.html
@@ -198,7 +198,7 @@
 
             <tbody>
               <tr>
-                <td colspan="3">
+                <td colspan="4">
                   <div class="progress">
                     <div class="progress-bar {% if disk_usage_percent < 90 %}progress-bar-success{% elif disk_usage_percent < 95 %}progress-bar-warning{% else %}progress-bar-danger{% endif %}"
                          role="progressbar"
@@ -211,15 +211,33 @@
                 </td>
               </tr>
               <tr>
+                <th>{% translate "Storage" %}</th>
                 <th>{% translate "Disk size" %}</th>
                 <th>{% translate "Disk used" %}</th>
                 <th>{% translate "Disk free" %}</th>
               </tr>
               <tr>
+                <th scope="row">{% translate "Server" %}</th>
                 <td>{{ disk_usage.total|filesizeformat }}</td>
                 <td>{{ disk_usage.used|filesizeformat }}</td>
                 <td>{{ disk_usage.free|filesizeformat }}</td>
               </tr>
+              {% if database_size is not None %}
+                <tr>
+                  <th scope="row">{% translate "PostgreSQL database" %}</th>
+                  {% if database_disk_usage %}
+                    <td>{{ database_disk_usage.total|filesizeformat }}</td>
+                  {% else %}
+                    <td>{% translate "Not available" %}</td>
+                  {% endif %}
+                  <td>{{ database_size|filesizeformat }}</td>
+                  {% if database_disk_usage %}
+                    <td>{{ database_disk_usage.free|filesizeformat }}</td>
+                  {% else %}
+                    <td>{% translate "Not available" %}</td>
+                  {% endif %}
+                </tr>
+              {% endif %}
             </tbody>
           </table>
         </div>

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -710,6 +710,14 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
                     "weblate.wladmin.views.measure_cache_latency",
                     measure_cache_latency,
                 ),
+                patch(
+                    "weblate.wladmin.views.get_database_size",
+                    return_value=123456789,
+                ),
+                patch(
+                    "weblate.wladmin.views.get_database_disk_usage",
+                    return_value=None,
+                ),
             ):
                 yield
         finally:

--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -35,11 +35,12 @@ from .celery import is_celery_queue_long
 from .checks import weblate_check
 from .classloader import ClassLoader
 from .const import HEARTBEAT_FREQUENCY
-from .data import data_path
+from .data import data_dir, data_path
 from .db import (
     PostgreSQLRegexLookup,
     PostgreSQLSearchLookup,
     PostgreSQLSubstringLookup,
+    get_database_size,
     measure_database_latency,
 )
 from .encoding import get_filesystem_encoding, get_locale_encoding, get_python_encoding
@@ -504,6 +505,58 @@ def check_encoding(
             "System encoding is not UTF-8, processing non-ASCII strings will break",
         )
     ]
+
+
+def get_database_backup_disk_usage():
+    """Return disk usage for the database backup destination."""
+    path = Path(data_dir("backups"))
+    while not path.exists():
+        if path == path.parent:
+            return None
+        path = path.parent
+    try:
+        return disk_usage(path)
+    except OSError:
+        return None
+
+
+@register(deploy=True)
+def check_database_size(
+    *,
+    app_configs: Sequence[AppConfig] | None,
+    databases: Sequence[str] | None,
+    **kwargs,
+) -> Iterable[CheckMessage]:
+    """Check that PostgreSQL database size can be collected."""
+    connection = connections["default"]
+    if connection.vendor != "postgresql":
+        return []
+
+    database_size = get_database_size()
+    if database_size is None:
+        return [
+            weblate_check(
+                "weblate.C045",
+                "Could not determine PostgreSQL database disk usage",
+            )
+        ]
+
+    if settings.DATABASE_BACKUP == "none":
+        return []
+
+    usage = get_database_backup_disk_usage()
+    if usage is None:
+        return []
+
+    if usage.free < database_size:
+        backup_dir = data_dir("backups")
+        message = (
+            f"There is not enough free space in {backup_dir} "
+            "to store a PostgreSQL database dump"
+        )
+        return [weblate_check("weblate.C046", message)]
+
+    return []
 
 
 @register(deploy=True)

--- a/weblate/utils/checks.py
+++ b/weblate/utils/checks.py
@@ -82,6 +82,8 @@ DOC_LINKS: dict[str, str | tuple[str] | tuple[str, str]] = {
     "weblate.C042": ("admin/config", "std-setting-REGISTRATION_ALLOW_BACKENDS"),
     "weblate.E043": ("admin/install", "hardware"),
     "weblate.C044": ("admin/config", "std-setting-CACHE_DIR"),
+    "weblate.C045": ("admin/install", "production-database"),
+    "weblate.C046": ("admin/backup",),
 }
 
 

--- a/weblate/utils/db.py
+++ b/weblate/utils/db.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 
 import time
 from shutil import disk_usage
+from typing import TYPE_CHECKING
 
 from django.db import DatabaseError, ProgrammingError, connections, transaction
-from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.lookups import Lookup, PatternLookup, Regex
 
 from .inv_regex import invert_re
+
+if TYPE_CHECKING:
+    from django.db.backends.base.base import BaseDatabaseWrapper
 
 ESCAPED = frozenset(".\\+*?[^]$(){}=!<>|:-")
 

--- a/weblate/utils/db.py
+++ b/weblate/utils/db.py
@@ -7,8 +7,10 @@
 from __future__ import annotations
 
 import time
+from shutil import disk_usage
 
-from django.db import ProgrammingError, connections, transaction
+from django.db import DatabaseError, ProgrammingError, connections, transaction
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models.lookups import Lookup, PatternLookup, Regex
 
 from .inv_regex import invert_re
@@ -53,6 +55,48 @@ def adjust_similarity_threshold(value: float, *, alias: str | None = None) -> No
         # Adjust threshold
         cursor.execute("SELECT set_limit(%s)", [value])
         connection.weblate_similarity = value  # type: ignore[attr-defined]
+
+
+def is_local_database(connection: BaseDatabaseWrapper) -> bool:
+    """Return whether the database connection points to the local host."""
+    host = connection.settings_dict.get("HOST", "")
+    return host in {"", "localhost", "127.0.0.1", "::1"} or host.startswith("/")
+
+
+def get_database_disk_usage(*, alias: str = "default"):
+    """Return disk usage for the local PostgreSQL data directory."""
+    connection = connections[alias]
+    if connection.vendor != "postgresql" or not is_local_database(connection):
+        return None
+
+    def get_data_directory() -> str:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT current_setting('data_directory')")
+            return cursor.fetchone()[0]
+
+    try:
+        if connection.in_atomic_block is True:
+            with transaction.atomic(using=alias):
+                data_directory = get_data_directory()
+        else:
+            data_directory = get_data_directory()
+        return disk_usage(data_directory)
+    except (DatabaseError, OSError):
+        return None
+
+
+def get_database_size(*, alias: str = "default") -> int | None:
+    """Return size of the current PostgreSQL database in bytes."""
+    connection = connections[alias]
+    if connection.vendor != "postgresql":
+        return None
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_database_size(current_database())")
+            return cursor.fetchone()[0]
+    except DatabaseError:
+        return None
 
 
 def count_alnum(string):

--- a/weblate/utils/tests/test_checks.py
+++ b/weblate/utils/tests/test_checks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 from weakref import WeakSet
 
@@ -19,6 +20,7 @@ from weblate.utils.apps import (
     CACHE_EXEC_CHECK_PREFIX,
     check_class_loader,
     check_data_writable,
+    check_database_size,
     check_errors,
     check_settings,
 )
@@ -148,6 +150,97 @@ class DataWritableCheckTestCase(SimpleTestCase):
 
         self.assertTrue(any(error.id == "weblate.C044" for error in errors))
         self.assertEqual(self.get_cache_probes(), [])
+
+
+class DatabaseSizeCheckTestCase(SimpleTestCase):
+    @patch(
+        "weblate.utils.apps.get_database_backup_disk_usage",
+        return_value=SimpleNamespace(free=123457),
+    )
+    @patch("weblate.utils.apps.get_database_size", return_value=123456)
+    @patch("weblate.utils.apps.connections")
+    def test_database_size_available(
+        self, connections_mock, database_size_mock, disk_usage_mock
+    ) -> None:
+        connections_mock.__getitem__.return_value.vendor = "postgresql"
+
+        errors = list(check_database_size(app_configs=None, databases=None))
+
+        self.assertFalse(
+            any(error.id in {"weblate.C045", "weblate.C046"} for error in errors)
+        )
+        database_size_mock.assert_called_once_with()
+        disk_usage_mock.assert_called_once_with()
+
+    @patch(
+        "weblate.utils.apps.get_database_backup_disk_usage",
+        return_value=SimpleNamespace(free=123455),
+    )
+    @patch("weblate.utils.apps.get_database_size", return_value=123456)
+    @patch("weblate.utils.apps.connections")
+    def test_database_size_not_enough_space(
+        self, connections_mock, database_size_mock, disk_usage_mock
+    ) -> None:
+        connections_mock.__getitem__.return_value.vendor = "postgresql"
+
+        errors = list(check_database_size(app_configs=None, databases=None))
+
+        self.assertTrue(any(error.id == "weblate.C046" for error in errors))
+        database_size_mock.assert_called_once_with()
+        disk_usage_mock.assert_called_once_with()
+
+    @override_settings(DATABASE_BACKUP="none")
+    @patch("weblate.utils.apps.get_database_backup_disk_usage")
+    @patch("weblate.utils.apps.get_database_size", return_value=123456)
+    @patch("weblate.utils.apps.connections")
+    def test_database_size_backup_disabled(
+        self, connections_mock, database_size_mock, disk_usage_mock
+    ) -> None:
+        connections_mock.__getitem__.return_value.vendor = "postgresql"
+
+        errors = list(check_database_size(app_configs=None, databases=None))
+
+        self.assertFalse(any(error.id == "weblate.C046" for error in errors))
+        database_size_mock.assert_called_once_with()
+        disk_usage_mock.assert_not_called()
+
+    @patch("weblate.utils.apps.get_database_backup_disk_usage", return_value=None)
+    @patch("weblate.utils.apps.get_database_size", return_value=123456)
+    @patch("weblate.utils.apps.connections")
+    def test_database_size_backup_usage_unavailable(
+        self, connections_mock, database_size_mock, disk_usage_mock
+    ) -> None:
+        connections_mock.__getitem__.return_value.vendor = "postgresql"
+
+        errors = list(check_database_size(app_configs=None, databases=None))
+
+        self.assertFalse(any(error.id == "weblate.C046" for error in errors))
+        database_size_mock.assert_called_once_with()
+        disk_usage_mock.assert_called_once_with()
+
+    @patch("weblate.utils.apps.get_database_size", return_value=None)
+    @patch("weblate.utils.apps.connections")
+    def test_database_size_unavailable(
+        self, connections_mock, database_size_mock
+    ) -> None:
+        connections_mock.__getitem__.return_value.vendor = "postgresql"
+
+        errors = list(check_database_size(app_configs=None, databases=None))
+
+        self.assertTrue(any(error.id == "weblate.C045" for error in errors))
+        database_size_mock.assert_called_once_with()
+
+    @patch("weblate.utils.apps.get_database_size")
+    @patch("weblate.utils.apps.connections")
+    def test_database_size_non_postgresql(
+        self, connections_mock, database_size_mock
+    ) -> None:
+        connections_mock.__getitem__.return_value.vendor = "sqlite"
+
+        errors = list(check_database_size(app_configs=None, databases=None))
+
+        self.assertFalse(any(error.id == "weblate.C045" for error in errors))
+        database_size_mock.assert_not_called()
 
 
 class SettingsCheckTestCase(SimpleTestCase):

--- a/weblate/utils/tests/test_db.py
+++ b/weblate/utils/tests/test_db.py
@@ -5,9 +5,16 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from django.db import DatabaseError
+
 from weblate.trans.models import Component, Project, Unit
 from weblate.trans.tests.test_views import FixtureComponentTestCase
-from weblate.utils.db import adjust_similarity_threshold, re_escape
+from weblate.utils.db import (
+    adjust_similarity_threshold,
+    get_database_disk_usage,
+    get_database_size,
+    re_escape,
+)
 
 BASE_SQL = 'SELECT "trans_unit"."id" FROM "trans_unit" WHERE '
 
@@ -48,6 +55,84 @@ class DbTest(TestCase):
         adjust_similarity_threshold(0.966)
 
         cursor.execute.assert_called_once_with("SELECT set_limit(%s)", [0.966])
+
+    @patch("weblate.utils.db.connections")
+    def test_get_database_size_postgresql(self, connections_mock) -> None:
+        cursor = MagicMock()
+        cursor.__enter__.return_value = cursor
+        cursor.fetchone.return_value = [123456]
+        connection = MagicMock(vendor="postgresql")
+        connection.cursor.return_value = cursor
+        connections_mock.__getitem__.return_value = connection
+
+        self.assertEqual(get_database_size(), 123456)
+        cursor.execute.assert_called_once_with(
+            "SELECT pg_database_size(current_database())"
+        )
+
+    @patch("weblate.utils.db.connections")
+    def test_get_database_size_non_postgresql(self, connections_mock) -> None:
+        connection = MagicMock(vendor="sqlite")
+        connections_mock.__getitem__.return_value = connection
+
+        self.assertIsNone(get_database_size())
+        connection.cursor.assert_not_called()
+
+    @patch("weblate.utils.db.connections")
+    def test_get_database_size_database_error(self, connections_mock) -> None:
+        connection = MagicMock(vendor="postgresql")
+        connection.cursor.side_effect = DatabaseError
+        connections_mock.__getitem__.return_value = connection
+
+        self.assertIsNone(get_database_size())
+
+    @patch("weblate.utils.db.disk_usage", return_value="usage")
+    @patch("weblate.utils.db.connections")
+    def test_get_database_disk_usage_postgresql(
+        self, connections_mock, disk_usage_mock
+    ) -> None:
+        cursor = MagicMock()
+        cursor.__enter__.return_value = cursor
+        cursor.fetchone.return_value = ["/var/lib/postgresql/data"]
+        connection = MagicMock(vendor="postgresql")
+        connection.settings_dict = {"HOST": ""}
+        connection.cursor.return_value = cursor
+        connections_mock.__getitem__.return_value = connection
+
+        self.assertEqual(get_database_disk_usage(), "usage")
+        cursor.execute.assert_called_once_with(
+            "SELECT current_setting('data_directory')"
+        )
+        disk_usage_mock.assert_called_once_with("/var/lib/postgresql/data")
+
+    @patch("weblate.utils.db.disk_usage")
+    @patch("weblate.utils.db.connections")
+    def test_get_database_disk_usage_remote_postgresql(
+        self, connections_mock, disk_usage_mock
+    ) -> None:
+        connection = MagicMock(vendor="postgresql")
+        connection.settings_dict = {"HOST": "database.example.com"}
+        connections_mock.__getitem__.return_value = connection
+
+        self.assertIsNone(get_database_disk_usage())
+        connection.cursor.assert_not_called()
+        disk_usage_mock.assert_not_called()
+
+    @patch("weblate.utils.db.disk_usage", side_effect=OSError)
+    @patch("weblate.utils.db.connections")
+    def test_get_database_disk_usage_error(
+        self, connections_mock, disk_usage_mock
+    ) -> None:
+        cursor = MagicMock()
+        cursor.__enter__.return_value = cursor
+        cursor.fetchone.return_value = ["/var/lib/postgresql/data"]
+        connection = MagicMock(vendor="postgresql")
+        connection.settings_dict = {"HOST": "localhost"}
+        connection.cursor.return_value = cursor
+        connections_mock.__getitem__.return_value = connection
+
+        self.assertIsNone(get_database_disk_usage())
+        disk_usage_mock.assert_called_once_with("/var/lib/postgresql/data")
 
 
 class PostgreSQLOperatorTest(TestCase):

--- a/weblate/wladmin/models.py
+++ b/weblate/wladmin/models.py
@@ -89,6 +89,8 @@ class ConfigurationErrorManager(models.Manager["ConfigurationError"]):
             "weblate.C041",
             "weblate.E006",
             "weblate.C044",
+            "weblate.C045",
+            "weblate.C046",
         }
         removals = []
         existing = {error.name: error for error in self.all()}

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -959,9 +959,19 @@ class AdminTest(ViewTestCase):
         self.assertNotContains(response, settings.BACKUP_DIR)
 
     def test_performance(self) -> None:
-        response = self.client.get(reverse("manage-performance"))
+        with (
+            patch("weblate.wladmin.views.get_database_size", return_value=123456789),
+            patch(
+                "weblate.wladmin.views.get_database_disk_usage",
+                return_value=SimpleNamespace(total=987654321, free=876543210),
+            ),
+        ):
+            response = self.client.get(reverse("manage-performance"))
         self.assertContains(response, "weblate.E005")
         self.assertContains(response, "Translation memory migration")
+        self.assertContains(response, "PostgreSQL database")
+        self.assertEqual(response.context["database_size"], 123456789)
+        self.assertEqual(response.context["database_disk_usage"].free, 876543210)
         self.assertIn("total", response.context["memory_migration_status"])
 
     def test_performance_memory_migration_status(self) -> None:

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -56,7 +56,11 @@ from weblate.trans.util import redirect_param
 from weblate.utils import messages
 from weblate.utils.cache import measure_cache_latency
 from weblate.utils.celery import get_queue_stats
-from weblate.utils.db import measure_database_latency
+from weblate.utils.db import (
+    get_database_disk_usage,
+    get_database_size,
+    measure_database_latency,
+)
 from weblate.utils.encoding import get_encoding_list
 from weblate.utils.errors import report_error
 from weblate.utils.stats import prefetch_stats
@@ -486,6 +490,9 @@ def performance(request: AuthenticatedHttpRequest) -> HttpResponse:
     else:
         disk_usage_percent = round(disk_usage_bytes.used * 100 / disk_usage_bytes.total)
 
+    database_size = get_database_size()
+    database_disk_usage = get_database_disk_usage()
+
     context = {
         "checks": checks,
         "errors": ConfigurationError.objects.filter(ignored=False),
@@ -499,6 +506,8 @@ def performance(request: AuthenticatedHttpRequest) -> HttpResponse:
         "cache_latency": measure_cache_latency(),
         "disk_usage": disk_usage_bytes,
         "disk_usage_percent": disk_usage_percent,
+        "database_size": database_size,
+        "database_disk_usage": database_disk_usage,
         "memory_migration_status": get_memory_migration_status(),
     }
 


### PR DESCRIPTION
### Motivation

- Surface PostgreSQL database size and local data-directory usage on the management performance page to help operators spot database storage problems. 
- Warn when the configured backup destination does not have enough free space to store a database dump and surface when database size cannot be determined.

### Description

- Added `get_database_size` and `get_database_disk_usage` helpers to `weblate.utils.db` to collect the current PostgreSQL database size and the data directory disk usage when the DB is local. 
- Added `get_database_backup_disk_usage` and a deployment check `check_database_size` in `weblate.utils.apps` to verify availability of DB size and backup destination free space, and to emit new check IDs `weblate.C045` and `weblate.C046` accordingly. 
- Wired the new DB helpers into the performance view (`weblate.wladmin.views`) and template (`weblate/templates/manage/performance.html`) to show server and PostgreSQL storage rows and to expose `database_size` and `database_disk_usage` in the template context. 
- Registered the new check IDs in `weblate.utils.checks` and ensured the configuration error manager includes them, and updated several tests and Selenium/management tests to patch and assert the new behavior. 
- Updated `docs/changes.rst` to mention the performance page enhancement.

### Testing

- Ran unit tests for the DB utilities and checks (`weblate.utils.tests.test_db`, `weblate.utils.tests.test_checks`) which exercise `get_database_size`, `get_database_disk_usage`, and `check_database_size`, and they passed. 
- Ran updated management tests (`weblate.wladmin.tests`) that validate the performance page rendering and context values, and they passed. 
- Ran the updated Selenium/functional test (`weblate.trans.tests.test_selenium`) changes that patch DB size/disk usage, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a414e6e9ef4832996e10282d86b4943)