### PR TITLE
fix(memory): bound duplicate compaction candidates

### DIFF
--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -354,14 +354,17 @@ def has_duplicate_memory_groups() -> bool:
 def get_duplicate_memory_candidate_group_queryset(
     memory_objects, *, last_memory_id: int = 0
 ):
-    # Group on the expressions covered by memory_md5_index. Exact identity
-    # splitting, including context/status/file ownership, happens after loading
-    # these candidates.
+    # Group on duplicate identity before loading candidates. Exact text
+    # comparisons still happen after loading to protect against hash
+    # collisions, but including all identity fields here avoids materializing
+    # large buckets of unrelated memories that only share source, target, and
+    # origin.
     queryset = (
         memory_objects.annotate(
             origin_md5=MD5("origin"),
             source_md5=MD5("source"),
             target_md5=MD5("target"),
+            context_md5=MD5("context"),
         )
         .values(
             "source_language_id",
@@ -369,6 +372,9 @@ def get_duplicate_memory_candidate_group_queryset(
             "origin_md5",
             "source_md5",
             "target_md5",
+            "context_md5",
+            "status",
+            "legacy_from_file",
         )
         .annotate(first_id=Min("id"), count=Count("id"))
         .filter(count__gt=1)
@@ -398,6 +404,9 @@ def get_duplicate_memory_candidate_memories(
             origin__md5=group["origin_md5"],
             source__md5=group["source_md5"],
             target__md5=group["target_md5"],
+            context__md5=group["context_md5"],
+            status=group["status"],
+            legacy_from_file=group["legacy_from_file"],
         )
         .order_by("id")
         .select_related(

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -49,6 +49,7 @@ from weblate.memory.tasks import (
     cleanup_orphaned_memory,
     compact_memory_scopes,
     get_duplicate_memory_candidate_groups,
+    get_duplicate_memory_candidate_memories,
     get_group_matching_memory,
     handle_unit_translation_change,
     import_memory,
@@ -2109,6 +2110,62 @@ msgstr "Nazdar svete!\n"
             name=MEMORY_SCOPE_COMPACTION_STATE
         )
         self.assertTrue(state.completed)
+
+    def test_duplicate_candidate_groups_keep_exact_identity_in_database(self) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        origin = "duplicate-candidate-exact-identity"
+        values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "source": "Exact identity candidate source",
+            "target": "Kandidatni cil s presnou identitou",
+            "origin": origin,
+        }
+        duplicate = Memory.objects.create(
+            context="button",
+            status=Memory.STATUS_ACTIVE,
+            legacy_project=self.project,
+            **values,
+        )
+        matching_duplicate = Memory.objects.create(
+            context="button",
+            status=Memory.STATUS_ACTIVE,
+            legacy_shared=True,
+            **values,
+        )
+        Memory.objects.create(
+            context="menu",
+            status=Memory.STATUS_ACTIVE,
+            legacy_user=self.user,
+            **values,
+        )
+        Memory.objects.create(
+            context="button",
+            status=Memory.STATUS_PENDING,
+            legacy_user=self.user,
+            **values,
+        )
+        Memory.objects.create(
+            context="button",
+            status=Memory.STATUS_ACTIVE,
+            legacy_from_file=True,
+            **values,
+        )
+
+        groups = get_duplicate_memory_candidate_groups(
+            Memory.objects.using("default").filter(origin=origin),
+            last_memory_id=0,
+            batch_size=10,
+        )
+        memories = get_duplicate_memory_candidate_memories(
+            Memory.objects.using("default"), groups[0]
+        )
+
+        self.assertEqual([group["first_id"] for group in groups], [duplicate.id])
+        self.assertEqual(
+            [memory.id for memory in memories], [duplicate.id, matching_duplicate.id]
+        )
 
     def test_duplicate_candidate_cursor_skips_processed_bucket(self) -> None:
         source_language = Language.objects.get(code="en")


### PR DESCRIPTION
### Motivation
- The compaction candidate grouping previously grouped only by language and MD5(origin/source/target), which could place many intentionally distinct rows into one candidate bucket and cause unbounded list materialization and worker OOM during compaction.
- The change keeps database-side grouping aligned with the exact duplicate identity so candidate buckets are bounded before materializing rows in Python.

### Description
- Include `context` (via `context_md5`), `status`, and `legacy_from_file` in the database grouping in `get_duplicate_memory_candidate_group_queryset` to narrow candidate buckets.
- Apply the same identity filters in `get_duplicate_memory_candidate_memories` so loaded rows match the grouped identity and unrelated rows are not materialized.
- Add `test_duplicate_candidate_groups_keep_exact_identity_in_database` to `weblate/memory/tests.py` to assert candidate grouping and loading are aligned with exact identity fields.

### Testing
- Ran the targeted pytest selection with `uv run pytest weblate/memory/tests.py -k 'duplicate_candidate_groups_keep_exact_identity_in_database or compact_memory_scopes_keeps_different_exact_identities or duplicate_candidate_cursor_skips_processed_bucket'` and received `3 passed, 106 deselected`.
- Ran repository checks with `uv run prek run --files weblate/memory/tasks.py weblate/memory/tests.py` and the pre-commit hooks / ruff format checks passed.
- Ran `git diff --check` as part of validation and it produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cf75564648329aea1abedd721f3b7)