### PR TITLE
fix(wladmin): avoid user management workspace queries

### DIFF
--- a/weblate/auth/forms.py
+++ b/weblate/auth/forms.py
@@ -231,11 +231,15 @@ class BaseInviteForm:
     def setup_group_field(self, project) -> None:
         self.project = project
         if project:
-            self.fields["group"].queryset = project.group_set.order()
-        else:
-            self.fields["group"].queryset = Group.objects.filter(
-                defining_project=None
+            self.fields["group"].queryset = project.group_set.select_related(
+                "defining_project", "defining_workspace"
             ).order()
+        else:
+            self.fields["group"].queryset = (
+                Group.objects.filter(defining_project=None)
+                .select_related("defining_project", "defining_workspace")
+                .order()
+            )
         if project and self.support_limit_languages:
             languages = project.languages
             self.fields["limit_languages"] = LimitLanguagesField(

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -1263,6 +1263,38 @@ class AdminTest(ViewTestCase):
         self.assertContains(response, "User invitation e-mail was sent")
         self.assertEqual(len(mail.outbox), 1)
 
+    def test_manage_users_workspace_teams_avoid_workspace_fetches(self) -> None:
+        workspace = Workspace.objects.create(name="User management workspace")
+        groups = [
+            Group.objects.create(
+                name=f"User management workspace team {index}",
+                defining_workspace=workspace,
+            )
+            for index in range(3)
+        ]
+        for index, group in enumerate(groups):
+            Invitation.objects.create(
+                author=self.user,
+                group=group,
+                email=f"workspace-invite-{index}@example.com",
+            )
+
+        # ruff: ignore[private-member-access]
+        workspace_table = Workspace._meta.db_table
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(reverse("manage-users"))
+
+        self.assertContains(response, "User management workspace team 0")
+        workspace_fetches = [
+            query["sql"]
+            for query in queries
+            if (
+                f'FROM "{workspace_table}"' in query["sql"]
+                and f'WHERE "{workspace_table}"."id"' in query["sql"]
+            )
+        ]
+        self.assertEqual(workspace_fetches, [])
+
     def test_bulk_invite_user(self) -> None:
         response = self.client.post(
             reverse("manage-users"),

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -675,7 +675,12 @@ class AdminUserList(UserList):
         result["invite_form"] = invite_form
         result["bulk_invite_form"] = bulk_invite_form
         result["search_form"] = self.form
-        result["invitations"] = Invitation.objects.all().select_related("user")
+        result["invitations"] = Invitation.objects.select_related(
+            "user",
+            "group",
+            "group__defining_project",
+            "group__defining_workspace",
+        )
         return result
 
 


### PR DESCRIPTION
Preload workspace-scoped teams and invitations on /manage/users/ to prevent N+1 workspace lookups while rendering team choices and pending invitations.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
