### PR TITLE
fix(addons): validate Fedora Messaging PEM blocks safely

### DIFF
--- a/weblate/addons/fedora_messaging.py
+++ b/weblate/addons/fedora_messaging.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import re
 import socket
 import ssl
 from copy import deepcopy
@@ -45,10 +44,10 @@ if TYPE_CHECKING:
     from weblate.trans.models import Category, Change, Component, Project
 
 
-PEM_BLOCK_RE = re.compile(
-    r"-----BEGIN ([A-Z0-9 ]+)-----\r?\n.*?\r?\n-----END \1-----",
-    re.DOTALL,
-)
+PEM_BEGIN_PREFIX = "-----BEGIN "
+PEM_END_PREFIX = "-----END "
+PEM_BOUNDARY_SUFFIX = "-----"
+PEM_LABEL_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ")
 TLS_CREDENTIAL_FIELDS = frozenset({"ca_cert", "client_key", "client_cert"})
 TLS_PROBE_TIMEOUT = 5
 SERVICE_STOP_TIMEOUT = 5
@@ -601,19 +600,38 @@ class FedoraMessagingAddon(ChangeBaseAddon):
 
     @staticmethod
     def _get_pem_block_labels(value: str) -> list[str]:
+        # Cryptography's PEM loaders ignore unrelated PEM blocks and text; validate
+        # the full PEM container before handing it to the type-specific loader.
         labels: list[str] = []
         position = 0
-        text = value.strip()
-        while position < len(text):
-            whitespace = re.match(r"\s*", text[position:])
-            if whitespace is not None:
-                position += whitespace.end()
-            match = PEM_BLOCK_RE.match(text, position)
-            if match is None:
+        lines = value.strip().splitlines()
+        while position < len(lines):
+            if not lines[position].strip():
+                position += 1
+                continue
+            label = FedoraMessagingAddon._get_pem_begin_label(lines[position])
+            if label is None:
                 return []
-            labels.append(match.group(1))
-            position = match.end()
+            end_boundary = f"{PEM_END_PREFIX}{label}{PEM_BOUNDARY_SUFFIX}"
+            position += 1
+            while position < len(lines) and lines[position].rstrip() != end_boundary:
+                position += 1
+            if position == len(lines):
+                return []
+            labels.append(label)
+            position += 1
         return labels
+
+    @staticmethod
+    def _get_pem_begin_label(line: str) -> str | None:
+        if not line.startswith(PEM_BEGIN_PREFIX) or not line.endswith(
+            PEM_BOUNDARY_SUFFIX
+        ):
+            return None
+        label = line[len(PEM_BEGIN_PREFIX) : -len(PEM_BOUNDARY_SUFFIX)]
+        if not label or any(char not in PEM_LABEL_CHARACTERS for char in label):
+            return None
+        return label
 
     @staticmethod
     def _normalize_pem(value: str | None) -> str | None:

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -8503,6 +8503,52 @@ class SlackWebhooksAddonsTest(BaseWebhookTests, ViewTestCase):
         self.do_translation_added_test(response_code=410, body=b"channel_is_archived")
 
 
+class FedoraMessagingPEMBlockTest(SimpleTestCase):
+    @staticmethod
+    def get_certificate() -> str:
+        return Path("weblate/trans/tests/data/saml.crt").read_text(encoding="utf-8")
+
+    @staticmethod
+    def get_private_key() -> str:
+        return Path("weblate/trans/tests/data/saml.key").read_text(encoding="utf-8")
+
+    def test_pem_block_labels_accept_multiple_blocks(self) -> None:
+        cert = self.get_certificate()
+
+        labels = FedoraMessagingAddon._get_pem_block_labels(  # noqa: SLF001
+            f"{cert}\n{cert}"
+        )
+
+        self.assertEqual(labels, ["CERTIFICATE", "CERTIFICATE"])
+
+    def test_pem_block_labels_reject_malformed_delimiter_input(self) -> None:
+        value = "-----BEGIN CERTIFICATE-----\n" + "\n".join(
+            "-----END PRIVATE KEY-----" for _ in range(100)
+        )
+
+        labels = FedoraMessagingAddon._get_pem_block_labels(value)  # noqa: SLF001
+
+        self.assertEqual(labels, [])
+
+    def test_pem_block_labels_include_blocks_after_trailing_whitespace_end(
+        self,
+    ) -> None:
+        cert = self.get_certificate()
+        key = self.get_private_key()
+        value = (
+            cert.replace("-----END CERTIFICATE-----", "-----END CERTIFICATE-----   ", 1)
+            + f"\n{key}\n{cert}"
+        )
+
+        labels = FedoraMessagingAddon._get_pem_block_labels(value)  # noqa: SLF001
+
+        self.assertEqual(labels, ["CERTIFICATE", "PRIVATE KEY", "CERTIFICATE"])
+        with self.assertRaisesMessage(ConfigurationException, "invalid certificate"):
+            FedoraMessagingAddon._validate_pem_certificates(  # noqa: SLF001
+                value, "invalid certificate"
+            )
+
+
 class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
     WEBHOOK_CLS = FedoraMessagingAddon
     # Not really used


### PR DESCRIPTION
Replace the vulnerable PEM block regex with line-oriented container validation.

Add regressions for malformed PEM delimiters and trailing whitespace boundaries.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
