### PR TITLE
fix(editor): escape machinery quality scores

### DIFF
--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -804,7 +804,9 @@
       const qualityCell = document.createElement("td");
       qualityCell.className = "number";
       if (el.show_quality) {
-        qualityCell.innerHTML = `<strong>${el.quality}</strong> %`;
+        const quality = document.createElement("strong");
+        quality.textContent = String(el.quality);
+        qualityCell.append(quality, " %");
       }
       row.append(qualityCell);
 


### PR DESCRIPTION
### Motivation
- Prevent DOM XSS when rendering machinery quality values by avoiding interpolation of backend-provided data into `innerHTML` in the translation editor.

### Description
- Replace `qualityCell.innerHTML = `<strong>${el.quality}</strong> %`` in `weblate/static/editor/full.js` with safe DOM construction: create a `<strong>` element, set `textContent` to `el.quality`, and append the element plus the literal percent sign so backend values are treated as text.

### Testing
- Ran pre-commit/format/lint checks with `uv run prek run --files weblate/static/editor/full.js` and a quick `git diff --check`, both of which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6309214ca483299a5b9d43a82a596d)