### PR TITLE
fix(backup): validate parsed Borg backup hostnames

### DIFF
--- a/weblate/utils/backup.py
+++ b/weblate/utils/backup.py
@@ -23,6 +23,7 @@ from weblate.utils.data import data_dir
 from weblate.utils.errors import add_breadcrumb, report_error
 from weblate.utils.files import cleanup_error_message
 from weblate.utils.lock import WeblateLock
+from weblate.utils.validators import DomainOrIPValidator
 from weblate.vcs.ssh import SSH_WRAPPER, add_host_key
 
 BORG_SSH_OPTIONS = (
@@ -149,6 +150,7 @@ def initialize(location: str, passphrase: str) -> BorgResult:
     """Initialize repository."""
     parsed = urlparse(location)
     if parsed.hostname:
+        DomainOrIPValidator()(parsed.hostname)
         add_host_key(None, parsed.hostname, parsed.port)
     return run_borg(
         ["init", "--encryption", "repokey-blake2", location],

--- a/weblate/utils/backup.py
+++ b/weblate/utils/backup.py
@@ -23,7 +23,6 @@ from weblate.utils.data import data_dir
 from weblate.utils.errors import add_breadcrumb, report_error
 from weblate.utils.files import cleanup_error_message
 from weblate.utils.lock import WeblateLock
-from weblate.utils.validators import DomainOrIPValidator
 from weblate.vcs.ssh import SSH_WRAPPER, add_host_key
 
 BORG_SSH_OPTIONS = (
@@ -150,7 +149,9 @@ def initialize(location: str, passphrase: str) -> BorgResult:
     """Initialize repository."""
     parsed = urlparse(location)
     if parsed.hostname:
-        DomainOrIPValidator()(parsed.hostname)
+        if parsed.hostname.startswith("-"):
+            msg = gettext("Invalid host name given!")
+            raise BackupError(msg)
         add_host_key(None, parsed.hostname, parsed.port)
     return run_borg(
         ["init", "--encryption", "repokey-blake2", location],

--- a/weblate/utils/tests/test_backup.py
+++ b/weblate/utils/tests/test_backup.py
@@ -10,7 +10,6 @@ from typing import cast
 from unittest.mock import patch
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase, TransactionTestCase
 from django.test.utils import override_settings
 
@@ -147,12 +146,27 @@ class InitializeBackupTest(SimpleTestCase):
         with (
             patch("weblate.utils.backup.add_host_key") as add_host_key,
             patch("weblate.utils.backup.run_borg") as run_borg,
-            self.assertRaises(ValidationError),
+            self.assertRaisesMessage(BackupError, "Invalid host name given!"),
         ):
             initialize("ssh://-f/etc/passwd:22/path", "key")
 
         add_host_key.assert_not_called()
         run_borg.assert_not_called()
+
+    def test_initialize_accepts_single_label_ssh_hostname(self) -> None:
+        with (
+            patch("weblate.utils.backup.add_host_key") as add_host_key,
+            patch(
+                "weblate.utils.backup.run_borg", return_value=BorgResult(output="")
+            ) as run_borg,
+        ):
+            initialize("ssh://backup/path", "key")
+
+        add_host_key.assert_called_once_with(None, "backup", None)
+        run_borg.assert_called_once_with(
+            ["init", "--encryption", "repokey-blake2", "ssh://backup/path"],
+            {"BORG_NEW_PASSPHRASE": "key"},
+        )
 
 
 class BackupCommandTest(SimpleTestCase):

--- a/weblate/utils/tests/test_backup.py
+++ b/weblate/utils/tests/test_backup.py
@@ -145,25 +145,25 @@ class InitializeBackupTest(SimpleTestCase):
     def test_initialize_rejects_option_as_ssh_hostname(self) -> None:
         with (
             patch("weblate.utils.backup.add_host_key") as add_host_key,
-            patch("weblate.utils.backup.run_borg") as run_borg,
+            patch("weblate.utils.backup.run_borg") as mock_run_borg,
             self.assertRaisesMessage(BackupError, "Invalid host name given!"),
         ):
             initialize("ssh://-f/etc/passwd:22/path", "key")
 
         add_host_key.assert_not_called()
-        run_borg.assert_not_called()
+        mock_run_borg.assert_not_called()
 
     def test_initialize_accepts_single_label_ssh_hostname(self) -> None:
         with (
             patch("weblate.utils.backup.add_host_key") as add_host_key,
             patch(
                 "weblate.utils.backup.run_borg", return_value=BorgResult(output="")
-            ) as run_borg,
+            ) as mock_run_borg,
         ):
             initialize("ssh://backup/path", "key")
 
         add_host_key.assert_called_once_with(None, "backup", None)
-        run_borg.assert_called_once_with(
+        mock_run_borg.assert_called_once_with(
             ["init", "--encryption", "repokey-blake2", "ssh://backup/path"],
             {"BORG_NEW_PASSPHRASE": "key"},
         )

--- a/weblate/utils/tests/test_backup.py
+++ b/weblate/utils/tests/test_backup.py
@@ -10,6 +10,7 @@ from typing import cast
 from unittest.mock import patch
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase, TransactionTestCase
 from django.test.utils import override_settings
 
@@ -139,6 +140,19 @@ class RunBorgTest(SimpleTestCase):
             str(raised.exception),
             "Borg exited with status 2 without any output",
         )
+
+
+class InitializeBackupTest(SimpleTestCase):
+    def test_initialize_rejects_option_as_ssh_hostname(self) -> None:
+        with (
+            patch("weblate.utils.backup.add_host_key") as add_host_key,
+            patch("weblate.utils.backup.run_borg") as run_borg,
+            self.assertRaises(ValidationError),
+        ):
+            initialize("ssh://-f/etc/passwd:22/path", "key")
+
+        add_host_key.assert_not_called()
+        run_borg.assert_not_called()
 
 
 class BackupCommandTest(SimpleTestCase):


### PR DESCRIPTION
### Motivation

- Prevent argument injection via crafted backup URLs by validating the parsed hostname before passing it to SSH host-key scanning utilities.

### Description

- Import and call `DomainOrIPValidator` in `weblate/utils/backup.py` to validate `parsed.hostname` inside `initialize()` before calling `add_host_key()`.
- Add `InitializeBackupTest` to `weblate/utils/tests/test_backup.py` which asserts a `ValidationError` for an option-like hostname (`ssh://-f/...`) and verifies that `add_host_key` and `run_borg` are not invoked when validation fails.

### Testing

- Ran `uv run pytest weblate/utils/tests/test_backup.py::InitializeBackupTest` and the test passed.
- Ran `uv run pytest weblate/utils/tests/test_backup.py` and the test suite passed.
- Ran `uv run prek run --files weblate/utils/backup.py weblate/utils/tests/test_backup.py` and `git diff --check`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a630affcbc48329b9e297b0063df921)