### PR TITLE
fix(screenshots): isolate retry sleep mock

### DIFF
--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -96,7 +96,7 @@ class TesseractDataTest(SimpleTestCase):
                         response,
                     ],
                 ) as fetch_url,
-                patch("weblate.screenshots.views.time.sleep") as sleep,
+                patch("weblate.screenshots.views.sleep") as sleep,
             ):
                 download_tesseract_data("https://example.com/eng", str(target))
 
@@ -136,7 +136,7 @@ class TesseractDataTest(SimpleTestCase):
                     "weblate.screenshots.views.fetch_url",
                     side_effect=requests.Timeout("timed out"),
                 ) as fetch_url,
-                patch("weblate.screenshots.views.time.sleep"),
+                patch("weblate.screenshots.views.sleep"),
                 self.assertRaises(requests.Timeout),
             ):
                 download_tesseract_data("https://example.com/eng", str(target))

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import difflib
 import os
 import tempfile
-import time
 from contextlib import contextmanager, suppress
+from time import sleep
 from typing import TYPE_CHECKING, ClassVar, cast
 
 from django.contrib.auth.decorators import login_required
@@ -197,7 +197,7 @@ def download_tesseract_data(url: str, full_name: str) -> None:
                     TESSERACT_DOWNLOAD_ATTEMPTS,
                     error,
                 )
-                time.sleep(2 ** (attempt - 1))
+                sleep(2 ** (attempt - 1))
                 continue
 
             with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
### Motivation
- Tests intermittently recorded many unrelated `time.sleep` calls causing flaky assertions about retry delays. 
- The retry delay used by Tesseract downloads should be mockable without affecting other in-process retry loops.

### Description
- Bind the module-local retry delay by replacing `import time` with `from time import sleep` in `weblate/screenshots/views.py` and call `sleep(...)` for the backoff. 
- Update tests to patch `weblate.screenshots.views.sleep` instead of the shared `weblate.screenshots.views.time.sleep` in `weblate/screenshots/tests.py`. 
- This prevents unrelated code paths that use `time.sleep` from being observed by the test mock while preserving the exponential backoff behavior.

### Testing
- Ran `uv run pytest weblate/screenshots/tests.py -k 'TesseractDataTest'`, which passed (`6 passed`).
- Ran `uv run prek run --files weblate/screenshots/views.py weblate/screenshots/tests.py`, which passed the repository pre-commit checks.
- Ran `git diff --check`, which produced no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63229329a883298b0003624f88c748)