### PR TITLE
fix(l10n): remove stale Bulgarian placeholder

### DIFF
--- a/weblate/locale/bg/LC_MESSAGES/django.po
+++ b/weblate/locale/bg/LC_MESSAGES/django.po
@@ -1911,7 +1911,7 @@ msgstr "настроено"
 #: weblate/addons/fedora_messaging.py:611
 msgid "Could not reset Fedora Messaging publisher service."
 msgstr ""
-"Рестартирането на услугата за съобщения на Fedora беше неуспешно: %(error)s"
+"Рестартирането на услугата за съобщения на Fedora беше неуспешно."
 
 #: weblate/addons/fedora_messaging.py:701
 msgid "CA certificates must be valid PEM encoded X.509 certificates."


### PR DESCRIPTION
### Motivation
- Fix a localization/UI bug where the Bulgarian translation for `Could not reset Fedora Messaging publisher service.` contained a stale `%(error)s` placeholder while the source `msgid` has no formatting placeholder, which caused the literal placeholder to appear to Bulgarian users.

### Description
- Removed the `%(error)s` placeholder from `weblate/locale/bg/LC_MESSAGES/django.po` so the `msgstr` matches the non-interpolated `msgid`; no runtime code changes were made.

### Testing
- Validated the catalog with `msgfmt -c -o /tmp/bg.mo weblate/locale/bg/LC_MESSAGES/django.po` and ran a targeted Python assertion that verifies the affected `msgstr` no longer contains `%(error)s`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5630e842a8832996ea5327844f3f39)