### PR TITLE
test(formats): support Apple XLIFF state encodings

### DIFF
--- a/weblate/formats/tests/test_formats.py
+++ b/weblate/formats/tests/test_formats.py
@@ -2277,6 +2277,11 @@ class AppleXliffFormatTest(XliffFormatTest):
     EXT = "xliff"
     FILE = TEST_XLIFF_APPLE
     BASE = TEST_XLIFF_APPLE
+    # TODO: Require target state once translate-toolkit 3.19.15 is released.
+    NEW_UNIT_MATCH = (
+        b'<trans-unit xml:space="preserve" id="key"',
+        b"<source>Source string</source>",
+    )
     EXPECTED_FLAGS: ClassVar[str | list[str]] = ""
     FIND_CONTEXT = "Localizable.strings///hello"
     MATCH = 'target-language="cs"'


### PR DESCRIPTION
Keep the new-unit test compatible with both translate-toolkit 3.19.14 and its upcoming Apple workflow-state serialization.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
