### PR TITLE
chore(lint): enforce readable Ruff overrides

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,6 +159,12 @@ repos:
     args: [--multiline]
     entry: gettext_lazy\([^\)]*\)(\s*%|.format\()
     language: pygrep
+  - id: py-ruff-code-override
+    name: Ruff override using a code instead of a human-readable name
+    description: Ruff overrides should use human-readable rule names
+    types: [python]
+    entry: '#\s*(noqa|ruff):[^\n]*\b[A-Z][A-Z0-9]*[0-9]{3}\b'
+    language: pygrep
 - repo: https://github.com/sphinx-contrib/sphinx-lint
   rev: v1.0.2
   hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ For application-developer workflows and broader product integration guidance, us
 
 - Follow existing Django patterns and project conventions.
 - Prefer the repository's configured Ruff-based formatting and linting rules.
+- Use human-readable Ruff rule names in overrides, such as
+  `# ruff: ignore[assert]`; do not use or rewrite them to cryptic codes such as
+  `# noqa: S102`, `# ruff: N801`, or `# ruff: noqa: F841`.
 - Prefer type hints and use `from __future__ import annotations` in Python
   modules.
 - Use `TYPE_CHECKING` imports for type-only dependencies when that avoids

--- a/scripts/generate-cjk-regexp.py
+++ b/scripts/generate-cjk-regexp.py
@@ -85,7 +85,7 @@ def parse_blocks(data: str) -> list[tuple[int, int, str]]:
 
 def fetch_blocks(version: str) -> str:
     url = UNICODE_BLOCKS_URL.format(version=version)
-    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+    with urllib.request.urlopen(url, timeout=30) as response:  # ruff: ignore[suspicious-url-open-usage]
         return response.read().decode("utf-8")
 
 

--- a/weblate/addons/fedora_messaging.py
+++ b/weblate/addons/fedora_messaging.py
@@ -81,13 +81,13 @@ class BrokerParameters(Protocol):
 
 
 class BrokerTLSContextFactory(Protocol):
-    def clientConnectionForTLS(  # noqa: N802
+    def clientConnectionForTLS(  # ruff: ignore[invalid-function-name]
         self, tls_protocol: object
     ) -> SSL.Connection: ...
 
 
 class BrokerTLSProbeFactory:
-    wrappedFactory = object()  # noqa: N815
+    wrappedFactory = object()  # ruff: ignore[mixed-case-variable-in-class-scope]
 
 
 class BrokerTLSProbeProtocol:
@@ -97,10 +97,10 @@ class BrokerTLSProbeProtocol:
         self.verification_failure: object | None = None
         self.aborted = False
 
-    def failVerification(self, failure: object) -> None:  # noqa: N802
+    def failVerification(self, failure: object) -> None:  # ruff: ignore[invalid-function-name]
         self.verification_failure = failure
 
-    def abortConnection(self) -> None:  # noqa: N802
+    def abortConnection(self) -> None:  # ruff: ignore[invalid-function-name]
         self.aborted = True
 
 
@@ -248,7 +248,7 @@ class FedoraMessagingAddon(ChangeBaseAddon):
         crochet.setup()
 
         if FedoraMessagingAddon._is_fedora_messaging_service_stale(
-            fedora_messaging.api._twisted_service  # noqa: SLF001
+            fedora_messaging.api._twisted_service  # ruff: ignore[private-member-access]
         ):
             LOGGER.warning("Resetting stale Fedora Messaging publisher service")
             add_breadcrumb(
@@ -357,7 +357,7 @@ class FedoraMessagingAddon(ChangeBaseAddon):
                 stop_service
             ) and not FedoraMessagingAddon._stop_fedora_messaging_service(stop_service):
                 return False
-            fedora_messaging.api._twisted_service = None  # noqa: SLF001
+            fedora_messaging.api._twisted_service = None  # ruff: ignore[private-member-access]
             return True
 
     @staticmethod

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -9001,7 +9001,7 @@ class FedoraMessagingPEMBlockTest(SimpleTestCase):
     def test_pem_block_labels_accept_multiple_blocks(self) -> None:
         cert = self.get_certificate()
 
-        labels = FedoraMessagingAddon._get_pem_block_labels(  # noqa: SLF001
+        labels = FedoraMessagingAddon._get_pem_block_labels(  # ruff: ignore[private-member-access]
             f"{cert}\n{cert}"
         )
 
@@ -9012,7 +9012,7 @@ class FedoraMessagingPEMBlockTest(SimpleTestCase):
             "-----END PRIVATE KEY-----" for _ in range(100)
         )
 
-        labels = FedoraMessagingAddon._get_pem_block_labels(value)  # noqa: SLF001
+        labels = FedoraMessagingAddon._get_pem_block_labels(value)  # ruff: ignore[private-member-access]
 
         self.assertEqual(labels, [])
 
@@ -9026,11 +9026,11 @@ class FedoraMessagingPEMBlockTest(SimpleTestCase):
             + f"\n{key}\n{cert}"
         )
 
-        labels = FedoraMessagingAddon._get_pem_block_labels(value)  # noqa: SLF001
+        labels = FedoraMessagingAddon._get_pem_block_labels(value)  # ruff: ignore[private-member-access]
 
         self.assertEqual(labels, ["CERTIFICATE", "PRIVATE KEY", "CERTIFICATE"])
         with self.assertRaisesMessage(ConfigurationException, "invalid certificate"):
-            FedoraMessagingAddon._validate_pem_certificates(  # noqa: SLF001
+            FedoraMessagingAddon._validate_pem_certificates(  # ruff: ignore[private-member-access]
                 value, "invalid certificate"
             )
 
@@ -9355,7 +9355,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
 
     def test_publish_message_success(self) -> None:
         service = object()
-        fedora_messaging.api._twisted_service = service  # noqa: SLF001
+        fedora_messaging.api._twisted_service = service  # ruff: ignore[private-member-access]
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
 
         with (
@@ -9379,35 +9379,35 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             DEFAULT_FEDORA_MESSAGING_PUBLISH_TIMEOUT,
         )
         report_error.assert_not_called()
-        self.assertIs(fedora_messaging.api._twisted_service, service)  # noqa: SLF001
+        self.assertIs(fedora_messaging.api._twisted_service, service)  # ruff: ignore[private-member-access]
 
     def test_reset_fedora_messaging_service_stops_existing_service(self) -> None:
         service = MagicMock()
-        fedora_messaging.api._twisted_service = service  # noqa: SLF001
+        fedora_messaging.api._twisted_service = service  # ruff: ignore[private-member-access]
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
 
         with patch.object(
             FedoraMessagingAddon, "_stop_fedora_messaging_service"
         ) as stop_service:
-            result = FedoraMessagingAddon._reset_fedora_messaging_service()  # noqa: SLF001
+            result = FedoraMessagingAddon._reset_fedora_messaging_service()  # ruff: ignore[private-member-access]
 
         stop_service.assert_called_once_with(service.stopService)
         self.assertTrue(result)
-        self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
+        self.assertIsNone(fedora_messaging.api._twisted_service)  # ruff: ignore[private-member-access]
 
     def test_reset_fedora_messaging_service_keeps_service_on_stop_failure(self) -> None:
         service = MagicMock()
-        fedora_messaging.api._twisted_service = service  # noqa: SLF001
+        fedora_messaging.api._twisted_service = service  # ruff: ignore[private-member-access]
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
 
         with patch.object(
             FedoraMessagingAddon, "_stop_fedora_messaging_service", return_value=False
         ) as stop_service:
-            result = FedoraMessagingAddon._reset_fedora_messaging_service()  # noqa: SLF001
+            result = FedoraMessagingAddon._reset_fedora_messaging_service()  # ruff: ignore[private-member-access]
 
         stop_service.assert_called_once_with(service.stopService)
         self.assertFalse(result)
-        self.assertIs(fedora_messaging.api._twisted_service, service)  # noqa: SLF001
+        self.assertIs(fedora_messaging.api._twisted_service, service)  # ruff: ignore[private-member-access]
 
     def test_stop_fedora_messaging_service_runs_in_reactor_and_waits(self) -> None:
         stop_service = MagicMock(return_value="stopped")
@@ -9421,7 +9421,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             return wrapper
 
         with patch("crochet.run_in_reactor", side_effect=run_in_reactor):
-            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # noqa: SLF001
+            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # ruff: ignore[private-member-access]
 
         stop_service.assert_called_once_with()
         self.assertEqual(result.value, "stopped")
@@ -9448,7 +9448,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             patch("crochet.run_in_reactor", side_effect=run_in_reactor),
             patch("weblate.addons.fedora_messaging.report_error") as report_error,
         ):
-            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # noqa: SLF001
+            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # ruff: ignore[private-member-access]
 
         stop_service.assert_called_once_with()
         self.assertEqual(result.value, "stopped")
@@ -9475,7 +9475,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             patch("crochet.run_in_reactor", side_effect=run_in_reactor),
             patch("weblate.addons.fedora_messaging.report_error") as report_error,
         ):
-            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # noqa: SLF001
+            stopped = FedoraMessagingAddon._stop_fedora_messaging_service(stop_service)  # ruff: ignore[private-member-access]
 
         stop_service.assert_called_once_with()
         result.wait.assert_called_once_with(timeout=SERVICE_STOP_TIMEOUT)
@@ -9495,7 +9495,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             jitter=0.119626565582,
         )
 
-        FedoraMessagingAddon._configure_fedora_messaging_publish_retries(  # noqa: SLF001
+        FedoraMessagingAddon._configure_fedora_messaging_publish_retries(  # ruff: ignore[private-member-access]
             SimpleNamespace(factory=factory), connection_attempts=4, retry_delay=6
         )
 
@@ -9511,7 +9511,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
     ) -> None:
         factory = SimpleNamespace()
 
-        FedoraMessagingAddon._configure_fedora_messaging_publish_retries(  # noqa: SLF001
+        FedoraMessagingAddon._configure_fedora_messaging_publish_retries(  # ruff: ignore[private-member-access]
             SimpleNamespace(factory=factory), connection_attempts=1, retry_delay=0
         )
 
@@ -9533,14 +9533,14 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         )
 
         self.assertTrue(
-            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # ruff: ignore[private-member-access]
         )
 
     def test_fedora_messaging_service_stale_when_stopped(self) -> None:
         service = SimpleNamespace(running=False)
 
         self.assertTrue(
-            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # ruff: ignore[private-member-access]
         )
 
     def test_fedora_messaging_service_stale_when_factory_stopped(self) -> None:
@@ -9550,7 +9550,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         )
 
         self.assertTrue(
-            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # ruff: ignore[private-member-access]
         )
 
     def test_fedora_messaging_service_not_stale_with_pending_retry(self) -> None:
@@ -9566,14 +9566,14 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         )
 
         self.assertFalse(
-            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # noqa: SLF001
+            FedoraMessagingAddon._is_fedora_messaging_service_stale(service)  # ruff: ignore[private-member-access]
         )
 
     def test_prepare_fedora_messaging_service_resets_stale_service(self) -> None:
         self.prepare_service_patcher.stop()
         stale_service = object()
         configured_service = SimpleNamespace(factory=SimpleNamespace())
-        fedora_messaging.api._twisted_service = stale_service  # noqa: SLF001
+        fedora_messaging.api._twisted_service = stale_service  # ruff: ignore[private-member-access]
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
         result = MagicMock()
 
@@ -9603,7 +9603,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
                 FedoraMessagingAddon, "_configure_fedora_messaging_publish_retries"
             ) as configure_retries,
         ):
-            FedoraMessagingAddon._prepare_fedora_messaging_service(  # noqa: SLF001
+            FedoraMessagingAddon._prepare_fedora_messaging_service(  # ruff: ignore[private-member-access]
                 connection_attempts=4, retry_delay=6
             )
 
@@ -9643,7 +9643,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             ),
             self.assertRaises(crochet.TimeoutError),
         ):
-            FedoraMessagingAddon._prepare_fedora_messaging_service(  # noqa: SLF001
+            FedoraMessagingAddon._prepare_fedora_messaging_service(  # ruff: ignore[private-member-access]
                 connection_attempts=4, retry_delay=6
             )
 
@@ -9654,7 +9654,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
 
     def test_first_publish_timeout_is_reported_and_resets_service(self) -> None:
         service = object()
-        fedora_messaging.api._twisted_service = service  # noqa: SLF001
+        fedora_messaging.api._twisted_service = service  # ruff: ignore[private-member-access]
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
         error = fedora_messaging_exceptions.PublishTimeout(
             "Publishing timed out after waiting 30 seconds."
@@ -9674,7 +9674,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
                 self.get_fedora_message(), self.addon_configuration["amqp_url"], None
             )
 
-        self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
+        self.assertIsNone(fedora_messaging.api._twisted_service)  # ruff: ignore[private-member-access]
         report_error.assert_called_once_with(
             "Fedora Messaging publish failed",
             level="error",
@@ -9684,7 +9684,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
 
     def test_repeated_publish_timeout_is_logged_and_resets_service(self) -> None:
         service = object()
-        fedora_messaging.api._twisted_service = service  # noqa: SLF001
+        fedora_messaging.api._twisted_service = service  # ruff: ignore[private-member-access]
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
         error = fedora_messaging_exceptions.PublishTimeout(
             "Publishing timed out after waiting 30 seconds."
@@ -9705,7 +9705,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
                 self.get_fedora_message(), self.addon_configuration["amqp_url"], None
             )
 
-        self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
+        self.assertIsNone(fedora_messaging.api._twisted_service)  # ruff: ignore[private-member-access]
         report_error.assert_called_once_with(
             "Fedora Messaging publish failed",
             level="error",
@@ -9721,7 +9721,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             self.assertNotIn("-----BEGIN PRIVATE KEY-----", str(value))
 
     def test_missing_publisher_is_reported_and_resets_service(self) -> None:
-        fedora_messaging.api._twisted_service = object()  # noqa: SLF001
+        fedora_messaging.api._twisted_service = object()  # ruff: ignore[private-member-access]
         self.addCleanup(setattr, fedora_messaging.api, "_twisted_service", None)
 
         with (
@@ -9741,7 +9741,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
                 self.get_fedora_message(), self.addon_configuration["amqp_url"], None
             )
 
-        self.assertIsNone(fedora_messaging.api._twisted_service)  # noqa: SLF001
+        self.assertIsNone(fedora_messaging.api._twisted_service)  # ruff: ignore[private-member-access]
         report_error.assert_called_once_with(
             "Fedora Messaging publish failed",
             level="error",
@@ -9930,7 +9930,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         def configure_tls_parameters(parameters) -> None:
             self.assertEqual(parameters.host, "rabbitmq.example.com")
             self.assertEqual(parameters.port, 12345)
-            parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
+            parameters._ssl_options = SimpleNamespace(  # ruff: ignore[private-member-access]
                 context=SimpleNamespace(), server_hostname=parameters.host
             )
 
@@ -9966,7 +9966,10 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         tls_connection.bio_read.assert_called_once_with(2**15)
 
     def test_broker_tls_probe_protocol_matches_twisted_factory_shape(self) -> None:
-        from twisted.internet import ssl as twisted_ssl  # noqa: PLC0415
+        # ruff: ignore[import-outside-top-level]
+        from twisted.internet import (
+            ssl as twisted_ssl,
+        )
 
         tls_context_factory = twisted_ssl.optionsForClientTLS("rabbitmq.example.com")
 
@@ -9988,7 +9991,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         ]
         tls_context_factory = self.get_broker_tls_context_factory(tls_connection)
 
-        FedoraMessagingAddon._perform_broker_tls_handshake(  # noqa: SLF001
+        FedoraMessagingAddon._perform_broker_tls_handshake(  # ruff: ignore[private-member-access]
             broker_connection, tls_context_factory, timeout=7
         )
 
@@ -10013,7 +10016,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
             ),
             self.assertRaisesMessage(TimeoutError, "TLS handshake timed out"),
         ):
-            FedoraMessagingAddon._perform_broker_tls_handshake(  # noqa: SLF001
+            FedoraMessagingAddon._perform_broker_tls_handshake(  # ruff: ignore[private-member-access]
                 broker_connection, tls_context_factory, timeout=7
             )
 
@@ -10029,7 +10032,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         tls_context_factory = self.get_broker_tls_context_factory(tls_connection)
 
         def configure_tls_parameters(parameters) -> None:
-            parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
+            parameters._ssl_options = SimpleNamespace(  # ruff: ignore[private-member-access]
                 context=SimpleNamespace(), server_hostname=parameters.host
             )
 
@@ -10061,7 +10064,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         tls_context_factory = self.get_broker_tls_context_factory()
 
         def configure_tls_parameters(parameters) -> None:
-            parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
+            parameters._ssl_options = SimpleNamespace(  # ruff: ignore[private-member-access]
                 context=SimpleNamespace(), server_hostname=parameters.host
             )
 
@@ -10089,7 +10092,7 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
 
     def test_broker_tls_validation_reports_connection_error(self) -> None:
         def configure_tls_parameters(parameters) -> None:
-            parameters._ssl_options = SimpleNamespace(  # noqa: SLF001
+            parameters._ssl_options = SimpleNamespace(  # ruff: ignore[private-member-access]
                 context=SimpleNamespace(),
                 server_hostname=parameters.host,
             )

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -714,7 +714,7 @@ def _get_anonymous() -> User:
 def get_anonymous() -> User:
     """Return an anonymous user instance."""
     user = copy(_get_anonymous())
-    fields_cache = user._state.fields_cache  # noqa: SLF001
+    fields_cache = user._state.fields_cache  # ruff: ignore[private-member-access]
     if profile := fields_cache.get("profile"):
         # Keep cached Profile properties local to this anonymous user copy.
         profile = copy(profile)

--- a/weblate/checks/mdx.py
+++ b/weblate/checks/mdx.py
@@ -41,7 +41,7 @@ def _regex_allowed(prev: str) -> bool:
     return not prev or prev in _REGEX_PRECEDERS
 
 
-def _scan_expression(text: str, start: int) -> int | None:  # noqa: C901
+def _scan_expression(text: str, start: int) -> int | None:  # ruff: ignore[complex-structure]
     """
     Find the closing brace of the JSX expression opening at ``start``.
 
@@ -317,7 +317,7 @@ class SafeMDXCheck(TargetCheck):
             )
         )
 
-    def get_jsx_expression_signatures(  # noqa: C901
+    def get_jsx_expression_signatures(  # ruff: ignore[complex-structure]
         self, text: str
     ) -> Iterator[tuple[str, str, tuple[str, ...], str]]:
         """Extract JSX expressions together with their syntactic context."""

--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -1116,7 +1116,7 @@ class MemoryScopeManager(models.Manager["MemoryScope"]):
     def get_write_db_for_memory(self, memory: Memory | None = None) -> str:
         if self._db is not None and self._db != "memory_db":
             return self._db
-        memory_db = None if memory is None else memory._state.db  # noqa: SLF001
+        memory_db = None if memory is None else memory._state.db  # ruff: ignore[private-member-access]
         if memory_db is not None and memory_db != "memory_db":
             return memory_db
         return router.db_for_write(self.model, instance=memory) or "default"

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -453,7 +453,7 @@ def setup_periodic_tasks(sender, **kwargs) -> None:
 
 
 @app.task(trail=False)
-def update_memory(  # noqa: PLR0913
+def update_memory(  # ruff: ignore[too-many-arguments]
     *,
     source_language_id: int,
     target_language_id: int,

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -88,24 +88,24 @@ def add_document(source: str = "Hello", target: str = "Ahoj") -> None:
 
 class MemoryReadReplicaRouter:
     def db_for_read(self, model: type[models.Model], **_hints: object) -> str | None:
-        if model._meta.app_label == "memory":  # noqa: SLF001
+        if model._meta.app_label == "memory":  # ruff: ignore[private-member-access]
             return "memory_db"
         return None
 
     def db_for_write(self, model: type[models.Model], **_hints: object) -> str | None:
-        if model._meta.app_label == "memory":  # noqa: SLF001
+        if model._meta.app_label == "memory":  # ruff: ignore[private-member-access]
             return "default"
         return None
 
 
 class MemoryReplicaWriteRouter:
     def db_for_read(self, model: type[models.Model], **_hints: object) -> str | None:
-        if model._meta.app_label == "memory":  # noqa: SLF001
+        if model._meta.app_label == "memory":  # ruff: ignore[private-member-access]
             return "memory_db"
         return None
 
     def db_for_write(self, model: type[models.Model], **_hints: object) -> str | None:
-        if model._meta.app_label == "memory":  # noqa: SLF001
+        if model._meta.app_label == "memory":  # ruff: ignore[private-member-access]
             return "memory_db"
         return None
 
@@ -305,7 +305,7 @@ class MemoryModelTest(FixtureTestCase):
     def test_legacy_memory_owner_fields_are_not_public(self) -> None:
         for field in ("project", "user", "shared", "from_file"):
             with self.assertRaises(FieldDoesNotExist):
-                Memory._meta.get_field(field)  # noqa: SLF001
+                Memory._meta.get_field(field)  # ruff: ignore[private-member-access]
 
         for lookup in (
             {"project": self.project},

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -867,7 +867,10 @@ class Translation(
         operation: Callable[[TranslationFormat], list[str] | None],
         no_changes_message: str,
     ) -> bool:
-        from weblate.auth.models import get_anonymous  # noqa: PLC0415
+        # ruff: ignore[import-outside-top-level]
+        from weblate.auth.models import (
+            get_anonymous,
+        )
 
         if not self.filename:
             messages.info(request, no_changes_message)
@@ -917,7 +920,10 @@ class Translation(
         self, alert_names: set[str] | None = None
     ) -> None:
         """Refresh import alerts after a single translation file was parsed."""
-        from weblate.trans.alerts.registry import get_import_alerts  # noqa: PLC0415
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.alerts.registry import (
+            get_import_alerts,
+        )
 
         if alert_names is None:
             alert_names = SINGLE_FILE_IMPORT_ALERTS

--- a/weblate/trans/views/hooks.py
+++ b/weblate/trans/views/hooks.py
@@ -694,7 +694,7 @@ def _handle_github_installation_target_event(
     )
 
 
-def _handle_github_installation_event(  # noqa: C901
+def _handle_github_installation_event(  # ruff: ignore[complex-structure]
     data: dict, installation, hostname: str | None
 ) -> None:
     """Handle ``installation`` and ``installation_repositories`` events."""
@@ -955,7 +955,10 @@ def github_integration_hook_helper(
             .distinct()
         )
         if workspace_ids:
-            from weblate.trans.models import Project  # noqa: PLC0415
+            # ruff: ignore[import-outside-top-level]
+            from weblate.trans.models import (
+                Project,
+            )
 
             project_ids = list(
                 Project.objects.filter(workspace_id__in=workspace_ids)

--- a/weblate/vcs/tests/test_github_hooks.py
+++ b/weblate/vcs/tests/test_github_hooks.py
@@ -68,7 +68,7 @@ class TestGitHubAppHooks(ViewTestCase):
         self.workspace = Workspace.objects.create(name="Hook Workspace")
         _make_credentials("github.com", GITHUB_COM_TOKEN, webhook_secret="s3cret")
 
-    def _post(self, event_type, data, *, secret: str | None = "s3cret", url=None):  # noqa: S107
+    def _post(self, event_type, data, *, secret: str | None = "s3cret", url=None):  # ruff: ignore[hardcoded-password-default]
         body = json.dumps(data)
         headers = {"X-GitHub-Event": event_type}
         if secret:

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -105,7 +105,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         accessible_ids: tuple[str, ...] = ("12345",),
         managed_installation_ids: tuple[str, ...] | None = None,
         installations: list[dict] | None = None,
-        token: str = "ghu_user",  # noqa: S107
+        token: str = "ghu_user",  # ruff: ignore[hardcoded-password-default]
     ) -> None:
         """Mock the install-time user-authorization (OAuth) verification."""
         oauth_base = (


### PR DESCRIPTION
Prevent numeric Ruff codes from being reintroduced after the human-readable suppression migration.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
