### PR TITLE
docs(translations): clarify intermediate language behavior

### DIFF
--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -710,6 +710,15 @@ are based on :ref:`component-template`. In case the string is not translated
 into the source language, translating to other languages is prohibited. This
 provides :ref:`source-quality-gateway`.
 
+The intermediate file can match an existing language file. While it is configured
+as intermediate, Weblate does not list it as a regular language in the component
+language list. Clearing this setting makes the file appear as a regular language
+again on the next component scan.
+
+Target strings can become read-only while the intermediate file is configured.
+This happens for strings where the matching source string in the
+:ref:`component-template` is not translated yet.
+
 .. seealso::
 
    * :ref:`source-quality-gateway`

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.7.1
 
 * Restricted components now show a status icon in component listings.
 * Permission checks now reuse materialized team membership data from lightweight relation lookups.
+* Documented that intermediate language files are hidden from language listings and can make target strings read-only.
 
 .. rubric:: Bug fixes
 

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -43,7 +43,12 @@ from weblate.trans.tests.test_views import (
 )
 from weblate.utils.files import remove_tree
 from weblate.utils.lock import WeblateLockTimeoutError
-from weblate.utils.state import STATE_EMPTY, STATE_READONLY, STATE_TRANSLATED
+from weblate.utils.state import (
+    STATE_EMPTY,
+    STATE_NEEDS_CHECKING,
+    STATE_READONLY,
+    STATE_TRANSLATED,
+)
 from weblate.vcs.base import RepositoryError, RepositoryRecoveryEvent
 from weblate.vcs.git import GitRepository
 from weblate.vcs.github import GitHubInstallation
@@ -2084,6 +2089,70 @@ class FileSyncPendingUnitOptimizationTest(ComponentTestCase):
 
         unit.refresh_from_db()
         self.assertEqual(unit.details["disk_state"], disk_state)
+
+
+class ExistingIntermediateLanguageFileTest(ComponentTestCase):
+    def create_component(self):
+        return self.create_po_mono(new_lang="add")
+
+    def test_existing_language_file_can_be_used_and_cleared_as_intermediate(
+        self,
+    ) -> None:
+        language = Language.objects.get(code="en_devel")
+        translation = self.component.add_new_language(
+            language, self.get_request(), show_messages=False
+        )
+
+        self.assertIsNotNone(translation)
+        translation = cast("Translation", translation)
+        self.assertEqual(translation.filename, "po-mono/en_devel.po")
+        self.assertTrue(os.path.exists(cast("str", translation.get_filename())))
+
+        self.component.intermediate = translation.filename
+        self.component.save()
+        component = Component.objects.get(pk=self.component.pk)
+
+        self.assertEqual(component.intermediate, "po-mono/en_devel.po")
+        self.assertNotIn("po-mono/en_devel.po", component.get_mask_matches())
+        self.assertFalse(component.translation_set.filter(language=language).exists())
+
+        component.intermediate = ""
+        component.save()
+        component = Component.objects.get(pk=component.pk)
+
+        self.assertEqual(component.intermediate, "")
+        self.assertIn("po-mono/en_devel.po", component.get_mask_matches())
+        restored = component.translation_set.get(language=language)
+        self.assertEqual(restored.filename, "po-mono/en_devel.po")
+        self.assertFalse(
+            component.translation_set.get(language_code="cs")
+            .unit_set.filter(state=STATE_READONLY)
+            .exists()
+        )
+
+    def test_clearing_intermediate_restores_readonly_target_state(self) -> None:
+        component = self.create_json_intermediate(
+            project=self.create_project(
+                name="Intermediate state",
+                slug="intermediate-state",
+            )
+        )
+        source_unit = component.source_translation.unit_set.get(source="Hello world!\n")
+        target_unit = source_unit.unit_set.get(translation__language_code="cs")
+        self.assertNotEqual(target_unit.state, STATE_READONLY)
+
+        source_unit.translate(None, "Hello, world!\n", STATE_NEEDS_CHECKING)
+        target_unit.refresh_from_db()
+        self.assertEqual(target_unit.state, STATE_READONLY)
+
+        component.intermediate = ""
+        component.save()
+        component = Component.objects.get(pk=component.pk)
+        target_unit = component.translation_set.get(language_code="cs").unit_set.get(
+            context="hello"
+        )
+
+        self.assertNotEqual(target_unit.state, STATE_READONLY)
 
 
 class ResetReapplyMissingTranslationFileTest(ComponentTestCase):


### PR DESCRIPTION
Explain that an existing language file can be used as an intermediate language, that it is hidden while configured, and that target strings can become read-only until source strings are translated.

Add regression coverage for clearing the intermediate language file and recalculating read-only state.

Fixes #20305

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
