### PR TITLE
fix(ui): standardize alert documentation links

### DIFF
--- a/docs/contributing/frontend.rst
+++ b/docs/contributing/frontend.rst
@@ -37,6 +37,20 @@ When changing the frontend:
 - Test changed workflows with keyboard-only navigation and, when practical, a
   screen reader spot check.
 
+User interface conventions
+--------------------------
+
+Documentation links
++++++++++++++++++++
+
+Use the information icon for contextual links to the Weblate documentation
+instead of a textual :guilabel:`Documentation` button. In Django templates,
+use the ``documentation_icon`` template tag so that the link has consistent
+styling, labeling, and external-link behavior. Documentation icons are
+interactive links and have to remain keyboard-focusable. Keep textual
+documentation links when they are part of explanatory prose rather than a
+contextual action.
+
 Dependency management
 ---------------------
 

--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -240,9 +240,9 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
         with self.captureOnCommitCallbacks(execute=True):
             return Announcement.objects.create(**kwargs)
 
-    def add_component_alert(self) -> None:
+    def add_component_alert(self, name: str = "PushFailure") -> None:
         with self.captureOnCommitCallbacks(execute=True):
-            self.component.add_alert("PushFailure", error="Some error")
+            self.component.add_alert(name, error="Some error")
 
     def test_notify_lock(self) -> None:
         self.create_with_callbacks(
@@ -756,6 +756,20 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
                 "[Weblate] New alert on Test/Test",
                 "[Weblate] Component Test/Test was locked",
             ],
+        )
+
+    def test_notify_alert_includes_documentation(self) -> None:
+        self.component.project.add_user(self.user, "Administration")
+        self.add_component_alert("UpdateFailure")
+        alert = self.component.alert_set.get(name="UpdateFailure")
+        alert_message = next(
+            message
+            for message in mail.outbox
+            if message.subject == "[Weblate] New alert on Test/Test"
+        )
+
+        self.assertIn(
+            alert.get_documentation_url(self.user), alert_message.alternatives[0][0]
         )
 
     def test_notify_admin(self) -> None:

--- a/weblate/templates/component.html
+++ b/weblate/templates/component.html
@@ -226,9 +226,7 @@
         {% for alert in alerts %}
           <div class="card">
             <div class="card-header">
-              {% if alert.obj.doc_page %}
-                {% documentation_icon alert.obj.doc_page alert.obj.doc_anchor right=True %}
-              {% endif %}
+              {% documentation_icon alert right=True %}
               {{ alert }}
               <span class="badge {{ alert.severity_class }}">{{ alert.get_severity_display }}</span>
               {% if alert.dismissed %}

--- a/weblate/templates/mail/new_alert.html
+++ b/weblate/templates/mail/new_alert.html
@@ -8,6 +8,12 @@
 
   {% with user=subscription_user %}
     {% render_alert alert %}
+    {% documentation alert as documentation_url %}
+    {% if documentation_url %}
+      <p>
+        <a href="{{ documentation_url }}">{% translate "Documentation" %}</a>
+      </p>
+    {% endif %}
   {% endwith %}
 
   <div class="line buttons">

--- a/weblate/templates/trans/alert/community.html
+++ b/weblate/templates/trans/alert/community.html
@@ -5,12 +5,5 @@
 {% if can_configure %}
   <p>
     <a class="btn btn-primary" href="{{ configure_url }}">{% translate "Configure" %}</a>
-    {% if doc_url %}
-      <a class="btn btn-link" href="{{ doc_url }}">{% translate "Documentation" %}</a>
-    {% endif %}
-  </p>
-{% elif doc_url %}
-  <p>
-    <a href="{{ doc_url }}">{% translate "Documentation" %}</a>
   </p>
 {% endif %}

--- a/weblate/templates/trans/alert/inexacthookmatch.html
+++ b/weblate/templates/trans/alert/inexacthookmatch.html
@@ -1,4 +1,4 @@
-{% load i18n permissions translations %}
+{% load i18n permissions %}
 
 <p>
   {% translate "The last webhook update for this component used fallback repository matching instead of an exact repository URL match." %}
@@ -50,10 +50,6 @@
 <p>
   {% if user_can_edit_component %}
     <a class="btn btn-primary" href="{% url 'settings' path=component.get_url_path %}">{% translate "Configure component" %}</a>
-    <a class="btn btn-link" href="{% documentation 'admin/continuous' 'update-vcs' %}">{% translate "Documentation" %}</a>
-  {% else %}
-    <a class="btn btn-primary"
-       href="{% documentation 'admin/continuous' 'update-vcs' %}">{% translate "Documentation" %}</a>
   {% endif %}
   <a class="btn btn-link" href="https://github.com/WeblateOrg/weblate/issues">{% translate "Report issue" %}</a>
 </p>

--- a/weblate/templates/trans/alert/repositorychanges.html
+++ b/weblate/templates/trans/alert/repositorychanges.html
@@ -1,8 +1,5 @@
-{% load i18n translations %}
+{% load i18n %}
 
 <p>
   {% translate "The VCS repository has many changes compared to the upstream. Please merge the changes manually or set up push to automate this." %}
 </p>
-
-<a class="btn btn-primary"
-   href="{% documentation 'admin/continuous' 'push-changes' %}">{% translate "Documentation" %}</a>

--- a/weblate/templates/trans/alert/repositoryoutdated.html
+++ b/weblate/templates/trans/alert/repositoryoutdated.html
@@ -1,8 +1,5 @@
-{% load i18n translations %}
+{% load i18n %}
 
 <p>
   {% translate "The VCS repository is not up to date with the upstream one. Please merge changes manually or set up hooks to automate this." %}
 </p>
-
-<a class="btn btn-primary button"
-   href="{% documentation 'admin/continuous' 'update-vcs' %}">{% translate "Documentation" %}</a>

--- a/weblate/trans/alerts/base.py
+++ b/weblate/trans/alerts/base.py
@@ -11,6 +11,8 @@ from django.db import models
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy
 
+from weblate.utils.docs import get_doc_url
+
 if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
 
@@ -58,6 +60,12 @@ class BaseAlert:
     @classmethod
     def get_doc_url(cls, component, user: User | None = None) -> str:  # ruff: ignore[unused-class-method-argument]
         return ""
+
+    @classmethod
+    def get_documentation_url(cls, component, user: User | None = None) -> str:
+        if not cls.doc_page:
+            return cls.get_doc_url(component, user)
+        return get_doc_url(cls.doc_page, cls.doc_anchor, user=user)
 
     @classmethod
     def is_relevant(cls, component) -> bool:  # ruff: ignore[unused-class-method-argument]

--- a/weblate/trans/alerts/community.py
+++ b/weblate/trans/alerts/community.py
@@ -134,7 +134,6 @@ class ChecklistAlert(BaseAlert):
         )
         result["description"] = alert_class.get_description(component)
         result["configure_url"] = configure_url if can_configure else ""
-        result["doc_url"] = doc_url
         result["can_configure"] = can_configure
         return result
 

--- a/weblate/trans/alerts/vcs.py
+++ b/weblate/trans/alerts/vcs.py
@@ -255,6 +255,8 @@ class RepositoryOutdated(BaseAlert):
     verbose = gettext_lazy("Repository outdated.")
     category = AlertCategory.VCS
     link_wide = True
+    doc_page = "admin/continuous"
+    doc_anchor = "update-vcs"
 
 
 @register
@@ -264,3 +266,5 @@ class RepositoryChanges(BaseAlert):
     category = AlertCategory.VCS
     link_wide = True
     dismissible = True
+    doc_page = "admin/continuous"
+    doc_anchor = "push-changes"

--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -93,6 +93,9 @@ class Alert(models.Model):
     def render(self, user: User) -> str:
         return self.obj.render(user)
 
+    def get_documentation_url(self, user: User | None = None) -> str:
+        return self.obj.get_documentation_url(self.component, user)
+
     @property
     def is_problem(self) -> bool:
         return self.severity >= AlertSeverity.ERROR

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -703,6 +703,9 @@ def documentation(context: Context, page, anchor=""):
     """Return link to Weblate documentation."""
     # User might not be present on error pages
     user = context.get("user")
+    # Alert documentation can differ from other help resources
+    if hasattr(page, "get_documentation_url"):
+        return page.get_documentation_url(user=user)
     # Use object method get_doc_url if present
     if hasattr(page, "get_doc_url"):
         return page.get_doc_url(user=user)
@@ -713,7 +716,7 @@ def render_documentation_icon(doc_url: str, *, right: bool = False):
     if not doc_url:
         return ""
     return format_html(
-        """<a class="{} doc-link" href="{}" title="{}" target="_blank" rel="noopener" tabindex="-1">{}</a>""",
+        """<a class="{} doc-link" href="{}" title="{}" target="_blank" rel="noopener">{}</a>""",
         "float-end" if right else "",
         doc_url,
         gettext("Documentation"),

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -953,6 +953,17 @@ class MonolingualAlertTest(ViewTestCase):
 
 
 class RepositoryAlertTemplateTest(SimpleTestCase):
+    def test_repository_guidance_uses_header_documentation_link(self) -> None:
+        for template_name in (
+            "trans/alert/repositoryoutdated.html",
+            "trans/alert/repositorychanges.html",
+        ):
+            with self.subTest(template_name=template_name):
+                rendered = render_to_string(template_name)
+
+                self.assertNotIn("Documentation", rendered)
+                self.assertNotIn("btn btn-primary", rendered)
+
     def test_bilingual_po_configured_as_monolingual_guidance(self) -> None:
         rendered = render_to_string(
             "trans/alert/bilingualpoconfiguredasmonolingual.html",

--- a/weblate/trans/tests/test_guidance.py
+++ b/weblate/trans/tests/test_guidance.py
@@ -40,6 +40,7 @@ from weblate.trans.alerts.vcs import RepositoryOutdated
 from weblate.trans.models import Project
 from weblate.trans.templatetags.translations import component_alerts
 from weblate.trans.tests.test_views import ViewTestCase
+from weblate.utils.docs import get_doc_url
 
 
 class RecommendedGenerateMoAddonTest(SimpleTestCase):
@@ -195,11 +196,14 @@ class ExtractorGuidanceAlertTest(ViewTestCase):
         self.make_manager()
 
         rendered = MissingRepositoryHook(alert).render(self.user)
+        doc_url = MissingRepositoryHook.get_doc_url(self.component, self.user)
 
         self.assertNotIn("btn btn-primary", rendered)
-        self.assertEqual(
-            rendered.count(MissingRepositoryHook.get_doc_url(self.component)), 1
-        )
+        self.assertNotIn(doc_url, rendered)
+        self.assertEqual(alert.get_documentation_url(self.user), doc_url)
+
+        response = self.client.get(self.component.get_absolute_url())
+        self.assertContains(response, doc_url, count=1)
 
     def test_unused_screenshot_does_not_make_component_problem(self) -> None:
         alert_name = UnusedScreenshot.__name__
@@ -241,9 +245,26 @@ class ExtractorGuidanceAlertTest(ViewTestCase):
         response = self.client.get(self.component.get_absolute_url())
         alert_names = [alert.name for alert in response.context["alerts"]]
         content = response.content.decode()
+        repository_alert = self.component.alert_set.get(
+            name=RepositoryOutdated.__name__
+        )
+        license_alert = self.component.alert_set.get(name=MissingLicense.__name__)
+        license_doc_url = get_doc_url(
+            "admin/projects", "component-license", user=self.user
+        )
 
         self.assertContains(response, "License info missing.")
         self.assertContains(response, "Repository outdated.")
+        self.assertContains(
+            response, repository_alert.get_documentation_url(self.user), count=1
+        )
+        self.assertEqual(
+            license_alert.get_documentation_url(self.user), license_doc_url
+        )
+        self.assertEqual(
+            MissingLicense.get_doc_url(self.component), "https://choosealicense.com/"
+        )
+        self.assertContains(response, license_doc_url, count=1)
         self.assertContains(
             response, "Add screenshots to show where strings are being used."
         )

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -26,6 +26,7 @@ from weblate.trans.templatetags.translations import (
     get_location_links,
     indicate_alerts,
     naturaltime,
+    render_documentation_icon,
     same_naturaltime,
     translation_progress_render,
 )
@@ -75,6 +76,14 @@ class NaturalTimeTest(SimpleTestCase):
                     timestamp - timedelta(seconds=125),
                 )
             )
+
+
+class DocumentationIconTest(SimpleTestCase):
+    def test_link_is_keyboard_focusable(self) -> None:
+        rendered = render_documentation_icon("https://docs.example.com/")
+
+        self.assertIn('href="https://docs.example.com/"', rendered)
+        self.assertNotIn("tabindex", rendered)
 
 
 class IndicateAlertsPriorityTest(SimpleTestCase):


### PR DESCRIPTION
Use Weblate's standard information icon consistently so alert documentation actions follow the established UI language.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
