### PR TITLE
fix(templates): satisfy updated djlint formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
   hooks:
   - id: validate-pyproject
 - repo: https://github.com/djlint/djLint
-  rev: v1.39.4
+  rev: v1.40.2
   hooks:
   - id: djlint-reformat-django
     types_or: [html, text]

--- a/weblate/templates/paginator.html
+++ b/weblate/templates/paginator.html
@@ -13,14 +13,9 @@
       </a>
     </li>
     <li class="page-item{% if not page_obj.has_previous %} disabled{% endif %}">
-      <a
-        {% if page_obj.has_previous %}
-          rel="prev"
-          {# djlint:off #}
+      <a {% if page_obj.has_previous %} rel="prev" {# djlint:off #}
           href="?page={{ page_obj.previous_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
-          {# djlint:on #}
-        {% endif %}
-        class="page-link green">
+          {# djlint:on #} {% endif %} class="page-link green">
         {% if LANGUAGE_BIDI %}
           {% icon "page-next.svg" %}
         {% else %}
@@ -71,14 +66,9 @@
       </a>
     </li>
     <li class="page-item{% if not page_obj.has_next %} disabled{% endif %}">
-      <a
-        {% if page_obj.has_next %}
-          rel="next"
-          {# djlint:off #}
+      <a {% if page_obj.has_next %} rel="next" {# djlint:off #}
           href="?page={{ page_obj.next_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
-          {# djlint:on #}
-        {% endif %}
-        class="page-link green">
+          {# djlint:on #} {% endif %} class="page-link green">
         {% if not LANGUAGE_BIDI %}
           {% icon "page-next.svg" %}
         {% else %}

--- a/weblate/templates/paginator.html
+++ b/weblate/templates/paginator.html
@@ -13,9 +13,9 @@
       </a>
     </li>
     <li class="page-item{% if not page_obj.has_previous %} disabled{% endif %}">
-      <a {% if page_obj.has_previous %} rel="prev" {# djlint:off #}
+      <a {% if page_obj.has_previous %}rel="prev" {# djlint:off #}
           href="?page={{ page_obj.previous_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
-          {# djlint:on #} {% endif %} class="page-link green">
+          {# djlint:on #}{% endif %} class="page-link green">
         {% if LANGUAGE_BIDI %}
           {% icon "page-next.svg" %}
         {% else %}
@@ -66,9 +66,9 @@
       </a>
     </li>
     <li class="page-item{% if not page_obj.has_next %} disabled{% endif %}">
-      <a {% if page_obj.has_next %} rel="next" {# djlint:off #}
+      <a {% if page_obj.has_next %}rel="next" {# djlint:off #}
           href="?page={{ page_obj.next_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
-          {# djlint:on #} {% endif %} class="page-link green">
+          {# djlint:on #}{% endif %} class="page-link green">
         {% if not LANGUAGE_BIDI %}
           {% icon "page-next.svg" %}
         {% else %}


### PR DESCRIPTION
### Motivation

- Prevent lint/pre-commit failures caused by the djLint formatting change introduced alongside dependency updates in PR #20460 by updating the hook reference and template layout to match the new formatter behavior.

### Description

- Bump the djLint pre-commit hook in `.pre-commit-config.yaml` from `v1.39.4` to `v1.40.2`.
- Reformat `weblate/templates/paginator.html` to consolidate conditional `rel`/`href` attributes into single `<a>` elements and place `djlint` off/on markers to satisfy the updated formatter.
- Commit recorded with the message `fix(templates): satisfy updated djlint formatting`.

### Testing

- Ran `git diff --check` which passed with no whitespace errors.
- Inspected `git diff --stat` to confirm only the intended files (`.pre-commit-config.yaml` and `weblate/templates/paginator.html`) changed.
- Attempted to run `uv run prek run djlint-django --all-files` and a local `djlint` invocation, but these were blocked by environment network restrictions (git fetch for the hook and PyPI fetch for `djlint` failed), so full automated hook verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48a1d5a4708329aa64ad6582624d9e)