### PR TITLE
fix(checks): return JSON for check dismissal

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,7 @@ Weblate 2026.7.1
 * GitHub App setup now explains that a workspace is required instead of showing a permission error when no workspace exists.
 * LLM automatic suggestion settings no longer show ``null`` for empty language-specific instructions.
 * Accepting a project invitation now automatically adds the project to the user's watched projects.
+* Dismissing a failing check no longer shows a JSON parsing error in the translation editor.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -2248,7 +2248,8 @@ class EditComplexTest(ViewTestCase):
             response = self.client.post(
                 reverse("js-ignore-check", kwargs={"check_id": check_id})
             )
-        self.assertContains(response, "ok")
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+        self.assertJSONEqual(response.content.decode("utf-8"), {})
 
         # Should have one less failing check
         unit = self.get_unit()

--- a/weblate/trans/views/js.py
+++ b/weblate/trans/views/js.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import translation
 from django.utils.http import urlencode
@@ -68,7 +68,7 @@ def ignore_check(request: AuthenticatedHttpRequest, check_id):
     # Mark check for ignoring
     obj.set_dismiss(state="revert" not in request.GET)
     # response for AJAX
-    return HttpResponse("ok")
+    return JsonResponse({})
 
 
 @require_POST


### PR DESCRIPTION
The translation editor expects the check dismissal endpoint to return JSON, but single-check dismissal returned plain text and triggered a client-side parse error.

Return an empty JSON response, update the regression test, and document the user-visible fix.

Fixes #20492

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
