### PR TITLE
fix(auth): isolate anonymous user permission caches

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.7.1
 
 * The :guilabel:`Things to check` panel no longer uses error highlighting for suggestions and other non-error translation states.
 * Translation workflow customization now makes it clearer when per-language workflow settings are disabled until customization is enabled.
+* Anonymous user permission caches are now isolated between requests.
 
 .. rubric:: Compatibility
 

--- a/weblate/accounts/middleware.py
+++ b/weblate/accounts/middleware.py
@@ -30,9 +30,6 @@ def get_user(request: AuthenticatedHttpRequest):
         user = auth.get_user(request)
         if isinstance(user, AnonymousUser):
             user = get_anonymous()
-            # Make sure user permissions are fetched again, needed as
-            # get_anonymous() is reusing same instance.
-            user.clear_cache()
 
         request.weblate_cached_user = user
     return request.weblate_cached_user

--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -713,7 +713,7 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
         )
         self.component.restricted = True
         self.component.save(update_fields=["restricted"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertFalse(self.user.can_access_component(self.component))
 
@@ -739,7 +739,7 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
         component_group.roles.add(Role.objects.get(name="Power user"))
         component_group.components.add(self.component)
         self.user.groups.add(component_group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.can_access_component(self.component))
 
         unit = self.get_unit()

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -8068,7 +8068,7 @@ class SiteWideAddonsTest(ViewTestCase):
         group, _created = Group.objects.get_or_create(name="Test management team")
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
     def test_history_filters_sitewide_changes(self) -> None:
         self.user.is_superuser = True

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1298,7 +1298,7 @@ class GroupAPITest(APIBaseTest):
         other_component = self.create_acl()
         group.roles.add(Role.objects.get(name="Administration"))
         admin.groups.add(group)
-        admin.clear_cache()
+        admin.clear_permissions_cache()
         self.assertNotIn(other_component.project, admin.allowed_projects)
         self.assertFalse(admin.has_perm("project.permissions", other_component.project))
         self.do_request(
@@ -1403,7 +1403,7 @@ class GroupAPITest(APIBaseTest):
         )
 
         workspace.add_owner(admin)
-        admin.clear_cache()
+        admin.clear_permissions_cache()
         self.do_request(
             "api:group-list",
             method="post",
@@ -1541,7 +1541,7 @@ class GroupAPITest(APIBaseTest):
         team = Group.objects.create(name="Global component group editors")
         team.roles.add(role)
         global_admin.groups.add(team)
-        global_admin.clear_cache()
+        global_admin.clear_permissions_cache()
         self.assertNotIn(private_component.project, global_admin.allowed_projects)
 
         self.client.credentials(
@@ -1629,7 +1629,7 @@ class GroupAPITest(APIBaseTest):
         team = Group.objects.create(name="Global group editors")
         team.roles.add(role)
         global_admin.groups.add(team)
-        global_admin.clear_cache()
+        global_admin.clear_permissions_cache()
         self.assertNotIn(private_project, global_admin.allowed_projects)
 
         self.client.credentials(
@@ -1913,7 +1913,7 @@ class GroupAPITest(APIBaseTest):
         team = Group.objects.create(name="Global component list group editors")
         team.roles.add(role)
         global_admin.groups.add(team)
-        global_admin.clear_cache()
+        global_admin.clear_permissions_cache()
         self.assertNotIn(private_component.project, global_admin.allowed_projects)
 
         self.client.credentials(
@@ -2997,7 +2997,7 @@ class ProjectAPITest(APIBaseTest):
         secret = "SECRET-RESTRICTED-STRING-XYZZY"
         self.component.restricted = True
         self.component.save(update_fields=["restricted"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         Change.objects.create(
             action=ActionEvents.NEW,
@@ -3944,7 +3944,7 @@ class ProjectAPITest(APIBaseTest):
         current_workspace.add_owner(self.user)
         target_workspace.add_owner(self.user)
         self.grant_perm_to_user("project.edit", project=self.project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.do_request(
             "api:project-detail",
@@ -3969,7 +3969,7 @@ class ProjectAPITest(APIBaseTest):
         current_workspace.add_owner(self.user)
         billing = create_test_billing(self.user)
         self.grant_perm_to_user("project.edit", project=self.project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.do_request(
             "api:project-detail",
@@ -3993,7 +3993,7 @@ class ProjectAPITest(APIBaseTest):
         self.grant_perm_to_user("project.edit", project=self.project)
 
         target_workspace.add_owner(self.user)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.do_request(
             "api:project-detail",
             self.project_kwargs,
@@ -4006,7 +4006,7 @@ class ProjectAPITest(APIBaseTest):
         self.assertEqual(self.project.workspace_id, current_workspace.pk)
 
         current_workspace.add_owner(self.user)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.do_request(
             "api:project-detail",
             self.project_kwargs,
@@ -4018,7 +4018,7 @@ class ProjectAPITest(APIBaseTest):
 
         Project.objects.filter(pk=self.project.pk).update(workspace=current_workspace)
         unauthorized_workspace = Workspace.objects.create(name="Unauthorized")
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.do_request(
             "api:project-detail",
             self.project_kwargs,
@@ -4045,7 +4045,7 @@ class ProjectAPITest(APIBaseTest):
         )
         group.roles.add(role)
         self.user.add_team(None, group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.do_request(
             "api:project-detail",
@@ -4062,7 +4062,7 @@ class ProjectAPITest(APIBaseTest):
         target_workspace = Workspace.objects.create(name="Target workspace")
         target_workspace.add_owner(self.user)
         self.grant_perm_to_user("project.edit", project=self.project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.do_request(
             "api:project-detail",
@@ -4094,7 +4094,7 @@ class ProjectAPITest(APIBaseTest):
         role.permissions.add(permission)
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.do_request(
             "api:project-detail",
             self.project_kwargs,
@@ -4115,7 +4115,7 @@ class ProjectAPITest(APIBaseTest):
         billing = create_test_billing(self.user)
         other_project = Project.objects.create(name="Other", slug="other")
         billing.add_project(other_project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.do_request(
             "api:project-detail",
@@ -4676,7 +4676,7 @@ class ProjectAPITest(APIBaseTest):
     def test_download_project_translations_prohibited(self) -> None:
         self.authenticate()
         self.user.groups.clear()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.do_request(
             "api:project-file",
             self.project_kwargs,
@@ -4788,7 +4788,7 @@ class ProjectAPITest(APIBaseTest):
     def test_download_project_translations_language_path_prohibited(self) -> None:
         self.authenticate()
         self.user.groups.clear()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.do_request(
             "api:project-language-file",
             {**self.project_kwargs, "language_code": "cs"},
@@ -9108,7 +9108,7 @@ class TranslationAPITest(APIBaseTest):
         self.authenticate()
         # Remove all permissions
         self.user.groups.clear()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         # Public project should fail with 403
         with open(TEST_PO, "rb") as handle:
@@ -11694,7 +11694,7 @@ class ComponentListAPITest(APIBaseTest):
         )
 
         self.grant_perm_to_user("componentlist.edit")
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.authenticate(False)
 
         response = self.client.get(reverse("api:componentlist-list"))
@@ -12961,7 +12961,7 @@ class AnnouncementAPITest(APIBaseTest):
         group.languages.add(czech_language)
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.do_request(
             "api:project-language-announcements",
@@ -13039,7 +13039,7 @@ class AnnouncementAPITest(APIBaseTest):
         group.languages.add(czech_language)
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.do_request(
             "api:project-language-delete-announcement",
@@ -13666,7 +13666,7 @@ class AnnouncementAPITest(APIBaseTest):
         group.languages.add(czech_language)
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.assertTrue(self.user.has_perm("announcement.delete", czech_translation))
         self.assertTrue(

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -7,6 +7,7 @@ import re
 import uuid
 from collections import defaultdict
 from contextvars import ContextVar
+from copy import copy
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import cache as functools_cache
@@ -591,11 +592,27 @@ class UserQuerySet(models.QuerySet["User", "User"]):
 
 
 @functools_cache
-def get_anonymous() -> User:
-    """Return an anonymous user."""
+def _get_anonymous() -> User:
+    """Return cached anonymous user prototype."""
     return User.objects.select_related("profile").get(
         username=settings.ANONYMOUS_USER_NAME
     )
+
+
+def get_anonymous() -> User:
+    """Return an anonymous user instance."""
+    user = copy(_get_anonymous())
+    fields_cache = user._state.fields_cache  # noqa: SLF001
+    if profile := fields_cache.get("profile"):
+        # Keep cached Profile properties local to this anonymous user copy.
+        profile = copy(profile)
+        profile.user = user
+        fields_cache["profile"] = profile
+    user.clear_permissions_cache()
+    return user
+
+
+get_anonymous.cache_clear = _get_anonymous.cache_clear  # type: ignore[attr-defined]
 
 
 def convert_groups(objs):
@@ -769,7 +786,7 @@ class User(AbstractBaseUser):
         if not self.is_active:
             self.date_expires = None
         super().save(*args, **kwargs)
-        self.clear_cache()
+        self.clear_permissions_cache()
         if (
             original
             and original.is_active != self.is_active
@@ -797,7 +814,8 @@ class User(AbstractBaseUser):
                 self.extra_data[name] = kwargs.pop(name)
         super().__init__(*args, **kwargs)
 
-    def clear_cache(self) -> None:
+    def clear_permissions_cache(self) -> None:
+        """Clear cached permission and access-scope data on this user instance."""
         self.cla_cache = {}
         perm_caches = (
             "_permissions",

--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -10,7 +10,15 @@ from django.contrib.auth.models import Group as DjangoGroup
 
 from weblate.auth import permissions as auth_permissions
 from weblate.auth.data import SELECTION_ALL, SELECTION_MANUAL
-from weblate.auth.models import Group, Permission, Role, TeamMembership, User, UserBlock
+from weblate.auth.models import (
+    Group,
+    Permission,
+    Role,
+    TeamMembership,
+    User,
+    UserBlock,
+    get_anonymous,
+)
 from weblate.auth.utils import format_membership_limit_language_codes
 from weblate.lang.models import Language
 from weblate.trans.models import Category, ComponentLink, ComponentList, Project
@@ -48,9 +56,34 @@ class ModelTest(FixtureComponentTestCase):
             language_selection=SELECTION_ALL,
         )
         anonymous.groups.add(group)
-        anonymous.clear_cache()
+        anonymous.clear_permissions_cache()
 
         self.assertIn(-SELECTION_ALL, anonymous.project_permissions)
+
+    def test_anonymous_user_is_not_shared(self) -> None:
+        anonymous = get_anonymous()
+        self.assertIsNotNone(anonymous.cached_memberships.query)
+        self.assertEqual(anonymous.profile.second_factors, [])
+
+        fresh_anonymous = get_anonymous()
+
+        self.assertIsNot(anonymous, fresh_anonymous)
+        self.assertIsNot(anonymous.profile, fresh_anonymous.profile)
+        self.assertIs(anonymous.profile.user, anonymous)
+        self.assertIs(fresh_anonymous.profile.user, fresh_anonymous)
+        self.assertNotIn("cached_memberships", fresh_anonymous.__dict__)
+        self.assertNotIn("second_factors", fresh_anonymous.profile.__dict__)
+
+    def test_anonymous_user_cache_clear_refreshes_prototype(self) -> None:
+        self.addCleanup(get_anonymous.cache_clear)
+        anonymous = get_anonymous()
+        User.objects.filter(pk=anonymous.pk).update(full_name="Updated anonymous")
+
+        self.assertEqual(get_anonymous().full_name, anonymous.full_name)
+
+        get_anonymous.cache_clear()
+
+        self.assertEqual(get_anonymous().full_name, "Updated anonymous")
 
     def test_format_membership_limit_language_codes_order(self) -> None:
         membership = TeamMembership.objects.create(user=self.user, group=self.group)
@@ -95,7 +128,7 @@ class ModelTest(FixtureComponentTestCase):
         project_group.languages.add(cs, de)
 
         self.user.groups.add(component_group, componentlist_group, project_group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         with self.assertNumQueries(10):
             self.assertEqual(len(self.user.component_permissions), 2)
@@ -109,13 +142,13 @@ class ModelTest(FixtureComponentTestCase):
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         # Access permission on adding to group
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.user.groups.add(self.group)
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         # Translate permission on adding role to group
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.group.roles.add(Role.objects.get(name="Power user"))
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
@@ -132,7 +165,7 @@ class ModelTest(FixtureComponentTestCase):
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         # Permissions should exist after adding to a component list
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.group.components.add(self.component)
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
@@ -147,12 +180,12 @@ class ModelTest(FixtureComponentTestCase):
         self.group.componentlists.add(clist)
 
         # No permissions as component list is empty
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertFalse(self.user.can_access_project(self.project))
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         # Permissions should exist after adding to a component list
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         clist.components.add(self.component)
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
@@ -166,12 +199,12 @@ class ModelTest(FixtureComponentTestCase):
         self.group.languages.set(Language.objects.filter(code="de"), clear=True)
 
         # Permissions should deny access
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         # Adding Czech language should unlock it
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.group.languages.add(Language.objects.get(code="cs"))
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
@@ -182,13 +215,13 @@ class ModelTest(FixtureComponentTestCase):
         membership = TeamMembership.objects.get(user=self.user, group=self.group)
         membership.limit_languages.set(Language.objects.filter(code="de"))
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         membership.limit_languages.add(Language.objects.get(code="cs"))
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
 
     def test_membership_limit_excludes_global_permissions(self) -> None:
@@ -202,13 +235,13 @@ class ModelTest(FixtureComponentTestCase):
         group.roles.add(role)
         user.groups.add(group)
 
-        user.clear_cache()
+        user.clear_permissions_cache()
         self.assertTrue(user.has_perm("user.edit"))
 
         membership = TeamMembership.objects.get(user=user, group=group)
         membership.limit_languages.set(Language.objects.filter(code="cs"))
 
-        user.clear_cache()
+        user.clear_permissions_cache()
         self.assertFalse(user.has_perm("user.edit"))
 
     def test_membership_limit_intersects_team_languages(self) -> None:
@@ -220,14 +253,14 @@ class ModelTest(FixtureComponentTestCase):
         membership = TeamMembership.objects.get(user=self.user, group=self.group)
         membership.limit_languages.set(Language.objects.filter(code="cs"))
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertFalse(self.user.can_access_project(self.project))
         self.assertEqual(self.user.get_project_permissions(self.project), [])
         self.assertFalse(self.user.has_perm("unit.edit", self.translation))
 
         self.group.languages.add(Language.objects.get(code="cs"))
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
 
@@ -238,7 +271,7 @@ class ModelTest(FixtureComponentTestCase):
         self.group.roles.add(Role.objects.get(name="Administration"))
         self.group.languages.set(Language.objects.filter(code="cs"), clear=True)
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.has_perm("project.edit", self.project))
         self.assertTrue(self.user.has_perm("translation.add", self.component))
         self.assertEqual(
@@ -266,7 +299,7 @@ class ModelTest(FixtureComponentTestCase):
             user=self.user, group=review_group
         ).limit_languages.set(Language.objects.filter(code="de"))
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
         self.assertFalse(self.user.has_perm("unit.review", self.translation))
 
@@ -274,7 +307,7 @@ class ModelTest(FixtureComponentTestCase):
             user=self.user, group=review_group
         ).limit_languages.add(Language.objects.get(code="cs"))
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         result = self.user.has_perm("unit.review", self.translation)
         self.assertTrue(result, getattr(result, "reason", result))
 
@@ -299,7 +332,7 @@ class ModelTest(FixtureComponentTestCase):
         self.component.category = category
         self.component.save(update_fields=["category"])
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertFalse(self.user.has_perm("translation.auto", self.project))
         self.assertFalse(self.user.has_perm("translation.auto", category))
         self.assertFalse(self.user.has_perm("translation.auto", self.component))
@@ -383,7 +416,7 @@ class ModelTest(FixtureComponentTestCase):
             category=shared_category,
         )
         self.group.projects.add(shared_project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         shared_project_language = ProjectLanguage(shared_project, german)
         shared_category_language = CategoryLanguage(shared_category, german)
         self.assertTrue(shared_project_language.translation_set)
@@ -399,7 +432,7 @@ class ModelTest(FixtureComponentTestCase):
 
         self.component.restricted = True
         self.component.save(update_fields=["restricted"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertFalse(
             self.user.has_perm(
                 "translation.delete", ProjectLanguage(self.project, german)
@@ -410,7 +443,7 @@ class ModelTest(FixtureComponentTestCase):
         )
 
         self.group.components.add(self.component)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(
             self.user.has_perm(
                 "translation.delete", ProjectLanguage(self.project, german)
@@ -422,7 +455,7 @@ class ModelTest(FixtureComponentTestCase):
 
         source = self.component.source_language
         membership.limit_languages.add(source)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertFalse(
             self.user.has_perm(
                 "translation.delete", ProjectLanguage(self.project, source)
@@ -433,7 +466,7 @@ class ModelTest(FixtureComponentTestCase):
         )
 
         self.group.roles.add(Role.objects.get(name="Administration"))
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertFalse(self.user.has_perm("project.edit", self.project))
         self.assertFalse(self.user.managed_projects.filter(pk=self.project.pk).exists())
         self.assertFalse(
@@ -573,7 +606,7 @@ class ModelTest(FixtureComponentTestCase):
         protected_project = Project.objects.create(
             slug="protected", name="Protected", access_control=Project.ACCESS_PROTECTED
         )
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertEqual(
             set(self.user.allowed_projects.values_list("slug", flat=True)),
             {public_project.slug, protected_project.slug},
@@ -582,7 +615,7 @@ class ModelTest(FixtureComponentTestCase):
             name="All projects", project_selection=SELECTION_ALL
         )
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertEqual(
             set(self.user.allowed_projects.values_list("slug", flat=True)),
             {public_project.slug, protected_project.slug, self.project.slug},
@@ -594,7 +627,7 @@ class ModelTest(FixtureComponentTestCase):
         )
         UserBlock.objects.create(user=self.user, project=public_project)
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.assertNotIn(public_project, self.user.allowed_projects)
 
@@ -603,14 +636,14 @@ class ModelTest(FixtureComponentTestCase):
             slug="public", name="Public", access_control=Project.ACCESS_PUBLIC
         )
 
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.needs_project_filter)
 
         group = Group.objects.create(
             name="All projects", project_selection=SELECTION_ALL
         )
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.assertFalse(self.user.needs_project_filter)
 
@@ -619,7 +652,7 @@ class ModelTest(FixtureComponentTestCase):
             name="All projects", project_selection=SELECTION_ALL
         )
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.assertIn(-SELECTION_ALL, self.user.project_permissions)
         with self.assertNumQueries(0):
@@ -631,7 +664,7 @@ class ModelTest(FixtureComponentTestCase):
         )
         self.user.groups.add(group)
         UserBlock.objects.create(user=self.user, project=self.project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.assertIn(-SELECTION_ALL, self.user.project_permissions)
         self.assertEqual(self.user.project_permissions[self.project.pk], [(None, None)])

--- a/weblate/auth/tests/test_permissions.py
+++ b/weblate/auth/tests/test_permissions.py
@@ -102,7 +102,7 @@ class PermissionsTest(FixtureComponentTestCase):
         group.roles.add(role)
 
         target.groups.add(group)
-        target.clear_cache()
+        target.clear_permissions_cache()
 
     def test_global_perms_granted(self) -> None:
         self.grant_global_management_permission()
@@ -138,7 +138,7 @@ class PermissionsTest(FixtureComponentTestCase):
         workspace = Workspace.objects.create(name="Project workspace")
         self.project.workspace = workspace
         self.project.save(update_fields=["workspace"])
-        self.admin.clear_cache()
+        self.admin.clear_permissions_cache()
 
         self.assertFalse(self.admin.has_perm("workspace.edit", workspace))
 
@@ -225,13 +225,13 @@ class PermissionsTest(FixtureComponentTestCase):
         self.assertTrue(self.user.has_perm("unit.edit", self.component))
 
         # Block user
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.user.userblock_set.create(project=self.project)
         self.assertFalse(self.user.has_perm("unit.edit", self.component))
         self.user.userblock_set.all().delete()
 
         # Block user with past expiry
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.user.userblock_set.create(
             project=self.project, expiry=timezone.now() - timedelta(days=1)
         )
@@ -239,7 +239,7 @@ class PermissionsTest(FixtureComponentTestCase):
         self.user.userblock_set.all().delete()
 
         # Block user with future expiry
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.user.userblock_set.create(
             project=self.project, expiry=timezone.now() + timedelta(days=1)
         )
@@ -367,7 +367,7 @@ class PermissionsTest(FixtureComponentTestCase):
         # Public projects with membership
         group.project_selection = SELECTION_ALL_PUBLIC
         group.save()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertEqual(
             list(
                 self.user.projects_with_perm("project.edit").values_list(
@@ -388,7 +388,7 @@ class PermissionsTest(FixtureComponentTestCase):
         # Protected projects without membership
         self.project.access_control = Project.ACCESS_PROTECTED
         self.project.save()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertEqual(
             list(
                 self.user.projects_with_perm("project.edit").values_list(
@@ -409,7 +409,7 @@ class PermissionsTest(FixtureComponentTestCase):
         # Protected projects with membership
         group.project_selection = SELECTION_ALL_PROTECTED
         group.save()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertEqual(
             list(
                 self.user.projects_with_perm("project.edit").values_list(

--- a/weblate/checks/tests/test_views.py
+++ b/weblate/checks/tests/test_views.py
@@ -116,7 +116,7 @@ class ChecksViewTest(FixtureTestCase):
         self.project.save(update_fields=["workspace"])
         self.component.restricted = True
         self.component.save(update_fields=["restricted"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.assertTrue(Check.objects.filter(name="same").exists())
 
@@ -145,7 +145,7 @@ class ChecksViewTest(FixtureTestCase):
     def test_restricted_component_hidden_in_existing_scopes(self) -> None:
         self.component.restricted = True
         self.component.save(update_fields=["restricted"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         language = self.translation.language
         project_language_path = [*self.project.get_url_path(), "-", language.code]
 

--- a/weblate/glossary/tests.py
+++ b/weblate/glossary/tests.py
@@ -941,7 +941,7 @@ class GlossaryTest(ViewTestCase):
         self.assertNotIn(removal_url, alert.render(self.user))
 
         self.make_manager()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.has_perm("translation.delete", glossary))
         self.assertIn(removal_url, alert.render(self.user))
 

--- a/weblate/trans/tests/test_acl.py
+++ b/weblate/trans/tests/test_acl.py
@@ -89,7 +89,6 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
     def test_anonymous_translate_view_permission_memberships(self) -> None:
         self.project.access_control = Project.ACCESS_PUBLIC
         self.project.save()
-        get_anonymous().clear_cache()
 
         with CaptureQueriesContext(connection) as queries:
             response = self.client.get(self.translate_url)

--- a/weblate/trans/tests/test_agreement.py
+++ b/weblate/trans/tests/test_agreement.py
@@ -21,8 +21,8 @@ class AgreementTest(FixtureComponentTestCase):
     def test_perms(self) -> None:
         self.assertTrue(self.user.has_perm("unit.edit", self.component))
         self.component.agreement = "CLA"
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertFalse(self.user.has_perm("unit.edit", self.component))
         ContributorAgreement.objects.create(self.user, self.component)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.has_perm("unit.edit", self.component))

--- a/weblate/trans/tests/test_autotranslate.py
+++ b/weblate/trans/tests/test_autotranslate.py
@@ -313,11 +313,11 @@ class AutoTranslationTest(ViewTestCase):
         group.projects.add(self.project)
         group.roles.add(Role.objects.get(name="Automatic translation"))
         limited_user.groups.add(group)
-        limited_user.clear_cache()
+        limited_user.clear_permissions_cache()
         translation = self.component2.translation_set.get(language_code="cs")
         unit = self.get_unit("Hello, world!\n", translation=translation)
         group.projects.add(translation.component.project)
-        limited_user.clear_cache()
+        limited_user.clear_permissions_cache()
 
         self.assertTrue(limited_user.has_perm("translation.auto", translation))
         self.assertFalse(limited_user.has_perm("unit.review", unit))
@@ -411,7 +411,7 @@ class AutoTranslationTest(ViewTestCase):
         )
         self.user.is_superuser = False
         self.user.save(update_fields=["is_superuser"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.get(
             reverse("show", kwargs={"path": project_language.get_url_path()})

--- a/weblate/trans/tests/test_comment.py
+++ b/weblate/trans/tests/test_comment.py
@@ -163,7 +163,7 @@ class CommentViewTest(FixtureTestCase):
     def test_comment_views_hide_private_unit_and_comment(self) -> None:
         self.project.access_control = Project.ACCESS_PRIVATE
         self.project.save(update_fields=["access_control"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         unit = self.get_unit()
         comment = Comment.objects.create(
@@ -192,7 +192,7 @@ class CommentViewTest(FixtureTestCase):
         )
         self.user.groups.add(group)
         UserBlock.objects.create(user=self.user, project=self.project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         unit = self.get_unit()
         comment = Comment.objects.create(

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -537,7 +537,7 @@ class EditAccessTest(ViewTestCase):
         private_translation = private_component.translation_set.get(language_code="cs")
         unit = self.get_unit("Hello, world!\n", translation=private_translation)
         UserBlock.objects.create(user=self.user, project=private_project)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.assert_unit_action_urls_not_found(unit)
 

--- a/weblate/trans/tests/test_files.py
+++ b/weblate/trans/tests/test_files.py
@@ -86,7 +86,7 @@ class UploadFormPermissionTest(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project.add_user(self.user, "Administration")
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
     def test_upload_form_hides_approved_conflicts_without_review(self) -> None:
         form = get_upload_form(self.user, self.translation)
@@ -98,7 +98,7 @@ class UploadFormPermissionTest(ViewTestCase):
     def test_upload_form_keeps_approved_conflicts_with_review(self) -> None:
         self.project.translation_review = True
         self.project.save()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         form = get_upload_form(self.user, self.translation)
 

--- a/weblate/trans/tests/test_js_views.py
+++ b/weblate/trans/tests/test_js_views.py
@@ -44,7 +44,7 @@ class JSViewsTest(FixtureTestCase):
     def test_get_unit_translations_hides_private_unit(self) -> None:
         self.project.access_control = Project.ACCESS_PRIVATE
         self.project.save(update_fields=["access_control"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         unit = self.get_unit()
         response = self.client.get(

--- a/weblate/trans/tests/test_manage.py
+++ b/weblate/trans/tests/test_manage.py
@@ -513,7 +513,7 @@ class AnnouncementPermissionTestCase(ViewTestCase):
         group.project_selection = SELECTION_ALL
         group.components.clear()
         group.save()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.post(
             reverse("announcement-delete", kwargs={"pk": second_announcement.pk})
@@ -551,14 +551,14 @@ class AnnouncementPermissionTestCase(ViewTestCase):
         group.roles.add(Role.objects.get(name="Translation coordinator"))
         group.projects.add(self.project)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.client.post(reverse("announcement-delete", kwargs={"pk": announcement.pk}))
         self.assertEqual(Announcement.objects.count(), 1)
 
         self.user.is_superuser = True
         self.user.save()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         self.client.post(reverse("announcement-delete", kwargs={"pk": announcement.pk}))
         self.assertEqual(Announcement.objects.count(), 0)
@@ -582,7 +582,7 @@ class AnnouncementPermissionTestCase(ViewTestCase):
 
         self.user.is_superuser = True
         self.user.save()
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.post(
             reverse("announcement-delete", kwargs={"pk": announcement.pk})

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -150,7 +150,7 @@ class SearchViewTest(ViewTestCase):
         self.project.save(update_fields=["workspace"])
         self.user.is_superuser = True
         self.user.save(update_fields=["is_superuser"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.post(
             reverse("bulk-edit", kwargs={"path": workspace.get_url_path()}),
@@ -172,7 +172,7 @@ class SearchViewTest(ViewTestCase):
         self.project.save(update_fields=["workspace"])
         self.user.is_superuser = True
         self.user.save(update_fields=["is_superuser"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         with patch(
             "weblate.trans.views.search.bulk_perform", return_value=0
@@ -749,7 +749,7 @@ class BulkEditTest(ViewTestCase):
         group.roles.add(Role.objects.get(name="Translate"))
         group.components.add(self.component)
         limited_user.groups.add(group)
-        limited_user.clear_cache()
+        limited_user.clear_permissions_cache()
 
         self.assertTrue(limited_user.has_perm("unit.edit", self.unit))
         self.assertFalse(limited_user.has_perm("unit.bulk_edit", self.unit))
@@ -785,7 +785,7 @@ class BulkEditTest(ViewTestCase):
         )
         group.components.add(self.component)
         limited_user.groups.add(group)
-        limited_user.clear_cache()
+        limited_user.clear_permissions_cache()
 
         self.assertTrue(limited_user.has_perm("unit.edit", self.unit))
         self.assertTrue(limited_user.has_perm("unit.bulk_edit", self.unit))

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -1046,7 +1046,7 @@ class SettingsTest(ViewTestCase):
         self.project.refresh_from_db()
         current_workspace.add_owner(self.user)
         target_workspace.add_owner(self.user)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.get(self.project.get_absolute_url())
         self.assertContains(response, "Move project")
@@ -1074,7 +1074,7 @@ class SettingsTest(ViewTestCase):
         self.project.refresh_from_db()
         current_workspace.add_owner(self.user)
         billing = create_test_billing(self.user)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.post(
             reverse("move", kwargs={"path": self.project.get_url_path()}),
@@ -1104,7 +1104,7 @@ class SettingsTest(ViewTestCase):
         )
         group.roles.add(role)
         self.user.add_team(None, group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.get(self.project.get_absolute_url())
         self.assertNotContains(response, "Move project")
@@ -1128,7 +1128,7 @@ class SettingsTest(ViewTestCase):
         current_workspace.add_owner(self.user)
         first_workspace.add_owner(self.user)
         second_workspace.add_owner(self.user)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         with patch("weblate.trans.forms.PROJECT_MOVE_WORKSPACE_SELECT_LIMIT", 1):
             response = self.client.get(self.project.get_absolute_url())

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -919,7 +919,7 @@ class BasicViewTest(ViewTestCase):
         self.user.groups.add(group)
         membership = TeamMembership.objects.get(user=self.user, group=group)
         membership.limit_languages.set([self.translation.language])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         for url, tab in (
             (self.project.get_absolute_url(), "#languages"),
@@ -938,7 +938,7 @@ class BasicViewTest(ViewTestCase):
         )
         group.projects.add(self.project)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         with patch(
             "weblate.auth.permissions._get_upload_child_translations"
@@ -967,7 +967,7 @@ class BasicViewTest(ViewTestCase):
         group.projects.add(project)
         group.roles.add(Role.objects.get(name="Power user"))
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         for url in (project.get_absolute_url(), category.get_absolute_url()):
             with self.subTest(url=url):
@@ -995,7 +995,7 @@ class BasicViewTest(ViewTestCase):
         group.components.add(component)
         group.roles.add(Role.objects.get(name="Power user"))
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         for url, tab in (
             (project.get_absolute_url(), "#languages"),
@@ -1049,7 +1049,7 @@ class BasicViewTest(ViewTestCase):
         upload_group.components.add(shared_component)
         upload_group.roles.add(Role.objects.get(name="Power user"))
         self.user.groups.add(access_group, upload_group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         response = self.client.get(linked_category.get_absolute_url())
         self.assert_upload_placeholder(response, "#languages")
@@ -1142,7 +1142,7 @@ class BasicViewTest(ViewTestCase):
         group.projects.add(self.project)
         group.roles.add(Role.objects.get(name="Manage glossary"))
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
         for url, tab in (
             (self.project.get_absolute_url(), "#languages"),
@@ -1337,7 +1337,7 @@ class BasicViewTest(ViewTestCase):
         role.permissions.add(Permission.objects.get(codename="componentlist.edit"))
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.client.login(username="testuser", password="testpassword")
 
         response = self.client.get(reverse("component-list", kwargs={"name": "testcl"}))
@@ -1358,7 +1358,7 @@ class BasicViewTest(ViewTestCase):
         role.permissions.add(Permission.objects.get(codename="componentlist.edit"))
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.client.login(username="testuser", password="testpassword")
 
         response = self.client.get(
@@ -1421,7 +1421,7 @@ class BasicViewTest(ViewTestCase):
         group.projects.add(self.project)
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         category_language = CategoryLanguage(category, self.translation.language)
 
         response = self.client.get(category_language.get_absolute_url())
@@ -1430,7 +1430,7 @@ class BasicViewTest(ViewTestCase):
 
         self.component.enable_suggestions = False
         self.component.save(update_fields=["enable_suggestions"])
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         category_language = CategoryLanguage(category, self.translation.language)
 
         response = self.client.get(category_language.get_absolute_url())
@@ -1444,7 +1444,7 @@ class BasicViewTest(ViewTestCase):
             language=self.translation.language,
             enable_suggestions=False,
         )
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         category_language = CategoryLanguage(category, self.translation.language)
 
         response = self.client.get(category_language.get_absolute_url())

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -56,7 +56,7 @@ def fixup_languages_seq() -> None:
 
 
 def clear_users_cache() -> None:
-    # Clear anonymous user cache
+    # Clear anonymous user prototype
     get_anonymous.cache_clear()
     # Clear bot cache
     bot_cache.get({}).clear()

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -96,7 +96,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         group = Group.objects.create(name=f"GitHub management {user.pk}")
         group.roles.add(role)
         user.groups.add(group)
-        user.clear_cache()
+        user.clear_permissions_cache()
 
     def _mock_oauth(
         self,
@@ -1508,7 +1508,7 @@ class GitHubAppManifestViewTest(TestCase):
         group, _created = Group.objects.get_or_create(name="Test GitHub App team")
         group.roles.add(role)
         user.groups.add(group)
-        user.clear_cache()
+        user.clear_permissions_cache()
 
     def _post_register(self, **fields):
         data = {"host": "github.com", "name": "Test Weblate", "public": "1"}

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -367,7 +367,7 @@ class WorkspaceCreateTest(ViewTestCase):
         workspace = Workspace.objects.get(name="Created workspace")
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], workspace.get_absolute_url())
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
         self.assertTrue(self.user.has_perm("workspace.edit", workspace))
         self.assertTrue(self.user.has_perm("workspace.add_project", workspace))
 
@@ -399,7 +399,7 @@ class ManagementAccessControlTest(ViewTestCase):
         group.save(update_fields=["enforced_2fa"])
         group.roles.add(role)
         self.user.groups.add(group)
-        self.user.clear_cache()
+        self.user.clear_permissions_cache()
 
     def assert_forbidden(self, url_name: str, method: str = "get", **kwargs) -> None:
         response = getattr(self.client, method)(reverse(url_name), **kwargs)

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -907,7 +907,7 @@ class WorkspaceCreateView(CreateView):
         self.object.acting_user = self.request.user
         self.object.save()
         self.object.add_owner(self.request.user, self.request)
-        self.request.user.clear_cache()
+        self.request.user.clear_permissions_cache()
         Change.objects.create(
             action=ActionEvents.CREATE_WORKSPACE,
             workspace=self.object,


### PR DESCRIPTION
Return anonymous users as copies of a cached prototype so per-request permission caches are not shared. Rename user permission cache invalidation for clarity and add a bug-fix changelog entry.

Fixes WEBLATE-3ADA
Fixes #20132

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
