### PR TITLE
fix(api): align authorization with web interface

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -284,7 +284,9 @@ team memberships same as with users.
 Site-wide access control
 ------------------------
 
-.. include:: /snippets/not-hosted.rst
+.. note::
+
+   This feature is unavailable on Hosted Weblate.
 
 The permission system is based on roles defining a set of permissions,
 and teams linking roles to users and translations, read :ref:`auth-model`

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -1251,7 +1251,10 @@ Components with higher priority are offered first to translators.
 Restricted access
 +++++++++++++++++
 
-.. include:: /snippets/not-hosted.rst
+.. note::
+
+   On Hosted Weblate, this requires a billing plan which permits private
+   projects.
 
 By default the component is visible to anybody who has access to the project,
 even if the person can not perform any changes in the component. This makes it

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1613,6 +1613,9 @@ Components
     :>json string credits_url: URL to list contributor credits; see :http:get:`/api/components/(string:project)/(string:component)/credits/`
     :>json string announcements_url: URL to announcements; see :http:get:`/api/components/(string:project)/(string:component)/announcements/`
 
+    Repository fields, including ``linked_component``, are returned only with
+    the :guilabel:`View upstream repository location` permission.
+
     **Example JSON data:**
 
     .. code-block:: json
@@ -1674,6 +1677,11 @@ Components
     :<json string name: name of component
     :<json string slug: slug of component
     :<json string repo: VCS repository URL
+
+    Linking to another Weblate component using an :ref:`internal URL
+    <internal-urls>` requires permission to edit the referenced component.
+    Changing :ref:`component-restricted` follows the same direct
+    component-access restrictions as the web interface.
 
     **CURL example:**
 
@@ -1887,6 +1895,9 @@ Components
 
     The response is same as for :http:get:`/api/projects/(string:project)/repository/`.
 
+    For a linked repository, permission is checked on the source component that
+    owns the repository.
+
     :param project: Project URL slug
     :type project: string
     :param component: Component URL slug
@@ -1903,6 +1914,9 @@ Components
     Performs the given operation on a VCS repository.
 
     See :http:post:`/api/projects/(string:project)/repository/` for documentation.
+
+    For a linked repository, permission is checked on the source component that
+    owns the repository.
 
     :param project: Project URL slug
     :type project: string
@@ -2078,6 +2092,9 @@ Components
 
     Returns projects linked with a component.
 
+    Component managers see every linked project. Other callers see only linked
+    projects they can access.
+
     .. versionadded:: 4.5
 
     :param project: Project URL slug
@@ -2089,6 +2106,8 @@ Components
 .. http:post:: /api/components/(string:project)/(string:component)/links/
 
     Associate project with a component.
+
+    This requires permission to edit the component and the target project.
 
     .. versionadded:: 4.5
     .. versionchanged:: 5.17
@@ -2358,6 +2377,8 @@ Translations
     :<json int state: String state; see :http:get:`/api/units/(int:id)/`
     :>json object unit: newly created unit; see :http:get:`/api/units/(int:id)/`
 
+    Creating a unit in the approved state requires permission to review strings.
+
     .. seealso::
 
        * :ref:`component-manage_units`
@@ -2441,6 +2462,10 @@ Translations
 
     The response is same as for :http:get:`/api/components/(string:project)/(string:component)/repository/`.
 
+    For a linked repository, permission is checked on the source component that
+    owns the repository. For an unlinked repository, permission can be limited
+    to the requested language.
+
     :param project: Project URL slug
     :type project: string
     :param component: Component URL slug
@@ -2453,6 +2478,11 @@ Translations
     Performs given operation on the VCS repository.
 
     See :http:post:`/api/projects/(string:project)/repository/` for documentation.
+
+    Repository operations affect the entire component and therefore require
+    component-wide permission on the component that owns the repository. A
+    permission limited to the requested language is sufficient for viewing
+    unlinked repository status, but not for performing an operation.
 
     :param project: Project URL slug
     :type project: string
@@ -2870,7 +2900,9 @@ Add-ons
 
 .. http:get:: /api/addons/
 
-    Returns a list of add-ons.
+    Returns a list of add-ons the caller can manage. Site-wide add-on managers
+    can access site-wide add-ons without gaining access to project or component
+    add-on configuration.
 
     .. seealso::
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,9 @@ Weblate 2026.8
 
 .. rubric:: Bug fixes
 
+* REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
+* Restricted components are now available on Hosted Weblate when the billing plan permits private projects.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/docs/snippets/not-hosted.rst
+++ b/docs/snippets/not-hosted.rst
@@ -1,3 +1,0 @@
-.. note::
-
-    This feature is unavailable on Hosted Weblate.

--- a/weblate/addons/models.py
+++ b/weblate/addons/models.py
@@ -81,6 +81,49 @@ class AddonCache:
 
 
 class AddonQuerySet(models.QuerySet["Addon", "Addon"]):
+    def filter_access(self, user: User):
+        """Return add-ons the user is allowed to manage."""
+        if user.is_superuser:
+            return self.all()
+
+        accessible_projects = user.allowed_projects
+        managed_projects = user.managed_projects.filter(pk__in=accessible_projects)
+        component_managed_projects = user.projects_with_perm("component.edit").filter(
+            pk__in=accessible_projects
+        )
+        explicitly_managed_component_ids = [
+            component_id
+            for component_id, scoped_permissions in user.component_permissions.items()
+            if any(
+                "component.edit" in permissions
+                and (languages is None or not languages.membership_limited)
+                for permissions, languages in scoped_permissions
+            )
+        ]
+        managed_components = Component.objects.filter(
+            project__in=accessible_projects
+        ).filter(
+            Q(project__in=component_managed_projects, restricted=False)
+            | Q(pk__in=explicitly_managed_component_ids)
+        )
+
+        if not user.is_bot and not user.profile.has_2fa:
+            managed_projects = managed_projects.filter(enforced_2fa=False)
+            managed_components = managed_components.filter(project__enforced_2fa=False)
+
+        query = (
+            Q(project__in=managed_projects)
+            | Q(category__project__in=managed_projects)
+            | Q(component__in=managed_components)
+        )
+        if user.has_perm("management.addons"):
+            query |= Q(
+                component__isnull=True,
+                category__isnull=True,
+                project__isnull=True,
+            )
+        return self.filter(query)
+
     def filter_component(self, component):
         return self.prefetch_related("event_set").filter(component=component)
 

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -62,10 +62,7 @@ from weblate.trans.models import (
     Unit,
 )
 from weblate.trans.models.translation import NewUnitParams
-from weblate.trans.util import (
-    check_upload_method_permissions,
-    cleanup_repo_url,
-)
+from weblate.trans.util import check_upload_method_permissions, cleanup_repo_url
 from weblate.trans.workspace_move import (
     get_project_move_billing_error,
     get_project_workspace_move_permission_error,
@@ -1348,6 +1345,7 @@ class ComponentSerializer(RemovableSerializer[Component]):
             result["git_export"] = None
             result["push_branch"] = None
             result["repoweb"] = None
+            result["linked_component"] = None
         return result
 
     def to_internal_value(self, data):
@@ -1404,11 +1402,17 @@ class ComponentSerializer(RemovableSerializer[Component]):
 
         return result
 
-    def get_linked_repository_component(self, instance: Component) -> Component | None:
+    @staticmethod
+    def get_linked_component_or_none(repo: str | None) -> Component | None:
+        if repo is None:
+            return None
         try:
-            return Component.objects.get_linked(instance.repo)
+            return Component.objects.get_linked(repo)
         except Component.DoesNotExist:
             return None
+
+    def get_linked_repository_component(self, instance: Component) -> Component | None:
+        return self.get_linked_component_or_none(instance.repo)
 
     def validate_linked_repository_setting_overrides(
         self, attrs, instance: Component
@@ -1416,6 +1420,35 @@ class ComponentSerializer(RemovableSerializer[Component]):
         linked_component = self.get_linked_repository_component(instance)
         if linked_component is None:
             return
+
+        changed_linked_settings = {
+            field
+            for field in self.linked_repository_setting_fields
+            if field in self.initial_data
+            and attrs.get(field, getattr(instance, field))
+            != getattr(linked_component, field)
+        }
+        requires_link_access = (
+            self.instance is None
+            or instance.repo != self.instance.repo
+            or bool(changed_linked_settings)
+        )
+        if not requires_link_access:
+            for field in self.linked_repository_setting_fields:
+                if field in self.initial_data:
+                    attrs.pop(field, None)
+            return
+
+        if not self.context["request"].user.has_perm(
+            "component.edit", linked_component
+        ):
+            raise serializers.ValidationError(
+                {
+                    "repo": gettext_lazy(
+                        "You do not have permission to access this component."
+                    )
+                }
+            )
 
         if self.instance is None or not self.instance.is_repo_link:
             for field in self.linked_repository_setting_fields:
@@ -1427,8 +1460,7 @@ class ComponentSerializer(RemovableSerializer[Component]):
         for field in self.linked_repository_setting_fields:
             if field not in self.initial_data:
                 continue
-            value = attrs.get(field, getattr(instance, field))
-            if value != getattr(linked_component, field):
+            if field in changed_linked_settings:
                 errors[field] = self.linked_repository_setting_error
             else:
                 attrs.pop(field, None)
@@ -1537,6 +1569,36 @@ class ComponentSerializer(RemovableSerializer[Component]):
             preserve_existing=preserve_existing,
         )
 
+    def check_restricted_permission(self, attrs) -> None:
+        if self.instance:
+            if (
+                "restricted" not in attrs
+                or attrs["restricted"] == self.instance.restricted
+            ):
+                return
+            component = self.instance
+        else:
+            restricted = attrs.get("restricted", False) or (
+                "restricted" not in self.initial_data
+                and settings.DEFAULT_RESTRICTED_COMPONENT
+            )
+            if not restricted:
+                return
+            attrs["restricted"] = True
+            component = Component(**attrs)
+        permission = self.context["request"].user.has_perm(
+            "billing:component.permissions", component
+        )
+        if not permission:
+            reason = (
+                permission.reason
+                if isinstance(permission, PermissionResult)
+                else gettext_lazy(
+                    "You do not have permission to change restricted access."
+                )
+            )
+            raise serializers.ValidationError({"restricted": reason})
+
     def validate(self, attrs):
         # Handle non-component args
         disable_autoshare = attrs.pop("disable_autoshare", False)
@@ -1596,6 +1658,7 @@ class ComponentSerializer(RemovableSerializer[Component]):
         self.set_create_inheritance_defaults(
             attrs, preserve_existing=source_component is not None
         )
+        self.check_restricted_permission(attrs)
 
         # Build new or patched Component instance with changed attributes
         if self.instance:
@@ -1634,7 +1697,10 @@ class ComponentSerializer(RemovableSerializer[Component]):
 
         if not self.instance and not disable_autoshare and source_component is None:
             repo = instance.suggest_repo_link()
-            if repo:
+            linked_component = self.get_linked_component_or_none(repo)
+            if linked_component is not None and self.context["request"].user.has_perm(
+                "component.edit", linked_component
+            ):
                 attrs["repo"] = instance.repo = repo
                 attrs["branch"] = instance.branch = ""
         if source_component is not None:
@@ -1995,12 +2061,19 @@ class ComponentLinkRequestSerializer(ReadOnlySerializer):
 
         project_slug = attrs["project_slug"]
         try:
-            project = request.user.allowed_projects.exclude(
-                pk=component.project_id
-            ).get(slug=project_slug)
+            project = (
+                request.user.managed_projects.filter(
+                    pk__in=request.user.allowed_projects
+                )
+                .exclude(pk=component.project_id)
+                .get(slug=project_slug)
+            )
         except Project.DoesNotExist as error:
             msg = f"No project slug {project_slug!r} found!"
             raise serializers.ValidationError({"project_slug": msg}) from error
+        if not request.user.has_perm("project.edit", project):
+            msg = f"No project slug {project_slug!r} found!"
+            raise serializers.ValidationError({"project_slug": msg})
         attrs["project"] = project
 
         category_id = attrs.get("category_id")

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -25,6 +25,7 @@ from django.db import DatabaseError
 from django.db.models import Q
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
+from django_otp.plugins.otp_totp.models import TOTPDevice
 from rest_framework.test import APITestCase
 from weblate_language_data.languages import LANGUAGES
 
@@ -47,7 +48,14 @@ from weblate.api.serializers import (
 )
 from weblate.api.views import MemoryFilter, MemoryViewSet
 from weblate.auth.data import ROLES, SELECTION_ALL, SELECTION_MANUAL
-from weblate.auth.models import Group, Permission, Role, TeamMembership, User
+from weblate.auth.models import (
+    Group,
+    Permission,
+    Role,
+    TeamMembership,
+    User,
+    UserBlock,
+)
 from weblate.lang.models import Language
 from weblate.memory.models import Memory, MemoryScope
 from weblate.screenshots.models import Screenshot
@@ -81,6 +89,7 @@ from weblate.utils.celery import get_task_metadata_key
 from weblate.utils.data import data_dir
 from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import (
+    STATE_APPROVED,
     STATE_EMPTY,
     STATE_NEEDS_CHECKING,
     STATE_NEEDS_REWRITING,
@@ -186,14 +195,17 @@ class APIBaseTest(APITestCase, RepoTestMixin):
         perm: str,
         group_name: str = "Permission group",
         project: Project | None = None,
+        component: Component | None = None,
     ) -> None:
         permission = Permission.objects.get(codename=perm)
         group = Group.objects.get_or_create(
             name=group_name, language_selection=SELECTION_ALL
         )[0]
-        if project:
+        if project is not None:
             group.projects.add(project)
-        role = Role.objects.create(name="Permission role")
+        if component is not None:
+            group.components.add(component)
+        role = Role.objects.get_or_create(name=f"{group_name} role")[0]
         role.permissions.add(permission)
         group.roles.add(role)
         self.user.groups.add(group)
@@ -680,17 +692,17 @@ class UserAPITest(APIBaseTest):
         inactive.is_active = False
         inactive.save()
         users = [
-            User.objects.get(username=settings.ANONYMOUS_USER_NAME),
-            inactive,
+            (User.objects.get(username=settings.ANONYMOUS_USER_NAME), 403),
+            (inactive, 400),
         ]
 
-        for target in users:
+        for target, code in users:
             self.do_request(
                 "api:user-groups",
                 kwargs={"username": target.username},
                 method="post",
                 superuser=True,
-                code=400,
+                code=code,
                 request={"group_id": group.id},
             )
             self.assertFalse(target.groups.filter(pk=group.pk).exists())
@@ -1127,6 +1139,41 @@ class UserAPITest(APIBaseTest):
         )
         protected_bot.refresh_from_db()
         self.assertEqual(protected_bot.full_name, "Addon Bot")
+
+    def test_protected_bot_related_mutation(self) -> None:
+        protected_bot = User.objects.create(
+            username="addon:related",
+            full_name="Related Addon Bot",
+            email="addon-related@example.org",
+            is_bot=True,
+            is_active=True,
+        )
+        group = Group.objects.create(name="Protected related mutation")
+        subscription_count = protected_bot.subscription_set.count()
+
+        self.do_request(
+            "api:user-groups",
+            kwargs={"username": protected_bot.username},
+            method="post",
+            superuser=True,
+            code=403,
+            request={"group_id": group.pk},
+        )
+        self.assertFalse(protected_bot.groups.filter(pk=group.pk).exists())
+
+        self.do_request(
+            "api:user-notifications",
+            kwargs={"username": protected_bot.username},
+            method="post",
+            superuser=True,
+            code=403,
+            request={
+                "notification": "RepositoryNotification",
+                "scope": NotificationScope.SCOPE_ALL,
+                "frequency": NotificationFrequency.FREQ_INSTANT,
+            },
+        )
+        self.assertEqual(protected_bot.subscription_set.count(), subscription_count)
 
     def test_project_token_mutation(self) -> None:
         project_token = User.objects.create(
@@ -3748,6 +3795,141 @@ class ProjectAPITest(APIBaseTest):
         component = Component.objects.get(slug="c-3")
         self.assertEqual(component.repo, repo)
 
+    def test_create_component_does_not_autoshare_inaccessible_component(self) -> None:
+        repo = self.component.repo
+        branch = self.component.branch
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        self.do_request(
+            "api:project-components",
+            self.project_kwargs,
+            method="post",
+            code=201,
+            request={
+                "name": "Independent repository",
+                "slug": "independent-repository",
+                "repo": repo,
+                "branch": branch,
+                "filemask": "po/*.po",
+                "file_format": "po",
+                "new_lang": "none",
+            },
+        )
+
+        component = Component.objects.get(slug="independent-repository")
+        self.assertEqual(component.repo, repo)
+        self.assertIsNone(component.linked_component_id)
+
+    def test_create_component_ignores_missing_autoshare_target(self) -> None:
+        repo = self.component.repo
+        link_repo = self.component.get_repo_link_url()
+        original_get_linked = Component.objects.get_linked
+
+        def get_linked(candidate):
+            if candidate == link_repo:
+                msg = "Component disappeared."
+                raise Component.DoesNotExist(msg)
+            return original_get_linked(candidate)
+
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        with patch.object(
+            Component.objects,
+            "get_linked",
+            side_effect=get_linked,
+        ):
+            self.do_request(
+                "api:project-components",
+                self.project_kwargs,
+                method="post",
+                code=201,
+                request={
+                    "name": "Missing autoshare target",
+                    "slug": "missing-autoshare-target",
+                    "repo": repo,
+                    "branch": self.component.branch,
+                    "filemask": "po/*.po",
+                    "file_format": "po",
+                    "new_lang": "none",
+                },
+            )
+
+        component = Component.objects.get(slug="missing-autoshare-target")
+        self.assertEqual(component.repo, repo)
+        self.assertIsNone(component.linked_component_id)
+
+    def test_create_restricted_component_requires_privileged_access(self) -> None:
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        self.do_request(
+            "api:project-components",
+            self.project_kwargs,
+            method="post",
+            code=400,
+            request={
+                "name": "Restricted component",
+                "slug": "restricted-component",
+                "repo": self.component.repo,
+                "branch": self.component.branch,
+                "filemask": "po/*.po",
+                "file_format": "po",
+                "new_lang": "none",
+                "restricted": True,
+            },
+        )
+        self.assertFalse(Component.objects.filter(slug="restricted-component").exists())
+
+    @override_settings(DEFAULT_RESTRICTED_COMPONENT=True)
+    def test_create_component_can_override_restricted_default(self) -> None:
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        request = {
+            "name": "Unrestricted component",
+            "slug": "unrestricted-component",
+            "repo": self.component.repo,
+            "branch": self.component.branch,
+            "filemask": "po/*.po",
+            "file_format": "po",
+            "new_lang": "none",
+            "restricted": False,
+        }
+        self.do_request(
+            "api:project-components",
+            self.project_kwargs,
+            method="post",
+            code=201,
+            request=request,
+        )
+        self.assertFalse(
+            Component.objects.get(slug="unrestricted-component").restricted
+        )
+
+        request.update(name="Default restricted component", slug="default-restricted")
+        request.pop("restricted")
+        self.do_request(
+            "api:project-components",
+            self.project_kwargs,
+            method="post",
+            code=400,
+            request=request,
+        )
+        self.assertFalse(Component.objects.filter(slug="default-restricted").exists())
+        self.do_request(
+            "api:project-components",
+            self.project_kwargs,
+            method="post",
+            code=201,
+            superuser=True,
+            request=request,
+        )
+        self.assertTrue(Component.objects.get(slug="default-restricted").restricted)
+
     def test_create_component_blank_request(self) -> None:
         self.do_request(
             "api:project-components",
@@ -5470,10 +5652,13 @@ class ComponentAPITest(APIBaseTest):
         )
 
     def test_get_component_hides_vcs_view_fields_without_permission(self) -> None:
+        private_component = self.create_acl()
         Component.objects.filter(pk=self.component.pk).update(
             git_export="https://example.com/export.git",
             push_branch="translations",
             repoweb="https://example.com/src/{{filename}}#L{{line}}",
+            repo=private_component.get_repo_link_url(),
+            linked_component=private_component,
         )
         self.project.access_control = Project.ACCESS_PROTECTED
         self.project.save(update_fields=["access_control"])
@@ -5485,6 +5670,7 @@ class ComponentAPITest(APIBaseTest):
         self.assertIsNone(response.data["git_export"])
         self.assertIsNone(response.data["push_branch"])
         self.assertIsNone(response.data["repoweb"])
+        self.assertIsNone(response.data["linked_component"])
 
     def test_get_component_uses_effective_linked_repository_settings(self) -> None:
         self.component.push_on_commit = True
@@ -5551,6 +5737,91 @@ class ComponentAPITest(APIBaseTest):
 
     def test_repo_status_denied(self) -> None:
         self.do_request("api:component-repository", self.component_kwargs, code=403)
+
+    def test_repo_status_with_component_permission(self) -> None:
+        self.grant_perm_to_user(
+            "vcs.update",
+            group_name="Component repository access",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+
+        self.do_request(
+            "api:component-repository",
+            self.component_kwargs,
+            code=200,
+        )
+        with patch.object(Component, "do_update", return_value=True) as do_update:
+            response = self.do_request(
+                "api:component-repository",
+                self.component_kwargs,
+                method="post",
+                code=200,
+                request={"operation": "pull"},
+            )
+        self.assertTrue(response.data["result"])
+        do_update.assert_called_once()
+
+    def test_linked_repo_operation_requires_source_permission(self) -> None:
+        linked_component = self.create_link_existing(
+            name="Linked repository operation",
+            slug="linked-repository-operation",
+            filemask="po/*.po",
+        )
+        linked_kwargs = {
+            "project__slug": linked_component.project.slug,
+            "slug": linked_component.slug,
+        }
+        child_group_name = "Linked child repository access"
+        self.grant_perm_to_user(
+            "vcs.update",
+            group_name=child_group_name,
+            component=linked_component,
+        )
+        self.user.clear_permissions_cache()
+
+        self.assertTrue(self.user.has_perm("vcs.update", linked_component))
+        self.assertFalse(self.user.has_perm("vcs.update", self.component))
+        self.do_request(
+            "api:component-repository",
+            linked_kwargs,
+            code=403,
+        )
+        with patch.object(Component, "do_update", return_value=True) as do_update:
+            self.do_request(
+                "api:component-repository",
+                linked_kwargs,
+                method="post",
+                code=403,
+                request={"operation": "pull"},
+            )
+        do_update.assert_not_called()
+
+        self.user.groups.remove(Group.objects.get(name=child_group_name))
+        self.grant_perm_to_user(
+            "vcs.update",
+            group_name="Linked source repository access",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+        self.assertFalse(self.user.has_perm("vcs.update", linked_component))
+        self.assertTrue(self.user.has_perm("vcs.update", self.component))
+        self.do_request(
+            "api:component-repository",
+            linked_kwargs,
+            code=200,
+        )
+
+        with patch.object(Component, "do_update", return_value=True) as do_update:
+            response = self.do_request(
+                "api:component-repository",
+                linked_kwargs,
+                method="post",
+                code=200,
+                request={"operation": "pull"},
+            )
+        self.assertTrue(response.data["result"])
+        do_update.assert_called_once()
 
     def test_repo_status(self) -> None:
         """Test basic component repository status endpoint."""
@@ -5830,6 +6101,204 @@ class ComponentAPITest(APIBaseTest):
             request={"name": "New Name"},
         )
         self.assertEqual(response.data["name"], "New Name")
+
+    def test_patch_rejects_inaccessible_repository_link(self) -> None:
+        private_component = self.create_acl()
+        original_repo = self.component.repo
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Source component managers",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+
+        self.do_request(
+            "api:component-detail",
+            self.component_kwargs,
+            method="patch",
+            code=400,
+            format="json",
+            request={
+                "repo": private_component.get_repo_link_url(),
+                "branch": "",
+                "push": "",
+                "push_branch": "",
+            },
+        )
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.repo, original_repo)
+        self.assertIsNone(self.component.linked_component_id)
+
+    def test_patch_linked_component_allows_unrelated_edit_without_source_access(
+        self,
+    ) -> None:
+        linked_component = self.create_link_existing(
+            name="Linked child without source access",
+            slug="linked-child-without-source-access",
+            filemask="po/*.po",
+        )
+        linked_kwargs = {
+            "project__slug": linked_component.project.slug,
+            "slug": linked_component.slug,
+        }
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Linked child component managers",
+            component=linked_component,
+        )
+        self.grant_perm_to_user(
+            "vcs.view",
+            group_name="Linked child component managers",
+            component=linked_component,
+        )
+        linked_component.push_on_commit = not self.component.push_on_commit
+        linked_component.commit_pending_age = self.component.commit_pending_age + 1
+        linked_component.auto_lock_error = not self.component.auto_lock_error
+        linked_component.save(
+            update_fields=[
+                "push_on_commit",
+                "commit_pending_age",
+                "auto_lock_error",
+            ]
+        )
+        self.user.clear_permissions_cache()
+
+        self.assertFalse(self.user.has_perm("component.edit", self.component))
+        self.do_request(
+            "api:component-detail",
+            linked_kwargs,
+            method="patch",
+            code=200,
+            format="json",
+            request={"name": "Renamed linked child"},
+        )
+        linked_component.refresh_from_db()
+        self.assertEqual(linked_component.name, "Renamed linked child")
+
+        component_data = self.do_request(
+            "api:component-detail",
+            linked_kwargs,
+            code=200,
+        ).data
+        self.assertEqual(component_data["repo"], self.component.repo)
+        for field in ("repo", "branch", "push", "push_branch"):
+            component_data[field] = getattr(linked_component, field)
+        for field in Component.LINKED_REPOSITORY_SETTINGS:
+            self.assertEqual(component_data[field], getattr(self.component, field))
+        component_data["name"] = "PUT renamed linked child"
+        self.do_request(
+            "api:component-detail",
+            linked_kwargs,
+            method="put",
+            code=200,
+            format="json",
+            request=component_data,
+        )
+        linked_component.refresh_from_db()
+        self.assertEqual(linked_component.name, "PUT renamed linked child")
+        self.assertEqual(linked_component.linked_component_id, self.component.pk)
+        self.assertNotEqual(
+            linked_component.push_on_commit, self.component.push_on_commit
+        )
+        self.assertNotEqual(
+            linked_component.commit_pending_age, self.component.commit_pending_age
+        )
+        self.assertNotEqual(
+            linked_component.auto_lock_error, self.component.auto_lock_error
+        )
+
+        response = self.do_request(
+            "api:component-detail",
+            linked_kwargs,
+            method="patch",
+            code=400,
+            format="json",
+            request={"push_on_commit": not self.component.push_on_commit},
+        )
+        self.assertEqual(response.data["errors"][0]["attr"], "repo")
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "You do not have permission to access this component.",
+        )
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_patch_restricted_requires_component_scoped_permission(self) -> None:
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Project component managers",
+            project=self.project,
+        )
+        self.user.clear_permissions_cache()
+
+        response = self.do_request(
+            "api:component-detail",
+            self.component_kwargs,
+            method="patch",
+            code=400,
+            format="json",
+            request={"restricted": True},
+        )
+        self.assertEqual(response.data["errors"][0]["attr"], "restricted")
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "You need explicit access to this component before enabling restricted access; otherwise, you would lock yourself out.",
+        )
+        self.component.refresh_from_db()
+        self.assertFalse(self.component.restricted)
+
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Explicit component managers",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+        self.do_request(
+            "api:component-detail",
+            self.component_kwargs,
+            method="patch",
+            code=200,
+            format="json",
+            request={"restricted": True},
+        )
+        self.component.refresh_from_db()
+        self.assertTrue(self.component.restricted)
+
+    @modify_settings(INSTALLED_APPS={"append": "weblate.billing"})
+    @override_settings(OFFER_HOSTING=True)
+    def test_patch_restricted_obeys_billing(self) -> None:
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Hosted component managers",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+
+        response = self.do_request(
+            "api:component-detail",
+            self.component_kwargs,
+            method="patch",
+            code=400,
+            format="json",
+            request={"restricted": True},
+        )
+        self.assertEqual(response.data["errors"][0]["attr"], "restricted")
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "The billing plan does not allow private access control.",
+        )
+
+        billing = create_test_billing(self.user)
+        billing.add_project(self.project)
+        self.do_request(
+            "api:component-detail",
+            self.component_kwargs,
+            method="patch",
+            code=200,
+            format="json",
+            request={"restricted": True},
+        )
+        self.component.refresh_from_db()
+        self.assertTrue(self.component.restricted)
 
     def test_patch_keeps_category_when_omitted(self) -> None:
         category = self.project.category_set.create(
@@ -7447,6 +7916,128 @@ class ComponentAPITest(APIBaseTest):
             code=204,
             superuser=True,
         )
+
+    def test_links_require_target_project_management(self) -> None:
+        target_project = Project.objects.create(name="Target", slug="target")
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Component sharing managers",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+
+        self.do_request(
+            "api:component-links",
+            self.component_kwargs,
+            method="post",
+            code=400,
+            request={"project_slug": target_project.slug},
+        )
+        self.assertFalse(
+            ComponentLink.objects.filter(
+                component=self.component, project=target_project
+            ).exists()
+        )
+
+        self.grant_perm_to_user(
+            "project.edit",
+            group_name="Target project managers",
+            project=target_project,
+        )
+        self.user.clear_permissions_cache()
+        block = UserBlock.objects.create(user=self.user, project=target_project)
+        self.user.clear_permissions_cache()
+        self.do_request(
+            "api:component-links",
+            self.component_kwargs,
+            method="post",
+            code=400,
+            request={"project_slug": target_project.slug},
+        )
+        self.assertFalse(
+            ComponentLink.objects.filter(
+                component=self.component, project=target_project
+            ).exists()
+        )
+
+        block.delete()
+        self.user.clear_permissions_cache()
+        self.do_request(
+            "api:component-links",
+            self.component_kwargs,
+            method="post",
+            code=201,
+            request={"project_slug": target_project.slug},
+        )
+
+    def test_links_require_target_project_two_factor_authentication(self) -> None:
+        target_project = Project.objects.create(
+            name="2FA target", slug="two-factor-target", enforced_2fa=True
+        )
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="2FA component sharing managers",
+            component=self.component,
+        )
+        self.grant_perm_to_user(
+            "project.edit",
+            group_name="2FA target project managers",
+            project=target_project,
+        )
+        self.user.clear_permissions_cache()
+
+        self.do_request(
+            "api:component-links",
+            self.component_kwargs,
+            method="post",
+            code=400,
+            request={"project_slug": target_project.slug},
+        )
+        self.assertFalse(
+            ComponentLink.objects.filter(
+                component=self.component, project=target_project
+            ).exists()
+        )
+
+        TOTPDevice.objects.create(user=self.user)
+        self.do_request(
+            "api:component-links",
+            self.component_kwargs,
+            method="post",
+            code=201,
+            request={"project_slug": target_project.slug},
+        )
+        self.assertTrue(
+            ComponentLink.objects.filter(
+                component=self.component, project=target_project
+            ).exists()
+        )
+
+    def test_links_hide_inaccessible_projects_from_component_readers(self) -> None:
+        private_component = self.create_acl()
+        ComponentLink.objects.create(
+            component=self.component, project=private_component.project
+        )
+
+        response = self.do_request(
+            "api:component-links",
+            self.component_kwargs,
+            code=200,
+        )
+        self.assertEqual(response.data["count"], 0)
+
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Component link managers",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+        response = self.do_request(
+            "api:component-links",
+            self.component_kwargs,
+            code=200,
+        )
+        self.assertEqual(response.data["count"], 1)
 
     def test_links_with_category(self) -> None:
         self.create_acl()
@@ -9573,6 +10164,38 @@ class TranslationAPITest(APIBaseTest):
     def test_repo_status_denied(self) -> None:
         self.do_request("api:translation-repository", self.translation_kwargs, code=403)
 
+    def test_repo_operations_require_component_wide_permission(self) -> None:
+        group_name = "Language-limited repository access"
+        permissions = ("vcs.commit", "vcs.push", "vcs.reset", "vcs.update")
+        for permission in permissions:
+            self.grant_perm_to_user(
+                permission,
+                group_name=group_name,
+                component=self.component,
+            )
+        membership = TeamMembership.objects.get(user=self.user, group__name=group_name)
+        membership.limit_languages.add(Language.objects.get(code="cs"))
+        self.user.clear_permissions_cache()
+
+        translation = self.component.translation_set.get(language_code="cs")
+        for permission in permissions:
+            self.assertTrue(self.user.has_perm(permission, translation))
+            self.assertFalse(self.user.has_perm(permission, self.component))
+
+        self.do_request(
+            "api:translation-repository",
+            self.translation_kwargs,
+            code=200,
+        )
+        for operation in RepoOperations.values:
+            self.do_request(
+                "api:translation-repository",
+                self.translation_kwargs,
+                method="post",
+                code=403,
+                request={"operation": operation},
+            )
+
     def test_repo_status(self) -> None:
         response = self.do_request(
             "api:translation-repository",
@@ -9913,6 +10536,7 @@ class TranslationAPITest(APIBaseTest):
             request={"source": "Source", "target": "Target"},
             code=200,
         )
+
         self.do_request(
             "api:translation-units",
             {
@@ -10022,6 +10646,53 @@ class TranslationAPITest(APIBaseTest):
             },
             code=200,
         )
+
+    def test_add_approved_unit_requires_review_permission(self) -> None:
+        self.component.manage_units = True
+        self.component.save(update_fields=["manage_units"])
+        self.project.translation_review = True
+        self.project.save(update_fields=["translation_review"])
+        self.grant_perm_to_user(
+            "unit.add",
+            group_name="Add units only",
+            project=self.project,
+        )
+        self.user.clear_permissions_cache()
+        request = {
+            "source": ["Approval source"],
+            "target": ["Approval target"],
+            "state": STATE_APPROVED,
+        }
+
+        self.do_request(
+            "api:translation-units",
+            self.translation_kwargs,
+            method="post",
+            request=request,
+            format="json",
+            code=400,
+        )
+        self.assertFalse(
+            self.component.translation_set.get(language_code="cs")
+            .unit_set.filter(source="Approval source")
+            .exists()
+        )
+
+        self.grant_perm_to_user(
+            "unit.review",
+            group_name="Review added units",
+            project=self.project,
+        )
+        self.user.clear_permissions_cache()
+        response = self.do_request(
+            "api:translation-units",
+            self.translation_kwargs,
+            method="post",
+            request=request,
+            format="json",
+            code=200,
+        )
+        self.assertEqual(response.data["state"], STATE_APPROVED)
 
     def test_add_bilingual_source(self) -> None:
         self.component.manage_units = True
@@ -11548,6 +12219,35 @@ class SearchAPITest(APIBaseTest):
             [{"category": "Language", "name": "Czech", "url": "/languages/cs/"}],
         )
 
+    def test_restricted_component_visibility(self) -> None:
+        restricted = self.create_po(
+            name="Restricted search result",
+            project=self.project,
+            restricted=True,
+        )
+
+        response = self.client.get(
+            reverse("api:search"), {"q": "Restricted search result"}
+        )
+        self.assertFalse(
+            any(result["category"] == "Component" for result in response.data)
+        )
+
+        access_group = Group.objects.create(
+            name="Restricted component viewers",
+            language_selection=SELECTION_ALL,
+        )
+        access_group.components.add(restricted)
+        self.user.groups.add(access_group)
+        self.user.clear_permissions_cache()
+        self.authenticate(False)
+        response = self.client.get(
+            reverse("api:search"), {"q": "Restricted search result"}
+        )
+        self.assertTrue(
+            any(result["category"] == "Component" for result in response.data)
+        )
+
 
 class ComponentListAPITest(APIBaseTest):
     def setUp(self) -> None:
@@ -11939,6 +12639,141 @@ class AddonAPITest(APIBaseTest):
             authenticated=True,
             superuser=False,
             add_user="Administration",
+        )
+
+    def test_sitewide_manager_access_is_scope_limited(self) -> None:
+        private_component = self.create_acl()
+        component_addon = private_component.addon_set.create(
+            name="weblate.gettext.linguas",
+            configuration={"secret": "component"},
+        )
+        project_addon = private_component.project.addon_set.create(
+            name="weblate.gettext.linguas",
+            configuration={"secret": "project"},
+        )
+        sitewide_addon = Addon.objects.create(
+            name="weblate.gettext.linguas",
+            configuration={"scope": "sitewide"},
+        )
+        self.grant_perm_to_user("management.addons")
+        self.user.clear_permissions_cache()
+
+        response = self.do_request("api:addon-list", code=200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], sitewide_addon.pk)
+        self.do_request(
+            "api:addon-detail",
+            kwargs={"pk": sitewide_addon.pk},
+            code=200,
+        )
+        for addon in (component_addon, project_addon):
+            self.do_request(
+                "api:addon-detail",
+                kwargs={"pk": addon.pk},
+                code=404,
+            )
+
+    def test_component_manager_can_access_component_addon(self) -> None:
+        component_addon = self.component.addon_set.create(
+            name="weblate.gettext.linguas"
+        )
+        project_addon = self.project.addon_set.create(name="weblate.gettext.linguas")
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Component add-on managers",
+            component=self.component,
+        )
+        self.user.clear_permissions_cache()
+
+        response = self.do_request("api:addon-list", code=200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], component_addon.pk)
+        self.do_request(
+            "api:addon-detail",
+            kwargs={"pk": component_addon.pk},
+            code=200,
+        )
+        self.do_request(
+            "api:addon-detail",
+            kwargs={"pk": project_addon.pk},
+            code=404,
+        )
+
+    def test_project_scoped_component_manager_can_access_component_addon(self) -> None:
+        component_addon = self.component.addon_set.create(
+            name="weblate.gettext.linguas"
+        )
+        project_addon = self.project.addon_set.create(name="weblate.gettext.linguas")
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Project component add-on managers",
+            project=self.project,
+        )
+        self.user.clear_permissions_cache()
+
+        response = self.do_request("api:addon-list", code=200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], component_addon.pk)
+        self.do_request(
+            "api:addon-detail",
+            kwargs={"pk": project_addon.pk},
+            code=404,
+        )
+
+    def test_blocked_component_manager_cannot_access_component_addon(self) -> None:
+        component_addon = self.component.addon_set.create(
+            name="weblate.gettext.linguas",
+            configuration={"secret": "blocked"},
+        )
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Blocked component add-on managers",
+            project=self.project,
+        )
+        UserBlock.objects.create(user=self.user, project=self.project)
+        self.user.clear_permissions_cache()
+
+        self.assertFalse(self.user.has_perm("component.edit", self.component))
+        response = self.do_request("api:addon-list", code=200)
+        self.assertEqual(response.data["count"], 0)
+        self.do_request(
+            "api:addon-detail",
+            kwargs={"pk": component_addon.pk},
+            code=404,
+        )
+
+    def test_project_manager_cannot_access_restricted_component_addon(self) -> None:
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        component_addon = self.component.addon_set.create(
+            name="weblate.gettext.linguas"
+        )
+        project_addon = self.project.addon_set.create(name="weblate.gettext.linguas")
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        response = self.do_request("api:addon-list", code=200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], project_addon.pk)
+        self.do_request(
+            "api:addon-detail",
+            kwargs={"pk": component_addon.pk},
+            code=404,
+        )
+
+    def test_project_addons_enforce_two_factor_requirement(self) -> None:
+        self.project.enforced_2fa = True
+        self.project.save(update_fields=["enforced_2fa"])
+        project_addon = self.project.addon_set.create(name="weblate.gettext.linguas")
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        response = self.do_request("api:addon-list", code=200)
+        self.assertEqual(response.data["count"], 0)
+        self.do_request(
+            "api:addon-detail",
+            kwargs={"pk": project_addon.pk},
+            code=404,
         )
 
     def test_configuration(self) -> None:

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -435,13 +435,24 @@ class DownloadViewSet(viewsets.ReadOnlyModelViewSet):
 class WeblateViewSet(DownloadViewSet):
     """Allow to skip content negotiation for certain requests."""
 
+    @staticmethod
+    def get_repository_permission_obj(
+        obj: Project | Component | Translation, *, component_scope: bool
+    ) -> Project | Component | Translation:
+        component = obj.component if isinstance(obj, Translation) else obj
+        if (
+            isinstance(component, Component)
+            and component.linked_component_id is not None
+        ):
+            return component.linked_component
+        return component if component_scope else obj
+
     @transaction.atomic
-    def repository_operation(
-        self, request: Request, obj, project: Project, operation: str
-    ):
+    def repository_operation(self, request: Request, obj, operation: str):
         permission, method, args, kwargs, takes_request = REPO_OPERATIONS[operation]
 
-        if not request.user.has_perm(permission, project):
+        permission_obj = self.get_repository_permission_obj(obj, component_scope=True)
+        if not request.user.has_perm(permission, permission_obj):
             raise PermissionDenied
 
         obj.acting_user = request.user
@@ -466,20 +477,13 @@ class WeblateViewSet(DownloadViewSet):
     def repository(self, request: Request, **kwargs):
         obj = self.get_object()
 
-        if isinstance(obj, Translation):
-            project = obj.component.project
-        elif isinstance(obj, Component):
-            project = obj.project
-        else:
-            project = obj
-
         if request.method == "POST":
             serializer = RepoRequestSerializer(data=request.data)
             serializer.is_valid(raise_exception=True)
 
             data = {
                 "result": self.repository_operation(
-                    request, obj, project, serializer.validated_data["operation"]
+                    request, obj, serializer.validated_data["operation"]
                 )
             }
 
@@ -489,7 +493,8 @@ class WeblateViewSet(DownloadViewSet):
 
             return Response(data)
 
-        if not request.user.has_perm("meta:vcs.status", project):
+        permission_obj = self.get_repository_permission_obj(obj, component_scope=False)
+        if not request.user.has_perm("meta:vcs.status", permission_obj):
             raise PermissionDenied
 
         data = {
@@ -806,7 +811,7 @@ class UserViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post", "delete"])
     def groups(self, request: Request, **kwargs):
         obj = self.get_object()
-        self.perm_check(request, obj)
+        self.perm_check(request, obj, protect_internal=True)
 
         if not isinstance(request.data, Mapping):
             raise ValidationError(
@@ -861,7 +866,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def notifications(self, request: Request, username: str):
         obj = self.get_object()
         if request.method == "POST":
-            self.perm_check(request, obj, allow_self=True)
+            self.perm_check(request, obj, allow_self=True, protect_internal=True)
             with transaction.atomic():
                 serializer = NotificationSerializer(
                     data=request.data, context={"request": request}
@@ -912,7 +917,7 @@ class UserViewSet(viewsets.ModelViewSet):
             raise not_found_http404(msg) from error
 
         if request.method == "DELETE":
-            self.perm_check(request, obj, allow_self=True)
+            self.perm_check(request, obj, allow_self=True, protect_internal=True)
             subscription.delete()
             return Response(status=HTTP_204_NO_CONTENT)
 
@@ -922,7 +927,7 @@ class UserViewSet(viewsets.ModelViewSet):
                 subscription, context={"request": request}
             )
         else:
-            self.perm_check(request, obj, allow_self=True)
+            self.perm_check(request, obj, allow_self=True, protect_internal=True)
             serializer = NotificationSerializer(
                 subscription,
                 data=request.data,
@@ -2301,6 +2306,7 @@ class ComponentViewSet(
     queryset = Component.objects.none()
     serializer_class = ComponentSerializer
     lookup_fields = ("project__slug", "slug")
+    request: AuthenticatedHttpRequest  # type: ignore[assignment]
 
     def get_queryset(self):
         return (
@@ -2636,10 +2642,13 @@ class ComponentViewSet(
     @action(detail=True, methods=["get", "post"])
     def links(self, request: Request, **kwargs):
         instance = self.get_object()
+        user = self.request.user
         if request.method == "POST":
             return self.add_link(request, instance)
 
         queryset = instance.links.order_by("id")
+        if not user.has_perm("component.edit", instance):
+            queryset = queryset.filter(pk__in=user.allowed_projects)
         page = self.paginate_queryset(queryset)
 
         serializer = ProjectSerializer(page, many=True, context={"request": request})
@@ -3197,6 +3206,21 @@ class TranslationViewSet(MultipleFieldViewSet, DestroyModelMixin, AnnouncementsM
                 data=request.data, context={"translation": obj}
             )
             input_serializer.is_valid(raise_exception=True)
+
+            if input_serializer.validated_data.get("state") == STATE_APPROVED:
+                can_review = request.user.has_perm("unit.review", obj)
+                if not can_review:
+                    raise ValidationError(
+                        {
+                            "state": getattr(
+                                can_review,
+                                "reason",
+                                gettext(
+                                    "You do not have permission to approve strings."
+                                ),
+                            )
+                        }
+                    )
 
             try:
                 unit = obj.add_unit(request, **input_serializer.as_kwargs())
@@ -3938,6 +3962,7 @@ class Search(APIView):
     """Site-wide search endpoint."""
 
     serializer_class = SearchResultSerializer
+    request: AuthenticatedHttpRequest  # type: ignore[assignment]
 
     @extend_schema(
         operation_id="api_search_retrieve",
@@ -3954,9 +3979,9 @@ class Search(APIView):
     # pylint: disable-next=redefined-builtin
     def get(self, request: Request, format=None):  # ruff: ignore[builtin-argument-shadowing]
         """Return site-wide search results as a list."""
-        user = request.user
+        user = self.request.user
         projects = user.allowed_projects
-        components = Component.objects.filter(project__in=projects)
+        components = Component.objects.filter_access(user)
         category = Category.objects.filter(project__in=projects)
         results: list[dict[str, str]] = []
         query = request.GET.get("q")
@@ -4117,15 +4142,10 @@ class TasksViewSet(ViewSet):
 class AddonViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelMixin):
     queryset = Addon.objects.none()
     serializer_class = AddonSerializer
+    request: AuthenticatedHttpRequest  # type: ignore[assignment]
 
     def get_queryset(self):
-        if self.request.user.has_perm("management.addons"):
-            return Addon.objects.order_by("id")
-        return Addon.objects.filter(
-            Q(project__in=self.request.user.managed_projects)
-            | Q(category__project__in=self.request.user.managed_projects)
-            | Q(component__project__in=self.request.user.managed_projects)
-        ).order_by("id")
+        return Addon.objects.filter_access(self.request.user).order_by("id")
 
     def perm_check(self, request: Request, instance: Addon) -> None:
         if instance.component:

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -1065,19 +1065,56 @@ def check_billing_view(
     )
 
 
+def billing_plan_allows_access_control(project: Project) -> bool:
+    """Return whether the billing plan allows private access control."""
+    return "weblate.billing" not in settings.INSTALLED_APPS or any(
+        billing.plan.change_access_control for billing in project.billings
+    )
+
+
+def billing_allows_access_control(project: Project) -> bool:
+    """Return whether billing allows changing project access control."""
+    return bool(project.access_control) or billing_plan_allows_access_control(project)
+
+
 @register_perm("billing:project.permissions")
-def check_billing(user: User, permission: str, obj: Project) -> bool | PermissionResult:
+def check_billing_project_permissions(
+    user: User, permission: str, obj: Project
+) -> bool | PermissionResult:
     if user.is_superuser:
         return True
-
-    if (
-        "weblate.billing" in settings.INSTALLED_APPS
-        and not any(billing.plan.change_access_control for billing in obj.billings)
-        and not obj.access_control
-    ):
+    if not billing_allows_access_control(obj):
         return False
-
     return check_permission(user, "project.permissions", obj)
+
+
+@register_perm("billing:component.permissions")
+def check_billing_component_permissions(
+    user: User, permission: str, obj: Component
+) -> PermissionResult:
+    """Return whether user can change component restricted access."""
+    if user.is_superuser:
+        return Allowed()
+    if obj.pk is None:
+        return Denied(
+            gettext(
+                "Create the component and grant yourself explicit access before enabling restricted access."
+            )
+        )
+    if not obj.restricted and not billing_plan_allows_access_control(obj.project):
+        return Denied(
+            gettext("The billing plan does not allow private access control.")
+        )
+    if not any(
+        _has_scoped_permission("component.edit", permissions, languages)
+        for permissions, languages in user.component_permissions.get(obj.pk, ())
+    ):
+        return Denied(
+            gettext(
+                "You need explicit access to this component before enabling restricted access; otherwise, you would lock yourself out."
+            )
+        )
+    return Allowed()
 
 
 @register_perm("announcement.delete")

--- a/weblate/auth/tests/test_permissions.py
+++ b/weblate/auth/tests/test_permissions.py
@@ -14,7 +14,7 @@ from weblate.auth.data import (
     SELECTION_ALL_PROTECTED,
     SELECTION_ALL_PUBLIC,
 )
-from weblate.auth.models import Group, Permission, Role, User
+from weblate.auth.models import Group, Permission, Role, TeamMembership, User
 from weblate.trans.models import Comment, Component, Project
 from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.trans.tests.utils import create_test_billing
@@ -177,6 +177,102 @@ class PermissionsTest(FixtureComponentTestCase):
         self.assertTrue(self.superuser.has_perm("unit.edit", self.component))
         self.assertFalse(self.admin.has_perm("unit.edit", self.component))
         self.assertFalse(self.user.has_perm("unit.edit", self.component))
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_billing_component_permissions(self) -> None:
+        self.assertTrue(
+            self.superuser.has_perm("billing:component.permissions", Component())
+        )
+        self.assertTrue(self.admin.has_perm("component.edit", self.component))
+        self.assertNotIn(self.component.pk, self.admin.component_permissions)
+        self.assert_denied_reason(
+            self.admin.has_perm("billing:component.permissions", self.component),
+            "You need explicit access to this component before enabling restricted access; otherwise, you would lock yourself out.",
+        )
+        self.assertNotIn(self.component.pk, self.admin.component_permissions)
+        self.component.restricted = True
+        self.assertFalse(self.admin.can_access_component(self.component))
+        self.component.restricted = False
+
+        role = Role.objects.create(name="Restricted component editor")
+        role.permissions.add(Permission.objects.get(codename="component.edit"))
+        group = Group.objects.create(name="Restricted component editors")
+        group.roles.add(role)
+        group.components.add(self.component)
+        self.admin.groups.add(group)
+        self.admin.clear_permissions_cache()
+
+        self.assertTrue(
+            self.admin.has_perm("billing:component.permissions", self.component)
+        )
+        self.assert_denied_reason(
+            self.admin.has_perm("billing:component.permissions", Component()),
+            "Create the component and grant yourself explicit access before enabling restricted access.",
+        )
+
+    @modify_settings(INSTALLED_APPS={"append": "weblate.billing"})
+    @override_settings(OFFER_HOSTING=True)
+    def test_billing_component_permissions_on_hosted(self) -> None:
+        role = Role.objects.create(name="Hosted restricted component editor")
+        role.permissions.add(Permission.objects.get(codename="component.edit"))
+        group = Group.objects.create(name="Hosted restricted component editors")
+        group.roles.add(role)
+        group.components.add(self.component)
+        self.admin.groups.add(group)
+        self.admin.clear_permissions_cache()
+
+        self.assert_denied_reason(
+            self.admin.has_perm("billing:component.permissions", self.component),
+            "The billing plan does not allow private access control.",
+        )
+
+        project = Project.objects.get(pk=self.project.pk)
+        billing = create_test_billing(self.admin)
+        billing.add_project(project)
+        component = Component.objects.select_related("project").get(
+            pk=self.component.pk
+        )
+        self.assertTrue(self.admin.has_perm("billing:component.permissions", component))
+
+        billing.plan.change_access_control = False
+        billing.plan.save(update_fields=["change_access_control"])
+        project.access_control = Project.ACCESS_PROTECTED
+        project.save(update_fields=["access_control"])
+        component = Component.objects.select_related("project").get(
+            pk=self.component.pk
+        )
+        self.assert_denied_reason(
+            self.admin.has_perm("billing:component.permissions", component),
+            "The billing plan does not allow private access control.",
+        )
+
+        component.restricted = True
+        component.save(update_fields=["restricted"])
+        self.assertTrue(self.admin.has_perm("billing:component.permissions", component))
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_billing_component_permissions_reject_language_limited_access(
+        self,
+    ) -> None:
+        role = Role.objects.create(name="Language limited component editor")
+        role.permissions.add(Permission.objects.get(codename="component.edit"))
+        group = Group.objects.create(name="Language limited component editors")
+        group.roles.add(role)
+        group.components.add(self.component)
+        self.admin.groups.add(group)
+        membership = TeamMembership.objects.get(user=self.admin, group=group)
+        membership.limit_languages.add(self.component.source_language)
+        self.admin.clear_permissions_cache()
+
+        self.assertTrue(self.admin.has_perm("component.edit", self.component))
+        self.assert_denied_reason(
+            self.admin.has_perm("billing:component.permissions", self.component),
+            "You need explicit access to this component before enabling restricted access; otherwise, you would lock yourself out.",
+        )
+
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        self.assertFalse(self.admin.has_perm("component.edit", self.component))
 
     def assert_denied_reason(self, result, reason: str) -> None:
         self.assertFalse(result)

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2248,8 +2248,16 @@ class ComponentSettingsForm(
             "category" if self.instance.category_id else "project"
         )
         self.setup_inherited_settings(parent_scope, has_parent=True)
-        if self.hide_restricted:
-            self.fields["restricted"].widget = forms.HiddenInput()
+        restricted_permission = request.user.has_perm(
+            "billing:component.permissions", self.instance
+        )
+        if not restricted_permission:
+            self.fields["restricted"].disabled = True
+            self.fields["restricted"].help_text = getattr(
+                restricted_permission,
+                "reason",
+                gettext("You do not have permission to change restricted access."),
+            )
         self.helper.layout = Layout(
             TabHolder(
                 Tab(
@@ -2442,23 +2450,9 @@ class ComponentSettingsForm(
             else:
                 field.help_text = inherited_note
 
-    @property
-    def hide_restricted(self) -> bool:
-        user = self.request.user
-        if user.is_superuser:
-            return False
-        if settings.OFFER_HOSTING:
-            return True
-        return not any(
-            "component.edit" in permissions
-            for permissions, _langs in user.component_permissions[self.instance.pk]
-        )
-
     def clean(self) -> None:
         super().clean()
         data = self.cleaned_data
-        if self.hide_restricted:
-            data["restricted"] = self.instance.restricted
         clean_integration_component_data(self, data, vcs=self.instance.vcs)
 
         repo = data.get("repo") or ""
@@ -2949,7 +2943,15 @@ class ComponentInitCreateForm(CleanRepoMixin, ComponentProjectForm):
 
         # Create linked repos automatically
         repo = instance.suggest_repo_link()
-        if repo:
+        try:
+            linked_component = (
+                Component.objects.get_linked(repo) if repo is not None else None
+            )
+        except Component.DoesNotExist:
+            linked_component = None
+        if linked_component is not None and self.request.user.has_perm(
+            "component.edit", linked_component
+        ):
             data["repo"] = repo
             data["branch"] = ""
             self.clean_instance(data)

--- a/weblate/trans/tests/test_create.py
+++ b/weblate/trans/tests/test_create.py
@@ -334,6 +334,51 @@ class CreateTest(ViewTestCase):
 
     @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
     @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_create_component_does_not_autolink_inaccessible_component(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        self.user.clear_permissions_cache()
+
+        self.client_create_component(
+            True,
+            repo=self.component.repo,
+            branch=self.component.branch,
+        )
+
+        component = Component.objects.get(slug="create-component")
+        self.assertFalse(component.is_repo_link)
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_create_component_ignores_missing_autolink_target(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        link_repo = self.component.get_repo_link_url()
+        original_get_linked = Component.objects.get_linked
+
+        def get_linked(repo):
+            if repo == link_repo:
+                msg = "Component disappeared."
+                raise Component.DoesNotExist(msg)
+            return original_get_linked(repo)
+
+        with patch.object(
+            Component.objects,
+            "get_linked",
+            side_effect=get_linked,
+        ):
+            self.client_create_component(
+                True,
+                repo=self.component.repo,
+                branch=self.component.branch,
+            )
+
+        component = Component.objects.get(slug="create-component")
+        self.assertEqual(component.repo, self.component.repo)
+        self.assertFalse(component.is_repo_link)
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     def test_create_git_component_keeps_repository_lock(self) -> None:
         self.user.is_superuser = True
         self.user.save()

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -48,6 +48,26 @@ from weblate.workspaces.models import Workspace
 
 
 class SettingsTest(ViewTestCase):
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_restricted_component_permission_denial(self) -> None:
+        self.project.add_user(self.user, "Administration")
+
+        form = ComponentSettingsForm(self.get_request(), instance=self.component)
+
+        field = form.fields["restricted"]
+        self.assertTrue(field.disabled)
+        self.assertFalse(field.widget.is_hidden)
+        self.assertEqual(
+            field.help_text,
+            "You need explicit access to this component before enabling restricted access; otherwise, you would lock yourself out.",
+        )
+
+        data = get_form_data(form.initial)
+        data["restricted"] = True
+        form = ComponentSettingsForm(self.get_request(), data, instance=self.component)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertFalse(form.cleaned_data["restricted"])
+
     def test_default_message_templates_render(self) -> None:
         validators = (
             (defaults.DEFAULT_COMMIT_MESSAGE, validate_render_commit),


### PR DESCRIPTION
Prevent REST endpoints from exposing or mutating resources beyond the permissions and hosting policy enforced by the web interface.

- Protect internal accounts from group and notification mutations.
- Scope add-on visibility to manageable projects and components, including restricted-component and two-factor rules.
- Require target-project management for component sharing and hide inaccessible linked projects.
- Require component access for repository links and prevent inaccessible automatic repository sharing in both API and UI.
- Hide linked repository metadata without repository-view permission and exclude restricted components from search.
- Evaluate repository operations against the actual project, component, or translation permission scope.
- Require review permission when creating approved units.
- Gate restricted components through billing while retaining explicit component access to prevent self-lockout.
- Return billing and self-lockout denial reasons through the API and display them beside the disabled UI field.
- Document the authorization behavior, Hosted Weblate eligibility, and add regression coverage.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
