### PR TITLE
docs(hosting): recommend Hosted Weblate GitHub App

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -16,8 +16,14 @@ Setup overview
 
 1. Grant Weblate access to the repository.
 
-   * For Hosted Weblate, add the hosted :guilabel:`weblate` user where it is
-     available, see :ref:`hosted-push`.
+   * For GitHub repositories on Hosted Weblate, use the
+     `Hosted Weblate app <https://github.com/apps/hosted-weblate>`_ from
+     Weblate's :guilabel:`Connect GitHub account` flow. The App gives Hosted
+     Weblate repository access without inviting the hosted :guilabel:`weblate`
+     user.
+   * For other Hosted Weblate repositories, and for direct SSH pushes outside
+     the GitHub App workflow, add the hosted :guilabel:`weblate` user where it
+     is available, see :ref:`hosted-push`.
    * For self-hosted Weblate, create a dedicated code hosting user and grant
      access using Weblate's SSH key or an HTTPS token, see
      :ref:`vcs-repos-code-hosting`.
@@ -188,6 +194,26 @@ GitHub
 GitHub repository access
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+Hosted Weblate GitHub App
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On Hosted Weblate, the recommended setup is to connect the
+`Hosted Weblate app <https://github.com/apps/hosted-weblate>`_ from the
+Weblate workspace where your project lives. Use the :guilabel:`Connect GitHub
+account` flow, install the App on the GitHub user or organization that owns
+your repositories, grant it access to the repositories you want to translate,
+and import components from the connected GitHub account.
+
+The App-backed workflow uses GitHub installation access tokens for cloning,
+pushing translation branches, creating pull requests, and receiving incoming
+notifications. You do not need to invite the Hosted Weblate
+:guilabel:`weblate` GitHub user or configure a separate repository webhook for
+components imported this way.
+
+Use the Hosted Weblate :guilabel:`weblate` GitHub user only when you
+intentionally configure direct SSH pushes outside the GitHub App workflow, see
+:ref:`hosted-push`.
+
 HTTPS with personal access token
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -212,8 +238,9 @@ For GitHub, create a dedicated user, for example ``weblate-bot``, and use
 GitHub SSH URLs for your repositories, for example
 ``git@github.com:owner/repo.git``.
 
-This approach is also used for Hosted Weblate, which has a dedicated
-:guilabel:`weblate` user for that purpose.
+On Hosted Weblate, use this SSH-user workflow only for direct SSH pushes outside
+the recommended `Hosted Weblate app <https://github.com/apps/hosted-weblate>`_
+workflow.
 
 .. note::
 
@@ -229,12 +256,13 @@ GitHub notifications
 
 Weblate comes with native support for GitHub.
 
-If you are using Hosted Weblate, the recommended approach for new installs is
-to install the `Hosted Weblate app <https://github.com/apps/hosted-weblate>`_.
-It uses the GitHub App integration documented below, so you do not need to
-configure a separate :guilabel:`Webhook` in GitHub. For direct pushes outside
-the App-backed workflow, add the Hosted Weblate :guilabel:`weblate` GitHub user
-as a collaborator with write access, see :ref:`hosted-push`.
+If you are using Hosted Weblate, use the
+`Hosted Weblate app <https://github.com/apps/hosted-weblate>`_ from
+Weblate's :guilabel:`Connect GitHub account` flow. It uses GitHub App
+webhooks, so you do not need to configure a separate :guilabel:`Webhook` in
+GitHub. Components imported from the connected GitHub account also use the App
+for repository access and pull requests, without inviting the Hosted Weblate
+:guilabel:`weblate` GitHub user.
 
 The `Hosted Weblate legacy app`_ is kept for existing webhook-only setups. Use
 it only when you need the legacy app to deliver GitHub notifications to Hosted

--- a/docs/snippets/code-hosting-ssh-repository-access.rst
+++ b/docs/snippets/code-hosting-ssh-repository-access.rst
@@ -18,5 +18,8 @@ Provider API credentials are still needed when using a provider-specific VCS
 backend to create pull or merge requests; those credentials are configured
 separately from the Git repository URL.
 
-On Hosted Weblate, use the hosted :guilabel:`weblate` user on supported code
-hosting sites, see :ref:`hosted-push`.
+On Hosted Weblate, use provider integrations where available. For GitHub, the
+recommended setup is the `Hosted Weblate app
+<https://github.com/apps/hosted-weblate>`_. For direct SSH access on supported
+code hosting sites, use the hosted :guilabel:`weblate` user, see
+:ref:`hosted-push`.

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -37,9 +37,18 @@ Accessing repositories from Hosted Weblate
    running your own self-hosted Weblate instance, please see
    :ref:`the next section <vcs-repos-code-hosting>` instead.
 
-For Hosted Weblate, there is a dedicated push user registered on GitHub,
-Bitbucket, Codeberg, and GitLab (with the username :guilabel:`weblate`, e-mail
-``hosted@weblate.org``, and a name or profile description :guilabel:`Weblate push user`).
+For GitHub repositories on Hosted Weblate, use the
+`Hosted Weblate app <https://github.com/apps/hosted-weblate>`_ from Weblate's
+:guilabel:`Connect GitHub account` flow whenever possible. The App grants
+repository access, receives incoming notifications, pushes translation
+branches, and creates pull requests without inviting the Hosted Weblate
+:guilabel:`weblate` user. See :ref:`code-hosting-github-repositories` for the
+full setup.
+
+For direct SSH access outside the GitHub App workflow, and for Bitbucket,
+Codeberg, and GitLab repositories, Hosted Weblate has a dedicated push user
+(with the username :guilabel:`weblate`, e-mail ``hosted@weblate.org``, and a
+name or profile description :guilabel:`Weblate push user`).
 
 .. hint::
 
@@ -52,17 +61,14 @@ repository (read-only is okay for cloning, write is required for pushing).
 Depending on the service and your organization’s settings, this happens immediately,
 or requires confirmation on the Weblate side.
 
-On GitHub, you need to add or invite the Hosted Weblate :guilabel:`weblate`
-user with write access even when you use the Hosted Weblate GitHub app. The
-app handles incoming notifications from GitHub, but pushing changes back
-still uses the Hosted Weblate :guilabel:`weblate` user.
+The :guilabel:`weblate` user on GitHub accepts invitations automatically within
+five minutes when you intentionally use direct SSH access there. Manual
+processing might be needed on the other services, so please be patient.
 
-The :guilabel:`weblate` user on GitHub accepts invitations automatically within five minutes.
-Manual processing might be needed on the other services, so please be patient.
-
-Once the :guilabel:`weblate` user is added to your repository, you can configure
-:ref:`component-repo` and :ref:`component-push` using the SSH protocol (for example
-``git@github.com:WeblateOrg/weblate.git``).
+For this direct SSH-user setup, once the :guilabel:`weblate` user is added to
+your repository, you can configure :ref:`component-repo` and
+:ref:`component-push` using the SSH protocol, for example
+``git@example.com:group/project.git``.
 
 .. _vcs-repos-code-hosting:
 


### PR DESCRIPTION
Hosted Weblate users should use the GitHub App connection for GitHub repositories instead of inviting the hosted weblate user. The App-backed flow grants repository access, handles GitHub notifications, pushes translation branches, and creates pull requests without relying on the Marketplace listing.

Clarify the setup overview, GitHub repository access, notification guidance, and Hosted Weblate repository access page so the hosted weblate user is documented only for direct SSH access outside the App workflow.

Fixes #20306

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
