### PR TITLE
docs: fix typo in installation guide

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -438,7 +438,7 @@ in this documentation, but the numbers will change once you customize the amount
 WSGI workers or adjust parallelism of Celery.
 
 The actual limit for the number of database connections needs to be higher to
-account following situations:
+account for the following situations:
 
 * :ref:`manage` need their connection as well.
 * If case process is killed (for example by OOM killer), it might block the existing connection until timeout.


### PR DESCRIPTION
Fixes a typo in the Weblate installation documentation.