### PR TITLE
fix(machinery): validate Azure Translator regions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,7 @@ Weblate 2026.7.1
 * Screenshot searches without an explicit field now match screenshot names only, and the search box links to the full screenshot search documentation.
 * Anonymous and internal bot accounts can no longer be edited through generic user management.
 * LLM machine translation suggestions now recover from more malformed structured JSON replies.
+* Azure AI Translator settings now reject malformed region names before validating service connectivity.
 
 .. rubric:: Compatibility
 

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -7519,6 +7519,37 @@ class CDNJSAddonTest(ViewTestCase):
         self.assertIn(AddonEvent.EVENT_POST_UPDATE, CDNJSAddon.events)
         self.assertNotIn(AddonEvent.EVENT_COMPONENT_UPDATE, CDNJSAddon.events)
 
+    @override_settings(
+        ALLOWED_ASSET_DOMAINS=["*"],
+        ASSET_RESTRICT_PRIVATE=True,
+        ASSET_PRIVATE_ALLOWLIST=[],
+    )
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+    )
+    def test_form_rejects_private_remote_file_before_request(
+        self, mocked_getaddrinfo
+    ) -> None:
+        form = CDNJSAddon.get_add_form(
+            self.user,
+            component=self.component,
+            data={
+                "threshold": 0,
+                "files": "https://private.example.com/messages.html",
+                "cookie_name": "django_languages",
+                "css_selector": ".l10n",
+            },
+        )
+
+        self.assertIsNotNone(form)
+        with patch("requests.sessions.Session.request") as mocked_request:
+            self.assertFalse(form.is_valid())
+
+        mocked_getaddrinfo.assert_called_once_with("private.example.com", None, type=1)
+        mocked_request.assert_not_called()
+        self.assertIn("internal or non-public address", str(form.errors["files"]))
+
     @tempdir_setting("LOCALIZE_CDN_PATH")
     @override_settings(LOCALIZE_CDN_URL="http://localhost/")
     def test_cdn(self) -> None:

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -21,6 +21,7 @@ from weblate.utils.validators import validate_machinery_hostname, validate_machi
 from .types import SourceLanguageChoices
 
 LLM_LANGUAGE_INSTRUCTION_LENGTH = 1000
+MICROSOFT_REGION_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?")
 
 
 class EmptyMappingJSONField(forms.JSONField):
@@ -95,6 +96,8 @@ class BaseMachineryForm(forms.Form):
         machinery.validate_settings()
 
     def clean(self) -> None:
+        if self.errors:
+            return
         try:
             self.validate_configuration()
         except ValidationError as error:
@@ -264,6 +267,12 @@ class MicrosoftMachineryForm(KeyMachineryForm):
         initial="general",
         required=False,
     )
+
+    def clean_region(self) -> str:
+        region = self.cleaned_data["region"]
+        if region and MICROSOFT_REGION_RE.fullmatch(region) is None:
+            raise ValidationError(gettext("Enter a valid Azure region name."))
+        return region
 
 
 class GoogleV3MachineryForm(BaseMachineryForm):

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -1173,6 +1173,32 @@ class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(machine.map_language_code("fr_CA"), "fr-ca")
         self.assertEqual(machine.map_language_code("iu_Latn"), "iu-Latn")
 
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+    )
+    @override_settings(OFFER_HOSTING=False)
+    def test_project_validation_blocks_private_base_url_resolution_before_request(
+        self, mocked_getaddrinfo
+    ) -> None:
+        form = self.MACHINE_CLS.settings_form(
+            self.MACHINE_CLS,
+            data=self.CONFIGURATION,
+            allow_private_targets=False,
+        )
+
+        with (
+            patch.object(self.MACHINE_CLS, "get_headers", return_value={}),
+            patch("requests.sessions.Session.request") as mocked_request,
+        ):
+            self.assertFalse(form.is_valid())
+
+        mocked_getaddrinfo.assert_called_once_with(
+            "api.cognitive.microsofttranslator.com", None, type=1
+        )
+        mocked_request.assert_not_called()
+        self.assertIn("internal or non-public address", str(form.non_field_errors()))
+
 
 class MicrosoftCognitiveTranslationRegionTest(MicrosoftCognitiveTranslationTest):
     CONFIGURATION: ClassVar[SettingsDict] = {
@@ -1209,6 +1235,30 @@ class MicrosoftCognitiveTranslationRegionTest(MicrosoftCognitiveTranslationTest)
             "translate?api-version=3.0&from=en&to=de&category=&textType=html",
             json=MICROSOFT_RESPONSE,
         )
+
+    @responses.activate
+    def test_validate_settings_uses_regional_token_host(self) -> None:
+        self.mock_response()
+        self.get_machine().validate_settings()
+
+        token_call = responses.calls[0]
+        self.assertEqual(
+            token_call.request.url,
+            "https://westeurope.api.cognitive.microsoft.com/sts/v1.0/issueToken",
+        )
+
+    def test_region_rejects_url_delimiters_before_request(self) -> None:
+        form = self.MACHINE_CLS.settings_form(
+            self.MACHINE_CLS,
+            data={**self.CONFIGURATION, "region": "127.0.0.1:11434/"},
+            allow_private_targets=False,
+        )
+
+        with patch("requests.sessions.Session.request") as mocked_request:
+            self.assertFalse(form.is_valid())
+
+        mocked_request.assert_not_called()
+        self.assertIn("valid Azure region name", str(form.errors["region"]))
 
     @responses.activate
     def test_regional_host_string_payload_raises_error(self) -> None:
@@ -8165,6 +8215,46 @@ class MachineryValidationTest(TestCase):
         self.assertNotIn("site administrator", str(form.errors["__all__"]))
         self.assertNotIn("site-wide", str(form.errors["__all__"]))
         self.assertNotIn("allowlisted", str(form.errors["__all__"]))
+
+    @override_settings(OFFER_HOSTING=False)
+    def test_project_ollama_rejects_private_url_before_request(self) -> None:
+        form = OllamaTranslation.settings_form(
+            OllamaTranslation,
+            data={
+                "base_url": "http://127.0.0.1:11434",
+                "model": "llama3.2:3b",
+                "persona": "",
+                "style": "",
+            },
+            allow_private_targets=False,
+        )
+
+        with patch("requests.sessions.Session.request") as mocked_request:
+            self.assertFalse(form.is_valid())
+
+        mocked_request.assert_not_called()
+        self.assertIn("internal or non-public address", str(form.errors["__all__"]))
+
+    @override_settings(OFFER_HOSTING=False)
+    def test_project_anthropic_rejects_private_url_before_request(self) -> None:
+        form = AnthropicTranslation.settings_form(
+            AnthropicTranslation,
+            data={
+                "key": "test-api-key",
+                "base_url": "http://127.0.0.1:11434",
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 4096,
+                "persona": "",
+                "style": "",
+            },
+            allow_private_targets=False,
+        )
+
+        with patch("requests.sessions.Session.request") as mocked_request:
+            self.assertFalse(form.is_valid())
+
+        mocked_request.assert_not_called()
+        self.assertIn("internal or non-public address", str(form.errors["__all__"]))
 
     def test_check_failure_hides_response_body(self) -> None:
         response = Mock()


### PR DESCRIPTION
Prevent crafted Azure region values from changing the token endpoint host and add regression coverage for SSRF validation paths.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
