### PR TITLE
fix(vcs): canonicalize repository redirects

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -2740,11 +2740,14 @@ When enabled, hostnames that cannot be resolved during validation are rejected
 unless they are explicitly included in :setting:`VCS_ALLOW_HOSTS`.
 
 For Git repositories accessed over HTTPS or SSH, Weblate binds each VCS command
-to the addresses approved during runtime validation. HTTPS redirects and proxy
-use are disabled for these protected commands because either could delegate
-hostname resolution to an unvalidated connection path. Mercurial, Subversion,
-custom VCS backends, and additional URL schemes are rejected unless the target
-host is explicitly included in :setting:`VCS_ALLOW_HOSTS`.
+to the addresses approved during runtime validation for direct connections.
+Configured HTTP proxies are trusted infrastructure and resolve repository
+hostnames instead. Automatic redirect following remains disabled. Permanent
+same-host HTTP redirects are probed separately through the same outbound route,
+validated, and stored as the canonical component repository URL. Cross-host
+redirects have to be configured manually. Mercurial, Subversion, custom VCS
+backends, and additional URL schemes are rejected unless the target host is
+explicitly included in :setting:`VCS_ALLOW_HOSTS`.
 
 Network-level egress filtering which blocks internal, loopback, link-local,
 reserved, and cloud metadata address ranges is recommended as defense in depth,

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,7 @@ Weblate 2026.8
 * Category, project, and comment statistics now stay consistent after component topology and comment changes, and category metrics are collected correctly.
 * Mercurial repository filenames beginning with a dash are now handled safely.
 * Protected outbound HTTP requests now bind connections to validated public addresses.
+* Permanent same-host Git HTTP redirects are now validated and stored as canonical component repository URLs.
 * VCS operations now bind protected Git connections to validated public addresses and fail closed for clients which cannot enforce that binding.
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -360,9 +360,13 @@ Build-time and configuration variants
        by runtime validation. Protected SSH operations validate the effective
        ``HostName`` and ``Port``. Trusted administrator SSH configuration can
        alter routing, and :setting:`SSH_EXTRA_ARGS` can override connection
-       binding. Git LFS object transfers are disabled and outside the supported
-       VCS integration surface. VCS clients without connection binding require
-       an explicit trusted-host exemption. *(maintainer)*
+       binding. Permanent same-host Git HTTP redirects are probed without
+       automatic redirect following. Every direct destination is independently
+       validated and bound before use; configured HTTP proxies use the shared
+       trusted outbound routing. Git LFS object transfers are disabled and
+       outside the supported VCS integration surface. VCS clients without
+       connection binding require an explicit trusted-host exemption.
+       *(maintainer)*
      - Allowlist settings and privileged configuration can intentionally expand
        reachability. *(documented)* (source: :setting:`ASSET_PRIVATE_ALLOWLIST`,
        :setting:`PROJECT_WEB_RESTRICT_ALLOWLIST`,

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -320,6 +320,13 @@ Git
    and pre-push uploads are disabled for Weblate-managed repositories, so LFS
    tracked files remain pointer files and cannot be used as translation files.
 
+.. note::
+
+   Weblate validates permanent HTTP redirects which stay on the repository
+   hostname and automatically stores the canonical repository URL. The change
+   is recorded in the component history as repository maintenance. Redirects
+   to another hostname have to be configured manually.
+
 .. seealso::
 
     See :ref:`vcs-repos` for info on how to access different kinds of repositories.

--- a/weblate/templates/trans/alert/common-repo.html
+++ b/weblate/templates/trans/alert/common-repo.html
@@ -1,5 +1,11 @@
 {% load i18n %}
 
+{% if analysis.redirect %}
+  <p>
+    {% translate "The repository URL returned a permanent HTTP redirect. Weblate automatically accepts only verified redirects on the same host. Update the component to use the canonical repository URL if the redirect points elsewhere." %}
+  </p>
+{% endif %}
+
 {% if analysis.not_found %}
   <p>
     {% translate "The upstream repository was not found. Please check whether it exists and is accessible to Weblate." %}
@@ -46,6 +52,8 @@
   </p>
 {% endif %}
 
-<p>
-  {% translate "Weblate will retry the operation once it is needed again, so the alert might disappear for the temporary issues." %}
-</p>
+{% if not analysis.redirect %}
+  <p>
+    {% translate "Weblate will retry the operation once it is needed again, so the alert might disappear for the temporary issues." %}
+  </p>
+{% endif %}

--- a/weblate/templates/trans/alert/mergefailure.html
+++ b/weblate/templates/trans/alert/mergefailure.html
@@ -2,6 +2,10 @@
 
 <p>{% translate "Weblate could not merge upstream changes while updating the repository." %}</p>
 
-<pre>{{ error }}</pre>
+{% if analysis.redirect %}
+  {% include "trans/alert/common-repo.html" %}
+{% else %}
+  <pre>{{ error }}</pre>
 
-{% include "trans/merge_instructions.html" %}
+  {% include "trans/merge_instructions.html" %}
+{% endif %}

--- a/weblate/templates/trans/alert/pushfailure.html
+++ b/weblate/templates/trans/alert/pushfailure.html
@@ -2,7 +2,7 @@
 
 <p>{% translate "Weblate could not push changes to the upstream repository." %}</p>
 
-<pre>{{ error }}</pre>
+{% if not analysis.redirect %}<pre>{{ error }}</pre>{% endif %}
 
 {% include "trans/alert/common-repo.html" %}
 

--- a/weblate/templates/trans/alert/repositoryoperationfailure.html
+++ b/weblate/templates/trans/alert/repositoryoperationfailure.html
@@ -2,7 +2,7 @@
 
 <p>{% translate "Weblate could not recover an interrupted repository operation." %}</p>
 
-<pre>{{ error }}</pre>
+{% if not analysis.redirect %}<pre>{{ error }}</pre>{% endif %}
 
 {% include "trans/alert/common-repo.html" %}
 

--- a/weblate/templates/trans/alert/updatefailure.html
+++ b/weblate/templates/trans/alert/updatefailure.html
@@ -2,7 +2,7 @@
 
 <p>{% translate "Weblate could not fetch upstream changes when updating the repository." %}</p>
 
-<pre>{{ error }}</pre>
+{% if not analysis.redirect %}<pre>{{ error }}</pre>{% endif %}
 
 {% include "trans/alert/common-repo.html" %}
 

--- a/weblate/trans/alerts/vcs.py
+++ b/weblate/trans/alerts/vcs.py
@@ -49,6 +49,18 @@ class RepositoryErrorAlert(ErrorAlert):
     category = AlertCategory.VCS
     repository_permissions: tuple[str, ...] = ()
 
+    def get_analysis(self) -> dict[str, Any]:
+        normalized = self.error.lower()
+        return {
+            "redirect": (
+                "returned error: 301" in normalized
+                or "returned error: 308" in normalized
+                or "http redirect" in normalized
+                or "permanently redirects" in normalized
+                or "repository url redirects" in normalized
+            )
+        }
+
     @classmethod
     def can_user_act_for(
         cls, user: User, component: Component, details: dict[str, Any]
@@ -214,6 +226,7 @@ class BaseGitFailure(RepositoryErrorAlert):
     )
 
     def get_analysis(self) -> dict[str, Any]:
+        analysis = super().get_analysis()
         terminal_disabled = self.terminal_message in self.error
         repo_suggestion = None
         force_push_suggestion = False
@@ -244,6 +257,7 @@ class BaseGitFailure(RepositoryErrorAlert):
             )
 
         return {
+            **analysis,
             "terminal": terminal_disabled,
             "behind": behind,
             "repo_suggestion": repo_suggestion,

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -26,6 +26,7 @@ from crispy_forms.layout import (
 )
 from django import forms
 from django.conf import settings
+from django.core import signing
 from django.core.exceptions import NON_FIELD_ERRORS, PermissionDenied, ValidationError
 from django.core.validators import FileExtensionValidator
 from django.db.models import Count, Q
@@ -142,6 +143,9 @@ from weblate.vcs.git import GitMergeRequestBase
 from weblate.vcs.models import VCS_REGISTRY
 from weblate.workspaces.models import Workspace
 
+REPOSITORY_REDIRECT_PROOF_SALT = "weblate.component.repository-redirect"
+REPOSITORY_REDIRECT_PROOF_MAX_AGE = 86400
+
 if TYPE_CHECKING:
     from django.db.models import QuerySet
     from django.http import QueryDict
@@ -167,6 +171,62 @@ def copy_form_data(
     if isinstance(result, MutableMapping):
         return result
     return dict(result)
+
+
+def create_repository_redirect_proof(
+    request: AuthenticatedHttpRequest,
+    data: Mapping[str, Any],
+    original_url: str,
+    canonical_url: str,
+) -> str:
+    """Sign repository redirect provenance for the component creation wizard."""
+    project = data.get("project")
+    return signing.dumps(
+        {
+            "user": request.user.pk,
+            "project": getattr(project, "pk", project),
+            "vcs": data.get("vcs"),
+            "original": original_url,
+            "canonical": canonical_url,
+        },
+        salt=REPOSITORY_REDIRECT_PROOF_SALT,
+        compress=True,
+    )
+
+
+def get_repository_redirect_change(
+    request: AuthenticatedHttpRequest,
+    data: Mapping[str, Any],
+) -> tuple[str, str, str] | None:
+    """Verify redirect provenance carried between component creation steps."""
+    proof = data.get("repository_redirect_proof")
+    if not isinstance(proof, str) or not proof:
+        return None
+    try:
+        details = signing.loads(
+            proof,
+            salt=REPOSITORY_REDIRECT_PROOF_SALT,
+            max_age=REPOSITORY_REDIRECT_PROOF_MAX_AGE,
+        )
+    except signing.BadSignature:
+        return None
+    if not isinstance(details, dict):
+        return None
+
+    project = data.get("project")
+    original_url = details.get("original")
+    canonical_url = data.get("repo")
+    if (
+        details.get("user") != request.user.pk
+        or details.get("project") != getattr(project, "pk", project)
+        or details.get("vcs") != data.get("vcs")
+        or details.get("canonical") != canonical_url
+        or not isinstance(original_url, str)
+        or not isinstance(canonical_url, str)
+        or original_url == canonical_url
+    ):
+        return None
+    return ("repo", original_url, canonical_url)
 
 
 def clean_integration_component_data(
@@ -2532,6 +2592,10 @@ class ComponentCreateForm(
     )
 
     detected_license = forms.CharField(required=False, widget=forms.HiddenInput)
+    repository_redirect_proof = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput,
+    )
     source_component = forms.ModelChoiceField(
         queryset=Component.objects.none(),
         required=False,
@@ -2651,6 +2715,7 @@ class ComponentCreateForm(
             "source_language",
             "is_glossary",
             "detected_license",
+            "repository_redirect_proof",
             "source_component",
         )
 
@@ -2741,6 +2806,12 @@ class ComponentCreateForm(
                 data["file_format"], data["file_format_params"]
             )
         self.preserve_inherited_values()
+        repository_redirect_change = get_repository_redirect_change(
+            self.request,
+            data,
+        )
+        if repository_redirect_change is not None:
+            self.instance.repository_redirect_changes = [repository_redirect_change]
         for field in ("license", "new_lang", "language_code_style"):
             if self.disables_inheritance_for_explicit_setting(field):
                 setattr(self.instance, get_inherit_field_name(field), False)
@@ -2958,6 +3029,10 @@ class ComponentInitCreateForm(CleanRepoMixin, ComponentProjectForm):
         help_text=Component.branch.field.help_text,
         required=False,
     )
+    repository_redirect_proof = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput,
+    )
     instance: Component  # type: ignore[assignment]
 
     def __init__(self, *args, **kwargs) -> None:
@@ -2972,9 +3047,15 @@ class ComponentInitCreateForm(CleanRepoMixin, ComponentProjectForm):
 
     def clean_instance(self, data) -> None:
         params = copy.copy(data)
-        for field in ("detected_license", "discovery", "source_component"):
+        for field in (
+            "detected_license",
+            "discovery",
+            "repository_redirect_proof",
+            "source_component",
+        ):
             params.pop(field, None)
 
+        original_repo = params.get("repo")
         instance = Component(**params)
         instance.clean_fields(
             exclude=(
@@ -2988,6 +3069,14 @@ class ComponentInitCreateForm(CleanRepoMixin, ComponentProjectForm):
         instance.validate_unique()
         instance.clean_unique_together()
         instance.clean_repo()
+        if original_repo != instance.repo:
+            data["repository_redirect_proof"] = create_repository_redirect_proof(
+                self.request,
+                data,
+                original_repo,
+                instance.repo,
+            )
+            data["repo"] = instance.repo
         instance.clean_category()
         self.instance = instance
 

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -175,6 +175,7 @@ from weblate.utils.validators import (
 from weblate.vcs.base import (
     RepositoryError,
     RepositoryRecoveryEvent,
+    RepositoryRedirectError,
     RepositoryRestrictedPathError,
     RepositorySymlinkError,
     is_ssh_host_key_mismatch_error,
@@ -528,6 +529,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
     # automatic translation-memory scopes after related project data is gone.
     memory_full_slug: str | None = None
     memory_workspace_id: UUID | None = None
+    repository_redirect_changes: list[tuple[str, str, str]] | None = None
 
     AUDIT_SETTINGS: ClassVar[tuple[str, ...]] = (
         "restricted",
@@ -1191,6 +1193,12 @@ class Component(  # ruff: ignore[too-many-public-methods]
         seed_source_component_id = getattr(self, "seed_source_component_id", None)
         copy_seed_addons = getattr(self, "copy_seed_addons", False)
         seed_author = getattr(self, "seed_author", None)
+        repository_redirect_changes = self.repository_redirect_changes or []
+        if repository_redirect_changes and kwargs.get("update_fields") is not None:
+            kwargs["update_fields"] = {
+                *kwargs["update_fields"],
+                *(field for field, _old, _new in repository_redirect_changes),
+            }
         acting_user_id = self.acting_user.pk if self.acting_user else None
 
         self.drop_file_format_cache()
@@ -1316,6 +1324,14 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         # Save/Create object
         super().save(*args, **kwargs)
+        if repository_redirect_changes:
+            self.repository_redirect_changes = None
+            for field, old_url, canonical_url in repository_redirect_changes:
+                self.record_repository_redirect_change(
+                    field,
+                    old_url,
+                    canonical_url,
+                )
 
         if cleanup_conflicting_repository_setup:
             transaction.on_commit(
@@ -1574,6 +1590,107 @@ class Component(  # ruff: ignore[too-many-public-methods]
             "OldComponentSetting",
             self.__dict__.get(name, current.get(name, default)),
         )
+
+    @staticmethod
+    def get_repository_maintenance_user() -> User:
+        """Return the internal identity for automatic repository maintenance."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.auth.models import User
+
+        return User.objects.get_or_create_bot(
+            scope="weblate",
+            name="repository",
+            verbose="Repository maintenance",
+        )
+
+    def record_repository_redirect_change(
+        self,
+        field: str,
+        old_url: str,
+        canonical_url: str,
+    ) -> None:
+        """Record an automatic repository URL canonicalization."""
+        user = self.get_repository_maintenance_user()
+        self.change_set.create(
+            action=ActionEvents.COMPONENT_SETTING_CHANGE,
+            target=field,
+            user=user,
+            author=user,
+            details={
+                "field": field,
+                "old": cleanup_repo_url(old_url),
+                "target": cleanup_repo_url(canonical_url),
+                "automatic": True,
+                "reason": "http_redirect",
+            },
+        )
+
+    def stage_repository_redirect(
+        self,
+        field: str,
+        error: RepositoryRedirectError,
+    ) -> bool:
+        """Apply a canonical URL to an instance which will be saved later."""
+        if getattr(self, field) != error.original_url:
+            return False
+        if len(error.canonical_url) > REPO_LENGTH:
+            return False
+        setattr(self, field, error.canonical_url)
+        changes = self.repository_redirect_changes
+        if changes is None:
+            changes = []
+            self.repository_redirect_changes = changes
+        changes.append((field, error.original_url, error.canonical_url))
+        return True
+
+    def persist_repository_redirect(
+        self,
+        field: str,
+        error: RepositoryRedirectError,
+    ) -> bool:
+        """Atomically persist and audit a canonical URL discovered at runtime."""
+        if not self.pk or getattr(self, field) != error.original_url:
+            return False
+        if len(error.canonical_url) > REPO_LENGTH:
+            return False
+
+        repository = self.repository
+        with repository.lock, transaction.atomic():
+            locked = Component.objects.get_for_update(pk=self.pk)
+            if getattr(locked, field) != error.original_url:
+                return False
+            Component.objects.filter(pk=self.pk).update(**{field: error.canonical_url})
+            setattr(self, field, error.canonical_url)
+            repository.configure_remote(
+                self.repo,
+                self.push,
+                self.branch,
+            )
+            self.record_repository_redirect_change(
+                field,
+                error.original_url,
+                error.canonical_url,
+            )
+        return True
+
+    def apply_repository_redirect(
+        self,
+        field: str,
+        error: RepositoryRedirectError,
+        *,
+        during_validation: bool = False,
+    ) -> bool:
+        """Apply a canonical URL in either validation or runtime context."""
+        if self.pk and not during_validation:
+            return self.persist_repository_redirect(field, error)
+        if not self.stage_repository_redirect(field, error):
+            return False
+        self.repository.configure_remote(
+            self.repo,
+            self.push,
+            self.branch,
+        )
+        return True
 
     def refresh_from_db(self, *args, **kwargs) -> None:
         super().refresh_from_db(*args, **kwargs)
@@ -2522,6 +2639,20 @@ class Component(  # ruff: ignore[too-many-public-methods]
         self.log_info("updating repository")
         previous_revision, error = self.update_remote_repository()
         if error is not None:
+            if (
+                retry
+                and isinstance(error, RepositoryRedirectError)
+                and self.apply_repository_redirect(
+                    "repo",
+                    error,
+                    during_validation=validate,
+                )
+            ):
+                return self.update_remote_branch(
+                    validate,
+                    retry=False,
+                    user=user,
+                )
             error_text = self.error_text(error)
             if validate and retry and should_auto_add_ssh_host_key(error_text):
                 self.handle_update_error(error_text, retry)
@@ -2799,6 +2930,18 @@ class Component(  # ruff: ignore[too-many-public-methods]
             try:
                 self.repository.push(self.push_branch)
             except RepositoryError as error:
+                redirect_field = (
+                    "push"
+                    if isinstance(error, RepositoryRedirectError)
+                    and self.push == error.original_url
+                    else "repo"
+                )
+                if (
+                    retry
+                    and isinstance(error, RepositoryRedirectError)
+                    and self.persist_repository_redirect(redirect_field, error)
+                ):
+                    return self.push_repo(request, user, retry=False)
                 error_text = self.error_text(error)
                 report_error(
                     "Could not push the repo",
@@ -5026,14 +5169,19 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 )
                 raise ValidationError({"push_branch": msg})
 
-    def clean_repo(self, *, validate_worktree: bool = True) -> None:
+    def clean_repo(
+        self,
+        *,
+        validate_worktree: bool = True,
+        redirect_retry: bool = True,
+    ) -> None:
         self.clean_repo_link()
         if self.is_repo_link:
-            return
+            return None
 
         # Bail out on failed repo validation
         if self.repo is None:
-            return
+            return None
 
         if not self.is_repo_local and self.repo == "local:":
             raise ValidationError(
@@ -5064,6 +5212,15 @@ class Component(  # ruff: ignore[too-many-public-methods]
             self.set_default_branch()
             self.clean_branches()
             self.validate_repository_access(validate_worktree=validate_worktree)
+        except RepositoryRedirectError as error:
+            if redirect_retry and self.stage_repository_redirect("repo", error):
+                return self.clean_repo(
+                    validate_worktree=validate_worktree,
+                    redirect_retry=False,
+                )
+            text = self.error_text(error)
+            msg = gettext("Could not update repository: %s") % text
+            raise ValidationError({"repo": msg}) from error
         except RepositoryError as error:
             text = self.error_text(error)
             if is_ssh_host_key_mismatch_error(text):
@@ -5087,6 +5244,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
             raise ValidationError({"repo": msg}) from error
 
         self.clean_push_branch_settings()
+        return None
 
     def has_only_push_url_changed(self, old: Component | None) -> bool:
         """Check whether repository validation can be limited to push URL."""

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -29,7 +29,7 @@ from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.alerts.base import AlertSeverity, MultiAlert
 from weblate.trans.alerts.registry import update_alerts
-from weblate.trans.alerts.vcs import UpdateFailure
+from weblate.trans.alerts.vcs import RepositoryErrorAlert, UpdateFailure
 from weblate.trans.diagnostics import DIAGNOSTICS_LINK_LIMIT, get_diagnostics_context
 from weblate.trans.models import (
     Category,
@@ -1685,7 +1685,13 @@ class MonolingualAlertTest(ViewTestCase):
 
 class RepositoryAlertTemplateTest(SimpleTestCase):
     @staticmethod
-    def render_failure_alert(template_name: str, permissions: set[str]) -> str:
+    def render_failure_alert(
+        template_name: str,
+        permissions: set[str],
+        *,
+        analysis: dict | None = None,
+        error: str = "Repository operation failed",
+    ) -> str:
         component = SimpleNamespace(get_url_path=lambda: ("test", "component"))
         user = SimpleNamespace(
             has_perm=lambda permission, _obj: permission in permissions
@@ -1693,12 +1699,43 @@ class RepositoryAlertTemplateTest(SimpleTestCase):
         return render_to_string(
             template_name,
             {
-                "analysis": {},
+                "analysis": analysis or {},
                 "component": component,
-                "error": "Repository operation failed",
+                "error": error,
                 "user": user,
             },
         )
+
+    def test_repository_redirect_failure_hides_raw_git_error(self) -> None:
+        raw_error = (
+            "fatal: unable to access repository URL: "
+            "The requested URL returned error: 301 (128)"
+        )
+        rendered = self.render_failure_alert(
+            "trans/alert/updatefailure.html",
+            set(),
+            analysis={"redirect": True},
+            error=raw_error,
+        )
+
+        self.assertIn("permanent HTTP redirect", rendered)
+        self.assertNotIn(raw_error, rendered)
+
+    def test_repository_redirect_errors_are_classified(self) -> None:
+        errors = (
+            "The repository URL permanently redirects to a canonical URL.",
+            "The repository returned a permanent HTTP redirect without a target URL.",
+            "The repository returned an HTTP redirect with an invalid hostname.",
+            "The repository returned too many HTTP redirects.",
+        )
+
+        for error in errors:
+            with self.subTest(error=error):
+                alert = RepositoryErrorAlert(
+                    cast("Alert", SimpleNamespace()),
+                    error,
+                )
+                self.assertTrue(alert.get_analysis()["redirect"])
 
     def test_repository_failure_settings_action_permissions(self) -> None:
         settings_url = (

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -49,7 +49,11 @@ from weblate.utils.state import (
     STATE_READONLY,
     STATE_TRANSLATED,
 )
-from weblate.vcs.base import RepositoryError, RepositoryRecoveryEvent
+from weblate.vcs.base import (
+    RepositoryError,
+    RepositoryRecoveryEvent,
+    RepositoryRedirectError,
+)
 from weblate.vcs.git import GitMergeRequestBase, GitRepository
 from weblate.vcs.github import GitHubInstallation
 from weblate.vcs.models import VCS_REGISTRY
@@ -90,6 +94,92 @@ class ComponentTest(RepoTestCase):
         )
         self.assertFalse(
             component.alert_set.filter(name="RepositoryOperationFailure").exists()
+        )
+
+    def test_persist_repository_redirect_uses_repository_bot(self) -> None:
+        component = self.create_component()
+        old_url = "https://user:secret@git.example/owner/repo"
+        canonical_url = "https://user:secret@git.example/owner/repo.git"
+        Component.objects.filter(pk=component.pk).update(repo=old_url)
+        component.repo = old_url
+        repository = component.repository
+
+        with patch.object(repository, "configure_remote") as configure_remote:
+            changed = component.persist_repository_redirect(
+                "repo",
+                RepositoryRedirectError(old_url, canonical_url, 301),
+            )
+
+        self.assertTrue(changed)
+        component.refresh_from_db()
+        self.assertEqual(component.repo, canonical_url)
+        configure_remote.assert_called_once_with(
+            canonical_url,
+            component.push,
+            component.branch,
+        )
+        change = component.change_set.get(
+            action=ActionEvents.COMPONENT_SETTING_CHANGE,
+            target="repo",
+        )
+        self.assertEqual(change.user.username, "weblate:repository")
+        self.assertEqual(change.author.username, "weblate:repository")
+        self.assertEqual(change.user.full_name, "Repository maintenance")
+        self.assertEqual(
+            change.details,
+            {
+                "field": "repo",
+                "old": "https://git.example/owner/repo",
+                "target": "https://git.example/owner/repo.git",
+                "automatic": True,
+                "reason": "http_redirect",
+            },
+        )
+
+    def test_validate_update_stages_repository_redirect(self) -> None:
+        component = self.create_component()
+        saved_url = component.repo
+        original_url = "https://git.example/owner/repo"
+        canonical_url = f"{original_url}.git"
+        component.repo = original_url
+        component.branch = "redirected"
+        component.drop_repository_cache()
+        repository = component.repository
+        repository.__dict__["last_remote_revision"] = None
+        repository.last_output = ""
+
+        with (
+            patch.object(
+                component,
+                "update_remote_repository",
+                side_effect=[
+                    (
+                        None,
+                        RepositoryRedirectError(
+                            original_url,
+                            canonical_url,
+                            301,
+                        ),
+                    ),
+                    (None, None),
+                ],
+            ) as update_remote,
+            patch.object(repository, "configure_remote") as configure_remote,
+        ):
+            updated = component.update_remote_branch(validate=True)
+
+        self.assertTrue(updated)
+        self.assertEqual(update_remote.call_count, 2)
+        self.assertEqual(component.repo, canonical_url)
+        self.assertEqual(
+            component.repository_redirect_changes,
+            [("repo", original_url, canonical_url)],
+        )
+        self.assertEqual(Component.objects.get(pk=component.pk).repo, saved_url)
+        configure_remote.assert_called_once_with(
+            canonical_url,
+            component.push,
+            component.branch,
         )
 
     def test_handle_repository_recovery_failure_adds_alert(self) -> None:

--- a/weblate/trans/tests/test_create.py
+++ b/weblate/trans/tests/test_create.py
@@ -489,6 +489,89 @@ class CreateTest(ViewTestCase):
         self.assertIn("vcs", form.errors)
 
     @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_create_component_carries_canonical_repository_url(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+        original_url = self.component.repo
+        canonical_url = f"{original_url}-canonical"
+        request = self.get_request()
+
+        def canonicalize(component: Component) -> None:
+            component.repo = canonical_url
+
+        form = ComponentInitCreateForm(
+            request,
+            data={
+                "name": "Redirected Component",
+                "slug": "redirected-component",
+                "project": self.project.pk,
+                "source_language": get_default_lang(),
+                "vcs": "git",
+                "repo": original_url,
+                "branch": "main",
+            },
+        )
+        form.fields["project"].queryset = Project.objects.filter(pk=self.project.pk)
+
+        with patch.object(Component, "clean_repo", autospec=True) as clean_repo:
+            clean_repo.side_effect = canonicalize
+            self.assertTrue(form.is_valid(), form.errors)
+
+        self.assertEqual(form.cleaned_data["repo"], canonical_url)
+        proof = form.cleaned_data["repository_redirect_proof"]
+        self.assertIsInstance(proof, str)
+
+        create_form = ComponentCreateForm(
+            request,
+            data={
+                "name": "Redirected Component",
+                "slug": "redirected-component",
+                "project": self.project.pk,
+                "source_language": get_default_lang(),
+                "vcs": "git",
+                "repo": canonical_url,
+                "branch": "main",
+                "file_format": "po",
+                "filemask": "po/*.po",
+                "new_lang": "add",
+                "language_regex": "^[^.]+$",
+                "repository_redirect_proof": proof,
+            },
+        )
+        with patch.object(Component, "clean"):
+            self.assertTrue(create_form.is_valid(), create_form.errors)
+        self.assertEqual(
+            create_form.instance.repository_redirect_changes,
+            [("repo", original_url, canonical_url)],
+        )
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_create_component_rejects_forged_repository_redirect_proof(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+
+        form = ComponentCreateForm(
+            self.get_request(),
+            data={
+                "name": "Redirected Component",
+                "slug": "redirected-component",
+                "project": self.project.pk,
+                "source_language": get_default_lang(),
+                "vcs": "git",
+                "repo": self.component.repo,
+                "branch": "main",
+                "file_format": "po",
+                "filemask": "po/*.po",
+                "new_lang": "add",
+                "language_regex": "^[^.]+$",
+                "repository_redirect_proof": "forged",
+            },
+        )
+        with patch.object(Component, "clean"):
+            self.assertTrue(form.is_valid(), form.errors)
+        self.assertIsNone(form.instance.repository_redirect_changes)
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
     def test_create_component_accepts_github_app_repository_link(self) -> None:
         self.user.is_superuser = True
         self.user.save()

--- a/weblate/trans/views/create.py
+++ b/weblate/trans/views/create.py
@@ -290,6 +290,7 @@ class CreateComponent(BaseCreateView):
     passthrough_fields = (
         "category",
         "is_glossary",
+        "repository_redirect_proof",
         "source_component",
         *ComponentCreateForm.CREATE_INHERITABLE_SETTINGS,
         *(

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -271,6 +271,24 @@ class RepositoryValidationError(RepositoryError):
     """Error raised when repository configuration violates runtime policy."""
 
 
+class RepositoryRedirectError(RepositoryError):
+    """A repository URL permanently redirects to a validated canonical URL."""
+
+    def __init__(
+        self,
+        original_url: str,
+        canonical_url: str,
+        status_code: int,
+    ) -> None:
+        super().__init__(
+            0,
+            gettext("The repository URL permanently redirects to a canonical URL."),
+        )
+        self.original_url = original_url
+        self.canonical_url = canonical_url
+        self.status_code = status_code
+
+
 class RepositorySymlinkError(ValueError):
     """Raised when symlink resolution fails due to links outside the repository tree or excessive symlink depth."""
 
@@ -637,12 +655,17 @@ class Repository:
             if self.component:
                 self.ensure_config_updated()
         remote_target = None
+        effective_remote_url = remote_url
         if remote_url:
             remote_target = self.validate_remote_url(remote_url)
         elif remote_op == "pull":
             remote_target = self.validate_pull_url()
+            if self.component is not None:
+                effective_remote_url = self.component.repo
         elif remote_op == "push":
             remote_target = self.validate_push_url()
+            if self.component is not None:
+                effective_remote_url = self.component.push or self.component.repo
         args, environment = self.prepare_remote_command(
             args, environment, remote_target
         )
@@ -660,6 +683,13 @@ class Repository:
         except RepositoryCommandError as error:
             if not is_status and not self.local:
                 self.log_status(error)
+            if effective_remote_url and remote_target is not None:
+                self.handle_remote_command_error(
+                    error,
+                    effective_remote_url,
+                    remote_target,
+                    environment,
+                )
             raise
         return self.last_output
 
@@ -771,6 +801,17 @@ class Repository:
     ) -> tuple[list[str], dict[str, str] | None]:
         """Bind a remote command to the addresses approved during validation."""
         return args, environment
+
+    @classmethod
+    def handle_remote_command_error(
+        cls,
+        _error: RepositoryCommandError,
+        _remote_url: str,
+        _target: ResolvedRepositoryURL,
+        _environment: dict[str, str] | None,
+    ) -> None:
+        """Convert backend-specific failures into structured repository errors."""
+        return
 
     def validate_remote_compatibility(self, pull_url: str, branch: str) -> None:
         """Validate that a remote branch is compatible with this checkout."""

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import base64
 import logging
 import os
 import os.path
@@ -16,6 +17,7 @@ import sys
 import urllib.parse
 from configparser import NoOptionError, NoSectionError, RawConfigParser
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass
 from ipaddress import ip_address
 from json import dumps
 from pathlib import Path
@@ -40,6 +42,7 @@ from django.core.cache import cache
 from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy
 from git.config import GitConfigParser
+from idna import IDNAError
 from idna import encode as idna_encode
 
 from weblate.utils.data import data_dir, data_path
@@ -50,7 +53,13 @@ from weblate.utils.files import (
 )
 from weblate.utils.lock import WeblateLock, WeblateLockTimeoutError
 from weblate.utils.render import render_template
-from weblate.utils.requests import JSON_RESPONSE_ERRORS, fetch_url
+from weblate.utils.requests import (
+    JSON_RESPONSE_ERRORS,
+    HTTPClient,
+    RedirectValidators,
+    _get_proxy,
+    fetch_url,
+)
 from weblate.utils.tracing import start_span
 from weblate.utils.xml import parse_xml
 from weblate.utils.zip import (
@@ -65,6 +74,7 @@ from weblate.vcs.base import (
     RepositoryCommandError,
     RepositoryError,
     RepositoryRecoveryEvent,
+    RepositoryRedirectError,
 )
 from weblate.vcs.gpg import get_gpg_sign_key
 from weblate.vcs.ssh import SSH_WRAPPER, resolve_ssh_destination
@@ -98,6 +108,236 @@ RECOVERABLE_ABORT_LOCKS = frozenset(
         "REVERT_HEAD.lock",
     }
 )
+GIT_REDIRECT_LIMIT = 5
+GIT_UPLOAD_PACK_MEDIA_TYPE = "application/x-git-upload-pack-advertisement"
+
+
+@dataclass
+class GitProbeRedirectValidators(RedirectValidators):
+    """Bind direct Git probes to the addresses approved by VCS validation."""
+
+    target: ResolvedRepositoryURL
+
+    def validate_request_url(
+        self, request_url: str, *, used_proxy: bool
+    ) -> tuple[str, ...]:
+        if used_proxy or not self.target.requires_pinning:
+            return ()
+        if not self.target.addresses:
+            raise RepositoryError(
+                0,
+                gettext("The repository redirect target has no validated address."),
+            )
+        return self.target.addresses
+
+
+def _normalize_redirect_hostname(hostname: str) -> str:
+    """Normalize hostnames for redirect-origin comparisons."""
+    normalized = hostname.rstrip(".")
+    try:
+        return str(ip_address(normalized))
+    except ValueError:
+        try:
+            return idna_encode(normalized, uts46=True).decode("ascii").lower()
+        except (IDNAError, UnicodeError) as error:
+            raise RepositoryError(
+                0,
+                gettext(
+                    "The repository returned an HTTP redirect with an invalid hostname."
+                ),
+            ) from error
+
+
+def _strip_url_credentials(url: str) -> str:
+    """Remove credentials without importing the component utility module."""
+    parsed = urlparse(url)
+    if parsed.username is None:
+        return url
+    return urlunparse(parsed._replace(netloc=parsed.netloc.rsplit("@", 1)[-1]))
+
+
+def _copy_url_credentials(source: str, target: str) -> str:
+    """Retain existing credentials across an accepted same-host redirect."""
+    source_parsed = urlparse(source)
+    if source_parsed.username is None:
+        return target
+    target_parsed = urlparse(target)
+    userinfo = source_parsed.netloc.rsplit("@", 1)[0]
+    return urlunparse(
+        target_parsed._replace(netloc=f"{userinfo}@{target_parsed.netloc}")
+    )
+
+
+def _build_git_probe_url(repository_url: str) -> str:
+    """Build the smart-HTTP upload-pack discovery endpoint."""
+    parsed = urlparse(repository_url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.append(("service", "git-upload-pack"))
+    return urlunparse(
+        parsed._replace(
+            path=f"{parsed.path.rstrip('/')}/info/refs",
+            query=urllib.parse.urlencode(query),
+            fragment="",
+        )
+    )
+
+
+def _repository_url_from_probe_redirect(
+    source_url: str,
+    probe_url: str,
+    location: str,
+) -> str:
+    """Derive a repository base URL from a redirected smart-HTTP endpoint."""
+    try:
+        location_parsed = urlparse(location)
+    except ValueError as error:
+        raise RepositoryError(
+            0, gettext("The repository returned an invalid HTTP redirect.")
+        ) from error
+    if location_parsed.username is not None:
+        raise RepositoryError(
+            0,
+            gettext(
+                "The repository HTTP redirect contains credentials and was rejected."
+            ),
+        )
+
+    redirected_probe = urllib.parse.urljoin(probe_url, location)
+    try:
+        parsed = urlparse(redirected_probe)
+        port = parsed.port
+    except ValueError as error:
+        raise RepositoryError(
+            0, gettext("The repository returned an invalid HTTP redirect.")
+        ) from error
+    if not parsed.hostname or not parsed.path.endswith("/info/refs"):
+        raise RepositoryError(
+            0,
+            gettext(
+                "The repository HTTP redirect does not point to a Git smart HTTP endpoint."
+            ),
+        )
+
+    source_parsed = urlparse(source_url)
+    if _normalize_redirect_hostname(parsed.hostname) != _normalize_redirect_hostname(
+        source_parsed.hostname or ""
+    ):
+        raise RepositoryError(
+            0,
+            gettext(
+                "The repository URL redirects to a different host. Automatic cross-host redirects are disabled for security; update the repository URL manually."
+            ),
+        )
+    if source_parsed.scheme == "https" and parsed.scheme != "https":
+        raise RepositoryError(
+            0,
+            gettext(
+                "The repository URL redirects from HTTPS to an insecure URL and was rejected."
+            ),
+        )
+    if parsed.scheme not in {"http", "https"}:
+        raise RepositoryError(
+            0, gettext("The repository URL redirects to an unsupported URL scheme.")
+        )
+
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query_without_service = [
+        (key, value)
+        for key, value in query
+        if not (key == "service" and value == "git-upload-pack")
+    ]
+    source_query = urllib.parse.parse_qsl(
+        source_parsed.query,
+        keep_blank_values=True,
+    )
+    if query_without_service != source_query:
+        raise RepositoryError(
+            0,
+            gettext("The repository HTTP redirect unexpectedly changed the URL query."),
+        )
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    netloc = host if port is None else f"{host}:{port}"
+    result = urlunparse(
+        parsed._replace(
+            netloc=netloc,
+            path=parsed.path.removesuffix("/info/refs").rstrip("/"),
+            query=source_parsed.query,
+            fragment="",
+        )
+    )
+    return _copy_url_credentials(source_url, result)
+
+
+def _get_git_probe_headers(
+    repository_url: str,
+    environment: dict[str, str] | None,
+) -> dict[str, str]:
+    """Build smart-HTTP headers, including explicitly configured Git auth."""
+    headers = {
+        "Accept": GIT_UPLOAD_PACK_MEDIA_TYPE,
+        "Git-Protocol": "version=2",
+    }
+    parsed = urlparse(repository_url)
+    if parsed.username is not None:
+        username = urllib.parse.unquote(parsed.username)
+        password = urllib.parse.unquote(parsed.password or "")
+        value = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+        headers["Authorization"] = f"Basic {value}"
+
+    environment = environment or {}
+    try:
+        config_count = int(environment.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        config_count = 0
+    for index in range(config_count):
+        if environment.get(f"GIT_CONFIG_KEY_{index}") != "http.extraHeader":
+            continue
+        value = environment.get(f"GIT_CONFIG_VALUE_{index}", "")
+        name, separator, header_value = value.partition(":")
+        if separator and name.lower() == "authorization":
+            headers["Authorization"] = header_value.strip()
+    return headers
+
+
+def _request_git_probe(
+    repository_url: str,
+    target: ResolvedRepositoryURL,
+    environment: dict[str, str] | None,
+) -> tuple[int, str | None, str]:
+    """Make one no-redirect smart-HTTP request using shared outbound routing."""
+    try:
+        return _perform_git_probe(repository_url, target, environment)
+    except httpx2.HTTPError as error:
+        raise RepositoryError(
+            0,
+            gettext("Could not probe the repository HTTP redirect: %s") % error,
+        ) from error
+
+
+def _perform_git_probe(
+    repository_url: str,
+    target: ResolvedRepositoryURL,
+    environment: dict[str, str] | None,
+) -> tuple[int, str | None, str]:
+    """Perform one Git smart-HTTP probe using the shared HTTP client."""
+    with HTTPClient() as client:
+        response = client.request(
+            "GET",
+            _build_git_probe_url(repository_url),
+            headers=_get_git_probe_headers(repository_url, environment),
+            timeout=20,
+            allow_redirects=False,
+            stream=True,
+            validators=GitProbeRedirectValidators(target),
+        )
+        try:
+            return (
+                response.status_code,
+                response.headers.get("Location"),
+                response.headers.get("Content-Type", ""),
+            )
+        finally:
+            response.close()
 
 
 class GitCredentials(TypedDict):
@@ -231,40 +471,42 @@ class GitRepository(Repository):
         target: ResolvedRepositoryURL | None,
     ) -> tuple[list[str], dict[str, str] | None]:
         """Pin Git's connection to addresses approved during validation."""
-        if target is None or not target.requires_pinning:
+        if target is None:
             return args, environment
 
-        if target.scheme == "https":
+        if target.scheme in {"http", "https"}:
             resolve_options: list[str] = []
-            try:
-                ip_address(target.hostname)
-            except ValueError:
-                resolve_hostname = idna_encode(target.hostname, uts46=True).decode(
-                    "ascii"
-                )
-                addresses = ",".join(
-                    f"[{address}]" if ":" in address else address
-                    for address in target.addresses
-                )
-                resolve_options = [
-                    "-c",
-                    f"http.curloptResolve={resolve_hostname}:{target.port}:{addresses}",
-                ]
-            # Numeric URL hosts cannot be rebound and older libcurl releases do
-            # not accept an IPv6 literal in CURLOPT_RESOLVE's host field.
+            proxy = _get_proxy(target.url)
+            proxy_environment = environment
+            if proxy is not None:
+                proxy_environment = dict(environment or {})
+                proxy_environment[f"{target.scheme}_proxy"] = proxy
+            elif target.requires_pinning:
+                try:
+                    ip_address(target.hostname)
+                except ValueError:
+                    resolve_hostname = idna_encode(target.hostname, uts46=True).decode(
+                        "ascii"
+                    )
+                    addresses = ",".join(
+                        f"[{address}]" if ":" in address else address
+                        for address in target.addresses
+                    )
+                    resolve_options = [
+                        "-c",
+                        f"http.curloptResolve={resolve_hostname}:{target.port}:{addresses}",
+                    ]
             return (
                 [
                     *resolve_options,
                     "-c",
                     "http.followRedirects=false",
-                    "-c",
-                    "http.proxy=",
                     *args,
                 ],
-                environment,
+                proxy_environment,
             )
 
-        if target.scheme == "ssh":
+        if target.scheme == "ssh" and target.requires_pinning:
             pinned_environment = dict(environment or {})
             host_key_alias = (
                 f"[{target.hostname}]:{target.port}"
@@ -292,6 +534,117 @@ class GitRepository(Repository):
             return args, pinned_environment
 
         return super().prepare_remote_command(args, environment, target)
+
+    @classmethod
+    def probe_remote_redirect(
+        cls,
+        repository_url: str,
+        target: ResolvedRepositoryURL,
+        environment: dict[str, str] | None,
+    ) -> tuple[int, str | None, str]:
+        """Probe one repository URL using the same proxy policy as Git."""
+        return _request_git_probe(
+            repository_url,
+            target,
+            environment,
+        )
+
+    @classmethod
+    def handle_remote_command_error(
+        cls,
+        error: RepositoryCommandError,
+        remote_url: str,
+        target: ResolvedRepositoryURL,
+        environment: dict[str, str] | None,
+    ) -> None:
+        """Turn permanent HTTP redirects into canonical URL suggestions."""
+        if target.scheme not in {"http", "https"}:
+            return
+        error_message = error.get_message().lower()
+        if not any(
+            f"returned error: {status_code}" in error_message
+            for status_code in (301, 308)
+        ):
+            return
+
+        original_url = remote_url
+        current_url = remote_url
+        current_target = target
+        seen = {_strip_url_credentials(current_url)}
+
+        try:
+            status_code, location, content_type = cls.probe_remote_redirect(
+                current_url,
+                current_target,
+                environment,
+            )
+        except RepositoryError:
+            # Preserve the original Git failure when the independent probe cannot
+            # establish that a redirect caused it.
+            return
+        if status_code not in {301, 308}:
+            return
+        initial_status = status_code
+
+        for _redirect_count in range(GIT_REDIRECT_LIMIT + 1):
+            if status_code in {301, 308}:
+                if location is None:
+                    raise RepositoryError(
+                        0,
+                        gettext(
+                            "The repository returned a permanent HTTP redirect without a target URL."
+                        ),
+                    ) from error
+                next_url = _repository_url_from_probe_redirect(
+                    current_url,
+                    _build_git_probe_url(current_url),
+                    location,
+                )
+                identity = _strip_url_credentials(next_url)
+                if identity in seen:
+                    raise RepositoryError(
+                        0, gettext("The repository HTTP redirect contains a loop.")
+                    ) from error
+                seen.add(identity)
+                validated_target = cls.validate_remote_url(next_url)
+                if validated_target is None:
+                    raise RepositoryError(
+                        0,
+                        gettext(
+                            "The repository HTTP redirect target could not be validated."
+                        ),
+                    ) from error
+                current_target = validated_target
+                current_url = next_url
+                status_code, location, content_type = cls.probe_remote_redirect(
+                    current_url,
+                    current_target,
+                    environment,
+                )
+                continue
+
+            if (
+                current_url != original_url
+                and status_code == 200
+                and content_type.split(";", 1)[0].strip().lower()
+                == GIT_UPLOAD_PACK_MEDIA_TYPE
+            ):
+                raise RepositoryRedirectError(
+                    original_url,
+                    current_url,
+                    initial_status,
+                ) from error
+
+            raise RepositoryError(
+                0,
+                gettext(
+                    "The repository HTTP redirect target could not be verified as a Git repository."
+                ),
+            ) from error
+
+        raise RepositoryError(
+            0, gettext("The repository returned too many HTTP redirects.")
+        ) from error
 
     @staticmethod
     def cleanup_stale_lock(lock: Path) -> bool:
@@ -345,6 +698,11 @@ class GitRepository(Repository):
         )
         try:
             result = cls._popen(args, environment=environment)
+        except RepositoryCommandError as error:
+            if target is not None:
+                cls.handle_remote_command_error(error, repo, target, environment)
+            report_error("Listing remote branch")
+            return super().get_remote_branch(repo)
         except RepositoryError:
             report_error("Listing remote branch")
             return super().get_remote_branch(repo)
@@ -673,7 +1031,17 @@ class GitRepository(Repository):
             self._get_auth_environment(source),
             remote_target,
         )
-        self._popen(args, environment=environment)
+        try:
+            self._popen(args, environment=environment)
+        except RepositoryCommandError as error:
+            if remote_target is not None:
+                self.handle_remote_command_error(
+                    error,
+                    source,
+                    remote_target,
+                    environment,
+                )
+            raise
 
     def get_config(self, path):
         """Read entry from configuration."""

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -20,8 +20,9 @@ from io import BytesIO
 from os import utime
 from pathlib import Path
 from time import time
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NoReturn, Protocol
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.core.cache import cache
@@ -37,9 +38,11 @@ from weblate.utils.render import render_template
 from weblate.utils.tests import http_mock as responses
 from weblate.utils.tests.http_mock import matchers
 from weblate.utils.zip import ZipSafetyLimits
+from weblate.vcs import git as git_module
 from weblate.vcs.base import (
     RepositoryCommandError,
     RepositoryError,
+    RepositoryRedirectError,
     RepositoryRestrictedPathError,
     RepositorySymlinkError,
     RepositoryValidationError,
@@ -50,6 +53,7 @@ from weblate.vcs.base import (
     should_auto_add_ssh_host_key,
 )
 from weblate.vcs.git import (
+    GIT_UPLOAD_PACK_MEDIA_TYPE,
     SSH_PROXY_PATH,
     AzureDevOpsRepository,
     BitbucketCloudRepository,
@@ -70,7 +74,6 @@ from weblate.vcs.ssh import SSH_WRAPPER, add_host_key
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
-    from unittest.mock import MagicMock
 
     from weblate.vcs.base import Repository
 
@@ -1276,6 +1279,216 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         self.assertEqual(environment["GIT_LFS_SKIP_PUSH"], "1")
         self.assertEqual(environment["GIT_LFS_SKIP_SMUDGE"], "1")
 
+    @responses.activate
+    def test_git_redirect_probe_uses_smart_http_and_validated_address(self) -> None:
+        probe_url = (
+            "https://user:secret@git.example/owner/repo/"
+            "info/refs?service=git-upload-pack"
+        )
+        responses.add(
+            responses.GET,
+            probe_url,
+            status=301,
+            headers={
+                "Location": "/owner/repo.git/info/refs?service=git-upload-pack",
+            },
+        )
+        target = SimpleNamespace(
+            requires_pinning=True,
+            addresses=("93.184.216.34",),
+        )
+
+        with (
+            patch(
+                "weblate.utils.requests._get_proxy",
+                return_value=None,
+            ),
+            patch("weblate.utils.version.USER_AGENT", "Weblate/test"),
+        ):
+            result = git_module._request_git_probe(  # ruff: ignore[private-member-access]
+                "https://user:secret@git.example/owner/repo",
+                target,  # type: ignore[arg-type]
+                None,
+            )
+
+        self.assertEqual(
+            result,
+            (
+                301,
+                "/owner/repo.git/info/refs?service=git-upload-pack",
+                "",
+            ),
+        )
+        self.assertEqual(len(responses.calls), 1)
+        request = responses.calls[0].request
+        self.assertEqual(
+            request.transport_url,
+            "https://user:secret@93.184.216.34/owner/repo/"
+            "info/refs?service=git-upload-pack",
+        )
+        self.assertEqual(request.headers["Host"], "git.example")
+        self.assertEqual(request.extensions["sni_hostname"], "git.example")
+        self.assertEqual(
+            request.headers["Accept"],
+            "application/x-git-upload-pack-advertisement",
+        )
+        self.assertEqual(request.headers["Git-Protocol"], "version=2")
+        self.assertEqual(request.headers["User-Agent"], "Weblate/test")
+        self.assertEqual(request.headers["Authorization"], "Basic dXNlcjpzZWNyZXQ=")
+
+    def test_git_redirect_probe_allows_shared_proxy_routing(self) -> None:
+        target = SimpleNamespace(
+            requires_pinning=True,
+            addresses=("93.184.216.34",),
+        )
+        validators = git_module.GitProbeRedirectValidators(
+            target,  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(
+            validators.validate_request_url(
+                "https://git.example/owner/repo",
+                used_proxy=True,
+            ),
+            (),
+        )
+
+    def test_git_redirect_probe_rejects_invalid_hostname(self) -> None:
+        with self.assertRaisesMessage(
+            RepositoryError,
+            "HTTP redirect with an invalid hostname",
+        ):
+            git_module._repository_url_from_probe_redirect(  # ruff: ignore[private-member-access]
+                "https://git.example/owner/repo",
+                "https://git.example/owner/repo/info/refs?service=git-upload-pack",
+                "https://invalid host/repo.git/info/refs?service=git-upload-pack",
+            )
+
+    def test_git_redirect_preserves_default_port_ipv6_brackets(self) -> None:
+        source_url = "https://[2001:db8::1]/owner/repo"
+
+        canonical_url = git_module._repository_url_from_probe_redirect(  # ruff: ignore[private-member-access]
+            source_url,
+            f"{source_url}/info/refs?service=git-upload-pack",
+            "/owner/repo.git/info/refs?service=git-upload-pack",
+        )
+
+        self.assertEqual(
+            canonical_url,
+            "https://[2001:db8::1]/owner/repo.git",
+        )
+
+    def test_permanent_same_host_redirect_returns_canonical_url(self) -> None:
+        original_url = "https://user:secret@git.example/owner/repo"
+        original_target = SimpleNamespace(scheme="https")
+        redirected_target = SimpleNamespace(scheme="https")
+        error = RepositoryCommandError(
+            128,
+            "fatal: unable to access repository URL: "
+            "The requested URL returned error: 301",
+        )
+
+        with (
+            patch(
+                "weblate.vcs.git.GitRepository.probe_remote_redirect",
+                side_effect=[
+                    (
+                        301,
+                        "/owner/repo.git/info/refs?service=git-upload-pack",
+                        "",
+                    ),
+                    (200, None, "application/x-git-upload-pack-advertisement"),
+                ],
+            ) as probe,
+            patch.object(
+                GitRepository,
+                "validate_remote_url",
+                return_value=redirected_target,
+            ) as validate,
+            self.assertRaises(RepositoryRedirectError) as raised,
+        ):
+            GitRepository.handle_remote_command_error(
+                error,
+                original_url,
+                original_target,  # type: ignore[arg-type]
+                None,
+            )
+
+        self.assertEqual(raised.exception.original_url, original_url)
+        self.assertEqual(
+            raised.exception.canonical_url,
+            "https://user:secret@git.example/owner/repo.git",
+        )
+        self.assertEqual(raised.exception.status_code, 301)
+        validate.assert_called_once_with(
+            "https://user:secret@git.example/owner/repo.git"
+        )
+        self.assertEqual(probe.call_count, 2)
+
+    def test_permanent_redirect_errors_are_probed(self) -> None:
+        for status_code in (301, 308):
+            with (
+                self.subTest(status_code=status_code),
+                patch.object(
+                    GitRepository,
+                    "probe_remote_redirect",
+                    return_value=(200, None, GIT_UPLOAD_PACK_MEDIA_TYPE),
+                ) as probe,
+            ):
+                GitRepository.handle_remote_command_error(
+                    RepositoryCommandError(
+                        128,
+                        f"The requested URL returned error: {status_code}",
+                    ),
+                    "https://git.example/repo",
+                    SimpleNamespace(scheme="https"),  # type: ignore[arg-type]
+                    None,
+                )
+
+            probe.assert_called_once()
+
+    def test_unrelated_http_errors_are_not_probed(self) -> None:
+        errors = (
+            "The requested URL returned error: 401",
+            "! [rejected] main -> main (non-fast-forward)",
+            "Failed to connect to git.example: Connection timed out",
+        )
+
+        with patch.object(GitRepository, "probe_remote_redirect") as probe:
+            for message in errors:
+                with self.subTest(message=message):
+                    GitRepository.handle_remote_command_error(
+                        RepositoryCommandError(128, message),
+                        "https://git.example/repo",
+                        SimpleNamespace(scheme="https"),  # type: ignore[arg-type]
+                        None,
+                    )
+
+        probe.assert_not_called()
+
+    def test_cross_host_redirect_is_rejected(self) -> None:
+        error = RepositoryCommandError(128, "The requested URL returned error: 301")
+        with (
+            patch(
+                "weblate.vcs.git.GitRepository.probe_remote_redirect",
+                return_value=(
+                    301,
+                    "https://other.example/repo.git/info/refs?service=git-upload-pack",
+                    "",
+                ),
+            ),
+            self.assertRaisesMessage(
+                RepositoryError,
+                "Automatic cross-host redirects are disabled",
+            ),
+        ):
+            GitRepository.handle_remote_command_error(
+                error,
+                "https://git.example/repo",
+                SimpleNamespace(scheme="https"),  # type: ignore[arg-type]
+                None,
+            )
+
     @override_settings(
         VCS_ALLOW_HOSTS=set(),
         VCS_ALLOW_SCHEMES={"https", "ssh"},
@@ -1290,6 +1503,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                     (0, 0, 0, "", ("2001:4860:4860::8888", 443, 0, 0)),
                 ],
             ),
+            patch("weblate.vcs.git._get_proxy", return_value=None),
             patch.object(
                 GitRepository,
                 "_popen",
@@ -1301,15 +1515,55 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         self.assertEqual(branch, "main")
         args = popen.call_args.args[0]
         self.assertEqual(
-            args[:6],
+            args[:4],
             [
                 "-c",
                 "http.curloptResolve=git.example:443:93.184.216.34,[2001:4860:4860::8888]",
                 "-c",
                 "http.followRedirects=false",
-                "-c",
-                "http.proxy=",
             ],
+        )
+
+    @override_settings(
+        VCS_ALLOW_HOSTS=set(),
+        VCS_ALLOW_SCHEMES={"https", "ssh"},
+        VCS_RESTRICT_PRIVATE=True,
+    )
+    def test_https_remote_forwards_environment_proxy(self) -> None:
+        with (
+            patch.dict(
+                os.environ,
+                {"ALL_PROXY": "http://proxy.example:8080"},
+                clear=True,
+            ),
+            patch(
+                "weblate.utils.outbound.socket.getaddrinfo",
+                return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
+            ),
+            patch.object(
+                GitRepository,
+                "_popen",
+                return_value="ref: refs/heads/main\tHEAD\n",
+            ) as popen,
+        ):
+            branch = GitRepository.get_remote_branch("https://git.example/repo.git")
+
+        self.assertEqual(branch, "main")
+        args = popen.call_args.args[0]
+        self.assertNotIn(
+            "http.curloptResolve=git.example:443:93.184.216.34",
+            args,
+        )
+        self.assertNotIn("http.proxy=", args)
+        self.assertIn("http.followRedirects=false", args)
+        environment = popen.call_args.kwargs["environment"]
+        self.assertEqual(
+            environment,
+            {"https_proxy": "http://proxy.example:8080"},
+        )
+        self.assertEqual(
+            GitRepository._getenv(environment)["https_proxy"],  # ruff: ignore[private-member-access]
+            "http://proxy.example:8080",
         )
 
     @override_settings(
@@ -1323,6 +1577,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                 "weblate.utils.outbound.socket.getaddrinfo",
                 return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
             ) as getaddrinfo,
+            patch("weblate.vcs.git._get_proxy", return_value=None),
             patch.object(
                 GitRepository,
                 "_popen",
@@ -1349,6 +1604,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         ):
             with (
                 self.subTest(url=url),
+                patch("weblate.vcs.git._get_proxy", return_value=None),
                 patch.object(
                     GitRepository,
                     "_popen",
@@ -1362,7 +1618,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                 any(arg.startswith("http.curloptResolve=") for arg in args)
             )
             self.assertIn("http.followRedirects=false", args)
-            self.assertIn("http.proxy=", args)
+            self.assertNotIn("http.proxy=", args)
 
     @override_settings(
         VCS_ALLOW_HOSTS=set(),
@@ -1376,6 +1632,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                 "weblate.utils.outbound.socket.getaddrinfo",
                 return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
             ) as getaddrinfo,
+            patch("weblate.vcs.git._get_proxy", return_value=None),
             patch.object(GitRepository, "validate_branch_name", return_value="main"),
             patch.object(GitRepository, "_popen", return_value="") as popen,
         ):


### PR DESCRIPTION
Git no longer follows HTTP redirects implicitly, which breaks common forge URLs that redirect to their canonical .git location. Resolve safe permanent redirects explicitly, persist the canonical URL, and surface actionable failures.

Built on top of https://github.com/WeblateOrg/weblate/pull/20871


<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
