### PR TITLE
fix(client): escape selection IDs for sorting

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -472,10 +472,10 @@ function loadTableSorting() {
               const parentA = a.dataset.parent;
               const parentB = b.dataset.parent;
               if (parentA) {
-                rowA = tbody.querySelector(`#${parentA}`) || rowA;
+                rowA = tbody.querySelector(`#${CSS.escape(parentA)}`) || rowA;
               }
               if (parentB) {
-                rowB = tbody.querySelector(`#${parentB}`) || rowB;
+                rowB = tbody.querySelector(`#${CSS.escape(parentB)}`) || rowB;
               }
               return (
                 inverse *


### PR DESCRIPTION
Due to a difference in behavior between jquery and native JS selector functions, some actions would throw when a selected ID began with a digit, wrapping in `CSS.escape` should fix this.
Fixes https://github.com/WeblateOrg/weblate/issues/19724
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
