### PR TITLE
fix(docs): correct Portuguese bot email placeholder

### DIFF
--- a/docs/locales/pt/LC_MESSAGES/docs.po
+++ b/docs/locales/pt/LC_MESSAGES/docs.po
@@ -6829,7 +6829,7 @@ msgid ""
 "Use ``{scope}`` and ``{name}`` when generating the e-mail local part. The "
 "``{username}`` value contains the internal ``scope:name`` username."
 msgstr ""
-"Utilize ``{scope}`` e ``{nome}`` ao gerar a parte local do email. O valor ``"
+"Utilize ``{scope}`` e ``{name}`` ao gerar a parte local do email. O valor ``"
 "{username}`` contém o nome de utilizador ``scope:name`` interno."
 
 #: admin/config.rst:1269


### PR DESCRIPTION
### Motivation
- The Portuguese translation for `INTERNAL_BOT_EMAIL_TEMPLATE` changed the literal `{name}` placeholder to `{nome}`, which does not match the formatter used in `weblate/auth/models.py` and can trigger a `KeyError` when internal bot e-mail addresses are generated.

### Description
- Restore the literal `{name}` placeholder in `docs/locales/pt/LC_MESSAGES/docs.po` so the translated guidance uses ``{name}`` instead of ``{nome}``.

### Testing
- Ran `git diff --check` and a Python assertion that verifies the corrected sentence contains ``{name}`` and no longer contains ``{nome}``, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50f7899894832980513a98396bb948)