### PR TITLE
Introduce explicit inherited settings scope and label helper for forms

### DIFF
--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1867,6 +1867,17 @@ class SettingsBaseForm(CleanRepoMixin, forms.ModelForm):
         self.helper.form_tag = False
 
 
+InheritedSettingsScope = Literal["workspace", "project", "category"]
+
+
+def get_inherited_settings_label(parent_scope: InheritedSettingsScope) -> str:
+    if parent_scope == "workspace":
+        return gettext("Inherit from workspace")
+    if parent_scope == "project":
+        return gettext("Inherit from project")
+    return gettext("Inherit from category")
+
+
 class InheritedSettingsFormMixin(forms.ModelForm):
     _inherited_setting_fields: set[str]
     _inherited_setting_restore_values: dict[str, Any]
@@ -1905,16 +1916,18 @@ class InheritedSettingsFormMixin(forms.ModelForm):
             "" if override_value is None else override_value
         )
 
-    def setup_inherited_settings(self, parent_name: str, *, has_parent: bool) -> None:
+    def setup_inherited_settings(
+        self, parent_scope: InheritedSettingsScope, *, has_parent: bool
+    ) -> None:
         setup_message_setting_site_defaults(self.fields)
         self._inherited_setting_fields = set()
         for field_name in INHERITABLE_COMPONENT_SETTINGS:
             inherit_field = get_inherit_field_name(field_name)
             if inherit_field not in self.fields:
                 continue
-            self.fields[inherit_field].label = gettext("Inherit from %(scope)s") % {
-                "scope": parent_name
-            }
+            self.fields[inherit_field].label = get_inherited_settings_label(
+                parent_scope
+            )
             if not has_parent:
                 self.fields[inherit_field].initial = False
                 self.fields[inherit_field].widget = forms.HiddenInput()
@@ -2226,10 +2239,10 @@ class ComponentSettingsForm(
 
     def __init__(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> None:
         super().__init__(request, *args, **kwargs)
-        parent_name = (
-            gettext("category") if self.instance.category_id else gettext("project")
+        parent_scope: InheritedSettingsScope = (
+            "category" if self.instance.category_id else "project"
         )
-        self.setup_inherited_settings(parent_name, has_parent=True)
+        self.setup_inherited_settings(parent_scope, has_parent=True)
         if self.hide_restricted:
             self.fields["restricted"].widget = forms.HiddenInput()
         self.helper.layout = Layout(
@@ -2614,15 +2627,16 @@ class ComponentCreateForm(
 
     def setup_create_inherited_settings(self) -> None:
         parent = self.get_selected_parent()
+        parent_scope: InheritedSettingsScope
         if isinstance(parent, Category):
             self.instance.category = parent
             self.instance.project = parent.project
-            parent_name = gettext("category")
+            parent_scope = "category"
         elif isinstance(parent, Project):
             self.instance.project = parent
-            parent_name = gettext("project")
+            parent_scope = "project"
         else:
-            parent_name = gettext("project")
+            parent_scope = "project"
 
         for field_name in self.CREATE_INHERITABLE_SETTINGS:
             if field_name in self.initial:
@@ -2652,7 +2666,7 @@ class ComponentCreateForm(
             self.initial["inherit_license"] = False
             self.instance.inherit_license = False
 
-        self.setup_inherited_settings(parent_name, has_parent=parent is not None)
+        self.setup_inherited_settings(parent_scope, has_parent=parent is not None)
 
     def disables_inheritance_for_explicit_setting(self, field: str) -> bool:
         inherit_field = get_inherit_field_name(field)
@@ -3208,10 +3222,10 @@ class CategorySettingsForm(
 
     def __init__(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> None:
         super().__init__(request, *args, **kwargs)
-        parent_name = (
-            gettext("category") if self.instance.category_id else gettext("project")
+        parent_scope: InheritedSettingsScope = (
+            "category" if self.instance.category_id else "project"
         )
-        self.setup_inherited_settings(parent_name, has_parent=True)
+        self.setup_inherited_settings(parent_scope, has_parent=True)
         self.helper.layout = Layout(
             TabHolder(
                 Tab(
@@ -3443,8 +3457,9 @@ class ProjectSettingsForm(
 
     def __init__(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> None:
         super().__init__(request, *args, **kwargs)
+        parent_scope: InheritedSettingsScope = "workspace"
         self.setup_inherited_settings(
-            gettext("workspace"), has_parent=self.instance.workspace_id is not None
+            parent_scope, has_parent=self.instance.workspace_id is not None
         )
         self.user = request.user
         self.user_can_change_access = request.user.has_perm(

--- a/weblate/trans/tests/test_forms.py
+++ b/weblate/trans/tests/test_forms.py
@@ -12,6 +12,8 @@ from django.template.loader import render_to_string
 from django.test import SimpleTestCase
 from django.utils.safestring import SafeString
 
+from weblate.trans.forms import get_inherited_settings_label
+
 
 class FormRenderingTest(SimpleTestCase):
     def test_icon_help_text_escapes_title_attribute(self) -> None:
@@ -35,3 +37,14 @@ class FormRenderingTest(SimpleTestCase):
         )
         self.assertNotIn('title="Quote "Needs editing"', rendered)
         self.assertNotIn("<strong>HTML help text</strong>", rendered)
+
+
+class InheritedSettingsLabelTest(SimpleTestCase):
+    def test_inherited_settings_labels_are_complete_translatable_strings(self) -> None:
+        self.assertEqual(
+            get_inherited_settings_label("workspace"), "Inherit from workspace"
+        )
+        self.assertEqual(get_inherited_settings_label("project"), "Inherit from project")
+        self.assertEqual(
+            get_inherited_settings_label("category"), "Inherit from category"
+        )

--- a/weblate/trans/tests/test_forms.py
+++ b/weblate/trans/tests/test_forms.py
@@ -44,7 +44,9 @@ class InheritedSettingsLabelTest(SimpleTestCase):
         self.assertEqual(
             get_inherited_settings_label("workspace"), "Inherit from workspace"
         )
-        self.assertEqual(get_inherited_settings_label("project"), "Inherit from project")
+        self.assertEqual(
+            get_inherited_settings_label("project"), "Inherit from project"
+        )
         self.assertEqual(
             get_inherited_settings_label("category"), "Inherit from category"
         )


### PR DESCRIPTION
### Motivation
- Make inherited-settings scope explicit and type-safe instead of passing translated `parent_name` strings around.
- Ensure consistent, fully-translatable labels for inheritance checkboxes across component/project/category/workspace scopes.

### Description
- Add `InheritedSettingsScope` (`Literal["workspace", "project", "category"]`) and `get_inherited_settings_label` helper which returns the appropriate `gettext` label.
- Change `InheritedSettingsFormMixin.setup_inherited_settings` signature to accept `parent_scope: InheritedSettingsScope` and use the new label helper instead of formatting `parent_name` strings.
- Update form classes to compute and pass `parent_scope` (`ComponentSettingsForm`, `ComponentCreateForm.setup_create_inherited_settings`, `CategorySettingsForm`, and `ProjectSettingsForm`) when setting up inherited settings.
- Add unit test `InheritedSettingsLabelTest` in `weblate/trans/tests/test_forms.py` to assert the three scope labels are correct.

### Testing
- Ran the form tests in `weblate/trans/tests/test_forms.py` including `InheritedSettingsLabelTest`, and they passed.
- Ran the project test suite for the modified forms module with `pytest` and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4220cc5f6c83299c6052941fef2ee8)