### PR TITLE
Allow image widgets to be sorted by translation percentage

### DIFF
--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -495,6 +495,15 @@ class MultiLanguageWidget(SVGWidget):
         "auto": None,
     }
 
+    def get_sorted_language_stats(self, request: HttpRequest):
+        language_stats = self.get_language_stats()
+        if request.GET.get("sort") == "percent":
+            return sorted(
+                language_stats,
+                key=lambda stats: (-stats.translated_percent, str(stats.language)),
+            )
+        return sort_unicode(language_stats, lambda stats: str(stats.language))
+
     def get_language_stats(self) -> list[BaseStats | ProjectLanguage]:
         if isinstance(self.stats, (ProjectLanguageStats, TranslationStats)):
             return [self.stats]
@@ -523,7 +532,7 @@ class MultiLanguageWidget(SVGWidget):
         offset = 20
         color = self.COLOR_MAP[self.color]
         language_width = 190
-        for stats in sort_unicode(self.get_language_stats(), lambda x: str(x.language)):
+        for stats in self.get_sorted_language_stats(request):
             # Skip empty translations
             if stats.translated == 0:
                 continue
@@ -691,7 +700,7 @@ class MatrixMultiLanguageWidget(MultiLanguageWidget):
     def render(self, request: HttpRequest, response: HttpResponse) -> None:
         cells: list[MatrixCellDict] = []
         color = self.COLOR_MAP[self.color]
-        for stats in sort_unicode(self.get_language_stats(), lambda x: str(x.language)):
+        for stats in self.get_sorted_language_stats(request):
             # Skip empty translations
             if stats.translated == 0:
                 continue


### PR DESCRIPTION
**Summary**

This change adds support for sorting image widgets by translation percentage.

Previously, language-based widgets were always sorted alphabetically by language name.

This update introduces an optional query parameter:

`?sort=percent`

which sorts languages by translation percentage in descending order.

 **Changes made**

* Added `get_sorted_language_stats()` helper method in `MultiLanguageWidget`
* Added support for `sort=percent` query parameter
* Updated `MultiLanguageWidget.render()` to use configurable sorting
* Updated `MatrixMultiLanguageWidget.render()` to use configurable sorting

 **Example**

Default behavior:

Alphabetical sorting by language name

New behavior:

`?sort=percent`

Sorts languages by highest translation percentage first.

**Benefit**

This allows project widgets to prioritize showing the most translated languages first, making progress visualization more useful.
