### PR TITLE
fix(addons): harden Fedora Messaging publishing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,7 +26,7 @@ Weblate 2026.7.1
 * Filtered translation and zen navigation now reuse a stable session result list, keeping positions and counts stable after translated strings leave the filter.
 * Component priority icons are no longer shown on translation listings.
 * :ref:`check-punctuation-spacing` no longer flags Markdown image markers as French punctuation and now shows which punctuation marks triggered the check.
-* :ref:`addon-weblate.fedora_messaging.publish` broker TLS validation now matches the Fedora Messaging transport when accepting non-strict CA certificate chains.
+* :ref:`addon-weblate.fedora_messaging.publish` received several reliability fixes.
 * The :guilabel:`Things to check` panel no longer uses error highlighting for suggestions and other non-error translation states.
 * Translation workflow customization now makes it clearer when per-language workflow settings are disabled until customization is enabled.
 * Anonymous user permission caches are now isolated between requests.

--- a/weblate/addons/fedora_messaging.py
+++ b/weblate/addons/fedora_messaging.py
@@ -4,10 +4,14 @@
 
 from __future__ import annotations
 
+import logging
 import socket
 import ssl
+import threading
 import time
 from copy import deepcopy
+from dataclasses import dataclass
+from hashlib import sha256
 from typing import TYPE_CHECKING, Protocol, cast
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -15,6 +19,7 @@ from cryptography import x509
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import serialization
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext, gettext_lazy
 from OpenSSL import SSL
@@ -43,6 +48,7 @@ if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
     from weblate_schemas.messages import WeblateV1Message
 
+    from weblate.addons.models import AddonActivityLog
     from weblate.trans.models import Category, Change, Component, Project
 
 
@@ -53,7 +59,19 @@ PEM_LABEL_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ")
 TLS_CREDENTIAL_FIELDS = frozenset({"ca_cert", "client_key", "client_cert"})
 TLS_PROBE_TIMEOUT = 5
 SERVICE_STOP_TIMEOUT = 5
+PUBLISH_TIMEOUT_REPORT_INTERVAL = 3600
 TOPIC_PREFIX_MAX_LENGTH = 50
+
+LOGGER = logging.getLogger(__name__)
+FEDORA_MESSAGING_PUBLISH_LOCK = threading.RLock()
+
+
+@dataclass
+class FedoraMessagingServiceState:
+    generation: int = 0
+
+
+FEDORA_MESSAGING_SERVICE_STATE = FedoraMessagingServiceState()
 
 
 class BrokerParameters(Protocol):
@@ -151,26 +169,42 @@ class FedoraMessagingAddon(ChangeBaseAddon):
             retry_delay=retry_delay,
         )
 
-        # Apply configuration
-        self.configure_fedora_messaging(
-            amqp_url=config["amqp_url"],
-            ca_cert=config.get("ca_cert"),
-            client_key=config.get("client_key"),
-            client_cert=config.get("client_cert"),
-            connection_attempts=connection_attempts,
-            retry_delay=retry_delay,
-        )
+        with FEDORA_MESSAGING_PUBLISH_LOCK:
+            # Apply configuration
+            self.configure_fedora_messaging(
+                amqp_url=config["amqp_url"],
+                ca_cert=config.get("ca_cert"),
+                client_key=config.get("client_key"),
+                client_cert=config.get("client_cert"),
+                connection_attempts=connection_attempts,
+                retry_delay=retry_delay,
+            )
 
-        # Build message payload
-        message = WeblateV1Message(
-            topic=self.get_prefixed_topic(
-                self.get_change_topic(change), config.get("topic_prefix")
-            ),
-            headers=self.get_change_headers(change),
-            body=self.get_change_body(change),
-        )
-        self.publish_message(message, amqp_url, change.project, timeout=publish_timeout)
+            # Build message payload
+            message = WeblateV1Message(
+                topic=self.get_prefixed_topic(
+                    self.get_change_topic(change), config.get("topic_prefix")
+                ),
+                headers=self.get_change_headers(change),
+                body=self.get_change_body(change),
+            )
+            self.publish_message(
+                message,
+                amqp_url,
+                change.project,
+                timeout=publish_timeout,
+                connection_attempts=connection_attempts,
+                retry_delay=retry_delay,
+            )
         return {"message_id": message.id}
+
+    def render_activity_log(self, activity: AddonActivityLog) -> str:
+        result = activity.details.get("result")
+        if isinstance(result, dict) and result.get("message_id"):
+            return gettext("Message ID: %(message_id)s") % {
+                "message_id": result["message_id"]
+            }
+        return super().render_activity_log(activity)
 
     @staticmethod
     def publish_message(
@@ -178,38 +212,156 @@ class FedoraMessagingAddon(ChangeBaseAddon):
         amqp_url: str,
         project: Project | None,
         timeout: int = DEFAULT_FEDORA_MESSAGING_PUBLISH_TIMEOUT,
+        connection_attempts: int = DEFAULT_FEDORA_MESSAGING_CONNECTION_ATTEMPTS,
+        retry_delay: int = DEFAULT_FEDORA_MESSAGING_RETRY_DELAY,
     ) -> None:
         """Publish message and report Fedora Messaging failures with context."""
         # ruff: ignore[import-outside-top-level]
         import fedora_messaging.api
 
-        try:
-            fedora_messaging.api.publish(message, timeout=timeout)
-        except Exception as error:
-            FedoraMessagingAddon._reset_fedora_messaging_service()
-            FedoraMessagingAddon._report_publish_error(
-                message, amqp_url, project, error
-            )
-            raise FedoraMessagingPublishError(
-                FedoraMessagingAddon._get_publish_error_message(error)
-            ) from error
+        with FEDORA_MESSAGING_PUBLISH_LOCK:
+            try:
+                FedoraMessagingAddon._prepare_fedora_messaging_service(
+                    connection_attempts=connection_attempts,
+                    retry_delay=retry_delay,
+                )
+                fedora_messaging.api.publish(message, timeout=timeout)
+            except Exception as error:
+                FedoraMessagingAddon._reset_fedora_messaging_service()
+                FedoraMessagingAddon._report_publish_error(
+                    message, amqp_url, project, error
+                )
+                raise FedoraMessagingPublishError(
+                    FedoraMessagingAddon._get_publish_error_message(error)
+                ) from error
 
     @staticmethod
-    def _reset_fedora_messaging_service() -> None:
+    def _prepare_fedora_messaging_service(
+        *, connection_attempts: int, retry_delay: int
+    ) -> None:
+        # ruff: ignore[import-outside-top-level]
+        import crochet
+
         # ruff: ignore[import-outside-top-level]
         import fedora_messaging.api
 
-        # A timeout can leave the Twisted publisher service in a stale state.
-        # Stop and reset it so the next publish attempt creates a fresh connection.
-        # ruff: ignore[private-member-access]
-        twisted_service = fedora_messaging.api._twisted_service
-        stop_service = getattr(twisted_service, "stopService", None)
-        if callable(stop_service):
-            FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)
-        fedora_messaging.api._twisted_service = None  # noqa: SLF001
+        crochet.setup()
+
+        if FedoraMessagingAddon._is_fedora_messaging_service_stale(
+            fedora_messaging.api._twisted_service  # noqa: SLF001
+        ):
+            LOGGER.warning("Resetting stale Fedora Messaging publisher service")
+            add_breadcrumb(
+                "fedora_messaging",
+                "Resetting stale Fedora Messaging publisher service",
+                level="warning",
+            )
+            if not FedoraMessagingAddon._reset_fedora_messaging_service():
+                msg = "Could not reset stale Fedora Messaging publisher service."
+                raise RuntimeError(msg)
+
+        cancel_prepare = threading.Event()
+        service_generation = (
+            FedoraMessagingAddon._get_fedora_messaging_service_generation()
+        )
+
+        @crochet.run_in_reactor
+        def prepare_service() -> None:
+            if (
+                cancel_prepare.is_set()
+                or service_generation
+                != FedoraMessagingAddon._get_fedora_messaging_service_generation()
+            ):
+                return
+            # Fedora Messaging uses Twisted for publishing. Pika parses
+            # connection_attempts and retry_delay from the AMQP URL, but those
+            # values do not drive Twisted's reconnect factory.
+            # ruff: ignore[private-member-access]
+            service = fedora_messaging.api._init_twisted_service()
+            FedoraMessagingAddon._configure_fedora_messaging_publish_retries(
+                service,
+                connection_attempts=connection_attempts,
+                retry_delay=retry_delay,
+            )
+
+        result = prepare_service()
+        try:
+            result.wait(timeout=SERVICE_STOP_TIMEOUT)
+        except crochet.TimeoutError:
+            cancel_prepare.set()
+            FedoraMessagingAddon._bump_fedora_messaging_service_generation()
+            result.cancel()
+            raise
 
     @staticmethod
-    def _stop_fedora_messaging_service(stop_service: Callable[[], object]) -> None:
+    def _get_fedora_messaging_service_generation() -> int:
+        return FEDORA_MESSAGING_SERVICE_STATE.generation
+
+    @staticmethod
+    def _bump_fedora_messaging_service_generation() -> None:
+        FEDORA_MESSAGING_SERVICE_STATE.generation += 1
+
+    @staticmethod
+    def _configure_fedora_messaging_publish_retries(
+        service: object, *, connection_attempts: int, retry_delay: int
+    ) -> None:
+        factory = getattr(service, "factory", None)
+        if factory is None:
+            return
+        factory.maxRetries = max(connection_attempts - 1, 0)
+        factory.initialDelay = retry_delay
+        factory.delay = retry_delay
+        factory.maxDelay = retry_delay
+        factory.factor = 1
+        factory.jitter = 0
+
+    @staticmethod
+    def _is_fedora_messaging_service_stale(service: object | None) -> bool:
+        if service is None:
+            return False
+        if not getattr(service, "running", True):
+            return True
+
+        factory = getattr(service, "factory", None)
+        if factory is None:
+            return False
+        if not getattr(factory, "continueTrying", True):
+            return True
+
+        client = getattr(factory, "_client", None)
+        if client is not None and not getattr(client, "is_closed", True):
+            return False
+        if getattr(factory, "_callID", None) is not None:
+            return False
+
+        max_retries = getattr(factory, "maxRetries", None)
+        retries = getattr(factory, "retries", 0)
+        return max_retries is not None and retries > max_retries
+
+    @staticmethod
+    def _reset_fedora_messaging_service() -> bool:
+        # ruff: ignore[import-outside-top-level]
+        import fedora_messaging.api
+
+        with FEDORA_MESSAGING_PUBLISH_LOCK:
+            # A timeout can leave the Twisted publisher service in a stale state.
+            # Stop and reset it so the next publish attempt creates a fresh connection.
+            # ruff: ignore[private-member-access]
+            twisted_service = fedora_messaging.api._twisted_service
+            if twisted_service is None:
+                return True
+
+            FedoraMessagingAddon._bump_fedora_messaging_service_generation()
+            stop_service = getattr(twisted_service, "stopService", None)
+            if callable(
+                stop_service
+            ) and not FedoraMessagingAddon._stop_fedora_messaging_service(stop_service):
+                return False
+            fedora_messaging.api._twisted_service = None  # noqa: SLF001
+            return True
+
+    @staticmethod
+    def _stop_fedora_messaging_service(stop_service: Callable[[], object]) -> bool:
         # ruff: ignore[import-outside-top-level]
         import crochet
 
@@ -223,8 +375,11 @@ class FedoraMessagingAddon(ChangeBaseAddon):
         except crochet.TimeoutError:
             result.cancel()
             report_error("Fedora Messaging service shutdown timed out", level="error")
+            return False
         except Exception:
             report_error("Fedora Messaging service shutdown failed", level="error")
+            return False
+        return True
 
     @staticmethod
     def _report_publish_error(
@@ -242,7 +397,35 @@ class FedoraMessagingAddon(ChangeBaseAddon):
             exception_class=error.__class__.__name__,
             **FedoraMessagingAddon._get_broker_context(amqp_url),
         )
-        report_error("Fedora Messaging publish failed", level="error", project=project)
+        report_error(
+            "Fedora Messaging publish failed",
+            level="error",
+            project=project,
+            skip_error_reporting=not FedoraMessagingAddon._should_report_publish_error(
+                error, amqp_url, project
+            ),
+        )
+
+    @staticmethod
+    def _should_report_publish_error(
+        error: Exception, amqp_url: str, project: Project | None
+    ) -> bool:
+        # ruff: ignore[import-outside-top-level]
+        from fedora_messaging import exceptions as fedora_messaging_exceptions
+
+        if not isinstance(error, fedora_messaging_exceptions.PublishTimeout):
+            return True
+
+        cache_key = "fedora-messaging-publish-timeout-report:{}".format(
+            sha256(
+                f"{project.slug if project else ''}\0{amqp_url}".encode()
+            ).hexdigest()
+        )
+        try:
+            return cache.add(cache_key, True, PUBLISH_TIMEOUT_REPORT_INTERVAL)
+        except Exception:
+            # Fail open so cache outages do not hide persistent publish failures.
+            return True
 
     @staticmethod
     def _get_broker_context(amqp_url: str) -> dict[str, object]:
@@ -270,7 +453,7 @@ class FedoraMessagingAddon(ChangeBaseAddon):
 
         if isinstance(error, fedora_messaging_exceptions.PublishTimeout):
             return gettext(
-                "Fedora Messaging publish timed out; the broker did not confirm delivery: %(error)s"
+                "Fedora Messaging publish timed out; the broker connection or delivery confirmation did not complete: %(error)s"
             ) % {"error": error}
         if FedoraMessagingAddon._is_missing_publisher_error(error):
             return gettext(
@@ -386,79 +569,86 @@ class FedoraMessagingAddon(ChangeBaseAddon):
     ) -> None:
         """Configure Fedora Messaging."""
         # ruff: ignore[import-outside-top-level]
-
         import fedora_messaging.config
 
-        ca_cert = FedoraMessagingAddon._normalize_pem(ca_cert)
-        client_key = FedoraMessagingAddon._normalize_pem(client_key)
-        client_cert = FedoraMessagingAddon._normalize_pem(client_cert)
-        amqp_url = FedoraMessagingAddon.get_configured_amqp_url(
-            amqp_url,
-            connection_attempts=connection_attempts,
-            retry_delay=retry_delay,
-        )
+        # ruff: ignore[import-outside-top-level]
+        from fedora_messaging.exceptions import ConfigurationException
 
-        # Hash certificates to detect configuration changes
-        cert_hash = siphash(
-            "Fedora Messaging", f"CA:{ca_cert},KEY:{client_key},CERT:{client_cert}"
-        )
+        with FEDORA_MESSAGING_PUBLISH_LOCK:
+            ca_cert = FedoraMessagingAddon._normalize_pem(ca_cert)
+            client_key = FedoraMessagingAddon._normalize_pem(client_key)
+            client_cert = FedoraMessagingAddon._normalize_pem(client_cert)
+            amqp_url = FedoraMessagingAddon.get_configured_amqp_url(
+                amqp_url,
+                connection_attempts=connection_attempts,
+                retry_delay=retry_delay,
+            )
 
-        messaging_config = fedora_messaging.config.conf
+            # Hash certificates to detect configuration changes
+            cert_hash = siphash(
+                "Fedora Messaging",
+                f"CA:{ca_cert},KEY:{client_key},CERT:{client_cert}",
+            )
 
-        if (
-            not force_update
-            and messaging_config.loaded
-            and messaging_config["amqp_url"] == amqp_url
-            and messaging_config["consumer_config"].get("weblate_cert_hash")
-            == cert_hash
-        ):
-            return
+            messaging_config = fedora_messaging.config.conf
 
-        FedoraMessagingAddon.validate_tls_credentials(
-            ca_cert=ca_cert, client_key=client_key, client_cert=client_cert
-        )
+            if (
+                not force_update
+                and messaging_config.loaded
+                and messaging_config["amqp_url"] == amqp_url
+                and messaging_config["consumer_config"].get("weblate_cert_hash")
+                == cert_hash
+            ):
+                return
 
-        # Discard existing Twisted service as configuration has changed
-        FedoraMessagingAddon._reset_fedora_messaging_service()
+            FedoraMessagingAddon.validate_tls_credentials(
+                ca_cert=ca_cert, client_key=client_key, client_cert=client_cert
+            )
 
-        # Avoid loading settings file
-        messaging_config.loaded = True
+            # Discard existing Twisted service as configuration has changed
+            if not FedoraMessagingAddon._reset_fedora_messaging_service():
+                raise ConfigurationException(
+                    gettext("Could not reset Fedora Messaging publisher service.")
+                )
 
-        # Apply defaults
-        messaging_config.update(deepcopy(fedora_messaging.config.DEFAULTS))
+            # Avoid loading settings file
+            messaging_config.loaded = True
 
-        # We misuse consumer configuration to store certificate info to allow fast change detection
-        messaging_config["consumer_config"]["weblate_cert_hash"] = cert_hash
+            # Apply defaults
+            messaging_config.update(deepcopy(fedora_messaging.config.DEFAULTS))
 
-        # Update AMQP URL
-        messaging_config["amqp_url"] = amqp_url
+            # We misuse consumer configuration to store certificate info to allow fast change detection
+            messaging_config["consumer_config"]["weblate_cert_hash"] = cert_hash
 
-        # Store TLS configuration
-        certs_path = data_path("cache") / "fedora-messaging"
-        certs_path.mkdir(parents=True, exist_ok=True)
-        if ca_cert:
-            ca_cert_file = certs_path / "ca.crt"
-            FedoraMessagingAddon._write_pem_file(ca_cert_file, ca_cert)
-            messaging_config["tls"]["ca_cert"] = ca_cert_file.as_posix()
-        if client_key:
-            key_file = certs_path / "client.key"
-            FedoraMessagingAddon._write_pem_file(key_file, client_key)
-            messaging_config["tls"]["keyfile"] = key_file.as_posix()
-        if client_cert:
-            cert_file = certs_path / "client.crt"
-            FedoraMessagingAddon._write_pem_file(cert_file, client_cert)
-            messaging_config["tls"]["certfile"] = cert_file.as_posix()
+            # Update AMQP URL
+            messaging_config["amqp_url"] = amqp_url
 
-        # Update client properties
-        messaging_config["client_properties"]["app"] = settings.SITE_TITLE
-        messaging_config["client_properties"]["app_url"] = settings.SITE_URL
-        messaging_config["client_properties"]["app_contacts_email"] = ", ".join(
-            settings.ADMINS
-        )
+            # Store TLS configuration
+            certs_path = data_path("cache") / "fedora-messaging"
+            certs_path.mkdir(parents=True, exist_ok=True)
+            if ca_cert:
+                ca_cert_file = certs_path / "ca.crt"
+                FedoraMessagingAddon._write_pem_file(ca_cert_file, ca_cert)
+                messaging_config["tls"]["ca_cert"] = ca_cert_file.as_posix()
+            if client_key:
+                key_file = certs_path / "client.key"
+                FedoraMessagingAddon._write_pem_file(key_file, client_key)
+                messaging_config["tls"]["keyfile"] = key_file.as_posix()
+            if client_cert:
+                cert_file = certs_path / "client.crt"
+                FedoraMessagingAddon._write_pem_file(cert_file, client_cert)
+                messaging_config["tls"]["certfile"] = cert_file.as_posix()
 
-        # Validate the configuration, there is currently no public API for this
-        # ruff: ignore[private-member-access]
-        messaging_config._validate()
+            # Update client properties
+            messaging_config["client_properties"]["app"] = settings.SITE_TITLE
+            messaging_config["client_properties"]["app_url"] = settings.SITE_URL
+            messaging_config["client_properties"]["app_contacts_email"] = ", ".join(
+                settings.ADMINS
+            )
+
+            # Validate the configuration, there is currently no public API for this
+            # ruff: ignore[private-member-access]
+            messaging_config._validate()
 
     @staticmethod
     def get_configured_amqp_url(

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -8,12 +8,14 @@ import base64
 import contextlib
 import importlib
 import json
+import math
 import os
 import re
 import shutil
 import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 import tempfile
+from copy import deepcopy
 from datetime import timedelta
 from io import StringIO
 from pathlib import Path
@@ -8882,8 +8884,15 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         super().setUp()
         self.patcher = patch("fedora_messaging.api._twisted_publish_wrapper")
         self.mock_class = self.patcher.start()
+        self.prepare_service_patcher = patch.object(
+            FedoraMessagingAddon, "_prepare_fedora_messaging_service"
+        )
+        self.prepare_service = self.prepare_service_patcher.start()
 
     def tearDown(self) -> None:
+        del self.prepare_service
+        self.prepare_service_patcher.stop()
+        del self.prepare_service_patcher
         del self.mock_class
         self.patcher.stop()
         del self.patcher
@@ -9046,6 +9055,136 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             message.topic,
             "org.fedoraproject.weblate.translation_added.test.test.cs",
         )
+        self.assertEqual(
+            publish_message.call_args.kwargs,
+            {
+                "timeout": DEFAULT_FEDORA_MESSAGING_PUBLISH_TIMEOUT,
+                "connection_attempts": DEFAULT_FEDORA_MESSAGING_CONNECTION_ATTEMPTS,
+                "retry_delay": DEFAULT_FEDORA_MESSAGING_RETRY_DELAY,
+            },
+        )
+
+    def test_change_event_serializes_configuration_and_publish(self) -> None:
+        self.WEBHOOK_CLS.create(configuration=self.addon_configuration)
+        locked = False
+        lock = MagicMock()
+
+        def enter_lock():
+            nonlocal locked
+
+            locked = True
+
+        def exit_lock(*_args):
+            nonlocal locked
+
+            locked = False
+
+        def configure_fedora_messaging(**_kwargs):
+            self.assertTrue(locked)
+
+        def publish_message(*_args, **_kwargs):
+            self.assertTrue(locked)
+
+        lock.__enter__.side_effect = enter_lock
+        lock.__exit__.side_effect = exit_lock
+
+        with (
+            patch(
+                "weblate.addons.fedora_messaging.FEDORA_MESSAGING_PUBLISH_LOCK", lock
+            ),
+            patch.object(
+                FedoraMessagingAddon,
+                "configure_fedora_messaging",
+                side_effect=configure_fedora_messaging,
+            ) as configure,
+            patch.object(
+                FedoraMessagingAddon, "publish_message", side_effect=publish_message
+            ) as publish,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self.edit_unit("Hello, world!\n", "Nazdar svete!\n")
+
+        configure.assert_called_once()
+        publish.assert_called_once()
+        lock.__enter__.assert_called_once_with()
+        lock.__exit__.assert_called_once()
+
+    def test_render_activity_log_formats_message_id(self) -> None:
+        addon = self.WEBHOOK_CLS.create(configuration=self.addon_configuration)
+        activity = AddonActivityLog(
+            addon=addon.instance,
+            details={"result": {"message_id": "77a2b12e-9f82-4411-aa83-249c984886fb"}},
+        )
+
+        self.assertEqual(
+            addon.render_activity_log(activity),
+            "Message ID: 77a2b12e-9f82-4411-aa83-249c984886fb",
+        )
+
+    def test_publish_message_serializes_prepare_publish_and_reporting(self) -> None:
+        locked = False
+        lock = MagicMock()
+        error = fedora_messaging_exceptions.PublishTimeout(
+            "Publishing timed out after waiting 30 seconds."
+        )
+
+        def enter_lock():
+            nonlocal locked
+
+            locked = True
+
+        def exit_lock(*_args):
+            nonlocal locked
+
+            locked = False
+
+        def prepare_service(**_kwargs):
+            self.assertTrue(locked)
+
+        def publish(*_args, **_kwargs):
+            self.assertTrue(locked)
+            raise error
+
+        def reset_service():
+            self.assertTrue(locked)
+            return True
+
+        def report_error(*_args, **_kwargs):
+            self.assertTrue(locked)
+
+        lock.__enter__.side_effect = enter_lock
+        lock.__exit__.side_effect = exit_lock
+
+        with (
+            patch(
+                "weblate.addons.fedora_messaging.FEDORA_MESSAGING_PUBLISH_LOCK", lock
+            ),
+            patch.object(
+                FedoraMessagingAddon,
+                "_prepare_fedora_messaging_service",
+                side_effect=prepare_service,
+            ) as prepare,
+            patch("fedora_messaging.api.publish", side_effect=publish) as publish_mock,
+            patch.object(
+                FedoraMessagingAddon,
+                "_reset_fedora_messaging_service",
+                side_effect=reset_service,
+            ) as reset,
+            patch.object(
+                FedoraMessagingAddon, "_report_publish_error", side_effect=report_error
+            ) as report,
+            self.assertRaises(FedoraMessagingPublishError),
+        ):
+            FedoraMessagingAddon.publish_message(
+                self.get_fedora_message(), self.addon_configuration["amqp_url"], None
+            )
+
+        prepare.assert_called_once()
+        publish_mock.assert_called_once()
+        reset.assert_called_once()
+        report.assert_called_once()
+        lock.__enter__.assert_called_once_with()
+        lock.__exit__.assert_called_once()
 
     def test_publish_message_success(self) -> None:
         service = object()
@@ -9053,6 +9192,9 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
 
         with (
+            patch.object(
+                FedoraMessagingAddon, "_prepare_fedora_messaging_service"
+            ) as prepare_service,
             patch("fedora_messaging.api.publish") as publish,
             patch("weblate.addons.fedora_messaging.report_error") as report_error,
         ):
@@ -9060,6 +9202,10 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
                 self.get_fedora_message(), self.addon_configuration["amqp_url"], None
             )
 
+        prepare_service.assert_called_once_with(
+            connection_attempts=DEFAULT_FEDORA_MESSAGING_CONNECTION_ATTEMPTS,
+            retry_delay=DEFAULT_FEDORA_MESSAGING_RETRY_DELAY,
+        )
         publish.assert_called_once()
         self.assertEqual(
             publish.call_args.kwargs["timeout"],
@@ -9076,10 +9222,25 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         with patch.object(
             FedoraMessagingAddon, "_stop_fedora_messaging_service"
         ) as stop_service:
-            FedoraMessagingAddon._reset_fedora_messaging_service()  # noqa: SLF001
+            result = FedoraMessagingAddon._reset_fedora_messaging_service()  # noqa: SLF001
 
         stop_service.assert_called_once_with(service.stopService)
+        self.assertTrue(result)
         self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
+
+    def test_reset_fedora_messaging_service_keeps_service_on_stop_failure(self) -> None:
+        service = MagicMock()
+        fedora_messaging.api._twisted_service = service  # noqa: SLF001
+        self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
+
+        with patch.object(
+            FedoraMessagingAddon, "_stop_fedora_messaging_service", return_value=False
+        ) as stop_service:
+            result = FedoraMessagingAddon._reset_fedora_messaging_service()  # noqa: SLF001
+
+        stop_service.assert_called_once_with(service.stopService)
+        self.assertFalse(result)
+        self.assertIs(fedora_messaging.api._twisted_service, service)  # noqa: SLF001
 
     def test_stop_fedora_messaging_service_runs_in_reactor_and_waits(self) -> None:
         stop_service = MagicMock(return_value="stopped")
@@ -9093,14 +9254,238 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             return wrapper
 
         with patch("crochet.run_in_reactor", side_effect=run_in_reactor):
-            FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # noqa: SLF001
+            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # noqa: SLF001
 
         stop_service.assert_called_once_with()
         self.assertEqual(result.value, "stopped")
         result.wait.assert_called_once_with(timeout=SERVICE_STOP_TIMEOUT)
         result.cancel.assert_not_called()
+        self.assertTrue(stopped)
 
-    def test_publish_timeout_is_reported_and_resets_service(self) -> None:
+    def test_stop_fedora_messaging_service_cancels_and_fails_on_timeout(self) -> None:
+        # ruff: ignore[import-outside-top-level]
+        import crochet
+
+        stop_service = MagicMock(return_value="stopped")
+        result = MagicMock()
+        result.wait.side_effect = crochet.TimeoutError
+
+        def run_in_reactor(function):
+            def wrapper():
+                result.value = function()
+                return result
+
+            return wrapper
+
+        with (
+            patch("crochet.run_in_reactor", side_effect=run_in_reactor),
+            patch("weblate.addons.fedora_messaging.report_error") as report_error,
+        ):
+            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # noqa: SLF001
+
+        stop_service.assert_called_once_with()
+        self.assertEqual(result.value, "stopped")
+        result.wait.assert_called_once_with(timeout=SERVICE_STOP_TIMEOUT)
+        result.cancel.assert_called_once_with()
+        report_error.assert_called_once_with(
+            "Fedora Messaging service shutdown timed out", level="error"
+        )
+        self.assertFalse(stopped)
+
+    def test_stop_fedora_messaging_service_fails_on_error(self) -> None:
+        stop_service = MagicMock(return_value="stopped")
+        result = MagicMock()
+        result.wait.side_effect = RuntimeError("failed")
+
+        def run_in_reactor(function):
+            def wrapper():
+                result.value = function()
+                return result
+
+            return wrapper
+
+        with (
+            patch("crochet.run_in_reactor", side_effect=run_in_reactor),
+            patch("weblate.addons.fedora_messaging.report_error") as report_error,
+        ):
+            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # noqa: SLF001
+
+        stop_service.assert_called_once_with()
+        result.wait.assert_called_once_with(timeout=SERVICE_STOP_TIMEOUT)
+        result.cancel.assert_not_called()
+        report_error.assert_called_once_with(
+            "Fedora Messaging service shutdown failed", level="error"
+        )
+        self.assertFalse(stopped)
+
+    def test_configure_fedora_messaging_publish_retries(self) -> None:
+        factory = SimpleNamespace(
+            maxRetries=None,
+            initialDelay=1,
+            delay=1,
+            maxDelay=3600,
+            factor=math.e,
+            jitter=0.119626565582,
+        )
+
+        FedoraMessagingAddon._configure_fedora_messaging_publish_retries(  # noqa: SLF001
+            SimpleNamespace(factory=factory), connection_attempts=4, retry_delay=6
+        )
+
+        self.assertEqual(factory.maxRetries, 3)
+        self.assertEqual(factory.initialDelay, 6)
+        self.assertEqual(factory.delay, 6)
+        self.assertEqual(factory.maxDelay, 6)
+        self.assertEqual(factory.factor, 1)
+        self.assertEqual(factory.jitter, 0)
+
+    def test_configure_fedora_messaging_publish_retries_allows_single_attempt(
+        self,
+    ) -> None:
+        factory = SimpleNamespace()
+
+        FedoraMessagingAddon._configure_fedora_messaging_publish_retries(  # noqa: SLF001
+            SimpleNamespace(factory=factory), connection_attempts=1, retry_delay=0
+        )
+
+        self.assertEqual(factory.maxRetries, 0)
+        self.assertEqual(factory.initialDelay, 0)
+        self.assertEqual(factory.delay, 0)
+        self.assertEqual(factory.maxDelay, 0)
+
+    def test_fedora_messaging_service_stale_after_exhausted_retries(self) -> None:
+        service = SimpleNamespace(
+            running=True,
+            factory=SimpleNamespace(
+                _client=None,
+                _callID=None,
+                continueTrying=True,
+                maxRetries=1,
+                retries=2,
+            ),
+        )
+
+        self.assertTrue(
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+        )
+
+    def test_fedora_messaging_service_stale_when_stopped(self) -> None:
+        service = SimpleNamespace(running=False)
+
+        self.assertTrue(
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+        )
+
+    def test_fedora_messaging_service_stale_when_factory_stopped(self) -> None:
+        service = SimpleNamespace(
+            running=True,
+            factory=SimpleNamespace(continueTrying=False),
+        )
+
+        self.assertTrue(
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+        )
+
+    def test_fedora_messaging_service_not_stale_with_pending_retry(self) -> None:
+        service = SimpleNamespace(
+            running=True,
+            factory=SimpleNamespace(
+                _client=None,
+                _callID=object(),
+                continueTrying=True,
+                maxRetries=1,
+                retries=2,
+            ),
+        )
+
+        self.assertFalse(
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+        )
+
+    def test_prepare_fedora_messaging_service_resets_stale_service(self) -> None:
+        self.prepare_service_patcher.stop()
+        stale_service = object()
+        configured_service = SimpleNamespace(factory=SimpleNamespace())
+        fedora_messaging.api._twisted_service = stale_service  # noqa: SLF001
+        self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
+        result = MagicMock()
+
+        def run_in_reactor(function):
+            def wrapper():
+                function()
+                return result
+
+            return wrapper
+
+        with (
+            patch("crochet.setup") as setup,
+            patch("crochet.run_in_reactor", side_effect=run_in_reactor),
+            patch(
+                "fedora_messaging.api._init_twisted_service",
+                return_value=configured_service,
+            ) as init_service,
+            patch.object(
+                FedoraMessagingAddon,
+                "_is_fedora_messaging_service_stale",
+                return_value=True,
+            ),
+            patch.object(
+                FedoraMessagingAddon, "_reset_fedora_messaging_service"
+            ) as reset_service,
+            patch.object(
+                FedoraMessagingAddon, "_configure_fedora_messaging_publish_retries"
+            ) as configure_retries,
+        ):
+            FedoraMessagingAddon._prepare_fedora_messaging_service(  # noqa: SLF001
+                connection_attempts=4, retry_delay=6
+            )
+
+        setup.assert_called_once_with()
+        reset_service.assert_called_once_with()
+        init_service.assert_called_once_with()
+        configure_retries.assert_called_once_with(
+            configured_service, connection_attempts=4, retry_delay=6
+        )
+        result.wait.assert_called_once_with(timeout=SERVICE_STOP_TIMEOUT)
+
+    def test_prepare_fedora_messaging_service_cancels_on_timeout(self) -> None:
+        # ruff: ignore[import-outside-top-level]
+        import crochet
+
+        self.prepare_service_patcher.stop()
+        result = MagicMock()
+        result.wait.side_effect = crochet.TimeoutError
+        scheduled_functions = []
+
+        def run_in_reactor(function):
+            scheduled_functions.append(function)
+
+            def wrapper():
+                return result
+
+            return wrapper
+
+        with (
+            patch("crochet.setup"),
+            patch("crochet.run_in_reactor", side_effect=run_in_reactor),
+            patch("fedora_messaging.api._init_twisted_service") as init_service,
+            patch.object(
+                FedoraMessagingAddon,
+                "_is_fedora_messaging_service_stale",
+                return_value=False,
+            ),
+            self.assertRaises(crochet.TimeoutError),
+        ):
+            FedoraMessagingAddon._prepare_fedora_messaging_service(  # noqa: SLF001
+                connection_attempts=4, retry_delay=6
+            )
+
+        result.wait.assert_called_once_with(timeout=SERVICE_STOP_TIMEOUT)
+        result.cancel.assert_called_once_with()
+        scheduled_functions[0]()
+        init_service.assert_not_called()
+
+    def test_first_publish_timeout_is_reported_and_resets_service(self) -> None:
         service = object()
         fedora_messaging.api._twisted_service = service  # noqa: SLF001
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
@@ -9109,11 +9494,13 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         )
 
         with (
+            patch.object(FedoraMessagingAddon, "_prepare_fedora_messaging_service"),
             patch("fedora_messaging.api.publish", side_effect=error),
-            patch("weblate.addons.fedora_messaging.add_breadcrumb") as add_breadcrumb,
+            patch("weblate.addons.fedora_messaging.cache.add", return_value=True),
             patch("weblate.addons.fedora_messaging.report_error") as report_error,
             self.assertRaisesMessage(
-                FedoraMessagingPublishError, "broker did not confirm delivery"
+                FedoraMessagingPublishError,
+                "broker connection or delivery confirmation did not complete",
             ),
         ):
             FedoraMessagingAddon.publish_message(
@@ -9122,7 +9509,41 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
 
         self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
         report_error.assert_called_once_with(
-            "Fedora Messaging publish failed", level="error", project=None
+            "Fedora Messaging publish failed",
+            level="error",
+            project=None,
+            skip_error_reporting=False,
+        )
+
+    def test_repeated_publish_timeout_is_logged_and_resets_service(self) -> None:
+        service = object()
+        fedora_messaging.api._twisted_service = service  # noqa: SLF001
+        self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
+        error = fedora_messaging_exceptions.PublishTimeout(
+            "Publishing timed out after waiting 30 seconds."
+        )
+
+        with (
+            patch.object(FedoraMessagingAddon, "_prepare_fedora_messaging_service"),
+            patch("fedora_messaging.api.publish", side_effect=error),
+            patch("weblate.addons.fedora_messaging.add_breadcrumb") as add_breadcrumb,
+            patch("weblate.addons.fedora_messaging.cache.add", return_value=False),
+            patch("weblate.addons.fedora_messaging.report_error") as report_error,
+            self.assertRaisesMessage(
+                FedoraMessagingPublishError,
+                "broker connection or delivery confirmation did not complete",
+            ),
+        ):
+            FedoraMessagingAddon.publish_message(
+                self.get_fedora_message(), self.addon_configuration["amqp_url"], None
+            )
+
+        self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
+        report_error.assert_called_once_with(
+            "Fedora Messaging publish failed",
+            level="error",
+            project=None,
+            skip_error_reporting=True,
         )
         add_breadcrumb.assert_called_once()
         breadcrumb_values = add_breadcrumb.call_args.args + tuple(
@@ -9137,6 +9558,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
 
         with (
+            patch.object(FedoraMessagingAddon, "_prepare_fedora_messaging_service"),
             patch(
                 "fedora_messaging.api.publish",
                 side_effect=AttributeError(
@@ -9154,11 +9576,15 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
 
         self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
         report_error.assert_called_once_with(
-            "Fedora Messaging publish failed", level="error", project=None
+            "Fedora Messaging publish failed",
+            level="error",
+            project=None,
+            skip_error_reporting=False,
         )
 
     def test_broker_rejection_is_reported(self) -> None:
         with (
+            patch.object(FedoraMessagingAddon, "_prepare_fedora_messaging_service"),
             patch(
                 "fedora_messaging.api.publish",
                 side_effect=fedora_messaging_exceptions.PublishForbidden(
@@ -9175,13 +9601,17 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             )
 
         report_error.assert_called_once_with(
-            "Fedora Messaging publish failed", level="error", project=None
+            "Fedora Messaging publish failed",
+            level="error",
+            project=None,
+            skip_error_reporting=False,
         )
 
     def test_reported_publish_failure_is_not_reported_twice(self) -> None:
         self.WEBHOOK_CLS.create(configuration=self.addon_configuration)
 
         with (
+            patch.object(FedoraMessagingAddon, "_prepare_fedora_messaging_service"),
             patch(
                 "fedora_messaging.api.publish",
                 side_effect=fedora_messaging_exceptions.PublishTimeout(
@@ -9191,18 +9621,25 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             patch(
                 "weblate.addons.fedora_messaging.report_error"
             ) as fedora_report_error,
+            patch.object(
+                FedoraMessagingAddon, "_should_report_publish_error", return_value=False
+            ),
             patch("weblate.addons.models.report_error") as generic_report_error,
             self.captureOnCommitCallbacks(execute=True),
         ):
             self.edit_unit("Hello, world!\n", "Nazdar svete!\n")
 
         fedora_report_error.assert_called_once()
+        self.assertTrue(fedora_report_error.call_args.kwargs["skip_error_reporting"])
         generic_report_error.assert_not_called()
         activity_log = AddonActivityLog.objects.filter(
             addon__name=self.WEBHOOK_CLS.name
         ).latest("created")
         self.assertTrue(activity_log.details["error"])
-        self.assertIn("broker did not confirm delivery", activity_log.details["result"])
+        self.assertIn(
+            "broker connection or delivery confirmation did not complete",
+            activity_log.details["result"],
+        )
 
     @tempdir_setting("CACHE_DIR")
     def test_tls_credentials_validation_accepts_pem(self) -> None:
@@ -9240,6 +9677,45 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             FedoraMessagingAddon.configure_fedora_messaging(**configuration)
 
         validate_tls_credentials.assert_not_called()
+
+    def test_configure_fedora_messaging_keeps_configuration_on_reset_failure(
+        self,
+    ) -> None:
+        messaging_config = fedora_messaging.config.conf
+        original_loaded = messaging_config.loaded
+        original_config = deepcopy(messaging_config.copy())
+
+        def restore_config():
+            messaging_config.loaded = True
+            messaging_config.clear()
+            messaging_config.update(original_config)
+            messaging_config.loaded = original_loaded
+
+        self.addCleanup(restore_config)
+        messaging_config.loaded = True
+        messaging_config.clear()
+        messaging_config.update(deepcopy(fedora_messaging.config.DEFAULTS))
+        messaging_config["amqp_url"] = "amqp://old.example.com"
+
+        with (
+            patch.object(
+                FedoraMessagingAddon,
+                "_reset_fedora_messaging_service",
+                return_value=False,
+            ) as reset_service,
+            self.assertRaisesMessage(
+                ConfigurationException,
+                "Could not reset Fedora Messaging publisher service.",
+            ),
+        ):
+            FedoraMessagingAddon.configure_fedora_messaging(
+                **self.get_tls_configuration(),
+                force_update=True,
+            )
+
+        reset_service.assert_called_once_with()
+        self.assertEqual(messaging_config["amqp_url"], "amqp://old.example.com")
+        self.assertNotIn("weblate_cert_hash", messaging_config["consumer_config"])
 
     @tempdir_setting("CACHE_DIR")
     def test_tls_credentials_are_written_with_separator(self) -> None:


### PR DESCRIPTION
Reset stale Twisted publishers and apply retry settings to avoid repeated publish timeouts; rate-limit timeout reports and improve activity log output.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
