### PR TITLE
perf(memory): aggregate origin summaries once

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Weblate 2026.8
 .. rubric:: Improvements
 
 * Expanded :ref:`change-actions` documentation with detailed event semantics and improved OpenAPI schema accuracy.
+* Translation memory management pages now load origin summaries with a single database aggregation.
 
 .. rubric:: Bug fixes
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -64,6 +64,7 @@ from weblate.memory.utils import (
     CATEGORY_PRIVATE_OFFSET,
     CATEGORY_SHARED,
 )
+from weblate.memory.views import MemoryView
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Change, Project
 from weblate.trans.tests.test_views import FixtureTestCase
@@ -2884,6 +2885,55 @@ msgstr "Nazdar svete!\n"
 
 
 class MemoryViewTest(FixtureTestCase):
+    def test_origin_counts_use_single_query(self) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        entries = [
+            Memory.objects.create(
+                source_language=source_language,
+                target_language=target_language,
+                source=f"Origin query source {scope}",
+                target=f"Origin query target {scope}",
+                origin="mixed-origin",
+                status=Memory.STATUS_ACTIVE,
+            )
+            for scope in (
+                MemoryScope.SCOPE_USER,
+                MemoryScope.SCOPE_USER_FILE,
+            )
+        ]
+        for entry, scope in zip(
+            entries,
+            (MemoryScope.SCOPE_USER, MemoryScope.SCOPE_USER_FILE),
+            strict=True,
+        ):
+            MemoryScope.objects.create(
+                memory=entry,
+                scope=scope,
+                user=self.user,
+            )
+
+        view = MemoryView()
+        view.objects = {"user": self.user}
+        with CaptureQueriesContext(connection) as queries:
+            origins = view.get_origins()
+
+        # ruff: ignore[private-member-access]
+        memory_table = Memory._meta.db_table
+        origin_queries = [
+            query["sql"]
+            for query in queries
+            if (f'FROM "{memory_table}"' in query["sql"] and "GROUP BY" in query["sql"])
+        ]
+        self.assertEqual(len(origin_queries), 1, "\n".join(origin_queries))
+        mixed_origins = [
+            origin for origin in origins if origin["origin"] == "mixed-origin"
+        ]
+        self.assertEqual(
+            [origin["id__count"] for origin in mixed_origins],
+            [1, 1],
+        )
+
     def upload_file(
         self,
         name,

--- a/weblate/memory/views.py
+++ b/weblate/memory/views.py
@@ -233,19 +233,19 @@ class MemoryView(TemplateView):
         file_scope = MemoryScope.objects.using(self.entries.db).filter(
             memory_id=OuterRef("pk"), scope__in=file_scopes
         )
-        entries = self.entries.alias(has_file_scope=Exists(file_scope))
-        from_file = list(
-            entries.filter(has_file_scope=True)
-            .values("origin")
+        entries = (
+            self.entries.annotate(has_file_scope=Exists(file_scope))
+            .values("origin", "has_file_scope")
             .order_by("origin")
             .annotate(Count("id"))
         )
-        result = list(
-            entries.filter(has_file_scope=False)
-            .values("origin")
-            .order_by("origin")
-            .annotate(Count("id"))
-        )
+        from_file = []
+        result = []
+        for entry in entries:
+            if entry.pop("has_file_scope"):
+                from_file.append(entry)
+            else:
+                result.append(entry)
         for entry in result:
             entry["url"] = get_url(entry["origin"])
         if "project" in self.objects:


### PR DESCRIPTION
The memory management page grouped potentially large querysets twice. Combine file-backed and regular origin counts to reduce page latency.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
