### PR TITLE
Preserve filtered translation navigation count and position in search session

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,7 @@ Weblate 2026.7.1
 
 .. rubric:: Bug fixes
 
+* Filtered translation navigation now keeps the result list, displayed position, and count stable after translated strings leave the filter.
 * Component priority icons are no longer shown on translation listings.
 * :ref:`check-punctuation-spacing` no longer flags Markdown image markers as French punctuation and now shows which punctuation marks triggered the check.
 * :ref:`addon-weblate.fedora_messaging.publish` broker TLS validation now matches the Fedora Messaging transport when accepting non-strict CA certificate chains.

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -1628,6 +1628,7 @@ class EditComplexTest(ViewTestCase):
 
         response = self.client.get(self.translate_url, {"q": "state:<translated"})
         self.assertEqual(response.context["unit"].pk, first.pk)
+        initial_count = response.context["filter_count"]
 
         params = {
             "checksum": first.checksum,
@@ -1652,6 +1653,8 @@ class EditComplexTest(ViewTestCase):
             self.translate_url, {"q": "state:<translated", "offset": 2}
         )
         self.assertEqual(response.context["unit"].pk, expected_unit_id)
+        self.assertEqual(response.context["filter_pos"], 2)
+        self.assertEqual(response.context["filter_count"], initial_count)
 
     def test_translate_post_offset_uses_limited_search_lookup(self) -> None:
         response = self.client.get(self.translate_url, {"offset": 1})

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -343,6 +343,14 @@ def get_search_partial_offset(session_data: SearchResult, default: int) -> int:
     return partial_offset
 
 
+def get_search_session_total(session_data: SearchResult) -> int | None:
+    """Return a valid total from search session data."""
+    total = session_data.get("total")
+    if not isinstance(total, int) or total < 0:
+        return None
+    return total
+
+
 def has_partial_next_id(
     unit_ids: list[int], partial_offset: int, current_offset: int
 ) -> bool:
@@ -480,7 +488,7 @@ def get_search_session_snapshot(
     return SearchSnapshot(
         ids=page_ids,
         offset=offset,
-        total=None,
+        total=get_search_session_total(session_data),
         last_section=len(page_ids) <= page_size,
     )
 
@@ -662,6 +670,11 @@ def save_partial_search_session(
 ) -> int:
     """Store a compact partial search result window in the session."""
     ttl = get_search_session_ttl()
+    total = get_search_session_total(session_data)
+    full_ids = get_search_session_id_list(session_data, "ids")
+    if total is None and full_ids is not None:
+        total = len(full_ids)
+
     session_data.pop("ids", None)
     session_data.update(
         {
@@ -675,6 +688,8 @@ def save_partial_search_session(
             "ttl": ttl,
         }
     )
+    if total is not None:
+        session_data["total"] = total
     session[session_key] = session_data
     return ttl
 
@@ -747,6 +762,9 @@ def search_post_unit(
     else:
         partial_offset = offset
         partial_window_ids = append_unique_ids([], unit_ids)
+
+    if get_search_session_total(session_data) is None:
+        session_data["total"] = get_ordered_units().count()
 
     ttl = save_partial_search_session(
         request.session,


### PR DESCRIPTION
### Motivation

* Ensure filtered translation navigation remains stable when translated strings leave the filter by keeping the result count and displayed position available from the session.
* Update tests and documentation to reflect the improved behavior for partial search sessions.

### Description

* Add `get_search_session_total` to validate and read a `total` value from search session data and use it when constructing snapshots via `get_search_session_snapshot`.
* Persist the overall result `total` into compact partial search session data in `save_partial_search_session` when available, and compute it via `get_ordered_units().count()` in `search_post_unit` when missing.
* Adjust partial-window logic in `search_post_unit` to record `total` before saving the partial window, and update session save behavior to include `total` if present.
* Update tests in `weblate/trans/tests/test_edit.py` to assert that `filter_pos` and `filter_count` remain stable after a translated string leaves the filter, and update `docs/changes.rst` with the new changelog entry.

### Testing

* Ran the updated test `weblate.trans.tests.test_edit.EditComplexTest::test_translate_filtered_search_keeps_stable_navigation` which passed.
* Ran the tests in `weblate/trans/tests/test_edit.py` to validate related pagination and search-session behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48a23ec5c08329ae679207eab74abd)