### PR TITLE
fix(trans): preserve repoweb user for linked repos

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -2295,7 +2295,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 )()
         if self.linked_component is not None:
             return self.linked_component.get_repoweb_link(
-                filename, line, template, user=self.acting_user
+                filename, line, template, user=user or self.acting_user
             )
         if not template:
             if filename.startswith("https://"):

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -3398,6 +3398,33 @@ class ComponentRepoWebTestCase(FixtureTestCase):
             "https://github.com/marcus/project-x/blob/main/test.py#L42", self.get_url()
         )
 
+    def create_github_repo_link(self) -> Component:
+        self.component.repo = "https://github.com/marcus/project-x.git"
+        Component.objects.filter(pk=self.component.pk).update(repo=self.component.repo)
+        return self.create_link_existing(
+            name="Linked repository browser",
+            slug="linked-repository-browser",
+        )
+
+    def test_repo_link_generation_linked_github_with_user(self) -> None:
+        """Test generated repository browser links for linked repositories."""
+        component = self.create_github_repo_link()
+
+        self.assertEqual(
+            "https://github.com/marcus/project-x/blob/main/test.py#L42",
+            component.get_repoweb_link("test.py", "42", user=self.user),
+        )
+
+    def test_repo_link_generation_linked_github_with_acting_user(self) -> None:
+        """Test generated repository browser links delegate acting user."""
+        component = self.create_github_repo_link()
+        component.acting_user = self.user
+
+        self.assertEqual(
+            "https://github.com/marcus/project-x/blob/main/test.py#L42",
+            component.get_repoweb_link("test.py", "42"),
+        )
+
     def test_repo_link_generation_pagure(self) -> None:
         """Test changing repo attribute to check repo generation links."""
         self.component.repo = "https://pagure.io/f/ATEST"


### PR DESCRIPTION
Keep repository browser fallback generation using the caller user across weblate:// links, while still using acting_user when no user is passed.

Fixes #20425

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
