### PR TITLE
fix(ssh): add `--` separator before hostname in `ssh-keyscan`

### DIFF
--- a/weblate/trans/tests/data/ssh-keyscan
+++ b/weblate/trans/tests/data/ssh-keyscan
@@ -1,5 +1,9 @@
 #!/bin/sh
 # Fake key scan program to return SSH key
+if [ "$1" = "--" ]; then
+    shift
+fi
+
 if [ "$1" = "1.2.3.4" ]; then
     exit 1
 elif [ "$1" = "2001:0db8:85a3:0000:0000:8a2e:0370:7334" ]; then

--- a/weblate/vcs/ssh.py
+++ b/weblate/vcs/ssh.py
@@ -375,7 +375,7 @@ def add_host_key(
         cmdline = ["ssh-keyscan"]
         if port:
             cmdline.extend(["-p", str(port)])
-        cmdline.append(host)
+        cmdline.extend(["--", host])
         try:
             result = subprocess.run(
                 cmdline,

--- a/weblate/vcs/tests/test_ssh.py
+++ b/weblate/vcs/tests/test_ssh.py
@@ -6,6 +6,7 @@ import os
 import shutil
 from pathlib import Path
 from time import time
+from unittest.mock import patch
 
 from django.conf import settings
 from django.test import TestCase
@@ -17,6 +18,7 @@ from weblate.utils.unittest import tempdir_setting
 from weblate.vcs.ssh import (
     STALE_WRAPPER_SECONDS,
     SSHWrapper,
+    add_host_key,
     cleanup_legacy_wrapper_dirs,
     cleanup_stale_wrapper_dirs,
     extract_url_host_port,
@@ -151,4 +153,15 @@ class SSHTest(TestCase):
         )
         self.assertEqual(
             ("github.com", 1234), extract_url_host_port("git://github.com:1234/repo")
+        )
+
+    @patch("weblate.vcs.ssh.subprocess.run")
+    def test_add_host_key_separates_hostname_from_options(self, mocked_run) -> None:
+        mocked_run.return_value.stdout = ""
+        mocked_run.return_value.stderr = ""
+
+        add_host_key(None, "-f", 22)
+
+        self.assertEqual(
+            mocked_run.call_args.args[0], ["ssh-keyscan", "-p", "22", "--", "-f"]
         )


### PR DESCRIPTION
### Motivation
- Prevent argument injection when `add_host_key()` calls `ssh-keyscan` so hostnames beginning with `-` are not interpreted as options.

### Description
- Change in `weblate/vcs/ssh.py`: replace `cmdline.append(host)` with `cmdline.extend(["--", host])` to pass the `--` option terminator before the hostname.
- Add regression test in `weblate/vcs/tests/test_ssh.py` that patches `subprocess.run` and asserts the command line becomes `["ssh-keyscan", "-p", "22", "--", "-f"]` when a dash-prefixed hostname is provided.

### Testing
- Ran `uv run pytest weblate/vcs/tests/test_ssh.py`; the test suite passed for the modified file.
- Ran pre-commit formatting/lint checks via `uv run prek run --files weblate/vcs/ssh.py weblate/vcs/tests/test_ssh.py`; all checks passed.
- Verified `git diff --check` showed no whitespace or formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a630d45a2648329b1be82b4346efa9f)