### PR TITLE
feat(search): add comment author shortcuts

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Weblate 2026.7.1
 * Comment notifications for strings you translated now also include strings you previously commented on or suggested translations for.
 * Comments and suggestions now auto-watch the project when :guilabel:`Automatically watch projects on contribution` is enabled.
 * Clarified Hosted Weblate repository access guidance in :doc:`/admin/code-hosting`.
+* :ref:`search-strings` now includes filters for comments by the current user and separate source string comment lookups.
 
 .. rubric:: Bug fixes
 

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -155,7 +155,7 @@ Fields
 ``pending:BOOLEAN``
    String pending for flushing to VCS.
 ``has:TEXT``
-   Search for string having attributes - ``plural``, ``context``, ``suggestion``, ``comment``, ``check``, ``dismissed-check``, ``translation``, ``variant``, ``screenshot``, ``flags``, ``explanation``, ``glossary``, ``note``, ``label``, ``location``.
+   Search for string having attributes - ``plural``, ``context``, ``suggestion``, ``comment``, ``source-comment``, ``check``, ``dismissed-check``, ``translation``, ``variant``, ``screenshot``, ``flags``, ``explanation``, ``glossary``, ``note``, ``label``, ``location``.
 ``is:TEXT``
    Filters string on a condition:
 
@@ -208,11 +208,21 @@ Fields
 ``dismissed_check:TEXT``
    String has dismissed check, see :doc:`/user/checks` for check identifiers.
 ``comment:TEXT``
-   Search in user comments.
+   Search in unresolved user comments on the string.
 ``resolved_comment:TEXT``
    Search in resolved comments.
 ``comment_author:TEXT``
    Filter by comment author.
+``source_comment:TEXT``
+   Search in unresolved source string comments.
+``resolved_source_comment:TEXT``
+   Search in resolved source string comments.
+``source_comment_author:TEXT``
+   Filter by source string comment author.
+
+   Source string comment filters match comments attached to the source string.
+   When searching across languages, matching target strings sharing that source
+   string can be included in the results.
 ``suggestion:TEXT``
    Search in suggestions.
 ``suggestion_author:TEXT``

--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -85,7 +85,17 @@ the original string, for example that it should be rephrased, or to ask
 questions about it.
 
 Markdown syntax can be used in all comments, as well as mentioning other
-users by using ``@username``.
+users by using ``@username``. Mention a maintainer or another translator when
+you need them to see a follow-up question; they can reply in the same
+:guilabel:`Comments` tab.
+
+To find comments again, open your :ref:`user-profile`; the comment count links
+to your comment activity. To find strings with comments by a specific user, use
+:doc:`/user/search`. For example, ``comment_author:USERNAME`` finds strings
+with comments by that user, and ``source_comment_author:USERNAME`` finds
+strings with source string comments by that user. When you are signed in, the
+search filter menu also includes shortcuts for comments by you and source
+comments by you.
 
 .. seealso::
 

--- a/weblate/trans/filter.py
+++ b/weblate/trans/filter.py
@@ -37,6 +37,11 @@ class FilterRegistry:
                 "state:<translated AND NOT has:suggestion",
             ),
             ("comments", gettext_lazy("Strings with comments"), "has:comment"),
+            (
+                "source_comments",
+                gettext_lazy("Strings with source comments"),
+                "has:source-comment",
+            ),
             ("allchecks", gettext_lazy("Strings with any failing checks"), "has:check"),
             (
                 "translated_checks",
@@ -126,6 +131,7 @@ def get_filter_choice(project=None):
         ("suggestions", gettext("Strings with suggestions")),
         ("nosuggestions", gettext("Unfinished strings without suggestions")),
         ("comments", gettext("Strings with comments")),
+        ("source_comments", gettext("Strings with source comments")),
         ("allchecks", gettext("Strings with any failing checks")),
         ("approved", gettext("Approved strings")),
         ("approved_suggestions", gettext("Approved strings with suggestions")),

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -18,7 +18,7 @@ from weblate.checks.models import Check
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.bulk import bulk_perform
-from weblate.trans.models import Change, Component, PendingUnitChange, Unit
+from weblate.trans.models import Change, Comment, Component, PendingUnitChange, Unit
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.ratelimit import reset_rate_limit
 from weblate.utils.state import (
@@ -92,6 +92,14 @@ class SearchViewTest(ViewTestCase):
         self.assertContains(response, '<span class="hlmatch">Hello</span>, world')
         response = self.client.get(url, {"q": "changed:>=2010-01-10"})
         self.assertContains(response, "2010-01-10")
+
+    def get_search_result_count(self, query: str) -> int:
+        response = self.client.get(
+            reverse("search", kwargs={"path": self.translation.get_url_path()}),
+            {"q": query},
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.context["total_strings"]
 
     @override_settings(RATELIMIT_SEARCH_ATTEMPTS=20000)
     def test_all_search(self) -> None:
@@ -252,6 +260,42 @@ class SearchViewTest(ViewTestCase):
         self.do_search({"q": "source:hello"}, "source:hello")
         # Short exact
         self.do_search({"q": "x", "search": "exact"}, None)
+
+    def test_comment_search_keeps_source_comments_separate(self) -> None:
+        unit = self.get_unit()
+        Comment.objects.all().delete()
+
+        Comment.objects.create(
+            unit=unit.source_unit,
+            comment="Source comment by me",
+            user=self.user,
+        )
+
+        self.assertEqual(self.get_search_result_count('comment_author:="testuser"'), 0)
+        self.assertEqual(self.get_search_result_count("has:comment"), 0)
+        self.assertEqual(
+            self.get_search_result_count('source_comment_author:="testuser"'), 1
+        )
+        self.assertEqual(self.get_search_result_count("has:source-comment"), 1)
+
+        Comment.objects.create(
+            unit=unit,
+            comment="Translation comment by me",
+            user=self.user,
+        )
+
+        self.assertEqual(self.get_search_result_count('comment_author:="testuser"'), 1)
+        self.assertEqual(self.get_search_result_count("has:comment"), 1)
+
+    def test_search_filter_dropdown_includes_comments_by_me(self) -> None:
+        response = self.client.get(
+            reverse("search", kwargs={"path": self.translation.get_url_path()})
+        )
+
+        self.assertContains(response, "Strings with comments by me")
+        self.assertContains(response, "comment_author:=&quot;testuser&quot;")
+        self.assertContains(response, "Strings with source comments by me")
+        self.assertContains(response, "source_comment_author:=&quot;testuser&quot;")
 
     def test_review(self) -> None:
         # Review

--- a/weblate/utils/forms.py
+++ b/weblate/utils/forms.py
@@ -30,6 +30,8 @@ from .validators import (
 if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
 
+    from weblate.auth.models import User
+
 
 class QueryField(forms.CharField):
     def __init__(
@@ -277,10 +279,10 @@ class SearchField(Field):
     ):
         if extra_context is not None:
             raise TypeError
-        extra_context = {"custom_filter_list": self.get_search_query_choices()}
+        extra_context = {"custom_filter_list": self.get_search_query_choices(form)}
         return super().render(form, context, template_pack, extra_context, **kwargs)
 
-    def get_search_query_choices(self):
+    def get_search_query_choices(self, form):
         """Return all filtering choices for query field."""
         filter_keys = [
             "nottranslated",
@@ -294,14 +296,32 @@ class SearchField(Field):
             "context",
             "nosuggestions",
             "comments",
+            "source_comments",
             "allchecks",
             "approved",
             "unapproved",
         ]
-        return [
+        result = [
             (key, FILTERS.get_filter_name(key), FILTERS.get_filter_query(key))
             for key in filter_keys
         ]
+        user: User | None = getattr(form, "user", None)
+        if user is not None and user.is_authenticated:
+            result.extend(
+                (
+                    (
+                        "comments_by_me",
+                        gettext_lazy("Strings with comments by me"),
+                        f'comment_author:="{user.username}"',
+                    ),
+                    (
+                        "source_comments_by_me",
+                        gettext_lazy("Strings with source comments by me"),
+                        f'source_comment_author:="{user.username}"',
+                    ),
+                )
+            )
+        return result
 
 
 class CachedQueryIterator(ModelChoiceIterator):

--- a/weblate/utils/search.py
+++ b/weblate/utils/search.py
@@ -669,6 +669,8 @@ class UnitTermExpr(BaseTermExpr):
         "suggestion": "suggestion__target",
         "comment": "comment__comment",
         "resolved_comment": "comment__comment",
+        "source_comment": "source_unit__comment__comment",
+        "resolved_source_comment": "source_unit__comment__comment",
         "key": "context",
         "explanation": "source_unit__explanation",
     }
@@ -677,6 +679,7 @@ class UnitTermExpr(BaseTermExpr):
         "project": "translation__component__project__slug",
         "suggestion_author": "suggestion__user__username",
         "comment_author": "comment__user__username",
+        "source_comment_author": "source_unit__comment__user__username",
     }
 
     def change_field_name(self, field: str, suffix: str | None = None) -> str:
@@ -754,6 +757,10 @@ class UnitTermExpr(BaseTermExpr):
             return Q(comment__resolved=False)
         if text in {"resolved-comment", "resolved_comment"}:
             return Q(comment__resolved=True)
+        if text in {"source-comment", "source_comment"}:
+            return Q(source_unit__comment__resolved=False)
+        if text in {"resolved-source-comment", "resolved_source_comment"}:
+            return Q(source_unit__comment__resolved=True)
         if text in {"check", "failing-check", "failing_check"}:
             return Q(check__dismissed=False)
         if text in {
@@ -953,6 +960,10 @@ class UnitTermExpr(BaseTermExpr):
             return query & Q(comment__resolved=False)
         if field == "resolved_comment":
             return query & Q(comment__resolved=True)
+        if field == "source_comment":
+            return query & Q(source_unit__comment__resolved=False)
+        if field == "resolved_source_comment":
+            return query & Q(source_unit__comment__resolved=True)
 
         return super().field_extra(field, query, match)
 

--- a/weblate/utils/tests/test_search.py
+++ b/weblate/utils/tests/test_search.py
@@ -155,6 +155,20 @@ class UnitQueryParserTest(SearchTestCase):
         self.assert_query(
             "comment_author:nijel", Q(comment__user__username__iexact="nijel")
         )
+        self.assert_query(
+            "source_comment:TEXT",
+            Q(source_unit__comment__comment__substring="TEXT")
+            & Q(source_unit__comment__resolved=False),
+        )
+        self.assert_query(
+            "resolved_source_comment:TEXT",
+            Q(source_unit__comment__comment__substring="TEXT")
+            & Q(source_unit__comment__resolved=True),
+        )
+        self.assert_query(
+            "source_comment_author:nijel",
+            Q(source_unit__comment__user__username__iexact="nijel"),
+        )
 
     def test_field(self) -> None:
         self.assert_query(
@@ -428,6 +442,11 @@ class UnitQueryParserTest(SearchTestCase):
         self.assert_query("has:note", ~Q(note=""))
         self.assert_query("has:location", ~Q(location=""))
         self.assert_query("has:resolved-comment", Q(comment__resolved=True))
+        self.assert_query("has:source-comment", Q(source_unit__comment__resolved=False))
+        self.assert_query("has:source_comment", Q(source_unit__comment__resolved=False))
+        self.assert_query(
+            "has:resolved-source-comment", Q(source_unit__comment__resolved=True)
+        )
         self.assert_query("has:dismissed-check", Q(check__dismissed=True))
         self.assert_query("has:translation", Q(state__gte=STATE_TRANSLATED))
         self.assert_query(


### PR DESCRIPTION
Help users find strings with comments they authored, including source comments, without changing existing comment search semantics.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
