### PR TITLE
fix(vcs): post GitHub app manifests directly

### DIFF
--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -316,6 +316,7 @@ class CSPBuilder:
         self.request = request
         self.response = response
         self.apply_csp_settings()
+        self.apply_request_csp_settings()
         self.build_csp_inline()
         self.build_csp_sentry()
         self.build_csp_piwik()
@@ -338,6 +339,12 @@ class CSPBuilder:
             value = getattr(settings, name)
             if value:
                 self.directives[rule].update(value)
+
+    def apply_request_csp_settings(self) -> None:
+        form_action_sources = getattr(self.request, "csp_form_action_sources", ())
+        if isinstance(form_action_sources, str):
+            form_action_sources = (form_action_sources,)
+        self.directives["form-action"].update(form_action_sources)
 
     def add_csp_host(self, url: str, *directives: CSP_KIND) -> str | None:
         domain = urlparse(url).hostname

--- a/weblate/templates/vcs/github_app_register.html
+++ b/weblate/templates/vcs/github_app_register.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n %}
+{% load crispy_forms_tags i18n %}
 
 {% block breadcrumbs %}
   <li class="breadcrumb-item">
@@ -29,12 +29,12 @@
       </p>
 
       {% if existing_hosts %}
-        <div class="alert {% if host_already_registered %}alert-danger{% else %}alert-info{% endif %}">
+        <div class="alert {% if host_already_registered %}alert-warning{% else %}alert-info{% endif %}">
           {% if host_already_registered %}
             {% blocktranslate trimmed with host=hostname %}
-              A Weblate GitHub App is already registered for <code>{{ host }}</code>.
-              Remove it from the Weblate GitHub Apps page before registering a
-              replacement.
+              The <code>{{ host }}</code> host already has stored GitHub App
+              credentials. You can edit the form, but submitting this host
+              again will be rejected.
             {% endblocktranslate %}
           {% else %}
             {% translate "GitHub hosts that already have a Weblate GitHub App registered:" %}
@@ -48,83 +48,7 @@
 
       <form method="post" action="{% url 'github-app-register-submit' %}">
         {% csrf_token %}
-        <div class="mb-3 row">
-          <label for="register-host" class="col-sm-3 col-form-label">{% translate "GitHub host" %}</label>
-          <div class="col-sm-9">
-            <input type="text"
-                   id="register-host"
-                   name="host"
-                   class="form-control"
-                   value="{{ hostname }}"
-                   placeholder="github.com">
-            <div class="form-text">
-              {% blocktranslate trimmed %}
-                Use github.com for GitHub.com, or the web hostname for GitHub
-                Enterprise Server.
-              {% endblocktranslate %}
-            </div>
-          </div>
-        </div>
-        <div class="mb-3 row">
-          <label for="register-org" class="col-sm-3 col-form-label">{% translate "Organization (optional)" %}</label>
-          <div class="col-sm-9">
-            <input type="text"
-                   id="register-org"
-                   name="org"
-                   class="form-control"
-                   value="{{ org }}"
-                   placeholder="{% translate "Leave blank to register on your personal account" %}">
-            <div class="form-text">
-              {% blocktranslate trimmed %}
-                Enter a GitHub organization slug to register the App under
-                that organization instead of your personal account.
-              {% endblocktranslate %}
-            </div>
-          </div>
-        </div>
-        <div class="mb-3 row">
-          <label for="register-name" class="col-sm-3 col-form-label">{% translate "App name" %}</label>
-          <div class="col-sm-9">
-            <input type="text"
-                   id="register-name"
-                   name="name"
-                   class="form-control"
-                   value="{{ name }}"
-                   maxlength="{{ name_max_length }}"
-                   required>
-            <div class="form-text">
-              {% blocktranslate trimmed with limit=name_max_length %}
-                GitHub App names must be unique and at most {{ limit }}
-                characters. You will still be able to change the name on
-                GitHub before confirming.
-              {% endblocktranslate %}
-            </div>
-          </div>
-        </div>
-        <div class="mb-3 row">
-          <label class="col-sm-3 col-form-label">{% translate "Visibility" %}</label>
-          <div class="col-sm-9">
-            <div class="form-check">
-              <input type="checkbox"
-                     id="register-public"
-                     name="public"
-                     value="1"
-                     class="form-check-input"
-                     {% if public %}checked{% endif %}>
-              <label class="form-check-label" for="register-public">
-                {% translate "Public (any GitHub account can install it)" %}
-              </label>
-            </div>
-            <div class="form-text">
-              {% blocktranslate trimmed %}
-                Required to install the App on more than one user or
-                organization. Public here only means the App is not
-                restricted to its owner; it does not list the App on the
-                GitHub Marketplace.
-              {% endblocktranslate %}
-            </div>
-          </div>
-        </div>
+        {% crispy register_form %}
         <div class="mb-3 row">
           <label class="col-sm-3 col-form-label">{% translate "Webhook URL" %}</label>
           <div class="col-sm-9">
@@ -156,9 +80,7 @@
           </div>
         </div>
         <div class="d-flex gap-2">
-          <button type="submit"
-                  class="btn btn-primary"
-                  {% if host_already_registered %}disabled{% endif %}>{% translate "Continue to GitHub" %}</button>
+          <button type="submit" class="btn btn-primary">{% translate "Continue to GitHub" %}</button>
           <a href="{% url 'manage-github-accounts' %}" class="btn btn-outline-secondary">{% translate "Cancel" %}</a>
         </div>
       </form>

--- a/weblate/templates/vcs/github_app_register_submit.html
+++ b/weblate/templates/vcs/github_app_register_submit.html
@@ -46,8 +46,7 @@
           {{ name }}
         </dd>
       </dl>
-      <form method="post" action="{% url 'github-app-register-redirect' %}">
-        {% csrf_token %}
+      <form method="post" action="{{ action_url }}">
         <input type="hidden" name="manifest" value="{{ manifest_json }}">
         <div class="d-flex gap-2">
           <button type="submit" class="btn btn-primary">

--- a/weblate/vcs/forms.py
+++ b/weblate/vcs/forms.py
@@ -1,0 +1,107 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext, gettext_lazy
+
+from weblate.utils.validators import WeblateServiceURLValidator
+from weblate.vcs.github import (
+    GITHUB_APP_NAME_MAX_LENGTH,
+    normalize_github_app_hostname,
+)
+
+
+def clean_github_app_hostname(value: str) -> str:
+    hostname = normalize_github_app_hostname(value.strip())
+    candidate_url = f"https://{hostname}/"
+    try:
+        WeblateServiceURLValidator()(candidate_url)
+        parsed = urlparse(candidate_url)
+        port = parsed.port
+    except (ValidationError, ValueError) as error:
+        raise ValidationError(gettext("Enter a valid GitHub host.")) from error
+
+    if (
+        parsed.username
+        or parsed.password
+        or port is not None
+        or not parsed.hostname
+        or parsed.path != "/"
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValidationError(gettext("Enter a valid GitHub host."))
+
+    return hostname
+
+
+class GitHubAppRegisterForm(forms.Form):
+    host = forms.CharField(
+        label=gettext_lazy("GitHub host"),
+        help_text=gettext_lazy(
+            "Use github.com for GitHub.com, or the web hostname for GitHub "
+            "Enterprise Server."
+        ),
+        widget=forms.TextInput(attrs={"placeholder": "github.com"}),
+    )
+    org = forms.CharField(
+        label=gettext_lazy("Organization (optional)"),
+        required=False,
+        help_text=gettext_lazy(
+            "Enter a GitHub organization slug to register the App under that "
+            "organization instead of your personal account."
+        ),
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": gettext_lazy(
+                    "Leave blank to register on your personal account"
+                )
+            }
+        ),
+    )
+    name = forms.CharField(
+        label=gettext_lazy("App name"),
+        help_text=gettext_lazy(
+            "GitHub App names must be unique and at most %(limit)s characters. "
+            "You will still be able to change the name on GitHub before confirming."
+        )
+        % {"limit": GITHUB_APP_NAME_MAX_LENGTH},
+        widget=forms.TextInput(attrs={"maxlength": GITHUB_APP_NAME_MAX_LENGTH}),
+    )
+    public = forms.BooleanField(
+        label=gettext_lazy("Public (any GitHub account can install it)"),
+        required=False,
+        help_text=gettext_lazy(
+            "Required to install the App on more than one user or organization. "
+            "Public here only means the App is not restricted to its owner; it "
+            "does not list the App on the GitHub Marketplace."
+        ),
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.setdefault("auto_id", "register-%s")
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.label_class = "col-sm-3"
+        self.helper.field_class = "col-sm-9"
+        self.helper.form_class = "form-horizontal"
+        self.helper.layout = Layout("host", "org", "name", "public")
+
+    def clean_host(self) -> str:
+        return clean_github_app_hostname(self.cleaned_data["host"])
+
+    def clean_name(self) -> str:
+        name = self.cleaned_data["name"].strip()
+        # GitHub rejects App names longer than 34 characters; truncate so we
+        # never build a manifest GitHub will refuse.
+        return name[:GITHUB_APP_NAME_MAX_LENGTH]

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -1301,21 +1301,75 @@ class GitHubAppManifestViewTest(TestCase):
         user.clear_cache()
 
     def _post_register(self, **fields):
-        return self.client.post(reverse("github-app-register-submit"), fields)
+        data = {"host": "github.com", "name": "Test Weblate", "public": "1"}
+        data.update(fields)
+        return self.client.post(reverse("github-app-register-submit"), data)
 
-    def _action_url(self) -> str:
-        return self.client.session["github_app_register_action_url"]
+    def _action_url(self, response) -> str:
+        return response.context["action_url"]
 
     def _capture_github_call(self, **fields) -> tuple[str, dict]:
         submit = self._post_register(**fields)
         self.assertEqual(submit.status_code, 200)
         manifest_json = submit.context["manifest_json"]
-        redirect = self.client.post(
-            reverse("github-app-register-redirect"),
-            {"manifest": manifest_json},
+        return self._action_url(submit), json.loads(manifest_json)
+
+    def _get_form_action_csp(self, response) -> str:
+        for directive in response["Content-Security-Policy"].split(";"):
+            directive = directive.strip()
+            if directive.startswith("form-action "):
+                return directive
+        msg = "Missing form-action directive"
+        raise AssertionError(msg)
+
+    def test_register_submit_posts_directly_to_github_with_csp(self):
+        for host in ("github.com", "github.example.com", "github"):
+            with self.subTest(host=host):
+                response = self._post_register(host=host)
+                self.assertEqual(response.status_code, 200)
+                action_url = self._action_url(response)
+
+                parsed = urlparse(action_url)
+                self.assertEqual(parsed.netloc, host)
+                self.assertEqual(parsed.path, "/settings/apps/new")
+
+                form_action_csp = self._get_form_action_csp(response)
+                self.assertIn("'self'", form_action_csp)
+                self.assertIn(f"https://{host}", form_action_csp)
+                self.assertContains(
+                    response, f'<form method="post" action="{action_url}">'
+                )
+                content = response.content.decode()
+                form_start = content.index(
+                    f'<form method="post" action="{action_url}">'
+                )
+                form_end = content.index("</form>", form_start)
+                self.assertNotIn("csrfmiddlewaretoken", content[form_start:form_end])
+
+    def test_register_submit_rejects_invalid_host(self):
+        for host in (
+            "github.com; script-src *",
+            "github.com@attacker.example",
+            "github.com:8443",
+            "https://github.com",
+            "github.com/path",
+            "github.com?query=1",
+        ):
+            with self.subTest(host=host):
+                response = self._post_register(host=host)
+
+                self.assertRedirects(response, reverse("github-app-register"))
+                self.assertNotIn("github_app_register_nonce", self.client.session)
+
+    def test_register_rejects_prefilled_invalid_host(self):
+        response = self.client.get(
+            reverse("github-app-register"),
+            {"host": "github.com@attacker.example"},
         )
-        self.assertEqual(redirect.status_code, 307)
-        return redirect["Location"], json.loads(manifest_json)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["hostname"], "github.com")
+        self.assertNotContains(response, "attacker.example")
 
     def test_register_post_sends_expected_manifest_to_github(self):
         url, manifest = self._capture_github_call(
@@ -1383,8 +1437,8 @@ class GitHubAppManifestViewTest(TestCase):
             json=MANIFEST_RESPONSE,
         )
         # Prime the session state via a POST to the register view
-        self._post_register(host="github.com")
-        state = parse_qs(urlparse(self._action_url()).query)["state"][0]
+        submit = self._post_register(host="github.com")
+        state = parse_qs(urlparse(self._action_url(submit)).query)["state"][0]
 
         response = self.client.get(
             reverse("github-app-register-callback"),
@@ -1412,8 +1466,8 @@ class GitHubAppManifestViewTest(TestCase):
             "https://api.github.com/app-manifests/tempcode123/conversions",
             json=MANIFEST_RESPONSE,
         )
-        self._post_register(host="github.com")
-        state = parse_qs(urlparse(self._action_url()).query)["state"][0]
+        submit = self._post_register(host="github.com")
+        state = parse_qs(urlparse(self._action_url(submit)).query)["state"][0]
         # Simulate a concurrent row appearing between submit and callback -
         # the callback should still upsert rather than crash.
         GitHubAppCredentials.objects.create(
@@ -1453,8 +1507,8 @@ class GitHubAppManifestViewTest(TestCase):
             "https://api.github.com/app-manifests/x/conversions",
             json={"id": 99},  # missing pem/slug/secret
         )
-        self._post_register(host="github.com")
-        state = parse_qs(urlparse(self._action_url()).query)["state"][0]
+        submit = self._post_register(host="github.com")
+        state = parse_qs(urlparse(self._action_url(submit)).query)["state"][0]
 
         response = self.client.get(
             reverse("github-app-register-callback"),
@@ -1476,7 +1530,6 @@ class GitHubAppManifestViewTest(TestCase):
         protected_urls: tuple[tuple[str, str, dict[str, str]], ...] = (
             ("get", reverse("github-app-register"), {}),
             ("post", reverse("github-app-register-submit"), {}),
-            ("post", reverse("github-app-register-redirect"), {}),
             ("get", reverse("github-app-register-callback"), {}),
         )
         for method, url, data in protected_urls:
@@ -1537,13 +1590,16 @@ class GitHubAppManifestViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["host_already_registered"])
         self.assertEqual(response.context["existing_hosts"], ["github.com"])
-        self.assertContains(response, "already registered")
-        # Submit button disabled when host conflicts
-        self.assertContains(response, "disabled")
+        self.assertContains(response, "already has stored GitHub App credentials")
+        content = response.content.decode()
+        button_start = content.index('type="submit"')
+        button_end = content.index("</button>", button_start)
+        self.assertNotIn("disabled", content[button_start:button_end])
 
         response = self._post_register(host="github.com")
-        self.assertRedirects(response, reverse("manage-github-accounts"))
-        self.assertNotIn("github_app_register_action_url", self.client.session)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "already registered for github.com")
+        self.assertNotIn("github_app_register_nonce", self.client.session)
 
         url, _manifest = self._capture_github_call(host="github.example.com")
 

--- a/weblate/vcs/urls.py
+++ b/weblate/vcs/urls.py
@@ -12,7 +12,6 @@ from weblate.vcs.views import (
     github_app_install,
     github_app_register,
     github_app_register_callback,
-    github_app_register_redirect,
     github_app_register_submit,
     github_app_repository_list,
     github_app_setup,
@@ -41,11 +40,6 @@ urlpatterns = [
         "manage/integrations/register/submit/",
         github_app_register_submit,
         name="github-app-register-submit",
-    ),
-    path(
-        "manage/integrations/register/redirect/",
-        github_app_register_redirect,
-        name="github-app-register-redirect",
     ),
     path(
         "manage/integrations/register/callback/",

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -16,7 +16,7 @@ from django.contrib.auth.decorators import login_required
 from django.core import signing
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.signing import BadSignature, SignatureExpired
-from django.http import HttpResponse, HttpResponseNotAllowed
+from django.http import HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -32,6 +32,7 @@ from weblate.trans.views.hooks import apply_pending_github_installation_event
 from weblate.utils import messages
 from weblate.utils.errors import report_error
 from weblate.utils.site import get_site_url
+from weblate.vcs.forms import GitHubAppRegisterForm, clean_github_app_hostname
 from weblate.vcs.github import (
     GITHUB_APP_MANIFEST_EVENTS,
     GITHUB_APP_MANIFEST_PERMISSIONS,
@@ -936,27 +937,26 @@ def _build_manifest_for_request(
     return manifest, webhook_url
 
 
-def _read_register_fields(request) -> tuple[str, str, str, bool]:
-    """Pull (hostname, org, name, public) from the request."""
-    source = request.POST if request.method == "POST" else request.GET
-    hostname_raw = source.get("host", "").strip() or "github.com"
-    hostname = normalize_github_app_hostname(hostname_raw)
-    org = source.get("org", "").strip()
-    name = source.get("name", "").strip() or _default_register_name(request)
-    # GitHub rejects App names longer than 34 characters; truncate so we never
-    # build a manifest GitHub will refuse.
-    name = name[:GITHUB_APP_NAME_MAX_LENGTH]
-    # Unticked checkboxes are absent from POST data; default the form to
-    # public on the initial GET so the visibility checkbox starts checked.
-    public = source.get("public") == "1" if request.method == "POST" else True
-    return hostname, org, name, public
+def _get_register_initial(request) -> dict[str, str | bool]:
+    hostname = request.GET.get("host", "").strip()
+    name = request.GET.get("name", "").strip() or _default_register_name(request)
+    return {
+        "host": clean_github_app_hostname(hostname) if hostname else "github.com",
+        "org": request.GET.get("org", "").strip(),
+        "name": name[:GITHUB_APP_NAME_MAX_LENGTH],
+        "public": True,
+    }
 
 
-@management_permission_required("management.configure")
-def github_app_register(request):
-    """Render the GitHub App registration form (editable host/org/name)."""
-    hostname, org, name, public = _read_register_fields(request)
-
+def _render_github_app_register(
+    request,
+    register_form: GitHubAppRegisterForm,
+    *,
+    hostname: str,
+    name: str,
+    public: bool,
+    status: int = 200,
+):
     webhook_token = _get_register_webhook_token(request)
     manifest, webhook_url = _build_manifest_for_request(
         request,
@@ -976,11 +976,8 @@ def github_app_register(request):
         "vcs/github_app_register.html",
         {
             "manifest_json": json.dumps(manifest, indent=2, sort_keys=True),
+            "register_form": register_form,
             "hostname": hostname,
-            "org": org,
-            "name": name,
-            "public": public,
-            "name_max_length": GITHUB_APP_NAME_MAX_LENGTH,
             "permissions": GITHUB_APP_MANIFEST_PERMISSIONS,
             "events": GITHUB_APP_MANIFEST_EVENTS,
             "webhook_url": webhook_url,
@@ -988,6 +985,34 @@ def github_app_register(request):
             "host_already_registered": hostname in existing_hosts,
             **_MENU_CONTEXT,
         },
+        status=status,
+    )
+
+
+@management_permission_required("management.configure")
+def github_app_register(request):
+    """Render the GitHub App registration form (editable host/org/name)."""
+    try:
+        initial = _get_register_initial(request)
+    except ValidationError:
+        messages.error(request, gettext("Enter a valid GitHub host."))
+        initial = {
+            "host": "github.com",
+            "org": "",
+            "name": _default_register_name(request),
+            "public": True,
+        }
+    register_form = GitHubAppRegisterForm(initial=initial)
+    hostname = str(initial["host"])
+    name = str(initial["name"])
+    public = bool(initial["public"])
+
+    return _render_github_app_register(
+        request,
+        register_form,
+        hostname=hostname,
+        name=name,
+        public=public,
     )
 
 
@@ -997,17 +1022,33 @@ def github_app_register_submit(request):
     if request.method != "POST":
         return redirect("github-app-register")
 
-    hostname, org, name, public = _read_register_fields(request)
-    if GitHubAppCredentials.objects.filter(hostname=hostname).exists():
+    form = GitHubAppRegisterForm(data=request.POST)
+    if not form.is_valid():
         messages.error(
             request,
+            gettext("Enter a valid GitHub App name and host."),
+        )
+        return redirect("github-app-register")
+    hostname = form.cleaned_data["host"]
+    org = form.cleaned_data["org"]
+    name = form.cleaned_data["name"]
+    public = form.cleaned_data["public"]
+    if GitHubAppCredentials.objects.filter(hostname=hostname).exists():
+        form.add_error(
+            "host",
             gettext(
                 "A Weblate GitHub App is already registered for %(hostname)s. "
                 "Remove it before registering another one."
             )
             % {"hostname": hostname},
         )
-        return redirect("manage-github-accounts")
+        return _render_github_app_register(
+            request,
+            form,
+            hostname=hostname,
+            name=name,
+            public=public,
+        )
 
     webhook_token = _get_register_webhook_token(request)
     manifest, _webhook_url = _build_manifest_for_request(
@@ -1022,15 +1063,13 @@ def github_app_register_submit(request):
         f"{get_github_app_manifest_new_url(hostname, org or None)}"
         f"?{urlencode({'state': state})}"
     )
-    # The intermediate form posts to ``github_app_register_redirect`` (same
-    # origin, allowed by CSP form-action 'self'); that view answers with a 307
-    # that re-sends the manifest body to GitHub.
-    request.session["github_app_register_action_url"] = action_url
+    request.csp_form_action_sources = (f"https://{hostname}",)
 
     return render(
         request,
         "vcs/github_app_register_submit.html",
         {
+            "action_url": action_url,
             "manifest_json": json.dumps(manifest),
             "hostname": hostname,
             "org": org,
@@ -1038,34 +1077,6 @@ def github_app_register_submit(request):
             **_MENU_CONTEXT,
         },
     )
-
-
-@management_permission_required("management.configure")
-def github_app_register_redirect(request):
-    """
-    307-redirect the POSTed manifest to GitHub, preserving the body.
-
-    The browser's CSP only checks the form ``action`` URL against
-    ``form-action``; redirects are not validated, so we can stay within
-    ``'self'`` while still POSTing the manifest cross-origin to GitHub.
-    """
-    if request.method != "POST":
-        return redirect("github-app-register")
-
-    action_url = request.session.pop("github_app_register_action_url", None)
-    if not action_url or not action_url.startswith("https://"):
-        messages.error(
-            request,
-            gettext(
-                "Start the Weblate GitHub App registration again to refresh "
-                "the request."
-            ),
-        )
-        return redirect("github-app-register")
-
-    response = HttpResponse(status=307)
-    response["Location"] = action_url
-    return response
 
 
 @management_permission_required("management.configure")


### PR DESCRIPTION
GitHub App registration could be blocked by CSP when the manifest form used an intermediate redirect. Post the manifest directly to GitHub and add a request-scoped, validated form-action source for the selected host.

Fixes #20360

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
