### PR TITLE
fix(auth): watch projects after accepting invitations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,7 @@ Weblate 2026.7.1
 * Anonymous user permission caches are now isolated between requests.
 * GitHub App setup now explains that a workspace is required instead of showing a permission error when no workspace exists.
 * LLM automatic suggestion settings no longer show ``null`` for empty language-specific instructions.
+* Accepting a project invitation now automatically adds the project to the user's watched projects.
 
 .. rubric:: Compatibility
 

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -1988,6 +1988,9 @@ class Invitation(models.Model):
             audit=had_membership,
         )
 
+        if self.group.defining_project:
+            user.profile.watched.add(self.group.defining_project)
+
         self.delete()
 
 

--- a/weblate/auth/views.py
+++ b/weblate/auth/views.py
@@ -328,10 +328,6 @@ def accept_invitation(
     except InvitationUserMismatchError as error:
         raise Http404 from error
 
-    # Let him watch the project
-    if invitation.group.defining_project:
-        user.profile.watched.add(invitation.group.defining_project)
-
     messages.success(
         request, gettext("Accepted invitation to the %s team.") % invitation.group
     )

--- a/weblate/trans/tests/test_acl.py
+++ b/weblate/trans/tests/test_acl.py
@@ -226,6 +226,9 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
         # Accept invitation
         invitation = Invitation.objects.get()
         invitation.accept(None, self.second_user)
+        self.assertTrue(
+            self.second_user.profile.watched.filter(pk=self.project.pk).exists()
+        )
 
         # Ensure user is now listed
         response = self.client.get(self.access_url)
@@ -691,6 +694,7 @@ class ACLTest(FixtureTestCase, RegistrationTestMixin):
         self.assertContains(response, "example-username")
 
         user = User.objects.get(username="example-username")
+        self.assertTrue(user.profile.watched.filter(pk=self.project.pk).exists())
 
         # Inspect audit log
         audit: AuditLog | None = None


### PR DESCRIPTION
Project invitees should see invited projects on their dashboard without searching for them manually.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
