### PR TITLE
Include machinery backend error details in logs

### DIFF
--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -919,10 +919,14 @@ class BatchMachineTranslation(DocVersionsMixin):
                 if self.is_rate_limit_error(exc):
                     self.set_rate_limit()
 
-                self.report_error("Could not fetch translations")
+                error_message = self.get_error_message(exc)
+                self.report_error(
+                    "Could not fetch translations",
+                    extra_log=error_message,
+                )
                 if isinstance(exc, MachineTranslationError):
                     raise
-                raise MachineTranslationError(self.get_error_message(exc)) from exc
+                raise MachineTranslationError(error_message) from exc
 
             # Postprocess translations
             for pending_key in batch_keys:


### PR DESCRIPTION
**Summary**

This change improves error reporting for machine translation backend failures.

Previously, when translation fetching failed, Weblate only reported a generic error message:

Could not fetch translations

This update extracts the actual backend error message and includes it in report_error() using extra_log.

**Changes made**

* Extract backend error message using get_error_message(exc)
* Pass detailed error message into report_error() through extra_log
* Reuse the extracted message when raising MachineTranslationError

**Benefit**

This helps administrators understand backend failures such as rate limits, invalid credentials, and temporary service outages.
