### PR TITLE
fix(fedora-messaging): align TLS broker probe with transport

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.7.1
 
 * Component priority icons are no longer shown on translation listings.
 * :ref:`check-punctuation-spacing` no longer flags Markdown image markers as French punctuation and now shows which punctuation marks triggered the check.
+* :ref:`addon-weblate.fedora_messaging.publish` broker TLS validation now matches the Fedora Messaging transport when accepting non-strict CA certificate chains.
 * The :guilabel:`Things to check` panel no longer uses error highlighting for suggestions and other non-error translation states.
 * Translation workflow customization now makes it clearer when per-language workflow settings are disabled until customization is enabled.
 * Anonymous user permission caches are now isolated between requests.

--- a/weblate/addons/fedora_messaging.py
+++ b/weblate/addons/fedora_messaging.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import socket
 import ssl
+import time
 from copy import deepcopy
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit, urlunsplit
 
 from cryptography import x509
@@ -16,6 +17,7 @@ from cryptography.hazmat.primitives import serialization
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext, gettext_lazy
+from OpenSSL import SSL
 from siphashc import siphash
 
 from weblate.addons.base import ChangeBaseAddon
@@ -53,15 +55,34 @@ TLS_PROBE_TIMEOUT = 5
 SERVICE_STOP_TIMEOUT = 5
 
 
-class BrokerSSLOptions(Protocol):
-    context: ssl.SSLContext
-    server_hostname: str | None
-
-
 class BrokerParameters(Protocol):
     host: str
     port: int
-    ssl_options: BrokerSSLOptions | None
+    ssl_options: object | None
+
+
+class BrokerTLSContextFactory(Protocol):
+    def clientConnectionForTLS(  # noqa: N802
+        self, tls_protocol: object
+    ) -> SSL.Connection: ...
+
+
+class BrokerTLSProbeFactory:
+    wrappedFactory = object()  # noqa: N815
+
+
+class BrokerTLSProbeProtocol:
+    factory = BrokerTLSProbeFactory()
+
+    def __init__(self) -> None:
+        self.verification_failure: object | None = None
+        self.aborted = False
+
+    def failVerification(self, failure: object) -> None:  # noqa: N802
+        self.verification_failure = failure
+
+    def abortConnection(self) -> None:  # noqa: N802
+        self.aborted = True
 
 
 class FedoraMessagingPublishError(RuntimeError):
@@ -485,7 +506,10 @@ class FedoraMessagingAddon(ChangeBaseAddon):
         )
 
     @staticmethod
-    def validate_broker_tls(amqp_url: str, timeout: float = TLS_PROBE_TIMEOUT) -> None:
+    def validate_broker_tls(
+        amqp_url: str,
+        timeout: float = TLS_PROBE_TIMEOUT,
+    ) -> None:
         """Validate TLS trust against the configured Fedora Messaging broker."""
         # ruff: ignore[import-outside-top-level]
         import pika  # type: ignore[import-untyped]
@@ -505,14 +529,19 @@ class FedoraMessagingAddon(ChangeBaseAddon):
             return
 
         try:
-            ssl_options = FedoraMessagingAddon._configure_broker_tls_options(parameters)
-            if ssl_options is None:
+            tls_context_factory = FedoraMessagingAddon._configure_broker_tls_options(
+                parameters
+            )
+            if tls_context_factory is None:
                 return
-            FedoraMessagingAddon._probe_broker_tls(parameters, ssl_options, timeout)
+            FedoraMessagingAddon._probe_broker_tls(
+                parameters, tls_context_factory, timeout
+            )
         except (
             ConfigurationException,
             ValidationError,
             OSError,
+            SSL.Error,
             TimeoutError,
             ssl.SSLError,
         ) as error:
@@ -526,7 +555,7 @@ class FedoraMessagingAddon(ChangeBaseAddon):
     @staticmethod
     def _configure_broker_tls_options(
         parameters: BrokerParameters,
-    ) -> BrokerSSLOptions | None:
+    ) -> BrokerTLSContextFactory | None:
         # ruff: ignore[import-outside-top-level]
         from fedora_messaging.twisted import service as fedora_messaging_service
 
@@ -534,11 +563,22 @@ class FedoraMessagingAddon(ChangeBaseAddon):
         # semantics stay aligned with the publisher implementation.
         # ruff: ignore[private-member-access]
         fedora_messaging_service._configure_tls_parameters(parameters)
-        return parameters.ssl_options
+        if parameters.ssl_options is None:
+            return None
+        # Use the same Twisted/pyOpenSSL context factory that Fedora Messaging
+        # uses for the actual AMQP transport instead of duplicating certificate
+        # verification policy with a stdlib SSLContext.
+        # ruff: ignore[private-member-access]
+        return cast(
+            "BrokerTLSContextFactory",
+            fedora_messaging_service._ssl_context_factory(parameters),
+        )
 
     @staticmethod
     def _probe_broker_tls(
-        parameters: BrokerParameters, ssl_options: BrokerSSLOptions, timeout: float
+        parameters: BrokerParameters,
+        tls_context_factory: BrokerTLSContextFactory,
+        timeout: float,
     ) -> None:
         with socket.create_connection(
             (parameters.host, parameters.port), timeout=timeout
@@ -550,10 +590,68 @@ class FedoraMessagingAddon(ChangeBaseAddon):
                 allow_private_targets=not settings.WEBHOOK_RESTRICT_PRIVATE,
                 allowed_domains=settings.WEBHOOK_PRIVATE_ALLOWLIST,
             )
-            with ssl_options.context.wrap_socket(
-                connection, server_hostname=ssl_options.server_hostname
-            ):
-                pass
+            FedoraMessagingAddon._perform_broker_tls_handshake(
+                connection, tls_context_factory, timeout
+            )
+
+    @staticmethod
+    def _perform_broker_tls_handshake(
+        connection: socket.socket,
+        tls_context_factory: BrokerTLSContextFactory,
+        timeout: float,
+    ) -> None:
+        protocol = BrokerTLSProbeProtocol()
+        tls_connection = tls_context_factory.clientConnectionForTLS(protocol)
+        tls_connection.set_connect_state()
+        deadline = time.monotonic() + timeout
+
+        while True:
+            FedoraMessagingAddon._set_broker_tls_timeout(connection, deadline)
+            try:
+                tls_connection.do_handshake()
+            except SSL.WantReadError as error:
+                FedoraMessagingAddon._flush_broker_tls_data(
+                    tls_connection, connection, deadline
+                )
+                FedoraMessagingAddon._set_broker_tls_timeout(connection, deadline)
+                data = connection.recv(2**15)
+                if not data:
+                    msg = "TLS connection closed during handshake"
+                    raise OSError(msg) from error
+                tls_connection.bio_write(data)
+            except SSL.WantWriteError:
+                FedoraMessagingAddon._flush_broker_tls_data(
+                    tls_connection, connection, deadline
+                )
+            else:
+                if protocol.verification_failure is not None:
+                    raise SSL.Error(str(protocol.verification_failure))
+                FedoraMessagingAddon._flush_broker_tls_data(
+                    tls_connection, connection, deadline
+                )
+                return
+
+    @staticmethod
+    def _flush_broker_tls_data(
+        tls_connection: SSL.Connection, connection: socket.socket, deadline: float
+    ) -> None:
+        while True:
+            try:
+                data = tls_connection.bio_read(2**15)
+            except SSL.WantReadError:
+                return
+            if not data:
+                return
+            FedoraMessagingAddon._set_broker_tls_timeout(connection, deadline)
+            connection.sendall(data)
+
+    @staticmethod
+    def _set_broker_tls_timeout(connection: socket.socket, deadline: float) -> None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            msg = "TLS handshake timed out"
+            raise TimeoutError(msg)
+        connection.settimeout(remaining)
 
     @staticmethod
     def _get_socket_peer_ip(connection: socket.socket) -> str | None:

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -11,7 +11,6 @@ import json
 import os
 import re
 import shutil
-import ssl
 import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 import tempfile
@@ -44,6 +43,7 @@ from django.utils import timezone
 from django_celery_beat.models import IntervalSchedule, PeriodicTask, PeriodicTasks
 from fedora_messaging import exceptions as fedora_messaging_exceptions
 from fedora_messaging.exceptions import ConfigurationException
+from OpenSSL import SSL
 from standardwebhooks.webhooks import Webhook, WebhookVerificationError
 from weblate_schemas.messages import WeblateV1Message
 
@@ -104,6 +104,7 @@ from .example import ExampleAddon
 from .example_pre import ExamplePreAddon
 from .fedora_messaging import (
     SERVICE_STOP_TIMEOUT,
+    BrokerTLSProbeProtocol,
     FedoraMessagingAddon,
     FedoraMessagingPublishError,
 )
@@ -8905,6 +8906,24 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             "client_cert": cert,
         }
 
+    @staticmethod
+    def get_broker_tls_connection() -> MagicMock:
+        tls_connection = MagicMock()
+        tls_connection.bio_read.side_effect = SSL.WantReadError()
+        return tls_connection
+
+    @staticmethod
+    def get_broker_tls_context_factory(
+        tls_connection: MagicMock | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            clientConnectionForTLS=MagicMock(
+                return_value=tls_connection
+                if tls_connection is not None
+                else FedoraMessagingAddonTestCase.get_broker_tls_connection()
+            )
+        )
+
     def test_topic(self):
         for change in Change.objects.all():
             self.assertIsNotNone(FedoraMessagingAddon.get_change_topic(change))
@@ -9212,16 +9231,14 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         broker_connection.getpeername.return_value = ("93.184.216.34", 12345)
         connection_context = MagicMock()
         connection_context.__enter__.return_value = broker_connection
-        tls_connection_context = MagicMock()
-        ssl_context = SimpleNamespace(
-            wrap_socket=MagicMock(return_value=tls_connection_context)
-        )
+        tls_connection = self.get_broker_tls_connection()
+        tls_context_factory = self.get_broker_tls_context_factory(tls_connection)
 
         def configure_tls_parameters(parameters) -> None:
             self.assertEqual(parameters.host, "rabbitmq.example.com")
             self.assertEqual(parameters.port, 12345)
             parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
-                context=ssl_context, server_hostname=parameters.host
+                context=SimpleNamespace(), server_hostname=parameters.host
             )
 
         with (
@@ -9229,6 +9246,10 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
                 "fedora_messaging.twisted.service._configure_tls_parameters",
                 side_effect=configure_tls_parameters,
             ) as configure_tls_parameters_mock,
+            patch(
+                "fedora_messaging.twisted.service._ssl_context_factory",
+                return_value=tls_context_factory,
+            ) as ssl_context_factory,
             patch(
                 "weblate.addons.fedora_messaging.socket.create_connection",
                 return_value=connection_context,
@@ -9240,35 +9261,93 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             )
 
         configure_tls_parameters_mock.assert_called_once()
+        ssl_context_factory.assert_called_once()
         create_connection.assert_called_once_with(
             ("rabbitmq.example.com", 12345), timeout=7
         )
-        broker_connection.settimeout.assert_called_once_with(7)
+        broker_connection.settimeout.assert_any_call(7)
         broker_connection.getpeername.assert_called_once_with()
-        ssl_context.wrap_socket.assert_called_once_with(
-            broker_connection, server_hostname="rabbitmq.example.com"
+        tls_context_factory.clientConnectionForTLS.assert_called_once()
+        tls_connection.set_connect_state.assert_called_once_with()
+        tls_connection.do_handshake.assert_called_once_with()
+        tls_connection.bio_read.assert_called_once_with(2**15)
+
+    def test_broker_tls_probe_protocol_matches_twisted_factory_shape(self) -> None:
+        from twisted.internet import ssl as twisted_ssl  # noqa: PLC0415
+
+        tls_context_factory = twisted_ssl.optionsForClientTLS("rabbitmq.example.com")
+
+        tls_connection = tls_context_factory.clientConnectionForTLS(
+            BrokerTLSProbeProtocol()
         )
+
+        self.assertIsInstance(tls_connection, SSL.Connection)
+
+    def test_broker_tls_handshake_pumps_twisted_memory_bio(self) -> None:
+        broker_connection = MagicMock()
+        broker_connection.recv.return_value = b"server hello"
+        tls_connection = self.get_broker_tls_connection()
+        tls_connection.do_handshake.side_effect = [SSL.WantReadError(), None]
+        tls_connection.bio_read.side_effect = [
+            b"client hello",
+            SSL.WantReadError(),
+            SSL.WantReadError(),
+        ]
+        tls_context_factory = self.get_broker_tls_context_factory(tls_connection)
+
+        FedoraMessagingAddon._perform_broker_tls_handshake(  # noqa: SLF001
+            broker_connection, tls_context_factory, timeout=7
+        )
+
+        tls_connection.set_connect_state.assert_called_once_with()
+        self.assertEqual(tls_connection.do_handshake.call_count, 2)
+        broker_connection.sendall.assert_called_once_with(b"client hello")
+        broker_connection.recv.assert_called_once_with(2**15)
+        tls_connection.bio_write.assert_called_once_with(b"server hello")
+
+    def test_broker_tls_handshake_enforces_deadline(self) -> None:
+        broker_connection = MagicMock()
+        broker_connection.recv.return_value = b"server hello"
+        tls_connection = self.get_broker_tls_connection()
+        tls_connection.do_handshake.side_effect = [SSL.WantReadError()]
+        tls_connection.bio_read.side_effect = SSL.WantReadError()
+        tls_context_factory = self.get_broker_tls_context_factory(tls_connection)
+
+        with (
+            patch(
+                "weblate.addons.fedora_messaging.time.monotonic",
+                side_effect=[0, 0, 8],
+            ),
+            self.assertRaisesMessage(TimeoutError, "TLS handshake timed out"),
+        ):
+            FedoraMessagingAddon._perform_broker_tls_handshake(  # noqa: SLF001
+                broker_connection, tls_context_factory, timeout=7
+            )
+
+        broker_connection.recv.assert_not_called()
 
     def test_broker_tls_validation_reports_certificate_error(self) -> None:
         broker_connection = MagicMock()
         broker_connection.getpeername.return_value = ("93.184.216.34", 5671)
         connection_context = MagicMock()
         connection_context.__enter__.return_value = broker_connection
-        ssl_context = SimpleNamespace(
-            wrap_socket=MagicMock(
-                side_effect=ssl.SSLCertVerificationError("certificate verify failed")
-            )
-        )
+        tls_connection = self.get_broker_tls_connection()
+        tls_connection.do_handshake.side_effect = SSL.Error("certificate verify failed")
+        tls_context_factory = self.get_broker_tls_context_factory(tls_connection)
 
         def configure_tls_parameters(parameters) -> None:
             parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
-                context=ssl_context, server_hostname=parameters.host
+                context=SimpleNamespace(), server_hostname=parameters.host
             )
 
         with (
             patch(
                 "fedora_messaging.twisted.service._configure_tls_parameters",
                 side_effect=configure_tls_parameters,
+            ),
+            patch(
+                "fedora_messaging.twisted.service._ssl_context_factory",
+                return_value=tls_context_factory,
             ),
             patch(
                 "weblate.addons.fedora_messaging.socket.create_connection",
@@ -9286,17 +9365,21 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         broker_connection.getpeername.return_value = ("127.0.0.1", 5671)
         connection_context = MagicMock()
         connection_context.__enter__.return_value = broker_connection
-        ssl_context = SimpleNamespace(wrap_socket=MagicMock())
+        tls_context_factory = self.get_broker_tls_context_factory()
 
         def configure_tls_parameters(parameters) -> None:
             parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
-                context=ssl_context, server_hostname=parameters.host
+                context=SimpleNamespace(), server_hostname=parameters.host
             )
 
         with (
             patch(
                 "fedora_messaging.twisted.service._configure_tls_parameters",
                 side_effect=configure_tls_parameters,
+            ),
+            patch(
+                "fedora_messaging.twisted.service._ssl_context_factory",
+                return_value=tls_context_factory,
             ),
             patch(
                 "weblate.addons.fedora_messaging.socket.create_connection",
@@ -9309,12 +9392,12 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         ):
             FedoraMessagingAddon.validate_broker_tls("amqps://rabbitmq.example.com")
 
-        ssl_context.wrap_socket.assert_not_called()
+        tls_context_factory.clientConnectionForTLS.assert_not_called()
 
     def test_broker_tls_validation_reports_connection_error(self) -> None:
         def configure_tls_parameters(parameters) -> None:
             parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
-                context=SimpleNamespace(wrap_socket=MagicMock()),
+                context=SimpleNamespace(),
                 server_hostname=parameters.host,
             )
 
@@ -9322,6 +9405,10 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             patch(
                 "fedora_messaging.twisted.service._configure_tls_parameters",
                 side_effect=configure_tls_parameters,
+            ),
+            patch(
+                "fedora_messaging.twisted.service._ssl_context_factory",
+                return_value=self.get_broker_tls_context_factory(),
             ),
             patch(
                 "weblate.addons.fedora_messaging.socket.create_connection",


### PR DESCRIPTION
Reuse Fedora Messaging's Twisted TLS context for broker validation.

Add a Twisted-compatible probe protocol and enforce an overall TLS handshake deadline.

Cover the transport-aligned probe, memory BIO handshake, and timeout behavior in tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
