### PR TITLE
fix(memory): speed up duplicate candidate scan

### DIFF
--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from uuid import UUID
 
 from django.db import transaction
-from django.db.models import Count, Min, Q, Value
+from django.db.models import Exists, F, OuterRef, Q, Value
 from django.db.models.functions import MD5
 from django.utils import timezone
 
@@ -354,14 +354,45 @@ def has_duplicate_memory_groups() -> bool:
 def get_duplicate_memory_candidate_group_queryset(
     memory_objects, *, last_memory_id: int = 0
 ):
-    # Group on the expressions covered by memory_md5_index. Exact identity
-    # splitting, including context/status/file ownership, happens after loading
-    # these candidates.
-    queryset = (
-        memory_objects.annotate(
-            origin_md5=MD5("origin"),
-            source_md5=MD5("source"),
-            target_md5=MD5("target"),
+    # Find the first row for each duplicate candidate instead of grouping the
+    # whole memory table every batch. Exact identity splitting, including
+    # context/status/file ownership, happens after loading these candidates.
+    queryset = memory_objects.order_by().annotate(
+        origin_md5=MD5("origin"),
+        source_md5=MD5("source"),
+        target_md5=MD5("target"),
+    )
+    if last_memory_id:
+        queryset = queryset.filter(id__gt=last_memory_id)
+
+    candidate_memory = memory_objects.order_by().annotate(
+        origin_md5=MD5("origin"),
+        source_md5=MD5("source"),
+        target_md5=MD5("target"),
+    )
+    matching_candidate_query = {
+        "source_language_id": OuterRef("source_language_id"),
+        "target_language_id": OuterRef("target_language_id"),
+        "origin_md5": OuterRef("origin_md5"),
+        "source_md5": OuterRef("source_md5"),
+        "target_md5": OuterRef("target_md5"),
+    }
+    previous_candidate = candidate_memory.filter(
+        **matching_candidate_query,
+        id__lt=OuterRef("id"),
+    )
+    next_candidate = candidate_memory.filter(
+        **matching_candidate_query,
+        id__gt=OuterRef("id"),
+    )
+    return (
+        queryset.alias(
+            has_previous_candidate=Exists(previous_candidate),
+            has_next_candidate=Exists(next_candidate),
+        )
+        .filter(
+            has_previous_candidate=False,
+            has_next_candidate=True,
         )
         .values(
             "source_language_id",
@@ -369,13 +400,9 @@ def get_duplicate_memory_candidate_group_queryset(
             "origin_md5",
             "source_md5",
             "target_md5",
+            first_id=F("id"),
         )
-        .annotate(first_id=Min("id"), count=Count("id"))
-        .filter(count__gt=1)
     )
-    if last_memory_id:
-        queryset = queryset.filter(first_id__gt=last_memory_id)
-    return queryset
 
 
 def get_duplicate_memory_candidate_groups(
@@ -386,14 +413,6 @@ def get_duplicate_memory_candidate_groups(
             memory_objects, last_memory_id=last_memory_id
         ).order_by("first_id")[:batch_size]
     )
-
-
-def get_duplicate_memory_candidate_group_count() -> int:
-    # TODO(2028.1): Remove this migration status helper once Weblate no longer
-    # supports direct upgrades from 2026 releases.
-    return get_duplicate_memory_candidate_group_queryset(
-        Memory.objects.using("default")
-    ).count()
 
 
 def get_duplicate_memory_candidate_memories(

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -2160,6 +2160,30 @@ msgstr "Nazdar svete!\n"
 
         self.assertEqual([group["first_id"] for group in groups], [later.id])
 
+    def test_duplicate_candidate_groups_skip_unique_memory(self) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        origin = "duplicate-candidate-unique"
+        values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "target": "Kandidatni unikatni cil",
+            "origin": origin,
+            "status": Memory.STATUS_ACTIVE,
+            "legacy_project": self.project,
+        }
+        Memory.objects.create(source="Unique candidate source", **values)
+        duplicate = Memory.objects.create(source="Duplicate candidate source", **values)
+        Memory.objects.create(source="Duplicate candidate source", **values)
+
+        groups = get_duplicate_memory_candidate_groups(
+            Memory.objects.using("default").filter(origin=origin),
+            last_memory_id=0,
+            batch_size=10,
+        )
+
+        self.assertEqual([group["first_id"] for group in groups], [duplicate.id])
+
     def test_compact_memory_scopes_resets_cursor_when_duplicates_remain(
         self,
     ) -> None:

--- a/weblate/templates/manage/performance.html
+++ b/weblate/templates/manage/performance.html
@@ -154,16 +154,6 @@
               <td class="number">{{ memory_migration_status.processed|intcomma }} / {{ memory_migration_status.total|intcomma }}</td>
             </tr>
             <tr>
-              <td>{% translate "Candidate duplicate buckets" %}</td>
-              <td class="number">
-                {% if memory_migration_status.duplicate_groups_known %}
-                  {{ memory_migration_status.duplicate_groups|intcomma }}
-                {% else %}
-                  {% translate "Not calculated during active scan" %}
-                {% endif %}
-              </td>
-            </tr>
-            <tr>
               <td>{% translate "Duplicate candidate scan" %}</td>
               <td>
                 <div class="progress">
@@ -209,11 +199,6 @@
             </tr>
           </tbody>
         </table>
-        <div class="card-footer">
-          <p class="help-block">
-            {% translate "Candidate buckets can include entries that are not mergeable because context, status, or file ownership differs." %}
-          </p>
-        </div>
       </div>
 
       {% if disk_usage %}

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -1003,8 +1003,6 @@ class AdminTest(ViewTestCase):
         assert first_memory is not None
         self.assertEqual(status["total"], first_memory.id)
         self.assertEqual(status["processed"], memory.id)
-        self.assertIsNone(status["duplicate_groups"])
-        self.assertFalse(status["duplicate_groups_known"])
         self.assertFalse(response.context["memory_migration_status"]["completed"])
 
     def test_performance_memory_migration_status_without_state(self) -> None:
@@ -1030,8 +1028,6 @@ class AdminTest(ViewTestCase):
         self.assertEqual(status["processed"], memory.id)
         self.assertFalse(status["completed"])
         self.assertTrue(status["compaction_active"])
-        self.assertIsNone(status["duplicate_groups"])
-        self.assertFalse(status["duplicate_groups_known"])
 
     def test_performance_memory_migration_status_with_duplicates(self) -> None:
         Memory.objects.all().delete()
@@ -1057,20 +1053,10 @@ class AdminTest(ViewTestCase):
         response = self.client.get(reverse("manage-performance"))
 
         self.assertContains(response, "Scanning duplicate candidates")
-        self.assertContains(response, "Candidate duplicate buckets")
+        self.assertNotContains(response, "Candidate duplicate buckets")
         self.assertContains(response, "Duplicate candidate scan")
-        self.assertContains(
-            response,
-            "Candidate buckets can include entries that are not mergeable",
-        )
-        self.assertContains(response, "Not calculated during active scan")
+        self.assertNotContains(response, "Not calculated during active scan")
         self.assertNotContains(response, "Duplicate groups pending consolidation")
-        self.assertIsNone(
-            response.context["memory_migration_status"]["duplicate_groups"]
-        )
-        self.assertFalse(
-            response.context["memory_migration_status"]["duplicate_groups_known"]
-        )
         self.assertFalse(response.context["memory_migration_status"]["completed"])
         self.assertEqual(
             response.context["memory_migration_status"]["compaction_last_memory_id"], 0
@@ -1152,8 +1138,6 @@ class AdminTest(ViewTestCase):
         self.assertTrue(status["completed"])
         self.assertTrue(status["compaction_completed"])
         self.assertFalse(status["compaction_active"])
-        self.assertEqual(status["duplicate_groups"], 0)
-        self.assertTrue(status["duplicate_groups_known"])
         self.assertEqual(status["compaction_percent"], 100)
 
     def test_performance_ordering(self) -> None:

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -434,8 +434,6 @@ def get_memory_migration_status() -> dict[str, Any]:
         if compaction_completed or not max_memory_id
         else 0
     )
-    duplicate_groups = 0 if compaction_completed or not max_memory_id else None
-
     return {
         "backfill_completed": backfill_completed,
         "backfill_percent": backfill_percent,
@@ -445,8 +443,6 @@ def get_memory_migration_status() -> dict[str, Any]:
         "compaction_last_memory_id": compaction_last_memory_id,
         "compaction_max_memory_id": max_memory_id,
         "compaction_percent": compaction_percent,
-        "duplicate_groups": duplicate_groups,
-        "duplicate_groups_known": duplicate_groups is not None,
         "last_memory_id": last_memory_id,
         "processed": processed,
         "state": state,


### PR DESCRIPTION
Avoid regrouping the full translation memory table for each compaction batch. Walk duplicate candidate first rows with EXISTS checks and cover unique-row filtering in tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
