### PR TITLE
fix(vcs): terminate Mercurial path options

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Weblate 2026.8
 
 .. rubric:: Bug fixes
 
+* Mercurial repository filenames beginning with a dash are now handled safely.
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
 * Suggestion submission and rejection now reject excessively long suggestion text and rejection reasons.

--- a/weblate/vcs/mercurial.py
+++ b/weblate/vcs/mercurial.py
@@ -332,6 +332,7 @@ class HgRepository(Repository):
 
         # Add files one by one, this has to deal with
         # removed, untracked and non existing files
+        commit_files = []
         if files is not None:
             for name in files:
                 try:
@@ -341,7 +342,10 @@ class HgRepository(Repository):
                         self.execute(["remove", "--", name], remote_op="none")
                     except RepositoryError:
                         continue
-                cmd.append(name)
+                commit_files.append(name)
+
+        if commit_files:
+            cmd.extend(["--", *commit_files])
 
         # Bail out if there is nothing to commit.
         # This can easily happen with squashing and reverting changes.
@@ -429,10 +433,10 @@ class HgRepository(Repository):
                 return
             raise
 
-    def get_file(self, path, revision):
+    def get_file(self, path: str, revision: str) -> str:
         """Return content of file at given revision."""
         return self.execute(
-            ["cat", "--rev", revision, path],
+            ["cat", "--rev", revision, "--", path],
             remote_op="none",
             needs_lock=False,
             merge_err=False,

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -3825,6 +3825,39 @@ class VCSHgTest(VCSGitTest):
         status = self.repo.status()
         self.assertEqual(status, "")
 
+    def test_get_file_option_shaped_filename(self) -> None:
+        filename = "--config=alias.cat=version"
+        content = "OPTION-SHAPED FILE\n"
+        Path(self.tempdir, filename).write_text(content, encoding="utf-8")
+
+        with self.repo.lock:
+            self.repo.commit(
+                "Add option-shaped filename",
+                "Test <test@example.net>",
+                timezone.now(),
+                [filename],
+            )
+
+        self.assertEqual(self.repo.get_file(filename, self.repo.last_revision), content)
+
+    def test_commit_option_shaped_filename(self) -> None:
+        filename = "--config=alias.commit=version"
+        Path(self.tempdir, filename).write_text("COMMITTED FILE\n", encoding="utf-8")
+        old_revision = self.repo.last_revision
+
+        with self.repo.lock:
+            self.repo.commit(
+                "Add option-shaped filename",
+                "Test <test@example.net>",
+                timezone.now(),
+                [filename],
+            )
+
+        self.assertNotEqual(self.repo.last_revision, old_revision)
+        self.assertEqual(
+            self.repo.get_file(filename, self.repo.last_revision), "COMMITTED FILE\n"
+        )
+
     def test_count_outgoing_runtime_private_url_rejected(self) -> None:
         self.repo.component.repo = "https://private.example/repo"
         with (


### PR DESCRIPTION
Prevent option-shaped repository filenames from being interpreted as Mercurial configuration or command aliases.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
