### PR TITLE
fix(api+ui): bound suggestion text and rejection-reason lengths

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,7 @@ Weblate 2026.8
 
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
+* Suggestion submission and rejection now reject excessively long suggestion text and rejection reasons.
 * Restricted components are now available on Hosted Weblate when the billing plan permits private projects.
 * Machine translation and translation memory AJAX lookups no longer disclose whether inaccessible unit IDs exist.
 * :ref:`RSS feeds <rss>` no longer disclose change history from inaccessible projects or restricted components.

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -53,7 +53,10 @@ from weblate.trans.defines import (
     PROJECT_NAME_LENGTH,
     REPO_LENGTH,
 )
-from weblate.trans.exceptions import SuggestionSimilarToTranslationError
+from weblate.trans.exceptions import (
+    SuggestionSimilarToTranslationError,
+    SuggestionTooLongError,
+)
 from weblate.trans.inherited_settings import (
     INHERITABLE_COMPONENT_SETTINGS,
     apply_create_inheritance_defaults,
@@ -2802,6 +2805,9 @@ class SuggestionSerializer(serializers.Serializer[Suggestion]):
             )
         except SuggestionSimilarToTranslationError as error:
             msg = gettext_lazy("Your suggestion is similar to the current translation!")
+            raise serializers.ValidationError({"target": msg}) from error
+        except SuggestionTooLongError as error:
+            msg = gettext_lazy("Translation text too long!")
             raise serializers.ValidationError({"target": msg}) from error
         self.add_result = result
         if result == SuggestionAddResult.DUPLICATE:

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -77,6 +77,10 @@ from weblate.trans.models import (
 )
 from weblate.trans.models.translation import NewUnitParams
 from weblate.trans.util import check_upload_method_permissions, cleanup_repo_url
+from weblate.trans.validators import (
+    SUGGESTION_REJECTION_REASON_LENGTH,
+    get_translation_text_max_length,
+)
 from weblate.trans.workspace_move import (
     get_project_move_billing_error,
     get_project_workspace_move_permission_error,
@@ -2766,8 +2770,18 @@ class SuggestionSerializer(serializers.Serializer[Suggestion]):
 
     def validate_target(self, value: list[str]) -> list[str]:
         unit = self.context.get("unit")
-        if unit is None or unit.translation.component.is_multivalue:
+        if unit is None:
             return value
+
+        max_length = get_translation_text_max_length(unit)
+        for text in value:
+            if len(text) > max_length:
+                msg = gettext_lazy("Translation text too long!")
+                raise serializers.ValidationError(msg)
+
+        if unit.translation.component.is_multivalue:
+            return value
+
         target_copy = value.copy()
         if target_copy != unit.adjust_plurals(value.copy()):
             msg = gettext_lazy("Number of plurals does not match")
@@ -2797,7 +2811,9 @@ class SuggestionSerializer(serializers.Serializer[Suggestion]):
 
 
 class SuggestionDeleteRequestSerializer(ReadOnlySerializer):
-    rejection_reason = serializers.CharField(required=False, allow_blank=True)
+    rejection_reason = serializers.CharField(
+        required=False, allow_blank=True, max_length=SUGGESTION_REJECTION_REASON_LENGTH
+    )
     is_spam = serializers.BooleanField(required=False, default=False)
 
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -89,6 +89,7 @@ from weblate.trans.tests.utils import (
     get_test_file,
 )
 from weblate.trans.util import join_plural
+from weblate.trans.validators import SUGGESTION_REJECTION_REASON_LENGTH
 from weblate.utils.celery import get_task_metadata_key
 from weblate.utils.data import data_dir
 from weblate.utils.lock import WeblateLockTimeoutError
@@ -11902,6 +11903,14 @@ class SuggestionAPITest(APIBaseTest):
             response.data["errors"][0]["detail"], "Please provide a suggestion"
         )
 
+    def test_add_suggestion_too_long(self) -> None:
+        unit = self._get_unit()
+        max_length = 10 * (unit.get_max_length() + 100)
+        response = self._add_suggestion(unit, "x" * (max_length + 1), code=400)
+        self.assertEqual(
+            response.data["errors"][0]["detail"], "Translation text too long!"
+        )
+
     def test_add_suggestion_duplicate(self) -> None:
         unit = self._get_unit()
         self._add_suggestion(unit, "Navrh")
@@ -12019,6 +12028,22 @@ class SuggestionAPITest(APIBaseTest):
             self.client.credentials(
                 HTTP_AUTHORIZATION=f"Token {guest_user.auth_token.key}"
             )
+
+    def test_delete_suggestion_reason_too_long(self) -> None:
+        unit = self._get_unit()
+        response = self._add_suggestion(unit, "Navrh")
+        suggestion_id = response.data["id"]
+        self.do_request(
+            "api:suggestion-detail",
+            kwargs={"pk": suggestion_id},
+            method="delete",
+            request={
+                "rejection_reason": "x" * (SUGGESTION_REJECTION_REASON_LENGTH + 1)
+            },
+            format="json",
+            code=400,
+        )
+        self.assertTrue(Suggestion.objects.filter(pk=suggestion_id).exists())
 
     def test_delete_suggestion_denied(self) -> None:
         unit = self._get_unit()

--- a/weblate/templates/snippets/suggestions.html
+++ b/weblate/templates/snippets/suggestions.html
@@ -87,6 +87,7 @@
                 {% endif %}
                 <input type="text"
                        name="rejection"
+                       maxlength="{{ suggestion_rejection_reason_length }}"
                        class="rejection-reason"
                        placeholder="{% translate "Rejection reason" %}">
                 <button type="submit"

--- a/weblate/trans/context_processors.py
+++ b/weblate/trans/context_processors.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext
 import weblate.utils.version
 from weblate.configuration.views import CustomCSSView
 from weblate.legal.utils import get_document_context
+from weblate.trans.validators import SUGGESTION_REJECTION_REASON_LENGTH
 from weblate.utils.site import get_site_domain, get_site_url
 from weblate.utils.version_display import (
     hide_detailed_version,
@@ -171,6 +172,7 @@ def weblate_context(request: AuthenticatedHttpRequest):
         "login_redirect_url": login_redirect_url,
         "has_antispam": False,  # Akismet integration removed
         "has_sentry": bool(settings.SENTRY_DSN),
+        "suggestion_rejection_reason_length": SUGGESTION_REJECTION_REASON_LENGTH,
         "watched_projects": watched_projects,
         "allow_index": False,
         "configuration_errors": ConfigurationError.objects.filter(

--- a/weblate/trans/exceptions.py
+++ b/weblate/trans/exceptions.py
@@ -36,6 +36,10 @@ class SuggestionSimilarToTranslationError(WeblateError):
     """Target of the Suggestion is similar to source."""
 
 
+class SuggestionTooLongError(WeblateError):
+    """Target of the Suggestion is too long."""
+
+
 EXPECTED_PARSE_ERRORS = (FileNotFoundError, TranslateParseError)
 
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -91,7 +91,10 @@ from weblate.trans.models import (
 )
 from weblate.trans.specialchars import RTL_CHARS_DATA, get_special_chars
 from weblate.trans.util import check_upload_method_permissions, is_repo_link
-from weblate.trans.validators import validate_check_flags
+from weblate.trans.validators import (
+    get_translation_text_max_length,
+    validate_check_flags,
+)
 from weblate.trans.workspace_move import (
     PROJECT_MOVE_WORKSPACE_SELECT_LIMIT,
     get_project_move_target_workspaces,
@@ -753,10 +756,7 @@ class TranslationForm(UnitForm):
 
         fuzzy_state = unit.state if unit.state in FUZZY_STATES else STATE_FUZZY
 
-        # Add extra margin to limit to allow XML tags which might
-        # be ignored for the length calculation. On the other side,
-        # we do not want to process arbitrarily long strings here.
-        max_length = 10 * (unit.get_max_length() + 100)
+        max_length = get_translation_text_max_length(unit)
         for text in self.cleaned_data["target"]:
             if len(text) > max_length:
                 raise ValidationError(gettext("Translation text too long!"))

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -18,9 +18,13 @@ from django.utils.translation import gettext
 from weblate.checks.models import CHECKS, Check
 from weblate.trans.actions import ActionEvents
 from weblate.trans.autofixes import fix_target
-from weblate.trans.exceptions import SuggestionSimilarToTranslationError
+from weblate.trans.exceptions import (
+    SuggestionSimilarToTranslationError,
+    SuggestionTooLongError,
+)
 from weblate.trans.mixins import UserDisplayMixin
 from weblate.trans.util import join_plural, split_plural
+from weblate.trans.validators import get_translation_text_max_length
 from weblate.utils import messages
 from weblate.utils.antispam import report_spam
 from weblate.utils.request import get_ip_address, get_user_agent_raw
@@ -36,6 +40,7 @@ class SuggestionAddResult(StrEnum):
     DUPLICATE = "duplicate"
     VOTED = "voted"
     SIMILAR = "similar"
+    TOO_LONG = "too_long"
 
 
 class SuggestionManager(models.Manager["Suggestion"]):
@@ -51,6 +56,12 @@ class SuggestionManager(models.Manager["Suggestion"]):
         """Create new suggestion for this unit."""
         # ruff: ignore[import-outside-top-level]
         from weblate.auth.models import get_anonymous
+
+        max_length = get_translation_text_max_length(unit)
+        if any(len(text) > max_length for text in target):
+            if raise_exception:
+                raise SuggestionTooLongError
+            return None, SuggestionAddResult.TOO_LONG
 
         # Apply fixups
         fixups: list[str] = []

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -69,6 +69,10 @@ class SuggestionManager(models.Manager["Suggestion"]):
             target, fixups = fix_target(target, unit)
 
         target_merged = join_plural(target)
+        if len(target_merged) > max_length:
+            if raise_exception:
+                raise SuggestionTooLongError
+            return None, SuggestionAddResult.TOO_LONG
 
         if user is None:
             user = request.user if request else get_anonymous()

--- a/weblate/trans/models/suggestion.py
+++ b/weblate/trans/models/suggestion.py
@@ -63,6 +63,12 @@ class SuggestionManager(models.Manager["Suggestion"]):
                 raise SuggestionTooLongError
             return None, SuggestionAddResult.TOO_LONG
 
+        target_merged = join_plural(target)
+        if len(target_merged) > max_length:
+            if raise_exception:
+                raise SuggestionTooLongError
+            return None, SuggestionAddResult.TOO_LONG
+
         # Apply fixups
         fixups: list[str] = []
         if not unit.translation.is_template:

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -406,6 +406,19 @@ class ProjectTest(RepoTestCase):
             )
             self.assertEqual(result, SuggestionAddResult.TOO_LONG)
 
+            unit.extra_flags = "max-length:*"
+            unit.save(update_fields=["extra_flags"])
+            unit = Unit.objects.get(pk=unit.pk)
+            suggestion, result = Suggestion.objects.add(
+                unit,
+                ["Invalid flag suggestion"],
+                None,
+                user=another_user,
+                raise_exception=True,
+            )
+            self.assertIsNotNone(suggestion)
+            self.assertEqual(result, SuggestionAddResult.CREATED)
+
             # check that user submitting suggestion twice doesn't create duplicated suggestions
             suggestion, result = Suggestion.objects.add(
                 unit, ["New suggestion"], None, user=another_user, raise_exception=True

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -395,6 +395,17 @@ class ProjectTest(RepoTestCase):
             )
             self.assertEqual(result, SuggestionAddResult.TOO_LONG)
 
+            max_length = get_translation_text_max_length(unit)
+            long_segments = ["x" * (max_length // 2 + 1)] * 2
+            _, result = Suggestion.objects.add(
+                unit,
+                long_segments,
+                None,
+                user=another_user,
+                raise_exception=False,
+            )
+            self.assertEqual(result, SuggestionAddResult.TOO_LONG)
+
             # check that user submitting suggestion twice doesn't create duplicated suggestions
             suggestion, result = Suggestion.objects.add(
                 unit, ["New suggestion"], None, user=another_user, raise_exception=True

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -32,7 +32,11 @@ from weblate.glossary.models import (
 )
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
-from weblate.trans.exceptions import FileParseError, SuggestionSimilarToTranslationError
+from weblate.trans.exceptions import (
+    FileParseError,
+    SuggestionSimilarToTranslationError,
+    SuggestionTooLongError,
+)
 from weblate.trans.models import (
     Announcement,
     AutoComponentList,
@@ -59,6 +63,7 @@ from weblate.trans.tests.utils import (
     fixup_languages_seq,
     get_optional_path,
 )
+from weblate.trans.validators import get_translation_text_max_length
 from weblate.utils.files import remove_tree
 from weblate.utils.state import (
     STATE_APPROVED,
@@ -371,6 +376,24 @@ class ProjectTest(RepoTestCase):
                 raise_exception=False,
             )
             self.assertEqual(result, SuggestionAddResult.SIMILAR)
+
+            too_long_target = "x" * (get_translation_text_max_length(unit) + 1)
+            with self.assertRaises(SuggestionTooLongError):
+                Suggestion.objects.add(
+                    unit,
+                    [too_long_target],
+                    None,
+                    user=another_user,
+                    raise_exception=True,
+                )
+            _, result = Suggestion.objects.add(
+                unit,
+                [too_long_target],
+                None,
+                user=another_user,
+                raise_exception=False,
+            )
+            self.assertEqual(result, SuggestionAddResult.TOO_LONG)
 
             # check that user submitting suggestion twice doesn't create duplicated suggestions
             suggestion, result = Suggestion.objects.add(

--- a/weblate/trans/validators.py
+++ b/weblate/trans/validators.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext
@@ -13,6 +14,18 @@ from pyparsing import ParseException
 from weblate.checks.flags import FlagsValidator
 from weblate.lang.models import Language
 from weblate.trans.defines import LANGUAGE_CODE_LENGTH
+
+if TYPE_CHECKING:
+    from weblate.trans.models.unit import Unit
+
+SUGGESTION_REJECTION_REASON_LENGTH = 200
+
+
+def get_translation_text_max_length(unit: Unit) -> int:
+    """Return maximum accepted translation text length for a unit."""
+    # Add extra margin to allow XML tags which might be ignored for length checks.
+    # On the other side, do not process arbitrarily long strings here.
+    return 10 * (unit.get_max_length() + 100)
 
 
 def validate_filemask(val) -> None:

--- a/weblate/trans/validators.py
+++ b/weblate/trans/validators.py
@@ -19,13 +19,18 @@ if TYPE_CHECKING:
     from weblate.trans.models.unit import Unit
 
 SUGGESTION_REJECTION_REASON_LENGTH = 200
+DEFAULT_TRANSLATION_MAX_LENGTH = 10000
 
 
 def get_translation_text_max_length(unit: Unit) -> int:
     """Return maximum accepted translation text length for a unit."""
     # Add extra margin to allow XML tags which might be ignored for length checks.
     # On the other side, do not process arbitrarily long strings here.
-    return 10 * (unit.get_max_length() + 100)
+    try:
+        max_length = unit.get_max_length()
+    except ValueError:
+        max_length = DEFAULT_TRANSLATION_MAX_LENGTH
+    return 10 * (max_length + 100)
 
 
 def validate_filemask(val) -> None:

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -34,7 +34,11 @@ from weblate.glossary.forms import TermForm
 from weblate.glossary.models import fetch_glossary_terms, get_glossary_terms
 from weblate.screenshots.forms import ScreenshotForm
 from weblate.trans.actions import ActionEvents
-from weblate.trans.exceptions import FileParseError, SuggestionSimilarToTranslationError
+from weblate.trans.exceptions import (
+    FileParseError,
+    SuggestionSimilarToTranslationError,
+    SuggestionTooLongError,
+)
 from weblate.trans.forms import (
     AutoForm,
     ChecksumForm,
@@ -827,6 +831,9 @@ def perform_suggestion(unit, form, request: AuthenticatedHttpRequest):
         messages.error(
             request, gettext("Your suggestion is similar to the current translation!")
         )
+        return False
+    except SuggestionTooLongError:
+        messages.error(request, gettext("Translation text too long!"))
         return False
     if result == SuggestionAddResult.DUPLICATE:
         messages.error(request, gettext("Your suggestion already exists!"))

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -65,6 +65,7 @@ from weblate.trans.templatetags.translations import (
     unit_state_title,
 )
 from weblate.trans.util import redirect_next, render
+from weblate.trans.validators import SUGGESTION_REJECTION_REASON_LENGTH
 from weblate.utils import messages
 from weblate.utils.antispam import is_spam
 from weblate.utils.hash import hash_to_checksum
@@ -1074,12 +1075,16 @@ def handle_suggestions(
         if "accept_edit" not in request.POST:
             redirect_url = next_unit_url
     elif "delete" in request.POST or "spam" in request.POST:
-        suggestion.delete_log(
-            request.user,
-            is_spam="spam" in request.POST,
-            rejection_reason=request.POST.get("rejection", ""),
-            old=unit.target,
-        )
+        rejection_reason = request.POST.get("rejection", "")
+        if len(rejection_reason) > SUGGESTION_REJECTION_REASON_LENGTH:
+            messages.error(request, gettext("Rejection reason is too long!"))
+        else:
+            suggestion.delete_log(
+                request.user,
+                is_spam="spam" in request.POST,
+                rejection_reason=rejection_reason,
+                old=unit.target,
+            )
     elif "upvote" in request.POST:
         suggestion.add_vote(request, Vote.POSITIVE)
         redirect_url = next_unit_url


### PR DESCRIPTION
### Motivation

- Prevent unbounded suggestion payloads that can be persisted via the Suggestions API and cause resource exhaustion by enforcing the same limits used by the UI form. 
- Align API and UI behavior by centralizing the translation-text length calculation and adding a reasonable cap for deletion `rejection_reason` values.

### Description

- Add `SUGGESTION_REJECTION_REASON_LENGTH = 200` and `get_translation_text_max_length(unit)` to `weblate/trans/validators.py` and reuse them across API and UI. 
- Enforce translation text length in the Suggestions API by updating `SuggestionSerializer.validate_target` to use `get_translation_text_max_length(unit)` and reject oversized submissions. 
- Limit rejection reasons in the API serializer by adding `max_length=SUGGESTION_REJECTION_REASON_LENGTH` to `SuggestionDeleteRequestSerializer`. 
- Apply the shared helper in the UI by switching `TranslationForm` to call `get_translation_text_max_length(unit)`, add a server-side check in `weblate/trans/views/edit.py` for rejection reason length, and expose `suggestion_rejection_reason_length` to templates so the input gets a `maxlength` attribute. 
- Add regression tests `test_add_suggestion_too_long` and `test_delete_suggestion_reason_too_long` in `weblate/api/tests.py` and include a short changelog entry in `docs/changes.rst`.

### Testing

- Compiled modified modules with `python -m compileall` and the compilation succeeded. 
- Ran targeted tests with `uv run pytest weblate/api/tests.py::SuggestionAPITest::test_add_suggestion_too_long weblate/api/tests.py::SuggestionAPITest::test_delete_suggestion_reason_too_long` and both tests passed. 
- Ran repository checks with `uv run prek run --files ...` (lint/format/hooks) for the changed files and the pre-commit checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a588ebfbe808329b69054b9fc287b6b)