### PR TITLE
fix(notifications): notify commenters about string comments

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,8 @@ Weblate 2026.7.1
 * Component diagnostics now warn when regular :ref:`gettext` PO files are configured as monolingual PO files.
 * Translation memory fuzzy lookups are now faster on large translation memories.
 * Permission denied messages when saving translations or voting on suggestions now show more specific reasons.
+* Comment notifications for strings you translated now also include strings you previously commented on or suggested translations for.
+* Comments and suggestions now auto-watch the project when :guilabel:`Automatically watch projects on contribution` is enabled.
 
 .. rubric:: Bug fixes
 

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -31424,7 +31424,7 @@ components:
         * `ComponentTranslatedNotificaton` - Component was translated
         * `NewCommentNotificaton` - Comment was added
         * `MentionCommentNotificaton` - You were mentioned in a comment
-        * `LastAuthorCommentNotificaton` - Your translation received a comment
+        * `LastAuthorCommentNotificaton` - String you contributed to received a comment
         * `TranslatedStringNotificaton` - String was edited by user
         * `ApprovedStringNotificaton` - String was approved
         * `ChangedStringNotificaton` - String was changed

--- a/docs/user/profile.rst
+++ b/docs/user/profile.rst
@@ -179,7 +179,7 @@ can be further tweaked (or muted) per project and component. Visit the component
 overview page and select appropriate choice from the :guilabel:`Watching` menu.
 
 In case :guilabel:`Automatically watch projects on contribution` is enabled you
-will automatically start watching projects upon translating a string. The
+will automatically start watching projects upon contributing to them. The
 default value depends on :setting:`DEFAULT_AUTO_WATCH`.
 
 .. note::

--- a/weblate/accounts/migrations/0032_alter_subscription_notification.py
+++ b/weblate/accounts/migrations/0032_alter_subscription_notification.py
@@ -1,0 +1,73 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts", "0031_alter_auditlog_activity"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="subscription",
+            name="notification",
+            field=models.CharField(
+                choices=[
+                    (
+                        "RepositoryNotification",
+                        "Operation was performed in the repository",
+                    ),
+                    ("LockNotification", "Component was locked or unlocked"),
+                    ("LicenseNotification", "License was changed"),
+                    ("ParseErrorNotification", "Parse error occurred"),
+                    ("NewStringNotificaton", "String is available for translation"),
+                    (
+                        "TranslationActivitySummaryNotification",
+                        "Translation activity summary",
+                    ),
+                    (
+                        "NewContributorNotificaton",
+                        "Contributor made their first translation",
+                    ),
+                    ("NewSuggestionNotificaton", "Suggestion was added"),
+                    ("LanguageTranslatedNotificaton", "Language was translated"),
+                    ("ComponentTranslatedNotificaton", "Component was translated"),
+                    ("NewCommentNotificaton", "Comment was added"),
+                    ("MentionCommentNotificaton", "You were mentioned in a comment"),
+                    (
+                        "LastAuthorCommentNotificaton",
+                        "String you contributed to received a comment",
+                    ),
+                    ("TranslatedStringNotificaton", "String was edited by user"),
+                    ("ApprovedStringNotificaton", "String was approved"),
+                    ("ChangedStringNotificaton", "String was changed"),
+                    (
+                        "NewTranslationNotificaton",
+                        "New language was added or requested",
+                    ),
+                    (
+                        "NewComponentNotificaton",
+                        "New translation component was created",
+                    ),
+                    ("NewAnnouncementNotificaton", "Announcement was published"),
+                    ("NewAlertNotificaton", "New alert emerged in a component"),
+                    ("MergeFailureNotification", "Repository operation failed"),
+                    ("PendingSuggestionsNotification", "Pending suggestions exist"),
+                    ("ToDoStringsNotification", "Unfinished strings exist"),
+                ],
+                max_length=100,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="profile",
+            name="auto_watch",
+            field=models.BooleanField(
+                default=True,
+                help_text="Projects are added to your watched projects when you contribute to them.",
+                verbose_name="Automatically watch projects on contribution",
+            ),
+        ),
+    ]

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -87,7 +87,7 @@ if TYPE_CHECKING:
 
     from weblate.accounts.types import DeviceType
     from weblate.auth.models import AuthenticatedHttpRequest
-    from weblate.trans.models import Unit
+    from weblate.trans.models import Project, Unit
 
 LOGGER = logging.getLogger("weblate.audit")
 
@@ -838,7 +838,7 @@ class Profile(models.Model):
         verbose_name=gettext_lazy("Automatically watch projects on contribution"),
         default=settings.DEFAULT_AUTO_WATCH,
         help_text=gettext_lazy(
-            "Whenever you translate a string in a project, you will start watching it."
+            "Projects are added to your watched projects when you contribute to them."
         ),
     )
     contribute_personal_tm = models.BooleanField(
@@ -1024,6 +1024,17 @@ class Profile(models.Model):
         if not parsed.hostname:
             return None
         return parsed._replace(path="/share", query="text=", fragment="").geturl()
+
+    def watch_on_contribution(self, project: Project) -> bool:
+        """Watch project when auto-watch on contribution is enabled."""
+        if (
+            self.user.is_anonymous
+            or not self.auto_watch
+            or self.watched.filter(pk=project.pk).exists()
+        ):
+            return False
+        self.watched.add(project)
+        return True
 
     def increase_count(self, item: str, increase: int = 1) -> None:
         """Update user actions counter."""

--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -34,6 +34,8 @@ from weblate.trans.actions import ActionEvents
 from weblate.trans.models import (
     Alert,
     Change,
+    Comment,
+    Suggestion,
     Translation,
 )
 from weblate.utils.errors import report_error
@@ -55,7 +57,6 @@ if TYPE_CHECKING:
     from weblate.accounts.tasks import OutgoingEmail
     from weblate.trans.models import (
         Announcement,
-        Comment,
         Component,
         Project,
         Unit,
@@ -1014,14 +1015,65 @@ class MentionCommentNotificaton(Notification):
 @register_notification
 class LastAuthorCommentNotificaton(Notification):
     actions = (ActionEvents.COMMENT,)
-    verbose = pgettext_lazy("Notification name", "Your translation received a comment")
+    verbose = pgettext_lazy(
+        "Notification name",
+        "String you contributed to received a comment",
+    )
     verbose_plural = pgettext_lazy(
-        "Notification name", "Your translation received comments"
+        "Notification name",
+        "Strings you contributed to received comments",
     )
     template_name = "new_comment"
-    ignore_watched = True
     required_attr = "comment"
-    skip_when_notify: ClassVar[set[type[Notification]]] = {MentionCommentNotificaton}
+    skip_when_notify: ClassVar[set[type[Notification]]] = {
+        MentionCommentNotificaton,
+        NewCommentNotificaton,
+    }
+
+    def get_change_users(self, change: Change) -> list[int]:
+        change_users: list[int] = []
+        seen: set[int] = set()
+
+        def add_user_id(user_id: int | None) -> None:
+            if user_id is not None and user_id not in seen:
+                seen.add(user_id)
+                change_users.append(user_id)
+
+        unit = cast("Unit", change.unit)
+        last_author = unit.get_last_content_change()[0]
+        if not last_author.is_anonymous:
+            add_user_id(last_author.pk)
+
+        comment = cast("Comment", change.comment)
+        unit_ids: list[int | None] = [unit.pk]
+        if not unit.is_source:
+            unit_ids.append(unit.source_unit_id)
+
+        comment_unit_ids = {unit_id for unit_id in unit_ids if unit_id is not None}
+        previous_comments = Q(timestamp__lt=comment.timestamp)
+        if comment.pk is not None:
+            previous_comments |= Q(timestamp=comment.timestamp, pk__lt=comment.pk)
+        commenter_ids = (
+            Comment.objects.filter(unit_id__in=comment_unit_ids)
+            .filter(previous_comments)
+            .exclude(user__isnull=True)
+            .values_list("user_id", flat=True)
+            .distinct()
+        )
+        for user_id in commenter_ids:
+            add_user_id(user_id)
+
+        if not unit.is_source:
+            suggestion_user_ids = (
+                Suggestion.objects.filter(unit=unit, timestamp__lt=comment.timestamp)
+                .exclude(user__isnull=True)
+                .values_list("user_id", flat=True)
+                .distinct()
+            )
+            for user_id in suggestion_user_ids:
+                add_user_id(user_id)
+
+        return change_users
 
     def get_users(
         self,
@@ -1032,13 +1084,15 @@ class LastAuthorCommentNotificaton(Notification):
         translation: Translation | None = None,
         users: list[int] | None = None,
     ) -> Iterable[User]:
-        change_users: list[int] = []
-        if change is not None:
-            last_author = cast("Unit", change.unit).get_last_content_change()[0]
-            if not last_author.is_anonymous:
-                change_users.append(last_author.pk)
+        if change is None or self.missing_required_attrs(change):
+            return []
         return super().get_users(
-            frequency, change, project, component, translation, change_users
+            frequency,
+            change,
+            project,
+            component,
+            translation,
+            self.get_change_users(change),
         )
 
 

--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -19,6 +19,7 @@ from weblate.accounts.data import DEFAULT_NOTIFICATIONS
 from weblate.accounts.models import AuditLog, Profile, Subscription
 from weblate.accounts.notifications import (
     RECIPIENT_USERNAME_HEADER,
+    LastAuthorCommentNotificaton,
     MergeFailureNotification,
     NotificationFrequency,
     NotificationScope,
@@ -436,6 +437,29 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
             action=ActionEvents.COMMENT,
         )
 
+    def create_comment_change(self, unit, user: User, comment="Foo") -> Comment:
+        comment_obj = Comment.objects.create(unit=unit, comment=comment, user=user)
+        self.create_with_callbacks(
+            unit.change_set,
+            comment=comment_obj,
+            user=user,
+            author=user,
+            action=ActionEvents.COMMENT,
+        )
+        return comment_obj
+
+    def subscribe_participation_comment(
+        self, user: User, *, watched: bool = True
+    ) -> None:
+        if watched:
+            user.profile.watched.add(self.project)
+        Subscription.objects.create(
+            user=user,
+            scope=NotificationScope.SCOPE_WATCHED,
+            notification="LastAuthorCommentNotificaton",
+            frequency=NotificationFrequency.FREQ_INSTANT,
+        )
+
     def test_notify_new_comment(self, expected=1, comment="Foo") -> None:
         self.add_comment(comment=comment)
 
@@ -474,6 +498,167 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
         # Notification for other user edit via  TranslatedStringNotificaton
         self.assertEqual(len(mail.outbox), 1)
         mail.outbox.clear()
+
+    def test_notify_new_comment_previous_commenter(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        unit = self.get_unit()
+        self.create_comment_change(unit, self.user, "Question")
+        mail.outbox.clear()
+
+        self.create_comment_change(unit, self.thirduser, "Answer")
+
+        self.validate_notifications(1, "[Weblate] New comment in Test/Test")
+        self.assertEqual(
+            mail.outbox[0].extra_headers[RECIPIENT_USERNAME_HEADER],
+            self.user.username,
+        )
+
+    def test_notify_new_comment_auto_watched_commenter(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user, watched=False)
+        self.user.profile.watched.clear()
+        unit = self.get_unit()
+
+        Comment.objects.add(
+            self.get_request(self.user), unit, "Question", "translation"
+        )
+        mail.outbox.clear()
+
+        self.assertTrue(self.user.profile.watched.filter(pk=self.project.pk).exists())
+
+        self.create_comment_change(unit, self.thirduser, "Answer")
+
+        self.validate_notifications(1, "[Weblate] New comment in Test/Test")
+        self.assertEqual(
+            mail.outbox[0].extra_headers[RECIPIENT_USERNAME_HEADER],
+            self.user.username,
+        )
+
+    def test_notify_new_comment_source_commenter(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        unit = self.get_unit()
+        self.create_comment_change(unit.source_unit, self.user, "Question")
+        mail.outbox.clear()
+
+        self.create_comment_change(unit, self.thirduser, "Answer")
+
+        self.validate_notifications(1, "[Weblate] New comment in Test/Test")
+        self.assertEqual(
+            mail.outbox[0].extra_headers[RECIPIENT_USERNAME_HEADER],
+            self.user.username,
+        )
+
+    def test_notify_new_comment_own_commenter(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        unit = self.get_unit()
+        self.create_comment_change(unit, self.user, "Question")
+        mail.outbox.clear()
+
+        self.create_comment_change(unit, self.user, "Follow-up")
+
+        self.validate_notifications(0)
+
+    def test_notify_new_comment_mentioned_commenter_once(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        Subscription.objects.create(
+            user=self.user,
+            scope=NotificationScope.SCOPE_ALL,
+            notification="MentionCommentNotificaton",
+            frequency=NotificationFrequency.FREQ_INSTANT,
+        )
+        unit = self.get_unit()
+        self.create_comment_change(unit, self.user, "Question")
+        mail.outbox.clear()
+
+        self.create_comment_change(
+            unit, self.thirduser, f"Answer @{self.user.username}"
+        )
+
+        self.validate_notifications(1, "[Weblate] New comment in Test/Test")
+        self.assertEqual(
+            mail.outbox[0].extra_headers[RECIPIENT_USERNAME_HEADER],
+            self.user.username,
+        )
+
+    def test_notify_new_comment_other_translation_commenter(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        unit = self.get_unit(language="cs")
+        other_unit = self.get_unit(language="de")
+        self.create_comment_change(unit, self.user, "Question")
+        mail.outbox.clear()
+
+        self.create_comment_change(other_unit, self.thirduser, "Answer")
+        self.create_comment_change(unit.source_unit, self.thirduser, "Source answer")
+
+        self.validate_notifications(0)
+
+    def test_notify_new_comment_stale_comment_change(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        unit = self.get_unit()
+
+        self.create_with_callbacks(
+            unit.change_set,
+            user=self.thirduser,
+            author=self.thirduser,
+            action=ActionEvents.COMMENT,
+        )
+
+        self.validate_notifications(0)
+
+    def test_notify_new_comment_delayed_change_skips_later_commenter(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        self.subscribe_participation_comment(self.anotheruser)
+        unit = self.get_unit()
+        Comment.objects.create(unit=unit, comment="Question", user=self.user)
+        comment = Comment.objects.create(
+            unit=unit, comment="Answer", user=self.thirduser
+        )
+        change = self.create_with_callbacks(
+            unit.change_set,
+            comment=comment,
+            user=self.thirduser,
+            author=self.thirduser,
+            action=ActionEvents.COMMENT,
+        )
+        mail.outbox.clear()
+        Comment.objects.create(unit=unit, comment="Later", user=self.anotheruser)
+
+        users = list(
+            LastAuthorCommentNotificaton([]).get_users(
+                NotificationFrequency.FREQ_INSTANT, change
+            )
+        )
+
+        self.assertIn(self.user, users)
+        self.assertNotIn(self.anotheruser, users)
+
+    def test_notify_new_comment_suggestion_author(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user, watched=False)
+        self.user.profile.watched.clear()
+        unit = self.get_unit()
+
+        Suggestion.objects.add(
+            unit, ["Suggestion"], self.get_request(self.user), user=self.user
+        )
+        mail.outbox.clear()
+
+        self.assertTrue(self.user.profile.watched.filter(pk=self.project.pk).exists())
+
+        self.create_comment_change(unit, self.thirduser, "Answer")
+
+        self.validate_notifications(1, "[Weblate] New comment in Test/Test")
+        self.assertEqual(
+            mail.outbox[0].extra_headers[RECIPIENT_USERNAME_HEADER],
+            self.user.username,
+        )
 
     def test_notify_new_component(self) -> None:
         self.create_with_callbacks(

--- a/weblate/trans/models/comment.py
+++ b/weblate/trans/models/comment.py
@@ -65,6 +65,7 @@ class CommentManager(models.Manager):
         )
 
         component = unit_scope.translation.component
+        user.profile.watch_on_contribution(component.project)
 
         # Add review label/flag
         if scope == "report":

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -90,8 +90,8 @@ class SuggestionManager(models.Manager["Suggestion"]):
             suggestion.add_vote(request, Vote.POSITIVE)
 
         # Update suggestion stats
-        if user is not None:
-            user.profile.increase_count("suggested")
+        user.profile.watch_on_contribution(unit.translation.component.project)
+        user.profile.increase_count("suggested")
 
         unit.invalidate_related_cache()
 

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -880,8 +880,7 @@ def perform_translation(unit, form, request: AuthenticatedHttpRequest) -> bool:
             )
             % {"language": language},
         )
-    if profile.auto_watch and not profile.watched.filter(pk=project.pk).exists():
-        profile.watched.add(project)
+    if profile.watch_on_contribution(project):
         messages.info(
             request,
             gettext(


### PR DESCRIPTION
Include users who previously commented on a string so discussions keep reaching participants, not only the last translator.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
