### PR TITLE
fix(backups): validate linked repository access

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,7 @@ Weblate 2026.8
 
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
+* Project backup imports now skip repository-linked components when the importer cannot access the target component.
 * Suggestion submission and rejection now reject excessively long suggestion text and rejection reasons.
 * Restricted components are now available on Hosted Weblate when the billing plan permits private projects.
 * Machine translation and translation memory AJAX lookups no longer disclose whether inaccessible unit IDs exist.

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -195,6 +195,7 @@ class ProjectBackup:
         self.components_cache: dict[str, Component] = {}
         self.categories_cache: dict[str, Category] = {}
         self.roles_cache: dict[str, Role] = {}
+        self.skipped_components: list[str] = []
         # Project.set_language_team field was migrated to file format parameters after 5.17
         self.set_language_team_project: bool = False
 
@@ -648,13 +649,16 @@ class ProjectBackup:
             },
         )
 
-    def get_restore_history_details(self) -> dict[str, str]:
+    def get_restore_history_details(self) -> dict[str, BackupValue]:
         metadata = self.data["metadata"]
-        return {
+        details: dict[str, BackupValue] = {
             "backup_timestamp": metadata["timestamp"],
             "backup_server": metadata["server"],
             "backup_domain": metadata["domain"],
         }
+        if self.skipped_components:
+            details["skipped_components"] = self.skipped_components
+        return details
 
     @staticmethod
     def get_component_backup_slug(data: dict[str, Any]) -> str:
@@ -800,7 +804,7 @@ class ProjectBackup:
                 if changes is None:
                     msg = "Need a restore changes list."
                     raise TypeError(msg)
-                self.restore_component(zipfile, data, actor, changes)
+                return self.restore_component(zipfile, data, actor, changes)
             return True
 
     @staticmethod
@@ -1305,13 +1309,25 @@ class ProjectBackup:
 
         memory.clear()
 
+    @staticmethod
+    def get_accessible_linked_component(repo: str, actor: User) -> Component | None:
+        try:
+            linked_component = Component.objects.get_linked(repo)
+        except (Component.DoesNotExist, ValueError):
+            return None
+        if linked_component is None or linked_component.is_repo_link:
+            return None
+        if not actor.has_perm("component.edit", linked_component):
+            return None
+        return linked_component
+
     def restore_component(
         self,
         zipfile: ZipFile,
         data: dict,
         actor: User,
         changes: list[Change],
-    ) -> None:
+    ) -> bool:
         if self.project is None:
             raise TypeError
         original_slug = self.get_component_backup_slug(data["component"])
@@ -1326,11 +1342,13 @@ class ProjectBackup:
             old_slug = f"weblate://{self.data['project']['slug']}/"
             new_slug = f"weblate://{self.project.slug}/"
             kwargs["repo"] = kwargs["repo"].replace(old_slug, new_slug)
-            # Update linked_component attribute
-            if kwargs["repo"].startswith(new_slug):
-                kwargs["linked_component"] = self.components_cache[
-                    kwargs["repo"].removeprefix(new_slug)
-                ]
+            linked_component = self.get_accessible_linked_component(
+                kwargs["repo"], actor
+            )
+            if linked_component is None:
+                self.skipped_components.append(original_slug)
+                return False
+            kwargs["linked_component"] = linked_component
 
         if "category" in kwargs:
             kwargs["category"] = self.categories_cache[kwargs["category"]]
@@ -1471,6 +1489,7 @@ class ProjectBackup:
 
         # Update cache
         self.components_cache[self.full_slug_without_project(component)] = component
+        return True
 
     def create_language_cache(self) -> None:
         if not self.languages_cache:
@@ -1521,6 +1540,7 @@ class ProjectBackup:
         if not self.validated:
             msg = "Project backup has to be validated before restore."
             raise ValueError(msg)
+        self.skipped_components.clear()
         with ZipFile(self.filename, "r") as zipfile:
             self.validate_zip_members(zipfile)
             self.load_data(zipfile)

--- a/weblate/trans/change_display.py
+++ b/weblate/trans/change_display.py
@@ -24,6 +24,7 @@ from weblate.trans.templatetags.translations import (
     format_unit_target,
 )
 from weblate.utils.files import FileUploadMethod, get_upload_message
+from weblate.utils.html import format_html_join_comma
 from weblate.utils.markdown import render_markdown
 from weblate.utils.pii import mask_email
 
@@ -592,7 +593,7 @@ class ShowBackupRestoreEvent(BaseChangeHistoryContext):
             ]
 
         if self.change.action == ActionEvents.PROJECT_RESTORE:
-            return [
+            fields = [
                 self.make_field(
                     gettext("Backup created"),
                     details["backup_timestamp"],
@@ -606,6 +607,18 @@ class ShowBackupRestoreEvent(BaseChangeHistoryContext):
                     details["backup_domain"],
                 ),
             ]
+            skipped_components = details.get("skipped_components")
+            if isinstance(skipped_components, list):
+                fields.append(
+                    self.make_field(
+                        gettext("Skipped components"),
+                        format_html_join_comma(
+                            "<code>{}</code>",
+                            ((component,) for component in skipped_components),
+                        ),
+                    )
+                )
+            return fields
 
         return [
             self.make_field(

--- a/weblate/trans/management/commands/import_projectbackup.py
+++ b/weblate/trans/management/commands/import_projectbackup.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.utils.translation import gettext
+
 from weblate.auth.models import User
 from weblate.trans.backups import ProjectBackup
 from weblate.utils.management.base import BaseCommand
@@ -40,3 +42,12 @@ class Command(BaseCommand):
         restore.validate()
 
         restore.restore(project_name=project_name, project_slug=project_slug, user=user)
+        for component in restore.skipped_components:
+            self.stderr.write(
+                self.style.WARNING(
+                    gettext(
+                        "Component %(component)s was skipped because its linked repository is unavailable."
+                    )
+                    % {"component": component}
+                )
+            )

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -1294,7 +1294,7 @@ def restore_project_backup(
     filename: str,
     billing_id: int | None,
     workspace_id: str | None = None,
-) -> Project:
+) -> tuple[Project, list[str]]:
     # ruff: ignore[import-outside-top-level]
     from weblate.trans.backups import ProjectBackup
 
@@ -1325,7 +1325,7 @@ def restore_project_backup(
         progress_callback=report_restore_component_progress,
     )
     report_task_progress(95)
-    return project
+    return project, restore.skipped_components.copy()
 
 
 @app.task(trail=False)
@@ -1336,9 +1336,9 @@ def import_project_backup(
     filename: str,
     billing_id: int | None = None,
     workspace_id: str | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     try:
-        project = restore_project_backup(
+        project, skipped_components = restore_project_backup(
             project_name,
             project_slug,
             user_id,
@@ -1349,6 +1349,20 @@ def import_project_backup(
     finally:
         with suppress(OSError):
             os.unlink(filename)
+
+    if skipped_components:
+        return {
+            "message": gettext(
+                "Project backup import completed with skipped components."
+            ),
+            "warnings": [
+                gettext(
+                    "Component %(component)s was skipped because its linked repository is unavailable."
+                )
+                % {"component": component}
+                for component in skipped_components
+            ],
+        }
 
     return {
         "message": gettext("Project backup import completed."),

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import warnings
 from contextlib import contextmanager, suppress
+from io import StringIO
 from shutil import copyfile
 from unittest.mock import MagicMock, patch
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
@@ -89,7 +90,11 @@ class BackupsTest(ViewTestCase):
             )
 
     def write_tampered_component_backup(
-        self, *, repo: str | None = None, push: str | None = None
+        self,
+        *,
+        repo: str | None = None,
+        push: str | None = None,
+        all_components: bool = False,
     ) -> str:
         backup = ProjectBackup()
         backup.backup_project(self.project)
@@ -103,9 +108,10 @@ class BackupsTest(ViewTestCase):
         ):
             for item in source_zip.infolist():
                 data = source_zip.read(item.filename)
-                if item.filename.endswith(
-                    f"{self.component.slug}.json"
-                ) and item.filename.startswith("components/"):
+                if item.filename.startswith("components/") and (
+                    all_components
+                    or item.filename.endswith(f"{self.component.slug}.json")
+                ):
                     component_data = json.loads(data.decode("utf-8"))
                     if repo is not None:
                         component_data["component"]["repo"] = repo
@@ -962,6 +968,124 @@ class BackupsTest(ViewTestCase):
                 },
             )
 
+    def test_restore_skips_inaccessible_linked_component(self) -> None:
+        victim_project = Project.objects.create(name="Victim", slug="victim")
+        victim_component = self.create_po(project=victim_project, name="Victim")
+        temp_name = self.write_tampered_component_backup(
+            repo=victim_component.get_repo_link_url()
+        )
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            restore.validate()
+            self.assertFalse(
+                self.anotheruser.has_perm("component.edit", victim_component)
+            )
+
+            restored = restore.restore(
+                project_name="Partial restore",
+                project_slug="partial-restore",
+                user=self.anotheruser,
+            )
+
+        self.assertFalse(
+            restored.component_set.filter(slug=self.component.slug).exists()
+        )
+        self.assertEqual(restore.skipped_components, [self.component.slug])
+        restore_change = restored.change_set.get(action=ActionEvents.PROJECT_RESTORE)
+        self.assertEqual(
+            restore_change.details["skipped_components"], [self.component.slug]
+        )
+        history_data = get_change_history_context(restore_change)
+        self.assertEqual(
+            [field["label"] for field in history_data["change_details_fields"]],
+            ["Backup created", "Backup server", "Backup domain", "Skipped components"],
+        )
+        self.assertIn(
+            f"<code>{self.component.slug}</code>",
+            history_data["change_details_fields"][-1]["content"],
+        )
+
+    def test_restore_skips_missing_linked_component(self) -> None:
+        temp_name = self.write_tampered_component_backup(
+            repo="weblate://missing-project/missing-component"
+        )
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            restore.validate()
+            restored = restore.restore(
+                project_name="Missing link restore",
+                project_slug="missing-link-restore",
+                user=self.anotheruser,
+            )
+
+        self.assertFalse(
+            restored.component_set.filter(slug=self.component.slug).exists()
+        )
+        self.assertEqual(restore.skipped_components, [self.component.slug])
+
+    def test_restore_allows_accessible_cross_project_link(self) -> None:
+        target_project = Project.objects.create(name="Target", slug="target")
+        target_component = self.create_po(project=target_project, name="Target")
+        target_project.add_user(self.anotheruser, "Administration")
+        self.anotheruser.clear_permissions_cache()
+        self.assertTrue(self.anotheruser.has_perm("component.edit", target_component))
+        temp_name = self.write_tampered_component_backup(
+            repo=target_component.get_repo_link_url()
+        )
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            restore.validate()
+            restored = restore.restore(
+                project_name="Linked restore",
+                project_slug="linked-restore",
+                user=self.anotheruser,
+            )
+
+        restored_component = restored.component_set.get(slug=self.component.slug)
+        self.assertEqual(restored_component.linked_component, target_component)
+        self.assertEqual(restore.skipped_components, [])
+
+    def test_import_task_keeps_empty_project_and_reports_skipped_components(
+        self,
+    ) -> None:
+        victim_project = Project.objects.create(name="Task victim", slug="task-victim")
+        victim_component = self.create_po(project=victim_project, name="Taskvictim")
+        temp_name = self.write_tampered_component_backup(
+            repo=victim_component.get_repo_link_url(), all_components=True
+        )
+
+        result = import_project_backup(
+            "Empty partial restore",
+            "empty-partial-restore",
+            self.anotheruser.id,
+            temp_name,
+        )
+
+        restored = Project.objects.get(slug="empty-partial-restore")
+        self.assertFalse(restored.component_set.exists())
+        self.assertNotIn("url", result)
+        self.assertEqual(
+            result["message"],
+            "Project backup import completed with skipped components.",
+        )
+        self.assertEqual(len(result["warnings"]), 2)
+        self.assertTrue(
+            all(
+                warning.endswith(
+                    "was skipped because its linked repository is unavailable."
+                )
+                for warning in result["warnings"]
+            )
+        )
+        restore_change = restored.change_set.get(action=ActionEvents.PROJECT_RESTORE)
+        self.assertEqual(
+            set(restore_change.details["skipped_components"]),
+            {"glossary", self.component.slug},
+        )
+
     def test_create_duplicate(self) -> None:
         def extract_names(qs) -> list[str]:
             return list(qs.order_by("name").values_list("name", flat=True))
@@ -991,6 +1115,9 @@ class BackupsTest(ViewTestCase):
             extract_names(Component.objects.filter(project=self.project)),
             extract_names(Component.objects.filter(project=restored)),
         )
+        restored_link = restored.component_set.get(category__isnull=False)
+        restored_target = restored.component_set.get(category__isnull=True, slug="test")
+        self.assertEqual(restored_link.linked_component, restored_target)
 
     def test_restore_4_14(self) -> None:
         restore = ProjectBackup(TEST_BACKUP)
@@ -1012,6 +1139,33 @@ class BackupsTest(ViewTestCase):
             "import_projectbackup", "Restored", "restored", "testuser", TEST_BACKUP
         )
         self.verify_restored()
+
+    def test_restore_cli_reports_skipped_components(self) -> None:
+        victim_project = Project.objects.create(name="CLI victim", slug="cli-victim")
+        victim_component = self.create_po(project=victim_project, name="Clivictim")
+        temp_name = self.write_tampered_component_backup(
+            repo=victim_component.get_repo_link_url()
+        )
+        stderr = StringIO()
+
+        with remove_file_after(temp_name):
+            call_command(
+                "import_projectbackup",
+                "CLI partial restore",
+                "cli-partial-restore",
+                self.anotheruser.username,
+                temp_name,
+                stderr=stderr,
+            )
+
+        restored = Project.objects.get(slug="cli-partial-restore")
+        self.assertFalse(
+            restored.component_set.filter(slug=self.component.slug).exists()
+        )
+        self.assertIn(
+            f"Component {self.component.slug} was skipped because its linked repository is unavailable.",
+            stderr.getvalue(),
+        )
 
     def verify_restored(self) -> None:
         restored = Project.objects.get(slug="restored")


### PR DESCRIPTION
Backup imports bypassed the component.edit check applied by normal component creation, allowing crafted links to private repositories. Resolve links with the import actor's permissions and report unsafe components as skipped.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
