### PR TITLE
fix(auth): prevent editing internal bot accounts

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,7 @@ Weblate 2026.7.1
 * Accepting a project invitation now automatically adds the project to the user's watched projects.
 * Dismissing a failing check no longer shows a JSON parsing error in the translation editor.
 * Screenshot searches without an explicit field now match screenshot names only, and the search box links to the full screenshot search documentation.
+* Anonymous and internal bot accounts can no longer be edited through generic user management.
 
 .. rubric:: Compatibility
 

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -306,6 +306,71 @@ class ViewTest(RepoTestCase):
         self.assertEqual(response.context["page_user_billings"], [billing])
         self.assertContains(response, 'data-bs-target="#billing"')
 
+    def test_protected_bot_user_page_is_read_only(self) -> None:
+        """Test protected bot user pages do not expose mutation controls."""
+        admin = self.get_user()
+        admin.is_superuser = True
+        admin.save(update_fields=["is_superuser"])
+        protected_bot = User.objects.create(
+            username="addon:test",
+            full_name="Addon Bot",
+            email="addon-test@example.org",
+            is_bot=True,
+            is_active=False,
+        )
+
+        self.client.login(username=admin.username, password="testpassword")
+        response = self.client.get(protected_bot.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["can_edit_page_user"])
+        self.assertContains(response, 'data-bs-target="#audit"')
+        self.assertNotContains(response, 'data-bs-target="#edit"')
+        self.assertNotContains(response, 'name="disable_password"')
+        self.assertNotContains(response, "Add user to a team")
+
+        response = self.client.post(
+            protected_bot.get_absolute_url(),
+            {
+                "username": protected_bot.username,
+                "full_name": "Renamed Bot",
+                "email": protected_bot.email,
+                "is_active": "on",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        protected_bot.refresh_from_db()
+        self.assertEqual(protected_bot.full_name, "Addon Bot")
+
+    def test_anonymous_user_page_is_read_only(self) -> None:
+        """Test anonymous user page does not allow direct mutations."""
+        admin = self.get_user()
+        admin.is_superuser = True
+        admin.save(update_fields=["is_superuser"])
+        anonymous = User.objects.get(username=settings.ANONYMOUS_USER_NAME)
+
+        self.client.login(username=admin.username, password="testpassword")
+        response = self.client.get(anonymous.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["can_edit_page_user"])
+        self.assertNotContains(response, 'data-bs-target="#edit"')
+
+        response = self.client.post(
+            anonymous.get_absolute_url(),
+            {
+                "username": anonymous.username,
+                "full_name": "Renamed Anonymous",
+                "email": anonymous.email,
+                "is_active": "on",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        anonymous.refresh_from_db()
+        self.assertEqual(anonymous.full_name, "Anonymous")
+
     def test_suggestions(self) -> None:
         """Test user pages."""
         # Setup user

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -26,6 +26,7 @@ from django.contrib.auth.views import LoginView, RedirectURLMixin
 from django.core.exceptions import (
     ImproperlyConfigured,
     ObjectDoesNotExist,
+    PermissionDenied,
     ValidationError,
 )
 from django.core.mail.message import EmailMessage
@@ -786,6 +787,8 @@ class UserPage(UpdateView):
     def post(self, request: AuthenticatedHttpRequest, *args, **kwargs):  # type: ignore[override]
         check_management_access(request, "user.edit")
         user = self.object = self.get_object()
+        if user.is_internal:
+            raise PermissionDenied(gettext("This user can not be edited."))
         if "add_group" in request.POST:
             response = self.handle_add_group(request, user)
             if response is not None:
@@ -894,6 +897,7 @@ class UserPage(UpdateView):
         )
 
         context["page_profile"] = user.profile
+        context["can_edit_page_user"] = not user.is_internal
         # Last user activity
         context["last_changes"] = all_changes.recent()
         context["last_changes_url"] = urlencode({"user": user.username})

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -1011,7 +1011,7 @@ class UserAPITest(APIBaseTest):
             kwargs={"username": settings.ANONYMOUS_USER_NAME},
             method="put",
             superuser=True,
-            code=200,
+            code=403,
             request={
                 "full_name": "Name",
                 "username": "apitest2",
@@ -1019,10 +1019,10 @@ class UserAPITest(APIBaseTest):
                 "is_active": True,
             },
         )
-        self.assertFalse(
+        self.assertTrue(
             User.objects.filter(username=settings.ANONYMOUS_USER_NAME).exists()
         )
-        self.assertEqual(User.objects.get(username="apitest2").full_name, "Name")
+        self.assertFalse(User.objects.filter(username="apitest2").exists())
 
     def test_put_self_without_user_view_keeps_email(self) -> None:
         self.do_request(
@@ -1072,12 +1072,81 @@ class UserAPITest(APIBaseTest):
             kwargs={"username": settings.ANONYMOUS_USER_NAME},
             method="patch",
             superuser=True,
-            code=200,
+            code=403,
             request={"full_name": "Other"},
         )
         self.assertEqual(
-            User.objects.get(username=settings.ANONYMOUS_USER_NAME).full_name, "Other"
+            User.objects.get(username=settings.ANONYMOUS_USER_NAME).full_name,
+            "Anonymous",
         )
+
+    def test_protected_bot_mutation(self) -> None:
+        protected_bot = User.objects.create(
+            username="addon:test",
+            full_name="Addon Bot",
+            email="addon-test@example.org",
+            is_bot=True,
+            is_active=False,
+        )
+
+        self.do_request(
+            "api:user-detail",
+            kwargs={"username": protected_bot.username},
+            method="get",
+            superuser=True,
+            code=200,
+        )
+        self.do_request(
+            "api:user-detail",
+            kwargs={"username": protected_bot.username},
+            method="patch",
+            superuser=True,
+            code=403,
+            request={"full_name": "Renamed Bot"},
+        )
+        self.do_request(
+            "api:user-detail",
+            kwargs={"username": protected_bot.username},
+            method="put",
+            superuser=True,
+            code=403,
+            request={
+                "full_name": "Renamed Bot",
+                "username": protected_bot.username,
+                "email": protected_bot.email,
+                "is_active": False,
+                "is_bot": True,
+            },
+        )
+        self.do_request(
+            "api:user-detail",
+            kwargs={"username": protected_bot.username},
+            method="delete",
+            superuser=True,
+            code=403,
+        )
+        protected_bot.refresh_from_db()
+        self.assertEqual(protected_bot.full_name, "Addon Bot")
+
+    def test_project_token_mutation(self) -> None:
+        project_token = User.objects.create(
+            username="bot-test-token",
+            full_name="Project Token",
+            email="bot-test-token@example.org",
+            is_bot=True,
+            is_active=False,
+        )
+
+        self.do_request(
+            "api:user-detail",
+            kwargs={"username": project_token.username},
+            method="patch",
+            superuser=True,
+            code=200,
+            request={"full_name": "Renamed Token"},
+        )
+        project_token.refresh_from_db()
+        self.assertEqual(project_token.full_name, "Renamed Token")
 
     def test_patch_logs_superuser_grant(self) -> None:
         target = User.objects.create_user("target", "target@example.org", "x")

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -748,8 +748,15 @@ class UserViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     def perm_check(
-        self, request: Request, obj: User | None = None, *, allow_self: bool = False
+        self,
+        request: Request,
+        obj: User | None = None,
+        *,
+        allow_self: bool = False,
+        protect_internal: bool = False,
     ) -> None:
+        if protect_internal and obj is not None and obj.is_internal:
+            self.permission_denied(request, gettext("This user can not be edited."))
         if allow_self and obj is not None and obj == request.user:
             return
         if not request.user.has_perm("user.edit"):
@@ -758,7 +765,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def update(self, request: Request, *args, **kwargs):
         """Change the user parameters."""
         instance = self.get_object()
-        self.perm_check(request, instance, allow_self=True)
+        self.perm_check(request, instance, allow_self=True, protect_internal=True)
         return super().update(request, *args, **kwargs)
 
     def create(self, request: Request, *args, **kwargs):
@@ -776,7 +783,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def destroy(self, request: Request, *args, **kwargs):
         """Delete all user information and mark the user inactive."""
         instance = self.get_object()
-        self.perm_check(request, instance)
+        self.perm_check(request, instance, protect_internal=True)
         remove_user(instance, cast("AuthenticatedHttpRequest", request))
         return Response(status=HTTP_204_NO_CONTENT)
 

--- a/weblate/auth/admin.py
+++ b/weblate/auth/admin.py
@@ -10,7 +10,7 @@ from django import forms
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.utils.translation import gettext, gettext_lazy
 
 from weblate.accounts.forms import FullNameField, UniqueEmailMixin, UniqueUsernameField
@@ -198,17 +198,24 @@ class WeblateUserAdmin(WeblateAuthAdmin, UserAdmin):
         return ",".join(obj.groups.values_list("name", flat=True))
 
     def action_checkbox(self, obj):
-        if obj.is_anonymous:
+        if obj.is_internal:
             return ""
         return super().action_checkbox(obj)
 
+    def has_change_permission(self, request: AuthenticatedHttpRequest, obj=None):
+        if obj and obj.is_internal:
+            return False
+        return super().has_change_permission(request, obj)
+
     def has_delete_permission(self, request: AuthenticatedHttpRequest, obj=None):
-        if obj and obj.is_anonymous:
+        if obj and obj.is_internal:
             return False
         return super().has_delete_permission(request, obj)
 
     def delete_model(self, request: AuthenticatedHttpRequest, obj) -> None:
         """Given a model instance delete it from the database."""
+        if obj.is_internal:
+            raise PermissionDenied
         remove_user(obj, request)
 
     def delete_queryset(self, request: AuthenticatedHttpRequest, queryset) -> None:
@@ -217,6 +224,8 @@ class WeblateUserAdmin(WeblateAuthAdmin, UserAdmin):
             self.delete_model(request, obj)
 
     def save_model(self, request: AuthenticatedHttpRequest, obj, form, change) -> None:
+        if change and obj.is_internal:
+            raise PermissionDenied
         if change:
             original = User.objects.get(pk=obj.pk)
             form.instance.store_audit_state(

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -902,6 +902,10 @@ class User(AbstractBaseUser):
     def is_anonymous(self):
         return self.username == settings.ANONYMOUS_USER_NAME
 
+    @cached_property
+    def is_internal(self):
+        return self.is_anonymous or (self.is_bot and ":" in self.username)
+
     def is_verified(self) -> bool:
         # django_otp overrides this method in OTPMiddleware
         return False

--- a/weblate/auth/tests/test_admin.py
+++ b/weblate/auth/tests/test_admin.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from django.conf import settings
 from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory, TestCase
 
 from weblate.auth.admin import WeblateUserAdmin
@@ -25,6 +27,52 @@ class WeblateUserAdminTest(TestCase):
         self.users_group = Group.objects.get(name="Users")
         self.viewers_group = Group.objects.get(name="Viewers")
         self.target.groups.set([self.users_group])
+
+    def test_protected_user_permissions(self) -> None:
+        request = self.factory.post("/")
+        request.user = self.actor
+        anonymous = User.objects.get(username=settings.ANONYMOUS_USER_NAME)
+        protected_bot = User.objects.create(
+            username="addon:test",
+            full_name="Addon Bot",
+            email="addon-test@example.org",
+            is_bot=True,
+            is_active=False,
+        )
+
+        for protected_user in (anonymous, protected_bot):
+            with self.subTest(username=protected_user.username):
+                self.assertEqual(self.user_admin.action_checkbox(protected_user), "")
+                self.assertFalse(
+                    self.user_admin.has_change_permission(request, protected_user)
+                )
+                self.assertFalse(
+                    self.user_admin.has_delete_permission(request, protected_user)
+                )
+                with self.assertRaises(PermissionDenied):
+                    self.user_admin.save_model(
+                        request,
+                        protected_user,
+                        SimpleNamespace(instance=protected_user),
+                        change=True,
+                    )
+                with self.assertRaises(PermissionDenied):
+                    self.user_admin.delete_model(request, protected_user)
+
+    def test_project_token_permissions(self) -> None:
+        request = self.factory.post("/")
+        request.user = self.actor
+        project_token = User.objects.create(
+            username="bot-test-token",
+            full_name="Project Token",
+            email="bot-test-token@example.org",
+            is_bot=True,
+            is_active=False,
+        )
+
+        self.assertNotEqual(self.user_admin.action_checkbox(project_token), "")
+        self.assertTrue(self.user_admin.has_change_permission(request, project_token))
+        self.assertTrue(self.user_admin.has_delete_permission(request, project_token))
 
     def test_save_related_audits_security_changes(self) -> None:
         request = self.factory.post("/")

--- a/weblate/templates/accounts/user.html
+++ b/weblate/templates/accounts/user.html
@@ -197,9 +197,11 @@
       <li class="nav-item">
         <a class="nav-link" data-bs-toggle="tab" data-bs-target="#groups" href="#">{% translate "Teams" %}</a>
       </li>
-      <li class="nav-item">
-        <a class="nav-link" data-bs-toggle="tab" data-bs-target="#edit" href="#">{% translate "Edit" %}</a>
-      </li>
+      {% if can_edit_page_user %}
+        <li class="nav-item">
+          <a class="nav-link" data-bs-toggle="tab" data-bs-target="#edit" href="#">{% translate "Edit" %}</a>
+        </li>
+      {% endif %}
     {% endif %}
   </ul>
 
@@ -350,11 +352,13 @@
                 </th>
                 <td class="number">{{ group.user__count }}</td>
                 <td>
-                  <a href=""
-                     class="btn btn-link btn-xs red link-post"
-                     data-href="{{ page_user.get_absolute_url }}"
-                     data-params='{"remove_group": {{ group.pk }} }'
-                     title="{% translate "Remove user from this team" %}">{% icon 'delete.svg' %}</a>
+                  {% if can_edit_page_user %}
+                    <a href=""
+                       class="btn btn-link btn-xs red link-post"
+                       data-href="{{ page_user.get_absolute_url }}"
+                       data-params='{"remove_group": {{ group.pk }} }'
+                       title="{% translate "Remove user from this team" %}">{% icon 'delete.svg' %}</a>
+                  {% endif %}
                 </td>
               </tr>
             {% endfor %}
@@ -376,163 +380,169 @@
                   <td></td>
                 {% endif %}
                 <td>
-                  <a href=""
-                     class="btn btn-link btn-xs link-post"
-                     data-href="{% url 'unblock-user' project=userblock.project.slug %}"
-                     data-params='{"user": "{{ userblock.user.username|escapejs }}"}'
-                     title="{% translate "Unblock user" %}">{% icon 'close.svg' %}</a>
+                  {% if can_edit_page_user %}
+                    <a href=""
+                       class="btn btn-link btn-xs link-post"
+                       data-href="{% url 'unblock-user' project=userblock.project.slug %}"
+                       data-params='{"user": "{{ userblock.user.username|escapejs }}"}'
+                       title="{% translate "Unblock user" %}">{% icon 'close.svg' %}</a>
+                  {% endif %}
                 </td>
               </tr>
             {% endfor %}
           </tbody>
         </table>
-        <div class="card">
-          <div class="card-header">
-            <h4 class="card-title">{% translate "Add user to a team" %}</h4>
+        {% if can_edit_page_user %}
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title">{% translate "Add user to a team" %}</h4>
+            </div>
+            <div class="card-body">{% crispy group_form %}</div>
           </div>
-          <div class="card-body">{% crispy group_form %}</div>
-        </div>
+        {% endif %}
       </div>
 
-      <div class="tab-pane" id="edit">
-        <form method="post">
-          {% csrf_token %}
-          <div class="card">
-            <div class="card-header">
-              <h4 class="card-title">{% translate "Edit user" %}</h4>
+      {% if can_edit_page_user %}
+        <div class="tab-pane" id="edit">
+          <form method="post">
+            {% csrf_token %}
+            <div class="card">
+              <div class="card-header">
+                <h4 class="card-title">{% translate "Edit user" %}</h4>
+              </div>
+              <div class="card-body">{{ form|crispy }}</div>
+              <div class="card-footer">
+                <input type="submit" value="{% translate "Save" %}" class="btn btn-primary" />
+              </div>
             </div>
-            <div class="card-body">{{ form|crispy }}</div>
-            <div class="card-footer">
-              <input type="submit" value="{% translate "Save" %}" class="btn btn-primary" />
-            </div>
-          </div>
-        </form>
-        <form method="post">
-          {% csrf_token %}
-          <div class="card">
-            <div class="card-header">
-              <h4 class="card-title">
-                {% documentation_icon 'admin/auth' '2fa' right=True %}
-                {% translate "Two-factor authentication" %}
-              </h4>
-            </div>
-            <div class="card-body">
+          </form>
+          <form method="post">
+            {% csrf_token %}
+            <div class="card">
+              <div class="card-header">
+                <h4 class="card-title">
+                  {% documentation_icon 'admin/auth' '2fa' right=True %}
+                  {% translate "Two-factor authentication" %}
+                </h4>
+              </div>
+              <div class="card-body">
+                {% if page_user.profile.has_2fa %}
+                  {% translate "The user has two-factor authentication." %}
+                {% else %}
+                  {% translate "The user doesn't have two-factor authentication." %}
+                {% endif %}
+              </div>
               {% if page_user.profile.has_2fa %}
-                {% translate "The user has two-factor authentication." %}
-              {% else %}
-                {% translate "The user doesn't have two-factor authentication." %}
+                <div class="card-footer">
+                  <input type="submit"
+                         name="remove_2fa"
+                         value="{% translate "Turn off two-factor authentication" %}"
+                         class="btn-danger red">
+                </div>
               {% endif %}
             </div>
-            {% if page_user.profile.has_2fa %}
+            <div class="card">
+              <div class="card-header text-bg-danger">
+                <h4 class="card-title">{% translate "Password reset" %}</h4>
+              </div>
+              <div class="card-body">{% translate "Disables password authentication for the user." %}</div>
               <div class="card-footer">
                 <input type="submit"
-                       name="remove_2fa"
-                       value="{% translate "Turn off two-factor authentication" %}"
-                       class="btn-danger red">
+                       name="disable_password"
+                       value="{% translate "Disable password" %}"
+                       class="btn btn-danger red">
               </div>
-            {% endif %}
-          </div>
-          <div class="card">
-            <div class="card-header text-bg-danger">
-              <h4 class="card-title">{% translate "Password reset" %}</h4>
             </div>
-            <div class="card-body">{% translate "Disables password authentication for the user." %}</div>
-            <div class="card-footer">
-              <input type="submit"
-                     name="disable_password"
-                     value="{% translate "Disable password" %}"
-                     class="btn btn-danger red">
+            <div class="card">
+              <div class="card-header text-bg-danger">
+                <h4 class="card-title">
+                  {% documentation_icon 'admin/access' 'cleanup-user-contributions' right=True %}
+                  {% translate "Contribution cleanup" %}
+                </h4>
+              </div>
+              <div class="card-body">
+                {% blocktranslate with user=page_user.username %}Clean up translations, suggestions, and comments from {{ user }} across all projects.{% endblocktranslate %}
+              </div>
+              <div class="card-footer">
+                <input type="button"
+                       name="cleanup_user_contributions"
+                       value="{% translate "Choose cleanup actions" %}"
+                       class="btn btn-primary"
+                       data-bs-toggle="modal"
+                       data-bs-target="#revert_user_edits_{{ page_user.id }}">
+              </div>
             </div>
-          </div>
-          <div class="card">
-            <div class="card-header text-bg-danger">
-              <h4 class="card-title">
-                {% documentation_icon 'admin/access' 'cleanup-user-contributions' right=True %}
-                {% translate "Contribution cleanup" %}
-              </h4>
-            </div>
-            <div class="card-body">
-              {% blocktranslate with user=page_user.username %}Clean up translations, suggestions, and comments from {{ user }} across all projects.{% endblocktranslate %}
-            </div>
-            <div class="card-footer">
-              <input type="button"
-                     name="cleanup_user_contributions"
-                     value="{% translate "Choose cleanup actions" %}"
-                     class="btn btn-primary"
-                     data-bs-toggle="modal"
-                     data-bs-target="#revert_user_edits_{{ page_user.id }}">
-            </div>
-          </div>
-          <div class="modal fade"
-               tabindex="-1"
-               role="dialog"
-               id="revert_user_edits_{{ page_user.id }}">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h4 class="modal-title">{% translate "Choose cleanup actions" %}</h4>
-                  <button type="button"
-                          class="btn-close"
-                          data-bs-dismiss="modal"
-                          aria-label="{% translate "Close" %}"></button>
-                </div>
-                <div class="modal-body">
-                  {% blocktranslate with user=page_user.username %}Choose which contributions by <b>{{ user }}</b> to clean up across all projects.{% endblocktranslate %}
-                  {% include "snippets/user-contribution-cleanup.html" with cleanup_user=page_user cleanup_id="admin" show_revert_edits=True cleanup_sitewide=True only %}
-                </div>
-                <div class="modal-footer">
-                  <input type="submit"
-                         name="cleanup_user_contributions"
-                         value="{% translate "Clean up selected contributions" %}"
-                         class="btn btn-danger" />
+            <div class="modal fade"
+                 tabindex="-1"
+                 role="dialog"
+                 id="revert_user_edits_{{ page_user.id }}">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h4 class="modal-title">{% translate "Choose cleanup actions" %}</h4>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="modal"
+                            aria-label="{% translate "Close" %}"></button>
+                  </div>
+                  <div class="modal-body">
+                    {% blocktranslate with user=page_user.username %}Choose which contributions by <b>{{ user }}</b> to clean up across all projects.{% endblocktranslate %}
+                    {% include "snippets/user-contribution-cleanup.html" with cleanup_user=page_user cleanup_id="admin" show_revert_edits=True cleanup_sitewide=True only %}
+                  </div>
+                  <div class="modal-footer">
+                    <input type="submit"
+                           name="cleanup_user_contributions"
+                           value="{% translate "Clean up selected contributions" %}"
+                           class="btn btn-danger" />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div class="card">
-            <div class="card-header text-bg-danger">
-              <h4 class="card-title">{% translate "Removal" %}</h4>
-            </div>
-            <div class="card-body">{% translate "Account removal deletes all user private data." %}</div>
-            <div class="card-footer">
-              <input type="button"
-                     name="remove_user"
-                     value="{% translate "Delete" %}"
-                     class="btn btn-danger red"
-                     data-bs-toggle="modal"
-                     data-bs-target="#delete_user_{{ page_user.id }}">
-            </div>
-          </div>
-          <div class="modal fade"
-               tabindex="-1"
-               role="dialog"
-               id="delete_user_{{ page_user.id }}">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h4 class="modal-title">{% translate "Are you absolutely sure?" %}</h4>
-                  <button type="button"
-                          class="btn-close"
-                          data-bs-dismiss="modal"
-                          aria-label="{% translate "Close" %}"></button>
-                </div>
-                <div class="modal-body">
-                  {% blocktranslate with user=page_user.username %}This will remove <b>{{ user }}</b> from Weblate.{% endblocktranslate %}
-                </div>
-                <div class="modal-footer">
-                  <input type="submit"
-                         name="remove_user"
-                         value="{% translate "Delete" %}"
-                         class="btn btn-danger" />
-                </div>
+            <div class="card">
+              <div class="card-header text-bg-danger">
+                <h4 class="card-title">{% translate "Removal" %}</h4>
               </div>
-              <!-- /.modal-content -->
+              <div class="card-body">{% translate "Account removal deletes all user private data." %}</div>
+              <div class="card-footer">
+                <input type="button"
+                       name="remove_user"
+                       value="{% translate "Delete" %}"
+                       class="btn btn-danger red"
+                       data-bs-toggle="modal"
+                       data-bs-target="#delete_user_{{ page_user.id }}">
+              </div>
             </div>
-            <!-- /.modal-dialog -->
-          </div>
-          <!-- /.modal -->
-        </form>
-      </div>
+            <div class="modal fade"
+                 tabindex="-1"
+                 role="dialog"
+                 id="delete_user_{{ page_user.id }}">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h4 class="modal-title">{% translate "Are you absolutely sure?" %}</h4>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="modal"
+                            aria-label="{% translate "Close" %}"></button>
+                  </div>
+                  <div class="modal-body">
+                    {% blocktranslate with user=page_user.username %}This will remove <b>{{ user }}</b> from Weblate.{% endblocktranslate %}
+                  </div>
+                  <div class="modal-footer">
+                    <input type="submit"
+                           name="remove_user"
+                           value="{% translate "Delete" %}"
+                           class="btn btn-danger" />
+                  </div>
+                </div>
+                <!-- /.modal-content -->
+              </div>
+              <!-- /.modal-dialog -->
+            </div>
+            <!-- /.modal -->
+          </form>
+        </div>
+      {% endif %}
 
     {% endif %}
 


### PR DESCRIPTION
Internal bot and anonymous accounts are managed by Weblate and can use usernames that do not validate through normal user forms. Block generic user editing surfaces while leaving project token users manageable through project access.

Fixes #20226

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
