### PR TITLE
fix(machinery): render empty LLM language instructions blank

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 2026.7.1
 * Translation workflow customization now makes it clearer when per-language workflow settings are disabled until customization is enabled.
 * Anonymous user permission caches are now isolated between requests.
 * GitHub App setup now explains that a workspace is required instead of showing a permission error when no workspace exists.
+* LLM automatic suggestion settings no longer show ``null`` for empty language-specific instructions.
 
 .. rubric:: Compatibility
 

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -23,6 +23,13 @@ from .types import SourceLanguageChoices
 LLM_LANGUAGE_INSTRUCTION_LENGTH = 1000
 
 
+class EmptyMappingJSONField(forms.JSONField):
+    def prepare_value(self, value):
+        if value is None or value == {}:
+            return ""
+        return super().prepare_value(value)
+
+
 class BaseMachineryForm(forms.Form):
     network_host_fields = frozenset({"base_url", "endpoint_url"})
 
@@ -457,7 +464,7 @@ class LLMBasicMachineryForm(BaseMachineryForm):
         ),
         required=False,
     )
-    language_instructions = forms.JSONField(
+    language_instructions = EmptyMappingJSONField(
         label=pgettext_lazy(
             "Automatic suggestion service configuration",
             "Language-specific instructions",

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -3391,6 +3391,30 @@ class LLMBasicMachineryFormTest(TestCase):
             {"language_instructions": language_instructions},
         )
 
+    def test_language_instructions_empty_initial_renders_blank(self) -> None:
+        for initial in (
+            {},
+            {"language_instructions": None},
+            {"language_instructions": {}},
+        ):
+            with self.subTest(initial=initial):
+                form = LLMBasicMachineryForm(
+                    self.DummyLLMTranslation,
+                    initial=initial,
+                )
+
+                self.assertEqual(form["language_instructions"].value(), "")
+
+    def test_language_instructions_initial_renders_json(self) -> None:
+        form = LLMBasicMachineryForm(
+            self.DummyLLMTranslation,
+            initial={"language_instructions": {"fr": "Use formal language."}},
+        )
+
+        self.assertEqual(
+            form["language_instructions"].value(), '{"fr": "Use formal language."}'
+        )
+
     def test_language_instructions_trim_instruction_text(self) -> None:
         form = self.get_form(
             {


### PR DESCRIPTION
Old LLM machinery configurations do not have language-specific instructions, so the JSON field rendered the missing value as null.

Use a JSON form field variant that displays empty mappings as blank while preserving JSON rendering for configured instructions.

Fixes #20439

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
