### PR TITLE
feat(workspaces): add workspace removal

### DIFF
--- a/docs/admin/workspaces.rst
+++ b/docs/admin/workspaces.rst
@@ -23,6 +23,17 @@ You can list all workspaces in the management interface at
 
 .. image:: /screenshots/workspaces.webp
 
+.. _workspace-removal:
+
+Workspace removal
+-----------------
+
+Users with the :guilabel:`Edit workspace settings` permission can remove a
+workspace from :guilabel:`Operations` ↓ :guilabel:`Organize or remove`.
+
+Only empty workspaces can be removed. Move or remove all projects in the
+workspace first. Workspaces associated with billing cannot be removed.
+
 .. _workspace-project-creation:
 
 Project creation and moves

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 2026.8
 * Translation memory management pages now load origin summaries with a single database aggregation.
 * Dashboard component list tabs now load without processing unrelated component lists.
 * Static assets now use content-hashed filenames, and CAPTCHA JavaScript is loaded only when needed.
+* :ref:`Empty workspaces <workspace-removal>` not associated with billing can now be removed from the workspace :guilabel:`Operations` menu.
 * :ref:`mt-aws` machine translation now supports configuring formality, brevity, and profanity masking.
 * Improved :ref:`screenshots` OCR reliability and error reporting when downloading recognition data.
 * Celery workers now prefetch fewer tasks by default to reduce memory usage and improve task distribution.

--- a/weblate/templates/workspace.html
+++ b/weblate/templates/workspace.html
@@ -77,6 +77,14 @@
                 <a class="dropdown-item" href="{% url 'workspace-access' pk=workspace.pk %}">{% translate "Access control" %}</a>
               </li>
             {% endif %}
+            {% if can_edit_workspace %}
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li>
+                <a class="dropdown-item" data-bs-target="#organize" data-bs-toggle="tab" href="#">{% translate "Organize or remove" %}</a>
+              </li>
+            {% endif %}
           {% endif %}
         </ul>
       </li>
@@ -150,6 +158,36 @@
             </div>
           </div>
         </form>
+      </div>
+    {% endif %}
+
+    {% if can_edit_workspace %}
+      <div class="tab-pane" id="organize">
+        {% if workspace_has_projects %}
+          <div class="alert alert-warning" role="alert">
+            {% translate "The workspace cannot be removed while it contains projects. Move or remove the projects first." %}
+          </div>
+        {% endif %}
+        {% if workspace_has_billing %}
+          <div class="alert alert-warning" role="alert">
+            {% translate "A workspace associated with billing cannot be removed." %}
+          </div>
+        {% endif %}
+        {% if delete_form %}
+          <form method="post" action="{% url 'workspace-remove' pk=workspace.pk %}">
+            <div class="card card-danger">
+              <div class="card-header">
+                <h4 class="card-title">{% translate "Are you absolutely sure?" %}</h4>
+              </div>
+              <div class="card-body">{% crispy delete_form %}</div>
+              <div class="card-footer">
+                <input type="submit"
+                       class="btn btn-danger"
+                       value="{% translate "I understand the consequences, delete this workspace" %}">
+              </div>
+            </div>
+          </form>
+        {% endif %}
       </div>
     {% endif %}
 

--- a/weblate/templates/workspaces/delete-workspace.html
+++ b/weblate/templates/workspaces/delete-workspace.html
@@ -1,0 +1,22 @@
+{% load i18n icons %}
+
+<p>
+  {% blocktranslate %}This action cannot be undone. This will permanently delete the {{ object }} workspace and all related workspace data.{% endblocktranslate %}
+  {% translate "This includes workspace access-control teams, translation memory, and code-hosting connections." %}
+</p>
+
+<div class="form-group">
+  <label class="control-label">{% translate "Workspace to remove" %}</label>
+  <div class="list-group">
+    <div class="list-group-item">
+      <div class="list-group-item-text">
+        <button type="button"
+                class="btn btn-link btn-xs float-end"
+                data-clipboard-value="{{ object.name }}"
+                title="{% translate "Copy to clipboard" %}">{% icon "copy.svg" %}</button>
+
+        {{ object.name }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -94,6 +94,11 @@ real_patterns = [
         weblate.workspaces.views.access,
         name="workspace-access",
     ),
+    path(
+        "workspaces/<uuid:pk>/remove/",
+        weblate.workspaces.views.remove,
+        name="workspace-remove",
+    ),
     # Bulk accept all suggestions from a specific user
     path(
         "js/bulk-accept-suggestions/<object_path:path>/",

--- a/weblate/workspaces/admin.py
+++ b/weblate/workspaces/admin.py
@@ -13,3 +13,15 @@ from .models import Workspace
 class WorkspaceAdmin(WeblateModelAdmin):
     list_display = ("name",)
     search_fields = ("name",)
+
+    def get_deleted_objects(self, objs, request):
+        (
+            deleted_objects,
+            model_count,
+            perms_needed,
+            protected,
+        ) = super().get_deleted_objects(objs, request)
+        # Workspace teams can not be deleted directly, but are owned by the
+        # workspace and should be removed together with it.
+        perms_needed.discard("Group")
+        return deleted_objects, model_count, perms_needed, protected

--- a/weblate/workspaces/forms.py
+++ b/weblate/workspaces/forms.py
@@ -5,13 +5,46 @@
 from __future__ import annotations
 
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Fieldset, Layout
+from crispy_forms.layout import Field, Fieldset, Layout
 from django import forms
-from django.utils.translation import gettext
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext, gettext_lazy
 
 from weblate.trans.forms import FieldDocsMixin, setup_message_setting_site_defaults
-from weblate.utils.forms import SearchableSelect, SortedSelect
+from weblate.utils.forms import ContextDiv, SearchableSelect, SortedSelect
 from weblate.workspaces.models import Workspace
+
+
+class WorkspaceDeleteForm(forms.Form):
+    confirm = forms.CharField(
+        label=gettext_lazy("Removal confirmation"),
+        help_text=gettext_lazy(
+            "Please type in the workspace name to confirm its removal."
+        ),
+        required=True,
+    )
+
+    def __init__(self, workspace: Workspace, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.workspace = workspace
+        self.helper = FormHelper(self)
+        self.helper.layout = Layout(
+            ContextDiv(
+                template="workspaces/delete-workspace.html",
+                css_class="form-group",
+                context={"object": workspace},
+            ),
+            Field("confirm"),
+        )
+        self.helper.form_tag = False
+
+    def clean_confirm(self) -> str:
+        confirm = self.cleaned_data["confirm"]
+        if confirm != self.workspace.name:
+            raise ValidationError(
+                gettext("The workspace name does not match the one marked for removal!")
+            )
+        return confirm
 
 
 class WorkspaceSettingsForm(FieldDocsMixin, forms.ModelForm):

--- a/weblate/workspaces/models.py
+++ b/weblate/workspaces/models.py
@@ -11,6 +11,8 @@ from uuid import uuid4
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy
 
@@ -401,3 +403,17 @@ class Workspace(models.Model):
             self.acting_user,
             update_fields,
         )
+
+
+@receiver(pre_delete, sender=Workspace)
+def workspace_pre_delete(sender, instance: Workspace, using: str, **kwargs) -> None:
+    # ruff: ignore[import-outside-top-level]
+    from weblate.trans.models import Change
+
+    # Changes for projects moved elsewhere retain their historical workspace.
+    # Detach these before the workspace cascade so the surviving project's
+    # history is preserved. Workspace-only history is still removed.
+    Change.objects.using(using).filter(
+        workspace=instance, project__isnull=False
+    ).update(workspace=None)
+    instance.delete_workspace_memory_scope()

--- a/weblate/workspaces/tests.py
+++ b/weblate/workspaces/tests.py
@@ -6,16 +6,21 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from django.contrib.admin.sites import AdminSite
 from django.core.exceptions import ValidationError
 from django.http import Http404
+from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from weblate.auth.admin import WeblateGroupAdmin
 from weblate.auth.data import SELECTION_ALL, SELECTION_MANUAL
-from weblate.auth.models import Group
+from weblate.auth.models import Group, User
 from weblate.billing.models import Billing, BillingQuerySet
+from weblate.lang.models import Language
+from weblate.memory.models import Memory, MemoryScope
 from weblate.trans.actions import ActionEvents
-from weblate.trans.models import Project
+from weblate.trans.models import Change, Project
 from weblate.trans.templatetags.translations import get_breadcrumbs
 from weblate.trans.tests.test_models import BaseTestCase
 from weblate.trans.tests.utils import (
@@ -24,6 +29,7 @@ from weblate.trans.tests.utils import (
     create_test_user,
 )
 from weblate.utils.views import UnsupportedPathObjectError, parse_path
+from weblate.workspaces.admin import WorkspaceAdmin
 from weblate.workspaces.models import WORKSPACE_PROJECT_CREATORS_GROUP, Workspace
 
 
@@ -210,6 +216,160 @@ class WorkspaceViewTest(BaseTestCase):
         self.assertContains(response, "Public project")
         self.assertNotContains(response, settings_url, status_code=200)
         self.assertNotContains(response, 'data-bs-target="#settings"', status_code=200)
+
+    def test_empty_workspace_can_be_removed_by_owner(self) -> None:
+        user = create_test_user()
+        workspace = Workspace.objects.create(name="Removal workspace")
+        workspace.add_owner(user)
+        moved_project = self.create_project(
+            workspace,
+            name="Moved project",
+            slug="moved-before-workspace-removal",
+        )
+        moved_project_change = Change.objects.create(
+            project=moved_project,
+            action=ActionEvents.CREATE_PROJECT,
+        )
+        workspace_change = Change.objects.create(
+            workspace=workspace,
+            action=ActionEvents.WORKSPACE_SETTING_CHANGE,
+        )
+        moved_project.workspace = None
+        moved_project.save(update_fields=["workspace"])
+        moved_project_change.refresh_from_db()
+        self.assertEqual(moved_project_change.workspace_id, workspace.pk)
+
+        workspace_id = workspace.pk
+        workspace_group_ids = list(
+            workspace.defined_groups.values_list("pk", flat=True)
+        )
+        remove_url = reverse("workspace-remove", kwargs={"pk": workspace.pk})
+
+        self.client.login(username=user.username, password="testpassword")
+        response = self.client.get(workspace.get_absolute_url())
+
+        self.assertContains(response, 'data-bs-target="#organize"')
+        self.assertContains(response, remove_url)
+        self.assertContains(response, "Workspace to remove")
+
+        response = self.client.post(
+            remove_url,
+            {"confirm": workspace.name},
+        )
+
+        self.assertRedirects(response, reverse("home"), fetch_redirect_response=False)
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, "The workspace has been removed.")
+        self.assertFalse(Workspace.objects.filter(pk=workspace_id).exists())
+        self.assertFalse(Group.objects.filter(pk__in=workspace_group_ids).exists())
+        moved_project_change.refresh_from_db()
+        self.assertIsNone(moved_project_change.workspace_id)
+        self.assertEqual(moved_project_change.project_id, moved_project.pk)
+        self.assertFalse(Change.objects.filter(pk=workspace_change.pk).exists())
+
+    def test_workspace_removal_requires_matching_name(self) -> None:
+        user = create_test_user()
+        workspace = Workspace.objects.create(name="Confirmation workspace")
+        workspace.add_owner(user)
+        remove_url = reverse("workspace-remove", kwargs={"pk": workspace.pk})
+
+        self.client.login(username=user.username, password="testpassword")
+        response = self.client.post(
+            remove_url,
+            {"confirm": "Wrong workspace"},
+            follow=True,
+        )
+
+        self.assertContains(
+            response,
+            "The workspace name does not match the one marked for removal!",
+        )
+        self.assertTrue(Workspace.objects.filter(pk=workspace.pk).exists())
+
+    def test_workspace_removal_is_hidden_without_workspace_edit(self) -> None:
+        workspace = Workspace.objects.create(name="Protected workspace")
+        project = self.create_project(
+            workspace,
+            name="Visible project",
+            slug="visible-removal-project",
+        )
+        user = create_another_user()
+        remove_url = reverse("workspace-remove", kwargs={"pk": workspace.pk})
+
+        self.client.login(username=user.username, password="testpassword")
+        response = self.client.get(project.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(workspace.get_absolute_url())
+
+        self.assertNotContains(response, 'data-bs-target="#organize"', status_code=200)
+        self.assertNotContains(response, remove_url, status_code=200)
+
+        response = self.client.post(remove_url, {"confirm": workspace.name})
+
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(Workspace.objects.filter(pk=workspace.pk).exists())
+
+    def test_workspace_with_projects_can_not_be_removed(self) -> None:
+        user = create_test_user()
+        workspace = Workspace.objects.create(name="Project workspace")
+        workspace.add_owner(user)
+        self.create_project(
+            workspace,
+            name="Remaining project",
+            slug="remaining-project",
+        )
+        remove_url = reverse("workspace-remove", kwargs={"pk": workspace.pk})
+
+        self.client.login(username=user.username, password="testpassword")
+        response = self.client.get(workspace.get_absolute_url())
+
+        self.assertContains(response, 'data-bs-target="#organize"')
+        self.assertContains(
+            response,
+            "The workspace cannot be removed while it contains projects.",
+        )
+        self.assertNotContains(response, remove_url, status_code=200)
+
+        response = self.client.post(
+            remove_url,
+            {"confirm": workspace.name},
+            follow=True,
+        )
+
+        self.assertContains(
+            response,
+            "The workspace cannot be removed while it contains projects.",
+        )
+        self.assertTrue(Workspace.objects.filter(pk=workspace.pk).exists())
+
+    def test_billing_workspace_can_not_be_removed(self) -> None:
+        user = create_test_user()
+        billing = create_test_billing(user, invoice=False)
+        workspace = billing.workspace
+        remove_url = reverse("workspace-remove", kwargs={"pk": workspace.pk})
+
+        self.client.login(username=user.username, password="testpassword")
+        response = self.client.get(workspace.get_absolute_url())
+
+        self.assertContains(response, 'data-bs-target="#organize"')
+        self.assertContains(
+            response,
+            "A workspace associated with billing cannot be removed.",
+        )
+        self.assertNotContains(response, remove_url, status_code=200)
+
+        response = self.client.post(
+            remove_url,
+            {"confirm": workspace.name},
+            follow=True,
+        )
+
+        self.assertContains(
+            response,
+            "A workspace associated with billing cannot be removed.",
+        )
+        self.assertTrue(Workspace.objects.filter(pk=workspace.pk).exists())
 
     def test_workspace_settings_update_name_as_workspace_owner(self) -> None:
         user = create_test_user()
@@ -585,3 +745,123 @@ class WorkspaceViewTest(BaseTestCase):
 
         group.refresh_from_db()
         self.assertEqual(group.language_selection, SELECTION_ALL)
+
+
+class WorkspaceAdminTest(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.factory = RequestFactory()
+        self.site = AdminSite()
+        self.site.register(Group, WeblateGroupAdmin)
+        self.workspace_admin = WorkspaceAdmin(Workspace, self.site)
+        self.actor = User.objects.create_user(
+            "workspace-admin", "workspace-admin@example.com", "testpassword"
+        )
+        self.actor.is_superuser = True
+        self.actor.save(update_fields=["is_superuser"])
+
+    def get_request(self):
+        request = self.factory.post("/")
+        request.user = self.actor
+        return request
+
+    def test_workspace_groups_do_not_block_admin_removal(self) -> None:
+        workspace = Workspace.objects.create(name="Admin removal workspace")
+        group_ids = list(workspace.defined_groups.values_list("pk", flat=True))
+
+        (
+            _deleted_objects,
+            _model_count,
+            perms_needed,
+            protected,
+        ) = self.workspace_admin.get_deleted_objects([workspace], self.get_request())
+
+        self.assertNotIn("Group", perms_needed)
+        self.assertEqual(protected, [])
+
+        workspace_id = workspace.pk
+        self.workspace_admin.delete_model(self.get_request(), workspace)
+
+        self.assertFalse(Workspace.objects.filter(pk=workspace_id).exists())
+        self.assertFalse(Group.objects.filter(pk__in=group_ids).exists())
+
+    def test_workspace_admin_removal_cleans_memory_scopes(self) -> None:
+        workspace = Workspace.objects.create(name="Admin memory removal workspace")
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        values = {
+            "source_language": source_language,
+            "target_language": target_language,
+            "origin": "workspace-admin-removal",
+            "status": Memory.STATUS_ACTIVE,
+        }
+        workspace_memory = Memory.objects.create(
+            source="Workspace admin removal source",
+            target="Workspace admin removal target",
+            **values,
+        )
+        mixed_memory = Memory.objects.create(
+            source="Mixed workspace admin removal source",
+            target="Mixed workspace admin removal target",
+            **values,
+        )
+        MemoryScope.objects.create(
+            memory=workspace_memory,
+            scope=MemoryScope.SCOPE_WORKSPACE,
+            workspace=workspace,
+        )
+        MemoryScope.objects.create(
+            memory=mixed_memory,
+            scope=MemoryScope.SCOPE_WORKSPACE,
+            workspace=workspace,
+        )
+        MemoryScope.objects.create(
+            memory=mixed_memory,
+            scope=MemoryScope.SCOPE_USER,
+            user=self.actor,
+        )
+
+        self.workspace_admin.delete_model(self.get_request(), workspace)
+
+        self.assertFalse(Memory.objects.filter(pk=workspace_memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=mixed_memory.pk).exists())
+        self.assertFalse(
+            mixed_memory.scopes.filter(scope=MemoryScope.SCOPE_WORKSPACE).exists()
+        )
+        self.assertTrue(
+            mixed_memory.scopes.filter(scope=MemoryScope.SCOPE_USER).exists()
+        )
+
+    def test_workspace_project_remains_protected_in_admin(self) -> None:
+        workspace = Workspace.objects.create(name="Protected admin workspace")
+        Project.objects.create(
+            name="Protected project",
+            slug="protected-admin-project",
+            web="https://example.com/",
+            workspace=workspace,
+        )
+
+        (
+            _deleted_objects,
+            _model_count,
+            perms_needed,
+            protected,
+        ) = self.workspace_admin.get_deleted_objects([workspace], self.get_request())
+
+        self.assertNotIn("Group", perms_needed)
+        self.assertTrue(protected)
+
+    def test_workspace_billing_remains_protected_in_admin(self) -> None:
+        billing = create_test_billing(self.actor, invoice=False)
+
+        (
+            _deleted_objects,
+            _model_count,
+            perms_needed,
+            protected,
+        ) = self.workspace_admin.get_deleted_objects(
+            [billing.workspace], self.get_request()
+        )
+
+        self.assertNotIn("Group", perms_needed)
+        self.assertTrue(protected)

--- a/weblate/workspaces/views.py
+++ b/weblate/workspaces/views.py
@@ -9,19 +9,24 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Count, Q
+from django.db import transaction
+from django.db.models import Count, ProtectedError, Q
 from django.http import Http404, HttpResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext
 from django.views.decorators.cache import never_cache
+from django.views.decorators.http import require_POST
 
 from weblate.trans.forms import AutoForm, BulkEditForm, SearchForm
 from weblate.trans.models.change import Change
 from weblate.trans.models.project import prefetch_project_flags
 from weblate.trans.views.reports import get_reports_context
-from weblate.utils.views import get_paginator
+from weblate.utils import messages
+from weblate.utils.views import get_paginator, show_form_errors
+from weblate.workspaces.forms import WorkspaceDeleteForm
 from weblate.workspaces.models import Workspace
 
 if TYPE_CHECKING:
@@ -76,6 +81,7 @@ def get_create_project_url(
 def detail(request: AuthenticatedHttpRequest, pk) -> HttpResponse:
     workspace = get_object_or_404(Workspace, pk=pk)
     projects = request.user.allowed_projects.filter(workspace=workspace).order()
+    workspace_has_projects = workspace.projects.exists()
     billing = get_workspace_billing(workspace)
     user_can_view_billing = billing is not None and request.user.has_perm(
         "meta:billing.view", billing
@@ -136,11 +142,16 @@ def detail(request: AuthenticatedHttpRequest, pk) -> HttpResponse:
             and request.user.has_perm("unit.edit", workspace)
             else None,
             "create_project_url": get_create_project_url(request, workspace, billing),
+            "delete_form": WorkspaceDeleteForm(workspace)
+            if can_edit_workspace and not workspace_has_projects and billing is None
+            else None,
             "last_changes": Change.objects.last_changes(
                 request.user, workspace=workspace
             ).recent(),
             "can_edit_workspace": can_edit_workspace,
             "can_manage_access": can_manage_access,
+            "workspace_has_billing": billing is not None,
+            "workspace_has_projects": workspace_has_projects,
             **(
                 get_reports_context(request, workspace)
                 if request.user.is_authenticated
@@ -149,6 +160,51 @@ def detail(request: AuthenticatedHttpRequest, pk) -> HttpResponse:
             **get_billing_context(request, billing),
         },
     )
+
+
+@never_cache
+@login_required
+@require_POST
+@transaction.atomic
+def remove(request: AuthenticatedHttpRequest, pk) -> HttpResponse:
+    workspace = get_object_or_404(Workspace.objects.select_for_update(), pk=pk)
+    if not request.user.has_perm("workspace.edit", workspace):
+        msg = "Access denied"
+        raise Http404(msg)
+
+    if workspace.projects.exists():
+        messages.error(
+            request,
+            gettext(
+                "The workspace cannot be removed while it contains projects. "
+                "Move or remove the projects first."
+            ),
+        )
+        return redirect(f"{workspace.get_absolute_url()}#organize")
+
+    if get_workspace_billing(workspace) is not None:
+        messages.error(
+            request,
+            gettext("A workspace associated with billing cannot be removed."),
+        )
+        return redirect(f"{workspace.get_absolute_url()}#organize")
+
+    form = WorkspaceDeleteForm(workspace, request.POST)
+    if not form.is_valid():
+        show_form_errors(request, form)
+        return redirect(f"{workspace.get_absolute_url()}#organize")
+
+    try:
+        workspace.delete()
+    except ProtectedError:
+        messages.error(
+            request,
+            gettext("The workspace cannot be removed because it is still being used."),
+        )
+        return redirect(f"{workspace.get_absolute_url()}#organize")
+
+    messages.success(request, gettext("The workspace has been removed."))
+    return redirect("home")
 
 
 @never_cache


### PR DESCRIPTION
Workspace owners had no supported way to remove obsolete workspaces, while Django admin deletion was blocked by workspace-owned internal groups. Add a guarded removal flow that preserves moved-project history and cleans workspace-scoped data.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
