### PR TITLE
fix(add-ons): corrected escaping detection

### DIFF
--- a/weblate/addons/properties.py
+++ b/weblate/addons/properties.py
@@ -62,7 +62,7 @@ def fix_newlines(lines) -> None:
 def format_unicode(lines) -> None:
     """Format unicode characters."""
     for i, line in enumerate(lines):
-        if UNICODE.findall(line) is None:
+        if not UNICODE.findall(line):
             continue
         lines[i] = UNICODE.sub(unicode_format, line)
 

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -154,7 +154,7 @@ from .models import (
     handle_addon_event,
     handle_daily_addon_event,
 )
-from .properties import PropertiesSortAddon
+from .properties import PropertiesSortAddon, format_unicode
 from .removal import RemoveComments, RemoveSuggestions
 from .resx import ResxUpdateAddon
 from .tasks import (
@@ -183,6 +183,18 @@ class GettextUtilityTest(SimpleTestCase):
         self.assertFalse(
             is_xgettext_placeholder_comment("# Copyright (C) 2026 Example Corp.\n")
         )
+
+
+class PropertiesUtilityTest(SimpleTestCase):
+    def test_format_unicode_only_rewrites_matching_lines(self) -> None:
+        lines = MagicMock(spec=list)
+        lines.__iter__.return_value = iter(
+            ["plain=value\n", "escaped=\\U00e1 and \\u00f3\n"]
+        )
+
+        format_unicode(lines)
+
+        lines.__setitem__.assert_called_once_with(1, "escaped=\\u00E1 and \\u00F3\n")
 
 
 class NoOpAddon(BaseAddon):


### PR DESCRIPTION
`re.findall` never returns `None`; it returns an empty list `[]` when there are no matches. The condition `is None` is always `False`, making the `continue` dead code. As a result, `UNICODE.sub` is called on every line regardless of whether it contains unicode escape sequences. The check should use a truthiness test (e.g. `if not UNICODE.findall(line):`) to skip lines without unicode escapes.

_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/WeblateOrg/weblate/security/quality/ai-findings)._