### PR TITLE
fix(auth): skip bot email sync for unmigrated databases

### DIFF
--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -21,7 +21,7 @@ from django.contrib.auth.models import Group as DjangoGroup
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator as DjangoEmailValidator
 from django.core.validators import MinValueValidator
-from django.db import models
+from django.db import models, router
 from django.db.models import Q, UniqueConstraint
 from django.db.models.functions import Upper
 from django.db.models.signals import m2m_changed, post_delete, post_save
@@ -536,6 +536,9 @@ def format_internal_bot_email(scope: str, name: str) -> str:
 def sync_internal_bot_emails(sender, **kwargs) -> None:
     """Update internal bot e-mails to match configured template."""
     using = kwargs.get("using")
+    if using is not None and not router.allow_migrate_model(using, User):
+        return
+
     queryset = User.objects.filter(is_bot=True, username__contains=":").order_by("pk")
     if using is not None:
         queryset = queryset.using(using)

--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -32,6 +32,13 @@ from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 
 
+class SkipWeblateAuthMigrationsRouter:
+    def allow_migrate(self, db, app_label, model_name=None, **hints) -> bool | None:
+        if app_label == "weblate_auth":
+            return False
+        return None
+
+
 class InternalBotEmailTest(TestCase):
     def setUp(self) -> None:
         bot_cache.get({}).clear()
@@ -130,6 +137,17 @@ class InternalBotEmailTest(TestCase):
     def test_format_internal_bot_email_validates_email(self) -> None:
         with self.assertRaises(ValidationError):
             format_internal_bot_email("mt", "addon")
+
+    @override_settings(
+        DATABASE_ROUTERS=[
+            "weblate.auth.tests.test_models.SkipWeblateAuthMigrationsRouter"
+        ]
+    )
+    def test_sync_internal_bot_emails_skips_unmigrated_database(self) -> None:
+        with patch.object(User.objects, "filter") as filter_mock:
+            sync_internal_bot_emails(None, using="default")
+
+        filter_mock.assert_not_called()
 
 
 class ModelTest(FixtureComponentTestCase):


### PR DESCRIPTION
Django emits post_migrate per database, including databases where routers block Weblate auth migrations. Avoid querying the user table there so hosted multi-database test setup does not fail.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
