### PR TITLE
fix(vcs): recover interrupted Git operations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -67,6 +67,7 @@ Weblate 2026.7
 * Anonymous permission checks no longer fail when loading teams scoped to projects or workspaces.
 * API project creation can again use the user's only eligible workspace when no explicit workspace is supplied.
 * Git auto-maintenance is now disabled for Weblate-managed repositories to avoid concurrent detached maintenance jobs.
+* Interrupted Git repository operations are now either recovered and recorded or surfaced as a repository alert.
 * Watched translations on the dashboard now include category path segments.
 * Unsupported upload levels now show an upload placeholder pointing to individual translations.
 * Component API responses no longer expose repository export, push branch, or repository browser links to users without repository access.

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -50,6 +50,18 @@ class GitSquashAddon(
     icon = "compress.svg"
     repo_scope = True
 
+    @staticmethod
+    def ensure_repository_clean(
+        component: Component, repository: GitRepository
+    ) -> None:
+        try:
+            repository.ensure_no_interrupted_operation()
+        except RepositoryError as error:
+            component.add_alert(
+                "RepositoryOperationFailure", error=component.error_text(error)
+            )
+            raise
+
     def squash_repo(
         self,
         component: Component,
@@ -57,8 +69,10 @@ class GitSquashAddon(
         remote: str,
         author: str | None = None,
     ) -> None:
+        self.ensure_repository_clean(component, repository)
         message = self.get_squash_commit_message(repository, "%B", remote)
         repository.execute(["reset", "--mixed", remote], remote_op="none")
+        self.ensure_repository_clean(component, repository)
         # Can happen for added and removed translation
         component.commit_files(
             author=author, message=message, signals=False, skip_push=True
@@ -280,6 +294,14 @@ class GitSquashAddon(
             self.squash_author_commits(
                 component, repository, commits, remote, tmp, gpg_sign
             )
+        except RepositoryError:
+            if repository.get_interrupted_operation() is not None:
+                raise
+            report_error("Failed squash", project=component.project)
+            # Revert to original branch without any changes
+            repository.execute(["reset", "--hard"], remote_op="none")
+            repository.execute(["checkout", repository.branch], remote_op="none")
+            repository.delete_branch(tmp)
         except Exception:
             report_error("Failed squash", project=component.project)
             # Revert to original branch without any changes
@@ -297,6 +319,7 @@ class GitSquashAddon(
         repository = cast("GitRepository", component.repository)
         branch_updated = False
         with repository.lock:
+            self.ensure_repository_clean(component, repository)
             # Ensure repository is rebased on current remote prior to squash, otherwise
             # we might be squashing upstream changes as well due to reset.
             if component.repo_needs_merge():

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -6276,6 +6276,53 @@ class GitSquashAddonTest(ViewTestCase):
     def test_squash_sitewide(self) -> None:
         self.test_squash(sitewide=True)
 
+    def test_squash_skips_interrupted_repository_operation(self) -> None:
+        addon = self.create("all")
+        repository = self.component.repository
+
+        with (
+            patch.object(
+                repository,
+                "ensure_no_interrupted_operation",
+                side_effect=RepositoryError(
+                    1, "Repository has an interrupted Git rebase operation."
+                ),
+            ),
+            self.assertRaises(RepositoryError),
+        ):
+            addon.post_commit(self.component, True)
+
+        alert = self.component.alert_set.get(name="RepositoryOperationFailure")
+        self.assertIn("interrupted Git rebase operation", alert.details["error"])
+
+    def test_author_squash_stops_on_interrupted_repository_operation(self) -> None:
+        addon = self.create("author")
+        repository = self.component.repository
+        error = RepositoryError(
+            1, "Repository has an interrupted Git cherry-pick operation."
+        )
+
+        with (
+            patch.object(
+                repository, "get_remote_branch_name", return_value="origin/main"
+            ),
+            patch.object(repository, "execute", return_value="") as execute,
+            patch.object(repository, "get_gpg_sign_args", return_value=[]),
+            patch.object(repository, "delete_branch"),
+            patch.object(
+                repository, "get_interrupted_operation", return_value="cherry-pick"
+            ),
+            patch.object(addon, "squash_author_commits", side_effect=error),
+            self.assertRaises(RepositoryError) as context,
+        ):
+            addon.squash_author(self.component, repository)
+
+        self.assertIs(context.exception, error)
+        execute.assert_called_once_with(
+            ["log", "--no-merges", "--format=%H %aE", "origin/main..HEAD"],
+            remote_op="none",
+        )
+
     def test_languages(self) -> None:
         self.test_squash("language", 2)
 

--- a/weblate/templates/trans/alert/repositoryoperationfailure.html
+++ b/weblate/templates/trans/alert/repositoryoperationfailure.html
@@ -1,0 +1,16 @@
+{% load i18n permissions %}
+
+<p>{% translate "Weblate could not recover an interrupted repository operation." %}</p>
+
+<pre>{{ error }}</pre>
+
+{% include "trans/alert/common-repo.html" %}
+
+{% perm 'vcs.reset' component as user_can_reset %}
+{% if user_can_reset %}
+  <p>
+    <a href="#"
+       class="btn btn-primary link-post"
+       data-href="{% url "reset" path=component.get_url_path %}">{% translate "Reset the repository" %}</a>
+  </p>
+{% endif %}

--- a/weblate/trans/alerts/vcs.py
+++ b/weblate/trans/alerts/vcs.py
@@ -137,6 +137,16 @@ class MergeFailure(ErrorAlert):
     doc_anchor = "merge"
 
 
+@register
+class RepositoryOperationFailure(ErrorAlert):
+    # Translators: Name of an alert
+    verbose = gettext_lazy("Could not recover the repository.")
+    category = AlertCategory.VCS
+    link_wide = True
+    doc_page = "admin/projects"
+    doc_anchor = "component-repo"
+
+
 class BaseGitFailure(ErrorAlert):
     category = AlertCategory.VCS
     link_wide = True

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -172,6 +172,7 @@ from weblate.utils.validators import (
 )
 from weblate.vcs.base import (
     RepositoryError,
+    RepositoryRecoveryEvent,
     RepositoryRestrictedPathError,
     RepositorySymlinkError,
     is_ssh_host_key_mismatch_error,
@@ -210,7 +211,13 @@ MERGE_CHOICES = (
     ("merge_noff", gettext_lazy("Merge without fast-forward")),
 )
 
-LOCKING_ALERTS = {"MergeFailure", "UpdateFailure", "PushFailure", "ParseError"}
+LOCKING_ALERTS = {
+    "MergeFailure",
+    "UpdateFailure",
+    "PushFailure",
+    "ParseError",
+    "RepositoryOperationFailure",
+}
 
 BITBUCKET_GIT_REPOS_REGEXP = [
     r"(?:ssh|https):\/\/(?:(?:git@|)bitbucket.org)\/([^/]*)\/([^/]*)",
@@ -2936,6 +2943,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
             self.delete_alert("MergeFailure")
             self.delete_alert("RepositoryOutdated")
             self.delete_alert("PushFailure")
+            self.delete_alert("RepositoryOperationFailure")
 
             if keep_changes and not self.restore_pending_translation_files(
                 request=request, user=user
@@ -2968,9 +2976,10 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         user = request.user if request else self.acting_user
         try:
-            previous_head = self.reset_repository_to_remote(
-                request, user, keep_changes=keep_changes
-            )
+            with self.repository.lock.without_recovery():
+                previous_head = self.reset_repository_to_remote(
+                    request, user, keep_changes=keep_changes
+                )
         except RepositoryError:
             report_error(
                 "Could not reset the repository",
@@ -3700,6 +3709,33 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
     def get_local_head_revision(self) -> str:
         return self.repository.last_revision
+
+    def handle_repository_recovery(
+        self, recovery_events: list[RepositoryRecoveryEvent]
+    ) -> None:
+        """Record automatic recovery from interrupted repository operations."""
+        if self._state.adding:
+            return
+        for event in recovery_events:
+            self.change_set.create(
+                action=ActionEvents.REPO_CLEANUP,
+                details={
+                    "recovery": True,
+                    "operation": event.operation,
+                    **event.details,
+                },
+            )
+        self.delete_alert("RepositoryOperationFailure")
+
+    def handle_repository_recovery_failure(self, error: Exception) -> None:
+        """Surface failed recovery from interrupted repository operations."""
+        if self._state.adding:
+            return
+        if isinstance(error, RepositoryError):
+            error_text = self.error_text(error)
+        else:
+            error_text = str(error)
+        self.add_alert("RepositoryOperationFailure", error=error_text)
 
     @perform_on_link
     @contextmanager

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -44,7 +44,7 @@ from weblate.trans.tests.test_views import (
 from weblate.utils.files import remove_tree
 from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import STATE_EMPTY, STATE_READONLY, STATE_TRANSLATED
-from weblate.vcs.base import RepositoryError
+from weblate.vcs.base import RepositoryError, RepositoryRecoveryEvent
 from weblate.vcs.git import GitRepository
 from weblate.vcs.github import GitHubInstallation
 from weblate.vcs.models import VCS_REGISTRY
@@ -69,6 +69,74 @@ class ComponentTest(RepoTestCase):
         self.assertTrue(queryset.query.select_for_update)
         self.assertEqual(queryset.query.select_for_update_of, ("self",))
         self.assertTrue(queryset.query.select_for_no_key_update)
+
+    def test_handle_repository_recovery_records_change_and_clears_alert(self) -> None:
+        component = self.create_component()
+        component.add_alert("RepositoryOperationFailure", error="failed")
+
+        component.handle_repository_recovery(
+            [RepositoryRecoveryEvent(operation="rebase", details={"branch": "main"})]
+        )
+
+        change = component.change_set.get(action=ActionEvents.REPO_CLEANUP)
+        self.assertEqual(
+            change.details,
+            {"recovery": True, "operation": "rebase", "branch": "main"},
+        )
+        self.assertFalse(
+            component.alert_set.filter(name="RepositoryOperationFailure").exists()
+        )
+
+    def test_handle_repository_recovery_failure_adds_alert(self) -> None:
+        component = self.create_component()
+
+        component.handle_repository_recovery_failure(
+            RepositoryError(128, "fatal: rebase abort failed")
+        )
+
+        alert = component.alert_set.get(name="RepositoryOperationFailure")
+        self.assertIn("fatal: rebase abort failed", alert.details["error"])
+
+    def test_clean_lock_recovery_clears_stale_failure_alert(self) -> None:
+        component = self.create_component()
+        component.add_alert("RepositoryOperationFailure", error="failed")
+        repository = component.repository
+        recover_lock_session = Mock(return_value=[])
+
+        with (
+            patch.object(repository, "recover_lock_session", recover_lock_session),
+            repository.lock,
+        ):
+            pass
+
+        recover_lock_session.assert_called_once_with()
+        self.assertFalse(
+            component.alert_set.filter(name="RepositoryOperationFailure").exists()
+        )
+
+    def test_reset_bypasses_failed_repository_recovery(self) -> None:
+        component = self.create_component()
+        repository = component.repository
+
+        def reset_repository_to_remote(request, user, *, keep_changes: bool):
+            with repository.lock:
+                return "old"
+
+        with (
+            patch.object(
+                repository,
+                "recover_lock_session",
+                side_effect=RepositoryError(128, "fatal: rebase abort failed"),
+            ) as recover_lock_session,
+            patch.object(
+                component,
+                "reset_repository_to_remote",
+                side_effect=reset_repository_to_remote,
+            ),
+        ):
+            self.assertTrue(component.do_reset(None))
+
+        recover_lock_session.assert_not_called()
 
     def verify_component(
         self,
@@ -2775,6 +2843,7 @@ class ResetDiscardRevisionTest(ComponentTestCase):
 
     def test_reset_updates_stored_local_revision(self) -> None:
         start_rev = self.component.repository.last_revision
+        self.component.add_alert("RepositoryOperationFailure", error="failed")
 
         self.change_unit("Ahoj svete!\n")
         self.component.commit_pending("test", self.user)
@@ -2789,6 +2858,9 @@ class ResetDiscardRevisionTest(ComponentTestCase):
         self.component.refresh_from_db()
         self.assertEqual(start_rev, self.component.repository.last_revision)
         self.assertEqual(start_rev, self.component.local_revision)
+        self.assertFalse(
+            self.component.alert_set.filter(name="RepositoryOperationFailure").exists()
+        )
 
     def test_file_scan_removes_stale_translation_with_change(self) -> None:
         translation = self.component.translation_set.get(language_code="cs")

--- a/weblate/utils/tests/test_lock.py
+++ b/weblate/utils/tests/test_lock.py
@@ -207,6 +207,51 @@ class RepositoryLockTest(SimpleTestCase):
                 self.assertTrue(inner_lock.begin_recovery())
                 inner_lock.finish_recovery()
 
+    def test_reused_lock_shares_active_recovery_skip(self) -> None:
+        with (
+            TemporaryDirectory() as lock_path,
+            patch("weblate.utils.lock.is_redis_cache", return_value=False),
+        ):
+            first_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+            second_lock = WeblateLock(
+                lock_path=lock_path,
+                scope="repository",
+                key=1,
+                slug="component",
+                timeout=5,
+                origin="project/component",
+            )
+            first_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=lambda: None),
+            )
+            second_recovery = MagicMock()
+            second_repository = cast(
+                "Repository",
+                SimpleNamespace(ensure_lock_session_recovered=second_recovery),
+            )
+            outer_lock = RepositoryLock(first_repository, first_lock)
+            inner_lock = RepositoryLock(second_repository, second_lock)
+
+            with outer_lock.without_recovery():
+                self.assertTrue(inner_lock.replace_lock_if_matching(outer_lock))
+                with inner_lock:
+                    pass
+
+            second_recovery.assert_not_called()
+
+            with inner_lock:
+                pass
+
+        second_recovery.assert_called_once_with()
+
     def test_component_repository_lock_name_is_stable_across_path_changes(self) -> None:
         with (
             TemporaryDirectory() as temp_dir,

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -12,11 +12,13 @@ import os
 import os.path
 import signal
 import subprocess  # ruff: ignore[suspicious-subprocess-import]
-from contextlib import suppress
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     ClassVar,
     Literal,
     NotRequired,
@@ -125,6 +127,17 @@ class CommitInfo(TypedDict):
 type RemoteOperation = Literal["none", "pull", "push"]
 
 
+@dataclass(slots=True)
+class RepositoryRecoveryEvent:
+    operation: str
+    details: dict[str, Any]
+
+
+@dataclass(slots=True)
+class RepositoryLockSkipState:
+    count: int = 0
+
+
 def parse_commit_date(value: str | datetime) -> datetime:
     """Parse a commit date string into a datetime object."""
     result = value if isinstance(value, datetime) else parser.parse(value)
@@ -139,6 +152,7 @@ class RepositoryLock:
         self._lock = lock
         self._recovery_pending = False
         self._recovering = False
+        self._skip_recovery = RepositoryLockSkipState()
 
     @property
     def lock_object(self) -> WeblateLock:
@@ -148,6 +162,7 @@ class RepositoryLock:
         self._lock = lock._lock
         self._recovery_pending = lock._recovery_pending
         self._recovering = lock._recovering
+        self._skip_recovery = lock._skip_recovery
 
     def replace_lock_if_matching(self, lock: Self) -> bool:
         if self._lock.name != lock._lock.name:
@@ -158,10 +173,11 @@ class RepositoryLock:
     def __enter__(self) -> None:
         outermost_enter = not self._lock.is_locked
         self._lock.__enter__()
-        if outermost_enter:
+        if outermost_enter and not self._skip_recovery.count:
             self._recovery_pending = True
         try:
-            self.repository.ensure_lock_session_recovered()
+            if not self._skip_recovery.count:
+                self.repository.ensure_lock_session_recovered()
         except Exception as error:
             self._lock.__exit__(type(error), error, error.__traceback__)
             if not self._lock.is_locked:
@@ -191,6 +207,14 @@ class RepositoryLock:
 
     def finish_recovery(self) -> None:
         self._recovering = False
+
+    @contextmanager
+    def without_recovery(self) -> Generator[None]:
+        self._skip_recovery.count += 1
+        try:
+            yield
+        finally:
+            self._skip_recovery.count -= 1
 
     def _reset_recovery_state(self) -> None:
         self._recovering = False
@@ -571,15 +595,21 @@ class Repository:
     def should_retry_popen(errormessage: str) -> bool:
         return False
 
-    def recover_lock_session(self) -> None:
+    def recover_lock_session(self) -> list[RepositoryRecoveryEvent]:
         self.cleanup_repo_temp_dir()
+        return []
 
     def ensure_lock_session_recovered(self) -> None:
         if not self.lock.begin_recovery():
             return
         try:
-            self.recover_lock_session()
-        except Exception:
+            recovery_events = self.recover_lock_session()
+            if self.component is not None:
+                self.component.handle_repository_recovery(recovery_events)
+        except Exception as error:
+            if self.component is not None:
+                with suppress(Exception):
+                    self.component.handle_repository_recovery_failure(error)
             self.lock.fail_recovery()
             raise
         self.lock.finish_recovery()

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -60,6 +60,7 @@ from weblate.vcs.base import (
     Repository,
     RepositoryCommandError,
     RepositoryError,
+    RepositoryRecoveryEvent,
 )
 from weblate.vcs.gpg import get_gpg_sign_key
 
@@ -88,6 +89,7 @@ RECOVERABLE_ABORT_LOCKS = frozenset(
         "MERGE_HEAD.lock",
         "ORIG_HEAD.lock",
         "REBASE_HEAD.lock",
+        "REVERT_HEAD.lock",
     }
 )
 
@@ -303,28 +305,81 @@ class GitRepository(Repository):
             ("gc", "auto", "0"),
         )
 
-    def recover_lock_session(self) -> None:
-        super().recover_lock_session()
-        if not self.is_valid():
-            return
-        current_branch = self.get_current_branch()
-        merge_in_progress = self.has_git_file("MERGE_HEAD")
-        rebase_in_progress = self.has_git_file("rebase-apply") or self.has_git_file(
-            "rebase-merge"
-        )
-        if merge_in_progress:
-            with suppress(RepositoryCommandError):
+    def get_interrupted_operation(self) -> str | None:
+        if self.has_git_file("rebase-apply") or self.has_git_file("rebase-merge"):
+            return "rebase"
+        if self.has_git_file("MERGE_HEAD"):
+            return "merge"
+        if self.has_git_file("CHERRY_PICK_HEAD"):
+            return "cherry-pick"
+        if self.has_git_file("REVERT_HEAD"):
+            return "revert"
+        return None
+
+    def ensure_no_interrupted_operation(self) -> None:
+        operation = self.get_interrupted_operation()
+        if operation is not None:
+            msg = gettext(
+                "Repository has an interrupted Git %(operation)s operation."
+            ) % {"operation": operation}
+            raise RepositoryError(1, msg)
+
+    def abort_interrupted_operation(self, operation: str) -> None:
+        match operation:
+            case "merge":
                 self.merge(abort=True)
-        if rebase_in_progress:
-            with suppress(RepositoryCommandError):
+            case "rebase":
                 self.rebase(abort=True)
+            case "cherry-pick":
+                self.execute_abort(["cherry-pick", "--abort"])
+                if self.needs_commit():
+                    self.execute(["reset", "--hard"], remote_op="none")
+            case "revert":
+                self.execute_abort(["revert", "--abort"])
+                if self.needs_commit():
+                    self.execute(["reset", "--hard"], remote_op="none")
+            case _:
+                msg = gettext(
+                    "Unsupported interrupted Git operation: %(operation)s"
+                ) % {"operation": operation}
+                raise RepositoryError(1, msg)
+        self.clean_revision_cache()
+
+    def recover_lock_session(self) -> list[RepositoryRecoveryEvent]:
+        recovery_events = super().recover_lock_session()
+        if not self.is_valid():
+            return recovery_events
+        current_branch = self.get_current_branch()
+        while operation := self.get_interrupted_operation():
+            self.abort_interrupted_operation(operation)
+            if self.get_interrupted_operation() is not None:
+                msg = gettext(
+                    "Could not recover interrupted Git %(operation)s operation."
+                ) % {"operation": operation}
+                raise RepositoryError(1, msg)
+            recovery_events.append(
+                RepositoryRecoveryEvent(
+                    operation=operation,
+                    details={"branch": current_branch},
+                )
+            )
         if current_branch not in TEMPORARY_BRANCHES:
-            return
+            return recovery_events
         self.execute(["reset", "--hard"], remote_op="none")
         self.checkout_with_temp_cleanup(self.branch)
         with suppress(RepositoryCommandError):
             self.execute(["branch", "-D", current_branch], remote_op="none")
         self.clean_revision_cache()
+        recovery_events.append(
+            RepositoryRecoveryEvent(
+                operation="temporary-branch",
+                details={
+                    "branch": current_branch,
+                    "target_branch": self.branch,
+                },
+            )
+        )
+        return recovery_events
 
     def get_current_branch(self) -> str:
         return self.execute(
@@ -506,12 +561,37 @@ class GitRepository(Repository):
         """Configure committer name."""
         self.config_update(("user", "name", name), ("user", "email", mail))
 
+    def clear_interrupted_operation(self) -> None:
+        """Clear interrupted Git operation metadata before a hard reset."""
+        for directory in ("rebase-apply", "rebase-merge", "sequencer"):
+            remove_tree(self.get_git_file_path(directory), ignore_errors=True)
+        for filename in (
+            "AUTO_MERGE",
+            "CHERRY_PICK_HEAD",
+            "MERGE_HEAD",
+            "MERGE_MODE",
+            "MERGE_MSG",
+            "REBASE_HEAD",
+            "REVERT_HEAD",
+        ):
+            with suppress(OSError):
+                self.get_git_file_path(filename).unlink()
+
     def reset(self) -> None:
         """Reset working copy to match remote branch."""
+        self.clear_interrupted_operation()
+        current_branch = self.get_current_branch()
+        local_branch = self.get_local_branch_name()
+        if current_branch != local_branch:
+            self.execute(["checkout", "--force", local_branch], remote_op="none")
+            if current_branch in TEMPORARY_BRANCHES:
+                with suppress(RepositoryCommandError):
+                    self.execute(["branch", "-D", current_branch], remote_op="none")
         self.execute(
             ["reset", "--hard", self.get_remote_branch_name()],
             remote_op="none",
         )
+        self.clear_interrupted_operation()
         self.clean_revision_cache()
 
     def reset_to_revision(self, revision: str) -> None:
@@ -559,9 +639,14 @@ class GitRepository(Repository):
         except RepositoryCommandError as error:
             if not self.cleanup_interrupted_abort_lock(error.args[0]):
                 raise
-            self.execute(args, remote_op="none")
+            if self.get_interrupted_operation() == args[0]:
+                self.execute(args, remote_op="none")
         else:
-            self.cleanup_interrupted_abort_lock(output)
+            if (
+                self.cleanup_interrupted_abort_lock(output)
+                and self.get_interrupted_operation() == args[0]
+            ):
+                self.execute(args, remote_op="none")
 
     def rebase(self, abort=False) -> None:
         """Rebase working copy on top of remote branch."""
@@ -1272,7 +1357,7 @@ class SubversionRepository(GitRepository):
         Git-svn does not support merge.
         """
         if abort:
-            self.execute(["rebase", "--abort"], remote_op="none")
+            self.execute_abort(["rebase", "--abort"])
         else:
             self.execute(["svn", "rebase"], remote_op="pull")
         self.clean_revision_cache()
@@ -1396,7 +1481,7 @@ class GitMergeRequestBase(GitForcePushRepository):
         # as we're expecting there will be an additional merge
         # commit created from the merge request.
         if abort:
-            self.execute(["merge", "--abort"], remote_op="none")
+            self.execute_abort(["merge", "--abort"])
             # Needed for compatibility with original merge code
             self.execute(["checkout", current_branch], remote_op="none")
         else:

--- a/weblate/vcs/tests/test_github_models.py
+++ b/weblate/vcs/tests/test_github_models.py
@@ -6,15 +6,13 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import cast
 from unittest.mock import patch
 
 import responses
 from django.core.cache import cache
 from django.test import TestCase
 
-from weblate.trans.models import Component
+from weblate.trans.models import Component, Project
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.github import (
     GitHubAppCredentials,
@@ -64,22 +62,31 @@ class TestGitHubInstallationManager(TestCase):
             repositories=[{"full_name": "test-org/repo1"}]
         )
 
+    def _make_component(
+        self,
+        repo: str = "https://github.com/test-org/repo1.git",
+        *,
+        has_workspace: bool = True,
+        push: str = "",
+    ) -> Component:
+        project = Project(
+            id=1,
+            name="Test",
+            slug="test",
+            workspace=self.installation.workspace if has_workspace else None,
+        )
+        return Component(
+            name="Component",
+            slug="component",
+            project=project,
+            repo=repo,
+            push=push,
+        )
+
     def _make_app_repository(
         self, repo: str = "https://github.com/test-org/repo1.git"
     ) -> GithubAppRepository:
-        component = cast(
-            "Component",
-            SimpleNamespace(
-                pk=None,
-                full_slug="test/project/component",
-                project_id=1,
-                project=SimpleNamespace(
-                    workspace_id=self.installation.workspace_id,
-                    workspace=self.installation.workspace,
-                ),
-                repo=repo,
-            ),
-        )
+        component = self._make_component(repo)
         return GithubAppRepository(".", branch="main", component=component, local=True)
 
     def test_get_for_repo(self):
@@ -282,16 +289,7 @@ class TestGitHubInstallationManager(TestCase):
 
     @responses.activate
     def test_github_repository_instance_auth_requires_workspace(self):
-        component = cast(
-            "Component",
-            SimpleNamespace(
-                pk=None,
-                full_slug="test/project/component",
-                project_id=1,
-                project=SimpleNamespace(workspace_id=None, workspace=None),
-                repo="https://github.com/test-org/repo1.git",
-            ),
-        )
+        component = self._make_component(has_workspace=False)
         repository = GithubAppRepository(
             ".", branch="main", component=component, local=True
         )
@@ -317,20 +315,7 @@ class TestGitHubInstallationManager(TestCase):
             "https://api.github.com/app/installations/67890/access_tokens",
             status=500,
         )
-        component = cast(
-            "Component",
-            SimpleNamespace(
-                pk=None,
-                full_slug="test/project/component",
-                project_id=1,
-                project=SimpleNamespace(
-                    workspace_id=self.installation.workspace_id,
-                    workspace=self.installation.workspace,
-                ),
-                repo="https://github.com/test-org/repo1.git",
-                push="",
-            ),
-        )
+        component = self._make_component()
         repository = GithubAppRepository(
             ".", branch="main", component=component, local=True
         )
@@ -351,19 +336,7 @@ class TestGitHubInstallationManager(TestCase):
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
-        component = cast(
-            "Component",
-            SimpleNamespace(
-                pk=None,
-                full_slug="test/project/component",
-                project_id=1,
-                project=SimpleNamespace(
-                    workspace_id=self.installation.workspace_id,
-                    workspace=self.installation.workspace,
-                ),
-                repo="https://github.com/test-org/repo1.git",
-            ),
-        )
+        component = self._make_component()
         repository = GithubAppRepository(
             ".", branch="main", component=component, local=True
         )
@@ -389,19 +362,7 @@ class TestGitHubInstallationManager(TestCase):
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
-        component = cast(
-            "Component",
-            SimpleNamespace(
-                pk=None,
-                full_slug="test/project/component",
-                project_id=1,
-                project=SimpleNamespace(
-                    workspace_id=self.installation.workspace_id,
-                    workspace=self.installation.workspace,
-                ),
-                repo="https://github.com/test-org/repo1.git",
-            ),
-        )
+        component = self._make_component()
         repository = GithubAppRepository(
             ".", branch="main", component=component, local=True
         )
@@ -433,19 +394,7 @@ class TestGitHubInstallationManager(TestCase):
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
-        component = cast(
-            "Component",
-            SimpleNamespace(
-                pk=None,
-                full_slug="test/project/component",
-                project_id=1,
-                project=SimpleNamespace(
-                    workspace_id=self.installation.workspace_id,
-                    workspace=self.installation.workspace,
-                ),
-                repo="https://github.com/test-org/repo1.git",
-            ),
-        )
+        component = self._make_component()
         repository = GithubAppRepository(
             ".", branch="main", component=component, local=True
         )

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -424,6 +424,26 @@ class RepositoryTest(SimpleTestCase):
                 with repo.lock:
                     self.assertEqual(recover_lock_session.call_count, 2)
 
+    def test_lock_session_recovery_can_be_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_path = Path(tempdir)
+            (repo_path / ".hg").mkdir()
+
+            repo = HgRepository(tempdir, local=True)
+
+            with (
+                patch.object(
+                    repo,
+                    "recover_lock_session",
+                    side_effect=RepositoryError(128, "recovery failed"),
+                ) as recover_lock_session,
+                repo.lock.without_recovery(),
+                repo.lock,
+            ):
+                pass
+
+            recover_lock_session.assert_not_called()
+
     def test_git_lock_session_recovery_aborts_interrupted_rebase(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo, git_dir = self.create_git_repository(
@@ -443,6 +463,7 @@ class RepositoryTest(SimpleTestCase):
                             128,
                             f"fatal: cannot lock ref 'CHERRY_PICK_HEAD': Unable to create '{lockfile}': File exists.",
                         )
+                    (git_dir / "rebase-merge").rmdir()
                     return ""
                 msg = f"Unexpected command: {args!r}"
                 raise AssertionError(msg)
@@ -472,10 +493,13 @@ class RepositoryTest(SimpleTestCase):
                 nonlocal abort_attempts
                 if args == ["rebase", "--abort"]:
                     abort_attempts += 1
-                    return (
-                        "warning: cleanup failed\n"
-                        f"Unable to create '{lockfile}': File exists."
-                    )
+                    if abort_attempts == 1:
+                        return (
+                            "warning: cleanup failed\n"
+                            f"Unable to create '{lockfile}': File exists."
+                        )
+                    (git_dir / "rebase-merge").rmdir()
+                    return ""
                 msg = f"Unexpected command: {args!r}"
                 raise AssertionError(msg)
 
@@ -485,7 +509,7 @@ class RepositoryTest(SimpleTestCase):
             with repo.lock:
                 pass
 
-            self.assertEqual(abort_attempts, 1)
+            self.assertEqual(abort_attempts, 2)
             self.assertFalse(lockfile.exists())
 
     def test_git_lock_session_recovery_aborts_interrupted_rebase_with_branch_ref_lock(
@@ -509,6 +533,7 @@ class RepositoryTest(SimpleTestCase):
                             128,
                             f"fatal: cannot lock ref 'refs/heads/main': Unable to create '{lockfile}': File exists.",
                         )
+                    (git_dir / "rebase-merge").rmdir()
                     return ""
                 msg = f"Unexpected command: {args!r}"
                 raise AssertionError(msg)
@@ -521,6 +546,111 @@ class RepositoryTest(SimpleTestCase):
 
             self.assertEqual(abort_attempts, 2)
             self.assertFalse(lockfile.exists())
+
+    def test_git_lock_session_recovery_reports_failed_rebase_abort(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo, git_dir = self.create_git_repository(
+                tempdir, git_dirs=("rebase-merge",)
+            )
+
+            def mocked_execute(args: list[str], **kwargs) -> str:
+                if args == ["rebase", "--abort"]:
+                    raise RepositoryCommandError(128, "fatal: rebase abort failed")
+                msg = f"Unexpected command: {args!r}"
+                raise AssertionError(msg)
+
+            self.mock_interrupted_git_rebase_recovery(
+                repo, execute_side_effect=mocked_execute
+            )
+            with self.assertRaises(RepositoryCommandError), repo.lock:
+                pass
+
+            self.assertTrue((git_dir / "rebase-merge").exists())
+
+    def test_git_reset_clears_interrupted_operation_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo, git_dir = self.create_git_repository(
+                tempdir, git_dirs=("rebase-merge", "sequencer")
+            )
+            for filename in (
+                "AUTO_MERGE",
+                "CHERRY_PICK_HEAD",
+                "MERGE_HEAD",
+                "MERGE_MODE",
+                "MERGE_MSG",
+                "REBASE_HEAD",
+                "REVERT_HEAD",
+            ):
+                (git_dir / filename).touch()
+
+            with (
+                patch.object(repo, "get_current_branch", return_value="main"),
+                patch.object(repo, "execute", return_value="") as execute,
+            ):
+                repo.reset()
+
+            execute.assert_called_once_with(
+                ["reset", "--hard", "origin/main"], remote_op="none"
+            )
+            self.assertFalse((git_dir / "rebase-merge").exists())
+            self.assertFalse((git_dir / "sequencer").exists())
+            self.assertIsNone(repo.get_interrupted_operation())
+
+    def test_git_reset_checks_out_real_branch_from_temporary_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo, _ = self.create_git_repository(tempdir)
+
+            with (
+                patch.object(
+                    repo, "get_current_branch", return_value="weblate-squash-tmp"
+                ),
+                patch.object(repo, "execute", return_value="") as execute,
+            ):
+                repo.reset()
+
+            self.assertEqual(
+                execute.call_args_list,
+                [
+                    call(["checkout", "--force", "main"], remote_op="none"),
+                    call(["branch", "-D", "weblate-squash-tmp"], remote_op="none"),
+                    call(["reset", "--hard", "origin/main"], remote_op="none"),
+                ],
+            )
+
+    def test_git_reset_reattaches_detached_head_to_real_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo, _ = self.create_git_repository(tempdir)
+
+            with (
+                patch.object(repo, "get_current_branch", return_value=""),
+                patch.object(repo, "execute", return_value="") as execute,
+            ):
+                repo.reset()
+
+            self.assertEqual(
+                execute.call_args_list,
+                [
+                    call(["checkout", "--force", "main"], remote_op="none"),
+                    call(["reset", "--hard", "origin/main"], remote_op="none"),
+                ],
+            )
+
+    def test_gerrit_reset_uses_local_branch_without_push_options(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = GitWithGerritRepository(
+                tempdir, branch="main%topic=l10n", local=True
+            )
+
+            with (
+                patch.object(GitWithGerritRepository, "_popen", return_value=""),
+                patch.object(repo, "get_current_branch", return_value="main"),
+                patch.object(repo, "execute", return_value="") as execute,
+            ):
+                repo.reset()
+
+            execute.assert_called_once_with(
+                ["reset", "--hard", "origin/main"], remote_op="none"
+            )
 
     def test_execute_abort_preserves_fresh_lock(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -542,6 +672,160 @@ class RepositoryTest(SimpleTestCase):
 
             execute.assert_called_once_with(["rebase", "--abort"], remote_op="none")
             self.assertTrue(lockfile.exists())
+
+    def test_execute_abort_retries_after_zero_exit_lock_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo, git_dir = self.create_git_repository(tempdir)
+            (git_dir / "CHERRY_PICK_HEAD").touch()
+            lockfile = git_dir / "CHERRY_PICK_HEAD.lock"
+            self.make_stale_lock(lockfile)
+
+            execute_attempts = 0
+
+            def mocked_execute(args: list[str], **kwargs) -> str:
+                nonlocal execute_attempts
+                if args == ["cherry-pick", "--abort"]:
+                    execute_attempts += 1
+                    if execute_attempts == 1:
+                        return (
+                            "warning: cleanup failed\n"
+                            f"Unable to create '{lockfile}': File exists."
+                        )
+                    return ""
+                msg = f"Unexpected command: {args!r}"
+                raise AssertionError(msg)
+
+            _, execute = self.enter_patch_contexts(
+                patch.object(repo, "ensure_lock_session_recovered"),
+                patch.object(repo, "execute", side_effect=mocked_execute),
+            )
+            with repo.lock:
+                repo.execute_abort(["cherry-pick", "--abort"])
+
+            self.assertEqual(execute_attempts, 2)
+            self.assertFalse(lockfile.exists())
+            self.assertEqual(
+                execute.call_args_list,
+                [
+                    call(["cherry-pick", "--abort"], remote_op="none"),
+                    call(["cherry-pick", "--abort"], remote_op="none"),
+                ],
+            )
+
+    def test_execute_abort_skips_retry_after_zero_exit_clears_operation(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo, git_dir = self.create_git_repository(
+                tempdir, git_dirs=("rebase-merge",)
+            )
+            lockfile = git_dir / "REBASE_HEAD.lock"
+            self.make_stale_lock(lockfile)
+
+            def mocked_execute(args: list[str], **kwargs) -> str:
+                if args == ["rebase", "--abort"]:
+                    (git_dir / "rebase-merge").rmdir()
+                    return (
+                        "warning: cleanup failed\n"
+                        f"Unable to create '{lockfile}': File exists."
+                    )
+                msg = f"Unexpected command: {args!r}"
+                raise AssertionError(msg)
+
+            _, execute = self.enter_patch_contexts(
+                patch.object(repo, "ensure_lock_session_recovered"),
+                patch.object(repo, "execute", side_effect=mocked_execute),
+            )
+            with repo.lock:
+                repo.execute_abort(["rebase", "--abort"])
+
+            self.assertFalse(lockfile.exists())
+            execute.assert_called_once_with(["rebase", "--abort"], remote_op="none")
+
+    def test_execute_abort_recovers_stale_revert_head_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo, git_dir = self.create_git_repository(tempdir)
+            (git_dir / "REVERT_HEAD").touch()
+            lockfile = git_dir / "REVERT_HEAD.lock"
+            self.make_stale_lock(lockfile)
+
+            error = RepositoryCommandError(
+                128,
+                f"fatal: cannot lock ref 'REVERT_HEAD': Unable to create '{lockfile}': File exists.",
+            )
+
+            _, execute = self.enter_patch_contexts(
+                patch.object(repo, "ensure_lock_session_recovered"),
+                patch.object(repo, "execute", side_effect=[error, ""]),
+            )
+            with repo.lock:
+                repo.execute_abort(["revert", "--abort"])
+
+            self.assertFalse(lockfile.exists())
+            self.assertEqual(
+                execute.call_args_list,
+                [
+                    call(["revert", "--abort"], remote_op="none"),
+                    call(["revert", "--abort"], remote_op="none"),
+                ],
+            )
+
+    def test_merge_request_abort_recovers_stale_merge_head_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            _, git_dir = self.create_git_repository(tempdir)
+            repo = GitMergeRequestBase(tempdir, branch="main", local=True)
+            (git_dir / "MERGE_HEAD").touch()
+            lockfile = git_dir / "MERGE_HEAD.lock"
+            self.make_stale_lock(lockfile)
+
+            error = RepositoryCommandError(
+                128,
+                f"fatal: Unable to create '{lockfile}': File exists.",
+            )
+
+            _, _, execute = self.enter_patch_contexts(
+                patch.object(repo, "ensure_lock_session_recovered"),
+                patch.object(repo, "validate_branch_name", return_value="main"),
+                patch.object(repo, "execute", side_effect=[error, "", ""]),
+            )
+            with repo.lock:
+                repo.merge(abort=True)
+
+            self.assertFalse(lockfile.exists())
+            self.assertEqual(
+                execute.call_args_list,
+                [
+                    call(["merge", "--abort"], remote_op="none"),
+                    call(["merge", "--abort"], remote_op="none"),
+                    call(["checkout", "main"], remote_op="none"),
+                ],
+            )
+
+    def test_subversion_rebase_abort_recovers_stale_rebase_head_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            _, git_dir = self.create_git_repository(tempdir, git_dirs=("rebase-merge",))
+            repo = SubversionRepository(tempdir, branch="main", local=True)
+            lockfile = git_dir / "REBASE_HEAD.lock"
+            self.make_stale_lock(lockfile)
+
+            error = RepositoryCommandError(
+                128,
+                f"fatal: Unable to create '{lockfile}': File exists.",
+            )
+
+            _, execute = self.enter_patch_contexts(
+                patch.object(repo, "ensure_lock_session_recovered"),
+                patch.object(repo, "execute", side_effect=[error, ""]),
+            )
+            with repo.lock:
+                repo.rebase(abort=True)
+
+            self.assertFalse(lockfile.exists())
+            self.assertEqual(
+                execute.call_args_list,
+                [
+                    call(["rebase", "--abort"], remote_op="none"),
+                    call(["rebase", "--abort"], remote_op="none"),
+                ],
+            )
 
     def test_git_lock_session_recovery_preserves_temp_branch_cleanup(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
Interrupted Git commands can leave rebase, merge, cherry-pick, or revert metadata behind when a worker exits during repository maintenance. Previously, lock recovery attempted to abort only merge and rebase operations and suppressed abort failures, which could leave the checkout in a confusing state without a Change-table entry or alert explaining what went wrong.

Return recovery events from lock-session recovery, record successful automatic recovery as repository cleanup changes, and surface failed recovery through a repository alert. Stop Git squash before rewriting the index when an interrupted operation is still present, including before reset --mixed can turn that state into a squashed commit.

Add the alert UI, focused recovery and squash tests, and a changelog entry for the visible behavior change.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
