### PR TITLE
fix: make workflow customization UX more clear

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -2247,18 +2247,18 @@ onReady(() => {
 
   /* Workflow customization form */
   document.querySelectorAll("#id_workflow-enable").forEach((enableInput) => {
-    enableInput.addEventListener("click", () => {
-      if (enableInput.checked) {
-        document.getElementById("workflow-enable-target").style.visibility =
-          "visible";
-        document.getElementById("workflow-enable-target").style.opacity = 1;
-      } else {
-        document.getElementById("workflow-enable-target").style.visibility =
-          "hidden";
-        document.getElementById("workflow-enable-target").style.opacity = 0;
+    const updateWorkflowVisibility = () => {
+      const target = document.getElementById("workflow-enable-target");
+      const hint = document.getElementById("workflow-enable-hint");
+      if (target !== null) {
+        target.style.display = enableInput.checked ? "" : "none";
       }
-    });
-    enableInput.dispatchEvent(new Event("click"));
+      if (hint !== null) {
+        hint.style.display = enableInput.checked ? "none" : "";
+      }
+    };
+    enableInput.addEventListener("change", updateWorkflowVisibility);
+    updateWorkflowVisibility();
   });
 
   /* Move current translation into the view */

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2415,11 +2415,6 @@ label .text-muted {
   font-weight: normal;
 }
 
-#workflow-enable-target {
-  transition: all 300ms linear;
-  -webkit-transition: all 300ms linear;
-}
-
 .img-check {
   background-color: #ccc;
   margin-bottom: 0;

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -4544,7 +4544,13 @@ class WorkflowSettingForm(FieldDocsMixin, forms.ModelForm):
         self.helper = FormHelper(self)
         self.helper.form_tag = False
         self.helper.layout = Layout(
-            Field("enable"),
+            Field("enable", template="bootstrap5/layout/switch.html"),
+            HTML(
+                format_html(
+                    '<p id="workflow-enable-hint" class="text-muted">{}</p>',
+                    gettext("Turn on customization above to change these settings."),
+                )
+            ),
             Div(
                 Field("translation_review"),
                 Field("enable_suggestions"),


### PR DESCRIPTION
Uses bootstrap switch element instead of a checkbox to turn on workflow customization, making it visually clearer and also adds a message clarifying its usage.
<img width="1115" height="270" alt="image" src="https://github.com/user-attachments/assets/fd39ca9e-6c8c-4503-8c50-8220c7078373" />
<img width="1141" height="377" alt="image" src="https://github.com/user-attachments/assets/5527379b-7df9-4ca6-9094-911ac4a5ff66" />
fixes #20399
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
