### PR TITLE
fix(l10n): restore missing %s placeholder in French bulk-accept message

### DIFF
--- a/weblate/locale/fr/LC_MESSAGES/djangojs.po
+++ b/weblate/locale/fr/LC_MESSAGES/djangojs.po
@@ -162,7 +162,7 @@ msgstr ""
 #, javascript-format
 msgid "This will accept %s suggestion from %s in this translation."
 msgid_plural "This will accept %s suggestions from %s in this translation."
-msgstr[0] "Cela permettra d'intégrer la suggestion de %s dans cette traduction."
+msgstr[0] "Cela permettra d'intégrer la suggestion de %s de %s dans cette traduction."
 msgstr[1] ""
 "Cela permettra d'accepter les suggestions de %s provenant de %s dans cette "
 "traduction."


### PR DESCRIPTION
### Motivation
- Fix the French singular translation which lost one `%s` placeholder and therefore dropped the username when accepting exactly one suggestion in the bulk-accept confirmation dialog (`weblate/static/js/bulk-accept-suggestions.js`).

### Description
- Restore the second `%s` in `weblate/locale/fr/LC_MESSAGES/djangojs.po` `msgstr[0]` so the JavaScript interpolation call `interpolate(..., [total, username])` receives two placeholders as expected.

### Testing
- Ran `msgfmt -c -o /tmp/djangojs-fr.mo weblate/locale/fr/LC_MESSAGES/djangojs.po` and a small Python assertion that checks the affected translation block contains both `%s` placeholders, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50fd16de18832993f65c36130e15fa)