### PR TITLE
feat(vcs): link failure alerts to component settings

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,7 @@ Weblate 2026.8
 * :ref:`Empty workspaces <workspace-removal>` not associated with billing can now be removed from the workspace :guilabel:`Operations` menu.
 * :ref:`mt-aws` machine translation now supports configuring formality, brevity, and profanity masking.
 * Improved :ref:`screenshots` OCR reliability and error reporting when downloading recognition data.
+* Repository failure alerts now link directly to component version control settings for users who can edit them.
 * Celery workers now prefetch fewer tasks by default to reduce memory usage and improve task distribution.
 * Improved the recommended :ref:`running-granian` configuration and Docker container worker resilience for Weblate's WSGI workload.
 * Added opt-in :ref:`running-granian-asgi` deployment support.

--- a/weblate/templates/trans/alert/pushfailure.html
+++ b/weblate/templates/trans/alert/pushfailure.html
@@ -7,10 +7,17 @@
 {% include "trans/alert/common-repo.html" %}
 
 {% perm 'vcs.push' component as user_can_push %}
-{% if user_can_push %}
+{% perm 'component.edit' component as user_can_edit_component %}
+{% if user_can_push or user_can_edit_component %}
   <p>
-    <a href="#"
-       class="btn btn-primary link-post"
-       data-href="{% url "push" path=component.get_url_path %}">{% translate "Push the repository" %}</a>
+    {% if user_can_push %}
+      <a href="#"
+         class="btn btn-primary link-post"
+         data-href="{% url "push" path=component.get_url_path %}">{% translate "Push the repository" %}</a>
+    {% endif %}
+    {% if user_can_edit_component %}
+      <a class="btn btn-link"
+         href="{% url 'settings' path=component.get_url_path %}#vcs">{% translate "Edit component settings" %}</a>
+    {% endif %}
   </p>
 {% endif %}

--- a/weblate/templates/trans/alert/repositoryoperationfailure.html
+++ b/weblate/templates/trans/alert/repositoryoperationfailure.html
@@ -7,10 +7,17 @@
 {% include "trans/alert/common-repo.html" %}
 
 {% perm 'vcs.reset' component as user_can_reset %}
-{% if user_can_reset %}
+{% perm 'component.edit' component as user_can_edit_component %}
+{% if user_can_reset or user_can_edit_component %}
   <p>
-    <a href="#"
-       class="btn btn-primary link-post"
-       data-href="{% url "reset" path=component.get_url_path %}">{% translate "Reset the repository" %}</a>
+    {% if user_can_reset %}
+      <a href="#"
+         class="btn btn-primary link-post"
+         data-href="{% url "reset" path=component.get_url_path %}">{% translate "Reset the repository" %}</a>
+    {% endif %}
+    {% if user_can_edit_component %}
+      <a class="btn btn-link"
+         href="{% url 'settings' path=component.get_url_path %}#vcs">{% translate "Edit component settings" %}</a>
+    {% endif %}
   </p>
 {% endif %}

--- a/weblate/templates/trans/alert/updatefailure.html
+++ b/weblate/templates/trans/alert/updatefailure.html
@@ -7,10 +7,17 @@
 {% include "trans/alert/common-repo.html" %}
 
 {% perm 'vcs.update' component as user_can_update %}
-{% if user_can_update %}
+{% perm 'component.edit' component as user_can_edit_component %}
+{% if user_can_update or user_can_edit_component %}
   <p>
-    <a href="#"
-       class="btn btn-primary link-post"
-       data-href="{% url "update" path=component.get_url_path %}">{% translate "Update the repository" %}</a>
+    {% if user_can_update %}
+      <a href="#"
+         class="btn btn-primary link-post"
+         data-href="{% url "update" path=component.get_url_path %}">{% translate "Update the repository" %}</a>
+    {% endif %}
+    {% if user_can_edit_component %}
+      <a class="btn btn-link"
+         href="{% url 'settings' path=component.get_url_path %}#vcs">{% translate "Edit component settings" %}</a>
+    {% endif %}
   </p>
 {% endif %}

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -1684,6 +1684,62 @@ class MonolingualAlertTest(ViewTestCase):
 
 
 class RepositoryAlertTemplateTest(SimpleTestCase):
+    @staticmethod
+    def render_failure_alert(template_name: str, permissions: set[str]) -> str:
+        component = SimpleNamespace(get_url_path=lambda: ("test", "component"))
+        user = SimpleNamespace(
+            has_perm=lambda permission, _obj: permission in permissions
+        )
+        return render_to_string(
+            template_name,
+            {
+                "analysis": {},
+                "component": component,
+                "error": "Repository operation failed",
+                "user": user,
+            },
+        )
+
+    def test_repository_failure_settings_action_permissions(self) -> None:
+        settings_url = (
+            reverse(
+                "settings",
+                kwargs={"path": ("test", "component")},
+            )
+            + "#vcs"
+        )
+        cases = (
+            (
+                "trans/alert/repositoryoperationfailure.html",
+                "vcs.reset",
+                "Reset the repository",
+            ),
+            (
+                "trans/alert/updatefailure.html",
+                "vcs.update",
+                "Update the repository",
+            ),
+            (
+                "trans/alert/pushfailure.html",
+                "vcs.push",
+                "Push the repository",
+            ),
+        )
+
+        for template_name, retry_permission, retry_label in cases:
+            with self.subTest(template_name=template_name, permission="component.edit"):
+                rendered = self.render_failure_alert(template_name, {"component.edit"})
+
+                self.assertIn("Edit component settings", rendered)
+                self.assertIn(f'href="{settings_url}"', rendered)
+                self.assertNotIn(retry_label, rendered)
+
+            with self.subTest(template_name=template_name, permission=retry_permission):
+                rendered = self.render_failure_alert(template_name, {retry_permission})
+
+                self.assertNotIn("Edit component settings", rendered)
+                self.assertIn(retry_label, rendered)
+
     def test_repository_guidance_uses_header_documentation_link(self) -> None:
         for template_name in (
             "trans/alert/repositoryoutdated.html",


### PR DESCRIPTION
Some repository failures require corrected VCS configuration before retrying, so authorized users need a direct path from the alert.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
