### PR TITLE
fix(translations): preserve user for repository links

### DIFF
--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -966,7 +966,12 @@ def unit_state_title(unit) -> str:
 
 
 def try_linkify_filename(
-    text, filename: str, line: str, unit, profile, link_class: str = ""
+    text,
+    filename: str,
+    line: str,
+    unit: Unit,
+    user: User | None,
+    link_class: str = "",
 ):
     """
     Attempt to convert `text` to a repo link to `filename:line`.
@@ -977,9 +982,9 @@ def try_linkify_filename(
     link = None
     if re.search(r"^https?://", text):
         link = text
-    elif profile:
+    elif user:
         link = unit.translation.component.get_repoweb_link(
-            filename, line, profile.editor_link
+            filename, line, user.profile.editor_link, user=user
         )
     if link:
         return format_html(SOURCE_LINK, link, text, link_class)
@@ -1001,18 +1006,12 @@ def get_location_links(user: User | None, unit):
     if unit.location.isdigit():
         return gettext("string ID %s") % unit.location
 
-    profile = user.profile if user else None
-
     # Go through all locations separated by comma
     return format_html_join(
         mark_safe('\n<span class="divisor">•</span>\n'),
         "{}",
         (
-            (
-                try_linkify_filename(
-                    location, filename, line, unit, profile, "wrap-text"
-                ),
-            )
+            (try_linkify_filename(location, filename, line, unit, user, "wrap-text"),)
             for location, filename, line in unit.get_locations()
         ),
     )

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -277,6 +277,61 @@ class LocationLinksTest(TestCase):
             """,
         )
 
+    def test_default_github_repoweb(self) -> None:
+        component = self.unit.translation.component
+        component.vcs = "github-app"
+        component.repo = "https://github.com/example/project.git"
+        component.branch = "main"
+
+        with patch.object(self.user, "has_perm", return_value=True):
+            for filename, line in (("foo.bar", "123"), ("bar.foo", "321")):
+                with self.subTest(filename=filename):
+                    self.unit.location = f"{filename}:{line}"
+                    self.assertHTMLEqual(
+                        get_location_links(self.user, self.unit),
+                        f"""
+                        <a class="wrap-text"
+                            href="https://github.com/example/project/blob/main/{filename}#L{line}"
+                            tabindex="-1" target="_blank" dir="ltr"
+                            rel="noopener noreferrer">
+                        {filename}:{line}
+                        </a>
+                        """,
+                    )
+
+    def test_default_github_repoweb_requires_permission(self) -> None:
+        component = self.unit.translation.component
+        component.vcs = "github-app"
+        component.repo = "https://github.com/example/project.git"
+        component.branch = "main"
+        self.unit.location = "foo.bar:123"
+
+        with patch.object(self.user, "has_perm", return_value=False):
+            self.assertEqual(
+                get_location_links(self.user, self.unit),
+                "foo.bar:123",
+            )
+
+    def test_default_github_repoweb_linked_component(self) -> None:
+        component = self.unit.translation.component
+        component.repo = "weblate://p/source"
+        component.linked_component = Component(
+            project=component.project,
+            source_language=component.source_language,
+            slug="source",
+            name="Source",
+            vcs="github-app",
+            repo="https://github.com/example/project.git",
+            branch="main",
+        )
+        self.unit.location = "foo.bar:123"
+
+        with patch.object(self.user, "has_perm", return_value=True):
+            self.assertIn(
+                'href="https://github.com/example/project/blob/main/foo.bar#L123"',
+                get_location_links(self.user, self.unit),
+            )
+
     def test_user_url(self) -> None:
         self.unit.translation.component.repoweb = (
             "http://example.net/{{filename}}#L{{line}}"

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -1389,7 +1389,7 @@ def translate(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
                 # '' or '0' on GitHub or GitLab, let's play it safe for now.
                 "1",
                 unit,
-                user.profile,
+                user,
             ),
         },
     )


### PR DESCRIPTION
Automatic repository browser templates are permission-gated, but the translation helpers dropped the current user and could not generate default GitHub links.

Pass the user through both link paths and cover direct, linked, repeated, and denied access cases.

Fixes #20425

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
