### PR TITLE
Add `location_mode` option to POT extraction and honor it in gettext add-ons

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,7 @@ Weblate 2026.7
 * Expanded :doc:`security documentation </security/index>` for data residency, EU cloud sovereignty, release artifacts, supported versions, release verification, SBOMs, dependency handling, vulnerability reporting, hosted-service incident response, and self-hosted operator responsibilities.
 * :ref:`addon-weblate.gettext.linguas` better detects ``LINGUAS`` file presence.
 * :ref:`addon-weblate.gettext.xgettext` can now leave the xgettext language blank to let xgettext guess it from source file extensions.
+* :ref:`addon-weblate.gettext.xgettext`, :ref:`addon-weblate.gettext.meson`, :ref:`addon-weblate.gettext.django`, and :ref:`addon-weblate.gettext.sphinx` can now keep source locations in generated POT files even when translated PO files omit locations.
 * Add-ons installed at higher scopes are now shown on lower-scope add-on pages, and broad-scope add-ons can list affected components with compatibility details.
 * :envvar:`WEBLATE_ALLOWED_ASSET_SIZE` is now available in Docker container.
 * LLM automatic suggestions now use translated examples, language-specific instructions, richer glossary context, and structured placeholder context for more reliable output.

--- a/docs/snippets/addons-autogenerated.rst
+++ b/docs/snippets/addons-autogenerated.rst
@@ -1033,34 +1033,33 @@ Update gettext template (Django)
 .. versionadded:: 5.17
 
 :Add-on ID: ``weblate.gettext.django``
-:Configuration: +----------------------+----------------------+----------------------------------------------------------------------------------+
-                | ``interval``         | Update frequency     | How often the add-on should update the POT file when the component is refreshed. |
-                |                      |                      |                                                                                  |
-                |                      |                      | .. list-table:: Available choices:                                               |
-                |                      |                      |    :width: 100%                                                                  |
-                |                      |                      |                                                                                  |
-                |                      |                      |    * - ``daily``                                                                 |
-                |                      |                      |      - Daily                                                                     |
-                |                      |                      |    * - ``weekly``                                                                |
-                |                      |                      |      - Weekly                                                                    |
-                |                      |                      |    * - ``monthly``                                                               |
-                |                      |                      |      - Monthly                                                                   |
-                +----------------------+----------------------+----------------------------------------------------------------------------------+
-                | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                   |
-                +----------------------+----------------------+----------------------------------------------------------------------------------+
-                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the |
-                |                      |                      | template while omitting them from translated PO files.                                           |
-                |                      |                      |                                                                                                  |
-                |                      |                      | .. list-table:: Available choices:                                                               |
-                |                      |                      |    :width: 100%                                                                                  |
-                |                      |                      |                                                                                                  |
-                |                      |                      |    * - ``file``                                                                                  |
-                |                      |                      |      - Use file format settings                                                                  |
-                |                      |                      |    * - ``keep``                                                                                  |
-                |                      |                      |      - Extract locations to the POT file                                                         |
-                |                      |                      |    * - ``omit``                                                                                  |
-                |                      |                      |      - Do not extract locations                                                                  |
-                +----------------------+----------------------+--------------------------------------------------------------------------------------------------+
+:Configuration: +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``interval``         | Update frequency     | How often the add-on should update the POT file when the component is refreshed.                                                                        |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                      |
+                |                      |                      |    :width: 100%                                                                                                                                         |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      |    * - ``daily``                                                                                                                                        |
+                |                      |                      |      - Daily                                                                                                                                            |
+                |                      |                      |    * - ``weekly``                                                                                                                                       |
+                |                      |                      |      - Weekly                                                                                                                                           |
+                |                      |                      |    * - ``monthly``                                                                                                                                      |
+                |                      |                      |      - Monthly                                                                                                                                          |
+                +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                                                                                          |
+                +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``location_mode``    | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files. |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                      |
+                |                      |                      |    :width: 100%                                                                                                                                         |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      |    * - ``file``                                                                                                                                         |
+                |                      |                      |      - Use file format settings                                                                                                                         |
+                |                      |                      |    * - ``keep``                                                                                                                                         |
+                |                      |                      |      - Extract locations to the POT file                                                                                                                |
+                |                      |                      |    * - ``omit``                                                                                                                                         |
+                |                      |                      |      - Do not extract locations                                                                                                                         |
+                +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 :Triggers: :ref:`addon-event-add-on-installation`, :ref:`addon-event-manual-trigger`, :ref:`addon-event-repository-post-update`
 
@@ -1124,6 +1123,18 @@ Update POT file (Meson)
                 +----------------------+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                                                                                                 |
                 +----------------------+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``location_mode``    | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files.        |
+                |                      |                      |                                                                                                                                                                |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                             |
+                |                      |                      |    :width: 100%                                                                                                                                                |
+                |                      |                      |                                                                                                                                                                |
+                |                      |                      |    * - ``file``                                                                                                                                                |
+                |                      |                      |      - Use file format settings                                                                                                                                |
+                |                      |                      |    * - ``keep``                                                                                                                                                |
+                |                      |                      |      - Extract locations to the POT file                                                                                                                       |
+                |                      |                      |    * - ``omit``                                                                                                                                                |
+                |                      |                      |      - Do not extract locations                                                                                                                                |
+                +----------------------+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``comment_mode``     | Code comments        | Choose whether xgettext should extract no comments, all comments, or only comments marked with a specific tag.                                                 |
                 |                      |                      |                                                                                                                                                                |
                 |                      |                      | .. list-table:: Available choices:                                                                                                                             |
@@ -1154,18 +1165,6 @@ Update POT file (Meson)
                 +----------------------+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``keyword``          | Additional keyword   | Optional extra keyword passed to xgettext using --keyword.                                                                                                     |
                 +----------------------+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files.         |
-                |                      |                      |                                                                                                                                                                 |
-                |                      |                      | .. list-table:: Available choices:                                                                                                                              |
-                |                      |                      |    :width: 100%                                                                                                                                                 |
-                |                      |                      |                                                                                                                                                                 |
-                |                      |                      |    * - ``file``                                                                                                                                                 |
-                |                      |                      |      - Use file format settings                                                                                                                                 |
-                |                      |                      |    * - ``keep``                                                                                                                                                 |
-                |                      |                      |      - Extract locations to the POT file                                                                                                                        |
-                |                      |                      |    * - ``omit``                                                                                                                                                 |
-                |                      |                      |      - Do not extract locations                                                                                                                                 |
-                +----------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``preset``           | Meson preset         | Built-in xgettext argument preset matching Meson gettext integration. The GLib preset adds the keyword and format-flag options used by Meson's gettext helper. |
                 |                      |                      |                                                                                                                                                                |
                 |                      |                      | .. list-table:: Available choices:                                                                                                                             |
@@ -1293,44 +1292,43 @@ Update POT file (Sphinx)
 .. versionadded:: 5.17
 
 :Add-on ID: ``weblate.gettext.sphinx``
-:Configuration: +----------------------+----------------------+-------------------------------------------------------------------------------------+
-                | ``interval``         | Update frequency     | How often the add-on should update the POT file when the component is refreshed.    |
-                |                      |                      |                                                                                     |
-                |                      |                      | .. list-table:: Available choices:                                                  |
-                |                      |                      |    :width: 100%                                                                     |
-                |                      |                      |                                                                                     |
-                |                      |                      |    * - ``daily``                                                                    |
-                |                      |                      |      - Daily                                                                        |
-                |                      |                      |    * - ``weekly``                                                                   |
-                |                      |                      |      - Weekly                                                                       |
-                |                      |                      |    * - ``monthly``                                                                  |
-                |                      |                      |      - Monthly                                                                      |
-                +----------------------+----------------------+-------------------------------------------------------------------------------------+
-                | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                      |
-                +----------------------+----------------------+-------------------------------------------------------------------------------------+
-                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the    |
-                |                      |                      | template while omitting them from translated PO files.                                              |
-                |                      |                      |                                                                                                     |
-                |                      |                      | .. list-table:: Available choices:                                                                  |
-                |                      |                      |    :width: 100%                                                                                     |
-                |                      |                      |                                                                                                     |
-                |                      |                      |    * - ``file``                                                                                     |
-                |                      |                      |      - Use file format settings                                                                     |
-                |                      |                      |    * - ``keep``                                                                                     |
-                |                      |                      |      - Extract locations to the POT file                                                            |
-                |                      |                      |    * - ``omit``                                                                                     |
-                |                      |                      |      - Do not extract locations                                                                     |
-                +----------------------+----------------------+-----------------------------------------------------------------------------------------------------+
-                | ``filter_mode``      | Filtering            | Optionally remove strings that are not useful to translate after Sphinx extraction. |
-                |                      |                      |                                                                                     |
-                |                      |                      | .. list-table:: Available choices:                                                  |
-                |                      |                      |    :width: 100%                                                                     |
-                |                      |                      |                                                                                     |
-                |                      |                      |    * - ``none``                                                                     |
-                |                      |                      |      - None                                                                         |
-                |                      |                      |    * - ``weblate_docs``                                                             |
-                |                      |                      |      - Weblate documentation                                                        |
-                +----------------------+----------------------+-------------------------------------------------------------------------------------+
+:Configuration: +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``interval``         | Update frequency     | How often the add-on should update the POT file when the component is refreshed.                                                                        |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                      |
+                |                      |                      |    :width: 100%                                                                                                                                         |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      |    * - ``daily``                                                                                                                                        |
+                |                      |                      |      - Daily                                                                                                                                            |
+                |                      |                      |    * - ``weekly``                                                                                                                                       |
+                |                      |                      |      - Weekly                                                                                                                                           |
+                |                      |                      |    * - ``monthly``                                                                                                                                      |
+                |                      |                      |      - Monthly                                                                                                                                          |
+                +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                                                                                          |
+                +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``location_mode``    | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files. |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                      |
+                |                      |                      |    :width: 100%                                                                                                                                         |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      |    * - ``file``                                                                                                                                         |
+                |                      |                      |      - Use file format settings                                                                                                                         |
+                |                      |                      |    * - ``keep``                                                                                                                                         |
+                |                      |                      |      - Extract locations to the POT file                                                                                                                |
+                |                      |                      |    * - ``omit``                                                                                                                                         |
+                |                      |                      |      - Do not extract locations                                                                                                                         |
+                +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``filter_mode``      | Filtering            | Optionally remove strings that are not useful to translate after Sphinx extraction.                                                                     |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                      |
+                |                      |                      |    :width: 100%                                                                                                                                         |
+                |                      |                      |                                                                                                                                                         |
+                |                      |                      |    * - ``none``                                                                                                                                         |
+                |                      |                      |      - None                                                                                                                                             |
+                |                      |                      |    * - ``weblate_docs``                                                                                                                                 |
+                |                      |                      |      - Weblate documentation                                                                                                                            |
+                +----------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 :Triggers: :ref:`addon-event-add-on-installation`, :ref:`addon-event-manual-trigger`, :ref:`addon-event-repository-post-update`
 
@@ -1380,6 +1378,18 @@ Update POT file (xgettext)
                 +----------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                                                                                                                                   |
                 +----------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``location_mode``    | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files.                                          |
+                |                      |                      |                                                                                                                                                                                                  |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                                                               |
+                |                      |                      |    :width: 100%                                                                                                                                                                                  |
+                |                      |                      |                                                                                                                                                                                                  |
+                |                      |                      |    * - ``file``                                                                                                                                                                                  |
+                |                      |                      |      - Use file format settings                                                                                                                                                                  |
+                |                      |                      |    * - ``keep``                                                                                                                                                                                  |
+                |                      |                      |      - Extract locations to the POT file                                                                                                                                                         |
+                |                      |                      |    * - ``omit``                                                                                                                                                                                  |
+                |                      |                      |      - Do not extract locations                                                                                                                                                                  |
+                +----------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``comment_mode``     | Code comments        | Choose whether xgettext should extract no comments, all comments, or only comments marked with a specific tag.                                                                                   |
                 |                      |                      |                                                                                                                                                                                                  |
                 |                      |                      | .. list-table:: Available choices:                                                                                                                                                               |
@@ -1410,18 +1420,6 @@ Update POT file (xgettext)
                 +----------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``keyword``          | Additional keyword   | Optional extra keyword passed to xgettext using --keyword.                                                                                                                                       |
                 +----------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files.          |
-                |                      |                      |                                                                                                                                                                  |
-                |                      |                      | .. list-table:: Available choices:                                                                                                                               |
-                |                      |                      |    :width: 100%                                                                                                                                                  |
-                |                      |                      |                                                                                                                                                                  |
-                |                      |                      |    * - ``file``                                                                                                                                                  |
-                |                      |                      |      - Use file format settings                                                                                                                                  |
-                |                      |                      |    * - ``keep``                                                                                                                                                  |
-                |                      |                      |      - Extract locations to the POT file                                                                                                                         |
-                |                      |                      |    * - ``omit``                                                                                                                                                  |
-                |                      |                      |      - Do not extract locations                                                                                                                                  |
-                +----------------------+----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``input_mode``       | Input source         | Choose whether xgettext should read source files from glob patterns or from a POTFILES/POTFILES.in manifest.                                                                                     |
                 |                      |                      |                                                                                                                                                                                                  |
                 |                      |                      | .. list-table:: Available choices:                                                                                                                                                               |

--- a/docs/snippets/addons-autogenerated.rst
+++ b/docs/snippets/addons-autogenerated.rst
@@ -1048,6 +1048,19 @@ Update gettext template (Django)
                 +----------------------+----------------------+----------------------------------------------------------------------------------+
                 | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                   |
                 +----------------------+----------------------+----------------------------------------------------------------------------------+
+                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the |
+                |                      |                      | template while omitting them from translated PO files.                                           |
+                |                      |                      |                                                                                                  |
+                |                      |                      | .. list-table:: Available choices:                                                               |
+                |                      |                      |    :width: 100%                                                                                  |
+                |                      |                      |                                                                                                  |
+                |                      |                      |    * - ``file``                                                                                  |
+                |                      |                      |      - Use file format settings                                                                  |
+                |                      |                      |    * - ``keep``                                                                                  |
+                |                      |                      |      - Extract locations to the POT file                                                         |
+                |                      |                      |    * - ``omit``                                                                                  |
+                |                      |                      |      - Do not extract locations                                                                  |
+                +----------------------+----------------------+--------------------------------------------------------------------------------------------------+
 
 :Triggers: :ref:`addon-event-add-on-installation`, :ref:`addon-event-manual-trigger`, :ref:`addon-event-repository-post-update`
 
@@ -1141,6 +1154,18 @@ Update POT file (Meson)
                 +----------------------+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``keyword``          | Additional keyword   | Optional extra keyword passed to xgettext using --keyword.                                                                                                     |
                 +----------------------+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files.         |
+                |                      |                      |                                                                                                                                                                 |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                              |
+                |                      |                      |    :width: 100%                                                                                                                                                 |
+                |                      |                      |                                                                                                                                                                 |
+                |                      |                      |    * - ``file``                                                                                                                                                 |
+                |                      |                      |      - Use file format settings                                                                                                                                 |
+                |                      |                      |    * - ``keep``                                                                                                                                                 |
+                |                      |                      |      - Extract locations to the POT file                                                                                                                        |
+                |                      |                      |    * - ``omit``                                                                                                                                                 |
+                |                      |                      |      - Do not extract locations                                                                                                                                 |
+                +----------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``preset``           | Meson preset         | Built-in xgettext argument preset matching Meson gettext integration. The GLib preset adds the keyword and format-flag options used by Meson's gettext helper. |
                 |                      |                      |                                                                                                                                                                |
                 |                      |                      | .. list-table:: Available choices:                                                                                                                             |
@@ -1283,6 +1308,19 @@ Update POT file (Sphinx)
                 +----------------------+----------------------+-------------------------------------------------------------------------------------+
                 | ``normalize_header`` | Normalize POT header | Updates gettext headers and replaces placeholder POT comments.                      |
                 +----------------------+----------------------+-------------------------------------------------------------------------------------+
+                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the    |
+                |                      |                      | template while omitting them from translated PO files.                                              |
+                |                      |                      |                                                                                                     |
+                |                      |                      | .. list-table:: Available choices:                                                                  |
+                |                      |                      |    :width: 100%                                                                                     |
+                |                      |                      |                                                                                                     |
+                |                      |                      |    * - ``file``                                                                                     |
+                |                      |                      |      - Use file format settings                                                                     |
+                |                      |                      |    * - ``keep``                                                                                     |
+                |                      |                      |      - Extract locations to the POT file                                                            |
+                |                      |                      |    * - ``omit``                                                                                     |
+                |                      |                      |      - Do not extract locations                                                                     |
+                +----------------------+----------------------+-----------------------------------------------------------------------------------------------------+
                 | ``filter_mode``      | Filtering            | Optionally remove strings that are not useful to translate after Sphinx extraction. |
                 |                      |                      |                                                                                     |
                 |                      |                      | .. list-table:: Available choices:                                                  |
@@ -1372,6 +1410,18 @@ Update POT file (xgettext)
                 +----------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``keyword``          | Additional keyword   | Optional extra keyword passed to xgettext using --keyword.                                                                                                                                       |
                 +----------------------+----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ``location_mode``   | Source locations     | Choose how extraction writes source locations to the POT file. Use this to keep locations in the template while omitting them from translated PO files.          |
+                |                      |                      |                                                                                                                                                                  |
+                |                      |                      | .. list-table:: Available choices:                                                                                                                               |
+                |                      |                      |    :width: 100%                                                                                                                                                  |
+                |                      |                      |                                                                                                                                                                  |
+                |                      |                      |    * - ``file``                                                                                                                                                  |
+                |                      |                      |      - Use file format settings                                                                                                                                  |
+                |                      |                      |    * - ``keep``                                                                                                                                                  |
+                |                      |                      |      - Extract locations to the POT file                                                                                                                         |
+                |                      |                      |    * - ``omit``                                                                                                                                                  |
+                |                      |                      |      - Do not extract locations                                                                                                                                  |
+                +----------------------+----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``input_mode``       | Input source         | Choose whether xgettext should read source files from glob patterns or from a POTFILES/POTFILES.in manifest.                                                                                     |
                 |                      |                      |                                                                                                                                                                                                  |
                 |                      |                      | .. list-table:: Available choices:                                                                                                                                                               |

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -180,8 +180,40 @@ class BaseExtractPotForm(BaseAddonForm):
             "Ensures the msgmerge add-on is installed and triggers it after the POT file is updated."
         ),
     )
+    location_mode = forms.ChoiceField(
+        label=gettext_lazy("Source locations"),
+        choices=(
+            ("file", gettext_lazy("Use file format settings")),
+            ("keep", gettext_lazy("Extract locations to the POT file")),
+            ("omit", gettext_lazy("Do not extract locations")),
+        ),
+        required=True,
+        initial="file",
+        help_text=gettext_lazy(
+            "Choose how extraction writes source locations to the POT file. "
+            "Use this to keep locations in the template while omitting them "
+            "from translated PO files."
+        ),
+    )
+
+    @staticmethod
+    def ensure_default_bound_value(data, key: str, value: str):
+        if data is None or key in data:
+            return data
+        if hasattr(data, "copy"):
+            data = data.copy()
+            if hasattr(data, "setlist"):
+                data.setlist(key, [value])
+            else:
+                data[key] = value
+        return data
 
     def __init__(self, *args, **kwargs) -> None:
+        data = self.ensure_default_bound_value(
+            kwargs.get("data"), "location_mode", "file"
+        )
+        if data is not None:
+            kwargs["data"] = data
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         if self._addon.instance.pk is None and not self._addon.documentation_build:
@@ -190,6 +222,7 @@ class BaseExtractPotForm(BaseAddonForm):
             Field("interval"),
             Field("normalize_header"),
             Field("update_po_files"),
+            Field("location_mode"),
         )
 
     def serialize_form(self):
@@ -247,18 +280,6 @@ class BaseXgettextExtractPotForm(BaseExtractPotForm):
         ),
     )
 
-    @staticmethod
-    def ensure_default_bound_value(data, key: str, value: str):
-        if data is None or key in data:
-            return data
-        if hasattr(data, "copy"):
-            data = data.copy()
-            if hasattr(data, "setlist"):
-                data.setlist(key, [value])
-            else:
-                data[key] = value
-        return data
-
     def __init__(self, *args, **kwargs) -> None:
         data = self.ensure_default_bound_value(
             kwargs.get("data"), "comment_mode", "off"
@@ -277,6 +298,7 @@ class BaseXgettextExtractPotForm(BaseExtractPotForm):
             comment_tag = ""
         cleaned_data["comment_tag"] = comment_tag
         cleaned_data["keyword"] = cleaned_data.get("keyword", "").strip()
+        cleaned_data["location_mode"] = cleaned_data.get("location_mode", "file")
         return cleaned_data
 
 
@@ -350,6 +372,7 @@ class XgettextExtractPotForm(BaseXgettextExtractPotForm):
             Field("comment_tag"),
             Field("checks"),
             Field("keyword"),
+            Field("location_mode"),
         ]
 
     @staticmethod
@@ -423,6 +446,7 @@ class MesonExtractPotForm(BaseXgettextExtractPotForm):
             Field("comment_tag"),
             Field("checks"),
             Field("keyword"),
+            Field("location_mode"),
         )
 
     def clean(self) -> dict[str, Any]:
@@ -490,6 +514,7 @@ class SphinxExtractPotForm(BaseExtractPotForm):
             Field("interval"),
             Field("normalize_header"),
             Field("update_po_files"),
+            Field("location_mode"),
             Field("filter_mode"),
         )
 

--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -528,14 +528,23 @@ class ExtractPotBaseAddon(GettextBaseAddon, UpdateBaseAddon):
     def get_template_filename(self, component: Component) -> str | None:
         return component.get_new_base_filename()
 
+    def get_location_mode(self) -> str:
+        return str(self.instance.configuration.get("location_mode", "file"))
+
     def get_gettext_format_args(self, component: Component) -> list[str]:
         """Return gettext CLI flags implied by component file-format settings."""
         file_format_cls = cast("PoFormat", component.file_format_cls)
-        return [
+        args = [
             arg
             for arg in file_format_cls.get_msgmerge_args(component)
             if arg in {"--no-location", "--no-wrap"}
         ]
+        location_mode = self.get_location_mode()
+        if location_mode == "keep":
+            return [arg for arg in args if arg != "--no-location"]
+        if location_mode == "omit" and "--no-location" not in args:
+            args.append("--no-location")
+        return args
 
     def ensure_msgmerge_addon(self) -> bool:
         from weblate.addons.models import Addon  # ruff: ignore[import-outside-top-level, unsorted-imports]
@@ -1908,13 +1917,26 @@ class SphinxAddon(ExtractPotBaseAddon):
         source_root = source_dir.resolve()
         build_root = build_dir.resolve()
         file_format_cls = cast("PoFormat", component.file_format_cls)
+        file_format_params = dict(component.file_format_params)
+        location_mode = self.get_location_mode()
+        if location_mode == "keep":
+            file_format_params["po_no_location"] = False
+        elif location_mode == "omit":
+            file_format_params["po_no_location"] = True
         store = file_format_cls(
             template,
-            file_format_params=component.file_format_params,
+            file_format_params=file_format_params,
             repo_temp_dir=component.repository.get_repo_temp_dir(),
         )
-        changed = False
+        changed = location_mode == "omit"
         for unit in store.content_units:
+            if location_mode == "omit":
+                unit.mainunit.sourcecomments = [
+                    comment
+                    for comment in unit.mainunit.sourcecomments
+                    if not comment.startswith("#:")
+                ]
+                continue
             locations = unit.mainunit.getlocations()
             normalized_locations = [
                 SphinxAddon.normalize_sphinx_location(location, source_root, build_root)

--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -1920,23 +1920,19 @@ class SphinxAddon(ExtractPotBaseAddon):
         file_format_params = dict(component.file_format_params)
         location_mode = self.get_location_mode()
         if location_mode == "keep":
-            file_format_params["po_no_location"] = False
+            effective_no_location = False
         elif location_mode == "omit":
-            file_format_params["po_no_location"] = True
+            effective_no_location = True
+        else:
+            effective_no_location = bool(file_format_params.get("po_no_location"))
+        file_format_params["po_no_location"] = effective_no_location
         store = file_format_cls(
             template,
             file_format_params=file_format_params,
             repo_temp_dir=component.repository.get_repo_temp_dir(),
         )
-        changed = location_mode == "omit"
+        changed = False
         for unit in store.content_units:
-            if location_mode == "omit":
-                unit.mainunit.sourcecomments = [
-                    comment
-                    for comment in unit.mainunit.sourcecomments
-                    if not comment.startswith("#:")
-                ]
-                continue
             locations = unit.mainunit.getlocations()
             normalized_locations = [
                 SphinxAddon.normalize_sphinx_location(location, source_root, build_root)
@@ -1962,6 +1958,15 @@ class SphinxAddon(ExtractPotBaseAddon):
             if len(filtered_units) != len(store.store.units):
                 store.store.units = filtered_units
                 changed = True
+
+        if effective_no_location:
+            for unit in store.content_units:
+                unit.mainunit.sourcecomments = [
+                    comment
+                    for comment in unit.mainunit.sourcecomments
+                    if not comment.startswith("#:")
+                ]
+            changed = True
 
         if changed:
             store.save()

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -3658,6 +3658,38 @@ msgstr ""
         template = Path(self.component.full_path) / self.component.new_base
         self.assertIn("#: index.rst:1", template.read_text(encoding="utf-8"))
 
+    def test_sphinx_uses_file_format_no_location_by_default(self) -> None:
+        self.component.new_base = "docs/locales/docs.pot"
+        params = get_default_params_for_file_format(self.component.file_format)
+        params.update({"po_no_location": True})
+        self.component.file_format_params = params
+        self.component.save(update_fields=["file_format_params"])
+        source_dir = Path(self.component.full_path) / "docs"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        addon = SphinxAddon.create(
+            component=self.component,
+            run=False,
+            configuration={"interval": "weekly", "normalize_header": False},
+        )
+
+        def run_process(component, command, env=None, cwd=None):
+            build_dir = Path(command[-1])
+            build_dir.mkdir(parents=True, exist_ok=True)
+            (build_dir / "docs.pot").write_text(
+                f'#: {source_dir / "index.rst"}:1\nmsgid "Hello"\nmsgstr ""\n',
+                encoding="utf-8",
+            )
+            return ""
+
+        with (
+            patch.object(SphinxAddon, "validate_repository_tree", return_value=True),
+            patch.object(SphinxAddon, "run_process", side_effect=run_process),
+        ):
+            addon.execute_update(self.component, "", [])
+
+        template = Path(self.component.full_path) / self.component.new_base
+        self.assertNotIn("#: index.rst:1", template.read_text(encoding="utf-8"))
+
     def test_sphinx_can_omit_pot_locations(self) -> None:
         self.component.new_base = "docs/locales/docs.pot"
         source_dir = Path(self.component.full_path) / "docs"
@@ -3929,6 +3961,43 @@ msgstr ""
         self.assertIn("Welcome to the admin docs.", content)
         self.assertNotIn('\nmsgid "Django"\n', content)
         self.assertNotIn('\nmsgid "foo_bar"\n', content)
+
+    def test_sphinx_weblate_docs_filter_runs_before_omitting_locations(self) -> None:
+        self.component.new_base = "docs/locales/docs.pot"
+        source_dir = Path(self.component.full_path) / "docs"
+        build_dir = Path(self.component.full_path) / "build"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        build_dir.mkdir(parents=True, exist_ok=True)
+        template = Path(self.component.full_path) / self.component.new_base
+        template.parent.mkdir(parents=True, exist_ok=True)
+        template.write_text(
+            f"#: {source_dir / 'admin' / 'management.rst'}:1\n"
+            'msgid "foo_bar"\n'
+            'msgstr ""\n\n'
+            f"#: {source_dir / 'admin' / 'access.rst'}:1\n"
+            'msgid "Welcome"\n'
+            'msgstr ""\n',
+            encoding="utf-8",
+        )
+        addon = SphinxAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "normalize_header": False,
+                "filter_mode": "weblate_docs",
+                "location_mode": "omit",
+            },
+        )
+
+        addon.postprocess_sphinx_template(
+            self.component, template, source_dir, build_dir
+        )
+
+        content = template.read_text(encoding="utf-8")
+        self.assertNotIn('msgid "foo_bar"', content)
+        self.assertIn('msgid "Welcome"', content)
+        self.assertNotIn("#:", content)
 
     def test_django_refuses_out_of_tree_symlinked_source_file(self) -> None:
         if not hasattr(os, "symlink"):

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -1164,6 +1164,7 @@ class GettextAddonTest(ViewTestCase):
         self.assertEqual(form.cleaned_data["comment_tag"], "")
         self.assertEqual(form.cleaned_data["checks"], [])
         self.assertEqual(form.cleaned_data["keyword"], "")
+        self.assertEqual(form.cleaned_data["location_mode"], "file")
 
     def test_xgettext_form_accepts_blank_language(self) -> None:
         form = XgettextAddon.get_add_form(None, component=self.component)
@@ -1224,6 +1225,7 @@ class GettextAddonTest(ViewTestCase):
                 "comment_tag": "TRANSLATORS",
                 "checks": ["ellipsis-unicode", "bullet-unicode"],
                 "keyword": "tr",
+                "location_mode": "keep",
             },
         )
         self.assertTrue(form.is_valid(), form.errors)
@@ -1233,6 +1235,7 @@ class GettextAddonTest(ViewTestCase):
             form.cleaned_data["checks"], ["ellipsis-unicode", "bullet-unicode"]
         )
         self.assertEqual(form.cleaned_data["keyword"], "tr")
+        self.assertEqual(form.cleaned_data["location_mode"], "keep")
 
     def test_xgettext_form_potfiles(self) -> None:
         form = XgettextAddon.get_add_form(
@@ -1403,6 +1406,7 @@ class GettextAddonTest(ViewTestCase):
                 "comment_tag": "TRANSLATORS",
                 "checks": ["ellipsis-unicode", "quote-unicode"],
                 "keyword": "tr",
+                "location_mode": "omit",
             },
         )
 
@@ -1416,6 +1420,7 @@ class GettextAddonTest(ViewTestCase):
             form.serialize_form()["checks"], ["ellipsis-unicode", "quote-unicode"]
         )
         self.assertEqual(form.serialize_form()["keyword"], "tr")
+        self.assertEqual(form.serialize_form()["location_mode"], "omit")
 
     def test_django_form(self) -> None:
         self.component.new_base = "locale/django.pot"
@@ -1429,6 +1434,7 @@ class GettextAddonTest(ViewTestCase):
             },
         )
         self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["location_mode"], "file")
 
     def test_django_form_po_template(self) -> None:
         self.component.filemask = "locale/*/LC_MESSAGES/django.po"
@@ -1524,6 +1530,7 @@ class GettextAddonTest(ViewTestCase):
             },
         )
         self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["location_mode"], "file")
 
     def test_sphinx_form_valid_root_component(self) -> None:
         self.component.new_base = "locales/docs.pot"
@@ -2024,6 +2031,64 @@ class GettextAddonTest(ViewTestCase):
         command = mocked.call_args.args[1]
         self.assertIn("--no-location", command)
         self.assertIn("--no-wrap", command)
+
+    def test_xgettext_can_keep_pot_locations_with_po_no_location(self) -> None:
+        source = Path(self.component.full_path) / "src" / "messages.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(
+            'from gettext import gettext as _\n_("Hello")\n', encoding="utf-8"
+        )
+        params = get_default_params_for_file_format(self.component.file_format)
+        params.update({"po_no_location": True})
+        self.component.file_format_params = params
+        self.component.save(update_fields=["file_format_params"])
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+                "location_mode": "keep",
+            },
+        )
+
+        with (
+            patch.object(XgettextAddon, "run_process", return_value="") as mocked,
+            patch.object(XgettextAddon, "validate_repository_tree", return_value=True),
+        ):
+            addon.update_translations(self.component, "", [])
+
+        command = mocked.call_args.args[1]
+        self.assertNotIn("--no-location", command)
+
+    def test_xgettext_can_omit_pot_locations(self) -> None:
+        source = Path(self.component.full_path) / "src" / "messages.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(
+            'from gettext import gettext as _\n_("Hello")\n', encoding="utf-8"
+        )
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+                "location_mode": "omit",
+            },
+        )
+
+        with (
+            patch.object(XgettextAddon, "run_process", return_value="") as mocked,
+            patch.object(XgettextAddon, "validate_repository_tree", return_value=True),
+        ):
+            addon.update_translations(self.component, "", [])
+
+        command = mocked.call_args.args[1]
+        self.assertIn("--no-location", command)
 
     def test_xgettext_uses_parametrized_arguments(self) -> None:
         source = Path(self.component.full_path) / "src" / "messages.py"
@@ -3275,6 +3340,72 @@ msgstr ""
         self.assertIn("--no-location", command)
         self.assertIn("--no-wrap", command)
 
+    def test_django_can_keep_pot_locations_with_po_no_location(self) -> None:
+        self.component.new_base = "locale/django.pot"
+        params = get_default_params_for_file_format(self.component.file_format)
+        params.update({"po_no_location": True})
+        self.component.file_format_params = params
+        self.component.save(update_fields=["file_format_params"])
+        addon = DjangoAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "normalize_header": False,
+                "location_mode": "keep",
+            },
+        )
+
+        def run_process(component, command, env=None, cwd=None):
+            locale_dir = Path(env["WEBLATE_EXTRACT_LOCALE_PATH"])
+            locale_dir.mkdir(parents=True, exist_ok=True)
+            (locale_dir / "django.pot").write_text(
+                'msgid ""\nmsgstr ""\n', encoding="utf-8"
+            )
+            return ""
+
+        with (
+            patch.object(
+                DjangoAddon, "validate_django_repository_tree", return_value=True
+            ),
+            patch.object(DjangoAddon, "run_process", side_effect=run_process) as mocked,
+        ):
+            addon.execute_update(self.component, "", [])
+
+        command = mocked.call_args.args[1]
+        self.assertNotIn("--no-location", command)
+
+    def test_django_can_omit_pot_locations(self) -> None:
+        self.component.new_base = "locale/django.pot"
+        addon = DjangoAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "normalize_header": False,
+                "location_mode": "omit",
+            },
+        )
+
+        def run_process(component, command, env=None, cwd=None):
+            locale_dir = Path(env["WEBLATE_EXTRACT_LOCALE_PATH"])
+            locale_dir.mkdir(parents=True, exist_ok=True)
+            (locale_dir / "django.pot").write_text(
+                'msgid ""\nmsgstr ""\n', encoding="utf-8"
+            )
+            return ""
+
+        with (
+            patch.object(
+                DjangoAddon, "validate_django_repository_tree", return_value=True
+            ),
+            patch.object(DjangoAddon, "run_process", side_effect=run_process) as mocked,
+        ):
+            addon.execute_update(self.component, "", [])
+
+        command = mocked.call_args.args[1]
+        self.assertIn("--no-location", command)
+
     def test_sphinx_scopes_to_repo_root_locales(self) -> None:
         self.component.new_base = "locales/docs.pot"
         addon = SphinxAddon.create(
@@ -3490,6 +3621,74 @@ msgstr ""
             os.path.join(self.component.full_path, "docs/locales/docs.pot"),
             addon.extra_files,
         )
+
+    def test_sphinx_can_keep_pot_locations_with_po_no_location(self) -> None:
+        self.component.new_base = "docs/locales/docs.pot"
+        params = get_default_params_for_file_format(self.component.file_format)
+        params.update({"po_no_location": True})
+        self.component.file_format_params = params
+        self.component.save(update_fields=["file_format_params"])
+        source_dir = Path(self.component.full_path) / "docs"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        addon = SphinxAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "normalize_header": False,
+                "location_mode": "keep",
+            },
+        )
+
+        def run_process(component, command, env=None, cwd=None):
+            build_dir = Path(command[-1])
+            build_dir.mkdir(parents=True, exist_ok=True)
+            (build_dir / "docs.pot").write_text(
+                f'#: {source_dir / "index.rst"}:1\nmsgid "Hello"\nmsgstr ""\n',
+                encoding="utf-8",
+            )
+            return ""
+
+        with (
+            patch.object(SphinxAddon, "validate_repository_tree", return_value=True),
+            patch.object(SphinxAddon, "run_process", side_effect=run_process),
+        ):
+            addon.execute_update(self.component, "", [])
+
+        template = Path(self.component.full_path) / self.component.new_base
+        self.assertIn("#: index.rst:1", template.read_text(encoding="utf-8"))
+
+    def test_sphinx_can_omit_pot_locations(self) -> None:
+        self.component.new_base = "docs/locales/docs.pot"
+        source_dir = Path(self.component.full_path) / "docs"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        addon = SphinxAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "normalize_header": False,
+                "location_mode": "omit",
+            },
+        )
+
+        def run_process(component, command, env=None, cwd=None):
+            build_dir = Path(command[-1])
+            build_dir.mkdir(parents=True, exist_ok=True)
+            (build_dir / "docs.pot").write_text(
+                f'#: {source_dir / "index.rst"}:1\nmsgid "Hello"\nmsgstr ""\n',
+                encoding="utf-8",
+            )
+            return ""
+
+        with (
+            patch.object(SphinxAddon, "validate_repository_tree", return_value=True),
+            patch.object(SphinxAddon, "run_process", side_effect=run_process),
+        ):
+            addon.execute_update(self.component, "", [])
+
+        template = Path(self.component.full_path) / self.component.new_base
+        self.assertNotIn("#: index.rst:1", template.read_text(encoding="utf-8"))
 
     def test_sphinx_refuses_out_of_tree_symlink(self) -> None:
         if not hasattr(os, "symlink"):


### PR DESCRIPTION
### Motivation

* Provide explicit control over whether source locations are written into generated POT files independent of PO file settings, allowing templates to keep locations even when translated PO files omit them.
* Surface the choice in add-on configuration forms so users can choose to `keep`, `omit`, or use file-format `file` defaults for source locations.

### Description

* Added a `location_mode` choice field to the POT extraction forms and centralized `ensure_default_bound_value` in `BaseExtractPotForm` to set sensible defaults for bound form data. 
* Implemented `get_location_mode` and updated `get_gettext_format_args` in the gettext add-on to add or remove the `--no-location` flag according to the configured `location_mode` and file-format parameters. 
* Updated Sphinx postprocessing to apply `location_mode` by toggling `po_no_location` in `file_format_params` and by stripping or preserving `#: ...` source comments in generated POT templates as appropriate. 
* Added/updated unit tests and docs: multiple form roundtrip tests and behavior tests for `Xgettext`, `Django`, and `Sphinx` add-ons covering `keep`/`omit`/default `file` behaviors, and updated release notes in `docs/changes.rst`.

### Testing

* Ran unit tests in `weblate.addons.tests.GettextAddonTest` including newly added tests `test_xgettext_can_keep_pot_locations_with_po_no_location`, `test_xgettext_can_omit_pot_locations`, `test_django_can_keep_pot_locations_with_po_no_location`, `test_django_can_omit_pot_locations`, `test_sphinx_can_keep_pot_locations_with_po_no_location`, and `test_sphinx_can_omit_pot_locations`, which all passed. 
* Verified existing gettext-related tests and form roundtrip assertions (defaults and serialization for `location_mode`) passed successfully. 
* No automated test failures were observed for the modified test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43fe8b16b0832997bc844ba4a8d3c5)