### PR TITLE
test(utils): isolate process ID mock

### DIFF
--- a/weblate/utils/tests/test_tracing.py
+++ b/weblate/utils/tests/test_tracing.py
@@ -320,16 +320,16 @@ class TracingTest(SimpleTestCase):
             patch(
                 "opentelemetry.instrumentation.psycopg.PsycopgInstrumentor"
             ) as psycopg,
-            patch("weblate.utils.errors.os.getpid", side_effect=[100, 101]),
-            patch("weblate.utils.errors.os.register_at_fork") as register_at_fork,
+            patch("weblate.utils.errors.os", autospec=True) as os_mock,
         ):
+            os_mock.getpid.side_effect = [100, 101]
             for instrumentor in (django, celery, redis, requests, psycopg):
                 instrumentor.return_value.is_instrumented_by_opentelemetry = False
             errors.init_opentelemetry()
             errors.init_opentelemetry()
 
         self.assertEqual(tracer_provider.call_count, 2)
-        register_at_fork.assert_called_once_with(
+        os_mock.register_at_fork.assert_called_once_with(
             # ruff: ignore[private-member-access]
             after_in_child=errors._init_opentelemetry_after_fork
         )


### PR DESCRIPTION
Mock the errors module's os reference so unrelated background calls cannot consume the simulated process IDs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
