### PR TITLE
docs(l10n): fix Spanish bot email template

### DIFF
--- a/docs/locales/es/LC_MESSAGES/docs.po
+++ b/docs/locales/es/LC_MESSAGES/docs.po
@@ -6988,7 +6988,7 @@ msgid ""
 "accounts. Defaults to ``\"noreply-{scope}-{name}@weblate.org\"``."
 msgstr ""
 "Plantilla utilizada para generar direcciones de correo-e para robot de "
-"cuentas Weblate internas. Por defecto a ``\"noreply-{scope-{name}"
+"cuentas Weblate internas. Por defecto a ``\"noreply-{scope}-{name}"
 "@weblate.org\"``."
 
 #: admin/config.rst:1263


### PR DESCRIPTION
### Motivation
- Fix a Spanish translation typo that documented the default `INTERNAL_BOT_EMAIL_TEMPLATE` as `noreply-{scope-{name}@weblate.org`, which could raise a `ValueError` if an operator copied the malformed string into configuration.

### Description
- Corrected the Spanish PO entry at `docs/locales/es/LC_MESSAGES/docs.po` to use the valid format string `"noreply-{scope}-{name}@weblate.org"` so the documented example matches the application default.

### Testing
- Ran a format-string smoke check with `python` to ensure `"noreply-{scope}-{name}@weblate.org".format(...)` succeeds, verified the PO file contains the corrected template, and ran `msgfmt --check docs/locales/es/LC_MESSAGES/docs.po` for syntax validation; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58890659948329bb36233ed773bf31)