### PR TITLE
feat(machinery): add asynchronous translation requests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,8 @@ Weblate 2026.8
 * Celery workers now prefetch fewer tasks by default to reduce memory usage and improve task distribution.
 * Improved the recommended :ref:`running-granian` configuration and Docker container worker resilience for Weblate's WSGI workload.
 * Added opt-in :ref:`running-granian-asgi` deployment support, including :envvar:`WEBLATE_ASGI` for Docker containers.
+* Added opt-in :ref:`running-granian-asgi` deployment support.
+* Machine translation editor requests now use asynchronous HTTP for DeepL, LibreTranslate, ModernMT, OpenAI-compatible, Anthropic, and Ollama services on ASGI deployments.
 * Deployment checks now detect corrupted PostgreSQL relation statistics.
 * :ref:`Community diagnostics <alerts>` now show source-string screenshot coverage, recommend key translation-instruction topics, and distinguish inbound from outbound repository automation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ dependencies = [
   "GitPython==3.1.57",
   "hiredis==3.4.0",
   "html2text==2025.4.15",
+  "httpx2[brotli,socks,zstd]==2.8.0",
   "idna==3.18",
   # Pin for translate-toolkit extra
   "iniparse==0.5",

--- a/scripts/list-translated-languages.py
+++ b/scripts/list-translated-languages.py
@@ -6,7 +6,7 @@
 
 from importlib.util import module_from_spec, spec_from_file_location
 
-import requests
+import httpx2
 from icu import Locale
 
 URL = "https://hosted.weblate.org/api/components/weblate/application/statistics/?format=json-flat"
@@ -21,7 +21,7 @@ def print_language(lang, fmt="{0} ({1})") -> None:
 
 def main() -> None:
     # load and parse data
-    data = requests.get(URL, timeout=5).json()
+    data = httpx2.get(URL, timeout=5, follow_redirects=True).json()
 
     # select languages
     languages_list = []

--- a/scripts/rtd-projects.py
+++ b/scripts/rtd-projects.py
@@ -10,7 +10,7 @@
 import subprocess
 from pathlib import Path
 
-import requests
+import httpx2
 from weblate_language_data.docs import DOCUMENTATION_LANGUAGES
 
 # List of translations
@@ -50,15 +50,20 @@ TOKEN = Path("~/.config/readthedocs.token").expanduser().read_text(encoding="utf
 
 AUTH = {"Authorization": f"Token {TOKEN}", "Content-Type": "application/json"}
 
-response = requests.get(
-    "https://readthedocs.org/api/v3/projects/weblate/", headers=AUTH, timeout=1
+response = httpx2.get(
+    "https://readthedocs.org/api/v3/projects/weblate/",
+    headers=AUTH,
+    timeout=1,
+    follow_redirects=True,
 )
 response.raise_for_status()
 base = response.json()
 
 result = {"next": "https://readthedocs.org/api/v3/projects/"}
 while result["next"]:
-    response = requests.get(result["next"], headers=AUTH, timeout=1)
+    response = httpx2.get(
+        result["next"], headers=AUTH, timeout=1, follow_redirects=True
+    )
     response.raise_for_status()
     result = response.json()
     for project in result["results"]:
@@ -79,7 +84,7 @@ while result["next"]:
                         f"Different {name} on {project['name']}: {current}",
                         project["urls"]["home"],
                     )
-                    response = requests.patch(
+                    response = httpx2.patch(
                         project["_links"]["_self"],
                         json={name: get_update(value)},
                         headers=AUTH,
@@ -89,8 +94,11 @@ while result["next"]:
             if not project["translation_of"] and code != "en":
                 print(f"Not a translation {project['name']}: ", project["urls"]["home"])
             # Check versions
-            versions_response = requests.get(
-                f"{project['_links']['versions']}?active=true", headers=AUTH, timeout=1
+            versions_response = httpx2.get(
+                f"{project['_links']['versions']}?active=true",
+                headers=AUTH,
+                timeout=1,
+                follow_redirects=True,
             )
             versions_response.raise_for_status()
             versions = versions_response.json()
@@ -103,8 +111,11 @@ while result["next"]:
                         project["urls"]["home"],
                     )
                     break
-                versions_response = requests.get(
-                    versions["next"], headers=AUTH, timeout=1
+                versions_response = httpx2.get(
+                    versions["next"],
+                    headers=AUTH,
+                    timeout=1,
+                    follow_redirects=True,
                 )
                 versions_response.raise_for_status()
                 versions = versions_response.json()
@@ -129,7 +140,7 @@ for language in LOCALES:
     }
     for name, expected_value in FIELDS.items():
         payload[name] = get_update(expected_value)
-    response = requests.post(
+    response = httpx2.post(
         "https://readthedocs.org/api/v3/projects/",
         json=payload,
         headers=AUTH,

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -12,7 +12,7 @@ import sys
 import time
 from pathlib import Path
 
-import requests
+import httpx2
 from ruamel.yaml import YAML
 from update_version import VERSION_FILES, replace_file, update_version
 
@@ -38,8 +38,11 @@ def prepend_file(name: str, content: str) -> None:
 def fetch_commit_activity(request_headers: dict[str, str]) -> list[dict[str, int]]:
     """Fetch commit activity, retrying while GitHub prepares the stats."""
     for _attempt in range(5):
-        activity_response = requests.get(
-            ACTIVITY_API, headers=request_headers, timeout=5
+        activity_response = httpx2.get(
+            ACTIVITY_API,
+            headers=request_headers,
+            timeout=5,
+            follow_redirects=True,
         )
         if activity_response.status_code != 202:
             activity_response.raise_for_status()
@@ -51,7 +54,9 @@ def fetch_commit_activity(request_headers: dict[str, str]) -> list[dict[str, int
 
 
 def fetch_fallback_stats(request_headers: dict[str, str]) -> dict[str, int]:
-    repo_response = requests.get(REPO_API, headers=request_headers, timeout=5)
+    repo_response = httpx2.get(
+        REPO_API, headers=request_headers, timeout=5, follow_redirects=True
+    )
     repo_response.raise_for_status()
     repo = repo_response.json()
     activity = sorted(
@@ -87,8 +92,12 @@ config = yaml.load(Path("~/.config/hub").expanduser().read_text(encoding="utf-8"
 milestones_api = f"{REPO_API}/milestones"
 api_auth = f"token {config['github.com'][0]['oauth_token']}"
 headers = {"Authorization": api_auth, "Accept": "application/vnd.github.v3+json"}
-response = requests.get(
-    milestones_api, headers=headers, timeout=1, params={"state": "open"}
+response = httpx2.get(
+    milestones_api,
+    headers=headers,
+    timeout=1,
+    params={"state": "open"},
+    follow_redirects=True,
 )
 response.raise_for_status()
 milestone_url = None
@@ -97,7 +106,7 @@ for milestone in response.json():
         milestone_url = milestone["html_url"]
 
 if milestone_url is None:
-    response = requests.post(
+    response = httpx2.post(
         milestones_api, headers=headers, json={"title": version}, timeout=1
     )
     payload = response.json()

--- a/uv.lock
+++ b/uv.lock
@@ -100,6 +100,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2067,6 +2080,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/50/a33260c2a959a7f12d3cf6b96bb35c7028c5d1904fa7b2f5850fa175af01/httpcore2-2.8.0.tar.gz", hash = "sha256:44be3730e7cd4fd206478488c00f57c0960b5e00ee9f7099ef18bb2b0c5cdb79", size = 66779, upload-time = "2026-07-23T11:54:40.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b7/76d6baa8c087cf5170f36dbeb92471e77c5c48f8f7ca8e5ba4ad613ea492/httpcore2-2.8.0-py3-none-any.whl", hash = "sha256:60ee2f9963ca942955ffd44553fc1111f00286283f9cc047d74e19888e061ace", size = 82638, upload-time = "2026-07-23T11:54:37.976Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/ca/928387a80e8e6ebbfa7ed020f1412e99038092657d63d801fe935f56677c/httpx2-2.8.0.tar.gz", hash = "sha256:7137d9278553773c672856112c36062ae691146212ab748a6a8362479b19bdee", size = 94485, upload-time = "2026-07-23T11:54:41.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/a7/aea061b450d51cf448c1ccc8e1fc6f04c0d8fdc97c17524c7f835018bb92/httpx2-2.8.0-py3-none-any.whl", hash = "sha256:9617a6af8354667c94dc06a1b7b88a32db618ffb1f0649f8be31c0639dc58227", size = 90232, upload-time = "2026-07-23T11:54:39.222Z" },
+]
+
+[package.optional-dependencies]
+brotli = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+]
+socks = [
+    { name = "socksio" },
+]
+zstd = [
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -4616,6 +4670,15 @@ wheels = [
 ]
 
 [[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5020,6 +5083,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -5433,6 +5505,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "hiredis" },
     { name = "html2text" },
+    { name = "httpx2", extra = ["brotli", "socks", "zstd"] },
     { name = "idna" },
     { name = "iniparse" },
     { name = "jsonschema" },
@@ -5728,6 +5801,7 @@ requires-dist = [
     { name = "granian", marker = "extra == 'wsgi'", specifier = "==2.7.9" },
     { name = "hiredis", specifier = "==3.4.0" },
     { name = "html2text", specifier = "==2025.4.15" },
+    { name = "httpx2", extras = ["brotli", "socks", "zstd"], specifier = "==2.8.0" },
     { name = "idna", specifier = "==3.18" },
     { name = "iniparse", specifier = "==0.5" },
     { name = "jsonschema", specifier = "==4.26.0" },
@@ -6143,6 +6217,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/ec/a0f8f3dad6e74992f4654bdd94802be0929eabca7b871cac3b6fbb5e961b/zope_interface-8.5-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0cd6a732ac84b94eb1ef9222a117347a27efd294ee16810ffdf7ecd307677ed5", size = 300885, upload-time = "2026-05-26T06:50:08.997Z" },
     { url = "https://files.pythonhosted.org/packages/0f/da/6881b48803a0ee8d23eb5efa30fce3ed218a2bd9de5758ce489d224fee81/zope_interface-8.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:798b7c87d0e59a7d5d086d642208d0d8700ff0d55c4029134b3c479c3bfb110f", size = 304672, upload-time = "2026-05-26T06:50:10.563Z" },
     { url = "https://files.pythonhosted.org/packages/2e/0e/b4c01320859ff1d585438bc231fd60bd258d096359bccf6654fecdf0cffb/zope_interface-8.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0fc3a9d45f114d27eaa1e53beeb144533689edca8a9f66505b1e8e8b3f075e42", size = 217241, upload-time = "2026-05-26T06:50:12.171Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]
 
 [[package]]

--- a/weblate/accounts/apps.py
+++ b/weblate/accounts/apps.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from ssl import CertificateError
 from typing import TYPE_CHECKING
 
+import httpx2
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.checks import register
@@ -54,7 +55,7 @@ def check_avatars(
         return []
     try:
         download_avatar_image("noreply@weblate.org", 32)
-    except (OSError, CertificateError) as error:
+    except (OSError, CertificateError, httpx2.HTTPError) as error:
         return [weblate_check("weblate.E018", f"Could not download avatar: {error}")]
     return []
 

--- a/weblate/accounts/avatar.py
+++ b/weblate/accounts/avatar.py
@@ -9,6 +9,7 @@ from ssl import CertificateError
 from typing import TYPE_CHECKING, Literal, cast
 from urllib.parse import urlencode
 
+import httpx2
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.core.cache import InvalidCacheBackendError, caches
@@ -68,7 +69,7 @@ def get_avatar_image(user: User, size: int) -> bytes:
         try:
             image = download_avatar_image(user.email, size)
             cache.set(cache_key, image)
-        except (OSError, CertificateError):
+        except (OSError, CertificateError, httpx2.HTTPError):
             report_error(f"Could not fetch avatar for {username}")
             return get_fallback_avatar(size)
 

--- a/weblate/accounts/tests/test_avatars.py
+++ b/weblate/accounts/tests/test_avatars.py
@@ -5,15 +5,18 @@
 """Tests for user handling."""
 
 from io import BytesIO
+from unittest.mock import patch
 
-import responses
+import httpx2
 from django.test import override_settings
 from django.urls import reverse
 from PIL import Image
 
 from weblate.accounts import avatar
+from weblate.accounts.apps import check_avatars
 from weblate.auth.models import User
 from weblate.trans.tests.test_views import FixtureTestCase
+from weblate.utils.tests import http_mock as responses
 
 TEST_URL = (
     "https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=identicon&s=32"
@@ -71,6 +74,17 @@ class AvatarTest(FixtureTestCase):
             reverse("user_avatar", kwargs={"user": self.user.username, "size": 32})
         )
         self.assert_png(response)
+
+    @override_settings(ENABLE_AVATARS=True)
+    def test_avatar_check_handles_http_error(self) -> None:
+        with patch(
+            "weblate.accounts.apps.download_avatar_image",
+            side_effect=httpx2.ConnectError("Avatar service unavailable"),
+        ):
+            errors = list(check_avatars(app_configs=None, databases=None))
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "weblate.E018")
 
     @responses.activate
     def test_avatar_rejects_unsupported_size_before_fetch(self) -> None:

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -10,6 +10,7 @@ from time import sleep
 from types import SimpleNamespace
 from unittest import mock
 
+import httpx2
 from django.conf import settings
 from django.core import mail
 from django.test.utils import modify_settings, override_settings
@@ -143,6 +144,28 @@ class ViewTest(RepoTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "[Weblate] Message from dark side")
         self.assertEqual(mail.outbox[0].to, list(settings.ADMINS))
+
+    @override_settings(
+        REGISTRATION_CAPTCHA=False,
+        ADMINS=("Weblate test <noreply@weblate.org>",),
+        ADMINS_CONTACT=["noreply@weblate.org"],
+        ZAMMAD_URL="https://support.example.com",
+    )
+    def test_contact_handles_zammad_http_error(self) -> None:
+        with (
+            mock.patch(
+                "weblate.accounts.views.submit_zammad_ticket",
+                side_effect=httpx2.ConnectError("Zammad unavailable"),
+            ),
+            mock.patch("weblate.accounts.views.report_error") as report_error,
+        ):
+            response = self.client.post(reverse("contact"), CONTACT_DATA, follow=True)
+
+        self.assertContains(
+            response,
+            "Could not open a ticket, please try again later.",
+        )
+        report_error.assert_called_once_with("Could not create ticket")
 
     @override_settings(
         REGISTRATION_CAPTCHA=False, ADMINS_CONTACT=["noreply@example.com"]

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -14,6 +14,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import quote
 
+import httpx2
 import qrcode
 import qrcode.image.svg
 from django.conf import settings
@@ -329,7 +330,7 @@ def mail_admins_contact(
             )
         except ZammadError as error:
             messages.error(request, str(error))
-        except OSError:
+        except (OSError, httpx2.HTTPError):
             report_error("Could not create ticket")
             messages.error(
                 request, gettext("Could not open a ticket, please try again later.")

--- a/weblate/addons/tasks.py
+++ b/weblate/addons/tasks.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+import httpx2
 from celery.schedules import crontab
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -52,6 +53,20 @@ def read_component_file(component: Component, filename: str) -> str:
     return Path(component.full_path, resolved).read_text(encoding="utf-8")
 
 
+def read_cdn_file(component: Component, filename: str) -> str:
+    if not filename.startswith(("http://", "https://")):
+        return read_component_file(component, filename)
+
+    with open_restricted_asset_url(
+        "get",
+        filename,
+        allow_private_targets=not settings.ASSET_RESTRICT_PRIVATE,
+        allowed_domains=settings.ASSET_PRIVATE_ALLOWLIST,
+    ) as response:
+        response.read()
+        return response.text
+
+
 def parse_cdn_html(addon: Addon, component: Component) -> list[dict[str, str]]:
     source_translation = component.source_translation
     source_units = set(source_translation.unit_set.values_list("source", flat=True))
@@ -61,17 +76,8 @@ def parse_cdn_html(addon: Addon, component: Component) -> list[dict[str, str]]:
     for filename in addon.configuration["files"].splitlines():
         filename = filename.strip()
         try:
-            if filename.startswith(("http://", "https://")):
-                with open_restricted_asset_url(
-                    "get",
-                    filename,
-                    allow_private_targets=not settings.ASSET_RESTRICT_PRIVATE,
-                    allowed_domains=settings.ASSET_PRIVATE_ALLOWLIST,
-                ) as handle:
-                    content = handle.text
-            else:
-                content = read_component_file(component, filename)
-        except (OSError, ValidationError, ValueError) as error:
+            content = read_cdn_file(component, filename)
+        except (OSError, httpx2.HTTPError, ValidationError, ValueError) as error:
             errors.append(
                 {
                     "addon": addon.name,

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -25,9 +25,8 @@ from unittest.mock import MagicMock, patch
 
 import fedora_messaging.api
 import fedora_messaging.config
+import httpx2
 import jsonschema.exceptions
-import requests
-import responses
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -83,6 +82,7 @@ from weblate.utils.state import (
     STATE_READONLY,
     STATE_TRANSLATED,
 )
+from weblate.utils.tests import http_mock as responses
 from weblate.utils.unittest import tempdir_setting
 from weblate.vcs.base import Repository, RepositoryError
 
@@ -163,21 +163,23 @@ from .tasks import (
     cleanup_addon_activity_log,
     daily_addons,
     language_consistency,
+    parse_cdn_html,
     run_addon_manually,
     update_addon_activity_log,
 )
-from .webhooks import SlackWebhookAddon, WebhookAddon
+from .webhooks import MessageNotDeliveredError, SlackWebhookAddon, WebhookAddon
 
 if TYPE_CHECKING:
     from weblate.trans.models import (
         Project,
     )
+    from weblate.utils.tests.http_mock import PreparedRequest
 
 
 def get_webhook_request_data(
-    request: requests.PreparedRequest,
+    request: PreparedRequest,
 ) -> tuple[bytes | str, dict[str, str]]:
-    """Return the concrete body and string headers prepared by requests."""
+    """Return the concrete body and string headers prepared by the HTTP client."""
     body = request.body
     assert isinstance(body, (bytes, str))
     headers: dict[str, str] = {}
@@ -8350,6 +8352,7 @@ class CDNJSAddonTest(ViewTestCase):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
+    @responses.activate
     def test_form_rejects_private_remote_file_before_request(
         self, mocked_getaddrinfo
     ) -> None:
@@ -8365,11 +8368,10 @@ class CDNJSAddonTest(ViewTestCase):
         )
 
         assert form is not None
-        with patch("requests.sessions.Session.request") as mocked_request:
-            self.assertFalse(form.is_valid())
+        self.assertFalse(form.is_valid())
 
         mocked_getaddrinfo.assert_called_once_with("private.example.com", None, type=1)
-        mocked_request.assert_not_called()
+        self.assertEqual(len(responses.calls), 0)
         self.assertIn("internal or non-public address", str(form.errors["files"]))
 
     @tempdir_setting("LOCALIZE_CDN_PATH")
@@ -8439,6 +8441,62 @@ class CDNJSAddonTest(ViewTestCase):
         self.assertEqual(
             Unit.objects.filter(translation__component=self.component).count(), 14
         )
+
+    @tempdir_setting("LOCALIZE_CDN_PATH")
+    @override_settings(LOCALIZE_CDN_URL="http://localhost/")
+    def test_extract_reads_streamed_remote_html(self) -> None:
+        addon = self.create_addon(
+            component=self.component,
+            configuration={
+                "threshold": 0,
+                "files": "https://cdn.example.com/messages.html",
+                "cookie_name": "django_languages",
+                "css_selector": ".l10n",
+            },
+            run=False,
+        )
+        response = httpx2.Response(
+            200,
+            stream=httpx2.ByteStream(
+                b"<html><body><div class='l10n'>Remote string</div></body></html>"
+            ),
+        )
+
+        with patch(
+            "weblate.addons.tasks.open_restricted_asset_url",
+            return_value=contextlib.nullcontext(response),
+        ):
+            errors = parse_cdn_html(addon.instance, self.component)
+
+        self.assertEqual(errors, [])
+        self.assertTrue(
+            self.component.source_translation.unit_set.filter(
+                source="Remote string"
+            ).exists()
+        )
+
+    @tempdir_setting("LOCALIZE_CDN_PATH")
+    @override_settings(LOCALIZE_CDN_URL="http://localhost/")
+    def test_extract_handles_remote_http_error(self) -> None:
+        addon = self.create_addon(
+            component=self.component,
+            configuration={
+                "threshold": 0,
+                "files": "https://cdn.example.com/messages.html",
+                "cookie_name": "django_languages",
+                "css_selector": ".l10n",
+            },
+            run=False,
+        )
+
+        with patch(
+            "weblate.addons.tasks.open_restricted_asset_url",
+            side_effect=httpx2.ConnectError("CDN unavailable"),
+        ):
+            errors = parse_cdn_html(addon.instance, self.component)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("CDN unavailable", errors[0]["error"])
 
     @tempdir_setting("LOCALIZE_CDN_PATH")
     @override_settings(LOCALIZE_CDN_URL="http://localhost/")
@@ -9084,6 +9142,37 @@ class TasksTest(TestCase):
         cleanup_addon_activity_log()
 
 
+class WebhookDeliveryTest(SimpleTestCase):
+    def test_transport_errors(self) -> None:
+        storage = MagicMock()
+        storage.configuration = {"webhook_url": "https://example.com/webhooks"}
+        addon = WebhookAddon(storage)
+        request = httpx2.Request("POST", storage.configuration["webhook_url"])
+        for error_class in (
+            httpx2.ConnectError,
+            httpx2.ConnectTimeout,
+            httpx2.ProxyError,
+            httpx2.ReadError,
+            httpx2.ReadTimeout,
+            httpx2.RemoteProtocolError,
+        ):
+            with self.subTest(error_class=error_class):
+                error = error_class("Webhook delivery failed", request=request)
+                with (
+                    patch(
+                        "weblate.addons.webhooks.fetch_validated_url",
+                        side_effect=error,
+                    ),
+                    self.assertRaisesMessage(
+                        MessageNotDeliveredError,
+                        "Unable to deliver webhook: could not connect to the remote server.",
+                    ) as raised,
+                ):
+                    addon.send_message(MagicMock(spec=Change), {}, {})
+
+                self.assertIs(raised.exception.__cause__, error)
+
+
 if TYPE_CHECKING:
 
     class _WebhookTestsTypingBase(ViewTestCase):
@@ -9317,7 +9406,10 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
     @responses.activate
     def test_connection_error(self) -> None:
         """Test connection error when during message delivery."""
-        self.do_translation_added_test(body=requests.ConnectionError())
+        request = httpx2.Request("POST", self.WEBHOOK_URL)
+        self.do_translation_added_test(
+            body=httpx2.ConnectError("Connection failed", request=request)
+        )
 
 
 class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):

--- a/weblate/addons/webhooks.py
+++ b/weblate/addons/webhooks.py
@@ -11,8 +11,8 @@ import json
 from math import floor
 from typing import TYPE_CHECKING
 
+import httpx2
 import jsonschema.exceptions
-import requests
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
@@ -73,7 +73,7 @@ class JSONWebhookBaseAddon(ChangeBaseAddon):
 
     def send_message(
         self, change: Change, headers: dict, payload: PayloadType
-    ) -> requests.Response:
+    ) -> httpx2.Response:
         try:
             return fetch_validated_url(
                 method="post",
@@ -87,7 +87,7 @@ class JSONWebhookBaseAddon(ChangeBaseAddon):
             )
         except ValidationError as error:
             raise MessageNotDeliveredError("; ".join(error.messages)) from error
-        except requests.exceptions.ConnectionError as error:
+        except httpx2.TransportError as error:
             msg = "Unable to deliver webhook: could not connect to the remote server."
             raise MessageNotDeliveredError(msg) from error
 
@@ -177,7 +177,10 @@ class WebhookAddon(JSONWebhookBaseAddon):
         }
         if secret := self.instance.configuration.get("secret", ""):
             headers["webhook-signature"] = standard_webhooks_sign(
-                secret, webhook_id, attempt_time, json.dumps(payload)
+                secret,
+                webhook_id,
+                attempt_time,
+                json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
             )
 
         return headers

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import responses
 import yaml
 from django.conf import settings
 from django.contrib import messages as django_messages
@@ -101,6 +100,7 @@ from weblate.utils.state import (
     STATE_NEEDS_REWRITING,
     STATE_TRANSLATED,
 )
+from weblate.utils.tests import http_mock as responses
 from weblate.utils.version import GIT_VERSION
 from weblate.utils.version_display import VERSION_DISPLAY_HIDE, VERSION_DISPLAY_SOFT
 from weblate.vcs.base import RepositoryError, RepositoryLock

--- a/weblate/machinery/alibaba.py
+++ b/weblate/machinery/alibaba.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote
 from uuid import uuid4
 
-from requests.exceptions import JSONDecodeError
+from weblate.utils.requests import JSON_RESPONSE_ERRORS
 
 from .base import (
     MACHINERY_DEFAULT_THRESHOLD,
@@ -23,7 +23,7 @@ from .forms import AlibabaMachineryForm
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from requests import Response
+    import httpx2
 
     from .base import DownloadTranslations
 
@@ -104,10 +104,10 @@ class AlibabaTranslation(MachineTranslation):
         )
         return query_params
 
-    def check_failure(self, response: Response) -> None:
+    def check_failure(self, response: httpx2.Response) -> None:
         try:
             payload = response.json()
-        except JSONDecodeError:
+        except JSON_RESPONSE_ERRORS:
             super().check_failure(response)
             return
 

--- a/weblate/machinery/anthropic.py
+++ b/weblate/machinery/anthropic.py
@@ -51,7 +51,37 @@ class AnthropicTranslation(BaseLLMTranslation):
         self, prompt: str, content: str, previous_content: str, previous_response: str
     ) -> str | None:
         model = self.get_traced_model()
-        payload = {
+        response = self.request(
+            "post",
+            self.get_chat_url(),
+            json=self.get_chat_payload(
+                model, prompt, content, previous_content, previous_response
+            ),
+        )
+        return self.parse_chat_response(response.json())
+
+    async def afetch_llm_translations(
+        self, prompt: str, content: str, previous_content: str, previous_response: str
+    ) -> str | None:
+        model = await self.aget_traced_model()
+        response = await self.arequest(
+            "post",
+            self.get_chat_url(),
+            json=self.get_chat_payload(
+                model, prompt, content, previous_content, previous_response
+            ),
+        )
+        return self.parse_chat_response(response.json())
+
+    def get_chat_payload(
+        self,
+        model: str,
+        prompt: str,
+        content: str,
+        previous_content: str,
+        previous_response: str,
+    ) -> dict:
+        return {
             "model": model,
             "max_tokens": self.settings.get("max_tokens", 4096),
             "system": prompt,
@@ -61,13 +91,15 @@ class AnthropicTranslation(BaseLLMTranslation):
                 {"role": "user", "content": content},
             ],
         }
-        api_url = urljoin(
+
+    def get_chat_url(self) -> str:
+        return urljoin(
             self.settings.get("base_url") or "https://api.anthropic.com",
             self.end_point,
         )
-        response = self.request("post", api_url, json=payload)
-        response_data = response.json()
 
+    @staticmethod
+    def parse_chat_response(response_data) -> str | None:
         content_blocks = response_data.get("content", [])
         for block in content_blocks:
             if isinstance(block, dict) and block.get("type") == "text":

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -11,18 +11,20 @@ import random
 import re
 import time
 from collections import defaultdict
+from dataclasses import dataclass
 from hashlib import md5
 from html import escape, unescape
 from itertools import chain
 from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote, urlparse
 
+import httpx2
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
 from django.utils.translation import gettext
-from requests.exceptions import HTTPError, JSONDecodeError, RequestException
 
 from weblate.checks.utils import highlight_string
 from weblate.lang.models import Language, PluralMapper
@@ -33,9 +35,11 @@ from weblate.utils.forms import WeblateServiceURLField
 from weblate.utils.hash import calculate_dict_hash, calculate_hash, hash_to_checksum
 from weblate.utils.outbound import is_allowlisted_hostname
 from weblate.utils.requests import (
+    JSON_RESPONSE_ERRORS,
+    async_fetch_url,
+    async_fetch_validated_url,
     fetch_url,
     fetch_validated_url,
-    validate_request_url,
 )
 from weblate.utils.similarity import Comparer
 from weblate.utils.site import get_site_url
@@ -48,9 +52,6 @@ MACHINERY_DEFAULT_THRESHOLD = 80
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
-
-    from requests import Response
-    from requests.auth import AuthBase
 
     from weblate.auth.models import User
     from weblate.checks.base import Highlight
@@ -90,6 +91,16 @@ class GlossaryAlreadyExistsError(MachineTranslationError):
 
 class GlossaryDoesNotExistError(MachineTranslationError):
     """Raised when glossary deletion fails because it does not exist."""
+
+
+@dataclass
+class TranslationDownloadPlan:
+    output: list[list[TranslationResultDict]]
+    pending: dict[str, list[tuple[int, Unit | None, str, dict[str, str]]]]
+    pending_units: dict[str, Unit | None]
+    pending_texts: dict[str, str]
+    pending_occurrences: dict[str, int]
+    cache_keys: dict[str, str | None]
 
 
 class BatchMachineTranslation(DocVersionsMixin):
@@ -191,30 +202,25 @@ class BatchMachineTranslation(DocVersionsMixin):
         """Add authentication headers to request."""
         return {}
 
-    def get_auth(self) -> tuple[str, str] | AuthBase | None:
+    def get_auth(self) -> tuple[str, str] | httpx2.Auth | None:
         return None
 
-    def check_failure(self, response: Response) -> None:
+    def check_failure(self, response: httpx2.Response) -> None:
         # Directly raise error as last resort, subclass can prepend this
         # with something more clever
         try:
             response.raise_for_status()
-        except HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             if detail := self.get_error_detail(response):
                 message = f"{error.args[0]}: {detail[:200]}"
-                raise HTTPError(message, response=response) from error
+                raise httpx2.HTTPStatusError(
+                    message, request=response.request, response=response
+                ) from error
             raise
 
     @property
     def allow_private_targets(self) -> bool:
         return "_project" not in self.settings
-
-    def validate_runtime_url(self, url: str) -> None:
-        validate_request_url(
-            url,
-            allow_private_targets=self.allow_private_targets,
-            allowed_domains=settings.ALLOWED_MACHINERY_DOMAINS,
-        )
 
     @staticmethod
     def get_host_from_setting(value: object) -> str | None:
@@ -267,28 +273,28 @@ class BatchMachineTranslation(DocVersionsMixin):
                 return True
         return False
 
-    def can_display_error_detail(self, response: Response) -> bool:
+    def can_display_error_detail(self, response: httpx2.Response) -> bool:
         if self.allow_private_targets:
             return True
         return self.is_trusted_error_host(response)
 
-    def is_trusted_error_host(self, response: Response) -> bool:
+    def is_trusted_error_host(self, response: httpx2.Response) -> bool:
         if (
             self.settings_form is not None
             and not self.has_configurable_outbound_target()
         ):
             return True
-        hostname = urlparse(response.url).hostname or ""
+        hostname = response.url.host
         return is_allowlisted_hostname(hostname, list(self.get_trusted_error_hosts()))
 
-    def get_error_detail(self, response: Response) -> str | None:
+    def get_error_detail(self, response: httpx2.Response) -> str | None:
         if not self.can_display_error_detail(response):
             return None
         trusted_host = self.is_trusted_error_host(response)
 
         try:
             payload = response.json()
-        except JSONDecodeError:
+        except JSON_RESPONSE_ERRORS:
             if trusted_host:
                 return response.text or None
             return None
@@ -311,8 +317,7 @@ class BatchMachineTranslation(DocVersionsMixin):
             return response.text or None
         return None
 
-    def request(self, method, url, skip_auth=False, **kwargs):
-        """Perform JSON request."""
+    def _prepare_request_kwargs(self, skip_auth: bool, kwargs: dict) -> dict:
         # Create custom headers
         headers = {
             "Referer": get_site_url(),
@@ -323,29 +328,51 @@ class BatchMachineTranslation(DocVersionsMixin):
         # Optional authentication
         if not skip_auth:
             headers.update(self.get_headers())
+        return {
+            **kwargs,
+            "headers": headers,
+            "timeout": self.request_timeout,
+            "auth": self.get_auth(),
+            "raise_for_status": False,
+        }
 
+    def request(self, method, url, skip_auth=False, **kwargs):
+        """Perform JSON request."""
+        request_kwargs = self._prepare_request_kwargs(skip_auth, kwargs)
         # Fire request
         if self.allow_private_targets:
             response = fetch_url(
                 method,
                 url,
-                headers=headers,
-                timeout=self.request_timeout,
-                auth=self.get_auth(),
-                raise_for_status=False,
-                **kwargs,
+                **request_kwargs,
             )
         else:
             response = fetch_validated_url(
                 method,
                 url,
-                headers=headers,
-                timeout=self.request_timeout,
-                auth=self.get_auth(),
-                raise_for_status=False,
                 allow_private_targets=False,
                 allowed_domains=settings.ALLOWED_MACHINERY_DOMAINS,
-                **kwargs,
+                **request_kwargs,
+            )
+
+        self.check_failure(response)
+
+        return response
+
+    async def arequest(self, method, url, skip_auth=False, **kwargs):
+        """Perform JSON request without blocking the event loop."""
+        request_kwargs = await sync_to_async(self._prepare_request_kwargs)(
+            skip_auth, kwargs
+        )
+        if self.allow_private_targets:
+            response = await async_fetch_url(method, url, **request_kwargs)
+        else:
+            response = await async_fetch_validated_url(
+                method,
+                url,
+                allow_private_targets=False,
+                allowed_domains=settings.ALLOWED_MACHINERY_DOMAINS,
+                **request_kwargs,
             )
 
         self.check_failure(response)
@@ -364,11 +391,18 @@ class BatchMachineTranslation(DocVersionsMixin):
         return code
 
     def report_error(
-        self, cause: str, extra_log: str | None = None, message: bool = False
+        self,
+        cause: str,
+        extra_log: str | None = None,
+        message: bool = False,
+        exception: BaseException | None = None,
     ) -> None:
         """Report error situations."""
         report_error(
-            f"machinery[{self.name}]: {cause}", extra_log=extra_log, message=message
+            f"machinery[{self.name}]: {cause}",
+            extra_log=extra_log,
+            message=message,
+            exception=exception,
         )
 
     def log_handled_error(self, cause: str, extra_log: str | None = None) -> None:
@@ -417,7 +451,7 @@ class BatchMachineTranslation(DocVersionsMixin):
     def is_rate_limit_error(self, exc: Exception) -> bool:
         if isinstance(exc, MachineryRateLimitError):
             return True
-        if not isinstance(exc, HTTPError) or exc.response is None:
+        if not isinstance(exc, httpx2.HTTPStatusError):
             return False
         # Apply rate limiting for following status codes:
         # HTTP 456 Client Error: Quota Exceeded (DeepL)
@@ -662,8 +696,7 @@ class BatchMachineTranslation(DocVersionsMixin):
             text=text,
         )
 
-    def search(self, unit, text, user: User | None):
-        """Search for known translations of `text`."""
+    def _prepare_search(self, unit, text):
         translation = unit.translation
         try:
             source_language, target_language = self.get_languages(
@@ -676,11 +709,31 @@ class BatchMachineTranslation(DocVersionsMixin):
                 translation.component.source_language.code,
                 translation.language.code,
             )
-            return []
+            return None
 
         self.account_usage(translation.component.project)
+        return source_language, target_language, [(text, unit)]
+
+    def search(self, unit, text, user: User | None):
+        """Search for known translations of `text`."""
+        prepared = self._prepare_search(unit, text)
+        if prepared is None:
+            return []
+        source_language, target_language, sources = prepared
         return self._translate_sources(
-            source_language, target_language, [(text, unit)], user, threshold=10
+            source_language, target_language, sources, user, threshold=10
+        )[0]
+
+    async def asearch(self, unit, text, user: User | None):
+        """Search for known translations without blocking the event loop."""
+        prepared = await sync_to_async(self._prepare_search)(unit, text)
+        if prepared is None:
+            return []
+        source_language, target_language, sources = prepared
+        return (
+            await self._atranslate_sources(
+                source_language, target_language, sources, user, threshold=10
+            )
         )[0]
 
     def get_default_source_language(self, translation: Translation) -> Language:
@@ -700,15 +753,12 @@ class BatchMachineTranslation(DocVersionsMixin):
 
         return self.get_default_source_language(translation)
 
-    def translate(
+    def _prepare_translate(
         self,
         unit: Unit,
-        user: User | None = None,
-        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
         *,
         source_language: Language | None = None,
     ):
-        """Return list of machine translations."""
         translation = unit.translation
         if source_language is None:
             # Fall back to component source language
@@ -728,7 +778,7 @@ class BatchMachineTranslation(DocVersionsMixin):
                 source_language.code,
                 translation.language.code,
             )
-            return []
+            return None
 
         self.account_usage(translation.component.project)
 
@@ -740,13 +790,68 @@ class BatchMachineTranslation(DocVersionsMixin):
             alternate_units = plural_mapper.get_other_units([unit], source_language)
 
         plural_mapper.map_units([unit], alternate_units)
-        return self._translate_sources(
+        return (
             mapped_source_language,
             target_language,
             [(text, unit) for text in unit.plural_map],
+        )
+
+    def translate(
+        self,
+        unit: Unit,
+        user: User | None = None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+        *,
+        source_language: Language | None = None,
+    ):
+        """Return list of machine translations."""
+        prepared = self._prepare_translate(unit, source_language=source_language)
+        if prepared is None:
+            return []
+        mapped_source_language, target_language, sources = prepared
+        return self._translate_sources(
+            mapped_source_language,
+            target_language,
+            sources,
             user,
             threshold=threshold,
         )
+
+    async def atranslate(
+        self,
+        unit: Unit,
+        user: User | None = None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+        *,
+        source_language: Language | None = None,
+    ):
+        """Return machine translations without blocking the event loop."""
+        prepared = await sync_to_async(self._prepare_translate)(
+            unit, source_language=source_language
+        )
+        if prepared is None:
+            return []
+        mapped_source_language, target_language, sources = prepared
+        return await self._atranslate_sources(
+            mapped_source_language,
+            target_language,
+            sources,
+            user,
+            threshold=threshold,
+        )
+
+    async def adownload_multiple_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        user: User | None = None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadMultipleTranslations:
+        """Download translations while keeping synchronous backends usable."""
+        return await sync_to_async(
+            self.download_multiple_translations, thread_sensitive=False
+        )(source_language, target_language, sources, user, threshold)
 
     def download_multiple_translations(
         self,
@@ -795,6 +900,47 @@ class BatchMachineTranslation(DocVersionsMixin):
         user=None,
         threshold: int = MACHINERY_DEFAULT_THRESHOLD,
     ) -> list[list[TranslationResultDict]]:
+        plan = self._prepare_translation_download(
+            source_language, target_language, sources, threshold
+        )
+        if plan.pending:
+            self._download_pending_translations(
+                plan,
+                source_language=source_language,
+                target_language=target_language,
+                user=user,
+                threshold=threshold,
+            )
+        return plan.output
+
+    async def _atranslate_sources(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        user=None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> list[list[TranslationResultDict]]:
+        plan = await sync_to_async(self._prepare_translation_download)(
+            source_language, target_language, sources, threshold
+        )
+        if plan.pending:
+            await self._adownload_pending_translations(
+                plan,
+                source_language=source_language,
+                target_language=target_language,
+                user=user,
+                threshold=threshold,
+            )
+        return plan.output
+
+    def _prepare_translation_download(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        threshold: int,
+    ) -> TranslationDownloadPlan:
         output: list[list[TranslationResultDict]] = [[] for _source in sources]
         pending: dict[str, list[tuple[int, Unit | None, str, dict[str, str]]]] = (
             defaultdict(list)
@@ -855,48 +1001,29 @@ class BatchMachineTranslation(DocVersionsMixin):
             pending_occurrences[pending_key] = source_occurrence
             cache_keys[pending_key] = cache_key
 
-        # Fetch pending strings to translate
-        if pending:
-            self._download_pending_translations(
-                pending,
-                pending_units,
-                pending_texts,
-                pending_occurrences,
-                cache_keys,
-                output,
-                source_language=source_language,
-                target_language=target_language,
-                user=user,
-                threshold=threshold,
-            )
-        return output
+        return TranslationDownloadPlan(
+            output=output,
+            pending=pending,
+            pending_units=pending_units,
+            pending_texts=pending_texts,
+            pending_occurrences=pending_occurrences,
+            cache_keys=cache_keys,
+        )
 
     def _download_pending_translations(
         self,
-        pending: dict[str, list[tuple[int, Unit | None, str, dict[str, str]]]],
-        pending_units: dict[str, Unit | None],
-        pending_texts: dict[str, str],
-        pending_occurrences: dict[str, int],
-        cache_keys: dict[str, str | None],
-        output: list[list[TranslationResultDict]],
+        plan: TranslationDownloadPlan,
         *,
         source_language,
         target_language,
         user=None,
         threshold: int = MACHINERY_DEFAULT_THRESHOLD,
     ) -> None:
-        remaining_keys = list(pending)
+        remaining_keys = list(plan.pending)
         while remaining_keys:
-            batch_keys: list[str] = []
-            batch_texts: set[str] = set()
-            next_remaining_keys: list[str] = []
-            for pending_key in remaining_keys:
-                text = pending_texts[pending_key]
-                if text in batch_texts:
-                    next_remaining_keys.append(pending_key)
-                    continue
-                batch_keys.append(pending_key)
-                batch_texts.add(text)
+            batch_keys, remaining_keys = self._get_pending_batch(
+                remaining_keys, plan.pending_texts
+            )
 
             # Unit is only used in WeblateMemory and it is used only to get a project
             # so it doesn't matter we potentially flatten this.
@@ -906,9 +1033,9 @@ class BatchMachineTranslation(DocVersionsMixin):
                     target_language,
                     [
                         (
-                            pending_texts[pending_key],
-                            pending_units[pending_key],
-                            pending_occurrences[pending_key],
+                            plan.pending_texts[pending_key],
+                            plan.pending_units[pending_key],
+                            plan.pending_occurrences[pending_key],
                         )
                         for pending_key in batch_keys
                     ],
@@ -916,31 +1043,93 @@ class BatchMachineTranslation(DocVersionsMixin):
                     threshold,
                 )
             except Exception as exc:
-                if self.is_rate_limit_error(exc):
-                    self.set_rate_limit()
+                self._handle_download_error(exc)
 
-                self.report_error("Could not fetch translations")
-                if isinstance(exc, MachineTranslationError):
-                    raise
-                raise MachineTranslationError(self.get_error_message(exc)) from exc
+            self._apply_downloaded_translations(plan, batch_keys, translations)
 
-            # Postprocess translations
-            for pending_key in batch_keys:
-                text = pending_texts[pending_key]
-                result = translations[text]
-                for index, _unit, original_source, replacements in pending[pending_key]:
-                    # Always operate on copy of the dictionaries
-                    partial = [x.copy() for x in result]
+    async def _adownload_pending_translations(
+        self,
+        plan: TranslationDownloadPlan,
+        *,
+        source_language,
+        target_language,
+        user=None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> None:
+        remaining_keys = list(plan.pending)
+        while remaining_keys:
+            batch_keys, remaining_keys = self._get_pending_batch(
+                remaining_keys, plan.pending_texts
+            )
+            try:
+                translations = await self.adownload_pending_translations(
+                    source_language,
+                    target_language,
+                    [
+                        (
+                            plan.pending_texts[pending_key],
+                            plan.pending_units[pending_key],
+                            plan.pending_occurrences[pending_key],
+                        )
+                        for pending_key in batch_keys
+                    ],
+                    user,
+                    threshold,
+                )
+            except Exception as exc:
+                await sync_to_async(self._handle_download_error)(exc)
 
-                    for item in partial:
-                        item["original_source"] = original_source
-                    if cache_key := cache_keys[pending_key]:
-                        cache.set(cache_key, partial, self.cache_expiry)
-                    if replacements or self.force_uncleanup:
-                        self.uncleanup_results(replacements, partial)
-                    output[index] = partial
+            await sync_to_async(self._apply_downloaded_translations)(
+                plan, batch_keys, translations
+            )
 
-            remaining_keys = next_remaining_keys
+    @staticmethod
+    def _get_pending_batch(
+        remaining_keys: list[str], pending_texts: dict[str, str]
+    ) -> tuple[list[str], list[str]]:
+        batch_keys: list[str] = []
+        batch_texts: set[str] = set()
+        next_remaining_keys: list[str] = []
+        for pending_key in remaining_keys:
+            text = pending_texts[pending_key]
+            if text in batch_texts:
+                next_remaining_keys.append(pending_key)
+                continue
+            batch_keys.append(pending_key)
+            batch_texts.add(text)
+        return batch_keys, next_remaining_keys
+
+    def _handle_download_error(self, exc: Exception) -> None:
+        if self.is_rate_limit_error(exc):
+            self.set_rate_limit()
+
+        self.report_error("Could not fetch translations", exception=exc)
+        if isinstance(exc, MachineTranslationError):
+            raise exc
+        raise MachineTranslationError(self.get_error_message(exc)) from exc
+
+    def _apply_downloaded_translations(
+        self,
+        plan: TranslationDownloadPlan,
+        batch_keys: list[str],
+        translations: DownloadMultipleTranslations,
+    ) -> None:
+        for pending_key in batch_keys:
+            text = plan.pending_texts[pending_key]
+            result = translations[text]
+            for index, _unit, original_source, replacements in plan.pending[
+                pending_key
+            ]:
+                # Always operate on copy of the dictionaries
+                partial = [x.copy() for x in result]
+
+                for item in partial:
+                    item["original_source"] = original_source
+                if cache_key := plan.cache_keys[pending_key]:
+                    cache.set(cache_key, partial, self.cache_expiry)
+                if replacements or self.force_uncleanup:
+                    self.uncleanup_results(replacements, partial)
+                plan.output[index] = partial
 
     def download_pending_translations(
         self,
@@ -958,10 +1147,34 @@ class BatchMachineTranslation(DocVersionsMixin):
             threshold,
         )
 
+    async def adownload_pending_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None, int]],
+        user: User | None = None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadMultipleTranslations:
+        if (
+            type(self).download_pending_translations
+            is BatchMachineTranslation.download_pending_translations
+        ):
+            return await self.adownload_multiple_translations(
+                source_language,
+                target_language,
+                [(text, unit) for text, unit, _occurrence in sources],
+                user,
+                threshold,
+            )
+        return await sync_to_async(
+            self.download_pending_translations, thread_sensitive=False
+        )(source_language, target_language, sources, user, threshold)
+
     def get_error_message(self, exc: Exception) -> str:
         message = f"{exc.__class__.__name__}: {exc}"
-        if isinstance(exc, RequestException) and exc.response:
-            detail = self.get_error_detail(exc.response)
+        response = getattr(exc, "response", None)
+        if isinstance(exc, httpx2.HTTPError) and response is not None:
+            detail = self.get_error_detail(response)
             if detail and detail not in str(exc):
                 return f"{message}: {detail}"
         return message
@@ -1056,6 +1269,30 @@ class BatchMachineTranslation(DocVersionsMixin):
 
 
 class MachineTranslation(BatchMachineTranslation):
+    async def adownload_translations(
+        self,
+        source_language,
+        target_language,
+        text: str,
+        unit: Unit | None,
+        user: User | None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadTranslations:
+        """Download one translation using a synchronous backend as fallback."""
+        return await sync_to_async(
+            lambda: list(
+                self.download_translations(
+                    source_language,
+                    target_language,
+                    text,
+                    unit,
+                    user,
+                    threshold=threshold,
+                )
+            ),
+            thread_sensitive=False,
+        )()
+
     def download_translations(
         self,
         source_language,
@@ -1098,6 +1335,28 @@ class MachineTranslation(BatchMachineTranslation):
             )
             for text, unit in sources
         }
+
+    async def adownload_multiple_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        user: User | None = None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadMultipleTranslations:
+        result: DownloadMultipleTranslations = {}
+        for text, unit in sources:
+            result[text] = list(
+                await self.adownload_translations(
+                    source_language,
+                    target_language,
+                    text,
+                    unit,
+                    user,
+                    threshold=threshold,
+                )
+            )
+        return result
 
 
 class InternalMachineTranslation(MachineTranslation):
@@ -1308,10 +1567,10 @@ class XMLMachineTranslationMixin(BatchMachineTranslation):
 
 
 class ResponseStatusMachineTranslation(MachineTranslation):
-    def check_failure(self, response: Response) -> None:
+    def check_failure(self, response: httpx2.Response) -> None:
         try:
             payload = response.json()
-        except JSONDecodeError:
+        except JSON_RESPONSE_ERRORS:
             super().check_failure(response)
             return
 

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -8,9 +8,10 @@ import contextlib
 from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import urlsplit, urlunsplit
 
+import httpx2
+from asgiref.sync import sync_to_async
 from dateutil.parser import isoparse
 from django.core.cache import cache
-from requests.exceptions import HTTPError, RequestException
 
 from .base import (
     MACHINERY_DEFAULT_THRESHOLD,
@@ -121,7 +122,7 @@ class DeepLTranslation(
         )
 
     def get_error_message(self, exc):
-        if isinstance(exc, RequestException) and exc.response is not None:
+        if isinstance(exc, httpx2.HTTPStatusError):
             try:
                 data = exc.response.json()
             except ValueError:
@@ -132,7 +133,7 @@ class DeepLTranslation(
                 except KeyError:
                     pass
 
-        if isinstance(exc, HTTPError) and exc.response.status_code == 456:
+        if isinstance(exc, httpx2.HTTPStatusError) and exc.response.status_code == 456:
             return "Quota exceeded. The character limit has been reached."
 
         return super().get_error_message(exc)
@@ -179,7 +180,42 @@ class DeepLTranslation(
         user: User | None = None,
         threshold: int = MACHINERY_DEFAULT_THRESHOLD,
     ) -> DownloadMultipleTranslations:
-        """Download list of possible translations from a service."""
+        """Download translations from DeepL."""
+        texts, params = self._prepare_translation_request(
+            source_language, target_language, sources
+        )
+        response = self.request(
+            "post",
+            self.get_api_url("v2", "translate"),
+            json=params,
+        )
+        return self._parse_translations(texts, response.json())
+
+    async def adownload_multiple_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        user: User | None = None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadMultipleTranslations:
+        """Download translations from DeepL without blocking."""
+        texts, params = await sync_to_async(self._prepare_translation_request)(
+            source_language, target_language, sources
+        )
+        response = await self.arequest(
+            "post",
+            self.get_api_url("v2", "translate"),
+            json=params,
+        )
+        return self._parse_translations(texts, response.json())
+
+    def _prepare_translation_request(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+    ) -> tuple[list[str], dict]:
         texts = [text for text, _unit in sources]
         unit = sources[0][1]
 
@@ -205,14 +241,11 @@ class DeepLTranslation(
             params["glossary_id"] = glossary_id
         if self.settings.get("next_gen"):
             params["model_type"] = "prefer_quality_optimized"
+        return texts, params
 
-        response = self.request(
-            "post",
-            self.get_api_url("v2", "translate"),
-            json=params,
-        )
-        payload = response.json()
-
+    def _parse_translations(
+        self, texts: list[str], payload: dict
+    ) -> DownloadMultipleTranslations:
         result: DownloadMultipleTranslations = {}
         for index, text in enumerate(texts):
             result[text] = [
@@ -305,7 +338,7 @@ class DeepLTranslation(
                 "delete",
                 self.get_api_url("v3", "glossaries", glossary_id),
             )
-        except HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             if error.response.status_code in {400, 404}:
                 raise GlossaryDoesNotExistError from error
 
@@ -330,7 +363,7 @@ class DeepLTranslation(
                 self.get_api_url("v3", "glossaries", glossary_id),
                 json={"name": name},
             )
-        except HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             if error.response.status_code == 404:
                 raise GlossaryDoesNotExistError from error
             raise

--- a/weblate/machinery/google.py
+++ b/weblate/machinery/google.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from requests.exceptions import RequestException
+import httpx2
 
 from .base import (
     MACHINERY_DEFAULT_THRESHOLD,
@@ -104,7 +104,7 @@ class GoogleTranslation(GoogleBaseTranslation):
         }
 
     def get_error_message(self, exc):
-        if isinstance(exc, RequestException) and exc.response is not None:
+        if isinstance(exc, httpx2.HTTPStatusError):
             data = exc.response.json()
             try:
                 return data["error"]["message"]

--- a/weblate/machinery/libretranslate.py
+++ b/weblate/machinery/libretranslate.py
@@ -79,6 +79,26 @@ class BaseLibreTranslateTranslation(BatchMachineTranslation):
         )
         return self._parse_translated_texts(response.json(), texts)
 
+    async def _arequest_translations(
+        self,
+        source_language: str,
+        target_language: str,
+        texts: list[str],
+        *,
+        scalar_query: bool = False,
+    ) -> list[str]:
+        response = await self.arequest(
+            "post",
+            self.get_api_url("translate"),
+            json={
+                "api_key": self.settings["key"],
+                "q": texts[0] if scalar_query else texts,
+                "source": source_language,
+                "target": target_language,
+            },
+        )
+        return self._parse_translated_texts(response.json(), texts)
+
     def download_translated_texts(
         self,
         source_language: str,
@@ -87,6 +107,17 @@ class BaseLibreTranslateTranslation(BatchMachineTranslation):
     ) -> list[str]:
         """Download translated texts from a service."""
         return self._request_translations(source_language, target_language, texts)
+
+    async def adownload_translated_texts(
+        self,
+        source_language: str,
+        target_language: str,
+        texts: list[str],
+    ) -> list[str]:
+        """Download translated texts without blocking."""
+        return await self._arequest_translations(
+            source_language, target_language, texts
+        )
 
     def format_translations(
         self, texts: list[str], translated_texts: list[str]
@@ -115,6 +146,21 @@ class BaseLibreTranslateTranslation(BatchMachineTranslation):
         """Download list of possible translations from a service."""
         texts = [text for text, _unit in sources]
         translated_texts = self.download_translated_texts(
+            source_language, target_language, texts
+        )
+        return self.format_translations(texts, translated_texts)
+
+    async def adownload_multiple_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        user=None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadMultipleTranslations:
+        """Download translations without blocking."""
+        texts = [text for text, _unit in sources]
+        translated_texts = await self.adownload_translated_texts(
             source_language, target_language, texts
         )
         return self.format_translations(texts, translated_texts)
@@ -148,3 +194,22 @@ class LTEngineTranslation(BaseLibreTranslateTranslation):
             )[0]
             for text in texts
         ]
+
+    async def adownload_translated_texts(
+        self,
+        source_language: str,
+        target_language: str,
+        texts: list[str],
+    ) -> list[str]:
+        """Download scalar translations without blocking."""
+        result = []
+        for text in texts:
+            result.extend(
+                await self._arequest_translations(
+                    source_language,
+                    target_language,
+                    [text],
+                    scalar_query=True,
+                )
+            )
+        return result

--- a/weblate/machinery/llm.py
+++ b/weblate/machinery/llm.py
@@ -14,6 +14,7 @@ from itertools import chain
 from operator import itemgetter
 from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, TypeGuard
 
+from asgiref.sync import sync_to_async
 from django.utils.html import strip_tags
 from django.utils.translation import override, pgettext
 
@@ -294,11 +295,26 @@ class BaseLLMTranslation(BatchMachineTranslation):
     ) -> str | None:
         raise NotImplementedError
 
+    async def afetch_llm_translations(
+        self, prompt: str, content: str, previous_content: str, previous_response: str
+    ) -> str | None:
+        return await sync_to_async(self.fetch_llm_translations, thread_sensitive=False)(
+            prompt, content, previous_content, previous_response
+        )
+
     def get_model(self) -> str:
         raise NotImplementedError
 
+    async def aget_model(self) -> str:
+        return await sync_to_async(self.get_model, thread_sensitive=False)()
+
     def get_traced_model(self) -> str:
         model = self.get_model()
+        add_breadcrumb(self.name, "model", model=model)
+        return model
+
+    async def aget_traced_model(self) -> str:
+        model = await self.aget_model()
         add_breadcrumb(self.name, "model", model=model)
         return model
 
@@ -2289,6 +2305,37 @@ class BaseLLMTranslation(BatchMachineTranslation):
             ],
         )
 
+    async def adownload_multiple_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        user=None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadMultipleTranslations:
+        return await self._adownload_multiple_translations(
+            source_language, target_language, sources, user, threshold
+        )
+
+    async def adownload_pending_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None, int]],
+        user=None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadMultipleTranslations:
+        return await self._adownload_multiple_translations(
+            source_language,
+            target_language,
+            [(text, unit) for text, unit, _occurrence in sources],
+            user,
+            threshold,
+            source_occurrences=[
+                source_occurrence for _text, _unit, source_occurrence in sources
+            ],
+        )
+
     def _download_multiple_translations(
         self,
         source_language,
@@ -2322,8 +2369,57 @@ class BaseLLMTranslation(BatchMachineTranslation):
         *,
         source_occurrences: list[int] | None = None,
     ) -> DownloadMultipleTranslations:
-        result: DownloadMultipleTranslations = defaultdict(list)
+        prompt, content, previous_content, previous_response = (
+            self._prepare_llm_translation(
+                source_language,
+                target_language,
+                sources,
+                source_occurrences,
+            )
+        )
+        translations_string = self.fetch_llm_translations(
+            prompt, content, previous_content, previous_response
+        )
+        return self._parse_llm_translations(
+            translations_string, sources, source_occurrences
+        )
 
+    async def _adownload_multiple_translations(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        user=None,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+        *,
+        source_occurrences: list[int] | None = None,
+    ) -> DownloadMultipleTranslations:
+        started_cache = await sync_to_async(self._ensure_secondary_context_cache)()
+        try:
+            prompt, content, previous_content, previous_response = await sync_to_async(
+                self._prepare_llm_translation
+            )(
+                source_language,
+                target_language,
+                sources,
+                source_occurrences,
+            )
+            translations_string = await self.afetch_llm_translations(
+                prompt, content, previous_content, previous_response
+            )
+            return await sync_to_async(self._parse_llm_translations)(
+                translations_string, sources, source_occurrences
+            )
+        finally:
+            await sync_to_async(self._clear_secondary_context_cache)(started_cache)
+
+    def _prepare_llm_translation(
+        self,
+        source_language,
+        target_language,
+        sources: list[tuple[str, Unit | None]],
+        source_occurrences: list[int] | None,
+    ) -> tuple[str, str, str, str]:
         prompt = self._get_prompt(target_language)
         content = self._get_message(
             source_language, target_language, sources, source_occurrences
@@ -2333,17 +2429,21 @@ class BaseLLMTranslation(BatchMachineTranslation):
         )
         add_breadcrumb(self.name, "prompt", prompt=prompt)
         add_breadcrumb(self.name, "chat", content=content)
+        return prompt, content, previous_content, previous_response
 
-        translations_string = self.fetch_llm_translations(
-            prompt, content, previous_content, previous_response
-        )
-
+    def _parse_llm_translations(
+        self,
+        translations_string: str | None,
+        sources: list[tuple[str, Unit | None]],
+        source_occurrences: list[int] | None,
+    ) -> DownloadMultipleTranslations:
         add_breadcrumb(self.name, "response", translations_string=translations_string)
         if translations_string is None or not translations_string:
             msg = "Blank assistant reply"
             self.log_handled_error(msg, extra_log=translations_string)
             raise MachineTranslationError(msg)
 
+        result: DownloadMultipleTranslations = defaultdict(list)
         try:
             translations = json.loads(translations_string)
         except json.JSONDecodeError as error:

--- a/weblate/machinery/microsoft.py
+++ b/weblate/machinery/microsoft.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import TYPE_CHECKING, ClassVar
-from urllib.parse import urlparse
 
 from django.utils import timezone
 
@@ -117,9 +116,9 @@ class MicrosoftCognitiveTranslation(XMLMachineTranslationMixin, MachineTranslati
 
     def check_failure(self, response) -> None:
         # Microsoft tends to use utf-8-sig instead of plain utf-8
-        response.encoding = response.apparent_encoding
+        response.encoding = "utf-8-sig"
         super().check_failure(response)
-        hostname = urlparse(response.url).hostname
+        hostname = response.url.host
         if response.status_code == 200 and hostname in self.get_application_hosts():
             payload = response.json()
 
@@ -144,7 +143,7 @@ class MicrosoftCognitiveTranslation(XMLMachineTranslationMixin, MachineTranslati
             "get", self.get_url("languages"), params={"api-version": "3.0"}
         )
         # Microsoft tends to use utf-8-sig instead of plain utf-8
-        response.encoding = response.apparent_encoding
+        response.encoding = "utf-8-sig"
         payload = response.json()
 
         return payload["translation"].keys()

--- a/weblate/machinery/modernmt.py
+++ b/weblate/machinery/modernmt.py
@@ -9,8 +9,9 @@ import os
 import tempfile
 from typing import TYPE_CHECKING, ClassVar
 
+import httpx2
+from asgiref.sync import sync_to_async
 from dateutil.parser import isoparse
-from requests.exceptions import HTTPError
 
 import weblate.utils.version
 
@@ -25,6 +26,7 @@ from .forms import ModernMTMachineryForm
 if TYPE_CHECKING:
     from .base import (
         DownloadTranslations,
+        TranslationResultDict,
     )
 
 
@@ -89,6 +91,39 @@ class ModernMTTranslation(GlossaryMachineTranslationMixin):
         threshold: int = MACHINERY_DEFAULT_THRESHOLD,
     ) -> DownloadTranslations:
         """Download list of possible translations from a service."""
+        params = self._prepare_translation_request(
+            source_language, target_language, text, unit
+        )
+        response = self.request(
+            "get",
+            self.get_api_url("translate"),
+            params=params,
+        )
+        yield self._format_translation(text, response.json())
+
+    async def adownload_translations(
+        self,
+        source_language,
+        target_language,
+        text: str,
+        unit,
+        user,
+        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
+    ) -> DownloadTranslations:
+        """Download a translation without blocking."""
+        params = await sync_to_async(self._prepare_translation_request)(
+            source_language, target_language, text, unit
+        )
+        response = await self.arequest(
+            "get",
+            self.get_api_url("translate"),
+            params=params,
+        )
+        return [self._format_translation(text, response.json())]
+
+    def _prepare_translation_request(
+        self, source_language, target_language, text: str, unit
+    ) -> dict[str, str]:
         params = {"q": text, "source": source_language, "target": target_language}
         glossary_id: str | None = self.get_glossary_id(
             source_language, target_language, unit
@@ -99,15 +134,10 @@ class ModernMTTranslation(GlossaryMachineTranslationMixin):
 
         if context_vector := self.settings.get("context_vector"):
             params["context_vector"] = context_vector
+        return params
 
-        response = self.request(
-            "get",
-            self.get_api_url("translate"),
-            params=params,
-        )
-        payload = response.json()
-
-        yield {
+    def _format_translation(self, text: str, payload: dict) -> TranslationResultDict:
+        return {
             "text": payload["data"]["translation"],
             "quality": self.max_score,
             "service": self.name,
@@ -146,7 +176,7 @@ class ModernMTTranslation(GlossaryMachineTranslationMixin):
         """Delete single glossary."""
         try:
             self.request("delete", self.get_api_url("memories", str(glossary_id)))
-        except HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             if error.response.status_code == 404:
                 raise GlossaryDoesNotExistError from error
 

--- a/weblate/machinery/ollama.py
+++ b/weblate/machinery/ollama.py
@@ -33,7 +33,37 @@ class OllamaTranslation(BaseLLMTranslation):
         self, prompt: str, content: str, previous_content: str, previous_response: str
     ) -> str | None:
         model = self.get_traced_model()
-        payload = {
+        response = self.request(
+            "post",
+            self.get_chat_url(),
+            json=self.get_chat_payload(
+                model, prompt, content, previous_content, previous_response
+            ),
+        )
+        return self.parse_chat_response(response.json())
+
+    async def afetch_llm_translations(
+        self, prompt: str, content: str, previous_content: str, previous_response: str
+    ) -> str | None:
+        model = await self.aget_traced_model()
+        response = await self.arequest(
+            "post",
+            self.get_chat_url(),
+            json=self.get_chat_payload(
+                model, prompt, content, previous_content, previous_response
+            ),
+        )
+        return self.parse_chat_response(response.json())
+
+    @staticmethod
+    def get_chat_payload(
+        model: str,
+        prompt: str,
+        content: str,
+        previous_content: str,
+        previous_response: str,
+    ) -> dict:
+        return {
             "model": model,
             "messages": [
                 {"role": "system", "content": prompt},
@@ -43,10 +73,13 @@ class OllamaTranslation(BaseLLMTranslation):
             ],
             "stream": False,
         }
-        api_url = urljoin(self.settings["base_url"], self.end_point)
-        response = self.request("post", api_url, json=payload)
 
-        if message := response.json().get("message"):
+    def get_chat_url(self) -> str:
+        return urljoin(self.settings["base_url"], self.end_point)
+
+    @staticmethod
+    def parse_chat_response(response_data) -> str | None:
+        if message := response_data.get("message"):
             return message["content"]
 
         return None

--- a/weblate/machinery/openai.py
+++ b/weblate/machinery/openai.py
@@ -37,23 +37,49 @@ class BaseOpenAITranslation(BaseLLMTranslation):
     def fetch_llm_translations(
         self, prompt: str, content: str, previous_content: str, previous_response: str
     ) -> str | None:
-        messages = [
-            {"role": "system", "content": prompt},
-            {"role": "user", "content": previous_content},
-            {"role": "assistant", "content": previous_response},
-            {"role": "user", "content": content},
-        ]
-        self.validate_runtime_url(self.get_runtime_base_url())
         model = self.get_traced_model()
         response = self.request(
             "post",
             self.get_chat_completions_url(),
-            json={
-                "model": model,
-                "messages": messages,
-            },
+            json=self.get_chat_payload(
+                model, prompt, content, previous_content, previous_response
+            ),
         )
-        payload = response.json()
+        return self.parse_chat_response(response.json())
+
+    async def afetch_llm_translations(
+        self, prompt: str, content: str, previous_content: str, previous_response: str
+    ) -> str | None:
+        model = await self.aget_traced_model()
+        response = await self.arequest(
+            "post",
+            self.get_chat_completions_url(),
+            json=self.get_chat_payload(
+                model, prompt, content, previous_content, previous_response
+            ),
+        )
+        return self.parse_chat_response(response.json())
+
+    @staticmethod
+    def get_chat_payload(
+        model: str,
+        prompt: str,
+        content: str,
+        previous_content: str,
+        previous_response: str,
+    ) -> dict:
+        return {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": previous_content},
+                {"role": "assistant", "content": previous_response},
+                {"role": "user", "content": content},
+            ],
+        }
+
+    @staticmethod
+    def parse_chat_response(payload) -> str | None:
         choices = payload.get("choices", []) if isinstance(payload, dict) else []
         if choices:
             first_choice = choices[0]
@@ -98,23 +124,43 @@ class OpenAITranslation(BaseOpenAITranslation):
                 # hiredis-py 3 makes list from set
                 self._models = set(models_cache)
             else:
-                self.validate_runtime_url(self.get_runtime_base_url())
                 payload = self.request("get", self.get_models_url()).json()
-                models = payload.get("data", []) if isinstance(payload, dict) else []
-                self._models = {
-                    model["id"]
-                    for model in models
-                    if isinstance(model, dict) and isinstance(model.get("id"), str)
-                }
+                self._models = self.parse_models(payload)
                 cache.set(cache_key, self._models, 3600)
 
-        if self.settings["model"] in self._models:
+        return self.select_model()
+
+    async def aget_model(self) -> str:
+        if self._models is None:
+            cache_key = self.get_cache_key("models")
+            models_cache = await cache.aget(cache_key)
+            if models_cache is not None:
+                self._models = set(models_cache)
+            else:
+                payload = (await self.arequest("get", self.get_models_url())).json()
+                self._models = self.parse_models(payload)
+                await cache.aset(cache_key, self._models, 3600)
+
+        return self.select_model()
+
+    @staticmethod
+    def parse_models(payload) -> set[str]:
+        models = payload.get("data", []) if isinstance(payload, dict) else []
+        return {
+            model["id"]
+            for model in models
+            if isinstance(model, dict) and isinstance(model.get("id"), str)
+        }
+
+    def select_model(self) -> str:
+        models = self._models if self._models is not None else set()
+        if self.settings["model"] in models:
             return self.settings["model"]
         if self.settings["model"] == "auto":
             for model, _name in self.settings_form.MODEL_CHOICES:
                 if model == "auto":
                     continue
-                if model in self._models:
+                if model in models:
                     return model
         if self.settings["model"] == "custom":
             return self.settings["custom_model"]
@@ -146,3 +192,6 @@ class AzureOpenAITranslation(BaseOpenAITranslation):
 
     def get_model(self) -> str:
         return self.settings["deployment"]
+
+    async def aget_model(self) -> str:
+        return self.get_model()

--- a/weblate/machinery/saptranslationhub.py
+++ b/weblate/machinery/saptranslationhub.py
@@ -11,7 +11,7 @@ from .base import MACHINERY_DEFAULT_THRESHOLD, MachineTranslation
 from .forms import SAPMachineryForm
 
 if TYPE_CHECKING:
-    from requests.auth import AuthBase
+    import httpx2
 
     from .base import DownloadTranslations
 
@@ -37,7 +37,7 @@ class SAPTranslationHub(MachineTranslation):
 
         return result
 
-    def get_auth(self) -> tuple[str, str] | AuthBase | None:
+    def get_auth(self) -> tuple[str, str] | httpx2.Auth | None:
         # to access the productive API
         if self.settings["username"] and self.settings["password"]:
             return (self.settings["username"], self.settings["password"])

--- a/weblate/machinery/systran.py
+++ b/weblate/machinery/systran.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import httpx2
+
 from .base import (
     MACHINERY_DEFAULT_THRESHOLD,
     MachineTranslation,
@@ -22,6 +24,9 @@ class SystranTranslation(MachineTranslation):
         return {"Authorization": f"Key {self.settings['key']}"}
 
     def check_failure(self, response) -> None:
+        if isinstance(response, httpx2.Response):
+            super().check_failure(response)
+            return
         if "error" not in response:
             return
         raise MachineTranslationError(response["error"]["message"])

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -13,10 +13,11 @@ from functools import partial
 from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, NoReturn, cast
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 from urllib.parse import parse_qs, urlparse
 
-import responses
+import httpx2
+from asgiref.sync import async_to_sync
 from botocore.stub import ANY, Stubber
 from django.conf import settings as django_settings
 from django.core.cache import cache
@@ -36,7 +37,6 @@ from google.cloud.translate import (
 )
 from google.cloud.translate_v3 import Glossary
 from google.oauth2 import service_account
-from requests.exceptions import HTTPError, JSONDecodeError
 
 from weblate.checks import flags as check_flags
 from weblate.checks import models as check_models
@@ -107,18 +107,33 @@ from weblate.trans.tests.test_views import (
 from weblate.trans.tests.utils import get_test_file
 from weblate.trans.util import join_plural
 from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
+from weblate.utils.tests import http_mock as responses
 
 from .types import SourceLanguageChoices
 
 if TYPE_CHECKING:
     from typing import Any
 
-    from requests import PreparedRequest
-
     from weblate.machinery.base import (
         BatchMachineTranslation,
         SettingsDict,
     )
+    from weblate.utils.tests.http_mock import PreparedRequest
+
+HTTPError = httpx2.HTTPStatusError
+
+
+def make_error_response(
+    url: str,
+    status_code: int,
+    *,
+    json_data: object | None = None,
+    text: str = "",
+) -> httpx2.Response:
+    request = httpx2.Request("GET", url)
+    if json_data is not None:
+        return httpx2.Response(status_code, request=request, json=json_data)
+    return httpx2.Response(status_code, request=request, text=text)
 
 
 class InternalTestTranslation(InternalMachineTranslation):
@@ -464,6 +479,23 @@ class BaseMachineTranslationTest(TestCase):
                         )
         return translation
 
+    def assert_async_translate(
+        self,
+        lang: str,
+        word: str,
+        expected_len: int,
+        *,
+        machine: BatchMachineTranslation | None = None,
+    ) -> None:
+        if machine is None:
+            machine = self.get_machine()
+        translation = async_to_sync(machine.atranslate)(
+            make_unit(code=lang, source=word)
+        )
+        self.assertGreater(len(translation), 0)
+        for items in translation:
+            self.assertEqual(len(items), expected_len)
+
     def mock_empty(self) -> None:
         pass
 
@@ -521,6 +553,30 @@ class BaseMachineTranslationTest(TestCase):
 
 
 class MachineTranslationTest(BaseMachineTranslationTest):
+    def test_async_translate_error_reports_original_exception(self) -> None:
+        machine = self.get_machine()
+        error = ValueError("Provider failed")
+
+        with (
+            patch.object(
+                machine,
+                "adownload_pending_translations",
+                new=AsyncMock(side_effect=error),
+            ),
+            patch("weblate.machinery.base.report_error") as report_error,
+            self.assertRaises(MachineTranslationError),
+        ):
+            async_to_sync(machine.atranslate)(
+                make_unit(code=self.SUPPORTED, source=self.SOURCE_TRANSLATED)
+            )
+
+        report_error.assert_called_once_with(
+            f"machinery[{machine.name}]: Could not fetch translations",
+            extra_log=None,
+            message=False,
+            exception=error,
+        )
+
     def test_translate_fallback(self) -> None:
         machine_translation = self.get_machine()
         self.assertEqual(
@@ -1085,7 +1141,7 @@ class MyMemoryTranslationTest(BaseMachineTranslationTest):
             self.assert_translate(self.SUPPORTED, self.SOURCE_BLANK, 0)
 
         self.assertIsInstance(raised.exception.__cause__, HTTPError)
-        self.assertIn("403 Client Error", str(raised.exception))
+        self.assertIn("403 Forbidden", str(raised.exception))
 
 
 class ApertiumAPYTranslationTest(BaseMachineTranslationTest):
@@ -1214,6 +1270,7 @@ class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
+    @responses.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_validation_blocks_private_base_url_resolution_before_request(
         self, mocked_getaddrinfo
@@ -1224,16 +1281,13 @@ class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
             allow_private_targets=False,
         )
 
-        with (
-            patch.object(self.MACHINE_CLS, "get_headers", return_value={}),
-            patch("requests.sessions.Session.request") as mocked_request,
-        ):
+        with patch.object(self.MACHINE_CLS, "get_headers", return_value={}):
             self.assertFalse(form.is_valid())
 
         mocked_getaddrinfo.assert_called_once_with(
             "api.cognitive.microsofttranslator.com", None, type=1
         )
-        mocked_request.assert_not_called()
+        self.assertEqual(len(responses.calls), 0)
         self.assertIn("internal or non-public address", str(form.non_field_errors()))
 
 
@@ -1284,6 +1338,7 @@ class MicrosoftCognitiveTranslationRegionTest(MicrosoftCognitiveTranslationTest)
             "https://westeurope.api.cognitive.microsoft.com/sts/v1.0/issueToken",
         )
 
+    @responses.activate
     def test_region_rejects_url_delimiters_before_request(self) -> None:
         form = self.MACHINE_CLS.settings_form(
             self.MACHINE_CLS,
@@ -1291,10 +1346,9 @@ class MicrosoftCognitiveTranslationRegionTest(MicrosoftCognitiveTranslationTest)
             allow_private_targets=False,
         )
 
-        with patch("requests.sessions.Session.request") as mocked_request:
-            self.assertFalse(form.is_valid())
+        self.assertFalse(form.is_valid())
 
-        mocked_request.assert_not_called()
+        self.assertEqual(len(responses.calls), 0)
         self.assertIn("valid Azure region name", str(form.errors["region"]))
 
     @responses.activate
@@ -2124,6 +2178,13 @@ class ModernMTTest(BaseMachineTranslationTest):
 
         self.mock_list_glossaries()
 
+    @responses.activate
+    def test_async_translate(self) -> None:
+        self.mock_response()
+        self.assert_async_translate(
+            self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
+        )
+
     def mock_list_glossaries(self, *id_name_date: tuple[int, str, str | None]) -> None:
         """Set up mock responses for list of glossaries in ModernMT."""
         data: list[dict] = [
@@ -2427,6 +2488,13 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
             responses.POST,
             "https://api.deepl.com/v2/translate",
             json=DEEPL_RESPONSE,
+        )
+
+    @responses.activate
+    def test_async_translate(self) -> None:
+        self.mock_response()
+        self.assert_async_translate(
+            self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
         )
 
     @responses.activate
@@ -2955,6 +3023,13 @@ class LibreTranslateTranslationTest(BaseMachineTranslationTest):
             responses.POST,
             self.get_api_url("translate"),
             json=LIBRETRANSLATE_TRANS_RESPONSE,
+        )
+
+    @responses.activate
+    def test_async_translate(self) -> None:
+        self.mock_response()
+        self.assert_async_translate(
+            self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
         )
 
     @responses.activate
@@ -3781,6 +3856,13 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                     "total_tokens": 21,
                 },
             },
+        )
+
+    @responses.activate
+    def test_async_translate(self) -> None:
+        self.mock_response()
+        self.assert_async_translate(
+            self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
         )
 
     def test_prompt_forbids_metadata_output(self) -> None:
@@ -6862,7 +6944,14 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         mock_log_handled.assert_called_once_with(handled_cause, extra_log="")
         mock_report_error.assert_called_once_with(
-            report_cause, extra_log=None, message=False
+            report_cause,
+            extra_log=None,
+            message=False,
+            exception=ANY,
+        )
+        self.assertIsInstance(
+            mock_report_error.call_args.kwargs["exception"],
+            MachineTranslationError,
         )
 
     @responses.activate
@@ -6889,7 +6978,14 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             extra_log='["Ahoj "svete"]',
         )
         mock_report_error.assert_called_once_with(
-            report_cause, extra_log=None, message=False
+            report_cause,
+            extra_log=None,
+            message=False,
+            exception=ANY,
+        )
+        self.assertIsInstance(
+            mock_report_error.call_args.kwargs["exception"],
+            MachineTranslationError,
         )
 
     @responses.activate
@@ -7167,19 +7263,17 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
+    @responses.activate
     def test_runtime_url_validation(self, mocked_getaddrinfo) -> None:
         machine = self.MACHINE_CLS(self.CONFIGURATION.copy())
         machine.delete_cache()
         machine.settings["_project"] = Mock()
 
-        with (
-            patch.object(machine, "request") as mocked_request,
-            self.assertRaises(ValidationError),
-        ):
+        with self.assertRaises(ValidationError):
             machine.get_model()
 
         mocked_getaddrinfo.assert_called_once()
-        mocked_request.assert_not_called()
+        self.assertEqual(len(responses.calls), 0)
 
     @responses.activate
     @patch(
@@ -7454,6 +7548,13 @@ class OllamaTranslationTest(BaseMachineTranslationTest):
             },
         )
 
+    @responses.activate
+    def test_async_translate(self) -> None:
+        self.mock_response()
+        self.assert_async_translate(
+            self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
+        )
+
 
 class OllamaRemoteModelTranslationTest(OllamaTranslationTest):
     CONFIGURATION: ClassVar[SettingsDict] = {
@@ -7541,6 +7642,13 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
                     "output_tokens": 5,
                 },
             },
+        )
+
+    @responses.activate
+    def test_async_translate(self) -> None:
+        self.mock_response()
+        self.assert_async_translate(
+            self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
         )
 
     @responses.activate
@@ -8002,6 +8110,46 @@ class ViewsTest(FixtureTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_translate_asgi(self) -> None:
+        self.ensure_dummy_mt()
+        unit = self.get_unit()
+        self.async_client.force_login(self.user)
+        response = async_to_sync(self.async_client.post)(
+            reverse("js-translate", kwargs={"unit_id": unit.id, "service": "dummy"})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["responseStatus"], 200)
+
+    def test_translate_asgi_reports_original_exception(self) -> None:
+        self.ensure_dummy_mt()
+        unit = self.get_unit()
+        project = unit.translation.component.project
+        error = ValueError("Provider failed")
+        self.async_client.force_login(self.user)
+
+        with (
+            patch.object(
+                DummyTranslation,
+                "atranslate",
+                new=AsyncMock(side_effect=error),
+            ),
+            patch("weblate.machinery.views.report_error") as report_error,
+        ):
+            response = async_to_sync(self.async_client.post)(
+                reverse(
+                    "js-translate",
+                    kwargs={"unit_id": unit.id, "service": "dummy"},
+                )
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["responseStatus"], 500)
+        report_error.assert_called_once_with(
+            "Machinery failed",
+            project=project,
+            exception=error,
+        )
+
     def test_translate_escapes_html(self) -> None:
         self.ensure_dummy_mt()
         unit = self.get_unit()
@@ -8013,19 +8161,21 @@ class ViewsTest(FixtureTestCase):
 
         with patch.object(
             DummyTranslation,
-            "translate",
-            return_value=[
-                [
-                    {
-                        "quality": 100,
-                        "plural_form": 0,
-                        "service": "Dummy",
-                        "text": payload,
-                        "source": source_payload,
-                        "original_source": "",
-                    }
+            "atranslate",
+            new=AsyncMock(
+                return_value=[
+                    [
+                        {
+                            "quality": 100,
+                            "plural_form": 0,
+                            "service": "Dummy",
+                            "text": payload,
+                            "source": source_payload,
+                            "original_source": "",
+                        }
+                    ]
                 ]
-            ],
+            ),
         ):
             response = self.client.post(
                 reverse("js-translate", kwargs={"unit_id": unit.id, "service": "dummy"})
@@ -8498,6 +8648,7 @@ class MachineryValidationTest(TestCase):
         self.assertNotIn("site-wide", str(form.errors["__all__"]))
         self.assertNotIn("allowlisted", str(form.errors["__all__"]))
 
+    @responses.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_ollama_rejects_private_url_before_request(self) -> None:
         form = OllamaTranslation.settings_form(
@@ -8511,12 +8662,12 @@ class MachineryValidationTest(TestCase):
             allow_private_targets=False,
         )
 
-        with patch("requests.sessions.Session.request") as mocked_request:
-            self.assertFalse(form.is_valid())
+        self.assertFalse(form.is_valid())
 
-        mocked_request.assert_not_called()
+        self.assertEqual(len(responses.calls), 0)
         self.assertIn("internal or non-public address", str(form.errors["__all__"]))
 
+    @responses.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_anthropic_rejects_private_url_before_request(self) -> None:
         form = AnthropicTranslation.settings_form(
@@ -8532,19 +8683,17 @@ class MachineryValidationTest(TestCase):
             allow_private_targets=False,
         )
 
-        with patch("requests.sessions.Session.request") as mocked_request:
-            self.assertFalse(form.is_valid())
+        self.assertFalse(form.is_valid())
 
-        mocked_request.assert_not_called()
+        self.assertEqual(len(responses.calls), 0)
         self.assertIn("internal or non-public address", str(form.errors["__all__"]))
 
     def test_check_failure_hides_response_body(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "500 Server Error: Internal Server Error for url: http://127.0.0.1/api"
+        response = make_error_response(
+            "http://127.0.0.1/api",
+            500,
+            text="aws_secret_key=AKIAIOSFODNN7EXAMPLE",
         )
-        response.url = "http://127.0.0.1/api"
-        response.text = "aws_secret_key=AKIAIOSFODNN7EXAMPLE"
         machine = DummyTranslation({})
 
         with self.assertRaises(HTTPError) as raised:
@@ -8553,12 +8702,11 @@ class MachineryValidationTest(TestCase):
         self.assertNotIn("aws_secret_key", str(raised.exception))
 
     def test_check_failure_shows_trusted_provider_message(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "400 Client Error: Bad Request for url: https://api.deepl.com/v2/translate"
+        response = make_error_response(
+            "https://api.deepl.com/v2/translate",
+            400,
+            json_data={"message": "Auth key is invalid."},
         )
-        response.url = "https://api.deepl.com/v2/translate"
-        response.json.return_value = {"message": "Auth key is invalid."}
         machine = DeepLTranslation({"key": "x", "url": "https://api.deepl.com/"})
 
         with self.assertRaises(HTTPError) as raised:
@@ -8567,13 +8715,11 @@ class MachineryValidationTest(TestCase):
         self.assertIn("Auth key is invalid.", str(raised.exception))
 
     def test_check_failure_shows_trusted_provider_plain_text_message(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "429 Client Error: Too Many Requests for url: https://api.deepl.com/v2/translate"
+        response = make_error_response(
+            "https://api.deepl.com/v2/translate",
+            429,
+            text="Rate limit exceeded.",
         )
-        response.url = "https://api.deepl.com/v2/translate"
-        response.text = "Rate limit exceeded."
-        response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
         machine = DeepLTranslation(
             {"key": "x", "url": "https://api.deepl.com/", "_project": Mock()}
         )
@@ -8583,14 +8729,24 @@ class MachineryValidationTest(TestCase):
 
         self.assertIn("Rate limit exceeded.", str(raised.exception))
 
-    def test_check_failure_shows_fixed_provider_plain_text_message(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "503 Server Error: Service Unavailable for url: https://translation.googleapis.com/language/translate/v2"
+    def test_check_failure_handles_invalid_json_encoding(self) -> None:
+        request = httpx2.Request("GET", "https://api.deepl.com/v2/translate")
+        response = httpx2.Response(429, request=request, content=b"\xff")
+        machine = DeepLTranslation(
+            {"key": "x", "url": "https://api.deepl.com/", "_project": Mock()}
         )
-        response.url = "https://translation.googleapis.com/language/translate/v2"
-        response.text = "Service temporarily unavailable."
-        response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+
+        with self.assertRaises(HTTPError) as raised:
+            machine.check_failure(response)
+
+        self.assertIn("\ufffd", str(raised.exception))
+
+    def test_check_failure_shows_fixed_provider_plain_text_message(self) -> None:
+        response = make_error_response(
+            "https://translation.googleapis.com/language/translate/v2",
+            503,
+            text="Service temporarily unavailable.",
+        )
         machine = GoogleTranslation({"key": "x", "_project": Mock()})
 
         with self.assertRaises(HTTPError) as raised:
@@ -8599,12 +8755,11 @@ class MachineryValidationTest(TestCase):
         self.assertIn("Service temporarily unavailable.", str(raised.exception))
 
     def test_check_failure_hides_untrusted_provider_message(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "400 Client Error: Bad Request for url: https://custom.example.com/v1"
+        response = make_error_response(
+            "https://custom.example.com/v1",
+            400,
+            json_data={"message": "Top secret."},
         )
-        response.url = "https://custom.example.com/v1"
-        response.json.return_value = {"message": "Top secret."}
         machine = OpenAITranslation(
             {
                 "key": "x",
@@ -8622,14 +8777,13 @@ class MachineryValidationTest(TestCase):
         self.assertNotIn("Top secret.", str(raised.exception))
 
     def test_get_error_message_hides_untrusted_response_body(self) -> None:
-        response = Mock()
-        response.url = "https://custom.example.com/v1"
-        response.text = "Top secret."
-        response.json.return_value = {"message": "Top secret."}
-        error = HTTPError(
-            "400 Client Error: Bad Request for url: https://custom.example.com/v1",
-            response=response,
+        response = make_error_response(
+            "https://custom.example.com/v1",
+            400,
+            json_data={"message": "Top secret."},
         )
+        with self.assertRaises(HTTPError) as raised:
+            response.raise_for_status()
         machine = OpenAITranslation(
             {
                 "key": "x",
@@ -8641,17 +8795,16 @@ class MachineryValidationTest(TestCase):
             }
         )
 
-        message = machine.get_error_message(error)
+        message = machine.get_error_message(raised.exception)
 
         self.assertNotIn("Top secret.", message)
 
     def test_check_failure_does_not_trust_non_endpoint_choice_values(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "400 Client Error: Bad Request for url: https://auto/v1"
+        response = make_error_response(
+            "https://auto/v1",
+            400,
+            json_data={"message": "Top secret."},
         )
-        response.url = "https://auto/v1"
-        response.json.return_value = {"message": "Top secret."}
         machine = OpenAITranslation(
             {
                 "key": "x",
@@ -8670,12 +8823,11 @@ class MachineryValidationTest(TestCase):
 
     @override_settings(ALLOWED_MACHINERY_DOMAINS=["api.sap.com"])
     def test_check_failure_handles_non_string_project_settings(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "400 Client Error: Bad Request for url: https://api.sap.com/v1/translate"
+        response = make_error_response(
+            "https://api.sap.com/v1/translate",
+            400,
+            json_data={"message": "Invalid credentials."},
         )
-        response.url = "https://api.sap.com/v1/translate"
-        response.json.return_value = {"message": "Invalid credentials."}
         machine = SAPTranslationHub(
             {
                 "key": "x",
@@ -8694,13 +8846,11 @@ class MachineryValidationTest(TestCase):
         self.assertIn("Invalid credentials.", str(raised.exception))
 
     def test_check_failure_shows_libretranslate_plain_text_message(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "429 Client Error: Too Many Requests for url: https://libretranslate.com/translate"
+        response = make_error_response(
+            "https://libretranslate.com/translate",
+            429,
+            text="Too many requests.",
         )
-        response.url = "https://libretranslate.com/translate"
-        response.text = "Too many requests."
-        response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
         machine = LibreTranslateTranslation(
             {"key": "", "url": "https://libretranslate.com/", "_project": Mock()}
         )
@@ -8714,6 +8864,7 @@ class MachineryValidationTest(TestCase):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
+    @responses.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_validation_uses_runtime_url_guard(
         self, mocked_getaddrinfo
@@ -8724,11 +8875,10 @@ class MachineryValidationTest(TestCase):
             allow_private_targets=False,
         )
 
-        with patch("requests.sessions.Session.request") as mocked_request:
-            self.assertFalse(form.is_valid())
+        self.assertFalse(form.is_valid())
 
         mocked_getaddrinfo.assert_called()
-        mocked_request.assert_not_called()
+        self.assertEqual(len(responses.calls), 0)
         self.assertIn(
             "internal or non-public address",
             str(form.non_field_errors()),
@@ -8738,12 +8888,11 @@ class MachineryValidationTest(TestCase):
 
     @override_settings(ALLOWED_MACHINERY_DOMAINS=[".example.com"])
     def test_check_failure_shows_wildcard_allowlisted_provider_message(self) -> None:
-        response = Mock()
-        response.raise_for_status.side_effect = HTTPError(
-            "400 Client Error: Bad Request for url: https://api.example.com/v1"
+        response = make_error_response(
+            "https://api.example.com/v1",
+            400,
+            json_data={"message": "Allowlisted provider error."},
         )
-        response.url = "https://api.example.com/v1"
-        response.json.return_value = {"message": "Allowlisted provider error."}
         machine = OpenAITranslation(
             {
                 "key": "x",

--- a/weblate/machinery/tmserver.py
+++ b/weblate/machinery/tmserver.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from requests.exceptions import HTTPError
+import httpx2
 
 from .base import MACHINERY_DEFAULT_THRESHOLD, MachineTranslation
 from .forms import URLMachineryForm
@@ -32,7 +32,7 @@ class TMServerTranslation(MachineTranslation):
             # This URL needs trailing slash, that's why blank string is included
             response = self.request("get", self.get_api_url("languages", ""))
             data = response.json()
-        except HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             if error.response.status_code == 404:
                 return []
             raise

--- a/weblate/machinery/views.py
+++ b/weblate/machinery/views.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from itertools import chain
 from typing import TYPE_CHECKING, cast
 
+from asgiref.sync import sync_to_async
 from django.core.exceptions import PermissionDenied
 from django.http import (
     Http404,
@@ -400,11 +401,61 @@ def get_machinery_translations(
 ) -> list[dict]:
     if search:
         translations = translation_service.search(unit, search, request.user)
+        return format_machinery_translations(
+            translations,
+            search=True,
+            targets=targets,
+            translation=translation,
+            source_translation=source_translation,
+        )
+
+    translations = translation_service.translate(unit, request.user)
+    return format_machinery_translations(
+        translations,
+        search=False,
+        targets=targets,
+        translation=translation,
+        source_translation=source_translation,
+    )
+
+
+async def get_machinery_translations_async(
+    request: AuthenticatedHttpRequest,
+    translation_service: BatchMachineTranslation,
+    unit: Unit,
+    search: str | None,
+    targets: list[str],
+    translation: Translation,
+    source_translation: Translation,
+) -> list[dict]:
+    if search:
+        translations = await translation_service.asearch(unit, search, request.user)
+        is_search = True
+    else:
+        translations = await translation_service.atranslate(unit, request.user)
+        is_search = False
+    return await sync_to_async(format_machinery_translations)(
+        translations,
+        search=is_search,
+        targets=targets,
+        translation=translation,
+        source_translation=source_translation,
+    )
+
+
+def format_machinery_translations(
+    translations,
+    *,
+    search: bool,
+    targets: list[str],
+    translation: Translation,
+    source_translation: Translation,
+) -> list[dict]:
+    if search:
         for item in translations:
             format_results_helper(item, targets, 0, translation, source_translation)
         return translations
 
-    translations = translation_service.translate(unit, request.user)
     for plural_form, possible_translations in enumerate(translations):
         for item in possible_translations:
             format_results_helper(
@@ -470,11 +521,79 @@ def handle_machinery(request: AuthenticatedHttpRequest, service, unit, search=No
     return JsonResponse(data=response)
 
 
+def get_machinery_unit(user, unit_id: int) -> Unit:
+    return get_object_or_404(
+        Unit.objects.filter_access(user).select_related(
+            "translation__component__project",
+            "translation__language",
+        ),
+        pk=unit_id,
+    )
+
+
 @require_POST
-def translate(request: AuthenticatedHttpRequest, unit_id: int, service: str):
+async def translate(request: AuthenticatedHttpRequest, unit_id: int, service: str):
     """AJAX handler for translating."""
-    unit = get_object_or_404(Unit.objects.filter_access(request.user), pk=unit_id)
-    return handle_machinery(request, service, unit)
+    unit = await sync_to_async(get_machinery_unit)(request.user, unit_id)
+    translation = await sync_to_async(lambda: unit.translation)()
+    component = await sync_to_async(lambda: translation.component)()
+    source_translation = await sync_to_async(lambda: component.source_translation)()
+    if not await sync_to_async(request.user.has_perm)("machinery.view", translation):
+        raise PermissionDenied
+
+    try:
+        translation_service_class = MACHINERY[service]
+    except KeyError as error:
+        msg = "Invalid service specified"
+        raise Http404(msg) from error
+
+    response = {
+        "responseStatus": 500,
+        "responseDetails": "",
+        "translations": [],
+        "lang": translation.language.code,
+        "dir": translation.language.direction,
+        "service": translation_service_class.name,
+    }
+
+    machinery_settings, targets = await sync_to_async(
+        lambda: (
+            component.project.get_machinery_settings(),
+            unit.get_target_plurals(),
+        )
+    )()
+    try:
+        translation_service = translation_service_class(machinery_settings[service])
+    except KeyError:
+        response["responseDetails"] = gettext("Service is currently not available.")
+    else:
+        try:
+            response["translations"] = await get_machinery_translations_async(
+                request,
+                translation_service,
+                unit,
+                None,
+                targets,
+                translation,
+                source_translation,
+            )
+            response["responseStatus"] = 200
+        except MachineTranslationError as exc:
+            response["responseDetails"] = str(exc)
+        except Exception as error:
+            await sync_to_async(report_error)(
+                "Machinery failed",
+                project=component.project,
+                exception=error,
+            )
+            response["responseDetails"] = f"{error.__class__.__name__}: {error}"
+
+    if response["responseStatus"] != 200:
+        await sync_to_async(translation.log_info)(
+            "machinery %s failed: %s", service, response["responseDetails"]
+        )
+
+    return JsonResponse(data=response)
 
 
 @require_POST

--- a/weblate/machinery/yandex.py
+++ b/weblate/machinery/yandex.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from requests.exceptions import RequestException
+import httpx2
 
 from .base import (
     MACHINERY_DEFAULT_THRESHOLD,
@@ -15,8 +15,6 @@ from .base import (
 from .forms import KeyMachineryForm
 
 if TYPE_CHECKING:
-    from requests import Response
-
     from weblate.auth.models import User
     from weblate.trans.models import Unit
 
@@ -30,7 +28,7 @@ class YandexTranslation(MachineTranslation):
     max_score = 90
     settings_form = KeyMachineryForm
 
-    def check_failure(self, response: Response) -> None:
+    def check_failure(self, response: httpx2.Response) -> None:
         super().check_failure(response)
         payload = response.json()
         if "message" in payload:
@@ -80,9 +78,10 @@ class YandexTranslation(MachineTranslation):
             }
 
     def get_error_message(self, exc: Exception) -> str:
-        if isinstance(exc, RequestException):
+        response = getattr(exc, "response", None)
+        if isinstance(exc, httpx2.HTTPError) and response is not None:
             try:
-                return exc.response.json()["message"]
+                return response.json()["message"]
             # ruff: ignore[try-except-pass]
             except Exception:
                 pass

--- a/weblate/machinery/yandexv2.py
+++ b/weblate/machinery/yandexv2.py
@@ -7,7 +7,7 @@ import json
 from typing import TYPE_CHECKING
 from urllib.parse import unquote_plus
 
-from requests.exceptions import RequestException
+import httpx2
 
 from .base import (
     MACHINERY_DEFAULT_THRESHOLD,
@@ -17,8 +17,6 @@ from .base import (
 from .forms import KeyMachineryForm
 
 if TYPE_CHECKING:
-    from requests import Response
-
     from weblate.auth.models import User
     from weblate.trans.models import Unit
 
@@ -33,7 +31,7 @@ class YandexV2Translation(MachineTranslation):
     settings_form = KeyMachineryForm
     version_added = "5.1"
 
-    def check_failure(self, response: Response) -> None:
+    def check_failure(self, response: httpx2.Response) -> None:
         super().check_failure(response)
         payload = response.json()
         if "message" in payload:
@@ -86,9 +84,10 @@ class YandexV2Translation(MachineTranslation):
             }
 
     def get_error_message(self, exc: Exception) -> str:
-        if isinstance(exc, RequestException):
+        response = getattr(exc, "response", None)
+        if isinstance(exc, httpx2.HTTPError) and response is not None:
             try:
-                return exc.response.json()["message"]
+                return response.json()["message"]
             # ruff: ignore[try-except-pass]
             except Exception:
                 pass

--- a/weblate/machinery/youdao.py
+++ b/weblate/machinery/youdao.py
@@ -14,7 +14,7 @@ from .base import (
 from .forms import KeySecretMachineryForm
 
 if TYPE_CHECKING:
-    from requests import Response
+    from httpx2 import Response
 
     from weblate.auth.models import User
     from weblate.trans.models import Unit

--- a/weblate/screenshots/forms.py
+++ b/weblate/screenshots/forms.py
@@ -6,7 +6,7 @@ import io
 from typing import Any, ClassVar, NoReturn, cast
 from urllib.parse import unquote, urlsplit
 
-import requests
+import httpx2
 from django import forms
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -35,7 +35,7 @@ class ScreenshotImageValidationMixin(BaseForm):
             allowed_domains=settings.ASSET_PRIVATE_ALLOWLIST,
         ) as response:
             content = b""
-            for chunk in response.iter_content(
+            for chunk in response.iter_bytes(
                 chunk_size=settings.ALLOWED_ASSET_SIZE + 1
             ):
                 if not content:
@@ -90,7 +90,7 @@ class ScreenshotImageValidationMixin(BaseForm):
                     % error.params
                 )
             self.raise_image_url_error(error.messages[0])
-        except requests.RequestException as e:
+        except httpx2.HTTPError as e:
             raise forms.ValidationError(
                 {
                     "image_url": gettext(

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -10,8 +10,7 @@ from pathlib import Path
 from shutil import copyfile, rmtree
 from unittest.mock import MagicMock, patch
 
-import requests
-import responses
+import httpx2
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
@@ -41,6 +40,7 @@ from weblate.trans.tests.test_models import RepoTestCase
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.tests.utils import create_test_user, get_test_file
 from weblate.utils.docs import get_doc_url
+from weblate.utils.tests import http_mock as responses
 
 TEST_SCREENSHOT = get_test_file("screenshot.png")
 PUBLIC_TEST_ADDRESS = "93.184.216.34"
@@ -65,10 +65,14 @@ class ScreenshotImageValidationTest(SimpleTestCase):
 
 class TesseractDataTest(SimpleTestCase):
     @staticmethod
-    def get_http_error(status_code: int) -> requests.HTTPError:
-        response = requests.Response()
-        response.status_code = status_code
-        return requests.HTTPError(response=response)
+    def get_http_error(status_code: int) -> httpx2.HTTPStatusError:
+        request = httpx2.Request("GET", "https://example.com/tesseract")
+        response = httpx2.Response(status_code, request=request)
+        try:
+            response.raise_for_status()
+        except httpx2.HTTPStatusError as error:
+            return error
+        raise AssertionError
 
     def test_cached_data(self) -> None:
         with tempfile.TemporaryDirectory() as cache_dir:
@@ -100,6 +104,7 @@ class TesseractDataTest(SimpleTestCase):
         makedirs.assert_called_once_with(str(tessdata), exist_ok=True)
 
     def test_transient_errors_are_retried(self) -> None:
+        request = httpx2.Request("GET", "https://example.com/eng")
         response = MagicMock(content=b"trained data")
         with tempfile.TemporaryDirectory() as cache_dir:
             target = Path(cache_dir) / "eng.traineddata"
@@ -107,8 +112,11 @@ class TesseractDataTest(SimpleTestCase):
                 patch(
                     "weblate.screenshots.views.fetch_url",
                     side_effect=[
-                        requests.Timeout("timed out"),
-                        self.get_http_error(503),
+                        httpx2.ReadError("connection reset", request=request),
+                        httpx2.RemoteProtocolError(
+                            "server disconnected",
+                            request=request,
+                        ),
                         response,
                     ],
                 ) as fetch_url,
@@ -136,7 +144,7 @@ class TesseractDataTest(SimpleTestCase):
                     "weblate.screenshots.views.fetch_url",
                     side_effect=self.get_http_error(404),
                 ) as fetch_url,
-                self.assertRaises(requests.HTTPError),
+                self.assertRaises(httpx2.HTTPStatusError),
             ):
                 download_tesseract_data("https://example.com/eng", str(target))
 
@@ -150,10 +158,10 @@ class TesseractDataTest(SimpleTestCase):
             with (
                 patch(
                     "weblate.screenshots.views.fetch_url",
-                    side_effect=requests.Timeout("timed out"),
+                    side_effect=httpx2.TimeoutException("timed out"),
                 ) as fetch_url,
                 patch("weblate.screenshots.views.sleep"),
-                self.assertRaises(requests.Timeout),
+                self.assertRaises(httpx2.TimeoutException),
             ):
                 download_tesseract_data("https://example.com/eng", str(target))
 
@@ -945,7 +953,7 @@ class ViewTest(FixtureTestCase):
         with (
             patch(
                 "weblate.screenshots.views.get_tesseract",
-                side_effect=requests.Timeout("timed out"),
+                side_effect=httpx2.TimeoutException("timed out"),
             ),
             self.assertLogs("weblate", level="WARNING") as logs,
         ):
@@ -1115,7 +1123,10 @@ class ViewTest(FixtureTestCase):
         responses.add(
             responses.GET,
             "https://example.com/broken-image.png",
-            body=requests.RequestException("Network error"),
+            body=httpx2.ConnectError(
+                "Network error",
+                request=httpx2.Request("GET", "https://example.com/broken-image.png"),
+            ),
         )
         response = self.do_upload(
             image="", image_url="https://example.com/missing-image.png"

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager, suppress
 from time import sleep
 from typing import TYPE_CHECKING, ClassVar, cast
 
+import httpx2
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count
@@ -22,8 +23,6 @@ from django.utils.translation import gettext, ngettext
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, ListView
 from PIL import Image
-from requests import ConnectionError as RequestsConnectionError
-from requests import HTTPError, RequestException, Timeout
 from tesserocr import OEM, PSM, RIL, PyTessBaseAPI, iterate_level
 
 from weblate.logger import LOGGER
@@ -165,10 +164,18 @@ TESSERACT_DOWNLOAD_ATTEMPTS = 3
 TESSERACT_DOWNLOAD_TIMEOUT = 30
 
 
-def is_retryable_tesseract_download_error(error: RequestException) -> bool:
-    if isinstance(error, (RequestsConnectionError, Timeout)):
+def is_retryable_tesseract_download_error(error: httpx2.HTTPError) -> bool:
+    if isinstance(
+        error,
+        (
+            httpx2.NetworkError,
+            httpx2.ProxyError,
+            httpx2.RemoteProtocolError,
+            httpx2.TimeoutException,
+        ),
+    ):
         return True
-    if not isinstance(error, HTTPError) or error.response is None:
+    if not isinstance(error, httpx2.HTTPStatusError):
         return False
     return error.response.status_code == 429 or error.response.status_code >= 500
 
@@ -185,7 +192,7 @@ def download_tesseract_data(url: str, full_name: str) -> None:
                         allow_redirects=True,
                         timeout=TESSERACT_DOWNLOAD_TIMEOUT,
                     )
-            except RequestException as error:
+            except httpx2.HTTPError as error:
                 if (
                     attempt == TESSERACT_DOWNLOAD_ATTEMPTS
                     or not is_retryable_tesseract_download_error(error)
@@ -741,7 +748,7 @@ def ocr_search(request: AuthenticatedHttpRequest, pk):
                     resolution=resolution,
                 )
             }
-    except RequestException as error:
+    except httpx2.HTTPError as error:
         LOGGER.warning("Could not download Tesseract data: %s", error)
         return search_results(
             request,

--- a/weblate/trans/tests/test_basic_views.py
+++ b/weblate/trans/tests/test_basic_views.py
@@ -4,9 +4,11 @@
 
 """Tests for data exports."""
 
+from json import JSONDecodeError
 from unittest.mock import patch
 
 from asgiref.sync import async_to_sync
+from django.core.cache import cache
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -14,7 +16,7 @@ from django.urls import reverse
 from weblate.auth.models import User
 from weblate.trans.context_processors import weblate_context
 from weblate.trans.tests.test_views import FixtureTestCase
-from weblate.trans.views.about import AboutView
+from weblate.trans.views.about import FALLBACK_STATS, AboutView, DonateView
 from weblate.utils.version import GIT_VERSION, VERSION
 from weblate.utils.version_display import (
     VERSION_DISPLAY_HIDE,
@@ -49,6 +51,18 @@ class BasicViewTest(FixtureTestCase):
     def test_donate(self) -> None:
         response = self.client.get(reverse("donate"))
         self.assertContains(response, "Support Weblate")
+
+    def test_donate_falls_back_on_malformed_github_json(self) -> None:
+        errors = (
+            JSONDecodeError("Invalid JSON", "", 0),
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+        )
+
+        for error in errors:
+            with self.subTest(error=error):
+                cache.delete(DonateView.cache_key)
+                with patch.object(DonateView, "fetch_url", side_effect=error):
+                    self.assertEqual(DonateView().get_stats(), FALLBACK_STATS)
 
     def test_healthz(self) -> None:
         response = self.client.get(reverse("healthz"))

--- a/weblate/trans/tests/test_commands.py
+++ b/weblate/trans/tests/test_commands.py
@@ -10,7 +10,7 @@ from typing import cast
 from unittest import SkipTest
 from unittest.mock import Mock, patch
 
-import requests
+import httpx2
 from django.core.management import call_command
 from django.core.management.base import CommandError, SystemCheckError
 from django.test import SimpleTestCase, TestCase
@@ -508,29 +508,30 @@ class ImportDemoTestCase(TestCase):
 class RequireGitHubTest(SimpleTestCase):
     repository = "https://github.com/WeblateOrg/demo.git"
 
-    @patch("weblate.trans.tests.utils.requests.get")
-    def test_success(self, get: Mock) -> None:
+    @patch("weblate.trans.tests.utils.fetch_url")
+    def test_success(self, fetch_url: Mock) -> None:
         require_github(self.repository)
 
-        get.assert_called_once_with(self.repository, timeout=1)
-        get.return_value.raise_for_status.assert_called_once_with()
+        fetch_url.assert_called_once_with("get", self.repository, timeout=1)
 
-    @patch("weblate.trans.tests.utils.requests.get")
-    def test_request_errors(self, get: Mock) -> None:
+    @patch("weblate.trans.tests.utils.fetch_url")
+    def test_request_errors(self, fetch_url: Mock) -> None:
         for exception in (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
-            requests.exceptions.RequestException,
+            httpx2.ConnectError,
+            httpx2.TimeoutException,
+            httpx2.HTTPError,
         ):
             with self.subTest(exception=exception):
-                get.side_effect = exception("unavailable")
+                fetch_url.side_effect = exception("unavailable")
                 with self.assertRaisesRegex(SkipTest, "GitHub not reachable"):
                     require_github(self.repository)
 
-    @patch("weblate.trans.tests.utils.requests.get")
-    def test_http_error(self, get: Mock) -> None:
-        get.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            "unavailable"
+    @patch("weblate.trans.tests.utils.fetch_url")
+    def test_http_error(self, fetch_url: Mock) -> None:
+        fetch_url.side_effect = httpx2.HTTPStatusError(
+            "unavailable",
+            request=httpx2.Request("GET", self.repository),
+            response=httpx2.Response(500),
         )
 
         with self.assertRaisesRegex(SkipTest, "GitHub not reachable"):

--- a/weblate/trans/tests/utils.py
+++ b/weblate/trans/tests/utils.py
@@ -12,7 +12,7 @@ from tarfile import TarFile
 from tempfile import mkdtemp
 from unittest import SkipTest
 
-import requests
+import httpx2
 import social_core.backends.utils
 from celery.contrib.testing.tasks import ping  # type: ignore[import-untyped]
 from celery.result import allow_join_result
@@ -32,6 +32,7 @@ from weblate.lang.models import Language, Plural
 from weblate.trans.inherited_settings import INHERITABLE_COMPONENT_FLAGS
 from weblate.trans.models import Category, Component, Project
 from weblate.utils.files import remove_tree
+from weblate.utils.requests import fetch_url
 from weblate.vcs.models import VCS_REGISTRY
 
 # Directory holding test data
@@ -45,9 +46,8 @@ TESTPASSWORD = make_password("testpassword")
 def require_github(repository: str) -> None:
     """Skip a test when a required GitHub repository is not reachable."""
     try:
-        response = requests.get(repository, timeout=1)
-        response.raise_for_status()
-    except requests.exceptions.RequestException as error:
+        fetch_url("get", repository, timeout=1)
+    except httpx2.HTTPError as error:
         msg = f"GitHub not reachable: {error}"
         raise SkipTest(msg) from error
 

--- a/weblate/trans/views/about.py
+++ b/weblate/trans/views/about.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import requests
+import httpx2
 from django.core.cache import cache
 from django.db.models import Sum
 from django.utils.translation import gettext, gettext_lazy
@@ -10,7 +10,7 @@ from django.views.generic import TemplateView
 
 from weblate.accounts.models import Profile
 from weblate.metrics.models import Metric
-from weblate.utils.requests import fetch_url
+from weblate.utils.requests import JSON_RESPONSE_ERRORS, fetch_url
 from weblate.utils.requirements import get_versions_list
 from weblate.utils.stats import GlobalStats
 from weblate.vcs.gpg import get_gpg_public_key, get_gpg_sign_key
@@ -115,7 +115,7 @@ class DonateView(AboutView):
             try:
                 repo = self.fetch_url(REPO_URL)
                 activity = self.fetch_url(ACTIVITY_URL)
-            except requests.exceptions.RequestException:
+            except (httpx2.HTTPError, *JSON_RESPONSE_ERRORS):
                 return FALLBACK_STATS
             activity = sorted(activity, key=lambda item: -item["week"])
             result = {

--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -16,6 +16,7 @@ from shutil import disk_usage
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, cast
 
+import httpx2
 from celery.exceptions import TimeoutError as CeleryTimeoutError
 from django.apps import AppConfig
 from django.conf import settings
@@ -591,7 +592,7 @@ def check_version(
 ) -> Iterable[CheckMessage]:
     try:
         latest = get_latest_version()
-    except (ValueError, OSError):
+    except (ValueError, OSError, httpx2.HTTPError):
         return []
     if Version(latest.version) > Version(VERSION_BASE):
         # With release every two months, this gets triggered after three releases

--- a/weblate/utils/errors.py
+++ b/weblate/utils/errors.py
@@ -9,6 +9,7 @@ import sys
 from contextlib import suppress
 from importlib import import_module
 from json import JSONDecodeError
+from traceback import format_exception
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from django.conf import settings
@@ -70,6 +71,7 @@ def report_error(
     extra_log: str | None = None,
     project=None,
     message: bool = False,
+    exception: BaseException | None = None,
 ) -> None:
     """
     Report errors.
@@ -79,14 +81,20 @@ def report_error(
     """
     # pylint: disable-next=unused-variable
     __traceback_hide__ = True  # ruff: ignore[unused-variable]
-    error = sys.exc_info()[1]
+    explicit_exception = exception is not None
+    error = exception if explicit_exception else sys.exc_info()[1]
     locale = get_language()
     report_as_message = message or error is None
 
     if not skip_error_reporting:
         if hasattr(settings, "ROLLBAR"):
             rollbar = get_rollbar()
-            rollbar.report_exc_info(level=level)
+            if explicit_exception and error is not None:
+                rollbar.report_exc_info(
+                    (type(error), error, error.__traceback__), level=level
+                )
+            else:
+                rollbar.report_exc_info(level=level)
 
         if settings.SENTRY_DSN:
             sentry_sdk = get_sentry_sdk()
@@ -97,6 +105,8 @@ def report_error(
             sentry_sdk.set_level(level)
             if report_as_message:
                 sentry_sdk.capture_message(cause)
+            elif explicit_exception:
+                sentry_sdk.capture_exception(error)
             else:
                 sentry_sdk.capture_exception()
 
@@ -104,6 +114,10 @@ def report_error(
         if google_client is not None:
             if report_as_message:
                 google_client.report(cause)
+            elif explicit_exception and error is not None:
+                google_client.report(
+                    "".join(format_exception(type(error), error, error.__traceback__))
+                )
             else:
                 google_client.report_exception()
 
@@ -117,7 +131,13 @@ def report_error(
             },
         )
 
-    _log_error(cause, level=level, extra_log=extra_log, print_tb=print_tb)
+    _log_error(
+        cause,
+        level=level,
+        extra_log=extra_log,
+        print_tb=print_tb,
+        exception=exception,
+    )
 
 
 def _log_error(
@@ -128,10 +148,11 @@ def _log_error(
     ] = "warning",
     extra_log: str | None = None,
     print_tb: bool = False,
+    exception: BaseException | None = None,
 ) -> None:
     """Log the current exception without reporting it to external services."""
     log = getattr(LOGGER, level)
-    error = sys.exc_info()[1]
+    error = exception if exception is not None else sys.exc_info()[1]
 
     # Include JSON document if available. It might be missing
     # when the error is raised from requests.
@@ -146,8 +167,14 @@ def _log_error(
         else:
             log("%s: %s", cause, extra_log)
     if print_tb:
-        # This is called from an exception handler
-        LOGGER.exception(cause)  # ruff: ignore[log-exception-outside-except-handler]
+        if exception is None:
+            # This is called from an exception handler
+            LOGGER.exception(cause)  # ruff: ignore[log-exception-outside-except-handler]
+        else:
+            LOGGER.error(
+                cause,
+                exc_info=(type(exception), exception, exception.__traceback__),
+            )
 
 
 def log_handled_exception(
@@ -190,6 +217,11 @@ def init_sentry() -> None:
     )
 
     # ruff: ignore[import-outside-top-level]
+    from sentry_sdk.integrations.httpx2 import (
+        Httpx2Integration,
+    )
+
+    # ruff: ignore[import-outside-top-level]
     from sentry_sdk.integrations.logging import (
         ignore_logger,
     )
@@ -202,6 +234,7 @@ def init_sentry() -> None:
     integrations = [
         CeleryIntegration(monitor_beat_tasks=settings.SENTRY_MONITOR_BEAT_TASKS),
         DjangoIntegration(),
+        Httpx2Integration(),
         RedisIntegration(),
     ]
 

--- a/weblate/utils/management/commands/sentry_deploy.py
+++ b/weblate/utils/management/commands/sentry_deploy.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import requests
+import httpx2
 from django.conf import settings
 from django.core.management.base import CommandError
 
@@ -22,14 +22,16 @@ class Command(BaseCommand):
         else:
             # Get commit hash from GitHub
             version = weblate.utils.version.TAG_NAME
-            response = requests.get(TAGS_API.format(version), timeout=5)
+            response = httpx2.get(
+                TAGS_API.format(version), timeout=5, follow_redirects=True
+            )
             response.raise_for_status()
             data = response.json()
             object_url = data["object"]["url"]
             if not object_url.startswith("https://api.github.com/"):
                 msg = f"Unexpected URL from GitHub: {object_url}"
                 raise CommandError(msg)
-            response = requests.get(object_url, timeout=5)
+            response = httpx2.get(object_url, timeout=5, follow_redirects=True)
             response.raise_for_status()
             ref = response.json()["object"]["sha"]
 
@@ -38,7 +40,9 @@ class Command(BaseCommand):
         release_url = f"{sentry_url}{version}/"
 
         # Ensure the release is tracked on Sentry
-        response = requests.get(release_url, headers=sentry_auth, timeout=30)
+        response = httpx2.get(
+            release_url, headers=sentry_auth, timeout=30, follow_redirects=True
+        )
         if response.status_code == 404:
             data = {
                 "version": version,
@@ -46,14 +50,14 @@ class Command(BaseCommand):
                 "ref": ref,
                 "refs": [{"repository": "WeblateOrg/weblate", "commit": ref}],
             }
-            response = requests.post(
+            response = httpx2.post(
                 sentry_url, json=data, headers=sentry_auth, timeout=30
             )
             self.stdout.write(f"Created new release {version}")
         response.raise_for_status()
 
         # Track the deploy
-        response = requests.post(
+        response = httpx2.post(
             f"{release_url}deploys/",
             data={"environment": settings.SENTRY_ENVIRONMENT},
             headers=sentry_auth,

--- a/weblate/utils/requests.py
+++ b/weblate/utils/requests.py
@@ -2,20 +2,27 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Shared synchronous and asynchronous outbound HTTP handling."""
+
 from __future__ import annotations
 
-from contextlib import contextmanager
+import json
+from collections.abc import Mapping
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import TYPE_CHECKING
-from urllib.parse import urljoin, urlparse
+from ipaddress import ip_address, ip_network
+from typing import TYPE_CHECKING, Self
+from urllib.parse import urlparse
+from urllib.request import getproxies, proxy_bypass
 
-import requests
+import httpx2
+from asgiref.sync import sync_to_async
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext
-from requests.adapters import HTTPAdapter
-from requests.utils import select_proxy
+from opentelemetry import propagate
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from weblate.logger import LOGGER
 from weblate.utils.outbound import (
@@ -24,24 +31,36 @@ from weblate.utils.outbound import (
     validate_outbound_url,
     validate_runtime_url,
 )
+from weblate.utils.tracing import get_opentelemetry_tracer
 from weblate.utils.validators import validate_asset_url
-from weblate.utils.version import USER_AGENT
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator
-
-    from requests import Response
+    from collections.abc import AsyncGenerator, Callable, Generator
 
 
+@dataclass
+class TestTransport:
+    transport: httpx2.MockTransport | None = None
+
+
+_TEST_TRANSPORT = TestTransport()
 PEER_IP_RESPONSE_ATTR = "_weblate_peer_ip"
+JSON_RESPONSE_ERRORS = (json.JSONDecodeError, UnicodeDecodeError)
+
+
+def set_test_transport(transport: httpx2.MockTransport | None) -> None:
+    """Override outbound transports in tests."""
+    _TEST_TRANSPORT.transport = transport
 
 
 @dataclass
 class RedirectValidators:
+    """Transport-neutral outbound request validation policy."""
+
     def validate_request_url(self, request_url: str, *, used_proxy: bool) -> None:
         return
 
-    def validate_response(self, response: Response, *, used_proxy: bool) -> None:
+    def validate_response(self, response: httpx2.Response, *, used_proxy: bool) -> None:
         return
 
 
@@ -70,7 +89,7 @@ class RuntimeRedirectValidators(RedirectValidators):
             request_url, allow_private_targets=self.allow_private_targets
         )
 
-    def validate_response(self, response: Response, *, used_proxy: bool) -> None:
+    def validate_response(self, response: httpx2.Response, *, used_proxy: bool) -> None:
         _validate_response_peer(
             response,
             allow_private_targets=self.allow_private_targets,
@@ -95,21 +114,66 @@ class RestrictedAssetRedirectValidators(RuntimeRedirectValidators):
 @dataclass
 class ChainedRedirectValidators(RedirectValidators):
     request_validators: tuple[Callable[[str], None], ...] = ()
-    response_validator: Callable[[Response, bool], None] | None = None
+    response_validator: Callable[[httpx2.Response, bool], None] | None = None
 
     def validate_request_url(self, request_url: str, *, used_proxy: bool) -> None:
         for validator in self.request_validators:
             validator(request_url)
 
-    def validate_response(self, response: Response, *, used_proxy: bool) -> None:
-        if self.response_validator is None:
-            return
-        self.response_validator(response, used_proxy)
+    def validate_response(self, response: httpx2.Response, *, used_proxy: bool) -> None:
+        if self.response_validator is not None:
+            self.response_validator(response, used_proxy)
 
 
 def _prepare_headers(headers: dict[str, str] | None) -> dict[str, str]:
+    # Lazy import avoids the version -> VCS -> HTTP import cycle during startup.
+    # ruff: ignore[import-outside-top-level]
+    from weblate.utils.version import USER_AGENT
+
     agent = {"User-Agent": USER_AGENT}
     return {**headers, **agent} if headers is not None else agent
+
+
+def _matches_no_proxy(hostname: str, port: int | None, no_proxy: str) -> bool:
+    no_proxy_hosts = (host for host in no_proxy.replace(" ", "").split(",") if host)
+    try:
+        address = ip_address(hostname)
+    except ValueError:
+        host_with_port = hostname if port is None else f"{hostname}:{port}"
+        for host in no_proxy_hosts:
+            host = host.lstrip(".").lower()
+            if host in {hostname, host_with_port}:
+                return True
+            suffix = f".{host}"
+            if hostname.endswith(suffix) or host_with_port.endswith(suffix):
+                return True
+    else:
+        for host in no_proxy_hosts:
+            try:
+                if address in ip_network(host, strict=False):
+                    return True
+            except ValueError:
+                if hostname == host:
+                    return True
+    return False
+
+
+def _get_proxy(url: str) -> str | None:
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return None
+    proxies = getproxies()
+    if (no_proxy := proxies.get("no")) and _matches_no_proxy(
+        parsed.hostname, parsed.port, no_proxy
+    ):
+        return None
+    if proxy_bypass(parsed.hostname):
+        return None
+    return proxies.get(parsed.scheme) or proxies.get("all")
+
+
+def _request_uses_proxy(url: str) -> bool:
+    return _get_proxy(url) is not None
 
 
 def validate_request_url(
@@ -118,219 +182,345 @@ def validate_request_url(
     allow_private_targets: bool = True,
     allowed_domains: list[str] | tuple[str, ...] = (),
 ) -> None:
-    with requests.Session() as session:
-        used_proxy = _request_uses_proxy(
-            session,
-            url,
-            stream=False,
-        )
-    if used_proxy:
-        validate_outbound_url(
-            url,
-            allow_private_targets=allow_private_targets,
-            allowed_domains=allowed_domains,
-        )
-        return
-
-    validate_runtime_url(url, allow_private_targets=allow_private_targets)
+    RuntimeRedirectValidators(
+        allow_private_targets=allow_private_targets,
+        allowed_domains=allowed_domains,
+    ).validate_request_url(url, used_proxy=_request_uses_proxy(url))
 
 
-def _request_uses_proxy(
-    session: requests.Session,
-    url: str,
-    *,
-    stream: bool,
-    request_kwargs: dict | None = None,
-) -> bool:
-    request_kwargs = request_kwargs or {}
-    request_settings = session.merge_environment_settings(
-        url,
-        request_kwargs.get("proxies") or {},
-        stream,
-        request_kwargs.get("verify"),
-        request_kwargs.get("cert"),
-    )
-    return select_proxy(url, request_settings["proxies"]) is not None
-
-
-def _strip_redirect_auth(
-    session: requests.Session,
-    request_headers: dict[str, str],
-    request_kwargs: dict,
-    current_url: str,
-    next_url: str,
-) -> None:
-    if not session.should_strip_auth(current_url, next_url):
-        return
-
-    request_headers.pop("Authorization", None)
-    request_headers.pop("Proxy-Authorization", None)
-    request_kwargs.pop("auth", None)
-
-
-def _should_redirect_to_get(status_code: int, method: str) -> bool:
-    normalized_method = method.upper()
-    if normalized_method == "HEAD":
-        return False
-    if status_code == 303:
-        return True
-    if status_code == 302:
-        return True
-    return status_code == 301 and normalized_method == "POST"
-
-
-class PeerIPHTTPAdapter(HTTPAdapter):
-    """HTTP adapter that captures the peer address before urllib3 can release it."""
-
-    def build_response(self, req, resp):
-        result = super().build_response(req, resp)
-        if (peer_ip := _extract_response_peer_ip(result)) is not None:
-            setattr(result, PEER_IP_RESPONSE_ATTR, peer_ip)
-        return result
-
-
-def _request_with_redirects(
-    method: str,
-    url: str,
-    *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
-    allow_redirects: bool = True,
-    stream: bool = False,
-    max_redirects: int = 5,
-    validators: RedirectValidators | None = None,
-    **kwargs,
-) -> Response:
-    request_kwargs = kwargs.copy()
-    request_kwargs["allow_redirects"] = False
-    history: list[Response] = []
-    current_url = url
-    current_method = method
-    request_headers = _prepare_headers(headers)
-
-    with requests.Session() as session:
-        if validators is not None:
-            adapter = PeerIPHTTPAdapter()
-            session.mount("http://", adapter)
-            session.mount("https://", adapter)
-        for _ in range(max_redirects + 1):
-            used_proxy = _request_uses_proxy(
-                session,
-                current_url,
-                stream=stream,
-                request_kwargs=request_kwargs,
-            )
-            if validators is not None:
-                validators.validate_request_url(current_url, used_proxy=used_proxy)
-            response = session.request(
-                current_method,
-                current_url,
-                headers=request_headers,
-                timeout=timeout,
-                stream=stream,
-                **request_kwargs,
-            )
-            response.history = history.copy()
-            if validators is not None:
-                try:
-                    validators.validate_response(response, used_proxy=used_proxy)
-                except Exception:
-                    response.close()
-                    raise
-
-            if not allow_redirects or not response.is_redirect:
-                return response
-
-            try:
-                next_url = urljoin(response.url, response.headers["location"])
-                _strip_redirect_auth(
-                    session, request_headers, request_kwargs, current_url, next_url
-                )
-                session.cookies.update(response.cookies)
-                history.append(response)
-            except Exception:
-                response.close()
-                raise
-
-            current_url = next_url
-
-            if _should_redirect_to_get(response.status_code, current_method):
-                current_method = "GET"
-                request_kwargs.pop("data", None)
-                request_kwargs.pop("json", None)
-                request_kwargs.pop("files", None)
-
-            response.close()
-
-    msg = f"Exceeded {max_redirects} redirects."
-    raise requests.TooManyRedirects(msg)
-
-
-def _get_response_peer_ip(response: Response) -> str | None:
-    cached_peer_ip = getattr(response, PEER_IP_RESPONSE_ATTR, None)
-    if cached_peer_ip is not None:
-        return str(cached_peer_ip)
-
-    return _extract_response_peer_ip(response)
-
-
-def _extract_response_peer_ip(response: Response) -> str | None:
+def _get_response_peer_ip(response: httpx2.Response) -> str | None:
+    if peer_ip := getattr(response, PEER_IP_RESPONSE_ATTR, None):
+        return str(peer_ip)
     try:
-        connection = getattr(response.raw, "connection", None)
-        if connection is None or connection.sock is None:
-            return None
-        peer = connection.sock.getpeername()
-    except (AttributeError, OSError):
+        stream = response.extensions["network_stream"]
+        peer = stream.get_extra_info("server_addr")
+    except (AttributeError, KeyError, OSError):
         return None
 
     if isinstance(peer, tuple) and peer:
         return str(peer[0])
+    if isinstance(peer, str):
+        return peer
     return None
 
 
 def _validate_response_peer(
-    response: Response,
+    response: httpx2.Response,
     *,
     allow_private_targets: bool,
     allowed_domains: list[str] | tuple[str, ...] = (),
     used_proxy: bool = False,
 ) -> None:
-    if allow_private_targets:
+    if allow_private_targets or used_proxy:
         return
-    if used_proxy:
-        return
-    hostname = urlparse(response.url).hostname or ""
+    hostname = urlparse(str(response.url)).hostname or ""
     if is_allowlisted_hostname(hostname, allowed_domains):
         return
     validate_connected_peer(
         hostname,
         _get_response_peer_ip(response),
         allow_private_targets=allow_private_targets,
+        allowed_domains=allowed_domains,
+        used_proxy=used_proxy,
     )
+
+
+def _normalize_request_kwargs(kwargs: dict) -> dict:
+    result = kwargs.copy()
+    data = result.get("data")
+    if isinstance(data, str | bytes) and "files" not in result:
+        result["content"] = result.pop("data")
+    elif isinstance(data, Mapping):
+        # Match Requests form encoding, which omitted mapping entries with null
+        # values instead of sending them as empty fields.
+        result["data"] = {
+            key: value for key, value in data.items() if value is not None
+        }
+    # Requests accepted this argument per request. HTTPX2 transport selection is
+    # handled centrally instead.
+    result.pop("proxies", None)
+    result.pop("verify", None)
+    result.pop("cert", None)
+    return result
+
+
+@contextmanager
+def trace_http_request(
+    request: httpx2.Request,
+) -> Generator[Span | None, None, None]:
+    tracer = get_opentelemetry_tracer()
+    if tracer is None:
+        yield None
+        return
+
+    attributes: dict[str, str | int] = {
+        "http.request.method": request.method,
+        "server.address": request.url.host,
+        "url.scheme": request.url.scheme,
+    }
+    if request.url.port is not None:
+        attributes["server.port"] = request.url.port
+    with tracer.start_as_current_span(
+        f"{request.method} {request.url.host}",
+        kind=SpanKind.CLIENT,
+        attributes=attributes,
+    ) as span:
+        propagate.inject(request.headers)
+        yield span
+
+
+def record_http_response(span: Span | None, response: httpx2.Response) -> None:
+    if span is None:
+        return
+    span.set_attribute("http.response.status_code", response.status_code)
+    if response.is_error:
+        span.set_status(Status(StatusCode.ERROR))
+
+
+@contextmanager
+def _close_response_on_error(
+    response: httpx2.Response,
+) -> Generator[None, None, None]:
+    try:
+        yield
+    except Exception:
+        response.close()
+        raise
+
+
+@asynccontextmanager
+async def _aclose_response_on_error(
+    response: httpx2.Response,
+) -> AsyncGenerator[None]:
+    try:
+        yield
+    except Exception:
+        await response.aclose()
+        raise
+
+
+class HTTPClient:
+    """Synchronous HTTPX2 client pool with per-hop proxy routing."""
+
+    def __init__(self) -> None:
+        self._clients: dict[str | None, httpx2.Client] = {}
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+    def close(self) -> None:
+        for client in self._clients.values():
+            client.close()
+        self._clients.clear()
+
+    def _get_client(self, url: str) -> tuple[httpx2.Client, bool]:
+        proxy = _get_proxy(url)
+        client = self._clients.get(proxy)
+        if client is None:
+            transport: httpx2.BaseTransport
+            if _TEST_TRANSPORT.transport is not None:
+                transport = _TEST_TRANSPORT.transport
+            else:
+                transport = httpx2.HTTPTransport(proxy=proxy, trust_env=True)
+            client = httpx2.Client(
+                transport=transport,
+                trust_env=False,
+                follow_redirects=False,
+            )
+            self._clients[proxy] = client
+        return client, proxy is not None
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = 5,
+        allow_redirects: bool = True,
+        stream: bool = False,
+        max_redirects: int = 5,
+        validators: RedirectValidators | None = None,
+        **kwargs,
+    ) -> httpx2.Response:
+        history: list[httpx2.Response] = []
+        current_request: httpx2.Request | None = None
+        request_kwargs = _normalize_request_kwargs(kwargs)
+        request_auth = request_kwargs.pop("auth", None)
+
+        for _ in range(max_redirects + 1):
+            request_url = url if current_request is None else str(current_request.url)
+            client, used_proxy = self._get_client(request_url)
+            if validators is not None:
+                validators.validate_request_url(request_url, used_proxy=used_proxy)
+
+            if current_request is None:
+                current_request = client.build_request(
+                    method,
+                    url,
+                    headers=_prepare_headers(headers),
+                    timeout=timeout,
+                    **request_kwargs,
+                )
+
+            with trace_http_request(current_request) as span:
+                response = client.send(
+                    current_request,
+                    stream=True,
+                    follow_redirects=False,
+                    auth=request_auth if not history else None,
+                )
+                record_http_response(span, response)
+                response.history = history.copy()
+                with _close_response_on_error(response):
+                    if validators is not None:
+                        validators.validate_response(response, used_proxy=used_proxy)
+
+                    next_request = response.next_request
+                    if not allow_redirects or next_request is None:
+                        if not stream:
+                            response.read()
+                            response.close()
+                        return response
+
+                    history.append(response)
+                    response.close()
+                    current_request = next_request
+
+        msg = f"Exceeded {max_redirects} redirects."
+        raise httpx2.TooManyRedirects(msg, request=current_request)
+
+
+class AsyncHTTPClient:
+    """Asynchronous HTTPX2 client pool with the same validation policy."""
+
+    def __init__(self) -> None:
+        self._clients: dict[str | None, httpx2.AsyncClient] = {}
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        for client in self._clients.values():
+            await client.aclose()
+        self._clients.clear()
+
+    def _get_client(self, url: str) -> tuple[httpx2.AsyncClient, bool]:
+        proxy = _get_proxy(url)
+        client = self._clients.get(proxy)
+        if client is None:
+            transport: httpx2.AsyncBaseTransport
+            if _TEST_TRANSPORT.transport is not None:
+                transport = _TEST_TRANSPORT.transport
+            else:
+                transport = httpx2.AsyncHTTPTransport(proxy=proxy, trust_env=True)
+            client = httpx2.AsyncClient(
+                transport=transport,
+                trust_env=False,
+                follow_redirects=False,
+            )
+            self._clients[proxy] = client
+        return client, proxy is not None
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = 5,  # ruff: ignore[async-function-with-timeout]
+        allow_redirects: bool = True,
+        stream: bool = False,
+        max_redirects: int = 5,
+        validators: RedirectValidators | None = None,
+        **kwargs,
+    ) -> httpx2.Response:
+        history: list[httpx2.Response] = []
+        current_request: httpx2.Request | None = None
+        request_kwargs = _normalize_request_kwargs(kwargs)
+        request_auth = request_kwargs.pop("auth", None)
+
+        for _ in range(max_redirects + 1):
+            request_url = url if current_request is None else str(current_request.url)
+            client, used_proxy = self._get_client(request_url)
+            if validators is not None:
+                await sync_to_async(
+                    validators.validate_request_url,
+                    thread_sensitive=False,
+                )(request_url, used_proxy=used_proxy)
+
+            if current_request is None:
+                current_request = client.build_request(
+                    method,
+                    url,
+                    headers=_prepare_headers(headers),
+                    timeout=timeout,
+                    **request_kwargs,
+                )
+
+            with trace_http_request(current_request) as span:
+                response = await client.send(
+                    current_request,
+                    stream=True,
+                    follow_redirects=False,
+                    auth=request_auth if not history else None,
+                )
+                record_http_response(span, response)
+                response.history = history.copy()
+                async with _aclose_response_on_error(response):
+                    if validators is not None:
+                        validators.validate_response(response, used_proxy=used_proxy)
+
+                    next_request = response.next_request
+                    if not allow_redirects or next_request is None:
+                        if not stream:
+                            await response.aread()
+                            await response.aclose()
+                        return response
+
+                    history.append(response)
+                    await response.aclose()
+                    current_request = next_request
+
+        msg = f"Exceeded {max_redirects} redirects."
+        raise httpx2.TooManyRedirects(msg, request=current_request)
+
+
+def _request_with_redirects(
+    method: str,
+    url: str,
+    **kwargs,
+) -> httpx2.Response:
+    with HTTPClient() as client:
+        return client.request(method, url, **kwargs)
+
+
+async def _async_request_with_redirects(
+    method: str,
+    url: str,
+    **kwargs,
+) -> httpx2.Response:
+    async with AsyncHTTPClient() as client:
+        return await client.request(method, url, **kwargs)
 
 
 def _validated_request_with_redirects(
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
-    allow_redirects: bool = True,
-    stream: bool = True,
     allow_private_targets: bool = True,
     allowed_domains: list[str] | tuple[str, ...] = (),
-    max_redirects: int = 5,
     **kwargs,
-) -> Response:
+) -> httpx2.Response:
     return _request_with_redirects(
         method,
         url,
-        headers=headers,
-        timeout=timeout,
-        allow_redirects=allow_redirects,
-        # Keep response socket open so peer IP can be validated per request.
-        stream=stream,
-        max_redirects=max_redirects,
         validators=RuntimeRedirectValidators(
             allow_private_targets=allow_private_targets,
             allowed_domains=allowed_domains,
@@ -339,50 +529,18 @@ def _validated_request_with_redirects(
     )
 
 
-def _asset_request_with_redirects(
+async def _async_validated_request_with_redirects(
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
-    stream: bool = False,
-    max_redirects: int = 5,
-    **kwargs,
-) -> Response:
-    return _request_with_redirects(
-        method,
-        url,
-        headers=headers,
-        timeout=timeout,
-        stream=stream,
-        allow_redirects=True,
-        max_redirects=max_redirects,
-        validators=AssetRedirectValidators(),
-        **kwargs,
-    )
-
-
-def _restricted_asset_request_with_redirects(
-    method: str,
-    url: str,
-    *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
-    stream: bool = False,
     allow_private_targets: bool = True,
     allowed_domains: list[str] | tuple[str, ...] = (),
-    max_redirects: int = 5,
     **kwargs,
-) -> Response:
-    return _request_with_redirects(
+) -> httpx2.Response:
+    return await _async_request_with_redirects(
         method,
         url,
-        headers=headers,
-        timeout=timeout,
-        stream=stream,
-        allow_redirects=True,
-        max_redirects=max_redirects,
-        validators=RestrictedAssetRedirectValidators(
+        validators=RuntimeRedirectValidators(
             allow_private_targets=allow_private_targets,
             allowed_domains=allowed_domains,
         ),
@@ -390,35 +548,27 @@ def _restricted_asset_request_with_redirects(
     )
 
 
-def _buffer_response(response: Response, *, raise_for_status: bool) -> Response:
-    try:
-        if raise_for_status:
-            response.raise_for_status()
-        _ = response.content
-    finally:
-        response.close()
-    return response
-
-
 def fetch_url(
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
     raise_for_status: bool = True,
-    allow_redirects: bool = True,
     **kwargs,
-) -> Response:
-    response = requests.request(
-        method,
-        url,
-        headers=_prepare_headers(headers),
-        timeout=timeout,
-        allow_redirects=allow_redirects,
-        stream=False,
-        **kwargs,
-    )
+) -> httpx2.Response:
+    response = _request_with_redirects(method, url, stream=False, **kwargs)
+    if raise_for_status:
+        response.raise_for_status()
+    return response
+
+
+async def async_fetch_url(
+    method: str,
+    url: str,
+    *,
+    raise_for_status: bool = True,
+    **kwargs,
+) -> httpx2.Response:
+    response = await _async_request_with_redirects(method, url, stream=False, **kwargs)
     if raise_for_status:
         response.raise_for_status()
     return response
@@ -428,28 +578,44 @@ def fetch_validated_url(
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
     raise_for_status: bool = True,
-    allow_redirects: bool = True,
     allow_private_targets: bool = True,
     allowed_domains: list[str] | tuple[str, ...] = (),
-    max_redirects: int = 5,
     **kwargs,
-) -> Response:
+) -> httpx2.Response:
     response = _validated_request_with_redirects(
         method,
         url,
-        headers=headers,
-        timeout=timeout,
-        allow_redirects=allow_redirects,
-        stream=True,
+        stream=False,
         allow_private_targets=allow_private_targets,
         allowed_domains=allowed_domains,
-        max_redirects=max_redirects,
         **kwargs,
     )
-    return _buffer_response(response, raise_for_status=raise_for_status)
+    if raise_for_status:
+        response.raise_for_status()
+    return response
+
+
+async def async_fetch_validated_url(
+    method: str,
+    url: str,
+    *,
+    raise_for_status: bool = True,
+    allow_private_targets: bool = True,
+    allowed_domains: list[str] | tuple[str, ...] = (),
+    **kwargs,
+) -> httpx2.Response:
+    response = await _async_validated_request_with_redirects(
+        method,
+        url,
+        stream=False,
+        allow_private_targets=allow_private_targets,
+        allowed_domains=allowed_domains,
+        **kwargs,
+    )
+    if raise_for_status:
+        response.raise_for_status()
+    return response
 
 
 @contextmanager
@@ -457,31 +623,57 @@ def open_validated_url(
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
     raise_for_status: bool = True,
-    allow_redirects: bool = True,
     allow_private_targets: bool = True,
     allowed_domains: list[str] | tuple[str, ...] = (),
-    max_redirects: int = 5,
     **kwargs,
-) -> Generator[Response, None, None]:
-    response = _validated_request_with_redirects(
-        method,
-        url,
-        headers=headers,
-        timeout=timeout,
-        allow_redirects=allow_redirects,
-        stream=True,
-        allow_private_targets=allow_private_targets,
-        allowed_domains=allowed_domains,
-        max_redirects=max_redirects,
-        **kwargs,
-    )
-    with response:
-        if raise_for_status:
-            response.raise_for_status()
-        yield response
+) -> Generator[httpx2.Response, None, None]:
+    with HTTPClient() as client:
+        response = client.request(
+            method,
+            url,
+            stream=True,
+            validators=RuntimeRedirectValidators(
+                allow_private_targets=allow_private_targets,
+                allowed_domains=allowed_domains,
+            ),
+            **kwargs,
+        )
+        try:
+            if raise_for_status:
+                response.raise_for_status()
+            yield response
+        finally:
+            response.close()
+
+
+@asynccontextmanager
+async def async_open_validated_url(
+    method: str,
+    url: str,
+    *,
+    raise_for_status: bool = True,
+    allow_private_targets: bool = True,
+    allowed_domains: list[str] | tuple[str, ...] = (),
+    **kwargs,
+) -> AsyncGenerator[httpx2.Response]:
+    async with AsyncHTTPClient() as client:
+        response = await client.request(
+            method,
+            url,
+            stream=True,
+            validators=RuntimeRedirectValidators(
+                allow_private_targets=allow_private_targets,
+                allowed_domains=allowed_domains,
+            ),
+            **kwargs,
+        )
+        try:
+            if raise_for_status:
+                response.raise_for_status()
+            yield response
+        finally:
+            await response.aclose()
 
 
 @contextmanager
@@ -489,32 +681,29 @@ def open_asset_url(
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
     raise_for_status: bool = True,
-    max_redirects: int = 5,
     **kwargs,
-) -> Generator[Response, None, None]:
-    """Fetch an asset while validating each redirect target before following it."""
-    response = _asset_request_with_redirects(
-        method,
-        url,
-        headers=headers,
-        timeout=timeout,
-        stream=True,
-        max_redirects=max_redirects,
-        **kwargs,
-    )
-    with response:
-        if raise_for_status and not 200 <= response.status_code < 300:
-            raise ValidationError(
-                gettext(
-                    "Unable to download asset from the provided URL (HTTP status code: %(code)s)."
-                ),
-                code="download_failed",
-                params={"code": response.status_code},
-            )
-        yield response
+) -> Generator[httpx2.Response, None, None]:
+    with HTTPClient() as client:
+        response = client.request(
+            method,
+            url,
+            stream=True,
+            validators=AssetRedirectValidators(),
+            **kwargs,
+        )
+        try:
+            if raise_for_status and not response.is_success:
+                raise ValidationError(
+                    gettext(
+                        "Unable to download asset from the provided URL (HTTP status code: %(code)s)."
+                    ),
+                    code="download_failed",
+                    params={"code": response.status_code},
+                )
+            yield response
+        finally:
+            response.close()
 
 
 @contextmanager
@@ -522,36 +711,34 @@ def open_restricted_asset_url(
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None = None,
-    timeout: float = 5,
     raise_for_status: bool = True,
     allow_private_targets: bool = True,
     allowed_domains: list[str] | tuple[str, ...] = (),
-    max_redirects: int = 5,
     **kwargs,
-) -> Generator[Response, None, None]:
-    """Fetch an asset while validating redirects and connected peer addresses."""
-    response = _restricted_asset_request_with_redirects(
-        method,
-        url,
-        headers=headers,
-        timeout=timeout,
-        stream=True,
-        allow_private_targets=allow_private_targets,
-        allowed_domains=allowed_domains,
-        max_redirects=max_redirects,
-        **kwargs,
-    )
-    with response:
-        if raise_for_status and not 200 <= response.status_code < 300:
-            raise ValidationError(
-                gettext(
-                    "Unable to download asset from the provided URL (HTTP status code: %(code)s)."
-                ),
-                code="download_failed",
-                params={"code": response.status_code},
-            )
-        yield response
+) -> Generator[httpx2.Response, None, None]:
+    with HTTPClient() as client:
+        response = client.request(
+            method,
+            url,
+            stream=True,
+            validators=RestrictedAssetRedirectValidators(
+                allow_private_targets=allow_private_targets,
+                allowed_domains=allowed_domains,
+            ),
+            **kwargs,
+        )
+        try:
+            if raise_for_status and not response.is_success:
+                raise ValidationError(
+                    gettext(
+                        "Unable to download asset from the provided URL (HTTP status code: %(code)s)."
+                    ),
+                    code="download_failed",
+                    params={"code": response.status_code},
+                )
+            yield response
+        finally:
+            response.close()
 
 
 def _probe_validated_url(
@@ -561,17 +748,20 @@ def _probe_validated_url(
     max_redirects: int = 5,
     validators: RedirectValidators,
 ) -> None:
-    response = _request_with_redirects(
-        "get",
-        url,
-        timeout=timeout,
-        allow_redirects=True,
-        stream=True,
-        max_redirects=max_redirects,
-        validators=validators,
-    )
-    with response:
-        response.raise_for_status()
+    with HTTPClient() as client:
+        response = client.request(
+            "get",
+            url,
+            timeout=timeout,
+            allow_redirects=True,
+            stream=True,
+            max_redirects=max_redirects,
+            validators=validators,
+        )
+        try:
+            response.raise_for_status()
+        finally:
+            response.close()
 
 
 def _uri_error_cache_key(
@@ -611,7 +801,6 @@ def get_uri_error(
         LOGGER.debug("URL check for %s, cached success", uri)
         return None
     if cached:
-        # The cache contains string here
         LOGGER.debug("URL check for %s, cached failure", uri)
         return cached
     try:
@@ -621,12 +810,9 @@ def get_uri_error(
                 allow_private_targets=allow_private_targets,
                 allowed_domains=allowed_domains,
             ),
-            timeout=5,
-            max_redirects=5,
         )
-    except (requests.exceptions.RequestException, ValidationError) as error:
+    except (httpx2.HTTPError, ValidationError) as error:
         if getattr(getattr(error, "response", None), "status_code", 0) == 429:
-            # Silently ignore rate limiting issues
             return None
         result = (
             format_validation_error(error)

--- a/weblate/utils/tests/http_mock.py
+++ b/weblate/utils/tests/http_mock.py
@@ -1,0 +1,333 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Small responses-compatible HTTPX2 mock used by the existing test suite."""
+
+from __future__ import annotations
+
+import json as json_module
+import re
+from collections import UserList
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx2
+
+from weblate.utils.requests import PEER_IP_RESPONSE_ATTR, set_test_transport
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+GET = "GET"
+POST = "POST"
+PUT = "PUT"
+PATCH = "PATCH"
+DELETE = "DELETE"
+HEAD = "HEAD"
+OPTIONS = "OPTIONS"
+
+type ResponseHeaders = dict[str, str] | list[tuple[str, str]] | None
+
+
+class Calls(UserList):
+    def reset(self) -> None:
+        self.clear()
+
+
+class PreparedRequest:
+    """Requests-shaped view of an HTTPX2 request for legacy callbacks."""
+
+    def __init__(self, request: httpx2.Request) -> None:
+        self._request = request
+        self.method = request.method
+        self.url = str(request.url.copy_with(fragment=None))
+        self.headers = request.headers
+        self.body = request.content or None
+        self.path_url = request.url.raw_path.decode("ascii")
+
+
+@dataclass
+class Call:
+    request: PreparedRequest
+    response: httpx2.Response | BaseException
+
+
+@dataclass
+class Registration:
+    method: str
+    url: str | re.Pattern[str]
+    body: str | bytes | BaseException = b""
+    json: object | None = None
+    status: int = 200
+    headers: ResponseHeaders = None
+    callback: (
+        Callable[[PreparedRequest], tuple[int, ResponseHeaders, object]] | None
+    ) = None
+    match: list[Callable[[PreparedRequest], tuple[bool, str]]] = field(
+        default_factory=list
+    )
+    calls: Calls = field(default_factory=Calls)
+
+    def matches(self, request: PreparedRequest) -> bool:
+        if self.method != request.method:
+            return False
+        if isinstance(self.url, re.Pattern):
+            if self.url.search(request.url) is None:
+                return False
+        elif self.url != request.url:
+            registered = urlsplit(self.url)
+            requested = urlsplit(request.url)
+            if registered.query or self.url != urlunsplit(
+                (requested.scheme, requested.netloc, requested.path, "", "")
+            ):
+                return False
+        return all(matcher(request)[0] for matcher in self.match)
+
+    def respond(
+        self, request: PreparedRequest, original: httpx2.Request
+    ) -> httpx2.Response:
+        try:
+            if self.callback is not None:
+                status, headers, body = self.callback(request)
+                response = _build_response(
+                    original,
+                    status=status,
+                    headers=headers,
+                    body=body,
+                )
+            else:
+                response = _build_response(
+                    original,
+                    status=self.status,
+                    headers=self.headers,
+                    body=self.body,
+                    json=self.json,
+                )
+        except Exception as error:
+            call = Call(request=request, response=error)
+            calls.append(call)
+            self.calls.append(call)
+            raise
+        call = Call(request=request, response=response)
+        calls.append(call)
+        self.calls.append(call)
+        return response
+
+
+calls = Calls()
+_registrations: list[Registration] = []
+
+
+class Matchers:
+    @staticmethod
+    def json_params_matcher(expected: object, *, strict_match: bool = True):
+        def match(request: PreparedRequest) -> tuple[bool, str]:
+            try:
+                actual = json_module.loads(request.body or b"null")
+            except (json_module.JSONDecodeError, UnicodeDecodeError) as error:
+                return False, f"request body is not valid JSON: {error}"
+            if (
+                not strict_match
+                and isinstance(actual, dict)
+                and isinstance(expected, dict)
+            ):
+                actual = _filter_mapping(actual, expected)
+            return (
+                actual == expected,
+                f"JSON body {actual!r} does not match {expected!r}",
+            )
+
+        return match
+
+    @staticmethod
+    def header_matcher(expected: dict[str, str]):
+        def match(request: PreparedRequest) -> tuple[bool, str]:
+            actual = {
+                name: request.headers.get(name)
+                for name in expected
+                if name in request.headers
+            }
+            return (
+                actual == expected,
+                f"headers {actual!r} do not match {expected!r}",
+            )
+
+        return match
+
+
+matchers = Matchers()
+
+
+def _filter_mapping(actual: dict, expected: dict) -> dict:
+    result = {}
+    for key, value in actual.items():
+        if key not in expected:
+            continue
+        if isinstance(value, dict) and isinstance(expected[key], dict):
+            value = _filter_mapping(value, expected[key])
+        result[key] = value
+    return result
+
+
+def _build_response(
+    request: httpx2.Request,
+    *,
+    status: int,
+    headers: ResponseHeaders = None,
+    body: object = b"",
+    json: object | None = None,
+) -> httpx2.Response:
+    if isinstance(body, BaseException):
+        raise body
+    if json is not None:
+        response = httpx2.Response(
+            status,
+            headers=headers,
+            json=json,
+            request=request,
+        )
+    elif isinstance(body, bytes):
+        response = httpx2.Response(
+            status,
+            headers=headers,
+            content=body,
+            request=request,
+        )
+    elif body is not None:
+        response = httpx2.Response(
+            status,
+            headers=headers,
+            text=str(body),
+            request=request,
+        )
+    else:
+        response = httpx2.Response(status, headers=headers, request=request)
+    setattr(response, PEER_IP_RESPONSE_ATTR, "93.184.216.34")
+    return response
+
+
+def _handler(request: httpx2.Request) -> httpx2.Response:
+    prepared = PreparedRequest(request)
+    matches = [
+        (index, registration)
+        for index, registration in enumerate(_registrations)
+        if registration.matches(prepared)
+    ]
+    if not matches:
+        msg = f"Connection refused: {request.method} {request.url}"
+        error = httpx2.ConnectError(msg, request=request)
+        calls.append(Call(request=prepared, response=error))
+        raise error
+    index, registration = matches[0]
+    if len(matches) > 1:
+        _registrations.pop(index)
+        if registration.calls:
+            registration = matches[1][1]
+    return registration.respond(prepared, request)
+
+
+def reset() -> None:
+    _registrations.clear()
+    calls.reset()
+
+
+def activate(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        reset()
+        set_test_transport(httpx2.MockTransport(_handler))
+        try:
+            return function(*args, **kwargs)
+        finally:
+            set_test_transport(None)
+            reset()
+
+    @wraps(function)
+    async def async_wrapper(*args, **kwargs):
+        reset()
+        set_test_transport(httpx2.MockTransport(_handler))
+        try:
+            return await function(*args, **kwargs)
+        finally:
+            set_test_transport(None)
+            reset()
+
+    return async_wrapper if function.__code__.co_flags & 0x80 else wrapper
+
+
+def add(
+    method: str,
+    url: str | re.Pattern[str],
+    body: str | bytes | BaseException = b"",
+    *,
+    json: object | None = None,
+    status: int = 200,
+    headers: dict[str, str] | list[tuple[str, str]] | None = None,
+    content_type: str | None = None,
+    match: list[Callable[[PreparedRequest], tuple[bool, str]]] | None = None,
+    **_kwargs,
+) -> Registration:
+    result_headers = dict(headers or {})
+    if content_type is not None:
+        result_headers["Content-Type"] = content_type
+    registration = Registration(
+        method=method.upper(),
+        url=url,
+        body=body,
+        json=json,
+        status=status,
+        headers=result_headers,
+        match=list(match or ()),
+    )
+    _registrations.append(registration)
+    return registration
+
+
+def add_callback(
+    method: str,
+    url: str | re.Pattern[str],
+    *,
+    callback,
+    match=None,
+    **kwargs,
+) -> Registration:
+    registration = add(method, url, match=match, **kwargs)
+    registration.callback = callback
+    return registration
+
+
+def remove(method: str, url: str | re.Pattern[str]) -> None:
+    _registrations[:] = [
+        registration
+        for registration in _registrations
+        if not (registration.method == method.upper() and registration.url == url)
+    ]
+
+
+def replace(method: str, url: str | re.Pattern[str], **kwargs) -> Registration:
+    remove(method, url)
+    return add(method, url, **kwargs)
+
+
+def assert_call_count(url: str, count: int) -> None:
+    actual = sum(call.request.url == url for call in calls)
+    if actual != count:
+        msg = f"Expected {url!r} to be called {count} times, called {actual} times."
+        raise AssertionError(msg)
+
+
+def get(url, **kwargs) -> Registration:
+    return add(GET, url, **kwargs)
+
+
+def post(url, **kwargs) -> Registration:
+    return add(POST, url, **kwargs)
+
+
+def delete(*args, **kwargs):
+    if len(args) == 2:
+        return remove(args[0], args[1])
+    return add(DELETE, args[0], **kwargs)

--- a/weblate/utils/tests/test_checks.py
+++ b/weblate/utils/tests/test_checks.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 from weakref import WeakSet
 
+import httpx2
 from django.conf import settings
 from django.core.cache import cache
 from django.db import DatabaseError
@@ -24,6 +25,7 @@ from weblate.utils.apps import (
     check_database_size,
     check_errors,
     check_settings,
+    check_version,
 )
 from weblate.utils.celery import is_celery_queue_long
 from weblate.utils.classloader import ClassLoader
@@ -271,3 +273,15 @@ class ErrorCollectionCheckTestCase(SimpleTestCase):
         errors = list(check_errors(app_configs=None, databases=None))
 
         self.assertFalse(any(error.id == "weblate.I021" for error in errors))
+
+
+class VersionCheckTestCase(SimpleTestCase):
+    @patch(
+        "weblate.utils.apps.get_latest_version",
+        side_effect=httpx2.ConnectError("PyPI unavailable"),
+    )
+    def test_http_error_is_ignored(self, get_latest_version) -> None:
+        errors = list(check_version(app_configs=None, databases=None))
+
+        self.assertEqual(errors, [])
+        get_latest_version.assert_called_once_with()

--- a/weblate/utils/tests/test_errors.py
+++ b/weblate/utils/tests/test_errors.py
@@ -200,6 +200,29 @@ class GoogleCloudErrorReportingTest(SimpleTestCase):
         client.report_exception.assert_called_once_with()
         client.report.assert_not_called()
 
+    @override_settings(SENTRY_DSN=None)
+    def test_report_error_reports_explicit_google_exception(self) -> None:
+        client = MagicMock()
+        # ruff: ignore[private-member-access]
+        errors._STATE["google_cloud_error_reporting_client"] = client
+        handled_error: ValueError | None = None
+        try:
+            raise_broken_error()
+        except ValueError as error:
+            handled_error = error
+
+        with patch("weblate.utils.errors.record_error"):
+            errors.report_error(
+                "Handled asynchronous error",
+                level="error",
+                exception=handled_error,
+            )
+
+        report = client.report.call_args.args[0]
+        self.assertIn("Traceback (most recent call last):", report)
+        self.assertIn("ValueError: broken", report)
+        client.report_exception.assert_not_called()
+
     @override_settings(SENTRY_DSN="https://public@example.com/1")
     def test_report_error_reports_sentry_message_without_exception(self) -> None:
         sentry_sdk = MagicMock()
@@ -228,6 +251,33 @@ class GoogleCloudErrorReportingTest(SimpleTestCase):
 
         sentry_sdk.capture_exception.assert_called_once_with()
         sentry_sdk.capture_message.assert_not_called()
+
+    @override_settings(
+        SENTRY_DSN="https://public@example.com/1",
+        ROLLBAR={},
+    )
+    def test_report_error_preserves_explicit_exception(self) -> None:
+        error = ValueError("async failure")
+        sentry_sdk = MagicMock()
+        rollbar = MagicMock()
+
+        with (
+            patch("weblate.utils.errors.get_sentry_sdk", return_value=sentry_sdk),
+            patch("weblate.utils.errors.get_rollbar", return_value=rollbar),
+            patch("weblate.utils.errors.record_error") as record_error,
+        ):
+            errors.report_error(
+                "Handled asynchronous error",
+                level="error",
+                exception=error,
+            )
+
+        sentry_sdk.capture_exception.assert_called_once_with(error)
+        rollbar.report_exc_info.assert_called_once_with(
+            (ValueError, error, error.__traceback__),
+            level="error",
+        )
+        self.assertIs(record_error.call_args.kwargs["exception"], error)
 
     @override_settings(SENTRY_DSN=None)
     def test_report_error_reports_google_message(self) -> None:

--- a/weblate/utils/tests/test_requests.py
+++ b/weblate/utils/tests/test_requests.py
@@ -3,24 +3,241 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
-from unittest.mock import Mock, patch
+from contextlib import contextmanager
+from threading import get_ident
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-import responses
+import httpx2
+from asgiref.sync import async_to_sync
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from requests.cookies import RequestsCookieJar
 
+from weblate.utils import tracing
 from weblate.utils.requests import (
     PEER_IP_RESPONSE_ATTR,
+    AsyncHTTPClient,
+    HTTPClient,
+    _get_proxy,
     _get_response_peer_ip,
     _validate_response_peer,
+    fetch_url,
     fetch_validated_url,
     get_uri_error,
     open_asset_url,
     open_restricted_asset_url,
+    trace_http_request,
 )
+from weblate.utils.tests import http_mock as responses
+
+
+class TrackedSyncStream(httpx2.SyncByteStream):
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def __iter__(self):
+        self.events.append("read")
+        yield b"response-body"
+
+
+class TrackedAsyncStream(httpx2.AsyncByteStream):
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def __aiter__(self):
+        self.events.append("read")
+        yield b"response-body"
+
+
+class FetchURLTest(SimpleTestCase):
+    @patch(
+        "weblate.utils.requests.getproxies",
+        return_value={
+            "https": "http://proxy.example:8080",
+            "no": "example.com:8443",
+        },
+    )
+    @patch("weblate.utils.requests.proxy_bypass", return_value=False)
+    def test_get_proxy_honors_no_proxy_port(
+        self, mocked_proxy_bypass, mocked_getproxies
+    ) -> None:
+        self.assertIsNone(_get_proxy("https://example.com:8443/source"))
+        self.assertEqual(
+            _get_proxy("https://example.com:443/source"),
+            "http://proxy.example:8080",
+        )
+
+    @patch(
+        "weblate.utils.requests.getproxies",
+        return_value={
+            "https": "http://proxy.example:8080",
+            "no": "10.0.0.0/8",
+        },
+    )
+    @patch("weblate.utils.requests.proxy_bypass", return_value=False)
+    def test_get_proxy_honors_no_proxy_cidr(
+        self, mocked_proxy_bypass, mocked_getproxies
+    ) -> None:
+        self.assertIsNone(_get_proxy("https://10.1.2.3/source"))
+        self.assertEqual(
+            _get_proxy("https://192.0.2.1/source"),
+            "http://proxy.example:8080",
+        )
+
+    @responses.activate
+    def test_fetch_url_omits_null_form_values(self) -> None:
+        responses.add(
+            responses.POST,
+            "https://gitlab.example.com/merge_requests",
+            status=201,
+        )
+
+        fetch_url(
+            "post",
+            "https://gitlab.example.com/merge_requests",
+            data={
+                "source_branch": "weblate",
+                "target_project_id": None,
+            },
+        )
+
+        self.assertEqual(
+            responses.calls[0].request.body,
+            b"source_branch=weblate",
+        )
+
+    def test_http_client_buffers_response_inside_span(self) -> None:
+        events: list[str] = []
+        request = httpx2.Request("GET", "https://example.com/data")
+        response = httpx2.Response(
+            200,
+            request=request,
+            stream=TrackedSyncStream(events),
+        )
+        transport_client = MagicMock()
+        transport_client.build_request.return_value = request
+        transport_client.send.return_value = response
+
+        @contextmanager
+        def tracked_span(_request):
+            events.append("span-start")
+            try:
+                yield None
+            finally:
+                events.append("span-end")
+
+        client = HTTPClient()
+        with (
+            patch.object(
+                client,
+                "_get_client",
+                return_value=(transport_client, False),
+            ),
+            patch(
+                "weblate.utils.requests.trace_http_request",
+                side_effect=tracked_span,
+            ),
+        ):
+            result = client.request("get", "https://example.com/data")
+
+        self.assertEqual(result.content, b"response-body")
+        self.assertEqual(events, ["span-start", "read", "span-end"])
+
+    def test_async_http_client_buffers_response_inside_span(self) -> None:
+        events: list[str] = []
+        request = httpx2.Request("GET", "https://example.com/data")
+        response = httpx2.Response(
+            200,
+            request=request,
+            stream=TrackedAsyncStream(events),
+        )
+        transport_client = MagicMock()
+        transport_client.build_request.return_value = request
+        transport_client.send = AsyncMock(return_value=response)
+
+        @contextmanager
+        def tracked_span(_request):
+            events.append("span-start")
+            try:
+                yield None
+            finally:
+                events.append("span-end")
+
+        client = AsyncHTTPClient()
+        with (
+            patch.object(
+                client,
+                "_get_client",
+                return_value=(transport_client, False),
+            ),
+            patch(
+                "weblate.utils.requests.trace_http_request",
+                side_effect=tracked_span,
+            ),
+        ):
+            result = async_to_sync(client.request)("get", "https://example.com/data")
+
+        self.assertEqual(result.content, b"response-body")
+        self.assertEqual(events, ["span-start", "read", "span-end"])
+
+    def test_async_http_client_validates_request_off_event_loop(self) -> None:
+        request = httpx2.Request("GET", "https://example.com/data")
+        response = httpx2.Response(
+            200,
+            request=request,
+            content=b"response-body",
+        )
+        transport_client = MagicMock()
+        transport_client.build_request.return_value = request
+        transport_client.send = AsyncMock(return_value=response)
+        validation_thread_ids: list[int] = []
+        validators = MagicMock()
+
+        def record_validation_thread(*_args, **_kwargs) -> None:
+            validation_thread_ids.append(get_ident())
+
+        validators.validate_request_url.side_effect = record_validation_thread
+        client = AsyncHTTPClient()
+
+        async def make_request() -> tuple[int, httpx2.Response]:
+            event_loop_thread_id = get_ident()
+            result = await client.request(
+                "get",
+                "https://example.com/data",
+                validators=validators,
+            )
+            return event_loop_thread_id, result
+
+        with patch.object(
+            client,
+            "_get_client",
+            return_value=(transport_client, False),
+        ):
+            event_loop_thread_id, result = async_to_sync(make_request)()
+
+        self.assertEqual(result.content, b"response-body")
+        self.assertEqual(len(validation_thread_ids), 1)
+        self.assertNotEqual(validation_thread_ids[0], event_loop_thread_id)
+        validators.validate_request_url.assert_called_once_with(
+            "https://example.com/data",
+            used_proxy=False,
+        )
+
+    def test_http_trace_uses_configured_tracer(self) -> None:
+        request = httpx2.Request("GET", "https://example.com/data")
+        span = MagicMock()
+        span_context = MagicMock()
+        span_context.__enter__.return_value = span
+        tracer = MagicMock()
+        tracer.start_as_current_span.return_value = span_context
+        tracing.configure_opentelemetry_tracer(tracer)
+        self.addCleanup(tracing.configure_opentelemetry_tracer, None)
+
+        with trace_http_request(request) as current_span:
+            self.assertIs(current_span, span)
+
+        tracer.start_as_current_span.assert_called_once()
 
 
 class OpenAssetURLTest(SimpleTestCase):
@@ -447,87 +664,83 @@ class GetUriErrorTest(SimpleTestCase):
 
 
 class FetchValidatedURLTest(SimpleTestCase):
+    @responses.activate
     def test_fetch_validated_url_strips_auth_on_cross_origin_redirect(self) -> None:
-        recorded_calls: list[tuple[dict[str, str], bool]] = []
-        redirect_response = Mock()
-        redirect_response.is_redirect = True
-        redirect_response.url = "https://public.example.com/source"
-        redirect_response.headers = {"location": "https://other.example.com/final"}
-        redirect_response.cookies = RequestsCookieJar()
-        redirect_response.history = []
-        redirect_response.close = Mock()
+        recorded_headers: list[dict[str, str]] = []
 
-        final_response = Mock()
-        final_response.is_redirect = False
-        final_response.url = "https://other.example.com/final"
-        final_response.headers = {}
-        final_response.history = []
-        final_response.raise_for_status = Mock()
-        final_response.content = b"ok"
-
-        with patch("requests.sessions.Session.request") as mocked_request:
-
-            def record_request(*args, **kwargs):
-                recorded_calls.append((dict(kwargs["headers"]), "auth" in kwargs))
-                if len(recorded_calls) == 1:
-                    return redirect_response
-                return final_response
-
-            mocked_request.side_effect = record_request
-
-            fetch_validated_url(
-                "get",
-                "https://public.example.com/source",
-                headers={"Authorization": "Bearer secret"},
-                auth=("user", "pass"),
-                allow_redirects=True,
+        def redirect(request):
+            recorded_headers.append(dict(request.headers))
+            return (
+                302,
+                {"Location": "https://other.example.com/final"},
+                b"",
             )
 
-        self.assertEqual(mocked_request.call_count, 2)
-        self.assertEqual(recorded_calls[0][0]["Authorization"], "Bearer secret")
-        self.assertNotIn("Authorization", recorded_calls[1][0])
-        self.assertFalse(recorded_calls[1][1])
+        def final(request):
+            recorded_headers.append(dict(request.headers))
+            return 200, {}, b"ok"
 
+        responses.add_callback(
+            responses.GET,
+            "https://public.example.com/source",
+            callback=redirect,
+        )
+        responses.add_callback(
+            responses.GET,
+            "https://other.example.com/final",
+            callback=final,
+        )
+
+        fetch_validated_url(
+            "get",
+            "https://public.example.com/source",
+            headers={"Authorization": "Bearer secret"},
+            auth=("user", "pass"),
+            allow_redirects=True,
+        )
+
+        self.assertEqual(len(recorded_headers), 2)
+        self.assertIn("authorization", recorded_headers[0])
+        self.assertNotIn("authorization", recorded_headers[1])
+
+    @responses.activate
     def test_fetch_validated_url_preserves_delete_method_on_301_redirect(self) -> None:
-        recorded_calls: list[tuple[str, dict[str, object]]] = []
-        redirect_response = Mock()
-        redirect_response.is_redirect = True
-        redirect_response.status_code = 301
-        redirect_response.url = "https://public.example.com/source"
-        redirect_response.headers = {"location": "https://public.example.com/final"}
-        redirect_response.cookies = RequestsCookieJar()
-        redirect_response.history = []
-        redirect_response.close = Mock()
+        recorded_calls: list[tuple[str, bytes | None]] = []
 
-        final_response = Mock()
-        final_response.is_redirect = False
-        final_response.url = "https://public.example.com/final"
-        final_response.headers = {}
-        final_response.history = []
-        final_response.raise_for_status = Mock()
-        final_response.content = b"ok"
-
-        with patch("requests.sessions.Session.request") as mocked_request:
-
-            def record_request(*args, **kwargs):
-                recorded_calls.append((args[0], dict(kwargs)))
-                if len(recorded_calls) == 1:
-                    return redirect_response
-                return final_response
-
-            mocked_request.side_effect = record_request
-
-            fetch_validated_url(
-                "delete",
-                "https://public.example.com/source",
-                allow_redirects=True,
-                data=b"payload",
+        def redirect(request):
+            recorded_calls.append((request.method, request.body))
+            return (
+                301,
+                {"Location": "https://public.example.com/final"},
+                b"",
             )
 
-        self.assertEqual(mocked_request.call_count, 2)
-        self.assertEqual(recorded_calls[0][0], "delete")
-        self.assertEqual(recorded_calls[1][0], "delete")
-        self.assertEqual(recorded_calls[1][1]["data"], b"payload")
+        def final(request):
+            recorded_calls.append((request.method, request.body))
+            return 200, {}, b"ok"
+
+        responses.add_callback(
+            responses.DELETE,
+            "https://public.example.com/source",
+            callback=redirect,
+        )
+        responses.add_callback(
+            responses.DELETE,
+            "https://public.example.com/final",
+            callback=final,
+        )
+
+        fetch_validated_url(
+            "delete",
+            "https://public.example.com/source",
+            allow_redirects=True,
+            data=b"payload",
+        )
+
+        self.assertEqual(
+            recorded_calls,
+            [("DELETE", b"payload"), ("DELETE", b"payload")],
+        )
 
     @responses.activate
     @patch(

--- a/weblate/utils/tests/test_version.py
+++ b/weblate/utils/tests/test_version.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
-import responses
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
@@ -15,6 +14,7 @@ from packaging.version import Version
 
 from weblate.trans.tests.utils import get_test_file
 from weblate.utils.docs import get_doc_url
+from weblate.utils.tests import http_mock as responses
 from weblate.utils.version import (
     PYPI,
     VERSION,

--- a/weblate/utils/tests/test_zammad.py
+++ b/weblate/utils/tests/test_zammad.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 from unittest import TestCase
 
-import responses
 from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import override_settings
 
-from weblate.utils.zammad import submit_zammad_ticket
+from weblate.utils.tests import http_mock as responses
+from weblate.utils.zammad import ZammadError, submit_zammad_ticket
 
 
 class ZammadTest(TestCase):
@@ -54,3 +54,18 @@ class ZammadTest(TestCase):
             submit_zammad_ticket(title="title", body="body", name="name", email="mail"),
             ("https://example.com/#ticket/zoom/123", "4123"),
         )
+
+    @override_settings(ZAMMAD_URL="https://example.com")
+    @responses.activate
+    def test_invalid_json_encoding(self) -> None:
+        responses.add(
+            responses.POST,
+            "https://example.com/api/v1/form_config",
+            body=b"\xff",
+            content_type="application/json",
+        )
+
+        with self.assertRaisesRegex(
+            ZammadError, "Customer care is currently unavailable"
+        ):
+            submit_zammad_ticket(title="title", body="body", name="name", email="mail")

--- a/weblate/utils/tracing.py
+++ b/weblate/utils/tracing.py
@@ -55,6 +55,11 @@ def configure_opentelemetry_tracer(tracer: Tracer | None) -> None:
     _STATE["opentelemetry_tracer"] = tracer
 
 
+def get_opentelemetry_tracer() -> Tracer | None:
+    """Return the OpenTelemetry tracer configured by Weblate."""
+    return cast("Tracer | None", _STATE["opentelemetry_tracer"])
+
+
 def _set_opentelemetry_attribute(span: AttributeSpan, name: str, value: object) -> None:
     if value is None:
         return
@@ -123,7 +128,7 @@ def _record_error(
     attributes: dict[str, object | None] | None = None,
 ) -> None:
     """Record a handled error in OpenTelemetry tracing."""
-    tracer = cast("Tracer | None", _STATE["opentelemetry_tracer"])
+    tracer = get_opentelemetry_tracer()
     if tracer is None:
         return
 
@@ -152,7 +157,7 @@ def start_span(
             sentry_sdk = get_sentry_sdk()
             stack.enter_context(sentry_sdk.start_span(op=op, name=name))
 
-        tracer = cast("Tracer | None", _STATE["opentelemetry_tracer"])
+        tracer = get_opentelemetry_tracer()
         if tracer is not None:
             span = stack.enter_context(tracer.start_as_current_span(op))
             _set_opentelemetry_attribute(span, "weblate.operation", op)

--- a/weblate/utils/zammad.py
+++ b/weblate/utils/zammad.py
@@ -4,17 +4,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+import httpx2
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from requests.exceptions import JSONDecodeError, RequestException
 
 from .errors import report_error
-from .requests import fetch_url
-
-if TYPE_CHECKING:
-    from requests import Response
+from .requests import JSON_RESPONSE_ERRORS, fetch_url
 
 FINGERPRINT = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASw"
 ERR_UNCONFIGURED = "ZAMMAD_URL is not configured!"
@@ -25,10 +20,10 @@ class ZammadError(Exception):
     pass
 
 
-def process_zammad_response(response: Response) -> dict:
+def process_zammad_response(response: httpx2.Response) -> dict:
     try:
         data = response.json()
-    except JSONDecodeError as error:
+    except JSON_RESPONSE_ERRORS as error:
         report_error("Zammad JSON response")
         raise ZammadError(ERR_TEMPORARY) from error
 
@@ -37,7 +32,7 @@ def process_zammad_response(response: Response) -> dict:
 
     try:
         response.raise_for_status()
-    except RequestException as error:
+    except httpx2.HTTPError as error:
         report_error("Zammad response status")
         raise ZammadError(ERR_TEMPORARY) from error
 

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -52,7 +52,7 @@ from weblate.vcs.ssh import SSH_WRAPPER
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterator
 
-    import requests
+    import httpx2
     from django_stubs_ext import StrOrPromise
 
     from weblate.trans.models import Component
@@ -384,7 +384,7 @@ class Repository:
         add_breadcrumb(category="vcs", message=message, **data)
 
     @classmethod
-    def add_response_breadcrumb(cls, response: requests.Response) -> None:
+    def add_response_breadcrumb(cls, response: httpx2.Response) -> None:
         cls.add_breadcrumb(
             "http.response",
             status_code=response.status_code,

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -17,7 +17,7 @@ import urllib.parse
 from configparser import NoOptionError, NoSectionError, RawConfigParser
 from contextlib import contextmanager, suppress
 from ipaddress import ip_address
-from json import JSONDecodeError, dumps
+from json import dumps
 from pathlib import Path
 from time import sleep, time
 from typing import (
@@ -34,14 +34,13 @@ from typing import (
 from urllib.parse import urlparse, urlunparse
 from zipfile import ZipFile
 
-import requests
+import httpx2
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy
 from git.config import GitConfigParser
 from idna import encode as idna_encode
-from requests.exceptions import HTTPError
 
 from weblate.utils.data import data_dir, data_path
 from weblate.utils.errors import report_error
@@ -51,6 +50,7 @@ from weblate.utils.files import (
 )
 from weblate.utils.lock import WeblateLock, WeblateLockTimeoutError
 from weblate.utils.render import render_template
+from weblate.utils.requests import JSON_RESPONSE_ERRORS, fetch_url
 from weblate.utils.tracing import start_span
 from weblate.utils.xml import parse_xml
 from weblate.utils.zip import (
@@ -75,7 +75,6 @@ if TYPE_CHECKING:
     from zipfile import ZipInfo
 
     from django_stubs_ext import StrOrPromise
-    from requests.auth import AuthBase
 
     from weblate.trans.models import Component
     from weblate.utils.validators import ResolvedRepositoryURL
@@ -123,12 +122,12 @@ class GitAPIRequestError(RepositoryError):
     """Error raised for failed hosting API responses without parsed errors."""
 
     def __init__(
-        self, response: requests.Response, response_data: dict, error: str = ""
+        self, response: httpx2.Response, response_data: dict, error: str = ""
     ) -> None:
         self.response = response
         self.response_data = response_data
         self.error = error
-        message = error or f"{response.status_code} {response.reason}".strip()
+        message = error or f"{response.status_code} {response.reason_phrase}".strip()
         if 500 <= response.status_code <= 599:
             message = gettext("%(message)s Please retry later.") % {"message": message}
         super().__init__(0, message)
@@ -1921,7 +1920,7 @@ class GitMergeRequestBase(GitForcePushRepository):
             self.get_fork_failed_message(error.error, credentials, error.response),
         ) from error
 
-    def add_api_retry_guidance(self, message: str, response: requests.Response) -> str:
+    def add_api_retry_guidance(self, message: str, response: httpx2.Response) -> str:
         if 500 <= response.status_code <= 599:
             return gettext("%(message)s Please retry later.") % {"message": message}
         return message
@@ -1930,13 +1929,13 @@ class GitMergeRequestBase(GitForcePushRepository):
         self,
         error: str,
         credentials: GitCredentials,
-        response: requests.Response,
+        response: httpx2.Response,
     ) -> str:
         hostname = credentials["hostname"]
         username = credentials["username"]
         try:
             data = response.json()
-        except JSONDecodeError:
+        except JSON_RESPONSE_ERRORS:
             data = response.text
         self.log(
             f"Creating fork via {response.url} failed ({response.status_code}): {data!r}",
@@ -1946,7 +1945,7 @@ class GitMergeRequestBase(GitForcePushRepository):
             error = f"Repository not found. Check whether exists and user '{username}' has access to it."
         if error.strip():
             message = f"Could not fork repository at {hostname}: {error}"
-        elif not response.ok:
+        elif not response.is_success:
             message = (
                 f"Could not fork repository at {hostname}: "
                 f"{self.get_response_status_message(response)}"
@@ -1985,7 +1984,7 @@ class GitMergeRequestBase(GitForcePushRepository):
 
     def get_auth(
         self, credentials: GitCredentials
-    ) -> tuple[str, str] | AuthBase | None:
+    ) -> tuple[str, str] | httpx2.Auth | None:
         return None
 
     def get_error_message(self, response_data: dict) -> str:
@@ -2026,19 +2025,19 @@ class GitMergeRequestBase(GitForcePushRepository):
 
         return ", ".join(errors)
 
-    def get_response_status_message(self, response: requests.Response) -> str:
-        return f"{response.status_code} {response.reason}".strip()
+    def get_response_status_message(self, response: httpx2.Response) -> str:
+        return f"{response.status_code} {response.reason_phrase}".strip()
 
     def get_response_error_message(
-        self, response: requests.Response, response_data: dict
+        self, response: httpx2.Response, response_data: dict
     ) -> str:
         error = self.get_error_message(response_data)
-        if error or response.ok:
+        if error or response.is_success:
             return error
         return ""
 
     def should_retry_request(
-        self, response: requests.Response, response_data: dict
+        self, response: httpx2.Response, response_data: dict
     ) -> bool:
         retry_after = response.headers.get("Retry-After")
         if retry_after and retry_after.isdigit():
@@ -2069,7 +2068,7 @@ class GitMergeRequestBase(GitForcePushRepository):
         data: dict | None,
         params: dict | None,
         json: dict | None,
-    ) -> tuple[bool, dict, requests.Response, bool]:
+    ) -> tuple[bool, dict, httpx2.Response, bool]:
         do_retry = False
         invalid_error_response = False
         with lock:
@@ -2079,7 +2078,7 @@ class GitMergeRequestBase(GitForcePushRepository):
                 with start_span(op="vcs.api_sleep", name=vcs_id):
                     sleep(next_api_time - now)
             try:
-                response = requests.request(
+                response = fetch_url(
                     method,
                     url,
                     headers=self.get_headers(credentials),
@@ -2088,8 +2087,9 @@ class GitMergeRequestBase(GitForcePushRepository):
                     json=json,
                     auth=self.get_auth(credentials),
                     timeout=settings.VCS_API_TIMEOUT,
+                    raise_for_status=False,
                 )
-            except (OSError, HTTPError) as error:
+            except (OSError, httpx2.HTTPError) as error:
                 report_error("Git API request")
                 raise RepositoryError(0, str(error)) from error
 
@@ -2100,8 +2100,8 @@ class GitMergeRequestBase(GitForcePushRepository):
             self.add_response_breadcrumb(response)
             try:
                 response_data = {} if response.status_code == 204 else response.json()
-            except JSONDecodeError as error:
-                if not response.ok:
+            except JSON_RESPONSE_ERRORS as error:
+                if not response.is_success:
                     response_data = {}
                     invalid_error_response = True
                     self.log(
@@ -2128,7 +2128,7 @@ class GitMergeRequestBase(GitForcePushRepository):
         params: dict | None = None,
         json: dict | None = None,
         retry: int = 0,
-    ) -> tuple[dict, requests.Response, str]:
+    ) -> tuple[dict, httpx2.Response, str]:
         do_retry = False
         vcs_id = self.get_identifier()
         self.log(f"HTTP {method} {url}")
@@ -2180,10 +2180,10 @@ class GitMergeRequestBase(GitForcePushRepository):
         )
 
     def get_api_request_failure_message(
-        self, response: requests.Response, action: str, error: str
+        self, response: httpx2.Response, action: str, error: str
     ) -> str:
         status = response.status_code
-        status_text = f"{status} {response.reason}".strip()
+        status_text = f"{status} {response.reason_phrase}".strip()
         error = error.strip()
         if error:
             message = gettext(
@@ -2209,7 +2209,7 @@ class GitMergeRequestBase(GitForcePushRepository):
         self,
         error: str,
         pr_url: str,
-        response: requests.Response,
+        response: httpx2.Response,
         data: dict,
     ) -> NoReturn:
         status_code = response.status_code
@@ -2230,11 +2230,11 @@ class GitMergeRequestBase(GitForcePushRepository):
         )
 
     @classmethod
-    def raise_for_response(cls, response: requests.Response) -> None:
+    def raise_for_response(cls, response: httpx2.Response) -> None:
         """
         Validate response status code.
 
-        Raises :class:`HTTPError`, if one occurred.
+        Raises :class:`httpx2.HTTPStatusError`, if one occurred.
 
         Some providers (Azure DevOps for instance) respond with codes in the 2XX range
         even though the response was an error. This method exists to let the
@@ -2242,7 +2242,7 @@ class GitMergeRequestBase(GitForcePushRepository):
         """
         try:
             response.raise_for_status()
-        except HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             report_error("Git API request")
             raise RepositoryError(0, str(error)) from error
 
@@ -2269,7 +2269,7 @@ class AzureDevOpsRepository(GitMergeRequestBase):
     )
 
     @classmethod
-    def raise_for_response(cls, response: requests.Response) -> None:
+    def raise_for_response(cls, response: httpx2.Response) -> None:
         super().raise_for_response(response)
 
         # Azure DevOps returns 203 when the token is invalid
@@ -2337,7 +2337,7 @@ class AzureDevOpsRepository(GitMergeRequestBase):
 
     def get_auth(
         self, credentials: GitCredentials
-    ) -> tuple[str, str] | AuthBase | None:
+    ) -> tuple[str, str] | httpx2.Auth | None:
         return ("", credentials["token"])
 
     def create_fork(self, credentials: GitCredentials) -> None:
@@ -2564,7 +2564,7 @@ class GithubRepository(GitMergeRequestBase):
         return headers
 
     def should_retry_request(
-        self, response: requests.Response, response_data: dict
+        self, response: httpx2.Response, response_data: dict
     ) -> bool:
         if super().should_retry_request(response, response_data):
             return True
@@ -2988,7 +2988,7 @@ class GitLabRepository(GitMergeRequestBase):
             "get", credentials, credentials["url"]
         )
         if "id" not in response_data:
-            detail = error or response.reason or gettext("Unknown error")
+            detail = error or response.reason_phrase or gettext("Unknown error")
             report_error(
                 "Could not get GitLab project",
                 message=True,
@@ -3299,18 +3299,18 @@ class BitbucketServerRepository(GitMergeRequestBase):
                 forks, response, error_message = self.request(
                     "get", credentials, forks_url, params={"limit": 1000, "start": page}
                 )
-                if "values" in forks:
-                    for f in forks["values"]:
-                        fork_slug = f["origin"]["slug"]
-                        fork_project_key = f["origin"]["project"]["key"]
-                        if (
-                            fork_slug == credentials["slug"]
-                            and fork_project_key.upper() == credentials["owner"].upper()
-                        ):
-                            self.bb_fork = f
-                            break
+                values = forks.get("values", [])
+                for fork in values:
+                    fork_slug = fork["origin"]["slug"]
+                    fork_project_key = fork["origin"]["project"]["key"]
+                    if (
+                        fork_slug == credentials["slug"]
+                        and fork_project_key.upper() == credentials["owner"].upper()
+                    ):
+                        self.bb_fork = fork
+                        break
 
-                if self.bb_fork or forks["isLastPage"] or not forks["values"]:
+                if self.bb_fork or forks.get("isLastPage", True) or not values:
                     break
 
                 page += 1

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -15,8 +15,8 @@ import uuid
 from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote, urlencode, urlparse
 
+import httpx2
 import jwt
-import requests
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -24,6 +24,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext, gettext_lazy
 
+from weblate.utils.requests import fetch_url
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.git import GithubRepository
 from weblate.vcs.models import Installation, InstallationProvider
@@ -233,10 +234,12 @@ def exchange_github_app_manifest_code(
     """Exchange a temporary manifest code for the created app's credentials."""
     code = quote(normalize_github_callback_code(code), safe="")
     api_base = get_github_api_base(normalize_github_app_hostname(hostname))
-    response = requests.post(
+    response = fetch_url(
+        "post",
         f"{api_base}/app-manifests/{code}/conversions",
         headers={"Accept": "application/vnd.github.v3+json"},
         timeout=30,
+        raise_for_status=False,
     )
     response.raise_for_status()
     return response.json()
@@ -317,13 +320,15 @@ def get_installation_token(
     token = generate_jwt(app_id, private_key_pem)
 
     api_base = get_github_api_base(hostname)
-    response = requests.post(
+    response = fetch_url(
+        "post",
         f"{api_base}/app/installations/{installation_id}/access_tokens",
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github.v3+json",
         },
         timeout=30,
+        raise_for_status=False,
     )
     response.raise_for_status()
     data = response.json()
@@ -349,13 +354,15 @@ def get_app_installation(
     private_key_pem = validate_private_key(private_key)
     token = generate_jwt(app_id, private_key_pem)
     api_base = get_github_api_base(hostname)
-    response = requests.get(
+    response = fetch_url(
+        "get",
         f"{api_base}/app/installations/{installation_id}",
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github.v3+json",
         },
         timeout=30,
+        raise_for_status=False,
     )
     response.raise_for_status()
     return response.json()
@@ -380,7 +387,9 @@ def get_app_repositories(
         "Accept": "application/vnd.github.v3+json",
     }
     while url:
-        response = requests.get(url, headers=headers, timeout=30)
+        response = fetch_url(
+            "get", url, headers=headers, timeout=30, raise_for_status=False
+        )
         response.raise_for_status()
         data = response.json()
 
@@ -493,7 +502,8 @@ def get_github_oauth_base(hostname: str) -> str:
 
 def exchange_github_user_code(config: GitHubAppCredentials, code: str) -> str:
     """Exchange an install-time OAuth ``code`` for a user-to-server access token."""
-    response = requests.post(
+    response = fetch_url(
+        "post",
         f"{get_github_oauth_base(config.hostname)}/login/oauth/access_token",
         data={
             "client_id": config.client_id,
@@ -502,6 +512,7 @@ def exchange_github_user_code(config: GitHubAppCredentials, code: str) -> str:
         },
         headers={"Accept": "application/json"},
         timeout=30,
+        raise_for_status=False,
     )
     response.raise_for_status()
     payload = response.json()
@@ -517,10 +528,12 @@ def get_authenticated_github_user(
 ) -> dict:
     """Return metadata for the authenticated GitHub user."""
     api_base = get_github_api_base(normalize_github_app_hostname(config.hostname))
-    response = requests.get(
+    response = fetch_url(
+        "get",
         f"{api_base}/user",
         headers=_get_github_user_headers(user_token),
         timeout=30,
+        raise_for_status=False,
     )
     response.raise_for_status()
     return response.json()
@@ -542,7 +555,9 @@ def _get_user_accessible_installation(
     url: str | None = f"{api_base}/user/installations?per_page=100"
     headers = _get_github_user_headers(user_token)
     while url:
-        response = requests.get(url, headers=headers, timeout=30)
+        response = fetch_url(
+            "get", url, headers=headers, timeout=30, raise_for_status=False
+        )
         response.raise_for_status()
         for installation in response.json().get("installations", []):
             if str(installation.get("id")) == installation_id:
@@ -565,10 +580,12 @@ def user_can_administer_org_installation(
     )
     headers = _get_github_user_headers(user_token)
     while url:
-        response = requests.get(url, headers=headers, timeout=30)
+        response = fetch_url(
+            "get", url, headers=headers, timeout=30, raise_for_status=False
+        )
         try:
             response.raise_for_status()
-        except requests.HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             if error.response is not None and error.response.status_code in {403, 404}:
                 return False
             raise
@@ -994,7 +1011,7 @@ class GithubAppRepository(GithubRepository):
         except ValueError as error:
             msg = gettext("Invalid GitHub App installation ID.")
             raise RepositoryError(0, msg) from error
-        except requests.RequestException as error:
+        except httpx2.HTTPError as error:
             msg = gettext("Could not obtain GitHub App access token: %s") % error
             raise RepositoryError(0, msg) from error
 

--- a/weblate/vcs/tests/test_github_hooks.py
+++ b/weblate/vcs/tests/test_github_hooks.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 from datetime import timedelta
 
-import responses
 from django.core.cache import cache
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -17,6 +16,7 @@ from rest_framework.test import APIClient
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Component
 from weblate.trans.tests.test_views import ViewTestCase
+from weblate.utils.tests import http_mock as responses
 from weblate.vcs.github import (
     GitHubAppCredentials,
     GitHubInstallation,

--- a/weblate/vcs/tests/test_github_models.py
+++ b/weblate/vcs/tests/test_github_models.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 from base64 import b64decode
 from unittest.mock import patch
 
-import responses
 from django.core.cache import cache
 from django.test import TestCase
 
 from weblate.trans.models import Component, Project
+from weblate.utils.tests import http_mock as responses
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.github import (
     GitHubAppCredentials,

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 from typing import cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
-import responses
 from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.test import TestCase
@@ -21,6 +20,7 @@ from weblate.auth.models import Group, Permission, Role, User
 from weblate.trans.models import Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.site import get_site_url
+from weblate.utils.tests import http_mock as responses
 from weblate.vcs.github import (
     GITHUB_APP_MANIFEST_EVENTS,
     GITHUB_APP_MANIFEST_PERMISSIONS,

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -24,18 +24,18 @@ from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NoReturn, Protocol
 from unittest.mock import call, patch
 from zipfile import ZIP_DEFLATED, ZipFile
 
-import responses
 from django.core.cache import cache
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
-from responses import matchers
 
 from weblate.trans import defaults
 from weblate.trans.models import Component, Project
 from weblate.trans.tests.utils import RepoTestMixin, TempDirMixin
 from weblate.utils.files import REPO_TEMP_DIRNAME
 from weblate.utils.render import render_template
+from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests.http_mock import matchers
 from weblate.utils.zip import ZipSafetyLimits
 from weblate.vcs.base import (
     RepositoryCommandError,
@@ -3581,6 +3581,7 @@ class VCSGitLabTest(VCSGitUpstreamTest):
         for body, content_type in (
             ("", None),
             ("<html><body>Bad gateway</body></html>", "text/html"),
+            (b"\xff", "application/json"),
         ):
             with self.subTest(body=body):
                 responses.reset()
@@ -4910,6 +4911,7 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
         for body, content_type in (
             ("", None),
             ("<html><body>Bad gateway</body></html>", "text/html"),
+            (b"\xff", "application/json"),
         ):
             with self.subTest(body=body):
                 responses.reset()

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -14,7 +14,6 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlparse
 
-import responses
 from django.conf import settings
 from django.core import mail
 from django.core.checks import Critical
@@ -37,6 +36,7 @@ from weblate.trans.tests.utils import get_test_file
 from weblate.utils.apps import check_data_writable
 from weblate.utils.backup import BackupError, BorgResult
 from weblate.utils.data import data_path
+from weblate.utils.tests import http_mock as responses
 from weblate.utils.unittest import tempdir_setting
 from weblate.wladmin.forms import ThemeColorField, ThemeColorWidget
 from weblate.wladmin.middleware import (

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -11,6 +11,7 @@ from shutil import disk_usage
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 from urllib.parse import quote, urlencode
 
+import httpx2
 from django.conf import settings
 from django.core.cache import cache
 from django.core.checks import run_checks
@@ -35,7 +36,6 @@ from django.utils.translation import gettext, gettext_lazy
 from django.views.decorators.http import require_POST
 from django.views.generic import ListView
 from django.views.generic.edit import CreateView, FormMixin
-from requests.exceptions import HTTPError, Timeout
 
 from weblate.accounts.forms import AdminUserSearchForm, ContactForm
 from weblate.accounts.views import UserList, get_initial_contact
@@ -421,7 +421,7 @@ def discovery_callback(request: AuthenticatedHttpRequest) -> HttpResponse:
         support.refresh(
             site_url=get_discovery_site_url(reverse("manage-discovery-callback"))
         )
-    except Timeout:
+    except httpx2.TimeoutException:
         report_error("Activation timeout")
         messages.error(
             request,
@@ -486,12 +486,12 @@ def activate(request: AuthenticatedHttpRequest) -> HttpResponse:
         activation_error = ""
         try:
             support.refresh()
-        except Timeout:
+        except httpx2.TimeoutException:
             report_error("Activation timeout")
             activation_error = gettext(
                 "Could not activate your installation. Please try again later."
             )
-        except HTTPError as error:
+        except httpx2.HTTPStatusError as error:
             report_error("Activation error")
             if error.response is not None and error.response.status_code == 404:
                 activation_error = gettext(


### PR DESCRIPTION
Replace Weblate-owned Requests usage with a dual-mode HTTPX2 transport so editor lookups can await provider I/O while sharing one SSRF and redirect-validation policy.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
