### PR TITLE
feat(search): keep replace preview parameters editable

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,8 @@ Weblate 2026.7
 * :ref:`addon-weblate.fedora_messaging.publish` now validates secure broker connections and exposes delivery timing settings.
 * Component diagnostics now sort entries by severity, color-code severity badges, and show the error count on the :guilabel:`Diagnostics` tab.
 * :ref:`manage-performance` now shows PostgreSQL database disk usage next to server disk usage and warns when the database usage cannot be collected.
+* :ref:`manage-performance` now shows PostgreSQL database disk usage next to server disk usage and warns when the database usage cannot be collected or there is not enough free space in the backup destination to store a database dump.
+* The :ref:`search-replace` preview now keeps the search parameters editable so the query can be refined before applying replacements.
 
 .. rubric:: Bug fixes
 

--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -500,6 +500,8 @@ strings using :guilabel:`Search and replace` in the :guilabel:`Operations` menu.
 
     Don't worry about messing up the strings, as it is a two-step process.
     A preview of edited strings is shown before confirming the change.
+    You can adjust the search parameters from the preview and update it before
+    applying the replacement.
 
 .. _bulk-edit:
 

--- a/weblate/templates/replace.html
+++ b/weblate/templates/replace.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n icons translations %}
+{% load crispy_forms_tags i18n icons translations %}
 
 {% block breadcrumbs %}
   {% path_object_breadcrumbs path_object %}
@@ -17,12 +17,15 @@
     {% show_message "warning" msg %}
   {% endif %}
 
+  <form method="post" class="result-page-form">
+    {% csrf_token %}
+    {% crispy form %}
+    <input type="submit" class="btn btn-primary" value="{% translate "Update preview" %}" />
+  </form>
+
   <form method="post">
     {% csrf_token %}
-    {{ form.q.as_hidden }}
-    {{ form.search.as_hidden }}
-    {{ form.replacement.as_hidden }}
-    {{ confirm.confirm }}
+    {% for field in confirm.hidden_fields %}{{ field }}{% endfor %}
 
     <table class="table replace-preview">
       {% for unit in matching %}
@@ -50,7 +53,7 @@
         </tr>
       {% endfor %}
     </table>
-    <input type="submit" class="btn btn-primary" value="{% translate "Replace" %}" />
+    <button type="submit" class="btn btn-primary">{% translate "Replace" %}</button>
   </form>
 
 {% endblock content %}

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -3783,10 +3783,19 @@ class ReplaceForm(forms.Form):
 
 
 class ReplaceConfirmForm(forms.Form):
+    q = forms.CharField(required=False, widget=forms.HiddenInput)
+    path = forms.CharField(required=False, widget=forms.HiddenInput)
+    search = forms.CharField(
+        min_length=1, required=True, strip=False, widget=forms.HiddenInput
+    )
+    replacement = forms.CharField(
+        min_length=1, required=True, strip=False, widget=forms.HiddenInput
+    )
     units = forms.ModelMultipleChoiceField(queryset=Unit.objects.none(), required=False)
     confirm = forms.BooleanField(required=True, initial=True, widget=forms.HiddenInput)
 
     def __init__(self, units, *args, **kwargs) -> None:
+        kwargs.setdefault("auto_id", False)
         super().__init__(*args, **kwargs)
         self.fields["units"].queryset = units
 

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -556,6 +556,56 @@ class ReplaceTest(ViewTestCase):
     def test_replace(self) -> None:
         self.do_replace_test(reverse("replace", kwargs=self.kw_translation))
 
+    def test_replace_preview_parameters_are_editable(self) -> None:
+        url = reverse("replace", kwargs=self.kw_translation)
+
+        response = self.client.post(
+            url,
+            {"q": "", "search": "Nazdar", "replacement": "Ahoj"},
+            follow=True,
+        )
+
+        self.assertContains(
+            response, "Please review and confirm the search and replace results."
+        )
+        self.assertContains(response, "Update preview")
+        self.assertContains(response, 'id="id_replace_search"')
+        self.assertContains(response, 'id="id_replace_replacement"')
+        content = response.content.decode()
+        self.assertEqual(content.count('id="id_replace_search"'), 1)
+        self.assertEqual(content.count('id="id_replace_replacement"'), 1)
+
+        response = self.client.post(
+            url,
+            {"q": "", "search": "Nazdar", "replacement": "Cau"},
+            follow=True,
+        )
+
+        unit = self.get_unit()
+        self.assertContains(
+            response, "Please review and confirm the search and replace results."
+        )
+        self.assertContains(response, 'value="Cau"')
+        self.assertEqual(unit.target, "Nazdar svete!\n")
+
+        response = self.client.post(
+            url,
+            {
+                "q": "",
+                "search": "Nazdar",
+                "replacement": "Cau",
+                "confirm": "1",
+                "units": unit.pk,
+            },
+            follow=True,
+        )
+
+        self.assertContains(
+            response, "Search and replace completed, 1 string was updated."
+        )
+        unit = self.get_unit()
+        self.assertEqual(unit.target, "Cau svete!\n")
+
     def test_replace_project(self) -> None:
         self.do_replace_test(
             reverse("replace", kwargs={"path": self.project.get_url_path()})

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -91,6 +91,12 @@ def search_replace(request: AuthenticatedHttpRequest, path):
 
         matching = Unit.objects.filter(id__in=matching_ids).prefetch()
 
+        confirm_initial = {
+            "q": query,
+            "path": form.cleaned_data.get("path", ""),
+            "search": search_text,
+            "replacement": replacement,
+        }
         confirm = ReplaceConfirmForm(matching, request.POST)
 
         if not confirm.is_valid():
@@ -104,7 +110,7 @@ def search_replace(request: AuthenticatedHttpRequest, path):
                     "replacement": replacement,
                     "form": form,
                     "limited": limited,
-                    "confirm": ReplaceConfirmForm(matching),
+                    "confirm": ReplaceConfirmForm(matching, initial=confirm_initial),
                 }
             )
             return render(request, "replace.html", context)


### PR DESCRIPTION
Keep the search and replace form visible on the preview page so maintainers can refine complex queries, search strings, and replacement text before applying changes.

Fixes #19775

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
