### PR TITLE
perf(changes): optimize category history loading

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,7 @@ Weblate 2026.8
 * Improved matrix view loading performance when displaying multiple languages.
 * Translation memory management pages now load origin summaries with a single database aggregation.
 * Dashboard component list tabs now load without processing unrelated component lists.
+* Category pages now load recent history and shared component listings more efficiently.
 * Static assets now use content-hashed filenames, and CAPTCHA JavaScript is loaded only when needed.
 * :ref:`Empty workspaces <workspace-removal>` not associated with billing can now be removed from the workspace :guilabel:`Operations` menu.
 * :ref:`mt-aws` machine translation now supports configuring formality, brevity, and profanity masking.

--- a/weblate/trans/migrations/0096_change_recent_indexes.py
+++ b/weblate/trans/migrations/0096_change_recent_indexes.py
@@ -1,0 +1,44 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0095_report"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="change",
+            index=models.Index(
+                condition=models.Q(("action", 46)),
+                fields=["-timestamp"],
+                name="trans_change_announce_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="change",
+            index=models.Index(
+                condition=models.Q(
+                    ("component__isnull", False),
+                    ("language__isnull", False),
+                ),
+                fields=["language", "component", "-timestamp"],
+                name="trans_change_lang_comp_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="change",
+            index=models.Index(
+                condition=models.Q(
+                    ("category__isnull", False),
+                    ("language__isnull", False),
+                ),
+                fields=["language", "category", "-timestamp"],
+                name="trans_change_lang_cat_idx",
+            ),
+        ),
+    ]

--- a/weblate/trans/models/category.py
+++ b/weblate/trans/models/category.py
@@ -455,15 +455,11 @@ class Category(
     def get_child_components_access(self, user: User):
         """List child components, including shared components linked to this category."""
         # ruff: ignore[import-outside-top-level]
-        from weblate.trans.models.component import (
-            Component,
-            ComponentLink,
-        )
+        from weblate.trans.models.component import Component
 
-        shared_ids = ComponentLink.objects.filter(category=self).values_list(
-            "component_id", flat=True
+        qs = Component.objects.filter(
+            pk__in=self.get_component_ids_with_links(include_descendants=False)
         )
-        qs = Component.objects.filter(Q(category=self) | Q(pk__in=shared_ids))
         return qs.filter_access(user).prefetch().order()
 
     def uses_parent_setting(self, field: str) -> bool:
@@ -565,21 +561,32 @@ class Category(
     def languages(self):
         """Return list of all languages used in category, including shared components."""
         # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models import Translation
+
+        language_ids = Translation.objects.filter(
+            component_id__in=self.get_component_ids_with_links()
+        ).values_list("language_id", flat=True)
+        return Language.objects.filter(pk__in=language_ids).order()
+
+    def get_component_ids_with_links(self, *, include_descendants: bool = True):
+        """Return a lazy query of owned and linked component identifiers."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models import Component
+
+        # ruff: ignore[import-outside-top-level]
         from weblate.trans.models.component import ComponentLink
 
-        shared_ids = ComponentLink.objects.filter(
-            Q(category=self)
-            | Q(category__category=self)
-            | Q(category__category__category=self)
-        ).values_list("component_id", flat=True)
-        return (
-            Language.objects.filter(
-                Q(translation__component_id__in=self.all_component_ids)
-                | Q(translation__component_id__in=shared_ids)
+        category_filter = Q(category=self)
+        if include_descendants:
+            category_filter |= Q(category__category=self) | Q(
+                category__category__category=self
             )
-            .distinct()
-            .order()
+
+        owned = Component.objects.filter(category_filter).values_list("pk", flat=True)
+        shared = ComponentLink.objects.filter(category_filter).values_list(
+            "component_id", flat=True
         )
+        return owned.union(shared)
 
     @cached_property
     def all_components(self) -> ComponentQuerySet:
@@ -612,6 +619,7 @@ class Category(
 
     @cached_property
     def all_component_ids(self):
+        """Return cached identifiers of components owned by this category tree."""
         return set(self.all_components.values_list("pk", flat=True))
 
     def generate_changes(self, old) -> None:

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -112,17 +112,8 @@ class ChangeQuerySet(models.QuerySet["Change", "Change"]):
         return base.filter(action__in=ACTIONS_CONTENT)
 
     def for_category(self, category: Category) -> Self:
-        # ruff: ignore[import-outside-top-level]
-        from weblate.trans.models.component import ComponentLink
-
-        shared_component_ids = ComponentLink.objects.filter(
-            Q(category=category)
-            | Q(category__category=category)
-            | Q(category__category__category=category)
-        ).values_list("component_id", flat=True)
         return self.filter(
-            Q(component_id__in=category.all_component_ids)
-            | Q(component_id__in=shared_component_ids)
+            Q(component_id__in=category.get_component_ids_with_links())
             | Q(category=category)
         )
 
@@ -264,15 +255,24 @@ class ChangeQuerySet(models.QuerySet["Change", "Change"]):
         """
         Return recent changes to show on object pages.
 
-        This uses iterator() as server-side cursors are typically
-        more effective here.
+        Fetch the identifiers first to keep the ordered and limited query
+        narrow. Related objects are loaded only for the selected changes.
         """
-        result: list[Change] = []
-        with transaction.atomic(), start_span(op="change.recent"):
-            for change in self.order().iterator(chunk_size=count):
-                result.append(change)
-                if len(result) >= count:
-                    break
+        with start_span(op="change.recent"):
+            change_ids = list(self.order().values_list("pk", flat=True)[:count])
+            if not change_ids:
+                return []
+
+            selected_changes = cast(
+                "ChangeQuerySet",
+                self.filter(pk__in=change_ids).prefetch_for_render().order(),
+            )
+            changes: dict[int, Change] = {
+                change.pk: change for change in selected_changes
+            }
+            result = [
+                changes[change_id] for change_id in change_ids if change_id in changes
+            ]
             return self.preload_list(result, skip_preload)
 
     def bulk_create(  # type: ignore[override]
@@ -395,6 +395,9 @@ class ChangeQuerySet(models.QuerySet["Change", "Change"]):
 
 
 class ChangeManager(models.Manager["Change"]):
+    def get_queryset(self) -> ChangeQuerySet:
+        return cast("ChangeQuerySet", super().get_queryset())
+
     def create(self, *, user: User | None = None, **kwargs) -> Change:
         """
         Create a change object.
@@ -404,6 +407,22 @@ class ChangeManager(models.Manager["Change"]):
         if user is not None and not user.is_authenticated:
             user = None
         return super().create(user=user, **kwargs)
+
+    def _last_category_changes(
+        self,
+        user: User,
+        category: Category,
+        language: Language | None,
+    ) -> ChangeQuerySet:
+        result = self.get_queryset()
+        if not user.can_access_project(category.project):
+            return result.none()
+        result = (
+            result.for_category(category).filter_projects(user).filter_components(user)
+        )
+        if language is not None:
+            result = result.filter(language=language)
+        return result
 
     def last_changes(
         self,
@@ -443,6 +462,8 @@ class ChangeManager(models.Manager["Change"]):
                 result = result.filter(language=language)
             if category is not None:
                 result = result.filter(category=category)
+        elif category is not None:
+            result = self._last_category_changes(user, category, language)
         elif workspace is not None:
             if not workspace.can_view(user):
                 return cast("ChangeQuerySet", self.none())
@@ -667,6 +688,21 @@ class Change(models.Model, UserDisplayMixin):
                 fields=["category", "-timestamp", "action"],
                 condition=Q(category__isnull=False),
                 name="trans_change_category_idx",
+            ),
+            models.Index(
+                fields=["-timestamp"],
+                condition=Q(action=ActionEvents.ANNOUNCEMENT),
+                name="trans_change_announce_idx",
+            ),
+            models.Index(
+                fields=["language", "component", "-timestamp"],
+                condition=Q(component__isnull=False) & Q(language__isnull=False),
+                name="trans_change_lang_comp_idx",
+            ),
+            models.Index(
+                fields=["language", "category", "-timestamp"],
+                condition=Q(category__isnull=False) & Q(language__isnull=False),
+                name="trans_change_lang_cat_idx",
             ),
             models.Index(
                 fields=["unit", "-timestamp", "action"],

--- a/weblate/trans/tests/test_changes.py
+++ b/weblate/trans/tests/test_changes.py
@@ -21,9 +21,9 @@ from weblate.utils.xml import parse_xml
 class FeedQueriesTest(FixtureTestCase):
     # Reverse managers populate different related objects up front, so the
     # fixed query budget differs between project/component/translation feeds.
-    PROJECT_FEED_QUERIES = 12
-    COMPONENT_FEED_QUERIES = 11
-    TRANSLATION_FEED_QUERIES = 11
+    PROJECT_FEED_QUERIES = 11
+    COMPONENT_FEED_QUERIES = 10
+    TRANSLATION_FEED_QUERIES = 10
 
     def setUp(self) -> None:
         super().setUp()

--- a/weblate/trans/tests/test_links.py
+++ b/weblate/trans/tests/test_links.py
@@ -420,13 +420,23 @@ class ComponentLinkTestCase(ViewTestCase):
         cat = Category.objects.create(
             name="Empty Cat", slug="empty-cat", project=self.other
         )
+        child = Category.objects.create(
+            name="Nested Cat",
+            slug="nested-cat",
+            project=self.other,
+            category=cat,
+        )
         self.assertEqual(cat.component_set.count(), 0)
         self.assertEqual(len(cat.languages), 0)
 
-        self.link.category = cat
+        self.link.category = child
         self.link.save()
 
         cat = Category.objects.get(pk=cat.pk)
+        component_ids = cat.get_component_ids_with_links()
+        self.assertIn("UNION", str(component_ids.query))
+        self.assertIn(self.component.pk, set(component_ids))
+        self.assertNotIn(self.component.pk, cat.all_component_ids)
         self.assertNotEqual(len(cat.languages), 0)
 
         comp_languages = set(

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -54,6 +54,8 @@ from weblate.trans.models import (
     Unit,
     Vote,
 )
+from weblate.trans.models.change import ChangeQuerySet
+from weblate.trans.models.component import ComponentLink
 from weblate.trans.models.project import CommitPolicyChoices
 from weblate.trans.removal import RemovalBatch
 from weblate.trans.tasks import actual_project_removal
@@ -1629,6 +1631,93 @@ class AnnouncementTest(ModelTestCase):
 
 class ChangeTest(ModelTestCase):
     """Test(s) for Change model."""
+
+    def test_recent_uses_limited_identifier_query(self) -> None:
+        Change.objects.all().delete()
+        changes = [
+            self.component.change_set.create(action=ActionEvents.LOCK) for _ in range(3)
+        ]
+        queryset = self.component.change_set.prefetch_for_render()
+
+        with CaptureQueriesContext(connection) as queries:
+            recent = queryset.recent(count=2)
+
+        self.assertEqual(
+            [change.pk for change in recent], [changes[2].pk, changes[1].pk]
+        )
+        candidate_sql = queries[0]["sql"]
+        self.assertIn("LIMIT 2", candidate_sql)
+        self.assertNotIn("trans_comment", candidate_sql)
+        self.assertNotIn("trans_suggestion", candidate_sql)
+
+    def test_recent_skips_changes_deleted_before_hydration(self) -> None:
+        Change.objects.all().delete()
+        changes = [
+            self.component.change_set.create(action=ActionEvents.LOCK) for _ in range(3)
+        ]
+        original_prefetch = ChangeQuerySet.prefetch_for_render
+
+        def delete_change_before_prefetch(
+            queryset: ChangeQuerySet,
+        ) -> ChangeQuerySet:
+            Change.objects.filter(pk=changes[1].pk).delete()
+            return original_prefetch(queryset)
+
+        with patch.object(
+            ChangeQuerySet,
+            "prefetch_for_render",
+            delete_change_before_prefetch,
+        ):
+            recent = self.component.change_set.recent(count=2)
+
+        self.assertEqual([change.pk for change in recent], [changes[2].pk])
+
+    def test_category_changes_exclude_inaccessible_linked_project(self) -> None:
+        source_project = self.component.project
+        source_project.access_control = Project.ACCESS_PRIVATE
+        source_project.save(update_fields=["access_control"])
+        target_project = Project.objects.create(
+            name="Category history target",
+            slug="category-history-target",
+        )
+        category = Category.objects.create(
+            name="Category history",
+            slug="category-history",
+            project=target_project,
+        )
+        ComponentLink.objects.create(
+            component=self.component,
+            project=target_project,
+            category=category,
+        )
+        user = User.objects.create_user(
+            "category-history",
+            "category-history@example.com",
+            "category-history",
+        )
+        language = self.component.translation_set.get(language_code="cs").language
+        visible_change = Change.objects.create(
+            action=ActionEvents.RENAME_CATEGORY,
+            project=target_project,
+            category=category,
+            language=language,
+        )
+        hidden_change = self.component.change_set.create(
+            action=ActionEvents.LOCK,
+            language=language,
+        )
+
+        self.assertTrue(user.can_access_project(target_project))
+        self.assertFalse(user.can_access_project(source_project))
+
+        changes = Change.objects.last_changes(
+            user,
+            category=category,
+            language=language,
+        )
+
+        self.assertIn(visible_change, changes)
+        self.assertNotIn(hidden_change, changes)
 
     def test_fixup_references_inherits_project_workspace(self) -> None:
         workspace = Workspace.objects.create(name="Change workspace")

--- a/weblate/trans/tests/test_reports.py
+++ b/weblate/trans/tests/test_reports.py
@@ -11,15 +11,21 @@ from django.utils import timezone
 
 from weblate.auth.models import User
 from weblate.memory.models import Memory
-from weblate.trans.forms import MIN_COST_ESTIMATE_TM_THRESHOLD, CountsReportsForm
+from weblate.trans.forms import (
+    MIN_COST_ESTIMATE_TM_THRESHOLD,
+    CountsReportsForm,
+    get_report_language_choices,
+)
 from weblate.trans.models import (
     Category,
     Change,
     PendingUnitChange,
+    Project,
     Report,
     Suggestion,
     Unit,
 )
+from weblate.trans.models.component import ComponentLink
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import TESTPASSWORD
 from weblate.trans.views.reports import (
@@ -228,6 +234,35 @@ class ReportsTest(BaseReportsTest):
                 }
             ],
         )
+
+    def test_category_reports_exclude_linked_components(self) -> None:
+        project = Project.objects.create(
+            name="Linked report project",
+            slug="linked-report-project",
+        )
+        category = self.create_category(project=project)
+        ComponentLink.objects.create(
+            component=self.component,
+            project=project,
+            category=category,
+        )
+        self.add_change()
+
+        credit_data = generate_credits(
+            None,
+            timezone.now() - timedelta(days=1),
+            timezone.now() + timedelta(days=1),
+            "",
+            category,
+            "date_joined",
+            "ascending",
+        )
+        costs = self.generate_cost_data(entity=category)
+        language_choices = get_report_language_choices({"category": category})
+
+        self.assertEqual(credit_data, [])
+        self.assertEqual(costs["total"]["count"], 0)
+        self.assertEqual(len(language_choices), 1)
 
     def test_counts_one(self) -> None:
         self.add_change()

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -388,11 +388,11 @@ def show_category_language(
     category_object = obj.category
     user = request.user
 
-    last_changes = (
-        Change.objects.last_changes(user, language=language_object)
-        .for_category(category_object)
-        .recent()
-    )
+    last_changes = Change.objects.last_changes(
+        user,
+        category=category_object,
+        language=language_object,
+    ).recent()
 
     translations = get_paginator(
         request,
@@ -569,9 +569,7 @@ def show_project(request: AuthenticatedHttpRequest, obj: Project) -> HttpRespons
 def show_category(request: AuthenticatedHttpRequest, obj: Category) -> HttpResponse:
     user = request.user
 
-    all_changes = (
-        Change.objects.for_category(obj).filter_components(request.user).prefetch()
-    )
+    all_changes = Change.objects.last_changes(user, category=obj)
 
     last_changes = all_changes.recent()
     last_announcements = all_changes.filter_announcements().recent()

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -1422,16 +1422,11 @@ class CategoryLanguage(BaseURLMixin, TranslationChecklistMixin):
     def get_translate_url(self):
         return reverse("translate", kwargs={"path": self.get_url_path()})
 
-    def _translation_filter(self) -> Q:
-        return (
-            Q(component__category__category__category=self.category)
-            | Q(component__category__category=self.category)
-            | Q(component__category=self.category)
-        )
-
     @property
     def action_translation_set(self):
-        return self.language.translation_set.filter(self._translation_filter())
+        return self.language.translation_set.filter(
+            component_id__in=self.category.all_component_ids
+        )
 
     @cached_property
     def has_action_translations(self) -> bool:
@@ -1443,14 +1438,8 @@ class CategoryLanguage(BaseURLMixin, TranslationChecklistMixin):
 
     @cached_property
     def translation_set(self):
-        # ruff: ignore[import-outside-top-level]
-        from weblate.trans.models.component import ComponentLink
-
-        shared_component_ids = ComponentLink.objects.filter(
-            category=self.category
-        ).values_list("component_id", flat=True)
         result = self.language.translation_set.filter(
-            self._translation_filter() | Q(component__pk__in=shared_component_ids)
+            component_id__in=self.category.get_component_ids_with_links()
         ).prefetch()
         for item in result:
             item.is_shared = (


### PR DESCRIPTION
Sentry traces showed category pages hydrating and joining more change rows than they display, with repeated work to resolve linked components. Limit before prefetching, reuse linked-component scopes, and add targeted indexes while preserving owned-only action and report boundaries.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
