### PR TITLE
fix: restore non-breaking spaces in prism markup

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -777,7 +777,18 @@ function initHighlight(root) {
       languageMode = extension;
     }
     const syncContent = () => {
-      highlight.innerHTML = Prism.highlight(editor.value, languageMode, mode);
+      /*
+       * Prism turns non-breaking spaces into regular spaces when generating
+       * markup. Restore them.
+       */
+      highlight.innerHTML = Prism.highlight(
+        editor.value,
+        languageMode,
+        mode,
+      ).replaceAll(
+        '<span class="token nbsp"> </span>',
+        '<span class="token nbsp">\u00A0</span>',
+      );
     };
     syncContent();
     editor.addEventListener("input", syncContent);

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -339,10 +339,6 @@ textarea.highlight-editor {
   outline: 1px dotted red;
 }
 
-.nbsp {
-  white-space: nowrap !important;
-}
-
 .space-tab,
 .space-nl,
 .space-space,


### PR DESCRIPTION
Prism strips non-breaking spaces from text when generating markup, this restores them.
Fixes https://github.com/WeblateOrg/weblate/issues/18444
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
