### PR TITLE
fix(memory): avoid expensive compaction status counts

### DIFF
--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -604,9 +604,13 @@ def update_memory(  # noqa: PLR0913
 
 
 @app.task(trail=False)
-def compact_memory_scopes(batch_size: int = MEMORY_SCOPE_COMPACTION_BATCH_SIZE) -> None:
+def compact_memory_scopes(**kwargs) -> None:
     # TODO(2028.1): Remove this background TM scope compaction once Weblate no
     # longer supports direct upgrades from 2026 releases.
+    # Accept and ignore legacy Celery kwargs, especially batch_size from queued
+    # tasks created before the default was raised.
+    _ = kwargs
+    batch_size = MEMORY_SCOPE_COMPACTION_BATCH_SIZE
     memory_objects = Memory.objects.using("default")
     memory_scope_objects = MemoryScope.objects.db_manager("default")
     migration_state_objects = MemoryScopeMigrationState.objects.using("default")
@@ -634,7 +638,7 @@ def compact_memory_scopes(batch_size: int = MEMORY_SCOPE_COMPACTION_BATCH_SIZE) 
     if not duplicate_groups:
         if compaction_state.last_memory_id and has_duplicate_memory_groups():
             set_memory_scope_compaction_completed(False, last_memory_id=0)
-            compact_memory_scopes.delay(batch_size=batch_size)
+            compact_memory_scopes.delay()
             return
         set_memory_scope_compaction_completed(True)
         return
@@ -650,10 +654,10 @@ def compact_memory_scopes(batch_size: int = MEMORY_SCOPE_COMPACTION_BATCH_SIZE) 
     set_memory_scope_compaction_completed(False, last_memory_id=last_memory_id)
 
     if len(duplicate_groups) == batch_size:
-        compact_memory_scopes.delay(batch_size=batch_size)
+        compact_memory_scopes.delay()
     elif has_duplicate_memory_groups():
         set_memory_scope_compaction_completed(False, last_memory_id=0)
-        compact_memory_scopes.delay(batch_size=batch_size)
+        compact_memory_scopes.delay()
     else:
         set_memory_scope_compaction_completed(True)
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -41,7 +41,6 @@ from weblate.memory.models import (
 from weblate.memory.tasks import (
     MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
     MEMORY_SCOPE_BACKFILL_STATE,
-    MEMORY_SCOPE_COMPACTION_BATCH_SIZE,
     MEMORY_SCOPE_COMPACTION_STALE_SECONDS,
     MEMORY_SCOPE_COMPACTION_STATE,
     MEMORY_UPDATE_LOOKUP_CHUNK_SIZE,
@@ -2050,10 +2049,13 @@ msgstr "Nazdar svete!\n"
         Memory.objects.create(legacy_project=self.project, **second_values)
         Memory.objects.create(legacy_shared=True, **second_values)
 
-        with patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact:
+        with (
+            patch("weblate.memory.tasks.MEMORY_SCOPE_COMPACTION_BATCH_SIZE", 1),
+            patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact,
+        ):
             compact_memory_scopes(batch_size=1)
 
-        compact.assert_called_once_with(batch_size=1)
+        compact.assert_called_once_with()
         state = MemoryScopeMigrationState.objects.get(
             name=MEMORY_SCOPE_COMPACTION_STATE
         )
@@ -2182,12 +2184,52 @@ msgstr "Nazdar svete!\n"
         with patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact:
             compact_memory_scopes()
 
-        compact.assert_called_once_with(batch_size=MEMORY_SCOPE_COMPACTION_BATCH_SIZE)
+        compact.assert_called_once_with()
         state = MemoryScopeMigrationState.objects.get(
             name=MEMORY_SCOPE_COMPACTION_STATE
         )
         self.assertFalse(state.completed)
         self.assertEqual(state.last_memory_id, 0)
+
+    def test_compact_memory_scopes_ignores_legacy_batch_size_kwarg(self) -> None:
+        MemoryScopeMigrationState.objects.all().delete()
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        first_values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "source": "Legacy batch compacted source 1",
+            "target": "Kompaktni cil davky 1",
+            "origin": self.component.full_slug,
+            "status": Memory.STATUS_ACTIVE,
+        }
+        second_values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "source": "Legacy batch compacted source 2",
+            "target": "Kompaktni cil davky 2",
+            "origin": self.component.full_slug,
+            "status": Memory.STATUS_ACTIVE,
+        }
+        Memory.objects.create(legacy_project=self.project, **first_values)
+        Memory.objects.create(legacy_shared=True, **first_values)
+        Memory.objects.create(legacy_project=self.project, **second_values)
+        Memory.objects.create(legacy_shared=True, **second_values)
+
+        with patch("weblate.memory.tasks.compact_memory_scopes.delay") as compact:
+            compact_memory_scopes(batch_size=1)
+
+        compact.assert_not_called()
+        state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_SCOPE_COMPACTION_STATE
+        )
+        self.assertTrue(state.completed)
+        self.assertEqual(
+            Memory.objects.filter(source=first_values["source"]).count(), 1
+        )
+        self.assertEqual(
+            Memory.objects.filter(source=second_values["source"]).count(), 1
+        )
 
     def test_compact_preserves_shared_source_projects(self) -> None:
         source_language = Language.objects.get(code="en")

--- a/weblate/templates/manage/performance.html
+++ b/weblate/templates/manage/performance.html
@@ -155,7 +155,13 @@
             </tr>
             <tr>
               <td>{% translate "Candidate duplicate buckets" %}</td>
-              <td class="number">{{ memory_migration_status.duplicate_groups|intcomma }}</td>
+              <td class="number">
+                {% if memory_migration_status.duplicate_groups_known %}
+                  {{ memory_migration_status.duplicate_groups|intcomma }}
+                {% else %}
+                  {% translate "Not calculated during active scan" %}
+                {% endif %}
+              </td>
             </tr>
             <tr>
               <td>{% translate "Duplicate candidate scan" %}</td>

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -998,10 +998,13 @@ class AdminTest(ViewTestCase):
         response = self.client.get(reverse("manage-performance"))
 
         self.assertContains(response, "Backfilling scopes")
-        self.assertEqual(response.context["memory_migration_status"]["total"], 2)
-        self.assertEqual(
-            response.context["memory_migration_status"]["duplicate_groups"], 0
-        )
+        status = response.context["memory_migration_status"]
+        first_memory = Memory.objects.order_by("-id").first()
+        assert first_memory is not None
+        self.assertEqual(status["total"], first_memory.id)
+        self.assertEqual(status["processed"], memory.id)
+        self.assertIsNone(status["duplicate_groups"])
+        self.assertFalse(status["duplicate_groups_known"])
         self.assertFalse(response.context["memory_migration_status"]["completed"])
 
     def test_performance_memory_migration_status_without_state(self) -> None:
@@ -1023,11 +1026,12 @@ class AdminTest(ViewTestCase):
 
         self.assertContains(response, "Not yet started")
         self.assertContains(response, "Scanning duplicate candidates")
-        self.assertEqual(response.context["memory_migration_status"]["processed"], 1)
-        self.assertFalse(response.context["memory_migration_status"]["completed"])
-        self.assertTrue(
-            response.context["memory_migration_status"]["compaction_active"]
-        )
+        status = response.context["memory_migration_status"]
+        self.assertEqual(status["processed"], memory.id)
+        self.assertFalse(status["completed"])
+        self.assertTrue(status["compaction_active"])
+        self.assertIsNone(status["duplicate_groups"])
+        self.assertFalse(status["duplicate_groups_known"])
 
     def test_performance_memory_migration_status_with_duplicates(self) -> None:
         Memory.objects.all().delete()
@@ -1059,9 +1063,13 @@ class AdminTest(ViewTestCase):
             response,
             "Candidate buckets can include entries that are not mergeable",
         )
+        self.assertContains(response, "Not calculated during active scan")
         self.assertNotContains(response, "Duplicate groups pending consolidation")
-        self.assertEqual(
-            response.context["memory_migration_status"]["duplicate_groups"], 1
+        self.assertIsNone(
+            response.context["memory_migration_status"]["duplicate_groups"]
+        )
+        self.assertFalse(
+            response.context["memory_migration_status"]["duplicate_groups_known"]
         )
         self.assertFalse(response.context["memory_migration_status"]["completed"])
         self.assertEqual(
@@ -1145,6 +1153,7 @@ class AdminTest(ViewTestCase):
         self.assertTrue(status["compaction_completed"])
         self.assertFalse(status["compaction_active"])
         self.assertEqual(status["duplicate_groups"], 0)
+        self.assertTrue(status["duplicate_groups_known"])
         self.assertEqual(status["compaction_percent"], 100)
 
     def test_performance_ordering(self) -> None:

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -48,10 +48,7 @@ from weblate.auth.models import (
 from weblate.configuration.models import Setting, SettingCategory
 from weblate.configuration.views import CustomCSSView
 from weblate.memory.models import Memory, MemoryScopeMigrationState
-from weblate.memory.tasks import (
-    MEMORY_SCOPE_COMPACTION_STATE,
-    get_duplicate_memory_candidate_group_count,
-)
+from weblate.memory.tasks import MEMORY_SCOPE_COMPACTION_STATE
 from weblate.trans.actions import ActionEvents
 from weblate.trans.alerts.base import AlertSeverity
 from weblate.trans.forms import AnnouncementForm
@@ -122,9 +119,6 @@ MENU: tuple[tuple[str, str, StrOrPromise], ...] = (
 )
 if "weblate.billing" in settings.INSTALLED_APPS:
     MENU += (("billing", "manage-billing", gettext_lazy("Billing")),)
-
-MEMORY_DUPLICATE_GROUP_COUNT_CACHE_KEY = "memory-duplicate-group-count"
-MEMORY_DUPLICATE_GROUP_COUNT_CACHE_TIMEOUT = 5 * 60
 
 
 @management_access
@@ -392,26 +386,6 @@ def backups(request: AuthenticatedHttpRequest) -> HttpResponse:
     return render(request, "manage/backups.html", context)
 
 
-def get_memory_duplicate_group_count(total: int | None = None) -> int:
-    # TODO(2028.1): Remove this migration status helper once Weblate no longer
-    # supports direct upgrades from 2026 releases.
-    """Return translation memory duplicate group count."""
-    if total is None:
-        total = Memory.objects.count()
-    cache_key = f"{MEMORY_DUPLICATE_GROUP_COUNT_CACHE_KEY}:{total}"
-    cached = cache.get(cache_key)
-    if cached is not None:
-        return cached
-
-    count = get_duplicate_memory_candidate_group_count()
-    cache.set(
-        cache_key,
-        count,
-        MEMORY_DUPLICATE_GROUP_COUNT_CACHE_TIMEOUT,
-    )
-    return count
-
-
 def get_memory_migration_status() -> dict[str, Any]:
     # TODO(2028.1): Remove this migration status helper once Weblate no longer
     # supports direct upgrades from 2026 releases.
@@ -422,47 +396,45 @@ def get_memory_migration_status() -> dict[str, Any]:
     compaction_state = MemoryScopeMigrationState.objects.filter(
         name=MEMORY_SCOPE_COMPACTION_STATE
     ).first()
-    total = Memory.objects.count()
     max_memory_id = Memory.objects.aggregate(max_id=Max("id"))["max_id"] or 0
     last_memory_id = state.last_memory_id if state is not None else 0
     compaction_last_memory_id = (
         compaction_state.last_memory_id if compaction_state is not None else 0
     )
     needs_backfill = state is not None and not state.completed
-    if state is None and total:
+    if state is None and max_memory_id:
         needs_backfill = (
             Memory.objects.alias(memory_has_scope=Memory.objects.get_has_scope_exists())
             .filter(memory_has_scope=False)
             .exists()
         )
-    backfill_completed = total == 0 or not needs_backfill
+    backfill_completed = max_memory_id == 0 or not needs_backfill
 
     if backfill_completed:
         backfill_percent = 100
-        processed = total
+        processed = max_memory_id
     else:
-        processed = Memory.objects.filter(id__lte=last_memory_id).count()
-        backfill_percent = min(round(processed * 100 / total), 100)
+        processed = last_memory_id
+        backfill_percent = (
+            min(round(processed * 100 / max_memory_id), 100) if max_memory_id else 0
+        )
 
-    if not backfill_completed or (
-        compaction_state is not None and compaction_state.completed
-    ):
-        duplicate_groups = 0
-    else:
-        duplicate_groups = get_memory_duplicate_group_count(total)
     compaction_completed = (
         backfill_completed
         and compaction_state is not None
         and compaction_state.completed
     )
-    compaction_active = backfill_completed and total > 0 and not compaction_completed
+    compaction_active = (
+        backfill_completed and max_memory_id > 0 and not compaction_completed
+    )
     compaction_percent = (
         min(round(compaction_last_memory_id * 100 / max_memory_id), 100)
         if max_memory_id and compaction_active
         else 100
-        if compaction_completed or not total
+        if compaction_completed or not max_memory_id
         else 0
     )
+    duplicate_groups = 0 if compaction_completed or not max_memory_id else None
 
     return {
         "backfill_completed": backfill_completed,
@@ -474,10 +446,11 @@ def get_memory_migration_status() -> dict[str, Any]:
         "compaction_max_memory_id": max_memory_id,
         "compaction_percent": compaction_percent,
         "duplicate_groups": duplicate_groups,
+        "duplicate_groups_known": duplicate_groups is not None,
         "last_memory_id": last_memory_id,
         "processed": processed,
         "state": state,
-        "total": total,
+        "total": max_memory_id,
         "updated": (
             compaction_state.updated
             if backfill_completed and compaction_state is not None


### PR DESCRIPTION
Use persisted migration cursors and max memory id for progress reporting.

Skip candidate bucket aggregation while duplicate compaction is active.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
