### PR TITLE
fix(screenshots): narrow default screenshot search

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,7 @@ Weblate 2026.7.1
 * LLM automatic suggestion settings no longer show ``null`` for empty language-specific instructions.
 * Accepting a project invitation now automatically adds the project to the user's watched projects.
 * Dismissing a failing check no longer shows a JSON parsing error in the translation editor.
+* Screenshot searches without an explicit field now match screenshot names only, and the search box links to the full screenshot search documentation.
 
 .. rubric:: Compatibility
 

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -263,9 +263,9 @@ Searching for screenshots
 The screenshot listing in a component accepts advanced queries using boolean
 operations, parentheses, or field specific lookup.
 
-When no field is defined, the lookup happens on the screenshot name, repository
-path, screenshot language, assigned source string, assigned context, and
-assigned location.
+When no field is defined, the lookup happens on the screenshot name. Use
+field-specific lookups to search repository paths, screenshot languages, or
+assigned source strings.
 
 Screenshot fields
 -----------------
@@ -305,7 +305,7 @@ Screenshot search examples
 --------------------------
 
 ``login``
-   Search for screenshots matching ``login`` in any default screenshot field.
+   Search for screenshots matching ``login`` in the screenshot name.
 ``name:login``
    Search for screenshots with ``login`` in the screenshot name.
 ``language:cs``

--- a/weblate/screenshots/forms.py
+++ b/weblate/screenshots/forms.py
@@ -217,6 +217,7 @@ class ScreenshotListSearchForm(forms.Form):
             attrs={
                 "class": "form-control",
                 "placeholder": gettext_lazy("Search screenshots"),
+                "aria-describedby": "screenshots-list-search-help",
             }
         ),
     )

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -46,6 +46,12 @@ class ViewTest(FixtureTestCase):
         self.assertContains(
             response, get_doc_url("admin/translating", "screenshots", user=self.user)
         )
+        self.assertContains(response, 'aria-describedby="screenshots-list-search-help"')
+        self.assertContains(response, 'id="screenshots-list-search-help"')
+        self.assertContains(response, "Search screenshot names.")
+        self.assertContains(
+            response, get_doc_url("user/search", "search-screenshots", user=self.user)
+        )
 
     def do_upload(self, **kwargs):
         with open(TEST_SCREENSHOT, "rb") as handle:
@@ -562,6 +568,18 @@ class ViewTest(FixtureTestCase):
 
         url = reverse("screenshots", kwargs=self.kw_component)
 
+        response = self.client.get(url, {"q": "login"})
+        self.assertContains(response, "Assigned login")
+        self.assertNotContains(response, "Unassigned help")
+
+        response = self.client.get(url, {"q": "hello"})
+        self.assertNotContains(response, "Assigned login")
+        self.assertNotContains(response, "Unassigned help")
+
+        response = self.client.get(url, {"q": "fastlane"})
+        self.assertNotContains(response, "Assigned login")
+        self.assertNotContains(response, "Unassigned help")
+
         response = self.client.get(url, {"q": "has:string"})
         self.assertContains(response, "Assigned login")
         self.assertNotContains(response, "Unassigned help")
@@ -571,6 +589,10 @@ class ViewTest(FixtureTestCase):
         self.assertNotContains(response, "Assigned login")
 
         response = self.client.get(url, {"q": "path:fastlane"})
+        self.assertContains(response, "Assigned login")
+        self.assertNotContains(response, "Unassigned help")
+
+        response = self.client.get(url, {"q": "repository:fastlane"})
         self.assertContains(response, "Assigned login")
         self.assertNotContains(response, "Unassigned help")
 

--- a/weblate/templates/screenshots/screenshot_list.html
+++ b/weblate/templates/screenshots/screenshot_list.html
@@ -114,6 +114,16 @@
               {{ search_form.q }}
             </div>
             {% if search_form.q.errors %}<div class="invalid-feedback d-block">{{ search_form.q.errors }}</div>{% endif %}
+            <div id="screenshots-list-search-help" class="form-text">
+              {% blocktranslate trimmed %}
+                Search screenshot names. Use field-specific queries for repository paths, languages, and assigned strings.
+              {% endblocktranslate %}
+              <a class="doc-link"
+                 href="{% documentation 'user/search' 'search-screenshots' %}"
+                 title="{% translate "Documentation" %}"
+                 target="_blank"
+                 rel="noopener">{% icon "info.svg" %}<span class="visually-hidden">{% translate "Screenshot search documentation" %}</span></a>
+            </div>
           </div>
           <div class="col-12 col-sm-auto">
             <div class="btn-group search-group sort-field" role="group">

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -1075,15 +1075,7 @@ class ScreenshotTermExpr(BaseTermExpr):
         super().fixup()
 
     def convert_non_field(self) -> Q:
-        return (
-            Q(name__icontains=self.match)
-            | Q(repository_filename__icontains=self.match)
-            | Q(translation__language__code__icontains=self.match)
-            | Q(translation__language__name__icontains=self.match)
-            | Q(units__source__icontains=self.match)
-            | Q(units__context__icontains=self.match)
-            | Q(units__location__icontains=self.match)
-        )
+        return Q(name__icontains=self.match)
 
     def language_field(self, text: str | RegexExpr, context: dict) -> Q:
         if isinstance(text, RegexExpr):

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -708,16 +708,7 @@ class ScreenshotQueryParserTest(SearchTestCase):
     parser: ClassVar[Literal["unit", "user", "superuser", "screenshot"]] = "screenshot"
 
     def test_simple(self) -> None:
-        self.assert_query(
-            "login",
-            Q(name__icontains="login")
-            | Q(repository_filename__icontains="login")
-            | Q(translation__language__code__icontains="login")
-            | Q(translation__language__name__icontains="login")
-            | Q(units__source__icontains="login")
-            | Q(units__context__icontains="login")
-            | Q(units__location__icontains="login"),
-        )
+        self.assert_query("login", Q(name__icontains="login"))
 
     def test_fields(self) -> None:
         self.assert_query("id:100", Q(id=100))


### PR DESCRIPTION
Plain screenshot searches matched assigned strings, paths, languages, contexts, and locations, which made name searches return surprising results.

Limit unqualified screenshot searches to screenshot names, keep explicit field searches for broader lookups, and link the search box to the screenshot search documentation.

Fixes #20071

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
