### PR TITLE
fix(vcs): update GitHub App manifest preview live

### DIFF
--- a/weblate/static/js/github-app-manifest-preview.js
+++ b/weblate/static/js/github-app-manifest-preview.js
@@ -1,0 +1,31 @@
+// Copyright © Michal Čihař <michal@weblate.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+document.addEventListener("DOMContentLoaded", () => {
+  const previewElement = document.getElementById("github-app-manifest-preview");
+  const nameField = document.getElementById("register-name");
+  const publicField = document.getElementById("register-public");
+
+  if (previewElement === null || nameField === null || publicField === null) {
+    return;
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(previewElement.textContent);
+  } catch (_error) {
+    return;
+  }
+
+  function updatePreview() {
+    manifest.name = nameField.value;
+    manifest.public = publicField.checked;
+    previewElement.textContent = JSON.stringify(manifest, null, 2);
+  }
+
+  nameField.addEventListener("input", updatePreview);
+  publicField.addEventListener("change", updatePreview);
+
+  updatePreview();
+});

--- a/weblate/templates/vcs/github_app_register.html
+++ b/weblate/templates/vcs/github_app_register.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 
-{% load crispy_forms_tags i18n %}
+{% load crispy_forms_tags i18n static %}
+
+{% block extra_script %}
+  <script defer
+          data-cfasync="false"
+          src="{% static 'js/github-app-manifest-preview.js' %}{{ cache_param }}"></script>
+{% endblock extra_script %}
 
 {% block breadcrumbs %}
   <li class="breadcrumb-item">
@@ -95,7 +101,7 @@
       <p class="text-body-secondary small">
         {% translate "The JSON document below is the manifest that GitHub will use to pre-fill the new App's settings." %}
       </p>
-      <pre class="mb-0"><code>{{ manifest_json }}</code></pre>
+      <pre class="mb-0"><code id="github-app-manifest-preview">{{ manifest_json }}</code></pre>
     </div>
   </div>
 


### PR DESCRIPTION
Add a script on the GitHub App registration form and wire it to the manifest preview.

Fixes #20300.