### PR TITLE
fix(backups): validate project restores before writing

### DIFF
--- a/docs/admin/backup.rst
+++ b/docs/admin/backup.rst
@@ -40,6 +40,10 @@ Import validation of uploaded project backups can be tuned using
 :setting:`PROJECT_BACKUP_IMPORT_MIN_RATIO_SIZE`, and
 :setting:`PROJECT_BACKUP_IMPORT_MAX_COMPRESSED_ENTRY_RATIO`.
 
+The complete backup is validated before restoring any data. Invalid object
+fields, references, repository paths, URLs, regular expressions, or screenshot
+files cause the import to be rejected without creating a partial project.
+
 Use the generated file to import project when :ref:`adding-projects` or in :wladmin:`import_projectbackup`.
 
 .. note::

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,7 +39,7 @@ Weblate 2026.8
 * Mercurial repository filenames beginning with a dash are now handled safely.
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
-* Project backup imports now skip repository-linked components when the importer cannot access the target component.
+* :ref:`Project backup imports <projectbackup>` now validate restored data before creating project state and skip repository-linked components when the importer cannot access the target component.
 * Suggestion submission and rejection now reject excessively long suggestion text and rejection reasons.
 * Restricted components are now available on Hosted Weblate when the billing plan permits private projects.
 * Machine translation and translation memory AJAX lookups no longer disclose whether inaccessible unit IDs exist.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -461,6 +461,10 @@ Size and rate assumptions:
 * Project backup imports are bounded by member count, aggregate uncompressed
   size, compressed entry size, minimum ratio size, and compression ratio
   settings. *(documented)* (source: :doc:`/admin/config`)
+* Project backup metadata, object references, repository paths, outbound URLs,
+  regular expressions, and screenshot content are validated before restore
+  writes project state. Failed restores remove repository and media objects
+  created by that attempt. *(documented)* (source: :ref:`projectbackup`)
 * API and selected web actions are expected to be protected by configured rate
   limits. *(documented)* (source: :doc:`/api`, :doc:`/admin/config`)
 * Repository size, number of projects, number of components, and worker

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -92,7 +92,6 @@ from weblate.utils.forms import QueryField
 from weblate.utils.site import get_site_url
 from weblate.utils.state import STATE_READONLY, StringState
 from weblate.utils.validators import (
-    validate_bitmap,
     validate_component_zip_upload_size,
     validate_file_extension,
     validate_plural_formula_range,
@@ -3390,7 +3389,7 @@ class ScreenshotCreateSerializer(ScreenshotSerializer):
 
 
 class ScreenshotFileSerializer(serializers.ModelSerializer[Screenshot]):
-    image = serializers.ImageField(validators=[validate_bitmap])
+    image = serializers.ImageField(validators=[Screenshot.validate_image_file])
 
     class Meta:
         model = Screenshot

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -21,6 +21,7 @@ from django.contrib import messages as django_messages
 from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.core.files import File
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import DatabaseError
 from django.db.models import Q
 from django.test.utils import modify_settings, override_settings
@@ -12364,6 +12365,26 @@ class ScreenshotAPITest(APIBaseTest):
 
     def test_upload_invalid(self) -> None:
         self.test_upload(True, 400, TEST_PO)
+
+    def test_upload_invalid_extension(self) -> None:
+        self.authenticate(True)
+        screenshot = Screenshot.objects.get()
+        original_name = screenshot.image.name
+        image = SimpleUploadedFile(
+            "screenshot.html",
+            Path(TEST_SCREENSHOT).read_bytes(),
+            content_type="image/png",
+        )
+
+        response = self.client.post(
+            reverse("api:screenshot-file", kwargs={"pk": screenshot.pk}),
+            {"image": image},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("invalid_extension", str(response.data))
+        screenshot.refresh_from_db()
+        self.assertEqual(screenshot.image.name, original_name)
 
     @override_settings(ALLOWED_ASSET_SIZE=1)
     def test_upload_too_big(self) -> None:

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-import re
 import uuid
 from collections import defaultdict
 from contextvars import ContextVar
@@ -13,6 +12,7 @@ from datetime import timedelta
 from functools import cache as functools_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypedDict, cast
 
+import regex
 from appconf import AppConf
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
@@ -57,11 +57,13 @@ from weblate.auth.utils import (
     migrate_permissions,
     migrate_roles,
 )
+from weblate.logger import LOGGER
 from weblate.trans.defines import EMAIL_LENGTH, FULLNAME_LENGTH, USERNAME_LENGTH
 from weblate.trans.fields import RegexField
 from weblate.trans.models import ComponentList, Project
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.fields import EmailField, UsernameField
+from weblate.utils.regex import regex_match
 from weblate.utils.search import parse_query
 from weblate.utils.tracing import start_span
 from weblate.utils.validators import (
@@ -1781,8 +1783,11 @@ def auto_assign_group(user: User) -> None:
         return
     # Add user to automatic groups
     for auto in AutoGroup.objects.prefetch_related("group"):
-        if re.match(auto.match, user.email or ""):
-            user.add_team(None, auto.group)
+        try:
+            if regex_match(auto.match, user.email or ""):
+                user.add_team(None, auto.group)
+        except (regex.error, TimeoutError):
+            LOGGER.error("Invalid automatic group rule %s", auto.pk)
 
 
 @receiver(m2m_changed, sender=ComponentList.components.through)

--- a/weblate/auth/tests/test_autogroup.py
+++ b/weblate/auth/tests/test_autogroup.py
@@ -34,3 +34,12 @@ class AutoGroupTest(TestCase):
         )
         user = self.create_user()
         self.assertEqual(user.groups.count(), 2)
+
+    def test_invalid_rule_does_not_break_user_creation(self) -> None:
+        AutoGroup.objects.bulk_create(
+            [AutoGroup(match="[", group=Group.objects.get(name="Guests"))]
+        )
+
+        user = self.create_user()
+
+        self.assertEqual(user.groups.count(), 2)

--- a/weblate/screenshots/fields.py
+++ b/weblate/screenshots/fields.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from django.core.validators import validate_image_file_extension
 from django.db.models import ImageField
 
 from weblate.utils.validators import validate_bitmap
@@ -11,4 +12,4 @@ class ScreenshotField(ImageField):
     """File field which forces certain image types."""
 
     # ruff: ignore[mutable-class-default]
-    default_validators = [validate_bitmap]
+    default_validators = [validate_image_file_extension, validate_bitmap]

--- a/weblate/screenshots/forms.py
+++ b/weblate/screenshots/forms.py
@@ -4,6 +4,7 @@
 
 import io
 from typing import Any, ClassVar, NoReturn, cast
+from urllib.parse import unquote, urlsplit
 
 import requests
 from django import forms
@@ -69,9 +70,7 @@ class ScreenshotImageValidationMixin(BaseForm):
         ):
             # download from image_url only if image is not provided and not updated
             cleaned_data["image"] = self.download_image(image_url)
-            # ruff: ignore[private-member-access]
-            image_field = Screenshot._meta.get_field("image")
-            image_field.run_validators(cleaned_data["image"])
+            Screenshot.validate_image_file(cleaned_data["image"])
 
         cleaned_data.pop("image_url", None)
         return cleaned_data
@@ -99,11 +98,11 @@ class ScreenshotImageValidationMixin(BaseForm):
                     )
                 }
             ) from e
-        filename = url.rsplit("/", maxsplit=1)[-1] or "screenshot"
+        filename = unquote(urlsplit(url).path).rsplit("/", maxsplit=1)[-1]
         return InMemoryUploadedFile(
             file=io.BytesIO(content),
             field_name="image",
-            name=filename,
+            name=filename or "screenshot",
             content_type=content_type,
             size=len(content),
             charset=None,

--- a/weblate/screenshots/models.py
+++ b/weblate/screenshots/models.py
@@ -29,7 +29,6 @@ from weblate.trans.models import Translation, Unit
 from weblate.trans.signals import component_post_update, vcs_post_update
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.errors import report_error
-from weblate.utils.validators import validate_bitmap
 from weblate.vcs.base import RepositorySymlinkError
 
 if TYPE_CHECKING:
@@ -101,6 +100,15 @@ class Screenshot(models.Model, UserDisplayMixin):
 
     def get_view_url(self) -> str:
         return reverse("screenshot-view", kwargs={"pk": self.pk})
+
+    @classmethod
+    def validate_image_file(cls, image: File) -> None:
+        """Validate screenshot uploads using the model field policy."""
+        field = cls._meta.get_field("image")
+        if not isinstance(field, ScreenshotField):
+            msg = "Screenshot.image is not a ScreenshotField."
+            raise TypeError(msg)
+        field.run_validators(image)
 
     @property
     def filter_name(self) -> str:
@@ -188,7 +196,7 @@ def validate_screenshot_image(component: Component, filename: str) -> str | None
     try:
         with open(full_name, "rb") as f:
             image_file = File(f, name=os.path.basename(filename))
-            validate_bitmap(image_file)
+            Screenshot.validate_image_file(image_file)
     except OSError as error:
         component.log_info(
             "ignoring screenshot %s, could not open: %s", filename, error

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -13,7 +13,9 @@ from unittest.mock import MagicMock, patch
 import requests
 import responses
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.files import File
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext, override_settings
@@ -45,6 +47,20 @@ PUBLIC_TEST_ADDRESS = "93.184.216.34"
 PRIVATE_TEST_ADDRESS = "127.0.0.1"
 PUBLIC_GETADDRINFO = [(0, 0, 0, "", (PUBLIC_TEST_ADDRESS, 443))]
 PRIVATE_GETADDRINFO = [(0, 0, 0, "", (PRIVATE_TEST_ADDRESS, 443))]
+
+
+class ScreenshotImageValidationTest(SimpleTestCase):
+    def test_rejects_invalid_extension(self) -> None:
+        image = SimpleUploadedFile(
+            "screenshot.html",
+            Path(TEST_SCREENSHOT).read_bytes(),
+            content_type="image/png",
+        )
+
+        with self.assertRaises(ValidationError) as error:
+            Screenshot.validate_image_file(image)
+
+        self.assertEqual(error.exception.error_list[0].code, "invalid_extension")
 
 
 class TesseractDataTest(SimpleTestCase):
@@ -983,19 +999,48 @@ class ViewTest(FixtureTestCase):
     )
     def test_upload_with_image_url(self, _mocked_getaddrinfo, _mocked_get_peer) -> None:
         data = Path(TEST_SCREENSHOT).read_bytes()
+        image_url = "https://example.com/test-image.png?signature=test#preview"
         responses.add(
             responses.GET,
-            "https://example.com/test-image.png",
+            "https://example.com/test-image.png?signature=test",
             content_type="image/png",
             body=data,
         )
 
         self.make_manager()
-        response = self.do_upload(
-            image="", image_url="https://example.com/test-image.png"
-        )
+        response = self.do_upload(image="", image_url=image_url)
         self.assertContains(response, "Obrazek")
         self.assertEqual(Screenshot.objects.count(), 1)
+        image_name = Screenshot.objects.get().image.name
+        assert image_name is not None
+        self.assertTrue(image_name.endswith(".png"))
+
+    @responses.activate
+    @patch(
+        "weblate.utils.requests._get_response_peer_ip",
+        return_value=PUBLIC_TEST_ADDRESS,
+    )
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=PUBLIC_GETADDRINFO,
+    )
+    def test_upload_with_image_url_invalid_extension(
+        self, _mocked_getaddrinfo, _mocked_get_peer
+    ) -> None:
+        responses.add(
+            responses.GET,
+            "https://example.com/test-image.html",
+            content_type="image/png",
+            body=Path(TEST_SCREENSHOT).read_bytes(),
+        )
+
+        self.make_manager()
+        response = self.do_upload(
+            image="", image_url="https://example.com/test-image.html"
+        )
+
+        self.assertContains(response, "File extension")
+        self.assertEqual(Screenshot.objects.count(), 0)
 
     @responses.activate
     @patch(

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import warnings
 from collections import defaultdict
 from datetime import datetime
@@ -30,10 +31,10 @@ from zipfile import ZipFile
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import HashedFilesMixin, staticfiles_storage
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.core.files import File
 from django.db import transaction
-from django.db.models import Exists, OuterRef, Prefetch
+from django.db.models import Exists, Field, Model, OuterRef, Prefetch
 from django.db.models.fields.files import FieldFile
 from django.db.models.signals import pre_save
 from django.utils import timezone
@@ -56,6 +57,7 @@ from weblate.memory.utils import CATEGORY_PRIVATE_OFFSET
 from weblate.screenshots.models import Screenshot
 from weblate.trans import defaults
 from weblate.trans.actions import ActionEvents
+from weblate.trans.defines import CATEGORY_DEPTH
 from weblate.trans.inherited_settings import (
     INHERITABLE_COMPONENT_FLAGS,
     INHERITABLE_COMPONENT_SETTINGS,
@@ -74,12 +76,9 @@ from weblate.trans.models import (
     Vote,
 )
 from weblate.utils.data import data_path
+from weblate.utils.files import remove_tree
 from weblate.utils.hash import checksum_to_hash, hash_to_checksum
-from weblate.utils.validators import (
-    validate_bitmap,
-    validate_filename,
-    validate_repo_url,
-)
+from weblate.utils.validators import validate_filename
 from weblate.utils.version import VERSION
 from weblate.utils.zip import (
     ZipSafetyLimits,
@@ -90,14 +89,12 @@ from weblate.utils.zip import (
 from weblate.utils.zip import (
     validate_zip_members as validate_safe_zip_members,
 )
-from weblate.vcs.models import VCS_REGISTRY
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from zipfile import ZipInfo
 
     from django.core.files.storage import Storage
-    from django.db.models import Model
 
     from weblate.billing.models import Billing
     from weblate.workspaces.models import Workspace
@@ -196,6 +193,17 @@ class ProjectBackup:
         self.categories_cache: dict[str, Category] = {}
         self.roles_cache: dict[str, Role] = {}
         self.skipped_components: list[str] = []
+        self.component_data: dict[str, dict[str, Any]] = {}
+        self.memory_data: list[dict[str, Any]] = []
+        self.memory_loaded = False
+        self.category_paths: set[str] = set()
+        self.component_full_slugs: set[str] = set()
+        self.component_repo_links: set[str] = set()
+        self.label_names: set[str] = set()
+        self.name_siblings: set[tuple[str, str]] = set()
+        self.path_siblings: set[tuple[str, str]] = set()
+        self.validation_project: Project | None = None
+        self.created_media: list[tuple[Storage, str]] = []
         # Project.set_language_team field was migrated to file format parameters after 5.17
         self.set_language_team_project: bool = False
 
@@ -207,6 +215,265 @@ class ProjectBackup:
 
     def validate_data(self) -> None:
         validate_schema(self.data, "weblate-backup.schema.json")
+
+    @staticmethod
+    def contextualize_validation_error(
+        error: ValidationError, path: str
+    ) -> ValidationError:
+        if not hasattr(error, "message_dict"):
+            return ValidationError({path: error.messages})
+        return ValidationError(
+            {
+                (
+                    path
+                    if name == NON_FIELD_ERRORS
+                    else f"{path}.{name}"
+                    if path
+                    else name
+                ): messages
+                for name, messages in error.message_dict.items()
+            }
+        )
+
+    @classmethod
+    def validate_model_data(
+        cls,
+        model: type[ModelT],
+        data: Mapping[str, Any],
+        path: str,
+        *,
+        exclude: frozenset[str] = frozenset(),
+        allow_blank: frozenset[str] = frozenset(),
+        overrides: Mapping[str, Any] | None = None,
+        model_clean: bool = False,
+    ) -> ModelT:
+        """Validate serialized values on an unsaved destination model."""
+        kwargs = {name: value for name, value in data.items() if name not in exclude}
+        kwargs.update(overrides or {})
+        try:
+            instance = model(**kwargs)
+        except (TypeError, ValueError) as error:
+            raise ValidationError({path: [str(error)]}) from error
+
+        # Relations are resolved separately from the archive graph. Fields absent
+        # from older backup formats retain their model defaults without making an
+        # otherwise compatible backup fail current validation. Empty values listed
+        # in allow_blank are synthesized later by the restore.
+        # ruff: ignore[private-member-access]
+        field_exclude = {
+            field.name
+            for field in model._meta.fields
+            if field.is_relation or field.name not in kwargs
+        }
+        field_exclude.update(exclude)
+        field_exclude.update(
+            name for name in allow_blank if data.get(name) in Field.empty_values
+        )
+        try:
+            if model_clean:
+                instance.full_clean(
+                    exclude=field_exclude,
+                    validate_unique=False,
+                    validate_constraints=False,
+                )
+            else:
+                instance.clean_fields(exclude=field_exclude)
+        except ValidationError as error:
+            raise cls.contextualize_validation_error(error, path) from error
+        return instance
+
+    @staticmethod
+    def validate_checksum(value: object, path: str) -> int:
+        """Validate the serialized 64-bit checksum and return its integer value."""
+        if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{16}", value) is None:
+            raise ValidationError(
+                {
+                    path: [
+                        gettext(
+                            "The checksum has to be exactly 16 hexadecimal characters."
+                        )
+                    ]
+                }
+            )
+        try:
+            return checksum_to_hash(value)
+        except (OverflowError, ValueError) as error:
+            raise ValidationError(
+                {path: [gettext("The checksum is invalid.")]}
+            ) from error
+
+    @staticmethod
+    def validate_language(code: str, path: str) -> Language:
+        """Resolve a language as restore would, without creating database rows."""
+        try:
+            # ruff: ignore[private-member-access]
+            Language._meta.get_field("code").clean(code, None)
+            return Language.objects.auto_get_or_create(code, create=False)
+        except (TypeError, ValueError, ValidationError) as error:
+            if isinstance(error, ValidationError):
+                messages = error.messages
+            else:
+                messages = [str(error)]
+            raise ValidationError({path: messages}) from error
+
+    def validate_categories(
+        self,
+        categories: list[dict[str, Any]],
+        *,
+        parent: str = "",
+        depth: int = 1,
+        path_prefix: str = "categories",
+        paths: set[str] | None = None,
+        names: set[tuple[str, str]] | None = None,
+        siblings: set[tuple[str, str]] | None = None,
+    ) -> tuple[set[str], set[tuple[str, str]]]:
+        if paths is None:
+            paths = set()
+        if siblings is None:
+            siblings = set()
+        if names is None:
+            names = set()
+        if categories and depth > CATEGORY_DEPTH:
+            raise ValidationError(
+                {path_prefix: [gettext("Too deep nesting of categories!")]}
+            )
+        for index, category in enumerate(categories):
+            path = f"{path_prefix}[{index}]"
+            self.validate_model_data(
+                Category,
+                category,
+                path,
+                exclude=frozenset({"categories", "secondary_language"}),
+            )
+            if secondary := category.get("secondary_language"):
+                self.validate_language(secondary, f"{path}.secondary_language")
+            sibling = (parent, category["slug"])
+            if sibling in siblings:
+                raise ValidationError(
+                    {f"{path}.slug": [gettext("Duplicate category or component slug.")]}
+                )
+            siblings.add(sibling)
+            name_sibling = (parent, category["name"])
+            if name_sibling in names:
+                raise ValidationError(
+                    {f"{path}.name": [gettext("Duplicate category or component name.")]}
+                )
+            names.add(name_sibling)
+            full_slug = f"{parent}/{category['slug']}" if parent else category["slug"]
+            if full_slug in paths:
+                raise ValidationError(
+                    {f"{path}.slug": [gettext("Duplicate category slug.")]}
+                )
+            paths.add(full_slug)
+            self.validate_categories(
+                category["categories"],
+                parent=full_slug,
+                depth=depth + 1,
+                path_prefix=f"{path}.categories",
+                paths=paths,
+                names=names,
+                siblings=siblings,
+            )
+        return paths, siblings
+
+    def validate_project_objects(
+        self,
+        *,
+        target_project_name: str | None = None,
+        target_project_slug: str | None = None,
+    ) -> None:
+        project = self.data["project"]
+        self.validation_project = self.validate_model_data(
+            Project,
+            project,
+            "project",
+            exclude=frozenset({"secondary_language", "set_language_team"}),
+            overrides={
+                "name": (
+                    project["name"]
+                    if target_project_name is None
+                    else target_project_name
+                ),
+                "slug": (
+                    project["slug"]
+                    if target_project_slug is None
+                    else target_project_slug
+                ),
+            },
+            model_clean=True,
+        )
+        # Component.clean_model_settings() skips validation without a project
+        # primary key. This sentinel keeps validation database-free while
+        # allowing it to reuse project-dependent model invariants.
+        self.validation_project.pk = -1
+        if secondary := project.get("secondary_language"):
+            self.validate_language(secondary, "project.secondary_language")
+
+        labels: set[str] = set()
+        for index, label in enumerate(self.data["labels"]):
+            self.validate_model_data(Label, label, f"labels[{index}]")
+            if label["name"] in labels:
+                raise ValidationError(
+                    {f"labels[{index}].name": [gettext("Duplicate label name.")]}
+                )
+            labels.add(label["name"])
+
+        self.category_paths, self.path_siblings = self.validate_categories(
+            self.data.get("categories", []), names=self.name_siblings
+        )
+        self.label_names = labels
+
+        team_names: set[str] = set()
+        for index, team in enumerate(self.data.get("teams", [])):
+            path = f"teams[{index}]"
+            self.validate_model_data(
+                Group,
+                team,
+                path,
+                exclude=frozenset(
+                    {
+                        "admins",
+                        "autogroups",
+                        "components",
+                        "languages",
+                        "members",
+                        "roles",
+                    }
+                ),
+            )
+            if team["name"] in team_names:
+                raise ValidationError(
+                    {f"{path}.name": [gettext("Duplicate team name.")]}
+                )
+            team_names.add(team["name"])
+            for autogroup_index, match in enumerate(team["autogroups"]):
+                self.validate_model_data(
+                    AutoGroup,
+                    {"match": match},
+                    f"{path}.autogroups[{autogroup_index}]",
+                )
+            for language_index, code in enumerate(team["languages"]):
+                self.validate_language(code, f"{path}.languages[{language_index}]")
+            for member_index, member in enumerate(team["members"]):
+                if isinstance(member, str):
+                    continue
+                for language_index, code in enumerate(member["limit_languages"]):
+                    self.validate_language(
+                        code,
+                        f"{path}.members[{member_index}].limit_languages[{language_index}]",
+                    )
+
+    def validate_memory_objects(self, data: list[dict[str, Any]]) -> None:
+        for index, item in enumerate(data):
+            path = f"memory[{index}]"
+            self.validate_model_data(
+                Memory,
+                item,
+                path,
+                exclude=frozenset({"category", "source_language", "target_language"}),
+            )
+            self.validate_language(item["source_language"], f"{path}.source_language")
+            self.validate_language(item["target_language"], f"{path}.target_language")
 
     def backup_value(self, value: object) -> BackupValue:
         if isinstance(value, Language):
@@ -671,7 +938,7 @@ class ProjectBackup:
         return [
             name
             for name in zipfile.namelist()
-            if name.startswith(self.COMPONENTS_PREFIX)
+            if name.startswith(self.COMPONENTS_PREFIX) and name.endswith(".json")
         ]
 
     @staticmethod
@@ -737,11 +1004,437 @@ class ProjectBackup:
         self.validate_data()
         self.timestamp = datetime.fromisoformat(self.data["metadata"]["timestamp"])
 
-    def load_memory(self, zipfile: ZipFile) -> dict:
+    def load_memory(self, zipfile: ZipFile) -> list[dict[str, Any]]:
+        if self.memory_loaded:
+            return self.memory_data
         with zipfile.open("weblate-memory.json") as handle:
             data = json.load(handle)
         validate_schema(data, "weblate-memory.schema.json")
+        self.validate_memory_objects(data)
+        self.memory_data = data
+        self.memory_loaded = True
         return data
+
+    # ruff: ignore[complex-structure, too-many-branches, too-many-statements, too-many-locals]
+    def validate_component_object(
+        self,
+        zipfile: ZipFile,
+        filename: str,
+        data: dict[str, Any],
+    ) -> None:
+        component = data["component"]
+        path = filename
+        # Keep the established top-level error keys for repository URLs while
+        # still using the validators declared on the Component model fields.
+        self.validate_model_data(
+            Component,
+            {"repo": component["repo"], "push": component["push"]},
+            "",
+        )
+        component_object = self.validate_model_data(
+            Component,
+            component,
+            f"{path}.component",
+            exclude=frozenset(
+                {
+                    "category",
+                    "push",
+                    "repo",
+                    "secondary_language",
+                    "source_language",
+                }
+            ),
+            overrides={
+                "project": self.validation_project,
+                "push": component["push"],
+                "repo": component["repo"],
+            },
+        )
+        source_language = self.validate_language(
+            component["source_language"], f"{path}.component.source_language"
+        )
+        component_object.source_language = source_language
+        if secondary := component.get("secondary_language"):
+            component_object.secondary_language = self.validate_language(
+                secondary, f"{path}.component.secondary_language"
+            )
+        try:
+            component_object.clean_model_settings()
+            component_object.clean_branches()
+        except ValidationError as error:
+            raise self.contextualize_validation_error(
+                error, f"{path}.component"
+            ) from error
+        enforced_checks: set[str] = set()
+        for index, name in enumerate(component["enforced_checks"]):
+            self.validate_model_data(
+                Check,
+                {"name": name, "dismissed": False},
+                f"{path}.component.enforced_checks[{index}]",
+            )
+            if name in enforced_checks:
+                raise ValidationError(
+                    {
+                        f"{path}.component.enforced_checks[{index}]": [
+                            gettext("Duplicate check name.")
+                        ]
+                    }
+                )
+            enforced_checks.add(name)
+
+        category = component.get("category", "")
+        if category and category not in self.category_paths:
+            raise ValidationError(
+                {
+                    f"{path}.component.category": [
+                        gettext("Referenced category does not exist.")
+                    ]
+                }
+            )
+        sibling = (category, component["slug"])
+        if sibling in self.path_siblings:
+            raise ValidationError(
+                {
+                    f"{path}.component.slug": [
+                        gettext("Duplicate category or component slug.")
+                    ]
+                }
+            )
+        self.path_siblings.add(sibling)
+        name_sibling = (category, component["name"])
+        if name_sibling in self.name_siblings:
+            raise ValidationError(
+                {
+                    f"{path}.component.name": [
+                        gettext("Duplicate category or component name.")
+                    ]
+                }
+            )
+        self.name_siblings.add(name_sibling)
+        full_slug = f"{category}/{component['slug']}" if category else component["slug"]
+        expected_filename = f"{self.COMPONENTS_PREFIX}{full_slug}.json"
+        if filename != expected_filename:
+            raise ValidationError(
+                {
+                    filename: [
+                        gettext(
+                            "Component filename does not match its category and slug."
+                        )
+                    ]
+                }
+            )
+        if full_slug in self.component_full_slugs:
+            raise ValidationError({filename: [gettext("Duplicate component slug.")]})
+        self.component_full_slugs.add(full_slug)
+        if component["repo"].startswith("weblate:"):
+            self.component_repo_links.add(full_slug)
+
+        translation_ids: set[int] = set()
+        translation_languages: dict[int, str] = {}
+        language_sources: dict[str, str] = {}
+        source_translation_ids: list[int] = []
+        for index, item in enumerate(data["translations"]):
+            item_path = f"{path}.translations[{index}]"
+            self.validate_model_data(
+                Translation,
+                item,
+                item_path,
+                exclude=frozenset({"id", "plural"}),
+                allow_blank=frozenset({"filename"}),
+            )
+            if item["filename"]:
+                try:
+                    validate_filename(item["filename"])
+                except ValidationError as error:
+                    raise ValidationError(
+                        {f"{item_path}.filename": error.messages}
+                    ) from error
+            self.validate_model_data(Plural, item["plural"], f"{item_path}.plural")
+            language = self.validate_language(
+                item["language_code"], f"{item_path}.language_code"
+            )
+            if item["id"] in translation_ids:
+                raise ValidationError(
+                    {f"{item_path}.id": [gettext("Duplicate translation identifier.")]}
+                )
+            if previous_code := language_sources.get(language.code):
+                values = [previous_code, item["language_code"]]
+                msg = (
+                    "Several languages from backup map to single language on this "
+                    f"server {values} -> {language.code}"
+                )
+                raise ValueError(msg)
+            translation_ids.add(item["id"])
+            translation_languages[item["id"]] = language.code
+            language_sources[language.code] = item["language_code"]
+            if language.code == source_language.code:
+                source_translation_ids.append(item["id"])
+        if len(source_translation_ids) != 1:
+            raise ValidationError(
+                {
+                    f"{path}.translations": [
+                        gettext(
+                            "Component has to contain exactly one source translation."
+                        )
+                    ]
+                }
+            )
+        source_translation_id = source_translation_ids[0]
+
+        unit_hashes_by_translation: dict[int, set[str]] = defaultdict(set)
+        for index, item in enumerate(data["units"]):
+            item_path = f"{path}.units[{index}]"
+            self.validate_model_data(
+                Unit,
+                item,
+                item_path,
+                allow_blank=frozenset({"details"}),
+                exclude=frozenset(
+                    {
+                        "checks",
+                        "comments",
+                        "id_hash",
+                        "labels",
+                        "pending",
+                        "suggestions",
+                        "translation_id",
+                    }
+                ),
+            )
+            self.validate_checksum(item["id_hash"], f"{item_path}.id_hash")
+            translation_id = item["translation_id"]
+            if translation_id not in translation_ids:
+                raise ValidationError(
+                    {
+                        f"{item_path}.translation_id": [
+                            gettext("Referenced translation does not exist.")
+                        ]
+                    }
+                )
+            if item["id_hash"] in unit_hashes_by_translation[translation_id]:
+                raise ValidationError(
+                    {f"{item_path}.id_hash": [gettext("Duplicate unit checksum.")]}
+                )
+            unit_hashes_by_translation[translation_id].add(item["id_hash"])
+            for label_index, label in enumerate(item["labels"]):
+                if label not in self.label_names:
+                    raise ValidationError(
+                        {
+                            f"{item_path}.labels[{label_index}]": [
+                                gettext("Referenced label does not exist.")
+                            ]
+                        }
+                    )
+            for comment_index, comment in enumerate(item["comments"]):
+                self.validate_model_data(
+                    Comment,
+                    comment,
+                    f"{item_path}.comments[{comment_index}]",
+                    exclude=frozenset({"user"}),
+                )
+            for suggestion_index, suggestion in enumerate(item["suggestions"]):
+                suggestion_path = f"{item_path}.suggestions[{suggestion_index}]"
+                self.validate_model_data(
+                    Suggestion,
+                    suggestion,
+                    suggestion_path,
+                    exclude=frozenset({"user", "votes"}),
+                )
+                for vote_index, vote in enumerate(suggestion["votes"]):
+                    self.validate_model_data(
+                        Vote,
+                        vote,
+                        f"{suggestion_path}.votes[{vote_index}]",
+                        exclude=frozenset({"user"}),
+                    )
+            check_names: set[str] = set()
+            for check_index, check in enumerate(item["checks"]):
+                self.validate_model_data(
+                    Check, check, f"{item_path}.checks[{check_index}]"
+                )
+                if check["name"] in check_names:
+                    raise ValidationError(
+                        {
+                            f"{item_path}.checks[{check_index}].name": [
+                                gettext("Duplicate check name.")
+                            ]
+                        }
+                    )
+                check_names.add(check["name"])
+
+        source_hashes = unit_hashes_by_translation[source_translation_id]
+        for translation_id, hashes in unit_hashes_by_translation.items():
+            if translation_id == source_translation_id:
+                continue
+            missing = hashes - source_hashes
+            if missing:
+                raise ValidationError(
+                    {
+                        f"{path}.units": [
+                            gettext(
+                                "A translated unit references a missing source unit."
+                            )
+                        ]
+                    }
+                )
+
+        for index, item in enumerate(data.get("pending_unit_changes", [])):
+            item_path = f"{path}.pending_unit_changes[{index}]"
+            self.validate_model_data(
+                PendingUnitChange,
+                item,
+                item_path,
+                exclude=frozenset({"author", "translation_id", "unit_id_hash"}),
+            )
+            self.validate_checksum(item["unit_id_hash"], f"{item_path}.unit_id_hash")
+            translation_id = item["translation_id"]
+            if translation_id not in translation_ids:
+                raise ValidationError(
+                    {
+                        f"{item_path}.translation_id": [
+                            gettext("Referenced translation does not exist.")
+                        ]
+                    }
+                )
+            if item["unit_id_hash"] not in unit_hashes_by_translation[translation_id]:
+                raise ValidationError(
+                    {
+                        f"{item_path}.unit_id_hash": [
+                            gettext("Referenced unit does not exist.")
+                        ]
+                    }
+                )
+
+        for index, item in enumerate(data["screenshots"]):
+            item_path = f"{path}.screenshots[{index}]"
+            self.validate_model_data(
+                Screenshot,
+                item,
+                item_path,
+                exclude=frozenset({"image", "translation_id", "units", "user"}),
+            )
+            translation_id = item["translation_id"]
+            if translation_id not in translation_ids:
+                raise ValidationError(
+                    {
+                        f"{item_path}.translation_id": [
+                            gettext("Referenced translation does not exist.")
+                        ]
+                    }
+                )
+            image = item["image"]
+            if (
+                image != os.path.basename(image)
+                or "/" in image
+                or "\\" in image
+                or not image
+            ):
+                raise ValidationError(
+                    {f"{item_path}.image": [gettext("Screenshot filename is invalid.")]}
+                )
+            member_name = f"screenshots/{image}"
+            try:
+                info = zipfile.getinfo(member_name)
+            except KeyError as error:
+                raise ValidationError(
+                    {
+                        f"{item_path}.image": [
+                            gettext("Referenced screenshot image does not exist.")
+                        ]
+                    }
+                ) from error
+            if info.file_size > settings.ALLOWED_ASSET_SIZE:
+                raise ValidationError(
+                    {f"{item_path}.image": [gettext("Uploaded file is too big.")]}
+                )
+            with zipfile.open(info) as handle:
+                content = handle.read(settings.ALLOWED_ASSET_SIZE + 1)
+            if len(content) > settings.ALLOWED_ASSET_SIZE:
+                raise ValidationError(
+                    {f"{item_path}.image": [gettext("Uploaded file is too big.")]}
+                )
+            restored_image = File(BytesIO(content), name=image)
+            try:
+                Screenshot.validate_image_file(restored_image)
+            except ValidationError as error:
+                raise ValidationError(
+                    {
+                        f"{item_path}.image": [
+                            gettext("Could not validate screenshot: %(error)s")
+                            % {"error": error}
+                        ]
+                    }
+                ) from error
+            for unit_index, checksum in enumerate(item["units"]):
+                self.validate_checksum(checksum, f"{item_path}.units[{unit_index}]")
+                if checksum not in unit_hashes_by_translation[translation_id]:
+                    raise ValidationError(
+                        {
+                            f"{item_path}.units[{unit_index}]": [
+                                gettext("Referenced unit does not exist.")
+                            ]
+                        }
+                    )
+
+    def validate_team_references(self, *, validate_roles: bool) -> None:
+        roles = {role.name for role in Role.objects.all()} if validate_roles else set()
+        for index, team in enumerate(self.data.get("teams", [])):
+            path = f"teams[{index}]"
+            for component_index, component in enumerate(team["components"]):
+                if component not in self.component_full_slugs:
+                    raise ValidationError(
+                        {
+                            f"{path}.components[{component_index}]": [
+                                gettext("Referenced component does not exist.")
+                            ]
+                        }
+                    )
+            if validate_roles:
+                for role_index, role in enumerate(team["roles"]):
+                    if role not in roles:
+                        raise ValidationError(
+                            {
+                                f"{path}.roles[{role_index}]": [
+                                    gettext("Referenced role does not exist.")
+                                ]
+                            }
+                        )
+
+    def validate_vcs_component_paths(self, zipfile: ZipFile) -> None:
+        """Ensure every restored repository member belongs to a local component."""
+        components = sorted(self.component_full_slugs, key=len, reverse=True)
+        for info in zipfile.infolist():
+            if info.is_dir() or not info.filename.startswith(self.VCS_PREFIX):
+                continue
+            path = info.filename[self.VCS_PREFIX_LEN :]
+            component = next(
+                (
+                    slug
+                    for slug in components
+                    if path == slug or path.startswith(f"{slug}/")
+                ),
+                None,
+            )
+            if component is None:
+                raise ValidationError(
+                    {
+                        info.filename: [
+                            gettext(
+                                "Repository data does not belong to a restored component."
+                            )
+                        ]
+                    }
+                )
+            if component in self.component_repo_links:
+                raise ValidationError(
+                    {
+                        info.filename: [
+                            gettext(
+                                "Repository-linked components can not contain repository data."
+                            )
+                        ]
+                    }
+                )
 
     @overload
     def load_component(
@@ -777,46 +1470,25 @@ class ProjectBackup:
         actor: User | None = None,
         changes: list[Change] | None = None,
     ) -> bool:
-        with zipfile.open(filename) as handle:
-            data = json.load(handle)
+        try:
+            data = self.component_data[filename]
+        except KeyError:
+            with zipfile.open(filename) as handle:
+                data = json.load(handle)
             validate_schema(data, "weblate-component.schema.json")
-            self.validate_component_urls(data["component"])
-            if skip_linked and data["component"]["repo"].startswith("weblate:"):
-                return False
-            if data["component"]["vcs"] not in VCS_REGISTRY:
-                msg = f"Component {data['component']['name']} uses unsupported VCS: {data['component']['vcs']}"
-                raise ValueError(msg)
-            # Validate translations have unique languages
-            languages = defaultdict(list)
-            for item in data["translations"]:
-                language = self.import_language(item["language_code"])
-                languages[language.code].append(item["language_code"])
-
-            for code, values in languages.items():
-                if len(values) > 1:
-                    msg = f"Several languages from backup map to single language on this server {values} -> {code}"
-                    raise ValueError(msg)
-
-            if do_restore:
-                if actor is None:
-                    msg = "Need a restore actor."
-                    raise TypeError(msg)
-                if changes is None:
-                    msg = "Need a restore changes list."
-                    raise TypeError(msg)
-                return self.restore_component(zipfile, data, actor, changes)
-            return True
-
-    @staticmethod
-    def validate_component_urls(component: dict[str, Any]) -> None:
-        for field in ("repo", "push"):
-            value = component.get(field)
-            if not value:
-                continue
-            try:
-                validate_repo_url(value)
-            except ValidationError as error:
-                raise ValidationError({field: error.messages}) from error
+            self.validate_component_object(zipfile, filename, data)
+            self.component_data[filename] = data
+        if skip_linked and data["component"]["repo"].startswith("weblate:"):
+            return False
+        if do_restore:
+            if actor is None:
+                msg = "Need a restore actor."
+                raise TypeError(msg)
+            if changes is None:
+                msg = "Need a restore changes list."
+                raise TypeError(msg)
+            return self.restore_component(zipfile, data, actor, changes)
+        return True
 
     @overload
     def load_components(
@@ -913,11 +1585,38 @@ class ProjectBackup:
             raise TypeError(msg)
         self.validated = False
         with ZipFile(input_file, "r") as zipfile:
-            self.validate_zip_members(zipfile)
-            self.load_data(zipfile)
-            self.load_memory(zipfile)
-            self.load_components(zipfile)
+            self.validate_archive(zipfile)
         self.validated = True
+
+    def validate_archive(
+        self,
+        zipfile: ZipFile,
+        *,
+        target_project_name: str | None = None,
+        target_project_slug: str | None = None,
+        validate_roles: bool = False,
+    ) -> None:
+        """Validate and cache all restore input before any state is changed."""
+        self.component_data.clear()
+        self.memory_data.clear()
+        self.memory_loaded = False
+        self.component_full_slugs = set()
+        self.component_repo_links = set()
+        self.category_paths = set()
+        self.path_siblings = set()
+        self.name_siblings = set()
+        self.label_names = set()
+        self.validation_project = None
+        self.validate_zip_members(zipfile)
+        self.load_data(zipfile)
+        self.validate_project_objects(
+            target_project_name=target_project_name,
+            target_project_slug=target_project_slug,
+        )
+        self.load_memory(zipfile)
+        self.load_components(zipfile)
+        self.validate_vcs_component_paths(zipfile)
+        self.validate_team_references(validate_roles=validate_roles)
 
     def restore_unit(
         self,
@@ -1442,19 +2141,19 @@ class ProjectBackup:
                 user=self.restore_user(item["user"]),
                 timestamp=item["timestamp"],
             )
-            with zipfile.open(os.path.join("screenshots", item["image"])) as handle:
+            member_name = f"screenshots/{item['image']}"
+            with zipfile.open(member_name) as handle:
                 restored_image = File(
-                    BytesIO(handle.read()), name=os.path.basename(item["image"])
+                    BytesIO(handle.read(settings.ALLOWED_ASSET_SIZE + 1)),
+                    name=os.path.basename(item["image"]),
                 )
-                try:
-                    validate_bitmap(restored_image)
-                except ValidationError as error:
-                    raise ValidationError(
-                        gettext("Could not restore screenshot %(name)s: %(error)s")
-                        % {"name": item["image"], "error": error}
-                    ) from error
-                screenshot.image.save(
-                    os.path.basename(item["image"]), restored_image, save=False
+            Screenshot.validate_image_file(restored_image)
+            screenshot.image.save(
+                os.path.basename(item["image"]), restored_image, save=False
+            )
+            if screenshot.image.name is not None:
+                self.created_media.append(
+                    (screenshot.image.storage, screenshot.image.name)
                 )
             screenshot.import_data = item
             screenshots.append(screenshot)
@@ -1472,7 +2171,7 @@ class ProjectBackup:
                 )
 
         # Trigger checks update, the implementation might have changed
-        component.schedule_update_checks()
+        transaction.on_commit(component.schedule_update_checks, robust=True)
 
         if not component.is_repo_link:
             component.configure_repo(pull=False)
@@ -1524,7 +2223,6 @@ class ProjectBackup:
             self.categories_cache[self.full_slug_without_project(obj)] = obj
             self.restore_categories(nested_categories, obj)
 
-    @transaction.atomic
     def restore(
         self,
         project_name: str,
@@ -1540,76 +2238,133 @@ class ProjectBackup:
         if not self.validated:
             msg = "Project backup has to be validated before restore."
             raise ValueError(msg)
+
         self.skipped_components.clear()
+        self.created_media.clear()
+        self.project = None
+        self.languages_cache.clear()
+        self.labels_map.clear()
+        self.components_cache.clear()
+        self.categories_cache.clear()
+        project_path = Path(Project(name=project_name, slug=project_slug).full_path)
+        if project_path.exists():
+            raise ValidationError(
+                {"slug": [gettext("The project repository directory already exists.")]}
+            )
+
         with ZipFile(self.filename, "r") as zipfile:
-            self.validate_zip_members(zipfile)
-            self.load_data(zipfile)
-            restore_changes: list[Change] = []
-
-            # Create project
-            kwargs = self.data["project"].copy()
-            kwargs["name"] = project_name
-            kwargs["slug"] = project_slug
-            self.import_inherited_settings(kwargs)
-            if workspace is not None:
-                for field in INHERITABLE_COMPONENT_FLAGS:
-                    kwargs[field] = False
-                kwargs["workspace"] = workspace
-            # the attribute `set_language_team` is present in legacy backups prior to 5.17.1
-            self.set_language_team_project = kwargs.pop("set_language_team", False)
-            self.project = project = Project.objects.create(**kwargs)
-
-            # Handle billing and ACL (creating user needs access)
-            self.project.post_create(user, billing)
-
-            # Create labels
-            labels = Label.objects.bulk_create(
-                Label(project=project, **entry) for entry in self.data["labels"]
-            )
-            self.labels_map = {label.name: label for label in labels}
-            if "categories" in self.data:
-                self.restore_categories(self.data["categories"], None)
-
-            # Import translation memory
-            self.restore_memory(zipfile, project)
-
-            # Extract VCS
-            project_path = Path(project.full_path)
-
-            def skip_vcs_member(info: ZipInfo) -> bool:
-                if info.is_dir() or not info.filename.startswith(self.VCS_PREFIX):
-                    return True
-                path = info.filename[self.VCS_PREFIX_LEN :]
-                # Skip potentially dangerous paths
-                return path != os.path.normpath(path) or self.is_unsafe_vcs_path(path)
-
-            def vcs_member_name(info: ZipInfo) -> str:
-                return info.filename[self.VCS_PREFIX_LEN :]
-
-            for info, targetpath in iter_safe_zip_members(
+            self.validate_archive(
                 zipfile,
-                project_path,
-                skip_member=skip_vcs_member,
-                member_name=vcs_member_name,
-            ):
-                extract_zip_member(zipfile, info, targetpath)
-                # Create possibly missing refs directory in .git, this is not restored as
-                # all references are in packed_refs after `git gc`.
-                if vcs_member_name(info).endswith(".git/packed-refs"):
-                    git_refs_dir = targetpath.parent / "refs"
-                    git_refs_dir.mkdir(parents=True, exist_ok=True)
-
-            # Create components
-            self.load_components(
-                zipfile,
-                do_restore=True,
-                actor=user,
-                changes=restore_changes,
-                progress_callback=progress_callback,
+                target_project_name=project_name,
+                target_project_slug=project_slug,
+                validate_roles=True,
             )
+            project_path_created = False
+            try:
+                project_path.mkdir(parents=True, exist_ok=False)
+                project_path_created = True
+                with transaction.atomic():
+                    project = self.restore_validated(
+                        zipfile,
+                        project_name,
+                        project_slug,
+                        user,
+                        billing=billing,
+                        workspace=workspace,
+                        progress_callback=progress_callback,
+                    )
+            except Exception:
+                restore_committed = (
+                    self.project is not None
+                    and self.project.pk is not None
+                    and Project.objects.filter(pk=self.project.pk).exists()
+                )
+                if not restore_committed:
+                    for storage, name in reversed(self.created_media):
+                        try:
+                            storage.delete(name)
+                        except Exception as error:
+                            warnings.warn(
+                                f"Could not remove restored media {name!r}: {error}",
+                                RuntimeWarning,
+                                stacklevel=2,
+                            )
+                    if project_path_created and project_path.exists():
+                        remove_tree(project_path, ignore_errors=True)
+                raise
 
-            if "teams" in self.data:
-                self.restore_teams(self.data["teams"])
+        self.created_media.clear()
+        return project
+
+    def restore_validated(
+        self,
+        zipfile: ZipFile,
+        project_name: str,
+        project_slug: str,
+        user: User,
+        *,
+        billing: Billing | None,
+        workspace: Workspace | None,
+        progress_callback: Callable[[int, int], None] | None,
+    ) -> Project:
+        """Apply a fully validated restore plan inside a database transaction."""
+        restore_changes: list[Change] = []
+
+        kwargs = self.data["project"].copy()
+        kwargs["name"] = project_name
+        kwargs["slug"] = project_slug
+        self.import_inherited_settings(kwargs)
+        if workspace is not None:
+            for field in INHERITABLE_COMPONENT_FLAGS:
+                kwargs[field] = False
+            kwargs["workspace"] = workspace
+        # The attribute is present in legacy backups prior to 5.17.1.
+        self.set_language_team_project = kwargs.pop("set_language_team", False)
+        self.project = project = Project.objects.create(**kwargs)
+
+        project.post_create(user, billing)
+
+        labels = Label.objects.bulk_create(
+            Label(project=project, **entry) for entry in self.data["labels"]
+        )
+        self.labels_map = {label.name: label for label in labels}
+        if "categories" in self.data:
+            self.restore_categories(self.data["categories"], None)
+
+        self.restore_memory(zipfile, project)
+
+        project_path = Path(project.full_path)
+
+        def skip_vcs_member(info: ZipInfo) -> bool:
+            if info.is_dir() or not info.filename.startswith(self.VCS_PREFIX):
+                return True
+            path = info.filename[self.VCS_PREFIX_LEN :]
+            return path != os.path.normpath(path) or self.is_unsafe_vcs_path(path)
+
+        def vcs_member_name(info: ZipInfo) -> str:
+            return info.filename[self.VCS_PREFIX_LEN :]
+
+        for info, targetpath in iter_safe_zip_members(
+            zipfile,
+            project_path,
+            skip_member=skip_vcs_member,
+            member_name=vcs_member_name,
+        ):
+            extract_zip_member(zipfile, info, targetpath)
+            if vcs_member_name(info).endswith(".git/packed-refs"):
+                git_refs_dir = targetpath.parent / "refs"
+                git_refs_dir.mkdir(parents=True, exist_ok=True)
+
+        self.load_components(
+            zipfile,
+            do_restore=True,
+            actor=user,
+            changes=restore_changes,
+            progress_callback=progress_callback,
+        )
+
+        if "teams" in self.data:
+            self.restore_teams(self.data["teams"])
 
         restore_changes.append(
             Change(
@@ -1621,8 +2376,7 @@ class ProjectBackup:
             )
         )
         Change.objects.bulk_create(restore_changes, batch_size=500)
-
-        return self.project
+        return project
 
     def store_for_import(self) -> str:
         backup_dir = data_path(PROJECTBACKUP_PREFIX) / "import"

--- a/weblate/trans/mixins.py
+++ b/weblate/trans/mixins.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Protocol
 
 from django.core.exceptions import ValidationError
@@ -97,7 +98,14 @@ class PathMixin(LoggerMixin, URLMixin):
 
     def _get_path(self) -> str:
         """Actual calculation of path."""
-        return os.path.join(data_dir("vcs"), *self.get_url_path())
+        root = Path(data_dir("vcs")).resolve()
+        path = root.joinpath(*self.get_url_path()).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError as error:
+            msg = f"Object path escapes the VCS directory: {path}"
+            raise ValueError(msg) from error
+        return path.as_posix()
 
     @cached_property
     def full_path(self) -> str:

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -74,6 +74,11 @@ def remove_file_after(filename: str):
             os.unlink(filename)
 
 
+def resolve_private_example(host, *args, **kwargs):
+    address = "127.0.0.1" if host == "private.example" else "8.8.8.8"
+    return [(0, 0, 0, "", (address, 443))]
+
+
 class BackupsTest(ViewTestCase):
     CREATE_GLOSSARIES: bool = True
 
@@ -92,8 +97,11 @@ class BackupsTest(ViewTestCase):
     def write_tampered_component_backup(
         self,
         *,
+        component_updates: dict | None = None,
         repo: str | None = None,
         push: str | None = None,
+        translation_updates: dict | None = None,
+        unit_updates: dict | None = None,
         all_components: bool = False,
     ) -> str:
         backup = ProjectBackup()
@@ -107,6 +115,16 @@ class BackupsTest(ViewTestCase):
             ZipFile(temp_name, "w") as target_zip,
         ):
             for item in source_zip.infolist():
+                if (
+                    repo is not None
+                    and repo.startswith("weblate:")
+                    and item.filename.startswith("vcs/")
+                    and (
+                        all_components
+                        or item.filename.startswith(f"vcs/{self.component.slug}/")
+                    )
+                ):
+                    continue
                 data = source_zip.read(item.filename)
                 if item.filename.startswith("components/") and (
                     all_components
@@ -117,7 +135,34 @@ class BackupsTest(ViewTestCase):
                         component_data["component"]["repo"] = repo
                     if push is not None:
                         component_data["component"]["push"] = push
+                    if component_updates is not None:
+                        component_data["component"].update(component_updates)
+                    if translation_updates is not None:
+                        component_data["translations"][0].update(translation_updates)
+                    if unit_updates is not None:
+                        component_data["units"][0].update(unit_updates)
                     data = json.dumps(component_data).encode("utf-8")
+                target_zip.writestr(item, data)
+
+        return temp_name
+
+    def write_tampered_project_backup(self, **updates) -> str:
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:
+            temp_name = temp_handle.name
+
+        with (
+            ZipFile(backup.filename, "r") as source_zip,
+            ZipFile(temp_name, "w") as target_zip,
+        ):
+            for item in source_zip.infolist():
+                data = source_zip.read(item.filename)
+                if item.filename == "weblate-backup.json":
+                    project_data = json.loads(data.decode("utf-8"))
+                    project_data["project"].update(updates)
+                    data = json.dumps(project_data).encode("utf-8")
                 target_zip.writestr(item, data)
 
         return temp_name
@@ -884,6 +929,58 @@ class BackupsTest(ViewTestCase):
 
         self.assertFalse(team.user_set.filter(pk=user.pk).exists())
 
+    def test_restore_rejects_invalid_autogroup_expression(self) -> None:
+        with self.assertRaises(ValidationError):
+            ProjectBackup.validate_model_data(
+                AutoGroup, {"match": "["}, "teams[0].autogroups[0]"
+            )
+
+    def test_checksum_validation_rejects_non_string(self) -> None:
+        path = "components/test.json.units[0].id_hash"
+        for value in (None, 123):
+            with (
+                self.subTest(value=value),
+                self.assertRaises(ValidationError) as error,
+            ):
+                ProjectBackup.validate_checksum(value, path)
+
+            self.assertEqual(set(error.exception.message_dict), {path})
+
+    def test_nested_category_validation_preserves_path(self) -> None:
+        categories = [
+            {
+                "name": "Parent",
+                "slug": "parent",
+                "categories": [
+                    {"name": "First", "slug": "duplicate", "categories": []},
+                    {"name": "Second", "slug": "duplicate", "categories": []},
+                ],
+            }
+        ]
+
+        with self.assertRaises(ValidationError) as error:
+            ProjectBackup().validate_categories(categories)
+
+        self.assertIn("categories[0].categories[1].slug", error.exception.message_dict)
+
+    def test_validation_resolves_languages_without_creating_them(self) -> None:
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+        language_count = Language.objects.count()
+
+        with patch.object(
+            Language.objects,
+            "auto_get_or_create",
+            wraps=Language.objects.auto_get_or_create,
+        ) as resolver:
+            ProjectBackup(backup.filename).validate()
+
+        self.assertGreater(resolver.call_count, 0)
+        self.assertTrue(
+            all(call.kwargs.get("create") is False for call in resolver.call_args_list)
+        )
+        self.assertEqual(Language.objects.count(), language_count)
+
     def test_restore_synthesizes_source_translation_check_flags(self) -> None:
         source = self.component.source_translation
         source.check_flags = "strict-same"
@@ -928,7 +1025,7 @@ class BackupsTest(ViewTestCase):
             with (
                 patch(
                     "weblate.utils.outbound.socket.getaddrinfo",
-                    return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+                    side_effect=resolve_private_example,
                 ),
                 self.assertRaises(ValidationError) as error,
             ):
@@ -953,7 +1050,7 @@ class BackupsTest(ViewTestCase):
             with (
                 patch(
                     "weblate.utils.outbound.socket.getaddrinfo",
-                    return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
+                    side_effect=resolve_private_example,
                 ),
                 self.assertRaises(ValidationError) as error,
             ):
@@ -967,6 +1064,76 @@ class BackupsTest(ViewTestCase):
                     ]
                 },
             )
+
+    def test_restore_rejects_invalid_component_slug(self) -> None:
+        temp_name = self.write_tampered_component_backup(
+            component_updates={"slug": "../../outside"}
+        )
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            with self.assertRaises(ValidationError) as error:
+                restore.validate()
+
+        self.assertIn("component.slug", next(iter(error.exception.message_dict)))
+
+    def test_component_path_rejects_escape(self) -> None:
+        component = Component(
+            project=Project(name="Path test", slug="path-test"),
+            name="Outside",
+            slug="/outside",
+        )
+
+        with self.assertRaisesRegex(ValueError, "escapes the VCS directory"):
+            self.assertIsInstance(component.full_path, str)
+
+    def test_restore_rejects_invalid_repository_browser_url(self) -> None:
+        temp_name = self.write_tampered_component_backup(
+            component_updates={"repoweb": "javascript:alert(1)"}
+        )
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            with self.assertRaises(ValidationError) as error:
+                restore.validate()
+
+        self.assertIn("component.repoweb", next(iter(error.exception.message_dict)))
+
+    def test_restore_rejects_invalid_project_url(self) -> None:
+        temp_name = self.write_tampered_project_backup(web="javascript:alert(1)")
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            with self.assertRaises(ValidationError) as error:
+                restore.validate()
+
+        self.assertIn("project.web", error.exception.message_dict)
+
+    def test_restore_rejects_malformed_unit_checksum(self) -> None:
+        temp_name = self.write_tampered_component_backup(
+            unit_updates={"id_hash": "x0123456789abcdefy"}
+        )
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            with self.assertRaises(ValidationError) as error:
+                restore.validate()
+
+        self.assertIn("units[0].id_hash", next(iter(error.exception.message_dict)))
+
+    def test_restore_rejects_unsafe_translation_filename(self) -> None:
+        temp_name = self.write_tampered_component_backup(
+            translation_updates={"filename": "../../outside.po"}
+        )
+
+        with remove_file_after(temp_name):
+            restore = ProjectBackup(temp_name)
+            with self.assertRaises(ValidationError) as error:
+                restore.validate()
+
+        self.assertIn(
+            "translations[0].filename", next(iter(error.exception.message_dict))
+        )
 
     def test_restore_skips_inaccessible_linked_component(self) -> None:
         victim_project = Project.objects.create(name="Victim", slug="victim")
@@ -1335,6 +1502,25 @@ class BackupsTest(ViewTestCase):
             with self.assertRaisesRegex(ValueError, "ZIP file contains invalid path"):
                 restore.validate()
 
+    def test_restore_rejects_unowned_repository_data(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:
+            temp_name = temp_handle.name
+
+        with remove_file_after(temp_name):
+            with (
+                ZipFile(TEST_BACKUP, "r") as source_zip,
+                ZipFile(temp_name, "w") as zipfile,
+            ):
+                for item in source_zip.infolist():
+                    zipfile.writestr(item, source_zip.read(item.filename))
+                zipfile.writestr("vcs/orphan/file", b"blocked")
+
+            restore = ProjectBackup(temp_name)
+            with self.assertRaises(ValidationError) as error:
+                restore.validate()
+
+        self.assertIn("vcs/orphan/file", error.exception.message_dict)
+
     @override_settings(
         PROJECT_BACKUP_IMPORT_MAX_COMPRESSED_ENTRY_RATIO=5,
         PROJECT_BACKUP_IMPORT_MIN_RATIO_SIZE=10,
@@ -1367,6 +1553,51 @@ class BackupsTest(ViewTestCase):
                 restore.restore(
                     project_name="Restored", project_slug="restored", user=self.user
                 )
+
+    def test_restore_failure_cleans_database_and_repository(self) -> None:
+        screenshot = Screenshot.objects.create(
+            name="Cleanup screenshot", translation=self.component.source_translation
+        )
+        with open(TEST_SCREENSHOT, "rb") as handle:
+            screenshot.image.save("cleanup-screenshot.png", File(handle))
+        screenshot_dir = os.path.join(settings.MEDIA_ROOT, "screenshots")
+        media_before = set(os.listdir(screenshot_dir))
+
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+        restore = ProjectBackup(backup.filename)
+        restore.validate()
+        project_path = Project(name="Restored", slug="restored").full_path
+
+        with (
+            patch.object(
+                Component, "configure_repo", side_effect=RuntimeError("failed")
+            ),
+            self.assertRaisesRegex(RuntimeError, "failed"),
+        ):
+            restore.restore(
+                project_name="Restored", project_slug="restored", user=self.user
+            )
+
+        self.assertFalse(Project.objects.filter(slug="restored").exists())
+        self.assertFalse(os.path.exists(project_path))
+        self.assertEqual(set(os.listdir(screenshot_dir)), media_before)
+
+    def test_restore_does_not_remove_existing_repository_directory(self) -> None:
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+        restore = ProjectBackup(backup.filename)
+        restore.validate()
+        project_path = Project(name="Restored", slug="restored").full_path
+        os.mkdir(project_path)
+        self.addCleanup(os.rmdir, project_path)
+
+        with self.assertRaises(ValidationError):
+            restore.restore(
+                project_name="Restored", project_slug="restored", user=self.user
+            )
+
+        self.assertTrue(os.path.isdir(project_path))
 
     def test_restore_skips_git_hooks(self) -> None:
         backup = ProjectBackup()
@@ -1436,11 +1667,80 @@ class BackupsTest(ViewTestCase):
                     target_zip.writestr(item, data)
 
             restore = ProjectBackup(temp_name)
-            restore.validate()
             with self.assertRaises(ValidationError):
-                restore.restore(
-                    project_name="Restored", project_slug="restored", user=self.user
-                )
+                restore.validate()
+
+    def test_restore_rejects_screenshot_with_invalid_extension(self) -> None:
+        screenshot = Screenshot.objects.create(
+            name="Invalid extension screenshot",
+            translation=self.component.source_translation,
+        )
+        with open(TEST_SCREENSHOT, "rb") as handle:
+            screenshot.image.save("screenshot.png", File(handle))
+
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:
+            temp_name = temp_handle.name
+
+        with remove_file_after(temp_name):
+            with ZipFile(backup.filename, "r") as source_zip:
+                entries = [
+                    (item, source_zip.read(item.filename))
+                    for item in source_zip.infolist()
+                ]
+
+            renamed_images: dict[str, str] = {}
+            updated_entries = []
+            for item, content in entries:
+                if item.filename.startswith("components/"):
+                    component_data = json.loads(content.decode())
+                    for screenshot_data in component_data["screenshots"]:
+                        image = screenshot_data["image"]
+                        renamed_images[image] = f"{image}.html"
+                        screenshot_data["image"] = renamed_images[image]
+                    content = json.dumps(component_data).encode()
+                updated_entries.append((item, content))
+
+            with ZipFile(temp_name, "w") as target_zip:
+                for item, content in updated_entries:
+                    image = item.filename.removeprefix("screenshots/")
+                    if (
+                        item.filename.startswith("screenshots/")
+                        and image in renamed_images
+                    ):
+                        target_zip.writestr(
+                            f"screenshots/{renamed_images[image]}", content
+                        )
+                    else:
+                        target_zip.writestr(item, content)
+
+            restore = ProjectBackup(temp_name)
+            with self.assertRaises(ValidationError) as error:
+                restore.validate()
+
+        self.assertIn("File extension", str(error.exception))
+        self.assertIn("html", str(error.exception))
+
+    def test_restore_rejects_oversized_screenshot_during_validation(self) -> None:
+        screenshot = Screenshot.objects.create(
+            name="Oversized screenshot", translation=self.component.source_translation
+        )
+        with open(TEST_SCREENSHOT, "rb") as handle:
+            screenshot.image.save("oversized-screenshot.png", File(handle))
+
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+
+        restore = ProjectBackup(backup.filename)
+        with (
+            override_settings(ALLOWED_ASSET_SIZE=1),
+            self.assertRaises(ValidationError) as error,
+        ):
+            restore.validate()
+
+        self.assertIn("screenshots[0].image", next(iter(error.exception.message_dict)))
 
     def test_cleanup(self) -> None:
         cleanup_project_backups()


### PR DESCRIPTION
Project backups can be structurally valid while containing unsafe or inconsistent object data. Preflight the complete restore with shared model validation so failures do not leave partial database, repository, or screenshot state.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
