### PR TITLE
test(widgets): cover RTL screenshot variants

### DIFF
--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -1785,9 +1785,14 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
             self.use_live_server_widget_preview()
             self.screenshot("promote.png")
             widget_select = Select(self.driver.find_element(By.ID, "widget-type"))
-            for widget_name in WIDGETS:
-                widget_select.select_by_value(widget_name)
-                self.screenshot_widget(widget_name)
+            language_select = Select(
+                self.driver.find_element(By.ID, "translation-language")
+            )
+            for language, suffix in (("", ""), ("he", "-rtl")):
+                language_select.select_by_value(language)
+                for widget_name in WIDGETS:
+                    widget_select.select_by_value(widget_name)
+                    self.screenshot_widget(f"{widget_name}{suffix}")
         with self.wait_for_page_load():
             self.driver.get(
                 f"{self.live_server_url}"


### PR DESCRIPTION
Capture widgets in Hebrew so visual regressions in right-to-left text rendering are detected.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
