### PR TITLE
refactor(security): harden outbound HTTP address binding

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -40,6 +40,7 @@ Weblate 2026.8
 
 * Category, project, and comment statistics now stay consistent after component topology and comment changes, and category metrics are collected correctly.
 * Mercurial repository filenames beginning with a dash are now handled safely.
+* Protected outbound HTTP requests now bind connections to validated public addresses.
 * VCS operations now bind protected Git connections to validated public addresses and fail closed for clients which cannot enforce that binding.
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -353,6 +353,9 @@ Build-time and configuration variants
        (source: :setting:`ASSET_RESTRICT_PRIVATE`,
        :setting:`PROJECT_WEB_RESTRICT_PRIVATE`,
        :setting:`WEBHOOK_RESTRICT_PRIVATE`, :setting:`VCS_RESTRICT_PRIVATE`)
+       Protected direct HTTP requests are bound to addresses approved by
+       runtime validation; configured proxies are trusted infrastructure and
+       resolve their destination hosts.
        Protected Git HTTPS and SSH operations are bound to addresses approved
        by runtime validation. Protected SSH operations validate the effective
        ``HostName`` and ``Port``. Trusted administrator SSH configuration can
@@ -595,9 +598,10 @@ Security properties Weblate provides
        :setting:`PROJECT_WEB_RESTRICT_PRIVATE`,
        :setting:`WEBHOOK_RESTRICT_PRIVATE`, :setting:`VCS_RESTRICT_PRIVATE`)
      - Default private-target checks are enabled and no trusted allowlist
-       exemption applies. VCS restrictions remain enabled, Git HTTPS and SSH
-       address binding is not bypassed, and VCS backends without binding use
-       only explicitly trusted hosts.
+       exemption applies. Direct protected HTTP requests and Git HTTPS and SSH
+       operations retain address binding, VCS restrictions remain enabled,
+       and VCS backends without binding use only explicitly trusted hosts.
+       Configured proxies remain trusted routing infrastructure.
      - A user-configurable screenshot URL, remote HTML URL, project website or
        repository browser URL, outbound webhook URL, Fedora Messaging AMQP
        broker URL, or VCS URL reaches an internal or non-public target despite

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -9277,6 +9277,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.WEBHOOK_CLS.create(
             configuration=self.addon_configuration, project=self.project
         )
+        responses.add(responses.POST, self.WEBHOOK_URL, status=200)
 
         self.reset_calls()
         with self.captureOnCommitCallbacks(execute=True):
@@ -9404,7 +9405,11 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.assertEqual(self.count_requests(), 2)
 
     @responses.activate
-    def test_connection_error(self) -> None:
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
+    )
+    def test_connection_error(self, _mocked_getaddrinfo) -> None:
         """Test connection error when during message delivery."""
         request = httpx2.Request("POST", self.WEBHOOK_URL)
         self.do_translation_added_test(

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+from asyncio import get_running_loop
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from django.core.exceptions import ValidationError
@@ -15,6 +17,9 @@ from idna import IDNAError
 from idna import encode as idna_encode
 
 from weblate.utils.errors import add_breadcrumb
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 LOCAL_HOST_SUFFIXES = (
     ".local",
@@ -276,8 +281,55 @@ def resolve_runtime_hostname(
     value: str, *, allow_private_targets: bool = True
 ) -> tuple[str, ...]:
     """Resolve a hostname and return all validated connection addresses."""
+    resolution_hostname, result = _prepare_runtime_hostname(
+        value, allow_private_targets=allow_private_targets
+    )
+    if resolution_hostname is None:
+        return result
+
+    try:
+        addresses = socket.getaddrinfo(
+            resolution_hostname, None, type=socket.SOCK_STREAM
+        )
+    except OSError as error:
+        raise ValidationError(
+            gettext("Could not resolve the URL domain: {}").format(error)
+        ) from error
+
+    return _validate_runtime_addresses(
+        addresses, allow_private_targets=allow_private_targets
+    )
+
+
+async def async_resolve_runtime_hostname(
+    value: str, *, allow_private_targets: bool = True
+) -> tuple[str, ...]:
+    """Asynchronously resolve all validated connection addresses."""
+    resolution_hostname, result = _prepare_runtime_hostname(
+        value, allow_private_targets=allow_private_targets
+    )
+    if resolution_hostname is None:
+        return result
+
+    try:
+        addresses = await get_running_loop().getaddrinfo(
+            resolution_hostname, None, type=socket.SOCK_STREAM
+        )
+    except OSError as error:
+        raise ValidationError(
+            gettext("Could not resolve the URL domain: {}").format(error)
+        ) from error
+
+    return _validate_runtime_addresses(
+        addresses, allow_private_targets=allow_private_targets
+    )
+
+
+def _prepare_runtime_hostname(
+    value: str, *, allow_private_targets: bool
+) -> tuple[str | None, tuple[str, ...]]:
     if allow_private_targets:
-        return ()
+        return None, ()
 
     normalized = _normalize_hostname(value)
 
@@ -285,18 +337,19 @@ def resolve_runtime_hostname(
         validate_runtime_ip(
             str(ip_address), allow_private_targets=allow_private_targets
         )
-        return (str(ip_address),)
+        return None, (str(ip_address),)
 
     try:
-        resolution_hostname = idna_encode(normalized, uts46=True).decode("ascii")
-        addresses = socket.getaddrinfo(
-            resolution_hostname, None, type=socket.SOCK_STREAM
-        )
-    except (IDNAError, OSError, UnicodeError) as error:
+        return idna_encode(normalized, uts46=True).decode("ascii"), ()
+    except (IDNAError, UnicodeError) as error:
         raise ValidationError(
             gettext("Could not resolve the URL domain: {}").format(error)
         ) from error
 
+
+def _validate_runtime_addresses(
+    addresses: Iterable[Any], *, allow_private_targets: bool
+) -> tuple[str, ...]:
     result: list[str] = []
     for _family, _type, _proto, _canonname, sockaddr in addresses:
         address = sockaddr[0]

--- a/weblate/utils/requests.py
+++ b/weblate/utils/requests.py
@@ -12,12 +12,12 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
 from ipaddress import ip_address, ip_network
-from typing import TYPE_CHECKING, Self
+from time import monotonic
+from typing import TYPE_CHECKING, Any, Self, cast
 from urllib.parse import urlparse
 from urllib.request import getproxies, proxy_bypass
 
 import httpx2
-from asgiref.sync import sync_to_async
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext
@@ -26,16 +26,27 @@ from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from weblate.logger import LOGGER
 from weblate.utils.outbound import (
+    async_resolve_runtime_hostname,
     is_allowlisted_hostname,
+    resolve_runtime_hostname,
     validate_connected_peer,
     validate_outbound_url,
-    validate_runtime_url,
 )
 from weblate.utils.tracing import get_opentelemetry_tracer
 from weblate.utils.validators import validate_asset_url
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Callable, Generator
+    from collections.abc import (
+        AsyncGenerator,
+        AsyncIterator,
+        Callable,
+        Generator,
+        Iterator,
+    )
+    from types import TracebackType
+    from typing import Never
+
+    from httpx2._types import AuthTypes
 
 
 @dataclass
@@ -45,7 +56,10 @@ class TestTransport:
 
 _TEST_TRANSPORT = TestTransport()
 PEER_IP_RESPONSE_ATTR = "_weblate_peer_ip"
+ORIGINAL_URL_REQUEST_EXTENSION = "weblate_original_url"
+VALIDATORS_REQUEST_EXTENSION = "weblate_redirect_validators"
 JSON_RESPONSE_ERRORS = (json.JSONDecodeError, UnicodeDecodeError)
+ADDRESS_FALLBACK_DELAY = 0.25
 
 
 def set_test_transport(transport: httpx2.MockTransport | None) -> None:
@@ -57,8 +71,17 @@ def set_test_transport(transport: httpx2.MockTransport | None) -> None:
 class RedirectValidators:
     """Transport-neutral outbound request validation policy."""
 
-    def validate_request_url(self, request_url: str, *, used_proxy: bool) -> None:
-        return
+    def validate_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
+        """Validate a request and return addresses to pin, when needed."""
+        return ()
+
+    async def validate_async_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
+        """Asynchronously validate a request and return addresses to pin."""
+        return self.validate_request_url(request_url, used_proxy=used_proxy)
 
     def validate_response(self, response: httpx2.Response, *, used_proxy: bool) -> None:
         return
@@ -69,7 +92,9 @@ class RuntimeRedirectValidators(RedirectValidators):
     allow_private_targets: bool = True
     allowed_domains: list[str] | tuple[str, ...] = ()
 
-    def validate_request_url(self, request_url: str, *, used_proxy: bool) -> None:
+    def _get_hostname_to_resolve(
+        self, request_url: str, *, used_proxy: bool
+    ) -> str | None:
         hostname = urlparse(request_url).hostname or ""
         if is_allowlisted_hostname(hostname, self.allowed_domains):
             validate_outbound_url(
@@ -77,16 +102,34 @@ class RuntimeRedirectValidators(RedirectValidators):
                 allow_private_targets=False,
                 allowed_domains=self.allowed_domains,
             )
-            return
+            return None
         if used_proxy:
             validate_outbound_url(
                 request_url,
                 allow_private_targets=self.allow_private_targets,
                 allowed_domains=self.allowed_domains,
             )
-            return
-        validate_runtime_url(
-            request_url, allow_private_targets=self.allow_private_targets
+            return None
+        return hostname
+
+    def validate_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
+        hostname = self._get_hostname_to_resolve(request_url, used_proxy=used_proxy)
+        if hostname is None:
+            return ()
+        return resolve_runtime_hostname(
+            hostname, allow_private_targets=self.allow_private_targets
+        )
+
+    async def validate_async_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
+        hostname = self._get_hostname_to_resolve(request_url, used_proxy=used_proxy)
+        if hostname is None:
+            return ()
+        return await async_resolve_runtime_hostname(
+            hostname, allow_private_targets=self.allow_private_targets
         )
 
     def validate_response(self, response: httpx2.Response, *, used_proxy: bool) -> None:
@@ -100,15 +143,28 @@ class RuntimeRedirectValidators(RedirectValidators):
 
 @dataclass
 class AssetRedirectValidators(RedirectValidators):
-    def validate_request_url(self, request_url: str, *, used_proxy: bool) -> None:
+    def validate_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
         validate_asset_url(request_url)
+        return ()
 
 
 @dataclass
 class RestrictedAssetRedirectValidators(RuntimeRedirectValidators):
-    def validate_request_url(self, request_url: str, *, used_proxy: bool) -> None:
+    def validate_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
         validate_asset_url(request_url)
-        super().validate_request_url(request_url, used_proxy=used_proxy)
+        return super().validate_request_url(request_url, used_proxy=used_proxy)
+
+    async def validate_async_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
+        validate_asset_url(request_url)
+        return await super().validate_async_request_url(
+            request_url, used_proxy=used_proxy
+        )
 
 
 @dataclass
@@ -116,9 +172,12 @@ class ChainedRedirectValidators(RedirectValidators):
     request_validators: tuple[Callable[[str], None], ...] = ()
     response_validator: Callable[[httpx2.Response, bool], None] | None = None
 
-    def validate_request_url(self, request_url: str, *, used_proxy: bool) -> None:
+    def validate_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
         for validator in self.request_validators:
             validator(request_url)
+        return ()
 
     def validate_response(self, response: httpx2.Response, *, used_proxy: bool) -> None:
         if self.response_validator is not None:
@@ -277,33 +336,568 @@ def record_http_response(span: Span | None, response: httpx2.Response) -> None:
         span.set_status(Status(StatusCode.ERROR))
 
 
-@contextmanager
-def _close_response_on_error(
+class TracedStream:
+    """Keep a client span open until its response stream is consumed."""
+
+    def __init__(self, trace) -> None:
+        self.trace = trace
+
+    def _finish(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        if self.trace is not None:
+            trace, self.trace = self.trace, None
+            trace.__exit__(exc_type, exc_value, traceback)
+
+
+class TracedSyncStream(TracedStream, httpx2.SyncByteStream):
+    """Synchronous traced response stream."""
+
+    def __init__(self, stream: httpx2.SyncByteStream, trace) -> None:
+        super().__init__(trace)
+        self.stream = stream
+
+    def __iter__(self) -> Iterator[bytes]:
+        try:
+            yield from self.stream
+        except BaseException as error:
+            self._finish(type(error), error, error.__traceback__)
+            raise
+        self._finish()
+
+    def close(self) -> None:
+        try:
+            self.stream.close()
+        except BaseException as error:
+            self._finish(type(error), error, error.__traceback__)
+            raise
+        self._finish()
+
+
+class TracedAsyncStream(TracedStream, httpx2.AsyncByteStream):
+    """Asynchronous traced response stream."""
+
+    def __init__(self, stream: httpx2.AsyncByteStream, trace) -> None:
+        super().__init__(trace)
+        self.stream = stream
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in self.stream:
+                yield chunk
+        except BaseException as error:
+            self._finish(type(error), error, error.__traceback__)
+            raise
+        self._finish()
+
+    async def aclose(self) -> None:
+        try:
+            await self.stream.aclose()
+        except BaseException as error:
+            self._finish(type(error), error, error.__traceback__)
+            raise
+        self._finish()
+
+
+def _build_pinned_request(
+    request: httpx2.Request, connection_address: str
+) -> httpx2.Request:
+    """Clone a request for a validated address while retaining its HTTP origin."""
+    extensions = {
+        **request.extensions,
+        ORIGINAL_URL_REQUEST_EXTENSION: request.url,
+        "sni_hostname": request.url.raw_host.decode("ascii"),
+    }
+    return httpx2.Request(
+        method=request.method,
+        url=request.url.copy_with(host=connection_address),
+        headers=request.headers,
+        stream=request.stream,
+        extensions=extensions,
+    )
+
+
+def _transport_key(
+    request: httpx2.Request,
+    *,
+    proxy: str | None,
+    connection_address: str | None,
+) -> tuple[str, ...]:
+    if proxy is not None:
+        return ("proxy", proxy)
+    if connection_address is None:
+        return ("direct",)
+    return (
+        "pinned",
+        request.url.scheme,
+        request.url.host,
+        str(request.url.port or ""),
+        connection_address,
+    )
+
+
+class OutboundTransportPool[
+    TransportType: httpx2.BaseTransport | httpx2.AsyncBaseTransport
+]:
+    """Share outbound transport selection and connection-pool isolation."""
+
+    def __init__(
+        self,
+        transport: TransportType | None,
+        transport_factory: Callable[[str | None], TransportType],
+    ) -> None:
+        self.transport_override = transport or cast(
+            "TransportType | None", _TEST_TRANSPORT.transport
+        )
+        self.transport_factory = transport_factory
+        self.transports: dict[tuple[str, ...], TransportType] = {}
+
+    def get(
+        self,
+        request: httpx2.Request,
+        *,
+        proxy: str | None,
+        connection_address: str | None,
+    ) -> TransportType:
+        if self.transport_override is not None:
+            return self.transport_override
+        key = _transport_key(
+            request,
+            proxy=proxy,
+            connection_address=connection_address,
+        )
+        if (transport := self.transports.get(key)) is None:
+            transport = self.transport_factory(proxy)
+            self.transports[key] = transport
+        return transport
+
+    def active(self) -> list[TransportType]:
+        if self.transport_override is not None:
+            return [self.transport_override]
+        return list(self.transports.values())
+
+    def clear(self) -> None:
+        self.transports.clear()
+
+
+@dataclass(frozen=True)
+class OutboundRequest:
+    """Transport-neutral details used to validate and route a request."""
+
+    url: str
+    proxy: str | None
+    validators: RedirectValidators | None
+
+    @property
+    def used_proxy(self) -> bool:
+        return self.proxy is not None
+
+
+def _prepare_outbound_request(request: httpx2.Request) -> OutboundRequest:
+    request_url = str(request.url)
+    return OutboundRequest(
+        url=request_url,
+        proxy=_get_proxy(request_url),
+        validators=cast(
+            "RedirectValidators | None",
+            request.extensions.get(VALIDATORS_REQUEST_EXTENSION),
+        ),
+    )
+
+
+async def _validate_async_outbound_request(
+    outbound: OutboundRequest,
+) -> tuple[str, ...]:
+    if outbound.validators is None:
+        return ()
+    return await outbound.validators.validate_async_request_url(
+        outbound.url,
+        used_proxy=outbound.used_proxy,
+    )
+
+
+def _route_outbound_request[
+    TransportType: httpx2.BaseTransport | httpx2.AsyncBaseTransport
+](
+    pool: OutboundTransportPool[TransportType],
+    request: httpx2.Request,
+    connection_addresses: tuple[str, ...],
+    *,
+    proxy: str | None,
+) -> tuple[tuple[TransportType, httpx2.Request], ...]:
+    addresses: tuple[str | None, ...] = connection_addresses or (None,)
+    return tuple(
+        (
+            pool.get(
+                request,
+                proxy=proxy,
+                connection_address=connection_address,
+            ),
+            (
+                _build_pinned_request(request, connection_address)
+                if connection_address is not None
+                else request
+            ),
+        )
+        for connection_address in addresses
+    )
+
+
+def _connection_deadline[
+    TransportType: httpx2.BaseTransport | httpx2.AsyncBaseTransport
+](
+    routes: tuple[tuple[TransportType, httpx2.Request], ...],
+) -> float | None:
+    if len(routes) == 1:
+        return None
+    connect_timeout = routes[0][1].extensions.get("timeout", {}).get("connect")
+    if connect_timeout is None:
+        return None
+    return monotonic() + float(connect_timeout)
+
+
+def _set_attempt_connect_timeout(
+    request: httpx2.Request,
+    *,
+    deadline: float | None,
+    probe: bool,
+) -> None:
+    if deadline is None:
+        connect_timeout = ADDRESS_FALLBACK_DELAY if probe else None
+    else:
+        remaining = max(0.0, deadline - monotonic())
+        connect_timeout = min(ADDRESS_FALLBACK_DELAY, remaining) if probe else remaining
+    timeouts = dict(request.extensions.get("timeout", {}))
+    timeouts["connect"] = connect_timeout
+    request.extensions["timeout"] = timeouts
+
+
+def _connection_budget_exhausted(deadline: float | None) -> bool:
+    return deadline is not None and monotonic() >= deadline
+
+
+class _ConnectionFallback[
+    TransportType: httpx2.BaseTransport | httpx2.AsyncBaseTransport
+]:
+    """
+    Track fast probes and retries within one request's connection budget.
+
+    AnyIO's Happy Eyeballs API resolves hostnames itself and cannot accept the
+    address set already approved by the SSRF validator.
+    """
+
+    def __init__(
+        self,
+        routes: tuple[tuple[TransportType, httpx2.Request], ...],
+    ) -> None:
+        self.routes = routes
+        self.deadline = _connection_deadline(routes)
+        self.timed_out_routes: list[tuple[TransportType, httpx2.Request]] = []
+        self.last_error: httpx2.ConnectError | httpx2.ConnectTimeout | None = None
+
+    def attempts(
+        self,
+    ) -> Iterator[tuple[TransportType, httpx2.Request, bool]]:
+        for probe, routes in (
+            (True, self.routes),
+            (False, self.timed_out_routes),
+        ):
+            for transport, request in routes:
+                _set_attempt_connect_timeout(
+                    request,
+                    deadline=self.deadline,
+                    probe=probe,
+                )
+                yield transport, request, probe
+
+    def record_failure(
+        self,
+        route: tuple[TransportType, httpx2.Request],
+        error: httpx2.ConnectError | httpx2.ConnectTimeout,
+        *,
+        probe: bool,
+    ) -> None:
+        if probe and isinstance(error, httpx2.ConnectTimeout):
+            self.timed_out_routes.append(route)
+        self.last_error = error
+        if _connection_budget_exhausted(self.deadline):
+            raise error
+
+    def raise_last_error(self) -> Never:
+        if self.last_error is not None:
+            raise self.last_error
+        msg = "No outbound routes available."
+        raise RuntimeError(msg)
+
+
+def _send_request_with_fallback(
+    routes: tuple[tuple[httpx2.BaseTransport, httpx2.Request], ...],
+) -> httpx2.Response:
+    if len(routes) == 1:
+        transport, request = routes[0]
+        return transport.handle_request(request)
+
+    fallback = _ConnectionFallback(routes)
+    for transport, request, probe in fallback.attempts():
+        try:
+            return transport.handle_request(request)
+        except (httpx2.ConnectError, httpx2.ConnectTimeout) as error:
+            fallback.record_failure(
+                (transport, request),
+                error,
+                probe=probe,
+            )
+    return fallback.raise_last_error()
+
+
+async def _send_async_request_with_fallback(
+    routes: tuple[tuple[httpx2.AsyncBaseTransport, httpx2.Request], ...],
+) -> httpx2.Response:
+    if len(routes) == 1:
+        transport, request = routes[0]
+        return await transport.handle_async_request(request)
+
+    fallback = _ConnectionFallback(routes)
+    for transport, request, probe in fallback.attempts():
+        try:
+            return await transport.handle_async_request(request)
+        except (httpx2.ConnectError, httpx2.ConnectTimeout) as error:
+            fallback.record_failure(
+                (transport, request),
+                error,
+                probe=probe,
+            )
+    return fallback.raise_last_error()
+
+
+def _validate_transport_response(
     response: httpx2.Response,
-) -> Generator[None, None, None]:
-    try:
-        yield
-    except Exception:
+    *,
+    request: httpx2.Request,
+    span: Span | None,
+    validators: RedirectValidators | None,
+    used_proxy: bool,
+) -> None:
+    response.request = request
+    record_http_response(span, response)
+    if validators is not None:
+        validators.validate_response(response, used_proxy=used_proxy)
+
+
+class OutboundHTTPTransport(httpx2.BaseTransport):
+    """Validate and route every synchronous HTTPX2 request hop."""
+
+    def __init__(self, transport: httpx2.BaseTransport | None = None) -> None:
+        self.pool = OutboundTransportPool(
+            transport,
+            lambda proxy: httpx2.HTTPTransport(proxy=proxy, trust_env=True),
+        )
+
+    def handle_request(self, request: httpx2.Request) -> httpx2.Response:
+        outbound = _prepare_outbound_request(request)
+        connection_addresses = (
+            outbound.validators.validate_request_url(
+                outbound.url, used_proxy=outbound.used_proxy
+            )
+            if outbound.validators is not None
+            else ()
+        )
+        trace = trace_http_request(request)
+        span = trace.__enter__()  # ruff: ignore[unnecessary-dunder-call]
+        response: httpx2.Response | None = None
+        try:
+            routes = _route_outbound_request(
+                self.pool,
+                request,
+                connection_addresses,
+                proxy=outbound.proxy,
+            )
+            response = _send_request_with_fallback(routes)
+            _validate_transport_response(
+                response,
+                request=request,
+                span=span,
+                validators=outbound.validators,
+                used_proxy=outbound.used_proxy,
+            )
+            response.stream = TracedSyncStream(
+                cast("httpx2.SyncByteStream", response.stream), trace
+            )
+        except BaseException as error:
+            try:
+                if response is not None:
+                    response.close()
+            finally:
+                trace.__exit__(type(error), error, error.__traceback__)
+            raise
+        return response
+
+    def close(self) -> None:
+        for transport in self.pool.active():
+            transport.close()
+        self.pool.clear()
+
+
+class AsyncOutboundHTTPTransport(httpx2.AsyncBaseTransport):
+    """Validate and route every asynchronous HTTPX2 request hop."""
+
+    def __init__(self, transport: httpx2.AsyncBaseTransport | None = None) -> None:
+        self.pool = OutboundTransportPool(
+            transport,
+            lambda proxy: httpx2.AsyncHTTPTransport(proxy=proxy, trust_env=True),
+        )
+
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        outbound = _prepare_outbound_request(request)
+        connection_addresses = await _validate_async_outbound_request(outbound)
+        trace = trace_http_request(request)
+        span = trace.__enter__()  # ruff: ignore[unnecessary-dunder-call]
+        response: httpx2.Response | None = None
+        try:
+            routes = _route_outbound_request(
+                self.pool,
+                request,
+                connection_addresses,
+                proxy=outbound.proxy,
+            )
+            response = await _send_async_request_with_fallback(routes)
+            _validate_transport_response(
+                response,
+                request=request,
+                span=span,
+                validators=outbound.validators,
+                used_proxy=outbound.used_proxy,
+            )
+            response.stream = TracedAsyncStream(
+                cast("httpx2.AsyncByteStream", response.stream), trace
+            )
+        except BaseException as error:
+            try:
+                if response is not None:
+                    await response.aclose()
+            finally:
+                trace.__exit__(type(error), error, error.__traceback__)
+            raise
+        return response
+
+    async def aclose(self) -> None:
+        for transport in self.pool.active():
+            await transport.aclose()
+        self.pool.clear()
+
+
+def _build_client_request(
+    client: httpx2.Client | httpx2.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None,
+    timeout: float,
+    validators: RedirectValidators | None,
+    kwargs: dict[str, Any],
+) -> tuple[httpx2.Request, AuthTypes | None]:
+    request_kwargs = _normalize_request_kwargs(kwargs)
+    request_auth = request_kwargs.pop("auth", None)
+    extensions = dict(request_kwargs.pop("extensions", {}) or {})
+    extensions[VALIDATORS_REQUEST_EXTENSION] = validators
+    request = client.build_request(
+        method,
+        url,
+        headers=_prepare_headers(headers),
+        timeout=timeout,
+        extensions=extensions,
+        **request_kwargs,
+    )
+    return request, request_auth
+
+
+def _next_streaming_redirect(
+    response: httpx2.Response,
+    history: list[httpx2.Response],
+    max_redirects: int,
+) -> httpx2.Request | None:
+    """Return HTTPX's next redirect request without consuming the response."""
+    response.history = list(history)
+    next_request = response.next_request
+    if next_request is None:
+        return None
+
+    history.append(response)
+    if len(history) > max_redirects:
+        msg = "Exceeded maximum allowed redirects."
+        raise httpx2.TooManyRedirects(
+            msg,
+            request=next_request,
+        )
+    return next_request
+
+
+def _send_with_redirects(
+    client: httpx2.Client,
+    request: httpx2.Request,
+    *,
+    auth: AuthTypes | None,
+    max_redirects: int,
+) -> httpx2.Response:
+    history: list[httpx2.Response] = []
+    while True:
+        response = client.send(
+            request,
+            stream=True,
+            auth=auth,
+            follow_redirects=False,
+        )
+        try:
+            next_request = _next_streaming_redirect(response, history, max_redirects)
+        except BaseException:
+            response.close()
+            raise
+        if next_request is None:
+            return response
         response.close()
-        raise
+        request = next_request
+        auth = None
 
 
-@asynccontextmanager
-async def _aclose_response_on_error(
-    response: httpx2.Response,
-) -> AsyncGenerator[None]:
-    try:
-        yield
-    except Exception:
+async def _async_send_with_redirects(
+    client: httpx2.AsyncClient,
+    request: httpx2.Request,
+    *,
+    auth: AuthTypes | None,
+    max_redirects: int,
+) -> httpx2.Response:
+    history: list[httpx2.Response] = []
+    while True:
+        response = await client.send(
+            request,
+            stream=True,
+            auth=auth,
+            follow_redirects=False,
+        )
+        try:
+            next_request = _next_streaming_redirect(response, history, max_redirects)
+        except BaseException:
+            await response.aclose()
+            raise
+        if next_request is None:
+            return response
         await response.aclose()
-        raise
+        request = next_request
+        auth = None
 
 
 class HTTPClient:
-    """Synchronous HTTPX2 client pool with per-hop proxy routing."""
+    """Synchronous HTTPX2 client using Weblate's outbound transport."""
 
-    def __init__(self) -> None:
-        self._clients: dict[str | None, httpx2.Client] = {}
+    def __init__(self, transport: httpx2.BaseTransport | None = None) -> None:
+        self.client = httpx2.Client(
+            transport=OutboundHTTPTransport(transport),
+            trust_env=False,
+            follow_redirects=False,
+        )
 
     def __enter__(self) -> Self:
         return self
@@ -312,26 +906,7 @@ class HTTPClient:
         self.close()
 
     def close(self) -> None:
-        for client in self._clients.values():
-            client.close()
-        self._clients.clear()
-
-    def _get_client(self, url: str) -> tuple[httpx2.Client, bool]:
-        proxy = _get_proxy(url)
-        client = self._clients.get(proxy)
-        if client is None:
-            transport: httpx2.BaseTransport
-            if _TEST_TRANSPORT.transport is not None:
-                transport = _TEST_TRANSPORT.transport
-            else:
-                transport = httpx2.HTTPTransport(proxy=proxy, trust_env=True)
-            client = httpx2.Client(
-                transport=transport,
-                trust_env=False,
-                follow_redirects=False,
-            )
-            self._clients[proxy] = client
-        return client, proxy is not None
+        self.client.close()
 
     def request(
         self,
@@ -346,59 +921,47 @@ class HTTPClient:
         validators: RedirectValidators | None = None,
         **kwargs,
     ) -> httpx2.Response:
-        history: list[httpx2.Response] = []
-        current_request: httpx2.Request | None = None
-        request_kwargs = _normalize_request_kwargs(kwargs)
-        request_auth = request_kwargs.pop("auth", None)
-
-        for _ in range(max_redirects + 1):
-            request_url = url if current_request is None else str(current_request.url)
-            client, used_proxy = self._get_client(request_url)
-            if validators is not None:
-                validators.validate_request_url(request_url, used_proxy=used_proxy)
-
-            if current_request is None:
-                current_request = client.build_request(
-                    method,
-                    url,
-                    headers=_prepare_headers(headers),
-                    timeout=timeout,
-                    **request_kwargs,
-                )
-
-            with trace_http_request(current_request) as span:
-                response = client.send(
-                    current_request,
-                    stream=True,
-                    follow_redirects=False,
-                    auth=request_auth if not history else None,
-                )
-                record_http_response(span, response)
-                response.history = history.copy()
-                with _close_response_on_error(response):
-                    if validators is not None:
-                        validators.validate_response(response, used_proxy=used_proxy)
-
-                    next_request = response.next_request
-                    if not allow_redirects or next_request is None:
-                        if not stream:
-                            response.read()
-                            response.close()
-                        return response
-
-                    history.append(response)
-                    response.close()
-                    current_request = next_request
-
-        msg = f"Exceeded {max_redirects} redirects."
-        raise httpx2.TooManyRedirects(msg, request=current_request)
+        request, request_auth = _build_client_request(
+            self.client,
+            method,
+            url,
+            headers=headers,
+            timeout=timeout,
+            validators=validators,
+            kwargs=kwargs,
+        )
+        if allow_redirects:
+            response = _send_with_redirects(
+                self.client,
+                request,
+                auth=request_auth,
+                max_redirects=max_redirects,
+            )
+            if stream:
+                return response
+            try:
+                response.read()
+            except BaseException:
+                response.close()
+                raise
+            return response
+        return self.client.send(
+            request,
+            stream=stream,
+            auth=request_auth,
+            follow_redirects=False,
+        )
 
 
 class AsyncHTTPClient:
-    """Asynchronous HTTPX2 client pool with the same validation policy."""
+    """Asynchronous HTTPX2 client using Weblate's outbound transport."""
 
-    def __init__(self) -> None:
-        self._clients: dict[str | None, httpx2.AsyncClient] = {}
+    def __init__(self, transport: httpx2.AsyncBaseTransport | None = None) -> None:
+        self.client = httpx2.AsyncClient(
+            transport=AsyncOutboundHTTPTransport(transport),
+            trust_env=False,
+            follow_redirects=False,
+        )
 
     async def __aenter__(self) -> Self:
         return self
@@ -407,26 +970,7 @@ class AsyncHTTPClient:
         await self.aclose()
 
     async def aclose(self) -> None:
-        for client in self._clients.values():
-            await client.aclose()
-        self._clients.clear()
-
-    def _get_client(self, url: str) -> tuple[httpx2.AsyncClient, bool]:
-        proxy = _get_proxy(url)
-        client = self._clients.get(proxy)
-        if client is None:
-            transport: httpx2.AsyncBaseTransport
-            if _TEST_TRANSPORT.transport is not None:
-                transport = _TEST_TRANSPORT.transport
-            else:
-                transport = httpx2.AsyncHTTPTransport(proxy=proxy, trust_env=True)
-            client = httpx2.AsyncClient(
-                transport=transport,
-                trust_env=False,
-                follow_redirects=False,
-            )
-            self._clients[proxy] = client
-        return client, proxy is not None
+        await self.client.aclose()
 
     async def request(
         self,
@@ -441,55 +985,36 @@ class AsyncHTTPClient:
         validators: RedirectValidators | None = None,
         **kwargs,
     ) -> httpx2.Response:
-        history: list[httpx2.Response] = []
-        current_request: httpx2.Request | None = None
-        request_kwargs = _normalize_request_kwargs(kwargs)
-        request_auth = request_kwargs.pop("auth", None)
-
-        for _ in range(max_redirects + 1):
-            request_url = url if current_request is None else str(current_request.url)
-            client, used_proxy = self._get_client(request_url)
-            if validators is not None:
-                await sync_to_async(
-                    validators.validate_request_url,
-                    thread_sensitive=False,
-                )(request_url, used_proxy=used_proxy)
-
-            if current_request is None:
-                current_request = client.build_request(
-                    method,
-                    url,
-                    headers=_prepare_headers(headers),
-                    timeout=timeout,
-                    **request_kwargs,
-                )
-
-            with trace_http_request(current_request) as span:
-                response = await client.send(
-                    current_request,
-                    stream=True,
-                    follow_redirects=False,
-                    auth=request_auth if not history else None,
-                )
-                record_http_response(span, response)
-                response.history = history.copy()
-                async with _aclose_response_on_error(response):
-                    if validators is not None:
-                        validators.validate_response(response, used_proxy=used_proxy)
-
-                    next_request = response.next_request
-                    if not allow_redirects or next_request is None:
-                        if not stream:
-                            await response.aread()
-                            await response.aclose()
-                        return response
-
-                    history.append(response)
-                    await response.aclose()
-                    current_request = next_request
-
-        msg = f"Exceeded {max_redirects} redirects."
-        raise httpx2.TooManyRedirects(msg, request=current_request)
+        request, request_auth = _build_client_request(
+            self.client,
+            method,
+            url,
+            headers=headers,
+            timeout=timeout,
+            validators=validators,
+            kwargs=kwargs,
+        )
+        if allow_redirects:
+            response = await _async_send_with_redirects(
+                self.client,
+                request,
+                auth=request_auth,
+                max_redirects=max_redirects,
+            )
+            if stream:
+                return response
+            try:
+                await response.aread()
+            except BaseException:
+                await response.aclose()
+                raise
+            return response
+        return await self.client.send(
+            request,
+            stream=stream,
+            auth=request_auth,
+            follow_redirects=False,
+        )
 
 
 def _request_with_redirects(

--- a/weblate/utils/tests/http_mock.py
+++ b/weblate/utils/tests/http_mock.py
@@ -16,7 +16,11 @@ from urllib.parse import urlsplit, urlunsplit
 
 import httpx2
 
-from weblate.utils.requests import PEER_IP_RESPONSE_ATTR, set_test_transport
+from weblate.utils.requests import (
+    ORIGINAL_URL_REQUEST_EXTENSION,
+    PEER_IP_RESPONSE_ATTR,
+    set_test_transport,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -42,11 +46,16 @@ class PreparedRequest:
 
     def __init__(self, request: httpx2.Request) -> None:
         self._request = request
+        self.extensions = dict(request.extensions)
+        request_url = request.extensions.get(
+            ORIGINAL_URL_REQUEST_EXTENSION, request.url
+        )
         self.method = request.method
-        self.url = str(request.url.copy_with(fragment=None))
+        self.url = str(request_url.copy_with(fragment=None))
+        self.transport_url = str(request.url.copy_with(fragment=None))
         self.headers = request.headers
         self.body = request.content or None
-        self.path_url = request.url.raw_path.decode("ascii")
+        self.path_url = request_url.raw_path.decode("ascii")
 
 
 @dataclass

--- a/weblate/utils/tests/test_requests.py
+++ b/weblate/utils/tests/test_requests.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import asyncio
 import os
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from threading import get_ident
+from threading import Event
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx2
-from asgiref.sync import async_to_sync
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
@@ -22,6 +23,7 @@ from weblate.utils.requests import (
     _get_proxy,
     _get_response_peer_ip,
     _validate_response_peer,
+    async_fetch_validated_url,
     fetch_url,
     fetch_validated_url,
     get_uri_error,
@@ -48,6 +50,16 @@ class TrackedAsyncStream(httpx2.AsyncByteStream):
     async def __aiter__(self):
         self.events.append("read")
         yield b"response-body"
+
+
+class TrackedRedirectSyncStream(TrackedSyncStream):
+    def close(self) -> None:
+        self.events.append("close")
+
+
+class TrackedRedirectAsyncStream(TrackedAsyncStream):
+    async def aclose(self) -> None:
+        self.events.append("close")
 
 
 class FetchURLTest(SimpleTestCase):
@@ -115,9 +127,6 @@ class FetchURLTest(SimpleTestCase):
             request=request,
             stream=TrackedSyncStream(events),
         )
-        transport_client = MagicMock()
-        transport_client.build_request.return_value = request
-        transport_client.send.return_value = response
 
         @contextmanager
         def tracked_span(_request):
@@ -127,17 +136,15 @@ class FetchURLTest(SimpleTestCase):
             finally:
                 events.append("span-end")
 
-        client = HTTPClient()
+        client = HTTPClient(
+            httpx2.MockTransport(lambda _request: response),
+        )
         with (
-            patch.object(
-                client,
-                "_get_client",
-                return_value=(transport_client, False),
-            ),
             patch(
                 "weblate.utils.requests.trace_http_request",
                 side_effect=tracked_span,
             ),
+            client,
         ):
             result = client.request("get", "https://example.com/data")
 
@@ -152,9 +159,6 @@ class FetchURLTest(SimpleTestCase):
             request=request,
             stream=TrackedAsyncStream(events),
         )
-        transport_client = MagicMock()
-        transport_client.build_request.return_value = request
-        transport_client.send = AsyncMock(return_value=response)
 
         @contextmanager
         def tracked_span(_request):
@@ -164,65 +168,227 @@ class FetchURLTest(SimpleTestCase):
             finally:
                 events.append("span-end")
 
-        client = AsyncHTTPClient()
-        with (
-            patch.object(
-                client,
-                "_get_client",
-                return_value=(transport_client, False),
-            ),
-            patch(
-                "weblate.utils.requests.trace_http_request",
-                side_effect=tracked_span,
-            ),
+        client = AsyncHTTPClient(
+            httpx2.MockTransport(lambda _request: response),
+        )
+
+        async def make_request() -> httpx2.Response:
+            async with client:
+                return await client.request("get", "https://example.com/data")
+
+        with patch(
+            "weblate.utils.requests.trace_http_request",
+            side_effect=tracked_span,
         ):
-            result = async_to_sync(client.request)("get", "https://example.com/data")
+            result = asyncio.run(make_request())
 
         self.assertEqual(result.content, b"response-body")
         self.assertEqual(events, ["span-start", "read", "span-end"])
 
-    def test_async_http_client_validates_request_off_event_loop(self) -> None:
+    def test_http_client_does_not_read_streaming_redirect_body(self) -> None:
+        events: list[str] = []
+
+        def handle_request(request):
+            if request.url.path == "/redirect":
+                return httpx2.Response(
+                    302,
+                    headers={"Location": "/final"},
+                    stream=TrackedRedirectSyncStream(events),
+                )
+            return httpx2.Response(200, content=b"final-response")
+
+        client = HTTPClient(httpx2.MockTransport(handle_request))
+        with client:
+            response = client.request(
+                "get",
+                "https://example.com/redirect",
+                stream=True,
+            )
+            try:
+                self.assertEqual(response.read(), b"final-response")
+                self.assertEqual(len(response.history), 1)
+                self.assertTrue(response.history[0].is_closed)
+            finally:
+                response.close()
+
+        self.assertEqual(events, ["close"])
+
+    def test_async_http_client_does_not_read_streaming_redirect_body(self) -> None:
+        events: list[str] = []
+
+        def handle_request(request):
+            if request.url.path == "/redirect":
+                return httpx2.Response(
+                    302,
+                    headers={"Location": "/final"},
+                    stream=TrackedRedirectAsyncStream(events),
+                )
+            return httpx2.Response(200, content=b"final-response")
+
+        client = AsyncHTTPClient(httpx2.MockTransport(handle_request))
+
+        async def make_request() -> httpx2.Response:
+            async with client:
+                response = await client.request(
+                    "get",
+                    "https://example.com/redirect",
+                    stream=True,
+                )
+                try:
+                    self.assertEqual(await response.aread(), b"final-response")
+                    self.assertEqual(len(response.history), 1)
+                    self.assertTrue(response.history[0].is_closed)
+                    return response
+                finally:
+                    await response.aclose()
+
+        asyncio.run(make_request())
+
+        self.assertEqual(events, ["close"])
+
+    def test_http_client_limits_streaming_redirects(self) -> None:
+        events: list[str] = []
+
+        def handle_request(_request):
+            return httpx2.Response(
+                302,
+                headers={"Location": "/redirect"},
+                stream=TrackedRedirectSyncStream(events),
+            )
+
+        client = HTTPClient(httpx2.MockTransport(handle_request))
+        with (
+            client,
+            self.assertRaises(httpx2.TooManyRedirects),
+        ):
+            client.request(
+                "get",
+                "https://example.com/redirect",
+                stream=True,
+                max_redirects=1,
+            )
+
+        self.assertEqual(events, ["close", "close"])
+
+    def test_http_client_keeps_redirect_limit_request_local(self) -> None:
+        short_started = Event()
+        long_started = Event()
+        short_finished = Event()
+
+        def handle_request(request):
+            if request.url.path == "/short":
+                short_started.set()
+                if not long_started.wait(5):
+                    msg = "Long request did not start."
+                    raise RuntimeError(msg)
+                return httpx2.Response(302, headers={"Location": "/short-final"})
+            if request.url.path == "/long":
+                long_started.set()
+                if not short_finished.wait(5):
+                    msg = "Short request did not finish."
+                    raise RuntimeError(msg)
+            return httpx2.Response(200)
+
+        client = HTTPClient(httpx2.MockTransport(handle_request))
+
+        def request_short_url() -> httpx2.Response:
+            try:
+                return client.request(
+                    "get",
+                    "https://example.com/short",
+                    max_redirects=0,
+                )
+            finally:
+                short_finished.set()
+
+        with client, ThreadPoolExecutor(max_workers=2) as executor:
+            short_result = executor.submit(request_short_url)
+            self.assertTrue(short_started.wait(5))
+            long_result = executor.submit(
+                client.request,
+                "get",
+                "https://example.com/long",
+                max_redirects=2,
+            )
+
+            with self.assertRaises(httpx2.TooManyRedirects):
+                short_result.result(timeout=5)
+            self.assertEqual(long_result.result(timeout=5).status_code, 200)
+
+    def test_async_http_client_keeps_redirect_limit_request_local(self) -> None:
+        async def run_requests() -> None:
+            short_started = asyncio.Event()
+            long_started = asyncio.Event()
+            short_finished = asyncio.Event()
+
+            async def handle_request(request):
+                if request.url.path == "/short":
+                    short_started.set()
+                    await asyncio.wait_for(long_started.wait(), timeout=5)
+                    return httpx2.Response(302, headers={"Location": "/short-final"})
+                if request.url.path == "/long":
+                    long_started.set()
+                    await asyncio.wait_for(short_finished.wait(), timeout=5)
+                return httpx2.Response(200)
+
+            client = AsyncHTTPClient(httpx2.MockTransport(handle_request))
+
+            async def request_short_url() -> httpx2.Response:
+                try:
+                    return await client.request(
+                        "get",
+                        "https://example.com/short",
+                        max_redirects=0,
+                    )
+                finally:
+                    short_finished.set()
+
+            async with client:
+                short_result = asyncio.create_task(request_short_url())
+                await asyncio.wait_for(short_started.wait(), timeout=5)
+                long_result = asyncio.create_task(
+                    client.request(
+                        "get",
+                        "https://example.com/long",
+                        max_redirects=2,
+                    )
+                )
+
+                with self.assertRaises(httpx2.TooManyRedirects):
+                    await short_result
+                self.assertEqual((await long_result).status_code, 200)
+
+        asyncio.run(run_requests())
+
+    def test_async_http_client_uses_async_validator(self) -> None:
         request = httpx2.Request("GET", "https://example.com/data")
         response = httpx2.Response(
             200,
             request=request,
             content=b"response-body",
         )
-        transport_client = MagicMock()
-        transport_client.build_request.return_value = request
-        transport_client.send = AsyncMock(return_value=response)
-        validation_thread_ids: list[int] = []
         validators = MagicMock()
+        validators.validate_async_request_url = AsyncMock(return_value=())
+        client = AsyncHTTPClient(
+            httpx2.MockTransport(lambda _request: response),
+        )
 
-        def record_validation_thread(*_args, **_kwargs) -> None:
-            validation_thread_ids.append(get_ident())
+        async def make_request() -> httpx2.Response:
+            async with client:
+                return await client.request(
+                    "get",
+                    "https://example.com/data",
+                    validators=validators,
+                )
 
-        validators.validate_request_url.side_effect = record_validation_thread
-        client = AsyncHTTPClient()
-
-        async def make_request() -> tuple[int, httpx2.Response]:
-            event_loop_thread_id = get_ident()
-            result = await client.request(
-                "get",
-                "https://example.com/data",
-                validators=validators,
-            )
-            return event_loop_thread_id, result
-
-        with patch.object(
-            client,
-            "_get_client",
-            return_value=(transport_client, False),
-        ):
-            event_loop_thread_id, result = async_to_sync(make_request)()
+        result = asyncio.run(make_request())
 
         self.assertEqual(result.content, b"response-body")
-        self.assertEqual(len(validation_thread_ids), 1)
-        self.assertNotEqual(validation_thread_ids[0], event_loop_thread_id)
-        validators.validate_request_url.assert_called_once_with(
+        validators.validate_async_request_url.assert_awaited_once_with(
             "https://example.com/data",
             used_proxy=False,
         )
+        validators.validate_request_url.assert_not_called()
 
     def test_http_trace_uses_configured_tracer(self) -> None:
         request = httpx2.Request("GET", "https://example.com/data")
@@ -664,6 +830,474 @@ class GetUriErrorTest(SimpleTestCase):
 
 
 class FetchValidatedURLTest(SimpleTestCase):
+    @responses.activate
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        side_effect=[
+            [
+                (0, 0, 0, "", ("93.184.216.34", 8443)),
+                (0, 0, 0, "", ("2606:2800:220:1:248:1893:25c8:1946", 8443)),
+            ],
+            [(0, 0, 0, "", ("127.0.0.1", 8443))],
+        ],
+    )
+    def test_fetch_validated_url_pins_validated_address(
+        self, mocked_getaddrinfo
+    ) -> None:
+        url = "https://public.example.com:8443/source"
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=b"pinned",
+        )
+
+        response = fetch_validated_url(
+            "get",
+            url,
+            allow_private_targets=False,
+        )
+
+        self.assertEqual(response.content, b"pinned")
+        self.assertEqual(str(response.url), url)
+        self.assertEqual(
+            responses.calls[0].request.transport_url,
+            "https://93.184.216.34:8443/source",
+        )
+        self.assertEqual(
+            responses.calls[0].request.headers["Host"],
+            "public.example.com:8443",
+        )
+        self.assertEqual(
+            responses.calls[0].request.extensions["sni_hostname"],
+            "public.example.com",
+        )
+        mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
+
+    @responses.activate
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[
+            (0, 0, 0, "", ("2606:2800:220:1:248:1893:25c8:1946", 443)),
+            (0, 0, 0, "", ("93.184.216.34", 443)),
+        ],
+    )
+    def test_fetch_validated_url_falls_back_to_validated_address(
+        self, mocked_getaddrinfo
+    ) -> None:
+        url = "https://public.example.com/source"
+        responses.add(
+            responses.GET,
+            url,
+            body=httpx2.ConnectError("IPv6 route unavailable"),
+        )
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=b"fallback",
+        )
+
+        with patch(
+            "weblate.utils.requests.monotonic",
+            side_effect=[0, 0, 0.25, 0.25],
+        ):
+            response = fetch_validated_url(
+                "get",
+                url,
+                allow_private_targets=False,
+            )
+
+        self.assertEqual(response.content, b"fallback")
+        self.assertEqual(
+            [call.request.transport_url for call in responses.calls],
+            [
+                "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
+                "https://93.184.216.34/source",
+            ],
+        )
+        self.assertEqual(
+            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [0.25, 0.25],
+        )
+        mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
+
+    @responses.activate
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[
+            (0, 0, 0, "", ("2606:2800:220:1:248:1893:25c8:1946", 443)),
+            (0, 0, 0, "", ("93.184.216.34", 443)),
+        ],
+    )
+    def test_fetch_validated_url_retries_slow_validated_address(
+        self, mocked_getaddrinfo
+    ) -> None:
+        url = "https://public.example.com/source"
+        responses.add(
+            responses.GET,
+            url,
+            body=httpx2.ConnectTimeout("IPv6 probe timed out"),
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=httpx2.ConnectTimeout("IPv4 probe timed out"),
+        )
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=b"slow-fallback",
+        )
+
+        with patch(
+            "weblate.utils.requests.monotonic",
+            side_effect=[0, 0, 0.25, 0.25, 0.25, 0.25],
+        ):
+            response = fetch_validated_url(
+                "get",
+                url,
+                allow_private_targets=False,
+            )
+
+        self.assertEqual(response.content, b"slow-fallback")
+        self.assertEqual(
+            [call.request.transport_url for call in responses.calls],
+            [
+                "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
+                "https://93.184.216.34/source",
+                "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
+            ],
+        )
+        self.assertEqual(
+            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [0.25, 0.25, 4.75],
+        )
+        mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
+
+    @responses.activate
+    @patch(
+        "weblate.utils.requests.async_resolve_runtime_hostname",
+        new_callable=AsyncMock,
+        return_value=("93.184.216.34",),
+    )
+    def test_async_fetch_validated_url_pins_validated_address(
+        self, mocked_resolve
+    ) -> None:
+        url = "https://public.example.com/source"
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=b"async-pinned",
+        )
+
+        response = asyncio.run(
+            async_fetch_validated_url(
+                "get",
+                url,
+                allow_private_targets=False,
+            )
+        )
+
+        self.assertEqual(response.content, b"async-pinned")
+        self.assertEqual(str(response.url), url)
+        self.assertEqual(
+            responses.calls[0].request.transport_url,
+            "https://93.184.216.34/source",
+        )
+        mocked_resolve.assert_awaited_once_with(
+            "public.example.com", allow_private_targets=False
+        )
+
+    @responses.activate
+    @patch(
+        "weblate.utils.requests.async_resolve_runtime_hostname",
+        new_callable=AsyncMock,
+        return_value=(
+            "2606:2800:220:1:248:1893:25c8:1946",
+            "93.184.216.34",
+        ),
+    )
+    def test_async_fetch_validated_url_falls_back_to_validated_address(
+        self, mocked_resolve
+    ) -> None:
+        url = "https://public.example.com/source"
+        responses.add(
+            responses.GET,
+            url,
+            body=httpx2.ConnectTimeout("IPv6 route timed out"),
+        )
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=b"async-fallback",
+        )
+
+        with patch(
+            "weblate.utils.requests.monotonic",
+            side_effect=[0, 0, 0.25, 0.25],
+        ):
+            response = asyncio.run(
+                async_fetch_validated_url(
+                    "get",
+                    url,
+                    allow_private_targets=False,
+                )
+            )
+
+        self.assertEqual(response.content, b"async-fallback")
+        self.assertEqual(
+            [call.request.transport_url for call in responses.calls],
+            [
+                "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
+                "https://93.184.216.34/source",
+            ],
+        )
+        self.assertEqual(
+            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [0.25, 0.25],
+        )
+        mocked_resolve.assert_awaited_once_with(
+            "public.example.com", allow_private_targets=False
+        )
+
+    @responses.activate
+    @patch(
+        "weblate.utils.requests.async_resolve_runtime_hostname",
+        new_callable=AsyncMock,
+        return_value=(
+            "2606:2800:220:1:248:1893:25c8:1946",
+            "93.184.216.34",
+        ),
+    )
+    def test_async_fetch_validated_url_retries_slow_validated_address(
+        self, mocked_resolve
+    ) -> None:
+        url = "https://public.example.com/source"
+        responses.add(
+            responses.GET,
+            url,
+            body=httpx2.ConnectTimeout("IPv6 probe timed out"),
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=httpx2.ConnectTimeout("IPv4 probe timed out"),
+        )
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=b"async-slow-fallback",
+        )
+
+        with patch(
+            "weblate.utils.requests.monotonic",
+            side_effect=[0, 0, 0.25, 0.25, 0.25, 0.25],
+        ):
+            response = asyncio.run(
+                async_fetch_validated_url(
+                    "get",
+                    url,
+                    allow_private_targets=False,
+                )
+            )
+
+        self.assertEqual(response.content, b"async-slow-fallback")
+        self.assertEqual(
+            [call.request.transport_url for call in responses.calls],
+            [
+                "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
+                "https://93.184.216.34/source",
+                "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
+            ],
+        )
+        self.assertEqual(
+            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [0.25, 0.25, 4.75],
+        )
+        mocked_resolve.assert_awaited_once_with(
+            "public.example.com", allow_private_targets=False
+        )
+
+    @responses.activate
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
+    )
+    def test_fetch_validated_url_uses_idna_sni_name(self, mocked_getaddrinfo) -> None:
+        responses.add(
+            responses.GET,
+            "https://xn--fa-hia.de/source",
+            status=200,
+            body=b"idna",
+        )
+
+        response = fetch_validated_url(
+            "get",
+            "https://faß.de/source",
+            allow_private_targets=False,
+        )
+
+        self.assertEqual(response.content, b"idna")
+        self.assertEqual(
+            responses.calls[0].request.extensions["sni_hostname"],
+            "xn--fa-hia.de",
+        )
+        mocked_getaddrinfo.assert_called_once_with("xn--fa-hia.de", None, type=1)
+
+    @responses.activate
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
+    )
+    def test_fetch_validated_url_injects_current_trace_before_pinning(
+        self, mocked_getaddrinfo
+    ) -> None:
+        responses.add(
+            responses.GET,
+            "https://public.example.com/source",
+            status=302,
+            headers={"Location": "/final"},
+        )
+        responses.add(
+            responses.GET,
+            "https://public.example.com/final",
+            status=200,
+            body=b"traced",
+        )
+        trace_headers = iter(
+            (
+                "00-00000000000000000000000000000001-0000000000000001-01",
+                "00-00000000000000000000000000000002-0000000000000002-01",
+            )
+        )
+
+        def inject(headers) -> None:
+            headers["traceparent"] = next(trace_headers)
+
+        tracer = MagicMock()
+        tracer.start_as_current_span.return_value.__enter__.return_value = MagicMock()
+        with (
+            patch(
+                "weblate.utils.requests.get_opentelemetry_tracer",
+                return_value=tracer,
+            ),
+            patch(
+                "weblate.utils.requests.propagate.inject",
+                side_effect=inject,
+            ),
+        ):
+            response = fetch_validated_url(
+                "get",
+                "https://public.example.com/source",
+                allow_private_targets=False,
+            )
+
+        self.assertEqual(response.content, b"traced")
+        self.assertEqual(
+            [call.request.headers["traceparent"] for call in responses.calls],
+            [
+                "00-00000000000000000000000000000001-0000000000000001-01",
+                "00-00000000000000000000000000000002-0000000000000002-01",
+            ],
+        )
+        self.assertEqual(mocked_getaddrinfo.call_count, 2)
+
+    @responses.activate
+    @patch(
+        "weblate.utils.requests.async_resolve_runtime_hostname",
+        new_callable=AsyncMock,
+        return_value=("93.184.216.34",),
+    )
+    def test_async_fetch_validated_url_injects_trace_before_pinning(
+        self, mocked_resolve
+    ) -> None:
+        responses.add(
+            responses.GET,
+            "https://public.example.com/source",
+            status=200,
+            body=b"async-traced",
+        )
+        trace_header = "00-00000000000000000000000000000001-0000000000000001-01"
+
+        def inject(headers) -> None:
+            headers["traceparent"] = trace_header
+
+        tracer = MagicMock()
+        tracer.start_as_current_span.return_value.__enter__.return_value = MagicMock()
+        with (
+            patch(
+                "weblate.utils.requests.get_opentelemetry_tracer",
+                return_value=tracer,
+            ),
+            patch(
+                "weblate.utils.requests.propagate.inject",
+                side_effect=inject,
+            ),
+        ):
+            response = asyncio.run(
+                async_fetch_validated_url(
+                    "get",
+                    "https://public.example.com/source",
+                    allow_private_targets=False,
+                )
+            )
+
+        self.assertEqual(response.content, b"async-traced")
+        self.assertEqual(
+            responses.calls[0].request.headers["traceparent"],
+            trace_header,
+        )
+        mocked_resolve.assert_awaited_once_with(
+            "public.example.com", allow_private_targets=False
+        )
+
+    @responses.activate
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
+    )
+    def test_fetch_validated_url_keeps_logical_url_for_relative_redirect(
+        self, mocked_getaddrinfo
+    ) -> None:
+        responses.add(
+            responses.GET,
+            "https://public.example.com/source",
+            status=302,
+            headers={"Location": "/final"},
+        )
+        responses.add(
+            responses.GET,
+            "https://public.example.com/final",
+            status=200,
+            body=b"redirected",
+        )
+
+        response = fetch_validated_url(
+            "get",
+            "https://public.example.com/source",
+            allow_private_targets=False,
+        )
+
+        self.assertEqual(response.content, b"redirected")
+        self.assertEqual(str(response.url), "https://public.example.com/final")
+        self.assertEqual(
+            [str(item.url) for item in response.history],
+            ["https://public.example.com/source"],
+        )
+        self.assertEqual(
+            [call.request.transport_url for call in responses.calls],
+            [
+                "https://93.184.216.34/source",
+                "https://93.184.216.34/final",
+            ],
+        )
+        self.assertEqual(mocked_getaddrinfo.call_count, 2)
+
     @responses.activate
     def test_fetch_validated_url_strips_auth_on_cross_origin_redirect(self) -> None:
         recorded_headers: list[dict[str, str]] = []

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -2,16 +2,21 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import asyncio
 import base64
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-from weblate.utils.outbound import validate_runtime_ip, validate_runtime_url
+from weblate.utils.outbound import (
+    async_resolve_runtime_hostname,
+    validate_runtime_ip,
+    validate_runtime_url,
+)
 from weblate.utils.render import validate_editor, validate_repoweb
 from weblate.utils.validators import (
     EmailValidator,
@@ -761,6 +766,26 @@ class FediverseURLTest(SimpleTestCase):
 
 
 class OutboundAddressValidationTest(SimpleTestCase):
+    @patch("weblate.utils.outbound.get_running_loop")
+    def test_async_resolve_runtime_hostname(self, mocked_get_loop) -> None:
+        resolver = AsyncMock(
+            return_value=[
+                (0, 0, 0, "", ("93.184.216.34", 443)),
+                (0, 0, 0, "", ("2001:4860:4860::8888", 443)),
+            ]
+        )
+        mocked_get_loop.return_value = MagicMock(getaddrinfo=resolver)
+
+        addresses = asyncio.run(
+            async_resolve_runtime_hostname("faß.de", allow_private_targets=False)
+        )
+
+        self.assertEqual(
+            addresses,
+            ("93.184.216.34", "2001:4860:4860::8888"),
+        )
+        resolver.assert_awaited_once_with("xn--fa-hia.de", None, type=1)
+
     def test_validate_runtime_ip_rejects_shared_address_space(self) -> None:
         with self.assertRaises(ValidationError) as error:
             validate_runtime_ip("100.64.0.1", allow_private_targets=False)


### PR DESCRIPTION
Prevent DNS rebinding between validation and connection by pinning each protected request hop to an approved address. Centralize routing so synchronous and asynchronous clients cannot drift in SSRF behavior.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
