### PR TITLE
docs(l10n): fix Portuguese HTTP scheme typo

### DIFF
--- a/docs/locales/pt/LC_MESSAGES/docs.po
+++ b/docs/locales/pt/LC_MESSAGES/docs.po
@@ -70789,7 +70789,7 @@ msgstr ""
 "Pode encontrar a sua chave no seu perfil no Weblate. Quando o URL da API é "
 "carregado através da configuração de projeto automaticamente descoberta, a "
 "opção :option:`--key` tem que ser utilizada com a :option:`--url`. Chaves de "
-"API são rejeitadas em relação a URLs ``htp://`` não locais por predefinição."
+"API são rejeitadas em relação a URLs ``http://`` não locais por predefinição."
 
 #: wlc.rst:182
 msgid ""


### PR DESCRIPTION
### Motivation
- Fix a Portuguese translation typo that rendered the insecure HTTP scheme as ``htp://``, which could confuse readers of security guidance.
- The change is documentation-only and does not alter application behavior.

### Description
- Corrected the translation in `docs/locales/pt/LC_MESSAGES/docs.po` replacing ``htp://`` with ``http://`` in the API key warning message.
- No functional code paths were changed; only the localized PO file was modified.

### Testing
- Ran `msgfmt --check docs/locales/pt/LC_MESSAGES/docs.po -o /tmp/docs-pt.mo`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3ea5f6c08329a4354e266738f929)