### PR TITLE
perf(dashboard): load only requested component list

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.8
 
 * Expanded :ref:`change-actions` documentation with detailed event semantics and improved OpenAPI schema accuracy.
 * Translation memory management pages now load origin summaries with a single database aggregation.
+* Dashboard component list tabs now load without processing unrelated component lists.
 
 .. rubric:: Bug fixes
 

--- a/weblate/trans/tests/test_dashboard.py
+++ b/weblate/trans/tests/test_dashboard.py
@@ -2,12 +2,15 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from unittest.mock import patch
+
 from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.accounts.models import Profile
 from weblate.lang.models import Language
 from weblate.trans.models import Announcement, ComponentList, Project
+from weblate.trans.models.component import translation_prefetch_tasks
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.utils.state import STATE_APPROVED
 
@@ -119,6 +122,25 @@ class DashboardTest(FixtureTestCase):
         # is always present in the languages drop down in the top bar and hence, it would
         # pass the test even if the ghost translation was not added.
         self.assertContains(response, f"{new_component} — Spanish")
+
+    @patch(
+        "weblate.trans.views.dashboard.translation_prefetch_tasks",
+        wraps=translation_prefetch_tasks,
+    )
+    def test_component_list_dashboard_fetches_only_requested_list(
+        self, prefetch_tasks
+    ) -> None:
+        requested = ComponentList.objects.create(name="Requested", slug="requested")
+        requested.components.add(self.component)
+        unrelated = ComponentList.objects.create(name="Unrelated", slug="unrelated")
+        unrelated.components.add(self.component)
+
+        response = self.client.get(
+            reverse("component-list-dashboard", kwargs={"name": requested.slug})
+        )
+
+        self.assertContains(response, "test/test")
+        prefetch_tasks.assert_called_once()
 
     def test_user_component_list(self) -> None:
         clist = ComponentList.objects.create(name="TestCL", slug="testcl")

--- a/weblate/trans/views/dashboard.py
+++ b/weblate/trans/views/dashboard.py
@@ -216,16 +216,18 @@ def home(request: AuthenticatedHttpRequest) -> HttpResponse:
 
 
 def fetch_componentlists(
-    user: User, user_translations: TranslationQuerySet
+    user: User,
+    user_translations: TranslationQuerySet,
+    *,
+    slug: str | None = None,
 ) -> list[ComponentList]:
-    componentlists = list(
-        ComponentList.objects.filter(
-            show_dashboard=True,
-            components__project__in=user.allowed_projects,
-        )
-        .distinct()
-        .order()
+    componentlists = ComponentList.objects.filter(
+        show_dashboard=True,
+        components__project__in=user.allowed_projects,
     )
+    if slug is not None:
+        componentlists = componentlists.filter(slug=slug)
+    componentlists = list(componentlists.distinct().order())
     for componentlist in componentlists:
         components = componentlist.components.filter_access(user)
         # Force fetching the query now
@@ -265,13 +267,11 @@ def component_list_user(request: AuthenticatedHttpRequest, name: str) -> HttpRes
 
     user_translations = get_user_translations(request, user, user_has_languages)
 
-    componentlist = None
-    for current in fetch_componentlists(request.user, user_translations):
-        if current.slug == name:
-            componentlist = current
+    componentlists = fetch_componentlists(request.user, user_translations, slug=name)
 
-    if componentlist is None:
+    if not componentlists:
         raise Http404
+    componentlist = componentlists[0]
 
     if user.is_authenticated and user.profile.hide_completed:
         componentlist.translations = get_untranslated(


### PR DESCRIPTION
Avoid processing every dashboard list when lazy-loading a single tab.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
