### PR TITLE
fix(billing): name managed workspaces from projects

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -3962,6 +3962,30 @@ class ProjectAPITest(APIBaseTest):
         self.assertEqual(change.details["old_workspace_name"], "Current workspace")
         self.assertEqual(change.details["workspace_name"], "Target workspace")
 
+    @modify_settings(INSTALLED_APPS={"append": "weblate.billing"})
+    def test_patch_workspace_move_to_billing_workspace_updates_name(self) -> None:
+        current_workspace = Workspace.objects.create(name="Current workspace")
+        Project.objects.filter(pk=self.project.pk).update(workspace=current_workspace)
+        current_workspace.add_owner(self.user)
+        billing = create_test_billing(self.user)
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_cache()
+
+        response = self.do_request(
+            "api:project-detail",
+            self.project_kwargs,
+            method="patch",
+            code=200,
+            format="json",
+            request={"workspace": str(billing.workspace_id)},
+        )
+
+        self.assertEqual(response.data["workspace"], billing.workspace_id)
+        self.project.refresh_from_db()
+        billing.workspace.refresh_from_db()
+        self.assertEqual(self.project.workspace_id, billing.workspace_id)
+        self.assertEqual(billing.workspace.name, self.project.name)
+
     def test_patch_workspace_requires_source_and_target_edit(self) -> None:
         current_workspace = Workspace.objects.create(name="Current workspace")
         target_workspace = Workspace.objects.create(name="Target workspace")

--- a/weblate/billing/migrations/0013_managed_workspace_project_names.py
+++ b/weblate/billing/migrations/0013_managed_workspace_project_names.py
@@ -1,0 +1,51 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import DEFAULT_DB_ALIAS, migrations
+
+WORKSPACE_NAME_LENGTH = 100
+
+
+def rename_single_project_billing_workspaces(apps, schema_editor) -> None:
+    Billing = apps.get_model("billing", "Billing")
+    Project = apps.get_model("trans", "Project")
+    Workspace = apps.get_model("workspaces", "Workspace")
+
+    db_alias = (
+        schema_editor.connection.alias
+        if schema_editor is not None
+        else DEFAULT_DB_ALIAS
+    )
+    workspace_ids = (
+        Billing.objects.using(db_alias)
+        .filter(customer_name="", workspace__name_managed=True)
+        .values_list("workspace_id", flat=True)
+    )
+
+    for workspace_id in workspace_ids.iterator():
+        project_names = list(
+            Project.objects.using(db_alias)
+            .filter(workspace_id=workspace_id)
+            .order_by("id")
+            .values_list("name", flat=True)[:2]
+        )
+        if len(project_names) != 1:
+            continue
+
+        name = project_names[0][:WORKSPACE_NAME_LENGTH]
+        Workspace.objects.using(db_alias).filter(
+            pk=workspace_id, name_managed=True
+        ).exclude(name=name).update(name=name)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("billing", "0012_migrate_owners_to_workspace"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_single_project_billing_workspaces, migrations.RunPython.noop
+        ),
+    ]

--- a/weblate/billing/models.py
+++ b/weblate/billing/models.py
@@ -409,11 +409,31 @@ class Billing(models.Model):
 
         if self.customer_name:
             name = self.customer_name
+        elif project_name := self.get_single_project_workspace_name(using=using):
+            name = project_name
         elif self.workspace_id:
             name = self.workspace.name
         else:
-            name = gettext("Billing")
+            name = "Billing"
         return name[:WORKSPACE_NAME_LENGTH]
+
+    def get_single_project_workspace_name(self, using=None) -> str | None:
+        if not self.workspace_id:
+            return None
+
+        project_objects = Project.objects
+        database = using or self._state.db
+        if database is not None:
+            project_objects = project_objects.db_manager(database)
+
+        project_names = list(
+            project_objects.filter(workspace_id=self.workspace_id)
+            .order_by("id")
+            .values_list("name", flat=True)[:2]
+        )
+        if len(project_names) != 1:
+            return None
+        return project_names[0]
 
     def update_workspace_name(self, using=None) -> None:
         # ruff: ignore[import-outside-top-level]
@@ -480,6 +500,7 @@ class Billing(models.Model):
             raise Project.DoesNotExist
         project.workspace = self.workspace
         project.billing_original_workspace_id = self.workspace_id
+        self.update_workspace_name()
         for key in ("billings", "paid", "is_trial", "is_libre_trial"):
             project.__dict__.pop(key, None)
         if previous_workspace_id and previous_workspace_id != self.workspace_id:
@@ -1262,6 +1283,11 @@ def update_project_bill(sender, instance, using=None, **kwargs) -> None:
         billings = instance.billing_set.all()
     for billing in billings:
         billing.check_limits()
+        if (
+            isinstance(instance, Project)
+            and billing.workspace_id == instance.workspace_id
+        ):
+            billing.update_workspace_name(using=using)
     if isinstance(instance, Project):
         instance.billing_original_workspace_id = instance.workspace_id
 

--- a/weblate/billing/tests.py
+++ b/weblate/billing/tests.py
@@ -2,12 +2,14 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import importlib
 import os.path
 from datetime import timedelta
 from io import StringIO
 from unittest.mock import patch
 from uuid import UUID
 
+from django.apps import apps
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
@@ -15,7 +17,7 @@ from django.db import models
 from django.template.loader import render_to_string
 from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone, translation
 from lxml import html
 
 from weblate.auth.models import Group, Permission, Role, TeamMembership, User
@@ -449,6 +451,14 @@ class BillingTest(BaseTestCase):
         self.assertIsInstance(billing.workspace_id, UUID)
         self.assertTrue(billing.workspace.name_managed)
 
+    def test_default_workspace_name_is_not_localized(self) -> None:
+        with translation.override("de"):
+            self.assertEqual(translation.gettext("Billing"), "Abrechnung")
+            billing = Billing.objects.create(plan=self.plan)
+
+        self.assertEqual(billing.workspace.name, "Billing")
+        self.assertTrue(billing.workspace.name_managed)
+
     def test_customer_name_used_for_workspace(self) -> None:
         billing = Billing.objects.create(
             plan=self.plan, customer_name="Acme Billing LLC"
@@ -456,6 +466,128 @@ class BillingTest(BaseTestCase):
 
         self.assertEqual(billing.workspace.name, "Acme Billing LLC")
         self.assertTrue(billing.workspace.name_managed)
+
+    def test_first_project_updates_managed_workspace_name(self) -> None:
+        project = Project.objects.create(
+            name="Hosted app",
+            slug="hosted-app",
+            access_control=Project.ACCESS_PROTECTED,
+        )
+
+        self.billing.add_project(project)
+
+        self.billing.workspace.refresh_from_db()
+        self.assertEqual(self.billing.workspace.name, "Hosted app")
+        self.assertTrue(self.billing.workspace.name_managed)
+
+    def test_second_project_keeps_managed_workspace_name(self) -> None:
+        first = Project.objects.create(
+            name="Hosted app",
+            slug="hosted-app",
+            access_control=Project.ACCESS_PROTECTED,
+        )
+        second = Project.objects.create(
+            name="Another hosted app",
+            slug="another-hosted-app",
+            access_control=Project.ACCESS_PROTECTED,
+        )
+        self.billing.add_project(first)
+
+        self.billing.add_project(second)
+
+        self.billing.workspace.refresh_from_db()
+        self.assertEqual(self.billing.workspace.name, "Hosted app")
+
+    def test_first_project_preserves_customer_workspace_name(self) -> None:
+        billing = Billing.objects.create(
+            plan=self.plan, customer_name="Acme Billing LLC"
+        )
+        project = Project.objects.create(
+            name="Hosted app",
+            slug="hosted-app",
+            access_control=Project.ACCESS_PROTECTED,
+        )
+
+        billing.add_project(project)
+
+        billing.workspace.refresh_from_db()
+        self.assertEqual(billing.workspace.name, "Acme Billing LLC")
+
+        billing.customer_name = ""
+        billing.save(update_fields=["customer_name"])
+
+        billing.workspace.refresh_from_db()
+        self.assertEqual(billing.workspace.name, project.name)
+
+    def test_first_project_preserves_manual_workspace_name(self) -> None:
+        self.billing.workspace.name = "Manual workspace name"
+        self.billing.workspace.save(update_fields=["name"])
+        project = Project.objects.create(
+            name="Hosted app",
+            slug="hosted-app",
+            access_control=Project.ACCESS_PROTECTED,
+        )
+
+        self.billing.add_project(project)
+
+        self.billing.workspace.refresh_from_db()
+        self.assertEqual(self.billing.workspace.name, "Manual workspace name")
+        self.assertFalse(self.billing.workspace.name_managed)
+
+    def test_managed_workspace_project_name_migration(self) -> None:
+        migration = importlib.import_module(
+            "weblate.billing.migrations.0013_managed_workspace_project_names"
+        )
+        repaired = Billing.objects.create(plan=self.plan)
+        Project.objects.create(
+            name="Migration repaired project",
+            slug="migration-repaired-project",
+            workspace=repaired.workspace,
+        )
+        Workspace.objects.filter(pk=repaired.workspace_id).update(name="Abrechnung")
+        manual = Billing.objects.create(plan=self.plan)
+        Project.objects.create(
+            name="Manual migration project",
+            slug="manual-migration-project",
+            workspace=manual.workspace,
+        )
+        Workspace.objects.filter(pk=manual.workspace_id).update(
+            name="Manual workspace name", name_managed=False
+        )
+        customer = Billing.objects.create(
+            plan=self.plan, customer_name="Acme Billing LLC"
+        )
+        Project.objects.create(
+            name="Customer migration project",
+            slug="customer-migration-project",
+            workspace=customer.workspace,
+        )
+        multiple = Billing.objects.create(plan=self.plan)
+        Project.objects.create(
+            name="First migration project",
+            slug="first-migration-project",
+            workspace=multiple.workspace,
+        )
+        Project.objects.create(
+            name="Second migration project",
+            slug="second-migration-project",
+            workspace=multiple.workspace,
+        )
+        Workspace.objects.filter(pk=multiple.workspace_id).update(name="Billing")
+        empty = Billing.objects.create(plan=self.plan)
+
+        migration.rename_single_project_billing_workspaces(apps, None)
+
+        repaired.workspace.refresh_from_db()
+        manual.workspace.refresh_from_db()
+        customer.workspace.refresh_from_db()
+        multiple.workspace.refresh_from_db()
+        empty.workspace.refresh_from_db()
+        self.assertEqual(repaired.workspace.name, "Migration repaired project")
+        self.assertEqual(manual.workspace.name, "Manual workspace name")
+        self.assertEqual(customer.workspace.name, "Acme Billing LLC")
+        self.assertEqual(multiple.workspace.name, "Billing")
+        self.assertEqual(empty.workspace.name, "Billing")
 
     def test_customer_name_updates_workspace_after_plan_change(self) -> None:
         paid_plan = Plan.objects.create(
@@ -1101,6 +1233,23 @@ class BillingTest(BaseTestCase):
         self.assertTrue(self.billing.in_limits)
         self.assertEqual(other.count_projects, 1)
         self.assertTrue(other.in_limits)
+        other.workspace.refresh_from_db()
+        self.assertEqual(other.workspace.name, project.name)
+
+    def test_project_workspace_change_preserves_previous_billing_name(self) -> None:
+        project = self.add_project()
+        remaining = self.add_project()
+        previous_name = self.billing.workspace.name
+        other = Billing.objects.create(plan=self.plan)
+
+        project.workspace = other.workspace
+        project.save(update_fields=["workspace"])
+
+        self.billing.workspace.refresh_from_db()
+        other.workspace.refresh_from_db()
+        self.assertEqual(self.billing.workspace.name, previous_name)
+        self.assertEqual(other.workspace.name, project.name)
+        self.assertEqual(self.billing.get_projects_queryset().get(), remaining)
 
     def test_project_billing_workspace_recording_ignores_unrelated_updates(
         self,
@@ -1272,6 +1421,26 @@ class BillingTest(BaseTestCase):
         target_custom_group = other.workspace.defined_groups.get(name=custom_group.name)
         self.assertEqual(set(target_custom_group.roles.all()), {custom_role})
         self.assertTrue(target_custom_group.user_set.filter(pk=custom_user.pk).exists())
+
+    def test_merge_updates_single_project_target_workspace_name(self) -> None:
+        other = Billing.objects.create(plan=self.billing.plan)
+        project = self.add_project()
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.login(username=self.user.username, password="testpassword")
+
+        response = self.client.post(
+            reverse("billing-merge", kwargs={"pk": self.billing.pk}),
+            {"other": other.pk, "confirm": 1},
+        )
+
+        self.assertRedirects(
+            response, reverse("billing-detail", kwargs={"pk": other.pk})
+        )
+        project.refresh_from_db()
+        other.workspace.refresh_from_db()
+        self.assertEqual(project.workspace_id, other.workspace_id)
+        self.assertEqual(other.workspace.name, project.name)
 
     def test_workspace_access_controls_billing_view(self) -> None:
         second_user = create_another_user()

--- a/weblate/billing/views.py
+++ b/weblate/billing/views.py
@@ -270,6 +270,7 @@ def merge(request: AuthenticatedHttpRequest, pk) -> HttpResponse:
             other.payment.setdefault("all", []).extend(billing.payment["all"])
         other.save()
         billing.get_projects_queryset().update(workspace=other.workspace)
+        other.update_workspace_name()
         merge_workspace_access(billing, other)
         billing.invoice_set.update(billing=other)
         billing.billinglog_set.update(billing=other)

--- a/weblate/trans/tests/test_create.py
+++ b/weblate/trans/tests/test_create.py
@@ -89,6 +89,8 @@ class CreateTest(ViewTestCase):
         # Create one project
         self.client_create_project(False, workspace=0)
         self.client_create_project(True, workspace=billing.workspace_id)
+        billing.workspace.refresh_from_db()
+        self.assertEqual(billing.workspace.name, "Create Project")
 
         # No more billings left
         self.client_create_project(

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -1066,6 +1066,28 @@ class SettingsTest(ViewTestCase):
             'Project moved from "Current workspace" to "Target workspace".',
         )
 
+    @modify_settings(INSTALLED_APPS={"append": "weblate.billing"})
+    def test_project_move_to_billing_workspace_updates_name(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        current_workspace = Workspace.objects.create(name="Current workspace")
+        Project.objects.filter(pk=self.project.pk).update(workspace=current_workspace)
+        self.project.refresh_from_db()
+        current_workspace.add_owner(self.user)
+        billing = create_test_billing(self.user)
+        self.user.clear_cache()
+
+        response = self.client.post(
+            reverse("move", kwargs={"path": self.project.get_url_path()}),
+            {"workspace": str(billing.workspace_id)},
+            follow=True,
+        )
+
+        self.assertContains(response, "Project moved.")
+        self.project.refresh_from_db()
+        billing.workspace.refresh_from_db()
+        self.assertEqual(self.project.workspace_id, billing.workspace_id)
+        self.assertEqual(billing.workspace.name, self.project.name)
+
     def test_project_move_requires_target_add_project(self) -> None:
         self.project.add_user(self.user, "Administration")
         current_workspace = Workspace.objects.create(name="Current workspace")


### PR DESCRIPTION
Use billing workspace auto-naming to prefer the single project name, keep customer and manual names intact, and repair existing managed workspaces.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
