### PR TITLE
chore(css): various cleanups

### DIFF
--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2365,7 +2365,7 @@ tbody.warning {
 }
 /* END: Shortcuts table styles */
 
-/** START: Search Previewe styles */
+/** START: Search Preview styles */
 #search-preview {
   display: none;
   width: 100%;

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -652,7 +652,7 @@ form + .login-label {
 }
 
 .login-label {
-  font-size: normal;
+  font-size: medium;
   font-weight: 600;
 }
 

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -390,10 +390,6 @@ span.replaced {
   margin-bottom: 0;
 }
 
-.card-body .table-sm {
-  margin-bottom: 0;
-}
-
 td .list-group {
   margin-bottom: 0;
 }

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -2404,7 +2404,7 @@ tbody.warning {
   color: var(--wl-color-primary);
   margin: 10px;
 }
-/** END: Search Previewe styles */
+/** END: Search Preview styles */
 
 /** START: Zen Editor sticky bottom styles */
 .sticky-bottom {

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -788,7 +788,7 @@ form + .login-label {
   right: 25%;
 }
 
-[dir="rtl"] .btn-float {
+[dir="rtl"] .col-sm-9 .btn-float {
   right: auto;
   left: 25%;
 }


### PR DESCRIPTION
* The `.card-body .table-sm` rule is defined twice (lines 389–391 and 393–395) with identical declarations. The duplicate rule can be removed.
* `font-size: normal` is not a valid CSS value for `font-size`. The valid keyword is `font-size: medium`, or a length/percentage value. This declaration will be ignored by the browser. It should likely be removed or replaced with a valid value such as `font-size: 1rem` or `font-size: 14px`.
* The `[dir="rtl"] .btn-float` selector is declared twice (lines 782–785 and 791–794). The second declaration overrides the first, making lines 782–785 (which set `left: 15px`) dead code. The intended behavior appears to be that `.col-sm-9 .btn-float` should scope the RTL override as well, so it should likely be `.col-sm-9 [dir="rtl"] .btn-float` or `[dir="rtl"] .col-sm-9 .btn-float`.
* "Previewe" is a misspelling of "Preview".

_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/WeblateOrg/weblate/security/quality/ai-findings)._