### PR TITLE
fix(l10n): correct Simplified Chinese SAML security documentation

### DIFF
--- a/docs/locales/zh_Hans/LC_MESSAGES/docs.po
+++ b/docs/locales/zh_Hans/LC_MESSAGES/docs.po
@@ -12585,15 +12585,15 @@ msgid "SAML Identity Provider settings, see :ref:`saml-auth`."
 msgstr "SAML 身份提供者设置，请参见 :ref:`saml-auth`。"
 
 #: admin/install/docker.rst:1813
-#, fuzzy
 msgid ""
 "SAML security configuration as a JSON object, passed to "
 "``SOCIAL_AUTH_SAML_SECURITY_CONFIG``. For example, to disable the "
 "``requestedAuthnContext`` (needed for some identity providers such as "
 "Microsoft Entra ID with multi-factor authentication):"
 msgstr ""
-"用于接收错误报告的 Google Cloud 项目标识（Project ID）。如未指定，Google 客户"
-"端将通过应用默认凭据（Application Default Credentials）自动识别项目。"
+"作为 JSON 对象的 SAML 安全配置，传递给 ``SOCIAL_AUTH_SAML_SECURITY_CONFIG``。"
+"例如，要禁用 ``requestedAuthnContext``（某些身份提供商需要这样做，例如启用了多"
+"重身份验证的 Microsoft Entra ID）："
 
 #: admin/install/docker.rst:1825
 msgid ""


### PR DESCRIPTION
### Motivation

- A Simplified Chinese translation entry for the SAML security configuration was incorrectly replaced with Google Cloud Error Reporting text, and the entry was left marked `fuzzy`, causing a documentation correctness issue and potential inclusion of the wrong text if `--use-fuzzy` is applied.

### Description

- Replace the wrong `msgstr` for the SAML security configuration entry in `docs/locales/zh_Hans/LC_MESSAGES/docs.po` with an accurate Simplified Chinese translation that preserves `SOCIAL_AUTH_SAML_SECURITY_CONFIG` and `requestedAuthnContext` identifiers and the Microsoft Entra ID MFA example. 
- Remove the `fuzzy` marker from the corrected entry so the translation is treated as reviewed and included in compiled catalogs. 
- Keep surrounding context and links intact so no other documentation meaning is changed.

### Testing

- Ran `git diff --check` to ensure no whitespace or diff issues, which succeeded. 
- Compiled the translated PO file with `msgfmt -c -o /tmp/weblate-docs-zh-Hans.mo docs/locales/zh_Hans/LC_MESSAGES/docs.po`, which succeeded with acceptable warnings. 
- Loaded the compiled catalog via a Python `gettext.GNUTranslations` check to assert the SAML msgid is translated, includes the configuration identifiers, and no longer contains Google Cloud text, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64af56e59c8329bd5cc0977b4fca59)