### PR TITLE
fix(screenshots): derive Content-Type from image contents when serving screenshots

### DIFF
--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -384,6 +384,20 @@ class ViewTest(FixtureTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["content-type"], "image/png")
 
+    def test_view_uses_image_content_type(self) -> None:
+        self.make_manager()
+        screenshot = Screenshot.objects.create(
+            name="Polyglot", translation=self.component.source_translation
+        )
+        with open(TEST_SCREENSHOT, "rb") as handle:
+            screenshot.image.save("polyglot.html", File(handle))
+
+        response = self.client.get(screenshot.get_view_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "image/png")
+        response.close()
+
     def test_private_screenshot_actions_hidden(self) -> None:
         self.make_manager()
         self.do_upload()

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -486,11 +486,13 @@ class ScreenshotBaseView(DetailView):
 class ScreenshotView(ScreenshotBaseView):
     def get(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> FileResponse:  # type: ignore[override]
         obj = self.get_object()
-        # Django will automatically set Content-Type based on the filename
+        with Image.open(obj.image.open(), formats=PIL_FORMATS) as image:
+            content_type = Image.MIME[cast("str", image.format)]
         return FileResponse(
             obj.image.open(),
             as_attachment=False,
             filename=os.path.basename(obj.image.name),
+            content_type=content_type,
         )
 
 


### PR DESCRIPTION
### Motivation

- Prevent stored XSS by avoiding filename-based `Content-Type` when serving uploaded screenshots, because a polyglot PNG+HTML file saved with an `.html` name would be served as `text/html` and rendered inline.

### Description

- Change `ScreenshotView.get()` to open the stored file with Pillow and set `content_type` on the `FileResponse` using `Image.MIME[image.format]` instead of relying on the filename.
- Use a safe `Image.open(..., formats=PIL_FORMATS)` context to derive the MIME type from the validated image contents before returning the response (`weblate/screenshots/views.py`).
- Add a regression test that saves a valid PNG under an `.html` filename and asserts the view returns `image/png` (`weblate/screenshots/tests.py`).

### Testing

- Ran the new/targeted tests: `uv run pytest weblate/screenshots/tests.py::ViewTest::test_view_uses_image_content_type weblate/screenshots/tests.py::ViewTest::test_view` and both tests passed.
- Ran the repository lint/format checks: `uv run prek run --files weblate/screenshots/views.py weblate/screenshots/tests.py` and the hooks passed.
- Observed an unrelated existing failure during a broader `weblate/screenshots` test run: `ViewTest::test_edit_image_url_private_target_keeps_existing_image` did not contain the expected private-address validation message; this is not caused by this change and was not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6313ef3ddc8329a54001aa707ce259)