### PR TITLE
fix(checks): prevent AsciiDoc regex backtracking

### DIFF
--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -1069,12 +1069,14 @@ class RSTSyntaxCheck(PluralResultDescriptionMixin, RSTBaseCheck):
 
 # inline (`name:target[attrs]`) and block (`name::target[attrs]`) macros.
 ASCIIDOC_MACRO = re.compile(
-    r"(?P<name>[a-z][a-z0-9]*)(?P<sep>::?)(?P<target>[^\s\[]*)\[(?P<attrs>(?:\\.|[^\]])*)\]"
+    r"(?<![a-z0-9])(?P<name>[a-z][a-z0-9]*?)(?P<sep>::?)(?P<target>[^\s\[]*+)\[(?P<attrs>(?:\\.|[^\]])*+)\]"
 )
 # cross references: <<id>> or <<id,text>>.
-ASCIIDOC_XREF = re.compile(r"<<(?P<id>[^,>]+)(?:,(?P<text>[^>]*))?>>")
+ASCIIDOC_XREF = re.compile(r"(?<!<)<<(?P<id>[^,>]++)(?:,(?P<text>[^>]*+))?>>")
 # inline anchors: [[id]] or [[id,label]].
-ASCIIDOC_INLINE_ANCHOR = re.compile(r"\[\[(?P<id>[^,\]]+)(?:,(?P<label>[^\]]*))?\]\]")
+ASCIIDOC_INLINE_ANCHOR = re.compile(
+    r"(?<!\[)\[\[(?P<id>[^,\]]++)(?:,(?P<label>[^\]]*+))?\]\]"
+)
 # passthroughs. Bare single-plus `+...+` is excluded to avoid false positives.
 ASCIIDOC_PASSTHROUGH = re.compile(
     r"\+\+\+.+?\+\+\+|\+\+.+?\+\+|`\+.+?\+`|\$\$.+?\$\$",

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -25,6 +25,7 @@ from weblate.checks.markup import (
     XMLCharsAroundTagsCheck,
     XMLTagsCheck,
     XMLValidityCheck,
+    extract_asciidoc_markup,
     extract_rst_references,
     has_changed_placeholder_attributes,
 )
@@ -1660,6 +1661,10 @@ class AsciiDocMarkupCheckTest(CheckTestCase):
             ],
             [(0, 13, r"kbd:[Ctrl+\]]")],
         )
+
+    def test_incomplete_markup(self) -> None:
+        for text in ("a" * 100_000, "<" * 100_000, "[" * 100_000):
+            self.assertEqual(extract_asciidoc_markup(text), {})
 
     def test_description(self) -> None:
         unit = make_unit(


### PR DESCRIPTION
### Motivation
- The AsciiDoc markup extractor used unbounded regex repetitions that exhibited catastrophic backtracking on long delimiter-free inputs, enabling CPU exhaustion when processing attacker-controlled strings. 
- The vulnerable patterns affected macro, cross-reference, and inline-anchor extraction and ran for both source and translation texts when the `asciidoc-text` flag was present. 

### Description
- Hardened the AsciiDoc regexes by adding start-context checks and possessive-style quantifiers to avoid repeated match restarts and backtracking while preserving intended matches (update to `ASCIIDOC_MACRO`, `ASCIIDOC_XREF`, and `ASCIIDOC_INLINE_ANCHOR` in `weblate/checks/markup.py`).
- Kept the existing passthrough handling unchanged and preserved existing escape logic via `is_preceded_by_asciidoc_escape`. 
- Added a regression test `test_incomplete_markup` to `weblate/checks/tests/test_markup_checks.py` that asserts `extract_asciidoc_markup` returns empty results for very large inputs composed only of `a`, `<`, or `[` characters.

### Testing
- Ran the AsciiDoc markup tests with `uv run pytest weblate/checks/tests/test_markup_checks.py::AsciiDocMarkupCheckTest`, and the suite completed successfully with `33 passed, 2 skipped`.
- Ran repository linters/formatters via `uv run prek run --files weblate/checks/markup.py weblate/checks/tests/test_markup_checks.py`, and all checks passed. 
- Verified the new unit test covers large incomplete inputs and prevents regression by asserting `extract_asciidoc_markup` returns `{}` for 100k-character inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62f1566d98832985bc13f40cd04981)