### PR TITLE
fix(notifications): enforce component access for recipients

### DIFF
--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -236,6 +236,16 @@ class Notification:
         except ObjectDoesNotExist:
             return False
 
+    def can_access_target(
+        self,
+        user: User,
+        project: Project | None,
+        component: Component | None,
+    ) -> bool:
+        if component is not None:
+            return user.can_access_component(component)
+        return project is None or user.can_access_project(project)
+
     def get_users(
         self,
         frequency: NotificationFrequency,
@@ -268,6 +278,8 @@ class Notification:
 
             last_user = user
             if subscription.frequency != frequency:
+                continue
+            if not self.can_access_target(user, project, component):
                 continue
             if frequency == NotificationFrequency.FREQ_INSTANT and (
                 change is None or self.should_skip(user, change)

--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -535,6 +535,23 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
             self.user.username,
         )
 
+    def test_notify_new_comment_skips_restricted_component_without_access(self) -> None:
+        Subscription.objects.all().delete()
+        self.subscribe_participation_comment(self.user)
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.can_access_project(self.project))
+        self.assertFalse(self.user.can_access_component(self.component))
+
+        unit = self.get_unit()
+        self.create_comment_change(unit, self.user, "Question")
+        mail.outbox.clear()
+
+        self.create_comment_change(unit, self.thirduser, "Answer")
+
+        self.validate_notifications(0)
+
     def test_notify_new_comment_source_commenter(self) -> None:
         Subscription.objects.all().delete()
         self.subscribe_participation_comment(self.user)


### PR DESCRIPTION
### Motivation
- Close a confidentiality leak where comment notifications could be sent to users who no longer have access to a restricted component because recipients were selected by project-only checks and historical participation.
- Ensure component-scoped notification delivery enforces the same component-level authorization used elsewhere (`can_access_component`).

### Description
- Add `can_access_target(self, user, project, component)` to `Notification` to require `user.can_access_component(component)` when a component is involved and fall back to project access otherwise (file: `weblate/accounts/notifications.py`).
- Apply the new access check in `get_users` so subscriptions are skipped if the user lacks access to the target component before yielding recipients (file: `weblate/accounts/notifications.py`).
- Add a regression test `test_notify_new_comment_skips_restricted_component_without_access` that verifies a previous commenter with project access but without component access does not receive follow-up comment notifications (file: `weblate/accounts/tests/test_notifications.py`).

### Testing
- Ran the focused pytest cases `weblate/accounts/tests/test_notifications.py::NotificationTest::test_notify_new_comment_skips_restricted_component_without_access` and `weblate/accounts/tests/test_notifications.py::NotificationTest::test_notify_new_comment_previous_commenter`, and both passed.
- Ran formatting and lint checks with `uv run prek run ruff-format --files weblate/accounts/notifications.py weblate/accounts/tests/test_notifications.py` and `uv run prek run ruff-check --files weblate/accounts/notifications.py weblate/accounts/tests/test_notifications.py`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e6ce9d7008329a040c74e5b998c48)