### PR TITLE
ci(macos): pin Homebrew core snapshot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,18 @@
       "groupSlug": "opentelemetry"
     },
     {
+      "description": "Update pinned macOS Homebrew snapshot monthly",
+      "matchPackageNames": [
+        "https://github.com/Homebrew/homebrew-core"
+      ],
+      "groupName": "macOS Homebrew snapshot",
+      "groupSlug": "macos-homebrew",
+      "schedule": [
+        "* * 1 * *"
+      ],
+      "automerge": false
+    },
+    {
       "description": "Allow OpenTelemetry instrumentation beta releases",
       "matchPackageNames": [
         "opentelemetry-instrumentation-celery",
@@ -64,6 +76,21 @@
       "datasourceTemplate": "custom.github-release-asset-digest",
       "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "{{{indentation}}}# renovate-cyclonedx-cli\n{{{indentation}}}CYCLONEDX_CLI_VERSION: {{{newValue}}}\n{{{indentation}}}CYCLONEDX_CLI_DIGEST: {{{newDigest}}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned Homebrew core Git revision for macOS CI",
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/macos\\.yml$/"
+      ],
+      "matchStrings": [
+        "(?<indentation>[ \\t]*)# renovate-homebrew-core\\r?\\n[ \\t]*HOMEBREW_CORE_REF: (?<currentDigest>[a-f0-9]{40})"
+      ],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "Homebrew/homebrew-core",
+      "packageNameTemplate": "https://github.com/Homebrew/homebrew-core",
+      "datasourceTemplate": "git-refs",
+      "autoReplaceStringTemplate": "{{{indentation}}}# renovate-homebrew-core\n{{{indentation}}}HOMEBREW_CORE_REF: {{{newDigest}}}"
     }
   ],
   "customDatasources": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,7 @@
     {
       "description": "Update pinned macOS Homebrew snapshot monthly",
       "matchPackageNames": [
+        "https://github.com/Homebrew/brew",
         "https://github.com/Homebrew/homebrew-core"
       ],
       "groupName": "macOS Homebrew snapshot",
@@ -76,6 +77,21 @@
       "datasourceTemplate": "custom.github-release-asset-digest",
       "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "{{{indentation}}}# renovate-cyclonedx-cli\n{{{indentation}}}CYCLONEDX_CLI_VERSION: {{{newValue}}}\n{{{indentation}}}CYCLONEDX_CLI_DIGEST: {{{newDigest}}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned Homebrew Git revision for macOS CI",
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/macos\\.yml$/"
+      ],
+      "matchStrings": [
+        "(?<indentation>[ \\t]*)# renovate-homebrew-brew\\r?\\n[ \\t]*HOMEBREW_BREW_REF: (?<currentDigest>[a-f0-9]{40})"
+      ],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "Homebrew/brew",
+      "packageNameTemplate": "https://github.com/Homebrew/brew",
+      "datasourceTemplate": "git-refs",
+      "autoReplaceStringTemplate": "{{{indentation}}}# renovate-homebrew-brew\n{{{indentation}}}HOMEBREW_BREW_REF: {{{newDigest}}}"
     },
     {
       "customType": "regex",

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,13 +33,23 @@ jobs:
       CI_DB_HOST: localhost
       DJANGO_SETTINGS_MODULE: weblate.settings_test
       CI_SKIP_SAML: 1
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      # renovate-homebrew-core
+      HOMEBREW_CORE_REF: 04649275cf811811662d08be52d409d7b6f59f0d
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
-    - run: brew update
-    - run: brew upgrade
-      continue-on-error: true
+    - name: Pin Homebrew core
+      run: |
+        brew tap --force homebrew/core
+        core_repo="$(brew --repo homebrew/core)"
+        git -C "${core_repo}" reset --hard
+        git -C "${core_repo}" clean -fd
+        git -C "${core_repo}" fetch --no-tags --depth=1 origin "${HOMEBREW_CORE_REF}"
+        git -C "${core_repo}" checkout --force --detach FETCH_HEAD
+        git -C "${core_repo}" rev-parse HEAD
+        echo "HOMEBREW_NO_INSTALL_FROM_API=1" >> "${GITHUB_ENV}"
     - run: brew list --versions
     - run: brew deps --tree --installed
     - run: brew config

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,14 +34,23 @@ jobs:
       DJANGO_SETTINGS_MODULE: weblate.settings_test
       CI_SKIP_SAML: 1
       HOMEBREW_NO_AUTO_UPDATE: '1'
+      # renovate-homebrew-brew
+      HOMEBREW_BREW_REF: 3dd092c77e7a19316aae454b4116f01fda61693e
       # renovate-homebrew-core
       HOMEBREW_CORE_REF: 55cdf140129160c1d6b5c300bb99e8e8c329fe84
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
-    - name: Pin Homebrew core
+    - name: Pin Homebrew snapshot
       run: |
+        brew_repo="$(brew --repo)"
+        git -C "${brew_repo}" reset --hard
+        git -C "${brew_repo}" clean -fd
+        git -C "${brew_repo}" fetch --no-tags --depth=1 origin "${HOMEBREW_BREW_REF}"
+        git -C "${brew_repo}" checkout --force -B stable FETCH_HEAD
+        brew --version
+
         brew tap --force homebrew/core
         core_repo="$(brew --repo homebrew/core)"
         git -C "${core_repo}" reset --hard

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
       CI_SKIP_SAML: 1
       HOMEBREW_NO_AUTO_UPDATE: '1'
       # renovate-homebrew-core
-      HOMEBREW_CORE_REF: 04649275cf811811662d08be52d409d7b6f59f0d
+      HOMEBREW_CORE_REF: 55cdf140129160c1d6b5c300bb99e8e8c329fe84
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:


### PR DESCRIPTION
Pin Homebrew formula metadata to avoid following live Homebrew changes on every macOS CI run. This is intended to address unstable CI builds; Renovate will update the pinned core revision monthly.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
