### PR TITLE
fix(machinery): recover malformed LLM JSON replies

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,7 @@ Weblate 2026.7.1
 * Dismissing a failing check no longer shows a JSON parsing error in the translation editor.
 * Screenshot searches without an explicit field now match screenshot names only, and the search box links to the full screenshot search documentation.
 * Anonymous and internal bot accounts can no longer be edited through generic user management.
+* LLM machine translation suggestions now recover from more malformed structured JSON replies.
 
 .. rubric:: Compatibility
 

--- a/weblate/machinery/llm.py
+++ b/weblate/machinery/llm.py
@@ -185,7 +185,8 @@ LLM_NEUTRAL_PREVIOUS_EXAMPLE_SOURCES = (
 )
 LLM_JSON_ARRAY_STRING_TERMINATORS = frozenset({",", "]"})
 LLM_JSON_OBJECT_KEY_STRING_TERMINATORS = frozenset({":"})
-LLM_JSON_OBJECT_VALUE_STRING_TERMINATORS = frozenset({",", "}"})
+# Accept "]" to repair object values missing a closing "}" before a parent array.
+LLM_JSON_OBJECT_VALUE_STRING_TERMINATORS = frozenset({",", "}", "]"})
 
 
 class LLMGlossaryEntry(TypedDict, total=False):
@@ -1321,6 +1322,14 @@ class BaseLLMTranslation(BatchMachineTranslation):
             if char == '"':
                 next_index = cls._skip_json_whitespace(content, index + 1)
                 if next_index < len(content) and content[next_index] == '"':
+                    after_quote = cls._skip_json_whitespace(content, next_index + 1)
+                    if after_quote < len(content) and (
+                        content[after_quote] in terminators
+                        and cls._has_valid_json_container_end(content, after_quote)
+                    ):
+                        repaired.append('\\"')
+                        index += 1
+                        continue
                     return None, index
                 if next_index < len(content) and (
                     content[next_index] not in terminators
@@ -1434,6 +1443,10 @@ class BaseLLMTranslation(BatchMachineTranslation):
                 index += 1
                 break
 
+            if item_count and content[index] == "]":
+                repaired.append("}")
+                break
+
             if item_count:
                 if content[index] != ",":
                     return None, index
@@ -1464,7 +1477,27 @@ class BaseLLMTranslation(BatchMachineTranslation):
         return "".join(repaired), index
 
     @classmethod
+    def _unwrap_json_code_fence(cls, content: str) -> str:
+        index = cls._skip_json_whitespace(content, 0)
+        end = len(content.rstrip())
+        if not content.startswith("```", index) or not content.startswith(
+            "```", end - 3
+        ):
+            return content
+
+        header_end = content.find("\n", index + 3, end)
+        if header_end == -1:
+            return content
+
+        fence_info = content[index + 3 : header_end].strip().lower()
+        if fence_info and fence_info != "json":
+            return content
+
+        return content[header_end + 1 : end - 3]
+
+    @classmethod
     def _repair_json_string_array(cls, content: str) -> str | None:
+        content = cls._unwrap_json_code_fence(content)
         index = cls._skip_json_whitespace(content, 0)
         if index >= len(content) or content[index] != "[":
             return None

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -4790,6 +4790,44 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         )
 
     @responses.activate
+    def test_translate_repairs_invalid_structured_json_string_quote_at_end(
+        self,
+    ) -> None:
+        source = "Synthetic source string for terminal quote recovery."
+        self.mock_response(
+            '[{"parts":[{"type":"text","text":"Synthetic terminal quote""}]}]'
+        )
+
+        translation = self.assert_translate(
+            "cs",
+            source,
+            1,
+        )
+
+        self.assertEqual(
+            translation[0][0]["text"],
+            'Synthetic terminal quote"',
+        )
+
+    @responses.activate
+    def test_translate_repairs_structured_json_code_fence(self) -> None:
+        source = "Synthetic source string for fenced JSON recovery."
+        self.mock_response(
+            '```json\n[{"parts":[{"type":"text","text":"Synthetic fenced translation"}]}]\n```'
+        )
+
+        translation = self.assert_translate(
+            "hr",
+            source,
+            1,
+        )
+
+        self.assertEqual(
+            translation[0][0]["text"],
+            "Synthetic fenced translation",
+        )
+
+    @responses.activate
     def test_translate_repairs_truncated_structured_json_container(self) -> None:
         self.mock_response(
             '[{"parts":[{"type":"text","text":"Genel Müdür"}]},'
@@ -4804,6 +4842,22 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         self.assertEqual(translation["CEO"][0]["text"], "Genel Müdür")
         self.assertEqual(translation["CEO Since"][0]["text"], "CEO'dan beri")
+
+    @responses.activate
+    def test_translate_repairs_missing_structured_part_object_close(self) -> None:
+        source = "Synthetic source string for missing object close recovery."
+        response = (
+            '[{"parts": [{"type": "text", "text": '
+            '"Synthetic missing object close translation."]}]'
+        )
+        self.mock_response(response)
+
+        translation = self.assert_translate("cs", source, 1)
+
+        self.assertEqual(
+            translation[0][0]["text"],
+            "Synthetic missing object close translation.",
+        )
 
     @responses.activate
     def test_translate_uses_llm_placeholder_syntax(self) -> None:


### PR DESCRIPTION
LLM providers sometimes wrap structured replies in code fences or emit nearly valid JSON. Repair these common shapes before strict validation so automatic suggestions do not fail unnecessarily.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
