### PR TITLE
docs: fix documentation typos

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -2851,7 +2851,7 @@ WEBLATE_EXPORTERS
 
 .. versionadded:: 4.2
 
-List of a available exporters offering downloading translations
+List of available exporters offering translation downloads
 or glossaries in various file formats.
 
 .. seealso::

--- a/docs/admin/languages.rst
+++ b/docs/admin/languages.rst
@@ -160,7 +160,7 @@ file-format specifications, CLDR, and other sources.
 
    Changing plural number or formula will affect only displaying of the
    strings, but not parsing and storing strings to the files. Should you think
-   Weblate behaves incorrectly, please file a issue in our issue tracker.
+   Weblate behaves incorrectly, please file an issue in our issue tracker.
 
 
 .. _plural-number:

--- a/docs/admin/management.rst
+++ b/docs/admin/management.rst
@@ -787,7 +787,7 @@ install_machinery
 
 .. weblate-admin:: install_machinery --service SERVICE
 
-Installs an site-wide automatic suggestion service.
+Installs a site-wide automatic suggestion service.
 
 .. weblate-admin-option:: --service SERVICE
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,9 +39,9 @@ the ``Authorization`` header:
     parameters here apply to all endpoints as well.
 
     :query format: Response format (overrides :http:header:`Accept`).
-                   Possible values depends on REST framework setup,
+                   Possible values depend on REST framework setup,
                    by default ``json``, ``csv`` and ``api`` are supported. The
-                   latter provides web browser interface for API.
+                   latter provides a web browser interface for the API.
     :query page: Returns given page of paginated results (use `next` and `previous` fields in response to automate the navigation).
     :query page_size: Return the given number of items per request.
                       The default is 50 and the maximum is 1000.

--- a/docs/contributing/issues.rst
+++ b/docs/contributing/issues.rst
@@ -48,7 +48,7 @@ says. AI-based tools frequently generate inaccurate or fabricated results.
 It is *rarely* a good idea to just copy and paste an AI-generated report to the
 project. Those generated reports typically are too wordy and rarely to the
 point (in addition to the common fabricated details). If you actually discover
-a issue with an AI and you have verified it yourself to be true, write the
+an issue with an AI and you have verified it yourself to be true, write the
 report yourself and explain the issue as you have learned it. This makes sure
 the AI-generated inaccuracies and invented issues are filtered out early before
 they waste more people's time.

--- a/docs/contributing/start.rst
+++ b/docs/contributing/start.rst
@@ -74,7 +74,7 @@ It will create a development Docker image and start it. Weblate is running on
 as the password. The new installation is empty, so you might want to continue with
 :ref:`adding-projects`.
 
-Weblate is configured to use :program:`maildev` container as a e-mail server.
+Weblate is configured to use :program:`maildev` container as an e-mail server.
 The delivered e-mails can be seen at <http://127.0.0.1:1080/>.
 
 The :file:`Dockerfile` and :file:`docker-compose.yml` for this are located in the

--- a/docs/contributing/trademark.rst
+++ b/docs/contributing/trademark.rst
@@ -46,7 +46,7 @@ General Guidelines
 Social Media Guidelines
 +++++++++++++++++++++++
 
-In addition to the General Guidelines above, the name and handle of your social media account and all pages cannot begin with an Weblate trademark. In addition, Weblate logos cannot be used in a way that might suggest affiliation with Weblate, including, but not limited to, the account, profile, or header images. The only exception to these requirements is if you've received prior permission from Weblate.
+In addition to the General Guidelines above, the name and handle of your social media account and all pages cannot begin with a Weblate trademark. In addition, Weblate logos cannot be used in a way that might suggest affiliation with Weblate, including, but not limited to, the account, profile, or header images. The only exception to these requirements is if you've received prior permission from Weblate.
 
 For example, you cannot name your account, page, or community "Weblate Representatives" or "Weblate Software". However, it would be acceptable to name your account, page, or community "Fans of Weblate" or "Information about Weblate Software" if you do not use the Weblate trademarks or Weblate logos or otherwise suggest any affiliation with Weblate.
 

--- a/docs/devel/community.rst
+++ b/docs/devel/community.rst
@@ -5,7 +5,7 @@ Following these recommendations supports the creation of a full, multilingual po
 
 Many times translators will find problems with the source strings. Make sure it is easy for them to report such problems.
 To gather this feedback, you can set up the :ref:`component-repoweb` field on your Weblate component, for translators to
-propose their changes to the upstream repository. You can also receive translator comments if you setup :ref:`component-report_source_bugs`.
+propose their changes to the upstream repository. You can also receive translator comments if you set up :ref:`component-report_source_bugs`.
 
 Component diagnostics
 ---------------------

--- a/docs/devel/review.rst
+++ b/docs/devel/review.rst
@@ -10,7 +10,7 @@ Activity reports
 
 Activity reports check changes of translations, for projects, components or individual users.
 
-The activity reports for a project or component is accessible from its dashboard, on the :guilabel:`Info`
+The activity reports for a project or component are accessible from its dashboard, on the :guilabel:`Info`
 tab.
 
 .. image:: /screenshots/activity.webp

--- a/docs/devel/sphinx.rst
+++ b/docs/devel/sphinx.rst
@@ -11,16 +11,16 @@ I will not focus on writing documentation itself, if you need guidance with
 that, just follow instructions on the `Sphinx`_ website. Once you have
 documentation ready, translating it is quite easy as Sphinx comes with support
 for this and it is quite nicely covered in their :ref:`sphinx:intl`. It's
-matter of few configuration directives and invoking of the ``sphinx-intl``
+matter of a few configuration directives and invoking the ``sphinx-intl``
 tool.
 
 If you are using Read the Docs service, you can start building translated
-documentation on the Read the Docs. Their :doc:`rtd:localization` covers pretty
-much everything you need - creating another project, set its language and link
-it from main project as a translation.
+documentation on Read the Docs. Their :doc:`rtd:localization` covers pretty
+much everything you need - creating another project, setting its language, and linking
+it from the main project as a translation.
 
 Now all you need is translating the documentation content. Sphinx generates PO
-file for each directory or top level file, what can lead to quite a lot of
+file for each directory or top-level file, which can lead to quite a lot of
 files to translate (depending on :confval:`sphinx:gettext_compact` settings).
 You can import the :file:`index.po` into Weblate as an initial component and
 then configure :ref:`addon-weblate.discovery.discovery` add-on to automatically

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -8,8 +8,8 @@ different and provides a different set of capabilities.
 
 .. hint::
 
-    When choosing a file format for your application, it's better to stick some
-    well established format in the toolkit/platform you use. This way your
+    When choosing a file format for your application, it's better to stick to some
+    well-established format in the toolkit/platform you use. This way your
     translators can additionally use whatever tools they are used to, and will more
     likely contribute to your project.
 


### PR DESCRIPTION
### Motivation
- Correct a set of grammar, article, and small wording issues found in documentation to improve readability and accuracy.
- Keep changes narrowly scoped to typo and grammar fixes without restructuring content or changing meaning.

### Description
- Fixed subject-verb agreement and article usage in the REST API docs (`docs/api.rst`) and multiple admin docs (`docs/admin/*.rst`).
- Corrected several article and phrasing issues in contributing and developer guides (`docs/contributing/*.rst`, `docs/devel/*.rst`).
- Standardized small style items such as "stick to some" and "top-level/file vs top level file" phrasing in `docs/formats.rst` and `docs/devel/sphinx.rst`.
- Updated 11 files with focused copy edits; changes are limited to wording and punctuation only.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors, which passed. 
- Ran targeted `rg` checks for the corrected patterns to ensure no remaining occurrences, which returned no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a490183e1508329aa656f045dc4970e)