### PR TITLE
perf(auth): optimize cached team memberships

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Weblate 2026.7.1
 .. rubric:: Improvements
 
 * Restricted components now show a status icon in component listings.
+* Permission checks now reuse materialized team membership data from lightweight relation lookups.
 
 .. rubric:: Bug fixes
 

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -11,7 +11,6 @@ from copy import copy
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import cache as functools_cache
-from itertools import chain
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypedDict, cast
 
 from appconf import AppConf
@@ -22,7 +21,7 @@ from django.contrib.auth.models import Group as DjangoGroup
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
-from django.db.models import Prefetch, Q, UniqueConstraint
+from django.db.models import Q, UniqueConstraint
 from django.db.models.functions import Upper
 from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
@@ -56,10 +55,9 @@ from weblate.auth.utils import (
     migrate_permissions,
     migrate_roles,
 )
-from weblate.lang.models import Language
 from weblate.trans.defines import FULLNAME_LENGTH, USERNAME_LENGTH
 from weblate.trans.fields import RegexField
-from weblate.trans.models import Component, ComponentList, Project
+from weblate.trans.models import ComponentList, Project
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.fields import EmailField, UsernameField
 from weblate.utils.search import parse_query
@@ -77,6 +75,7 @@ if TYPE_CHECKING:
     from weblate.accounts.models import Subscription
     from weblate.accounts.strategy import WeblateStrategy
     from weblate.auth.results import PermissionResult
+    from weblate.lang.models import Language
     from weblate.wladmin.models import SupportStatusDict
 
     SimplePermissionList = list[tuple[set[str], PermissionLanguageScope | None]]
@@ -95,6 +94,21 @@ if TYPE_CHECKING:
         projects: PermissionCacheType
         components: SimplePermissionCacheType
         workspaces: dict[uuid.UUID, set[str]]
+
+
+@dataclass(slots=True)
+class CachedPermissionMembership:
+    defining_workspace_id: uuid.UUID | None
+    project_selection: int
+    language_selection: int
+    enforced_2fa: bool
+    limit_language_ids: set[int]
+    language_ids: set[int]
+    permission_codenames: set[str]
+    componentlist_component_values: set[tuple[int, int]]
+    has_componentlists: bool
+    component_values: set[tuple[int, int]]
+    project_ids: set[int]
 
 
 class Permission(models.Model):
@@ -166,6 +180,54 @@ class Role(models.Model):
 
     def __str__(self) -> str:
         return pgettext("Access-control role", self.name)
+
+
+def _fetch_relation_ids(
+    through: type[models.Model],
+    source_field: str,
+    target_field: str,
+    source_ids: Iterable[int],
+) -> defaultdict[int, set[int]]:
+    source_ids = set(source_ids)
+    result: defaultdict[int, set[int]] = defaultdict(set)
+    if not source_ids:
+        return result
+
+    for source_id, target_id in through.objects.filter(
+        **{f"{source_field}__in": source_ids}
+    ).values_list(source_field, target_field):
+        result[source_id].add(target_id)
+    return result
+
+
+def _fetch_role_permissions(role_ids: Iterable[int]) -> defaultdict[int, set[str]]:
+    role_ids = set(role_ids)
+    result: defaultdict[int, set[str]] = defaultdict(set)
+    if not role_ids:
+        return result
+
+    for role_id, codename in Role.permissions.through.objects.filter(
+        role_id__in=role_ids
+    ).values_list("role_id", "permission__codename"):
+        result[role_id].add(codename)
+    return result
+
+
+def _fetch_component_values(
+    through: type[models.Model],
+    source_field: str,
+    source_ids: Iterable[int],
+) -> defaultdict[int, set[tuple[int, int]]]:
+    source_ids = set(source_ids)
+    result: defaultdict[int, set[tuple[int, int]]] = defaultdict(set)
+    if not source_ids:
+        return result
+
+    for source_id, component_id, project_id in through.objects.filter(
+        **{f"{source_field}__in": source_ids}
+    ).values_list(source_field, "component_id", "component__project_id"):
+        result[source_id].add((component_id, project_id))
+    return result
 
 
 class GroupQuerySet(models.QuerySet["Group", "Group"]):
@@ -826,7 +888,6 @@ class User(AbstractBaseUser):
             "owned_projects",
             "managed_projects",
             "global_permissions",
-            "cached_groups",
             "cached_memberships",
         )
         for name in perm_caches:
@@ -1043,56 +1104,156 @@ class User(AbstractBaseUser):
         return set(self.administered_group_set.values_list("id", flat=True))
 
     @cached_property
-    def cached_groups(self) -> list[Group]:
-        """Materialized group list built from cached memberships."""
-        return [membership.group for membership in self.cached_memberships]
+    def cached_memberships(self) -> list[CachedPermissionMembership]:
+        limit_languages = TeamMembership.limit_languages.through
+        group_componentlists = Group.componentlists.through
+        group_components = Group.components.through
+        group_projects = Group.projects.through
 
-    @cached_property
-    def cached_memberships(self) -> Iterable[TeamMembership]:
-        return (
-            self.team_memberships.select_related("group")
-            .prefetch_related(
-                Prefetch("limit_languages", queryset=Language.objects.only("id")),
-                "group__roles__permissions",
-                Prefetch(
-                    "group__componentlists__components",
-                    queryset=Component.objects.only("id", "project_id"),
+        membership_rows = list(
+            self.team_memberships.annotate(
+                has_limit_languages=models.Exists(
+                    limit_languages.objects.filter(
+                        teammembership_id=models.OuterRef("pk")
+                    )
                 ),
-                # The name and slug are used when rendering the groups
-                Prefetch(
-                    "group__components",
-                    queryset=Component.objects.all().only(
-                        "id", "project_id", "name", "slug"
-                    ),
+                has_componentlists=models.Exists(
+                    group_componentlists.objects.filter(
+                        group_id=models.OuterRef("group_id")
+                    )
                 ),
-                # The name and slug are used when rendering the groups
-                Prefetch(
-                    "group__projects",
-                    queryset=Project.objects.only("id", "name", "slug"),
+                has_components=models.Exists(
+                    group_components.objects.filter(
+                        group_id=models.OuterRef("group_id")
+                    )
                 ),
-                # The name and code are used when rendering the groups
-                Prefetch(
-                    "group__languages",
-                    queryset=Language.objects.only("id", "name", "code"),
+                has_projects=models.Exists(
+                    group_projects.objects.filter(group_id=models.OuterRef("group_id"))
                 ),
             )
-            .order_by("group__name", "group_id")
+            .values(
+                "id",
+                "group_id",
+                "group__defining_workspace_id",
+                "group__project_selection",
+                "group__language_selection",
+                "group__enforced_2fa",
+                "has_limit_languages",
+                "has_componentlists",
+                "has_components",
+                "has_projects",
+            )
+            .order_by("group_id")
+        )
+        if not membership_rows:
+            return []
+
+        group_ids = [row["group_id"] for row in membership_rows]
+        limited_membership_ids = [
+            row["id"] for row in membership_rows if row["has_limit_languages"]
+        ]
+        componentlist_group_ids = [
+            row["group_id"] for row in membership_rows if row["has_componentlists"]
+        ]
+        component_group_ids = [
+            row["group_id"] for row in membership_rows if row["has_components"]
+        ]
+        project_group_ids = [
+            row["group_id"] for row in membership_rows if row["has_projects"]
+        ]
+        manual_language_group_ids = [
+            row["group_id"]
+            for row in membership_rows
+            if row["group__language_selection"] != SELECTION_ALL
+        ]
+
+        limit_language_ids = _fetch_relation_ids(
+            TeamMembership.limit_languages.through,
+            "teammembership_id",
+            "language_id",
+            limited_membership_ids,
+        )
+        group_language_ids = _fetch_relation_ids(
+            Group.languages.through,
+            "group_id",
+            "language_id",
+            manual_language_group_ids,
+        )
+        group_role_ids = _fetch_relation_ids(
+            Group.roles.through, "group_id", "role_id", group_ids
+        )
+        role_permissions = _fetch_role_permissions(
+            role_id for role_ids in group_role_ids.values() for role_id in role_ids
+        )
+        group_permission_codenames: defaultdict[int, set[str]] = defaultdict(set)
+        for group_id, role_ids in group_role_ids.items():
+            for role_id in role_ids:
+                group_permission_codenames[group_id].update(role_permissions[role_id])
+
+        group_componentlist_ids = _fetch_relation_ids(
+            Group.componentlists.through,
+            "group_id",
+            "componentlist_id",
+            componentlist_group_ids,
+        )
+        componentlist_component_values = _fetch_component_values(
+            ComponentList.components.through,
+            "componentlist_id",
+            (
+                componentlist_id
+                for componentlist_ids in group_componentlist_ids.values()
+                for componentlist_id in componentlist_ids
+            ),
+        )
+        group_component_values = _fetch_component_values(
+            Group.components.through, "group_id", component_group_ids
         )
 
+        group_componentlist_component_values: defaultdict[int, set[tuple[int, int]]] = (
+            defaultdict(set)
+        )
+        for group_id, componentlist_ids in group_componentlist_ids.items():
+            for componentlist_id in componentlist_ids:
+                group_componentlist_component_values[group_id].update(
+                    componentlist_component_values[componentlist_id]
+                )
+
+        group_project_ids = _fetch_relation_ids(
+            Group.projects.through, "group_id", "project_id", project_group_ids
+        )
+
+        return [
+            CachedPermissionMembership(
+                defining_workspace_id=row["group__defining_workspace_id"],
+                project_selection=row["group__project_selection"],
+                language_selection=row["group__language_selection"],
+                enforced_2fa=row["group__enforced_2fa"],
+                limit_language_ids=limit_language_ids[row["id"]],
+                language_ids=group_language_ids[row["group_id"]],
+                permission_codenames=group_permission_codenames[row["group_id"]],
+                componentlist_component_values=group_componentlist_component_values[
+                    row["group_id"]
+                ],
+                has_componentlists=bool(group_componentlist_ids[row["group_id"]]),
+                component_values=group_component_values[row["group_id"]],
+                project_ids=group_project_ids[row["group_id"]],
+            )
+            for row in membership_rows
+        ]
+
     def group_enforces_2fa(self) -> bool:
-        return any(group.enforced_2fa for group in self.cached_groups)
+        return any(membership.enforced_2fa for membership in self.cached_memberships)
 
     @staticmethod
     def get_membership_languages(
-        membership: TeamMembership,
+        membership: CachedPermissionMembership,
     ) -> PermissionLanguageScope | None:
-        group = membership.group
-        if group.language_selection == SELECTION_ALL:
+        if membership.language_selection == SELECTION_ALL:
             group_languages = None
         else:
-            group_languages = {language.id for language in group.languages.all()}
+            group_languages = membership.language_ids
 
-        limit_languages = membership.get_limit_language_ids()
+        limit_languages = membership.limit_language_ids
         if not limit_languages:
             if group_languages is None:
                 return None
@@ -1112,9 +1273,8 @@ class User(AbstractBaseUser):
 
         with start_span(op="auth.permissions", name=self.username):
             for membership in self.cached_memberships:
-                group = membership.group
                 # Skip permissions for not verified users
-                if group.enforced_2fa and not self.profile.has_2fa:
+                if membership.enforced_2fa and not self.profile.has_2fa:
                     continue
                 languages = self.get_membership_languages(membership)
                 if (
@@ -1123,15 +1283,10 @@ class User(AbstractBaseUser):
                     and not languages.language_ids
                 ):
                     continue
-                permissions = {
-                    permission.codename
-                    for permission in chain.from_iterable(
-                        role.permissions.all() for role in group.roles.all()
-                    )
-                }
-                if group.defining_workspace_id:
+                permissions = membership.permission_codenames
+                if membership.defining_workspace_id:
                     if languages is None or not languages.membership_limited:
-                        workspaces[group.defining_workspace_id].update(
+                        workspaces[membership.defining_workspace_id].update(
                             permission
                             for permission in permissions
                             if permission.startswith("workspace.")
@@ -1139,44 +1294,36 @@ class User(AbstractBaseUser):
                     continue
 
                 # Component list specific permissions
-                componentlist_values = {
-                    (component.id, component.project_id)
-                    for component in chain.from_iterable(
-                        clist.components.all() for clist in group.componentlists.all()
-                    )
-                }
                 # Even if componentlist_values is empty, having a componentlist assignment
                 # means we need to stop processing here.
-                if group.componentlists.exists():
-                    for component, project in componentlist_values:
+                if membership.has_componentlists:
+                    for component, project in membership.componentlist_component_values:
                         components[component].append((permissions, languages))
                         # Grant access to the project
                         projects[project].append((set(), languages))
                     continue
 
                 # Component specific permissions
-                component_values = {
-                    (component.id, component.project_id)
-                    for component in group.components.all()
-                }
-                if component_values:
-                    for component, project in component_values:
+                if membership.component_values:
+                    for component, project in membership.component_values:
                         components[component].append((permissions, languages))
                         # Grant access to the project
                         projects[project].append((set(), languages))
                     continue
 
                 # Handle project selection
-                if group.project_selection in {
+                if membership.project_selection in {
                     SELECTION_ALL_PUBLIC,
                     SELECTION_ALL_PROTECTED,
                     SELECTION_ALL,
                 }:
-                    projects[-group.project_selection].append((permissions, languages))
+                    projects[-membership.project_selection].append(
+                        (permissions, languages)
+                    )
                 else:
                     # Project specific permissions
-                    for project_obj in group.projects.all():
-                        projects[project_obj.id].append((permissions, languages))
+                    for project_id in membership.project_ids:
+                        projects[project_id].append((permissions, languages))
         # Apply blocking
         now = timezone.now()
         for block in self.userblock_set.all():

--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -36,17 +36,60 @@ class ModelTest(FixtureComponentTestCase):
         self.group.projects.add(self.project)
 
     def test_num_queries(self) -> None:
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(4):
             self.assertEqual(len(self.user.component_permissions), 0)
             self.assertEqual(len(self.user.project_permissions), 2)
 
-    def test_cached_memberships_query_avoids_scoped_name_joins(self) -> None:
-        sql = str(self.user.cached_memberships.query)
+    def test_cached_memberships_are_materialized(self) -> None:
+        self.group.projects.remove(self.project)
+        power_user = Role.objects.get(name="Power user")
+        czech = Language.objects.get(code="cs")
+        german = Language.objects.get(code="de")
+        other_component = self.create_link_existing(
+            slug="test-cached", name="Test cached"
+        )
 
-        self.assertIn('"weblate_auth_group"."name"', sql)
-        self.assertIn('"weblate_auth_user_groups"."group_id"', sql)
-        self.assertNotIn("trans_project", sql)
-        self.assertNotIn("workspaces_workspace", sql)
+        component_group = Group.objects.create(
+            name="Cached components", language_selection=SELECTION_MANUAL
+        )
+        component_group.roles.add(power_user)
+        component_group.components.add(self.component)
+        component_group.languages.add(czech)
+
+        componentlist = ComponentList.objects.create(
+            name="Cached memberships", slug="cached-memberships"
+        )
+        componentlist.components.add(other_component)
+        componentlist_group = Group.objects.create(
+            name="Cached component lists", language_selection=SELECTION_MANUAL
+        )
+        componentlist_group.roles.add(power_user)
+        componentlist_group.componentlists.add(componentlist)
+        componentlist_group.languages.add(czech)
+
+        project_group = Group.objects.create(
+            name="Cached projects", language_selection=SELECTION_MANUAL
+        )
+        project_group.roles.add(power_user)
+        project_group.projects.add(self.project)
+        project_group.languages.add(czech, german)
+
+        self.user.groups.add(component_group, componentlist_group, project_group)
+        TeamMembership.objects.get(
+            user=self.user, group=project_group
+        ).limit_languages.add(czech)
+        self.user.clear_permissions_cache()
+
+        memberships = self.user.cached_memberships
+
+        self.assertIsInstance(memberships, list)
+        self.assertNotIsInstance(memberships[0], TeamMembership)
+        with self.assertNumQueries(1) as context:
+            self.assertIn(self.component.pk, self.user.component_permissions)
+            self.assertIn(other_component.pk, self.user.component_permissions)
+            self.assertIn(self.project.pk, self.user.project_permissions)
+            self.assertFalse(self.user.group_enforces_2fa())
+        self.assertIn("weblate_auth_userblock", context.captured_queries[0]["sql"])
 
     def test_anonymous_project_permissions(self) -> None:
         anonymous = User.objects.get(username=settings.ANONYMOUS_USER_NAME)
@@ -62,7 +105,7 @@ class ModelTest(FixtureComponentTestCase):
 
     def test_anonymous_user_is_not_shared(self) -> None:
         anonymous = get_anonymous()
-        self.assertIsNotNone(anonymous.cached_memberships.query)
+        self.assertIsInstance(anonymous.cached_memberships, list)
         self.assertEqual(anonymous.profile.second_factors, [])
 
         fresh_anonymous = get_anonymous()
@@ -130,7 +173,7 @@ class ModelTest(FixtureComponentTestCase):
         self.user.groups.add(component_group, componentlist_group, project_group)
         self.user.clear_permissions_cache()
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             self.assertEqual(len(self.user.component_permissions), 2)
             self.assertIn(self.component.pk, self.user.component_permissions)
             self.assertIn(other_component.pk, self.user.component_permissions)

--- a/weblate/trans/tests/test_acl.py
+++ b/weblate/trans/tests/test_acl.py
@@ -11,8 +11,7 @@ from unittest.mock import patch
 from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ValidationError
-from django.db import connection
-from django.test.utils import CaptureQueriesContext, modify_settings, override_settings
+from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
 from social_django.models import UserSocialAuth
 
@@ -86,23 +85,15 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
         response = self.client.get(self.translate_url)
         self.assertContains(response, ' name="save"')
 
-    def test_anonymous_translate_view_permission_memberships(self) -> None:
+    def test_anonymous_translate_view_checksum_access(self) -> None:
         self.project.access_control = Project.ACCESS_PUBLIC
         self.project.save()
+        get_anonymous().clear_permissions_cache()
+        unit = self.get_unit()
 
-        with CaptureQueriesContext(connection) as queries:
-            response = self.client.get(self.translate_url)
+        response = self.client.get(self.translate_url, {"checksum": unit.checksum})
 
         self.assertContains(response, ' name="save"')
-        membership_queries = [
-            query["sql"]
-            for query in queries
-            if query["sql"].startswith('SELECT "weblate_auth_user_groups"')
-        ]
-        self.assertTrue(membership_queries)
-        for query in membership_queries:
-            self.assertNotIn('ORDER BY "trans_project"', query)
-            self.assertNotIn('ORDER BY "workspaces_workspace"', query)
 
     def test_acl_protected(self) -> None:
         """Test ACL protected project."""


### PR DESCRIPTION
Materialize permission memberships as thin cached data, populate relation ids through lightweight lookups, and cover anonymous checksum translation permission checks in tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
