### PR TITLE
fix(trans): detect bilingual PO set as monolingual

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Weblate 2026.7.1
 * Restricted components now show a status icon in component listings.
 * Permission checks now reuse materialized team membership data from lightweight relation lookups.
 * Documented that intermediate language files are hidden from language listings and can make target strings read-only.
+* Component diagnostics now warn when regular :ref:`gettext` PO files are configured as monolingual PO files.
 
 .. rubric:: Bug fixes
 

--- a/docs/devel/alerts.rst
+++ b/docs/devel/alerts.rst
@@ -16,7 +16,7 @@ Currently the following is covered:
 * Repository containing too many outgoing or missing commits
 * Missing licenses
 * Errors when running add-on (see :doc:`/admin/addons`)
-* Misconfigured monolingual translation.
+* Misconfigured monolingual or bilingual translation.
 * Broken :ref:`component`
 * Broken URLs
 * Unused screenshots

--- a/weblate/templates/trans/alert/bilingualpoconfiguredasmonolingual.html
+++ b/weblate/templates/trans/alert/bilingualpoconfiguredasmonolingual.html
@@ -1,0 +1,4 @@
+{% load i18n translations %}
+
+<p>{% translate "The component looks like it contains regular gettext PO files, but it is configured as monolingual gettext PO." %}</p>
+<p>{% translate "If these are bilingual PO files, change the file format to gettext PO file, clear the monolingual base language file, and update the component." %} {% documentation_icon "formats" "bimono" %}</p>

--- a/weblate/trans/alerts/config.py
+++ b/weblate/trans/alerts/config.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db.models import Value
+from django.db.models.functions import MD5
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
@@ -18,6 +20,7 @@ from weblate_language_data.ambiguous import AMBIGUOUS
 from weblate.formats.models import FILE_FORMATS
 from weblate.trans.alerts.base import AlertSeverity, BaseAlert, MultiAlert
 from weblate.trans.alerts.registry import register
+from weblate.trans.util import PLURAL_SEPARATOR
 from weblate.utils.requests import (
     format_validation_error,
     get_uri_error,
@@ -37,6 +40,20 @@ if TYPE_CHECKING:
     from weblate.auth.models import User
     from weblate.trans.models.component import Component
     from weblate.trans.models.translation import Translation
+
+
+LIKELY_BILINGUAL_PO_SAMPLE_SIZE = 20
+MIN_LIKELY_BILINGUAL_PO_UNITS = 4
+EMPTY_SOURCE_VALUES = ("", *(PLURAL_SEPARATOR * count for count in range(1, 10)))
+
+
+def _looks_like_source_text(value: str) -> bool:
+    text = value.strip()
+    if not text or not any(char.isalpha() for char in text):
+        return False
+    if any(char.isspace() for char in text):
+        return True
+    return text.endswith((".", "?", "!")) or any(char in text for char in ",;:")
 
 
 def _get_validated_uri_error(
@@ -132,6 +149,47 @@ class MonolingualTranslation(BaseAlert):
         )
         return (
             allunits.count() > 3 and not source_space.exists() and target_space.exists()
+        )
+
+
+@register
+class BilingualPOConfiguredAsMonolingual(BaseAlert):
+    # Translators: Name of an alert
+    verbose = gettext_lazy("Bilingual gettext PO file configured as monolingual.")
+    doc_page = "formats"
+    doc_anchor = "bimono"
+
+    @staticmethod
+    def check_component(component: Component) -> bool | dict | None:
+        if (
+            component.is_glossary
+            or component.file_format != "po-mono"
+            or not component.template
+            or component.source_language_id is None
+            or not component.source_language.uses_whitespace()
+        ):
+            return False
+
+        units = list(
+            component.source_translation.unit_set.filter(
+                source__lower__md5__in=[
+                    MD5(Value(source)) for source in EMPTY_SOURCE_VALUES
+                ]
+            )
+            .exclude(context__lower__md5=MD5(Value("")))
+            .values_list("source", "context")[:LIKELY_BILINGUAL_PO_SAMPLE_SIZE]
+        )
+        contexts = [
+            context
+            for source, context in units
+            if not source.replace(PLURAL_SEPARATOR, "")
+        ]
+        if len(contexts) < MIN_LIKELY_BILINGUAL_PO_UNITS:
+            return False
+
+        return (
+            sum(1 for context in contexts if _looks_like_source_text(context))
+            >= MIN_LIKELY_BILINGUAL_PO_UNITS
         )
 
 

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -897,6 +897,11 @@ class MonolingualAlertTest(ViewTestCase):
         self.assertFalse(
             self.component.alert_set.filter(name="MonolingualTranslation").exists()
         )
+        self.assertFalse(
+            self.component.alert_set.filter(
+                name="BilingualPOConfiguredAsMonolingual"
+            ).exists()
+        )
 
     def test_false_bilingual(self) -> None:
         with self.captureOnCommitCallbacks(execute=True):
@@ -907,9 +912,58 @@ class MonolingualAlertTest(ViewTestCase):
         self.assertTrue(
             component.alert_set.filter(name="MonolingualTranslation").exists()
         )
+        self.assertFalse(
+            component.alert_set.filter(
+                name="BilingualPOConfiguredAsMonolingual"
+            ).exists()
+        )
+
+    def test_bilingual_po_configured_as_monolingual(self) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            component = self._create_component(
+                "po-mono",
+                "po/*.po",
+                "po/hello.pot",
+                project=self.project,
+                name="bilingual-po-as-mono",
+            )
+        update_alerts(component)
+        self.assertTrue(
+            component.alert_set.filter(
+                name="BilingualPOConfiguredAsMonolingual"
+            ).exists()
+        )
+
+    def test_bilingual_po_configured_as_monolingual_ignores_glossary(self) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            component = self._create_component(
+                "po-mono",
+                "po/*.po",
+                "po/hello.pot",
+                project=self.project,
+                name="glossary-po-as-mono",
+            )
+        component.is_glossary = True
+        update_alerts(component, {"BilingualPOConfiguredAsMonolingual"})
+        self.assertFalse(
+            component.alert_set.filter(
+                name="BilingualPOConfiguredAsMonolingual"
+            ).exists()
+        )
 
 
 class RepositoryAlertTemplateTest(SimpleTestCase):
+    def test_bilingual_po_configured_as_monolingual_guidance(self) -> None:
+        rendered = render_to_string(
+            "trans/alert/bilingualpoconfiguredasmonolingual.html",
+        )
+
+        self.assertIn(
+            "regular gettext PO files, but it is configured as monolingual",
+            rendered,
+        )
+        self.assertIn("change the file format to gettext PO file", rendered)
+
     def test_no_mask_matches_explains_empty_repository_state(self) -> None:
         rendered = render_to_string(
             "trans/alert/nomaskmatches.html",


### PR DESCRIPTION
Warn when a gettext PO component is configured as monolingual but imports empty source text from regular PO/POT files. Use existing MD5 indexes for the diagnostic query so the daily alert remains cheap.

Fixes #20210

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
