### PR TITLE
fix(wladmin): avoid spawning health check processes

### DIFF
--- a/weblate/wladmin/middleware.py
+++ b/weblate/wladmin/middleware.py
@@ -4,78 +4,115 @@
 
 from __future__ import annotations
 
-import multiprocessing
 import time
-from random import randint
-from threading import Thread
+from threading import Lock, Thread
 from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import connections
 from django.shortcuts import redirect
 from django.urls import reverse
 
 from weblate.accounts.models import AuditLog
-from weblate.runner import main
+from weblate.utils.errors import report_error
+from weblate.wladmin.models import ConfigurationError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from django.core.checks import CheckMessage
+
     from weblate.auth.models import AuthenticatedHttpRequest
 
 CHECK_CACHE_KEY = "weblate-health-check"
+CHECK_ATTEMPT_CACHE_KEY = f"{CHECK_CACHE_KEY}-attempt"
+CHECK_INTERVAL = 3600
+CHECK_ATTEMPT_TIMEOUT = 300
+CHECK_POLL_INTERVAL = 60
+
+
+def claim_configuration_health_check() -> bool:
+    """Atomically claim a health-check attempt across web workers."""
+    return cache.add(
+        CHECK_ATTEMPT_CACHE_KEY,
+        time.time(),
+        timeout=CHECK_ATTEMPT_TIMEOUT,
+    )
+
+
+def perform_configuration_health_check(
+    checks: Iterable[CheckMessage] | None = None,
+) -> bool:
+    """Run and persist a configuration health check."""
+    try:
+        ConfigurationError.objects.configuration_health_check(checks)
+        cache.set(CHECK_CACHE_KEY, time.time(), timeout=None)
+    except Exception:
+        report_error("Configuration health check failed")
+        return False
+    return True
+
+
+def run_background_configuration_health_check() -> None:
+    """Run a health check and close connections owned by this thread."""
+    try:
+        perform_configuration_health_check()
+    finally:
+        connections.close_all()
 
 
 class ManageMiddleware:
     """
     Middleware to trigger periodic management tasks.
 
-    These have to be triggered from the UWSGI context to be able to detect differences
-    between Celery and UWSGI environments.
+    These have to run in the website process to detect differences between the
+    Celery and website environments.
     """
 
     def __init__(self, get_response=None) -> None:
         self.get_response = get_response
+        self._poll_lock = Lock()
+        self._next_poll = 0.0
+
+    def should_poll(self) -> bool:
+        """Limit shared-cache polling in each web process."""
+        with self._poll_lock:
+            now = time.monotonic()
+            if now < self._next_poll:
+                return False
+            self._next_poll = now + CHECK_POLL_INTERVAL
+        return True
 
     @staticmethod
     def trigger_check() -> None:
         if not settings.BACKGROUND_ADMIN_CHECKS:
             return
-        # Update last execution timestamp
-        cache.set(CHECK_CACHE_KEY, time.time())
+        if not claim_configuration_health_check():
+            return
 
-        # Use safer spawn method
-        context = multiprocessing.get_context("spawn")
+        try:
+            thread = Thread(
+                target=run_background_configuration_health_check,
+                name="configuration-health-check",
+                daemon=False,
+            )
+            thread.start()
+        except Exception:
+            report_error("Could not start configuration health check")
 
-        # Spawn a management process to do a configuration health check
-        # - using threads causes problems with a database connections
-        #   (SSL initialization and keeping open persistent connections)
-        # - spawning directly the method using multiprocessing is not easy
-        #   because of missing invocation of django.setup()
-        process = context.Process(
-            target=main, kwargs={"argv": ["weblate", "configuration_health_check"]}
-        )
-        process.start()
-
-        # Make sure we catch SIGCHLD from the spawned process
-        thread = Thread(target=process.join)
-        thread.start()
+    def trigger_check_if_due(self) -> None:
+        if not settings.BACKGROUND_ADMIN_CHECKS or not self.should_poll():
+            return
+        last_success = cache.get(CHECK_CACHE_KEY)
+        if last_success is None or time.time() - last_success >= CHECK_INTERVAL:
+            self.trigger_check()
 
     def __call__(self, request: AuthenticatedHttpRequest):
         if request.session.pop("redirect_to_donate", False):
             AuditLog.objects.create(request.user, request, "donate")
             return redirect(reverse("donate"))
         response = self.get_response(request)
-        if (
-            request.resolver_match
-            and request.resolver_match.view_name == "manage-performance"
-        ):
-            # Always trigger on the performance page
-            self.trigger_check()
-        # ruff: ignore[suspicious-non-cryptographic-random-usage]
-        elif randint(0, 100) == 1:
-            # Trigger when last check is too old
-            last_run = cache.get(CHECK_CACHE_KEY)
-            now = time.time()
-            if last_run is None or now - last_run > 900:
-                self.trigger_check()
+        self.trigger_check_if_due()
 
         return response

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -39,6 +39,17 @@ from weblate.utils.backup import BackupError, BorgResult
 from weblate.utils.data import data_path
 from weblate.utils.unittest import tempdir_setting
 from weblate.wladmin.forms import ThemeColorField, ThemeColorWidget
+from weblate.wladmin.middleware import (
+    CHECK_ATTEMPT_CACHE_KEY,
+    CHECK_ATTEMPT_TIMEOUT,
+    CHECK_CACHE_KEY,
+    CHECK_INTERVAL,
+    CHECK_POLL_INTERVAL,
+    ManageMiddleware,
+    claim_configuration_health_check,
+    perform_configuration_health_check,
+    run_background_configuration_health_check,
+)
 from weblate.wladmin.models import (
     BackupService,
     ConfigurationError,
@@ -685,6 +696,164 @@ class ManagementAccessControlTest(ViewTestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class ManageMiddlewareTest(TestCase):
+    def test_claim_configuration_health_check(self) -> None:
+        with (
+            patch("weblate.wladmin.middleware.time.time", return_value=123),
+            patch(
+                "weblate.wladmin.middleware.cache.add", return_value=True
+            ) as cache_add,
+        ):
+            self.assertTrue(claim_configuration_health_check())
+
+        cache_add.assert_called_once_with(
+            CHECK_ATTEMPT_CACHE_KEY,
+            123,
+            timeout=CHECK_ATTEMPT_TIMEOUT,
+        )
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=False)
+    def test_disabled(self) -> None:
+        middleware = ManageMiddleware(Mock())
+        with patch.object(middleware, "should_poll") as should_poll:
+            middleware.trigger_check_if_due()
+        should_poll.assert_not_called()
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=True)
+    def test_poll_interval(self) -> None:
+        middleware = ManageMiddleware(Mock())
+        with (
+            patch(
+                "weblate.wladmin.middleware.time.monotonic",
+                side_effect=[100, 120, 100 + CHECK_POLL_INTERVAL],
+            ),
+            patch("weblate.wladmin.middleware.cache.get", return_value=None),
+            patch.object(middleware, "trigger_check") as trigger_check,
+        ):
+            middleware.trigger_check_if_due()
+            middleware.trigger_check_if_due()
+            middleware.trigger_check_if_due()
+
+        self.assertEqual(trigger_check.call_count, 2)
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=True)
+    def test_recent_check(self) -> None:
+        middleware = ManageMiddleware(Mock())
+        with (
+            patch("weblate.wladmin.middleware.time.monotonic", return_value=100),
+            patch("weblate.wladmin.middleware.time.time", return_value=1000),
+            patch(
+                "weblate.wladmin.middleware.cache.get",
+                return_value=1000 - CHECK_INTERVAL + 1,
+            ),
+            patch.object(middleware, "trigger_check") as trigger_check,
+        ):
+            middleware.trigger_check_if_due()
+
+        trigger_check.assert_not_called()
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=True)
+    def test_atomic_attempt_claim(self) -> None:
+        with (
+            patch(
+                "weblate.wladmin.middleware.claim_configuration_health_check",
+                return_value=False,
+            ),
+            patch("weblate.wladmin.middleware.Thread") as thread,
+        ):
+            ManageMiddleware.trigger_check()
+
+        thread.assert_not_called()
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=True)
+    def test_starts_background_thread(self) -> None:
+        with (
+            patch(
+                "weblate.wladmin.middleware.claim_configuration_health_check",
+                return_value=True,
+            ),
+            patch("weblate.wladmin.middleware.Thread") as thread,
+        ):
+            ManageMiddleware.trigger_check()
+
+        thread.assert_called_once_with(
+            target=run_background_configuration_health_check,
+            name="configuration-health-check",
+            daemon=False,
+        )
+        thread.return_value.start.assert_called_once_with()
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=True)
+    def test_thread_start_failure(self) -> None:
+        with (
+            patch(
+                "weblate.wladmin.middleware.claim_configuration_health_check",
+                return_value=True,
+            ),
+            patch(
+                "weblate.wladmin.middleware.Thread",
+                side_effect=RuntimeError("thread failed"),
+            ),
+            patch("weblate.wladmin.middleware.report_error") as report_error,
+        ):
+            ManageMiddleware.trigger_check()
+
+        report_error.assert_called_once_with(
+            "Could not start configuration health check"
+        )
+
+    def test_perform_configuration_health_check(self) -> None:
+        checks = [Critical(msg="Test error", id="weblate.E002")]
+        with (
+            patch.object(
+                ConfigurationError.objects, "configuration_health_check"
+            ) as health_check,
+            patch("weblate.wladmin.middleware.time.time", return_value=123),
+            patch("weblate.wladmin.middleware.cache.set") as cache_set,
+        ):
+            self.assertTrue(perform_configuration_health_check(checks))
+
+        health_check.assert_called_once_with(checks)
+        cache_set.assert_called_once_with(CHECK_CACHE_KEY, 123, timeout=None)
+
+    def test_perform_configuration_health_check_failure(self) -> None:
+        with (
+            patch.object(
+                ConfigurationError.objects,
+                "configuration_health_check",
+                side_effect=RuntimeError("check failed"),
+            ),
+            patch("weblate.wladmin.middleware.cache.set") as cache_set,
+            patch("weblate.wladmin.middleware.report_error") as report_error,
+        ):
+            self.assertFalse(perform_configuration_health_check())
+
+        cache_set.assert_not_called()
+        report_error.assert_called_once_with("Configuration health check failed")
+
+    def test_background_check_closes_connections(self) -> None:
+        with (
+            patch("weblate.wladmin.middleware.perform_configuration_health_check"),
+            patch("weblate.wladmin.middleware.connections.close_all") as close_all,
+        ):
+            run_background_configuration_health_check()
+
+        close_all.assert_called_once_with()
+
+    def test_background_check_closes_connections_on_failure(self) -> None:
+        with (
+            patch(
+                "weblate.wladmin.middleware.perform_configuration_health_check",
+                side_effect=RuntimeError("reporting failed"),
+            ),
+            patch("weblate.wladmin.middleware.connections.close_all") as close_all,
+            self.assertRaises(RuntimeError),
+        ):
+            run_background_configuration_health_check()
+
+        close_all.assert_called_once_with()
+
+
 class AdminTest(ViewTestCase):
     """Test for customized admin interface."""
 
@@ -1235,6 +1404,51 @@ class AdminTest(ViewTestCase):
             list(response.context["queues"]),
             [("aqueue", 2), ("zqueue", 1)],
         )
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=True)
+    def test_performance_persists_existing_checks(self) -> None:
+        checks = [Critical(msg="Test Error", id="weblate.E002")]
+        with (
+            patch("weblate.wladmin.views.run_checks", return_value=checks),
+            patch(
+                "weblate.wladmin.views.claim_configuration_health_check",
+                return_value=True,
+            ) as claim_health_check,
+            patch(
+                "weblate.wladmin.views.perform_configuration_health_check"
+            ) as perform_health_check,
+            patch(
+                "weblate.wladmin.middleware.ManageMiddleware.should_poll",
+                return_value=False,
+            ),
+        ):
+            response = self.client.get(reverse("manage-performance"))
+
+        self.assertEqual(response.status_code, 200)
+        claim_health_check.assert_called_once_with()
+        perform_health_check.assert_called_once_with(checks)
+
+    @override_settings(BACKGROUND_ADMIN_CHECKS=True)
+    def test_performance_skips_persistence_during_active_check(self) -> None:
+        checks = [Critical(msg="Test Error", id="weblate.E002")]
+        with (
+            patch("weblate.wladmin.views.run_checks", return_value=checks),
+            patch(
+                "weblate.wladmin.views.claim_configuration_health_check",
+                return_value=False,
+            ),
+            patch(
+                "weblate.wladmin.views.perform_configuration_health_check"
+            ) as perform_health_check,
+            patch(
+                "weblate.wladmin.middleware.ManageMiddleware.should_poll",
+                return_value=False,
+            ),
+        ):
+            response = self.client.get(reverse("manage-performance"))
+
+        self.assertEqual(response.status_code, 200)
+        perform_health_check.assert_not_called()
 
     def test_error(self) -> None:
         ConfigurationError.objects.create(name="Test error", message="FOOOOOOOOOOOOOO")

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -94,6 +94,10 @@ from weblate.wladmin.forms import (
     WorkspaceCreateForm,
     WorkspaceSearchForm,
 )
+from weblate.wladmin.middleware import (
+    claim_configuration_health_check,
+    perform_configuration_health_check,
+)
 from weblate.wladmin.models import (
     BackupService,
     ConfigurationError,
@@ -657,12 +661,11 @@ def performance(request: AuthenticatedHttpRequest) -> HttpResponse:
         if not request.user.has_perm("management.configure"):
             raise PermissionDenied
         return handle_dismiss(request)
+    all_checks = run_checks(include_deployment_checks=True)
+    if settings.BACKGROUND_ADMIN_CHECKS and claim_configuration_health_check():
+        perform_configuration_health_check(all_checks)
     checks = sorted(
-        (
-            check
-            for check in run_checks(include_deployment_checks=True)
-            if not check.is_silenced()
-        ),
+        (check for check in all_checks if not check.is_silenced()),
         key=lambda check: (check.id, check.msg),
     )
 


### PR DESCRIPTION
Run website configuration checks in-process with atomic scheduling and explicit connection cleanup. This avoids costly process startup while making retries and cross-worker execution reliable.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
