### PR TITLE
fix: use fractional sizing for highlight overlays

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -649,9 +649,9 @@ function initHighlight(root) {
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         if (entry.target === input) {
-          // match the height and width of the output area to the input area
-          highlight.style.height = `${input.offsetHeight}px`;
-          highlight.style.width = `${input.offsetWidth}px`;
+          const rect = input.getBoundingClientRect();
+          highlight.style.height = `${rect.height}px`;
+          highlight.style.width = `${rect.width}px`;
         }
       }
     });
@@ -758,9 +758,9 @@ function initHighlight(root) {
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         if (entry.target === editor) {
-          // match the height and width of the output area to the input area
-          highlight.style.height = `${editor.offsetHeight}px`;
-          highlight.style.width = `${editor.offsetWidth}px`;
+          const rect = editor.getBoundingClientRect();
+          highlight.style.height = `${rect.height}px`;
+          highlight.style.width = `${rect.width}px`;
         }
       }
     });


### PR DESCRIPTION
Uses fractional sizing for highlighting, fixing most occurances of the disappearing characters bug
Fixes https://github.com/WeblateOrg/weblate/issues/13977
Note: this doesn't remove the issue entirely, browser inline box size rounding can still make this occur, however this fix should make the issue much rarer
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
