### PR TITLE
fix(auth): reset stale invitation session links

### DIFF
--- a/weblate/accounts/tests/test_registration.py
+++ b/weblate/accounts/tests/test_registration.py
@@ -397,6 +397,46 @@ class RegistrationTest(BaseRegistrationTest):
         self.assertFalse(Invitation.objects.filter(pk=invitation.pk).exists())
 
     @override_settings(REGISTRATION_OPEN=False, REGISTRATION_CAPTCHA=False)
+    def test_email_invitation_link_overrides_stale_session_invitation(self) -> None:
+        _, stale_invitation = self.create_registration_invitation(
+            email="stale@example.com"
+        )
+        invited_group = Group.objects.create(name="Current invitation")
+        invitation = Invitation.objects.create(
+            author=stale_invitation.author,
+            email=REGISTRATION_DATA["email"],
+            username=REGISTRATION_DATA["username"],
+            full_name=REGISTRATION_DATA["fullname"],
+            group=invited_group,
+        )
+        self.use_invitation(stale_invitation)
+
+        response = self.client.get(invitation.get_absolute_url())
+
+        self.assertRedirects(response, reverse("register"))
+        self.assertEqual(self.client.session["invitation_link"], str(invitation.pk))
+
+    @override_settings(REGISTRATION_OPEN=False, REGISTRATION_CAPTCHA=False)
+    def test_user_invitation_link_clears_stale_session_invitation(self) -> None:
+        _, stale_invitation = self.create_registration_invitation(
+            email="stale@example.com"
+        )
+        author = User.objects.create_user("inviter", "inviter@example.com", "x")
+        invited_user = User.objects.create_user("invited", "invited@example.com", "x")
+        invited_group = Group.objects.create(name="Invited user")
+        invitation = Invitation.objects.create(
+            author=author,
+            user=invited_user,
+            group=invited_group,
+        )
+        self.use_invitation(stale_invitation)
+
+        response = self.client.get(invitation.get_absolute_url())
+
+        self.assertContains(response, "Please sign-in to view this invitation.")
+        self.assertNotIn("invitation_link", self.client.session)
+
+    @override_settings(REGISTRATION_OPEN=False, REGISTRATION_CAPTCHA=False)
     def test_expired_invitation_does_not_open_registration(self) -> None:
         _, invitation = self.create_registration_invitation()
         self.expire_invitation(invitation)

--- a/weblate/auth/views.py
+++ b/weblate/auth/views.py
@@ -222,12 +222,14 @@ class InvitationView(DetailView):
         self, request: AuthenticatedHttpRequest
     ) -> HttpResponse | None:
         if self.object.is_expired():
+            request.session.pop("invitation_link", None)
             messages.error(request, gettext("This invitation has expired."))
             if request.user.is_authenticated:
                 return redirect_param("profile", "#account")
             return redirect("register")
 
         if request.user.is_authenticated:
+            request.session.pop("invitation_link", None)
             if not self.object.matches_user(request.user):
                 messages.error(
                     request,
@@ -238,11 +240,14 @@ class InvitationView(DetailView):
                 )
                 return redirect_param("profile", "#account")
             return None
-        if not self.object.user:
-            # When inviting new user go through registration
-            request.session["invitation_link"] = str(self.object.pk)
-            return redirect("register")
-        return None
+
+        if self.object.user:
+            request.session.pop("invitation_link", None)
+            return None
+
+        # When inviting new user go through registration.
+        request.session["invitation_link"] = str(self.object.pk)
+        return redirect("register")
 
     def get(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> HttpResponse:
         self.object = self.get_object()


### PR DESCRIPTION
Ensure a clicked invitation replaces or clears any stale session invitation so login and registration continue against the current link.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
