### PR TITLE
perf(api): reduce unit list prefetch overhead

### DIFF
--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -3357,12 +3357,7 @@ class TranslationViewSet(MultipleFieldViewSet, DestroyModelMixin, AnnouncementsM
             msg = f"Could not parse query string: {error}"
             raise ValidationError({"q": msg}) from error
 
-        queryset = (
-            obj.unit_set.search(query_string)
-            .order_by("id")
-            .prefetch_full()
-            .prefetch_related("pending_changes")
-        )
+        queryset = obj.unit_set.search(query_string).order_by("id").prefetch_api()
         page = self.paginate_queryset(queryset)
 
         serializer = UnitSerializer(page, many=True, context={"request": request})
@@ -3503,8 +3498,7 @@ class UnitViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelM
         return (
             Unit.objects.filter_access(self.request.user)
             .prefetch()
-            .prefetch_full()
-            .prefetch_related("pending_changes")
+            .prefetch_api()
             .order_by("id")
         )
 

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -258,6 +258,32 @@ class UnitQuerySet(models.QuerySet["Unit", "Unit"]):
             )
         )
 
+    def prefetch_api(self):
+        """Prefetch relations used by the unit API serializer."""
+        return self.prefetch_related(
+            "labels",
+            models.Prefetch(
+                "check_set",
+                queryset=Check.objects.filter(dismissed=False).only("unit_id"),
+                to_attr="api_failing_checks",
+            ),
+            models.Prefetch(
+                "suggestion_set",
+                queryset=Suggestion.objects.only("unit_id"),
+                to_attr="api_suggestions",
+            ),
+            models.Prefetch(
+                "comment_set",
+                queryset=Comment.objects.filter(resolved=False).only("unit_id"),
+                to_attr="api_comments",
+            ),
+            models.Prefetch(
+                "pending_changes",
+                queryset=PendingUnitChange.objects.only("unit_id"),
+                to_attr="api_pending_changes",
+            ),
+        )
+
     def prefetch_embed(self):
         """Prefetch relations needed by snippets/embed-units.html."""
         return (
@@ -923,16 +949,22 @@ class Unit(models.Model, LoggerMixin):
 
     @property
     def has_failing_check(self) -> bool:
+        if "api_failing_checks" in self.__dict__:
+            return bool(self.__dict__["api_failing_checks"])
         return bool(self.active_checks)
 
     @property
     def has_comment(self) -> bool:
+        if "api_comments" in self.__dict__:
+            return bool(self.__dict__["api_comments"])
         # Use bool here as unresolved_comments might be list
         # or a queryset (from prefetch)
         return bool(self.unresolved_comments)
 
     @property
     def has_suggestion(self) -> bool:
+        if "api_suggestions" in self.__dict__:
+            return bool(self.__dict__["api_suggestions"])
         return bool(self.suggestions)
 
     def source_unit_save(self) -> None:
@@ -2720,6 +2752,8 @@ class Unit(models.Model, LoggerMixin):
 
     @property
     def has_pending_changes(self) -> bool:
+        if "api_pending_changes" in self.__dict__:
+            return bool(self.__dict__["api_pending_changes"])
         return self.pending_changes.exists()
 
     @property

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -1068,6 +1068,37 @@ class SourceUnitTest(ModelTestCase):
 
 
 class UnitTest(ModelTestCase):
+    def test_prefetch_api(self) -> None:
+        unit = Unit.objects.filter(translation__language_code="cs").first()
+        if unit is None:
+            self.fail("Expected a unit in test fixture.")
+
+        user = create_test_user()
+        Comment.objects.create(unit=unit, comment="Comment")
+        Suggestion.objects.create(unit=unit, target="Suggestion", user=user)
+        PendingUnitChange.objects.create(unit=unit, author=user)
+
+        expected = (
+            unit.check_set.filter(dismissed=False).exists(),
+            unit.comment_set.filter(resolved=False).exists(),
+            unit.suggestion_set.exists(),
+            unit.pending_changes.exists(),
+        )
+        with self.assertNumQueries(6):
+            unit = Unit.objects.filter(pk=unit.pk).prefetch_api().get()
+
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                (
+                    unit.has_failing_check,
+                    unit.has_comment,
+                    unit.has_suggestion,
+                    unit.has_pending_changes,
+                ),
+                expected,
+            )
+            list(unit.labels.all())
+
     def test_newlines(self) -> None:
         user = create_test_user()
         unit = Unit.objects.filter(


### PR DESCRIPTION
UnitSerializer only needs labels and boolean presence data for checks, comments, suggestions, and pending changes. Avoid prefetching complete source-unit relationships and unused related objects.

This reduces the tested 500-unit translation response from 34 to 24 database queries while preserving the response payload.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
