### PR TITLE
fix(screenshots): make OCR downloads resilient

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Weblate 2026.8
 * Translation memory management pages now load origin summaries with a single database aggregation.
 * Dashboard component list tabs now load without processing unrelated component lists.
 * Static assets now use content-hashed filenames, and CAPTCHA JavaScript is loaded only when needed.
+* Improved :ref:`screenshots` OCR reliability and error reporting when downloading recognition data.
 
 .. rubric:: Bug fixes
 

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -15,6 +15,7 @@ import responses
 from django.conf import settings
 from django.core.files import File
 from django.db import connection
+from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -24,7 +25,14 @@ from rest_framework.test import APITestCase
 from weblate.auth.models import Group
 from weblate.lang.models import Language
 from weblate.screenshots.models import Screenshot
-from weblate.screenshots.views import get_tesseract, ocr_get_strings
+from weblate.screenshots.views import (
+    TESSERACT_DOWNLOAD_ATTEMPTS,
+    TESSERACT_DOWNLOAD_TIMEOUT,
+    download_tesseract_data,
+    ensure_tesseract_language,
+    get_tesseract,
+    ocr_get_strings,
+)
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Change, Project
 from weblate.trans.tests.test_models import RepoTestCase
@@ -37,6 +45,121 @@ PUBLIC_TEST_ADDRESS = "93.184.216.34"
 PRIVATE_TEST_ADDRESS = "127.0.0.1"
 PUBLIC_GETADDRINFO = [(0, 0, 0, "", (PUBLIC_TEST_ADDRESS, 443))]
 PRIVATE_GETADDRINFO = [(0, 0, 0, "", (PRIVATE_TEST_ADDRESS, 443))]
+
+
+class TesseractDataTest(SimpleTestCase):
+    @staticmethod
+    def get_http_error(status_code: int) -> requests.HTTPError:
+        response = requests.Response()
+        response.status_code = status_code
+        return requests.HTTPError(response=response)
+
+    def test_cached_data(self) -> None:
+        with tempfile.TemporaryDirectory() as cache_dir:
+            tessdata = Path(cache_dir) / "tesseract"
+            tessdata.mkdir()
+            (tessdata / "eng.traineddata").write_bytes(b"english")
+            (tessdata / "osd.traineddata").write_bytes(b"orientation")
+
+            with (
+                override_settings(CACHE_DIR=cache_dir),
+                patch("weblate.screenshots.views.WeblateLock"),
+                patch("weblate.screenshots.views.fetch_url") as fetch_url,
+            ):
+                ensure_tesseract_language("eng")
+
+        fetch_url.assert_not_called()
+
+    def test_cache_directory_creation_is_race_safe(self) -> None:
+        with tempfile.TemporaryDirectory() as cache_dir:
+            tessdata = Path(cache_dir) / "tesseract"
+            with (
+                override_settings(CACHE_DIR=cache_dir),
+                patch("weblate.screenshots.views.WeblateLock"),
+                patch("weblate.screenshots.views.os.makedirs") as makedirs,
+                patch("weblate.screenshots.views.download_tesseract_data"),
+            ):
+                ensure_tesseract_language("eng")
+
+        makedirs.assert_called_once_with(str(tessdata), exist_ok=True)
+
+    def test_transient_errors_are_retried(self) -> None:
+        response = MagicMock(content=b"trained data")
+        with tempfile.TemporaryDirectory() as cache_dir:
+            target = Path(cache_dir) / "eng.traineddata"
+            with (
+                patch(
+                    "weblate.screenshots.views.fetch_url",
+                    side_effect=[
+                        requests.Timeout("timed out"),
+                        self.get_http_error(503),
+                        response,
+                    ],
+                ) as fetch_url,
+                patch("weblate.screenshots.views.time.sleep") as sleep,
+            ):
+                download_tesseract_data("https://example.com/eng", str(target))
+
+            self.assertEqual(target.read_bytes(), b"trained data")
+            self.assertEqual(list(Path(cache_dir).iterdir()), [target])
+
+        self.assertEqual(fetch_url.call_count, TESSERACT_DOWNLOAD_ATTEMPTS)
+        fetch_url.assert_called_with(
+            "GET",
+            "https://example.com/eng",
+            allow_redirects=True,
+            timeout=TESSERACT_DOWNLOAD_TIMEOUT,
+        )
+        self.assertEqual([call.args for call in sleep.call_args_list], [(1,), (2,)])
+
+    def test_permanent_error_is_not_retried(self) -> None:
+        with tempfile.TemporaryDirectory() as cache_dir:
+            target = Path(cache_dir) / "eng.traineddata"
+            with (
+                patch(
+                    "weblate.screenshots.views.fetch_url",
+                    side_effect=self.get_http_error(404),
+                ) as fetch_url,
+                self.assertRaises(requests.HTTPError),
+            ):
+                download_tesseract_data("https://example.com/eng", str(target))
+
+            self.assertFalse(target.exists())
+
+        fetch_url.assert_called_once()
+
+    def test_exhausted_retries_leave_no_file(self) -> None:
+        with tempfile.TemporaryDirectory() as cache_dir:
+            target = Path(cache_dir) / "eng.traineddata"
+            with (
+                patch(
+                    "weblate.screenshots.views.fetch_url",
+                    side_effect=requests.Timeout("timed out"),
+                ) as fetch_url,
+                patch("weblate.screenshots.views.time.sleep"),
+                self.assertRaises(requests.Timeout),
+            ):
+                download_tesseract_data("https://example.com/eng", str(target))
+
+            self.assertEqual(list(Path(cache_dir).iterdir()), [])
+
+        self.assertEqual(fetch_url.call_count, TESSERACT_DOWNLOAD_ATTEMPTS)
+
+    def test_interrupted_install_removes_temporary_file(self) -> None:
+        response = MagicMock(content=b"trained data")
+        with tempfile.TemporaryDirectory() as cache_dir:
+            target = Path(cache_dir) / "eng.traineddata"
+            with (
+                patch("weblate.screenshots.views.fetch_url", return_value=response),
+                patch(
+                    "weblate.screenshots.views.os.replace",
+                    side_effect=OSError("No space left on device"),
+                ),
+                self.assertRaises(OSError),
+            ):
+                download_tesseract_data("https://example.com/eng", str(target))
+
+            self.assertEqual(list(Path(cache_dir).iterdir()), [])
 
 
 class ViewTest(FixtureTestCase):
@@ -763,6 +886,30 @@ class ViewTest(FixtureTestCase):
             self.client.post(reverse("screenshot-js-ocr", kwargs={"pk": screenshot.pk}))
 
         self.assertGreaterEqual(image.close.call_count, 1)
+
+    def test_ocr_tesseract_download_error(self) -> None:
+        self.make_manager()
+        self.do_upload()
+        screenshot = Screenshot.objects.all()[0]
+
+        with (
+            patch(
+                "weblate.screenshots.views.get_tesseract",
+                side_effect=requests.Timeout("timed out"),
+            ),
+            self.assertLogs("weblate", level="WARNING") as logs,
+        ):
+            response = self.client.post(
+                reverse("screenshot-js-ocr", kwargs={"pk": screenshot.pk})
+            )
+
+        data = response.json()
+        self.assertEqual(data["responseCode"], 503)
+        self.assertEqual(
+            data["error"],
+            "OCR data could not be downloaded. Please try again later.",
+        )
+        self.assertIn("Could not download Tesseract data", "\n".join(logs.output))
 
     def test_translation_manipulations(self) -> None:
         self.make_manager()

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import difflib
 import os
-from contextlib import contextmanager
+import tempfile
+import time
+from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, ClassVar, cast
 
 from django.contrib.auth.decorators import login_required
@@ -20,6 +22,8 @@ from django.utils.translation import gettext, ngettext
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, ListView
 from PIL import Image
+from requests import ConnectionError as RequestsConnectionError
+from requests import HTTPError, RequestException, Timeout
 from tesserocr import OEM, PSM, RIL, PyTessBaseAPI, iterate_level
 
 from weblate.logger import LOGGER
@@ -157,6 +161,59 @@ TESSERACT_LANGUAGES = {
 }
 
 TESSERACT_URL = "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/main/{}"
+TESSERACT_DOWNLOAD_ATTEMPTS = 3
+TESSERACT_DOWNLOAD_TIMEOUT = 30
+
+
+def is_retryable_tesseract_download_error(error: RequestException) -> bool:
+    if isinstance(error, (RequestsConnectionError, Timeout)):
+        return True
+    if not isinstance(error, HTTPError) or error.response is None:
+        return False
+    return error.response.status_code == 429 or error.response.status_code >= 500
+
+
+def download_tesseract_data(url: str, full_name: str) -> None:
+    temporary_name: str | None = None
+    try:
+        for attempt in range(1, TESSERACT_DOWNLOAD_ATTEMPTS + 1):
+            try:
+                with start_span(op="ocr.download", name=url):
+                    response = fetch_url(
+                        "GET",
+                        url,
+                        allow_redirects=True,
+                        timeout=TESSERACT_DOWNLOAD_TIMEOUT,
+                    )
+            except RequestException as error:
+                if (
+                    attempt == TESSERACT_DOWNLOAD_ATTEMPTS
+                    or not is_retryable_tesseract_download_error(error)
+                ):
+                    raise
+                LOGGER.warning(
+                    "Tesseract data download failed, retrying (%d/%d): %s",
+                    attempt,
+                    TESSERACT_DOWNLOAD_ATTEMPTS,
+                    error,
+                )
+                time.sleep(2 ** (attempt - 1))
+                continue
+
+            with tempfile.NamedTemporaryFile(
+                dir=os.path.dirname(full_name),
+                prefix=f".{os.path.basename(full_name)}.",
+                delete=False,
+            ) as handle:
+                temporary_name = handle.name
+                handle.write(response.content)
+            os.replace(temporary_name, full_name)
+            temporary_name = None
+            return
+    finally:
+        if temporary_name is not None:
+            with suppress(FileNotFoundError):
+                os.unlink(temporary_name)
 
 
 def ensure_tesseract_language(lang: str) -> None:
@@ -177,8 +234,7 @@ def ensure_tesseract_language(lang: str) -> None:
         ),
         start_span(op="ocr.models"),
     ):
-        if not os.path.isdir(tessdata):
-            os.makedirs(tessdata)
+        os.makedirs(tessdata, exist_ok=True)
 
         for code in (lang, "eng", "osd"):
             filename = f"{code}.traineddata"
@@ -190,11 +246,7 @@ def ensure_tesseract_language(lang: str) -> None:
 
             LOGGER.debug("downloading tesseract data %s", url)
 
-            with start_span(op="ocr.download", name=url):
-                response = fetch_url("GET", url, allow_redirects=True)
-
-            with open(full_name, "xb") as handle:
-                handle.write(response.content)
+            download_tesseract_data(url, full_name)
 
 
 def add_sources(request: AuthenticatedHttpRequest, obj) -> dict[str, int | bool]:
@@ -520,7 +572,14 @@ def remove_source(request: AuthenticatedHttpRequest, pk):
     return redirect(obj)
 
 
-def search_results(request: AuthenticatedHttpRequest, code, obj, units=None):
+def search_results(
+    request: AuthenticatedHttpRequest,
+    code,
+    obj,
+    units=None,
+    *,
+    error: str | None = None,
+):
     if units is None:
         units = []
         count = 0
@@ -532,28 +591,29 @@ def search_results(request: AuthenticatedHttpRequest, code, obj, units=None):
         )
         count = len(units)
 
-    return JsonResponse(
-        data={
-            "responseCode": code,
-            "count": count,
-            "summary": ngettext(
-                "%(count)s matching source string found.",
-                "%(count)s matching source strings found.",
-                count,
-            )
-            % {"count": count},
-            "empty": gettext("No new matching source strings found."),
-            "results": render_to_string(
-                "screenshots/screenshot_sources_search.html",
-                {
-                    "object": obj,
-                    "units": units,
-                    "user": request.user,
-                    "search_query": "",
-                },
-            ),
-        }
-    )
+    data = {
+        "responseCode": code,
+        "count": count,
+        "summary": ngettext(
+            "%(count)s matching source string found.",
+            "%(count)s matching source strings found.",
+            count,
+        )
+        % {"count": count},
+        "empty": gettext("No new matching source strings found."),
+        "results": render_to_string(
+            "screenshots/screenshot_sources_search.html",
+            {
+                "object": obj,
+                "units": units,
+                "user": request.user,
+                "search_query": "",
+            },
+        ),
+    }
+    if error is not None:
+        data["error"] = error
+    return JsonResponse(data=data)
 
 
 @login_required
@@ -677,6 +737,14 @@ def ocr_search(request: AuthenticatedHttpRequest, pk):
                     resolution=resolution,
                 )
             }
+    except RequestException as error:
+        LOGGER.warning("Could not download Tesseract data: %s", error)
+        return search_results(
+            request,
+            503,
+            obj,
+            error=gettext("OCR data could not be downloaded. Please try again later."),
+        )
     finally:
         ocr_image.close()
 

--- a/weblate/settings_test.py
+++ b/weblate/settings_test.py
@@ -42,6 +42,8 @@ else:
     BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 DATA_DIR = os.path.join(BASE_DIR, "data-test")
+# Share cached external assets between xdist workers and CI runs.
+CACHE_DIR = os.path.join(DATA_DIR, "cache")
 
 # Use random data directory when running in parallel
 if "PYTEST_XDIST_TESTRUNUID" in os.environ:
@@ -50,7 +52,6 @@ if "PYTEST_XDIST_TESTRUNUID" in os.environ:
     DATA_DIR_TMP = TemporaryDirectory(dir=DATA_DIR, prefix="xdist-")
     DATA_DIR = DATA_DIR_TMP.name
 
-CACHE_DIR = os.path.join(DATA_DIR, "cache")
 MEDIA_ROOT = os.path.join(DATA_DIR, "media")
 STATIC_ROOT = os.path.join(DATA_DIR, "static")
 CELERY_TASK_ALWAYS_EAGER = True

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -364,7 +364,10 @@ function screenshotLoaded(data) {
     summary.textContent = data.summary || "";
   }
   if (data.responseCode !== 200) {
-    screenshotResultError("danger", gettext("Error loading search results!"));
+    screenshotResultError(
+      "danger",
+      data.error || gettext("Error loading search results!"),
+    );
   } else if (data.count === 0) {
     screenshotResultError(
       "warning",


### PR DESCRIPTION
Reuse Tesseract data across parallel tests and retry transient downloads to avoid flaky CI and user-facing failures. Install models atomically and report exhausted downloads clearly.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
