### PR TITLE
fix(l10n): restore Dutch punctuation placeholder

### DIFF
--- a/weblate/locale/nl/LC_MESSAGES/django.po
+++ b/weblate/locale/nl/LC_MESSAGES/django.po
@@ -4962,8 +4962,8 @@ msgstr "Ontbrekende niet-breekbare spatie vóór dubbel leesteken."
 #: weblate/checks/chars.py:680
 msgid "Missing non breakable space before punctuation mark {}."
 msgid_plural "Missing non breakable space before punctuation marks {}."
-msgstr[0] "Ontbrekende niet-breekbare spatie vóór dubbel leesteken."
-msgstr[1] "Ontbrekende niet-breekbare spatie vóór dubbele leestekens."
+msgstr[0] "Ontbrekende niet-breekbare spatie vóór leesteken {}."
+msgstr[1] "Ontbrekende niet-breekbare spatie vóór leestekens {}."
 
 #: weblate/checks/chars.py:730
 msgid "Multiple capitals"


### PR DESCRIPTION
### Motivation
- Fix a non-security localization bug where the Dutch translation for the non-breakable-space punctuation check omitted the `{}` placeholder so the generated list of offending punctuation characters was not rendered.

### Description
- Restore the `{}` placeholder in the singular and plural `msgstr` entries in `weblate/locale/nl/LC_MESSAGES/django.po` so `ngettext(...)` + `format_html(..., format_html_join_comma(...))` can insert the punctuation list.

### Testing
- Ran `msgfmt --check-format -o /tmp/django-nl.mo weblate/locale/nl/LC_MESSAGES/django.po` which succeeded, and a targeted Python `gettext` check that verified both singular and plural Dutch messages include the formatted punctuation list.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58890643c08329892a9fc0a19b5f3c)