### PR TITLE
fix: always init machinery

### DIFF
--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -279,6 +279,15 @@
       }
       this.initMachinery();
     });
+
+    /* The active tab is restored before the listener above is registered, load it now in that case. */
+    const machineryTab = document.querySelector('[data-load="machinery"]');
+    if (machineryTab?.classList.contains("active")) {
+      if (this.isMachineryLoaded) {
+        return;
+      }
+      this.initMachinery();
+    }
   };
 
   FullEditor.prototype.initMachinery = function () {


### PR DESCRIPTION
It was possible for the machinery tab to be open before the listener to initialize it is registered, this makes sure that machinery is initialized in those cases
fixes #20440
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
