### PR TITLE
feat(translations): show restricted component indicator

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,8 +7,11 @@ Weblate 2026.7.1
 
 .. rubric:: Improvements
 
+* Restricted components now show a status icon in component listings.
+
 .. rubric:: Bug fixes
 
+* Component priority icons are no longer shown on translation listings.
 * The :guilabel:`Things to check` panel no longer uses error highlighting for suggestions and other non-error translation states.
 * Translation workflow customization now makes it clearer when per-language workflow settings are disabled until customization is enabled.
 * Anonymous user permission caches are now isolated between requests.

--- a/weblate/static/state/shield.svg
+++ b/weblate/static/state/shield.svg
@@ -1,0 +1,1 @@
+<svg width="14" height="14" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m12 1-9 4v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12v-6l-9-4z" fill="#2a3744"/></svg>

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -47,7 +47,6 @@ from weblate.utils.diff import Differ
 from weblate.utils.docs import get_doc_url
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.html import format_html_join_comma, list_to_tuples
-from weblate.utils.icons import load_icon
 from weblate.utils.markdown import render_markdown
 from weblate.utils.messages import get_message_kind as get_message_kind_impl
 from weblate.utils.random import get_random_identifier
@@ -1140,26 +1139,38 @@ def get_filter_name(name: str) -> str:
     return names[name]
 
 
+def get_alert_css_class(icon_name: str, css_class: str = "") -> str:
+    if css_class:
+        return css_class
+    if icon_name == "state/ghost.svg":
+        return "grey"
+    if icon_name == "state/alert.svg":
+        return "red"
+    return ""
+
+
 def translation_alerts(
     translation: Translation | ProjectLanguage | GhostTranslation,
-) -> Iterable[tuple[str, StrOrPromise, str | None]]:
+) -> Iterable[tuple[str, StrOrPromise, str | None, str]]:
     if translation.is_source:
         yield (
             "state/source.svg",
             gettext("This language is used for source strings."),
             None,
+            "",
         )
 
 
 def component_alerts(
     component: Component,
-) -> Iterable[tuple[str, StrOrPromise, str | None]]:
+) -> Iterable[tuple[str, StrOrPromise, str | None, str]]:
     if component.is_repo_link:
         yield (
             "state/link.svg",
             gettext("This component is linked to the %(target)s repository.")
             % {"target": component.linked_component},
             None,
+            "",
         )
 
     if component.all_problem_alerts:
@@ -1167,29 +1178,34 @@ def component_alerts(
             "state/alert.svg",
             gettext("Fix this component to clear its diagnostics."),
             f"{component.get_absolute_url()}#alerts",
+            "",
         )
 
     if component.locked:
-        yield ("state/lock.svg", gettext("This translation is locked."), None)
+        yield ("state/lock.svg", gettext("This translation is locked."), None, "")
 
     if component.in_progress():
         yield (
             "state/update.svg",
             gettext("Updating translation component…"),
             f"{reverse('show_progress', kwargs={'path': component.get_url_path()})}?info=1",
+            "",
         )
 
 
-def project_alerts(project: Project) -> Iterable[tuple[str, StrOrPromise, str | None]]:
+def project_alerts(
+    project: Project,
+) -> Iterable[tuple[str, StrOrPromise, str | None, str]]:
     if project.has_alerts:
         yield (
             "state/alert.svg",
             gettext("Some of the components within this project have diagnostics."),
             None,
+            "",
         )
 
     if project.locked:
-        yield ("state/lock.svg", gettext("This translation is locked."), None)
+        yield ("state/lock.svg", gettext("This translation is locked."), None, "")
 
 
 def get_alerts(
@@ -1205,18 +1221,25 @@ def get_alerts(
     component: Component | None,
     project: Project | None,
     project_language: ProjectLanguage | None,
-) -> Iterable[tuple[str, StrOrPromise, str | None]]:
+) -> Iterable[tuple[str, StrOrPromise, str | None, str]]:
     global_base = context.get("global_base")
+
+    if isinstance(obj, Component) and (priority := obj.priority) in PRIORITY_ICONS:
+        selected_svg, css_class, title_text = PRIORITY_ICONS[priority]
+        yield f"priorities/{selected_svg}.svg", title_text, None, css_class
 
     if project_language is not None:
         # For source language
         yield from translation_alerts(project_language)
 
     if project is not None and context["user"].has_perm("project.edit", project):
-        yield ("state/admin.svg", gettext("You administrate this project."), None)
+        yield ("state/admin.svg", gettext("You administrate this project."), None, "")
 
     if translation is not None:
         yield from translation_alerts(translation)
+
+    if isinstance(obj, Component) and obj.restricted:
+        yield ("state/shield.svg", gettext("Restricted component"), None, "")
 
     if component is not None:
         yield from (component_alerts(component))
@@ -1225,7 +1248,12 @@ def get_alerts(
 
     if getattr(obj, "is_ghost", False):
         yield (
-            ("state/ghost.svg", gettext("This translation does not yet exist."), None)
+            (
+                "state/ghost.svg",
+                gettext("This translation does not yet exist."),
+                None,
+                "",
+            )
         )
     elif global_base:
         if isinstance(global_base, str):
@@ -1244,6 +1272,7 @@ def get_alerts(
                     )
                     % {"count": intcomma(count)},
                     None,
+                    "",
                 )
             )
 
@@ -1253,6 +1282,7 @@ def get_alerts(
                 "state/share.svg",
                 gettext("Shared from the %s project.") % is_shared,
                 None,
+                "",
             )
         )
 
@@ -1288,37 +1318,19 @@ def indicate_alerts(
     # GhostProjectLanguageStats and GhostCategoryLanguageStats as these would
     # be confusing (showing alert or admin icon on ghost containers).
 
-    priority_html = ""
-    if component and (priority := component.priority) in PRIORITY_ICONS:
-        selected_svg, css_class, title_text = PRIORITY_ICONS[priority]
-
-        priority_html = format_html(
-            '<span class="state-icon {}" data-bs-toggle="tooltip" title="{}" alt="{}" style="margin: 0">{}</span>',
-            css_class,
-            title_text,
-            title_text,
-            mark_safe(  # noqa: S308
-                load_icon(f"priorities/{selected_svg}.svg", auto_prefix=False).decode()
-            ),
-        )
-
     icons = format_html_join(
         "\n",
         '{}<span class="state-icon {}" title="{}" alt="{}">{}</span>{}',
         (
             (
                 format_html('<a href="{}">', url) if url else "",
-                "grey"
-                if icon_name == "state/ghost.svg"
-                else "red"
-                if icon_name == "state/alert.svg"
-                else "",
+                get_alert_css_class(icon_name, css_class),
                 text,
                 text,
                 icon(icon_name),
                 mark_safe("</a>") if url else "",
             )
-            for icon_name, text, url in get_alerts(
+            for icon_name, text, url, css_class in get_alerts(
                 context=context,
                 translation=translation,
                 component=component,
@@ -1341,7 +1353,7 @@ def indicate_alerts(
             component.effective_license,
         )
 
-    return format_html("{}{}{}", priority_html, icons, license_badge)
+    return format_html("{}{}", icons, license_badge)
 
 
 @register.filter(is_safe=True)

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
+from django.contrib.auth.models import AnonymousUser
 from django.template import Context
 from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
+from django.utils.html import format_html
 
 from weblate.auth.models import User
 from weblate.checks.flags import Flags
@@ -78,24 +80,18 @@ class NaturalTimeTest(SimpleTestCase):
 class IndicateAlertsPriorityTest(SimpleTestCase):
     def test_priority_icons(self) -> None:
         project = Project(slug="p", name="p")
-        context = Context({})
+        context = Context({"user": AnonymousUser()})
 
         cases = [
             (priority, svg, css, f'title="{title}"')
             for priority, (svg, css, title) in PRIORITY_ICONS.items()
         ]
 
-        def fake_load_icon(path: str, *, auto_prefix: bool = True) -> bytes:
-            return f'<svg data-icon="{path}"></svg>'.encode()
+        def fake_icon(path: str) -> str:
+            return format_html('<svg data-icon="{}"></svg>', path)
 
-        with (
-            patch(
-                "weblate.trans.templatetags.translations.get_alerts", return_value=[]
-            ),
-            patch(
-                "weblate.trans.templatetags.translations.load_icon",
-                side_effect=fake_load_icon,
-            ),
+        with patch(
+            "weblate.trans.templatetags.translations.icon", side_effect=fake_icon
         ):
             for priority, svg, css_class, title in cases:
                 component = Component(
@@ -105,6 +101,7 @@ class IndicateAlertsPriorityTest(SimpleTestCase):
                     priority=priority,
                     source_language=Language(),
                 )
+                component.__dict__["all_problem_alerts"] = []
                 html = str(indicate_alerts(context, component))
                 self.assertIn(f'data-icon="priorities/{svg}.svg"', html)
                 self.assertIn(f'class="state-icon {css_class}"', html)
@@ -118,8 +115,79 @@ class IndicateAlertsPriorityTest(SimpleTestCase):
                 priority=100,
                 source_language=Language(),
             )
+            default_component.__dict__["all_problem_alerts"] = []
             html = str(indicate_alerts(context, default_component))
             self.assertNotIn('data-icon="priorities/', html)
+
+    def test_priority_icon_skipped_for_translation(self) -> None:
+        project = Project(slug="p", name="p")
+        context = Context({"user": AnonymousUser()})
+        component = Component(
+            project=project,
+            slug="c",
+            name="c",
+            priority=60,
+            source_language=Language(),
+        )
+        component.__dict__["all_problem_alerts"] = []
+        translation = Translation(component=component, language=Language())
+
+        def fake_icon(path: str) -> str:
+            return format_html('<svg data-icon="{}"></svg>', path)
+
+        with patch(
+            "weblate.trans.templatetags.translations.icon", side_effect=fake_icon
+        ):
+            html = str(indicate_alerts(context, translation))
+
+        self.assertNotIn('data-icon="priorities/', html)
+
+
+class IndicateAlertsRestrictedTest(SimpleTestCase):
+    def test_restricted_component_icon(self) -> None:
+        context = Context({"user": AnonymousUser()})
+        component = Component(
+            project=Project(slug="p", name="p"),
+            slug="c",
+            name="c",
+            restricted=True,
+            source_language=Language(pk=1),
+        )
+        component.__dict__["all_problem_alerts"] = []
+
+        def fake_icon(path: str) -> str:
+            return format_html('<svg data-icon="{}"></svg>', path)
+
+        with patch(
+            "weblate.trans.templatetags.translations.icon", side_effect=fake_icon
+        ):
+            html = str(indicate_alerts(context, component))
+
+        self.assertIn('data-icon="state/shield.svg"', html)
+        self.assertIn('title="Restricted component"', html)
+
+    def test_restricted_component_icon_skipped_for_translation(self) -> None:
+        context = Context({"user": AnonymousUser()})
+        component = Component(
+            project=Project(slug="p", name="p"),
+            slug="c",
+            name="c",
+            restricted=True,
+            source_language=Language(pk=1),
+        )
+        component.__dict__["all_problem_alerts"] = []
+        translation = Translation(component=component, language=Language(pk=2))
+
+        def fake_icon(path: str) -> str:
+            return format_html('<svg data-icon="{}"></svg>', path)
+
+        with patch(
+            "weblate.trans.templatetags.translations.icon", side_effect=fake_icon
+        ):
+            html = str(indicate_alerts(context, translation))
+
+        self.assertNotIn('data-icon="state/shield.svg"', html)
+        self.assertNotIn('title="Restricted component"', html)
 
 
 class LocationLinksTest(TestCase):


### PR DESCRIPTION
Restricted and priority markers describe component state, so they should appear only on component rows.

Render both through get_alerts to keep component status handling in one place and hide priority icons from translation listings.

Fixes #20308

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
