### PR TITLE
fix(memory): speed up fuzzy TM lookups

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -493,6 +493,7 @@ It is usually a good idea to run Weblate in a separate database, and separate us
 
         CREATE EXTENSION IF NOT EXISTS pg_trgm;
         CREATE EXTENSION IF NOT EXISTS btree_gin;
+        CREATE EXTENSION IF NOT EXISTS btree_gist;
 
 .. _config-postgresql:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.7.1
 * Permission checks now reuse materialized team membership data from lightweight relation lookups.
 * Documented that intermediate language files are hidden from language listings and can make target strings read-only.
 * Component diagnostics now warn when regular :ref:`gettext` PO files are configured as monolingual PO files.
+* Translation memory fuzzy lookups are now faster on large translation memories.
 
 .. rubric:: Bug fixes
 
@@ -32,6 +33,8 @@ Weblate 2026.7.1
 .. rubric:: Upgrading
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
+
+* Weblate now requires the PostgreSQL ``btree_gist`` extension for translation memory lookups. The migration installs it automatically when the database user has sufficient privileges. Installations using a non-superuser database user should pre-create it before upgrading; see :ref:`dbsetup-postgres`.
 
 .. rubric:: Contributors
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -12,7 +12,7 @@ from datetime import UTC, date, datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import responses
 import yaml
@@ -8797,7 +8797,7 @@ class MemoryAPITest(APIBaseTest):
         ordered_queryset.distinct.assert_called_once_with("source")
         self.assertEqual(matches, {first.source: first, second.source: second})
 
-    def test_lookup_uses_read_alias_for_similarity_threshold(self) -> None:
+    def test_lookup_delegates_fuzzy_matching_to_queryset(self) -> None:
         source_language = Language.objects.get(code="en")
         target_language = Language.objects.get(code="cs")
         candidate = self.create_memory(
@@ -8806,143 +8806,38 @@ class MemoryAPITest(APIBaseTest):
             project=self.component.project,
             origin=self.component.full_slug,
         )
-        filtered_queryset = self.mock_queryset(db="memory_db")
-        annotated_queryset = self.mock_queryset(db="memory_db")
-        ordered_queryset = self.mock_queryset(db="memory_db")
-        ordered_queryset.__getitem__.return_value = [candidate]
-        annotated_queryset.order_by.return_value = ordered_queryset
-        filtered_queryset.annotate.return_value = annotated_queryset
 
         base_queryset = self.mock_queryset(db="memory_db")
-        base_queryset.filter.return_value = filtered_queryset
+        base_queryset.get_best_fuzzy_match.return_value = candidate
 
         queryset = self.mock_queryset()
         queryset.filter.return_value = base_queryset
 
         view = MemoryViewSet()
-        with (
-            patch("weblate.api.views.adjust_similarity_threshold") as adjust_threshold,
-            patch.object(Memory.objects, "threshold_to_similarity", return_value=0.8),
-            patch.object(Memory.objects, "minimum_similarity", return_value=0.8),
-            patch.object(view.comparer, "similarity", return_value=95),
-        ):
+        with patch.object(view.comparer, "similarity", return_value=95) as similarity:
             match = view.get_fuzzy_match(
                 queryset,
                 source_language,
                 target_language,
                 "Memory routed fuzzy entri",
+                threshold=75,
             )
+            call_args = base_queryset.get_best_fuzzy_match.call_args
+            scorer = call_args.args[1]
+            scored_quality = scorer(candidate)
 
         self.assertEqual(match, candidate)
-        adjust_threshold.assert_called_once_with(0.8, alias="memory_db")
-
-    def test_lookup_retries_lower_similarity_threshold(self) -> None:
-        source_language = Language.objects.get(code="en")
-        target_language = Language.objects.get(code="cs")
-        low_quality_candidate = self.create_memory(
-            source="Retry fuzzy source",
-            target="Nizka fuzzy shoda",
-            project=self.component.project,
-            origin=self.component.full_slug,
+        queryset.filter.assert_called_once_with(
+            source_language=source_language,
+            target_language=target_language,
         )
-        candidate = self.create_memory(
-            source="Retry fuzzy sourca",  # codespell:ignore sourca
-            target="Opakovana fuzzy shoda",
-            project=self.component.project,
-            origin=self.component.full_slug,
+        base_queryset.get_best_fuzzy_match.assert_called_once()
+        self.assertEqual(call_args.args[0], "Memory routed fuzzy entri")
+        self.assertEqual(call_args.kwargs, {"threshold": 75})
+        self.assertEqual(scored_quality, 95)
+        similarity.assert_called_once_with(
+            "Memory routed fuzzy entri", "Memory routed fuzzy entry"
         )
-        first_filtered_queryset = self.mock_queryset(db="memory_db")
-        first_annotated_queryset = self.mock_queryset(db="memory_db")
-        first_ordered_queryset = self.mock_queryset(db="memory_db")
-        first_ordered_queryset.__getitem__.return_value = [low_quality_candidate]
-        first_annotated_queryset.order_by.return_value = first_ordered_queryset
-        first_filtered_queryset.annotate.return_value = first_annotated_queryset
-
-        second_filtered_queryset = self.mock_queryset(db="memory_db")
-        second_annotated_queryset = self.mock_queryset(db="memory_db")
-        second_ordered_queryset = self.mock_queryset(db="memory_db")
-        second_ordered_queryset.__getitem__.return_value = [
-            low_quality_candidate,
-            candidate,
-        ]
-        second_annotated_queryset.order_by.return_value = second_ordered_queryset
-        second_filtered_queryset.annotate.return_value = second_annotated_queryset
-
-        base_queryset = self.mock_queryset(db="memory_db")
-        base_queryset.filter.side_effect = [
-            first_filtered_queryset,
-            second_filtered_queryset,
-        ]
-
-        queryset = self.mock_queryset()
-        queryset.filter.return_value = base_queryset
-
-        view = MemoryViewSet()
-        with (
-            patch("weblate.api.views.adjust_similarity_threshold") as adjust_threshold,
-            patch.object(Memory.objects, "threshold_to_similarity", return_value=0.95),
-            patch.object(Memory.objects, "minimum_similarity", return_value=0.9),
-            patch.object(view.comparer, "similarity", side_effect=[60, 95]),
-        ):
-            match = view.get_fuzzy_match(
-                queryset,
-                source_language,
-                target_language,
-                "Retry fuzzy sourc",  # codespell:ignore sourc
-            )
-
-        self.assertIsNotNone(match)
-        self.assertEqual(
-            adjust_threshold.call_args_list,
-            [call(0.95, alias="memory_db"), call(0.9, alias="memory_db")],
-        )
-
-    def test_lookup_uses_later_fuzzy_candidate_meeting_quality_threshold(self) -> None:
-        source_language = Language.objects.get(code="en")
-        target_language = Language.objects.get(code="cs")
-        low_quality_candidate = self.create_memory(
-            source="Short source typo",
-            target="Nizka kvalita",
-            project=self.component.project,
-            origin=self.component.full_slug,
-        )
-        accepted_candidate = self.create_memory(
-            source="Short source typa",
-            target="Prijata kvalita",
-            project=self.component.project,
-            origin=self.component.full_slug,
-        )
-        filtered_queryset = self.mock_queryset(db="memory_db")
-        annotated_queryset = self.mock_queryset(db="memory_db")
-        ordered_queryset = self.mock_queryset(db="memory_db")
-        ordered_queryset.__getitem__.return_value = [
-            low_quality_candidate,
-            accepted_candidate,
-        ]
-        annotated_queryset.order_by.return_value = ordered_queryset
-        filtered_queryset.annotate.return_value = annotated_queryset
-
-        base_queryset = self.mock_queryset(db="memory_db")
-        base_queryset.filter.return_value = filtered_queryset
-
-        queryset = self.mock_queryset()
-        queryset.filter.return_value = base_queryset
-
-        view = MemoryViewSet()
-        with (
-            patch("weblate.api.views.adjust_similarity_threshold"),
-            patch.object(Memory.objects, "threshold_to_similarity", return_value=0.85),
-            patch.object(Memory.objects, "minimum_similarity", return_value=0.85),
-            patch.object(view.comparer, "similarity", side_effect=[60, 95]),
-        ):
-            match = view.get_fuzzy_match(
-                queryset,
-                source_language,
-                target_language,
-                "Short source typi",
-            )
-
-        self.assertEqual(match, accepted_candidate)
 
     def test_get_scoped_queryset_uses_project_subquery_on_memory_db(self) -> None:
         user = self.mock_user_with_allowed_projects([1, 2, 3])

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -16,7 +16,6 @@ from celery.result import AsyncResult
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages import get_messages
-from django.contrib.postgres.search import TrigramSimilarity
 from django.core.cache import cache
 from django.core.exceptions import (
     PermissionDenied,
@@ -130,7 +129,7 @@ from weblate.lang.forms import validate_language_code
 from weblate.lang.models import Language
 from weblate.machinery.base import MACHINERY_DEFAULT_THRESHOLD
 from weblate.machinery.models import validate_service_configuration
-from weblate.memory.models import MEMORY_LOOKUP_LIMIT, Memory, MemoryScope
+from weblate.memory.models import Memory, MemoryScope
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.autotranslate import AutoTranslate
@@ -169,7 +168,6 @@ from weblate.utils.celery import (
     get_task_progress,
     store_task_metadata,
 )
-from weblate.utils.db import adjust_similarity_threshold
 from weblate.utils.docs import get_doc_url
 from weblate.utils.errors import report_error
 from weblate.utils.lock import WeblateLockTimeoutError
@@ -2822,31 +2820,11 @@ class MemoryViewSet(viewsets.ReadOnlyModelViewSet, DestroyModelMixin):
             source_language=source_language,
             target_language=target_language,
         )
-        if threshold >= 100:
-            return base.filter(source=text).order_by("-status", "id").first()
-
-        similarity_threshold = Memory.objects.threshold_to_similarity(text, threshold)
-        minimum_similarity = Memory.objects.minimum_similarity(text, threshold)
-        seen_candidates: set[int] = set()
-
-        while similarity_threshold >= minimum_similarity:
-            adjust_similarity_threshold(similarity_threshold, alias=base.db)
-            candidates = (
-                base.filter(source__trgm_search=text)
-                .annotate(match_similarity=TrigramSimilarity("source", text))
-                .order_by("-match_similarity", "-status", "pk")[:MEMORY_LOOKUP_LIMIT]
-            )
-            for candidate in candidates:
-                if candidate.pk in seen_candidates:
-                    continue
-                seen_candidates.add(candidate.pk)
-                if self.comparer.similarity(text, candidate.source) >= threshold:
-                    return candidate
-            similarity_threshold = round(similarity_threshold - 0.05, 3)
-            if similarity_threshold < minimum_similarity < similarity_threshold + 0.05:
-                similarity_threshold = minimum_similarity
-
-        return None
+        return base.get_best_fuzzy_match(
+            text,
+            lambda candidate: self.comparer.similarity(text, candidate.source),
+            threshold=threshold,
+        )
 
     def serialize_lookup_result(
         self, query: str, match: Memory | None

--- a/weblate/memory/machine.py
+++ b/weblate/memory/machine.py
@@ -11,10 +11,14 @@ from weblate.machinery.base import (
     MACHINERY_DEFAULT_THRESHOLD,
     InternalMachineTranslation,
 )
-from weblate.memory.models import Memory
+from weblate.memory.models import (
+    MEMORY_LOOKUP_LIMIT,
+    Memory,
+)
 
 if TYPE_CHECKING:
     from weblate.machinery.base import DownloadTranslations
+    from weblate.machinery.types import TranslationResultDict
 
 PENDING_MEMORY_PENALTY_FACTOR = 0.7
 DIFFERENT_CONTEXT_PENALTY_FACTOR = 0.95
@@ -27,6 +31,30 @@ class WeblateMemory(InternalMachineTranslation):
     rank_boost = 2
     same_languages = True
 
+    def get_quality(self, text: str, result: Memory, unit) -> int:
+        quality = self.comparer.similarity(text, result.source)
+        if result.status == Memory.STATUS_PENDING:
+            quality = round(quality * PENDING_MEMORY_PENALTY_FACTOR)
+        # Compare context when translation memory has one
+        if result.context and unit.context != result.context:
+            quality = round(quality * DIFFERENT_CONTEXT_PENALTY_FACTOR)
+        return quality
+
+    def format_result(
+        self, result: Memory, quality: int, project, user
+    ) -> TranslationResultDict:
+        return {
+            "text": result.target,
+            "quality": quality,
+            "service": self.name,
+            "origin": result.get_origin_display(project=project, user=user),
+            "source": result.source,
+            "show_quality": True,
+            "delete_url": reverse("api:memory-detail", kwargs={"pk": result.id})
+            if user is not None and user.has_perm("memory.delete", result)
+            else None,
+        }
+
     def download_translations(
         self,
         source_language,
@@ -38,32 +66,25 @@ class WeblateMemory(InternalMachineTranslation):
     ) -> DownloadTranslations:
         """Download list of possible translations from a service."""
         project = unit.translation.component.project
-        for result in Memory.objects.lookup(
+        queryset = Memory.objects.get_lookup_queryset(
             source_language,
             target_language,
-            text,
             user,
             project,
             project.use_shared_tm,
-            threshold=threshold,
-        ):
-            quality = self.comparer.similarity(text, result.source)
-            if result.status == Memory.STATUS_PENDING:
-                quality = round(quality * PENDING_MEMORY_PENALTY_FACTOR)
-            # Compare context when translation memory has one
-            if result.context and unit.context != result.context:
-                quality = round(quality * DIFFERENT_CONTEXT_PENALTY_FACTOR)
+        )
+        if threshold >= self.max_score:
+            scored_results = []
+            for result in queryset.filter(source=text)[:MEMORY_LOOKUP_LIMIT]:
+                quality = self.get_quality(text, result, unit)
+                if quality >= threshold:
+                    scored_results.append((quality, result))
+        else:
+            scored_results = queryset.get_scored_fuzzy_candidates(
+                text,
+                lambda result: self.get_quality(text, result, unit),
+                threshold=threshold,
+            )
 
-            if quality < threshold:
-                continue
-            yield {
-                "text": result.target,
-                "quality": quality,
-                "service": self.name,
-                "origin": result.get_origin_display(project=project, user=user),
-                "source": result.source,
-                "show_quality": True,
-                "delete_url": reverse("api:memory-detail", kwargs={"pk": result.id})
-                if user is not None and user.has_perm("memory.delete", result)
-                else None,
-            }
+        for quality, result in scored_results:
+            yield self.format_result(result, quality, project, user)

--- a/weblate/memory/migrations/0006_memory_source_gist_prefix.py
+++ b/weblate/memory/migrations/0006_memory_source_gist_prefix.py
@@ -1,0 +1,29 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from django.contrib.postgres import indexes as postgres_indexes
+from django.contrib.postgres.operations import BtreeGistExtension
+from django.db import migrations, models
+from django.db.models.functions import Left
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("memory", "0005_memory_scopes"),
+    ]
+
+    operations = [
+        BtreeGistExtension(),
+        migrations.AddIndex(
+            model_name="memory",
+            index=postgres_indexes.GistIndex(
+                models.F("source_language"),
+                models.F("target_language"),
+                postgres_indexes.OpClass(Left("source", 2048), name="gist_trgm_ops"),
+                name="memory_source_gist_prefix",
+            ),
+        ),
+    ]

--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -12,9 +12,10 @@ from typing import TYPE_CHECKING, BinaryIO, NotRequired, Self, TypedDict, cast
 
 from django.conf import settings
 from django.contrib.postgres import indexes as postgres_indexes
+from django.contrib.postgres.search import TrigramDistance, TrigramSimilarity
 from django.db import models, router, transaction
 from django.db.models import Exists, F, OuterRef, Prefetch, Q, Value
-from django.db.models.functions import MD5
+from django.db.models.functions import MD5, Left
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.translation import gettext, gettext_lazy, pgettext, pgettext_lazy
@@ -35,6 +36,8 @@ from weblate.utils.db import adjust_similarity_threshold
 from weblate.utils.errors import report_error
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
     from weblate.auth.models import AuthenticatedHttpRequest, User
     from weblate.trans.models import Project
 
@@ -51,6 +54,7 @@ SUPPORTED_FORMATS = (
 MIN_SIMILARITY_THRESHOLD = 0.3
 MAX_MACHINERY_SIMILARITY_BACKOFF = 0.2
 MEMORY_LOOKUP_LIMIT = 50
+MEMORY_LOOKUP_PREFIX_LENGTH = 2048
 
 
 class MemoryDict(TypedDict):
@@ -328,6 +332,135 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
             return minimum
         return MIN_SIMILARITY_THRESHOLD
 
+    def get_fuzzy_candidates(self, text: str, limit: int = MEMORY_LOOKUP_LIMIT) -> Self:
+        lookup_prefix = text[:MEMORY_LOOKUP_PREFIX_LENGTH]
+        return self.alias(
+            match_distance=TrigramDistance(
+                Left("source", MEMORY_LOOKUP_PREFIX_LENGTH), lookup_prefix
+            )
+        ).order_by("match_distance", "-status", "pk")[:limit]
+
+    def get_full_source_fuzzy_candidates(
+        self,
+        text: str,
+        *,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+        exclude_ids: Iterable[int] = (),
+        limit: int = MEMORY_LOOKUP_LIMIT,
+    ) -> Iterator[Memory]:
+        if limit <= 0:
+            return
+
+        seen_ids = set(exclude_ids)
+        yielded = 0
+
+        similarity_threshold = self.threshold_to_similarity(text, threshold)
+        minimum_similarity = self.minimum_similarity(text, threshold)
+
+        while similarity_threshold >= minimum_similarity and yielded < limit:
+            remaining = limit - yielded
+            queryset = self.exclude(pk__in=sorted(seen_ids)) if seen_ids else self
+            adjust_similarity_threshold(similarity_threshold, alias=self.db)
+            candidates = (
+                queryset.filter(source__trgm_search=text)
+                .annotate(match_similarity=TrigramSimilarity("source", text))
+                .order_by("-match_similarity", "-status", "pk")[:remaining]
+            )
+            for candidate in candidates:
+                if candidate.pk in seen_ids:
+                    continue
+                seen_ids.add(candidate.pk)
+                yielded += 1
+                yield candidate
+                if yielded >= limit:
+                    return
+
+            similarity_threshold = round(similarity_threshold - 0.05, 3)
+            if similarity_threshold < minimum_similarity < similarity_threshold + 0.05:
+                similarity_threshold = minimum_similarity
+
+    def get_scored_fuzzy_candidates(
+        self,
+        text: str,
+        scorer: Callable[[Memory], int],
+        *,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+        limit: int = MEMORY_LOOKUP_LIMIT,
+    ) -> list[tuple[int, Memory]]:
+        candidates: list[Memory] = list(self.get_fuzzy_candidates(text, limit=limit))
+        accepted: list[tuple[int, int, Memory]] = []
+        best_quality = threshold - 1
+
+        for candidate in candidates:
+            quality = scorer(candidate)
+            if quality < threshold:
+                continue
+            best_quality = max(best_quality, quality)
+            accepted.append((quality, len(accepted), candidate))
+
+        if (
+            best_quality < 100
+            and len(text) > MEMORY_LOOKUP_PREFIX_LENGTH
+            and len(candidates) >= limit
+        ):
+            checked_ids = [candidate.pk for candidate in candidates]
+            for candidate in self.get_full_source_fuzzy_candidates(
+                text,
+                threshold=threshold,
+                exclude_ids=checked_ids,
+                limit=limit,
+            ):
+                quality = scorer(candidate)
+                if quality < threshold:
+                    continue
+                best_quality = max(best_quality, quality)
+                accepted.append((quality, len(accepted), candidate))
+
+        return [
+            (quality, candidate)
+            for quality, _sequence, candidate in sorted(
+                accepted, key=lambda item: (-item[0], item[1])
+            )[:limit]
+        ]
+
+    def get_best_fuzzy_match(
+        self,
+        text: str,
+        scorer: Callable[[Memory], int],
+        *,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> Memory | None:
+        if threshold >= 100:
+            return self.filter(source=text).order_by("-status", "id").first()
+
+        candidates = self.get_scored_fuzzy_candidates(text, scorer, threshold=threshold)
+        if candidates:
+            return candidates[0][1]
+        return None
+
+    def get_lookup_queryset(
+        self,
+        source_language,
+        target_language,
+        user,
+        project,
+        use_shared,
+    ) -> Self:
+        return (
+            self.filter_type(
+                user=user,
+                project=project,
+                use_shared=use_shared,
+                from_file=True,
+                use_workspace=True,
+            )
+            .prefetch_scopes()
+            .filter(
+                source_language=source_language,
+                target_language=target_language,
+            )
+        )
+
     def lookup(
         self,
         source_language,
@@ -338,52 +471,31 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         use_shared,
         threshold: int = MACHINERY_DEFAULT_THRESHOLD,
     ):
-        base = self.filter_type(
-            user=user,
-            project=project,
-            use_shared=use_shared,
-            from_file=True,
-            use_workspace=True,
-        ).prefetch_scopes()
-
+        queryset = self.get_lookup_queryset(
+            source_language, target_language, user, project, use_shared
+        )
         if threshold >= 100:
-            return base.filter(
-                source=text,
-                source_language=source_language,
-                target_language=target_language,
-            )[:MEMORY_LOOKUP_LIMIT]
+            return queryset.filter(source=text)[:MEMORY_LOOKUP_LIMIT]
 
-        # Adjust similarity based on string length to get more relevant matches
-        # for long strings
-        similarity_threshold = self.threshold_to_similarity(text, threshold)
-        minimum_similarity = self.minimum_similarity(text, threshold)
+        return queryset.get_fuzzy_candidates(text)
 
-        results = self.none()
-
-        while len(results) == 0 and similarity_threshold >= minimum_similarity:
-            # Change PostgreSQL similarity threshold configuration
-            adjust_similarity_threshold(similarity_threshold)
-
-            # Actual database query
-            results = base.filter(
-                # Full-text search on source
-                source__trgm_search=text,
-                # Language filtering
-                source_language=source_language,
-                target_language=target_language,
-            )
-            results = results[:MEMORY_LOOKUP_LIMIT]
-            # Decrease threshold in case no matches were found
-            similarity_threshold = round(similarity_threshold - 0.05, 3)
-            if (
-                len(results) == 0
-                and similarity_threshold
-                < minimum_similarity
-                < similarity_threshold + 0.05
-            ):
-                similarity_threshold = minimum_similarity
-
-        return results
+    def lookup_full_source(
+        self,
+        source_language,
+        target_language,
+        text: str,
+        user,
+        project,
+        use_shared,
+        *,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+        exclude_ids: Iterable[int] = (),
+    ) -> Iterator[Memory]:
+        return self.get_lookup_queryset(
+            source_language, target_language, user, project, use_shared
+        ).get_full_source_fuzzy_candidates(
+            text, threshold=threshold, exclude_ids=exclude_ids
+        )
 
     def prefetch_lang(self) -> Self:
         return self.prefetch_related("source_language", "target_language")
@@ -838,6 +950,14 @@ class Memory(models.Model):
                 models.F("target_language"),
                 models.F("source_language"),
                 name="memory_source_trgm",
+            ),
+            postgres_indexes.GistIndex(
+                models.F("source_language"),
+                models.F("target_language"),
+                postgres_indexes.OpClass(
+                    Left("source", MEMORY_LOOKUP_PREFIX_LENGTH), name="gist_trgm_ops"
+                ),
+                name="memory_source_gist_prefix",
             ),
         ]
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -30,6 +30,8 @@ from weblate.lang.data import FORMULA_WITH_ZERO
 from weblate.lang.models import Language, Plural
 from weblate.memory.machine import WeblateMemory
 from weblate.memory.models import (
+    MEMORY_LOOKUP_LIMIT,
+    MEMORY_LOOKUP_PREFIX_LENGTH,
     Memory,
     MemoryImportError,
     MemoryQuerySet,
@@ -3376,13 +3378,160 @@ class LookupPolicyTest(SimpleTestCase):
         self.assertEqual(queryset.db, "memory_db")
         using_mock.assert_called_once_with("memory_db")
 
-    @patch("weblate.memory.models.adjust_similarity_threshold")
-    def test_lookup_short_strings_stop_backing_off_early(
-        self, adjust_threshold
+    def test_get_fuzzy_candidates_orders_by_prefix_distance(self) -> None:
+        text = "x" * MEMORY_LOOKUP_PREFIX_LENGTH + "suffix"
+        queryset = Memory.objects.all().get_fuzzy_candidates(text)
+
+        self.assertEqual(queryset.query.order_by, ("match_distance", "-status", "pk"))
+        annotation = queryset.query.annotations["match_distance"]
+        self.assertEqual(
+            annotation.get_source_expressions()[1].value,
+            text[:MEMORY_LOOKUP_PREFIX_LENGTH],
+        )
+        self.assertEqual(queryset.query.high_mark, MEMORY_LOOKUP_LIMIT)
+
+    def test_get_full_source_fuzzy_candidates_caps_backoff_results(self) -> None:
+        text = "x" * (MEMORY_LOOKUP_PREFIX_LENGTH + 1)
+        first_candidate = MagicMock()
+        first_candidate.pk = 1
+        second_candidate = MagicMock()
+        second_candidate.pk = 2
+
+        def build_search(candidates):
+            filtered = MagicMock()
+            annotated = filtered.annotate.return_value
+            ordered = annotated.order_by.return_value
+            ordered.__getitem__.return_value = candidates
+            return filtered, ordered
+
+        queryset = MagicMock()
+        queryset.db = "default"
+        queryset.threshold_to_similarity.return_value = 0.96
+        queryset.minimum_similarity.return_value = 0.9
+        first_filtered, first_ordered = build_search([first_candidate])
+        queryset.filter.return_value = first_filtered
+
+        excluded_queryset = MagicMock()
+        second_filtered, second_ordered = build_search([second_candidate])
+        excluded_queryset.filter.return_value = second_filtered
+        queryset.exclude.return_value = excluded_queryset
+
+        with patch("weblate.memory.models.adjust_similarity_threshold") as adjust:
+            results = list(
+                MemoryQuerySet.get_full_source_fuzzy_candidates(
+                    queryset, text, threshold=75, limit=2
+                )
+            )
+
+        self.assertEqual(results, [first_candidate, second_candidate])
+        self.assertEqual(adjust.call_count, 2)
+        first_ordered.__getitem__.assert_called_once_with(slice(None, 2))
+        second_ordered.__getitem__.assert_called_once_with(slice(None, 1))
+        queryset.exclude.assert_called_once_with(pk__in=[first_candidate.pk])
+
+    def test_get_scored_fuzzy_candidates_falls_back_for_saturated_long_candidates(
+        self,
     ) -> None:
+        text = "x" * (MEMORY_LOOKUP_PREFIX_LENGTH + 1)
+        prefix_candidates = []
+        for index in range(MEMORY_LOOKUP_LIMIT):
+            candidate = MagicMock()
+            candidate.pk = index
+            candidate.source = f"{text[:MEMORY_LOOKUP_PREFIX_LENGTH]} low {index}"
+            prefix_candidates.append(candidate)
+        accepted = MagicMock()
+        accepted.pk = MEMORY_LOOKUP_LIMIT + 1
+        accepted.source = f"{text[:MEMORY_LOOKUP_PREFIX_LENGTH]} accepted"
+
+        queryset = MagicMock()
+        queryset.get_fuzzy_candidates.return_value = prefix_candidates
+        queryset.get_full_source_fuzzy_candidates.return_value = [accepted]
+
+        def scorer(candidate):
+            if candidate is accepted:
+                return 95
+            return 80
+
+        results = MemoryQuerySet.get_scored_fuzzy_candidates(
+            queryset, text, scorer, threshold=75
+        )
+
+        self.assertEqual(results[0], (95, accepted))
+        self.assertEqual(len(results), MEMORY_LOOKUP_LIMIT)
+        self.assertNotIn(
+            id(prefix_candidates[-1]),
+            {id(candidate) for _quality, candidate in results},
+        )
+        queryset.get_full_source_fuzzy_candidates.assert_called_once_with(
+            text,
+            threshold=75,
+            exclude_ids=[candidate.pk for candidate in prefix_candidates],
+            limit=MEMORY_LOOKUP_LIMIT,
+        )
+
+    def test_get_scored_fuzzy_candidates_skips_fallback_for_exact_quality(self) -> None:
+        text = "x" * (MEMORY_LOOKUP_PREFIX_LENGTH + 1)
+        prefix_candidates = []
+        for index in range(MEMORY_LOOKUP_LIMIT):
+            candidate = MagicMock()
+            candidate.pk = index
+            candidate.source = f"{text[:MEMORY_LOOKUP_PREFIX_LENGTH]} low {index}"
+            prefix_candidates.append(candidate)
+
+        queryset = MagicMock()
+        queryset.get_fuzzy_candidates.return_value = prefix_candidates
+
+        def scorer(candidate):
+            if candidate is prefix_candidates[0]:
+                return 100
+            return 80
+
+        results = MemoryQuerySet.get_scored_fuzzy_candidates(
+            queryset, text, scorer, threshold=75
+        )
+
+        self.assertEqual(results[0], (100, prefix_candidates[0]))
+        queryset.get_full_source_fuzzy_candidates.assert_not_called()
+
+    def test_get_scored_fuzzy_candidates_skips_unsaturated_fallback(self) -> None:
+        text = "x" * (MEMORY_LOOKUP_PREFIX_LENGTH + 1)
+        candidate = MagicMock()
+        candidate.pk = 1
+        candidate.source = f"{text[:MEMORY_LOOKUP_PREFIX_LENGTH]} low"
+
+        queryset = MagicMock()
+        queryset.get_fuzzy_candidates.return_value = [candidate]
+
+        results = MemoryQuerySet.get_scored_fuzzy_candidates(
+            queryset, text, lambda _result: 60, threshold=75
+        )
+
+        self.assertEqual(results, [])
+        queryset.get_full_source_fuzzy_candidates.assert_not_called()
+
+    def test_get_best_fuzzy_match_exact_threshold_uses_exact_query(self) -> None:
+        match = MagicMock()
+        queryset = MagicMock()
+        filtered_queryset = MagicMock()
+        ordered_queryset = MagicMock()
+        queryset.filter.return_value = filtered_queryset
+        filtered_queryset.order_by.return_value = ordered_queryset
+        ordered_queryset.first.return_value = match
+
+        result = MemoryQuerySet.get_best_fuzzy_match(
+            queryset, "Username", lambda _candidate: 0, threshold=100
+        )
+
+        self.assertEqual(result, match)
+        queryset.filter.assert_called_once_with(source="Username")
+        filtered_queryset.order_by.assert_called_once_with("-status", "id")
+
+    def test_lookup_uses_shared_fuzzy_candidates(self) -> None:
         base = MagicMock()
+        typed_base = MagicMock()
         base.prefetch_scopes.return_value = base
-        base.filter.return_value = []
+        base.filter.return_value = typed_base
+        typed_base.get_fuzzy_candidates.return_value = []
 
         with patch.object(
             MemoryQuerySet, "filter_type", return_value=base
@@ -3398,42 +3547,134 @@ class LookupPolicyTest(SimpleTestCase):
             use_workspace=True,
         )
         base.prefetch_scopes.assert_called_once_with()
-        self.assertEqual(adjust_threshold.call_args_list, [call(0.97), call(0.92)])
+        base.filter.assert_called_once_with(
+            source_language="en",
+            target_language="cs",
+        )
+        typed_base.get_fuzzy_candidates.assert_called_once_with("Username")
 
-    @patch("weblate.memory.models.adjust_similarity_threshold")
-    def test_lookup_long_strings_stop_backing_off_for_machinery(
-        self, adjust_threshold
-    ) -> None:
+    def test_lookup_full_source_uses_scoped_full_source_candidates(self) -> None:
         base = MagicMock()
+        typed_base = MagicMock()
         base.prefetch_scopes.return_value = base
-        base.filter.return_value = []
-        text = "x" * 50
-        initial = Memory.objects.threshold_to_similarity(text, 80)
-        minimum = Memory.objects.minimum_similarity(text, 80)
+        base.filter.return_value = typed_base
+        typed_base.get_full_source_fuzzy_candidates.return_value = []
 
-        with patch.object(MemoryQuerySet, "filter_type", return_value=base):
-            results = Memory.objects.lookup("en", "cs", text, None, None, False, 80)
+        with patch.object(
+            MemoryQuerySet, "filter_type", return_value=base
+        ) as filter_type:
+            results = Memory.objects.lookup_full_source(
+                "en",
+                "cs",
+                "Username",
+                None,
+                None,
+                False,
+                threshold=80,
+                exclude_ids=[1, 2],
+            )
 
         self.assertEqual(list(results), [])
+        filter_type.assert_called_once_with(
+            user=None,
+            project=None,
+            use_shared=False,
+            from_file=True,
+            use_workspace=True,
+        )
         base.prefetch_scopes.assert_called_once_with()
-        self.assertEqual(
-            adjust_threshold.call_args_list,
-            [
-                call(initial),
-                call(round(initial - 0.05, 3)),
-                call(round(initial - 0.1, 3)),
-                call(round(initial - 0.15, 3)),
-                call(minimum),
-            ],
+        base.filter.assert_called_once_with(
+            source_language="en",
+            target_language="cs",
+        )
+        typed_base.get_full_source_fuzzy_candidates.assert_called_once_with(
+            "Username", threshold=80, exclude_ids=[1, 2]
         )
 
-    @patch("weblate.memory.models.adjust_similarity_threshold")
-    def test_lookup_exact_threshold_uses_single_exact_probe(
-        self, adjust_threshold
-    ) -> None:
+    def test_weblate_memory_uses_scored_model_candidates(self) -> None:
+        text = "x" * (MEMORY_LOOKUP_PREFIX_LENGTH + 1)
+        accepted = MagicMock()
+        accepted.pk = MEMORY_LOOKUP_LIMIT + 1
+        accepted.id = accepted.pk
+        accepted.source = f"{text[:MEMORY_LOOKUP_PREFIX_LENGTH]} accepted"
+        accepted.target = "Prijata dlouha shoda"
+        accepted.status = Memory.STATUS_ACTIVE
+        accepted.context = ""
+        accepted.get_origin_display.return_value = "Project: test"
+
+        project = MagicMock()
+        project.use_shared_tm = False
+        unit = MagicMock()
+        unit.context = ""
+        unit.translation.component.project = project
+
+        queryset = MagicMock()
+        queryset.get_scored_fuzzy_candidates.return_value = [(95, accepted)]
+
+        service = WeblateMemory({})
+        with patch.object(
+            Memory.objects, "get_lookup_queryset", return_value=queryset
+        ) as get_lookup_queryset:
+            results = list(
+                service.download_translations(
+                    "en", "cs", text, unit, None, threshold=75
+                )
+            )
+
+        self.assertEqual(results[0]["text"], accepted.target)
+        get_lookup_queryset.assert_called_once_with(
+            "en",
+            "cs",
+            None,
+            project,
+            False,
+        )
+        queryset.get_scored_fuzzy_candidates.assert_called_once()
+        call_args = queryset.get_scored_fuzzy_candidates.call_args
+        self.assertEqual(call_args.args[0], text)
+        self.assertEqual(call_args.kwargs, {"threshold": 75})
+
+    def test_weblate_memory_exact_threshold_uses_exact_lookup(self) -> None:
+        text = "x" * (MEMORY_LOOKUP_PREFIX_LENGTH + 1)
+        candidate = MagicMock()
+        candidate.pk = 1
+        candidate.id = candidate.pk
+        candidate.source = text
+        candidate.target = "Prijata shoda"
+        candidate.status = Memory.STATUS_ACTIVE
+        candidate.context = ""
+        candidate.get_origin_display.return_value = "Project: test"
+
+        project = MagicMock()
+        project.use_shared_tm = False
+        unit = MagicMock()
+        unit.context = ""
+        unit.translation.component.project = project
+
+        queryset = MagicMock()
+        queryset.filter.return_value = [candidate]
+
+        service = WeblateMemory({})
+        with (
+            patch.object(Memory.objects, "get_lookup_queryset", return_value=queryset),
+            patch.object(service.comparer, "similarity", return_value=100),
+        ):
+            results = list(
+                service.download_translations(
+                    "en", "cs", text, unit, None, threshold=100
+                )
+            )
+
+        self.assertEqual(results[0]["text"], candidate.target)
+        queryset.filter.assert_called_once_with(source=text)
+        queryset.get_scored_fuzzy_candidates.assert_not_called()
+
+    def test_lookup_exact_threshold_uses_single_exact_probe(self) -> None:
         base = MagicMock()
+        typed_base = MagicMock()
         base.prefetch_scopes.return_value = base
-        base.filter.return_value = []
+        base.filter.return_value = typed_base
+        typed_base.filter.return_value = []
 
         with patch.object(
             MemoryQuerySet, "filter_type", return_value=base
@@ -3451,9 +3692,8 @@ class LookupPolicyTest(SimpleTestCase):
             use_workspace=True,
         )
         base.prefetch_scopes.assert_called_once_with()
-        adjust_threshold.assert_not_called()
         base.filter.assert_called_once_with(
-            source="Username",
             source_language="en",
             target_language="cs",
         )
+        typed_base.filter.assert_called_once_with(source="Username")

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -199,6 +199,7 @@ GROUP_TEMPLATE = """
 TOOLBAR_TEMPLATE = """
 <div class="btn-toolbar float-end editor-toolbar">{0}</div>
 """
+MIN_COST_ESTIMATE_TM_THRESHOLD = 75
 
 
 class FieldDocsMixin(forms.Form):
@@ -1793,7 +1794,7 @@ class CostEstimateReportsForm(forms.Form):
     tm_threshold = forms.IntegerField(
         label=gettext_lazy("Translation memory threshold"),
         initial=MACHINERY_DEFAULT_THRESHOLD,
-        min_value=1,
+        min_value=MIN_COST_ESTIMATE_TM_THRESHOLD,
         max_value=100,
     )
     rate_new = forms.DecimalField(

--- a/weblate/trans/tests/test_reports.py
+++ b/weblate/trans/tests/test_reports.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from weblate.auth.models import User
 from weblate.memory.models import Memory
-from weblate.trans.forms import CountsReportsForm
+from weblate.trans.forms import MIN_COST_ESTIMATE_TM_THRESHOLD, CountsReportsForm
 from weblate.trans.models import Category, Change, PendingUnitChange, Suggestion, Unit
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import TESTPASSWORD
@@ -349,7 +349,7 @@ class ReportsTest(BaseReportsTest):
     def test_cost_estimate_fuzzy_memory(self) -> None:
         self.add_memory("Thank you for using Weblate!")
 
-        data = self.generate_cost_data(threshold=1)
+        data = self.generate_cost_data(threshold=MIN_COST_ESTIMATE_TM_THRESHOLD)
         buckets = {bucket["slug"]: bucket for bucket in data["buckets"]}
 
         self.assertEqual(buckets["tm_fuzzy"]["count"], 1)
@@ -588,6 +588,12 @@ class ReportsComponentTest(BaseReportsTest):
         self.assertContains(
             response,
             "Error in parameter tm_threshold: Ensure this value is less than or equal to 100.",
+        )
+
+        response = self.get_costs("json", tm_threshold="1", follow=True)
+        self.assertContains(
+            response,
+            "Error in parameter tm_threshold: Ensure this value is greater than or equal to 75.",
         )
 
     def test_counts_view_30days(self) -> None:


### PR DESCRIPTION
Use a GiST KNN prefix index for the primary candidate slice and keep a full-source trigram fallback for saturated long strings so suffix-relevant matches are preserved.

Share the fuzzy selection policy between the machinery and API lookup paths.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
