### PR TITLE
Separate Argos CI uploads for pushes and pull requests and reuse upload steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,12 +160,12 @@ jobs:
     name: Argos CI upload
     needs:
     - test
-    if: github.repository_owner == 'WeblateOrg'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'WeblateOrg'
     permissions:
       contents: read
       id-token: write
       pull-requests: read
-    steps:
+    steps: &argos-upload-steps
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
@@ -183,3 +183,14 @@ jobs:
     - name: Argos CI upload
       working-directory: ./client
       run: yarn argos upload ../test-images/
+
+  argos-pull-request:
+    runs-on: ubuntu-24.04
+    name: Argos CI pull request upload
+    needs:
+    - test
+    if: github.event_name == 'pull_request' && github.repository_owner == 'WeblateOrg'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps: *argos-upload-steps


### PR DESCRIPTION
### Motivation
- Prevent Argos uploads from running on every branch by restricting the existing `argos` job to pushes to `refs/heads/main` while still allowing uploads for pull requests. 
- Avoid duplicating job steps by extracting the shared upload sequence into a YAML anchor so both push and pull-request jobs can reuse the same steps.

### Description
- Changed the `argos` job `if` condition to `github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'WeblateOrg'` so it only runs for main branch pushes. 
- Extracted the common upload steps into an anchor `&argos-upload-steps` and referenced it from both jobs to remove duplicated step definitions. 
- Added a new `argos-pull-request` job that runs when `github.event_name == 'pull_request'` and reuses the anchored steps, with appropriate `permissions` for PR uploads.

### Testing
- Ran the repository CI `test` workflow (matrix) and confirmed the unit test matrix completed successfully. 
- Validated the modified workflow file for YAML syntax and ensured the new `argos-pull-request` job can reference the shared steps without duplication.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47666c4d188329a1414f1b1a845615)