### PR TITLE
fix(vcs): explain missing workspace for GitHub App setup

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,7 @@ Weblate 2026.7.1
 * The :guilabel:`Things to check` panel no longer uses error highlighting for suggestions and other non-error translation states.
 * Translation workflow customization now makes it clearer when per-language workflow settings are disabled until customization is enabled.
 * Anonymous user permission caches are now isolated between requests.
+* GitHub App setup now explains that a workspace is required instead of showing a permission error when no workspace exists.
 
 .. rubric:: Compatibility
 

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -198,6 +198,26 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertEqual(response.status_code, 302)
         return response["Location"]
 
+    def _remove_workspaces(self) -> None:
+        self.project.workspace = None
+        self.project.save(update_fields=["workspace"])
+        self.workspace.delete()
+        self.user.clear_permissions_cache()
+
+    def assert_missing_workspace_message(self, response) -> None:
+        response_messages = [
+            str(message) for message in get_messages(response.wsgi_request)
+        ]
+        self.assertEqual(
+            response_messages,
+            [
+                (
+                    "Create a workspace before connecting a GitHub account. "
+                    "GitHub App connections are linked to workspaces."
+                )
+            ],
+        )
+
     def assert_installation_remove_modal(
         self, response, installation: GitHubInstallation
     ) -> None:
@@ -228,6 +248,32 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertEqual(parsed.netloc, "github.com")
         self.assertEqual(parsed.path, "/apps/weblate-app/installations/select_target")
         self.assertIn("state", parse_qs(parsed.query))
+
+    def test_install_without_workspace_redirects_with_message(self):
+        self._remove_workspaces()
+
+        response = self.client.get(reverse("github-app-install"))
+
+        self.assertRedirects(response, reverse("manage-github-accounts"))
+        self.assert_missing_workspace_message(response)
+
+    def test_setup_without_workspace_redirects_with_message(self):
+        self._remove_workspaces()
+
+        response = self.client.get(
+            reverse("github-app-setup"),
+            {
+                "installation_id": "12345",
+                "setup_action": "install",
+                "code": "oauth-code",
+            },
+        )
+
+        self.assertRedirects(response, reverse("manage-github-accounts"))
+        self.assertFalse(
+            GitHubInstallation.objects.filter(installation_id="12345").exists()
+        )
+        self.assert_missing_workspace_message(response)
 
     def test_management_overview_uses_single_workspace_for_install_link(self):
         response = self.client.get(reverse("manage-github-accounts"))

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -17,7 +17,7 @@ from django.contrib.auth.decorators import login_required
 from django.core import signing
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.signing import BadSignature, SignatureExpired
-from django.http import HttpResponseNotAllowed
+from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -93,9 +93,19 @@ def _user_can_install_github_app(user) -> bool:
     return _installation_workspaces(user).exists()
 
 
-def _require_github_app_access(request) -> None:
-    if not _user_can_install_github_app(request.user):
-        raise PermissionDenied
+def _handle_missing_github_app_access(request, next_url: str) -> HttpResponse | None:
+    if _user_can_install_github_app(request.user):
+        return None
+    if request.user.has_perm("management.use") and not Workspace.objects.exists():
+        messages.error(
+            request,
+            gettext(
+                "Create a workspace before connecting a GitHub account. "
+                "GitHub App connections are linked to workspaces."
+            ),
+        )
+        return redirect(next_url)
+    raise PermissionDenied
 
 
 def _default_next_url(request, workspace: Workspace | None = None) -> str:
@@ -536,9 +546,10 @@ def refresh_repositories(request, pk):
 @login_required
 def github_app_install(request):
     """Start the Weblate GitHub app installation flow."""
-    _require_github_app_access(request)
-
     next_url = _get_next_url(request)
+    if response := _handle_missing_github_app_access(request, next_url):
+        return response
+
     configs = get_github_app_configurations()
     if not configs:
         messages.error(
@@ -686,7 +697,8 @@ def github_app_setup(request):
         )
         return redirect(next_url)
 
-    _require_github_app_access(request)
+    if response := _handle_missing_github_app_access(request, next_url):
+        return response
 
     hostname = ""
     workspace = None


### PR DESCRIPTION
Redirect GitHub App install and setup callbacks with a clear workspace-required message when no workspace exists instead of showing a permission error.

Fixes #20416

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
