### PR TITLE
fix(zammad): normalize ticket submission failures

### DIFF
--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -10,7 +10,6 @@ from time import sleep
 from types import SimpleNamespace
 from unittest import mock
 
-import httpx2
 from django.conf import settings
 from django.core import mail
 from django.test.utils import modify_settings, override_settings
@@ -50,6 +49,7 @@ from weblate.trans.tests.utils import (
 )
 from weblate.utils.ratelimit import reset_rate_limit
 from weblate.utils.state import STATE_TRANSLATED
+from weblate.utils.zammad import ZammadError
 from weblate.workspaces.models import Workspace
 
 CONTACT_DATA = {
@@ -151,21 +151,17 @@ class ViewTest(RepoTestCase):
         ADMINS_CONTACT=["noreply@weblate.org"],
         ZAMMAD_URL="https://support.example.com",
     )
-    def test_contact_handles_zammad_http_error(self) -> None:
-        with (
-            mock.patch(
-                "weblate.accounts.views.submit_zammad_ticket",
-                side_effect=httpx2.ConnectError("Zammad unavailable"),
-            ),
-            mock.patch("weblate.accounts.views.report_error") as report_error,
+    def test_contact_handles_zammad_error(self) -> None:
+        with mock.patch(
+            "weblate.accounts.views.submit_zammad_ticket",
+            side_effect=ZammadError("Customer care is currently unavailable."),
         ):
             response = self.client.post(reverse("contact"), CONTACT_DATA, follow=True)
 
         self.assertContains(
             response,
-            "Could not open a ticket, please try again later.",
+            "Customer care is currently unavailable.",
         )
-        report_error.assert_called_once_with("Could not create ticket")
 
     @override_settings(
         REGISTRATION_CAPTCHA=False, ADMINS_CONTACT=["noreply@example.com"]

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -14,7 +14,6 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import quote
 
-import httpx2
 import qrcode
 import qrcode.image.svg
 from django.conf import settings
@@ -330,11 +329,6 @@ def mail_admins_contact(
             )
         except ZammadError as error:
             messages.error(request, str(error))
-        except (OSError, httpx2.HTTPError):
-            report_error("Could not create ticket")
-            messages.error(
-                request, gettext("Could not open a ticket, please try again later.")
-            )
         else:
             messages.success(
                 request,

--- a/weblate/utils/tests/test_zammad.py
+++ b/weblate/utils/tests/test_zammad.py
@@ -5,31 +5,54 @@
 from __future__ import annotations
 
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
+import httpx2
 from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import override_settings
 
 from weblate.utils.tests import http_mock as responses
 from weblate.utils.zammad import ZammadError, submit_zammad_ticket
 
+ZAMMAD_URL = "https://example.com"
+CONFIG_URL = f"{ZAMMAD_URL}/api/v1/form_config"
+SUBMIT_URL = f"{ZAMMAD_URL}/api/v1/form_submit"
+TICKET_DATA = {
+    "title": "title",
+    "body": "body",
+    "name": "name",
+    "email": "mail",
+}
+
 
 class ZammadTest(TestCase):
+    def assert_zammad_failure(self) -> tuple[Mock, ZammadError]:
+        with (
+            patch("weblate.utils.zammad.report_error") as report_error,
+            self.assertRaisesRegex(
+                ZammadError, "Customer care is currently unavailable"
+            ) as raised,
+        ):
+            submit_zammad_ticket(**TICKET_DATA)
+
+        report_error.assert_called_once()
+        return report_error, raised.exception
+
     def mock_zammad(self) -> None:
-        submit_url = "https://example.com/api/v1/form_submit"
         responses.add(
             responses.POST,
-            "https://example.com/api/v1/form_config",
-            json={"enabled": True, "endpoint": submit_url, "token": "token"},
+            CONFIG_URL,
+            json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
         )
         responses.add(
-            responses.POST, submit_url, json={"ticket": {"id": 123, "number": 4123}}
+            responses.POST, SUBMIT_URL, json={"ticket": {"id": 123, "number": 4123}}
         )
 
     @override_settings(ZAMMAD_URL=None)
     @responses.activate
     def test_unconfigured(self) -> None:
         with self.assertRaises(ImproperlyConfigured):
-            submit_zammad_ticket(title="title", body="body", name="name", email="mail")
+            submit_zammad_ticket(**TICKET_DATA)
 
     @override_settings(ZAMMAD_URL=None)
     @responses.activate
@@ -37,35 +60,181 @@ class ZammadTest(TestCase):
         self.mock_zammad()
         self.assertEqual(
             submit_zammad_ticket(
-                title="title",
-                body="body",
-                name="name",
-                email="mail",
-                zammad_url="https://example.com",
+                **TICKET_DATA,
+                zammad_url=ZAMMAD_URL,
             ),
-            ("https://example.com/#ticket/zoom/123", "4123"),
+            (f"{ZAMMAD_URL}/#ticket/zoom/123", "4123"),
         )
 
-    @override_settings(ZAMMAD_URL="https://example.com")
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
     @responses.activate
     def test_configured(self) -> None:
         self.mock_zammad()
         self.assertEqual(
-            submit_zammad_ticket(title="title", body="body", name="name", email="mail"),
-            ("https://example.com/#ticket/zoom/123", "4123"),
+            submit_zammad_ticket(**TICKET_DATA),
+            (f"{ZAMMAD_URL}/#ticket/zoom/123", "4123"),
         )
 
-    @override_settings(ZAMMAD_URL="https://example.com")
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
     @responses.activate
     def test_invalid_json_encoding(self) -> None:
         responses.add(
             responses.POST,
-            "https://example.com/api/v1/form_config",
+            CONFIG_URL,
             body=b"\xff",
             content_type="application/json",
         )
 
-        with self.assertRaisesRegex(
-            ZammadError, "Customer care is currently unavailable"
-        ):
-            submit_zammad_ticket(title="title", body="body", name="name", email="mail")
+        self.assert_zammad_failure()
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_configuration_connection_error(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            body=httpx2.ConnectError("Zammad unavailable"),
+        )
+
+        _, error = self.assert_zammad_failure()
+        self.assertIsInstance(error.__cause__, httpx2.ConnectError)
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_submission_connection_error(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
+        )
+        responses.add(
+            responses.POST,
+            SUBMIT_URL,
+            body=httpx2.ConnectError("Zammad unavailable"),
+        )
+
+        _, error = self.assert_zammad_failure()
+        self.assertIsInstance(error.__cause__, httpx2.ConnectError)
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_configuration_timeout(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            body=httpx2.ReadTimeout("Zammad timed out"),
+        )
+
+        _, error = self.assert_zammad_failure()
+        self.assertIsInstance(error.__cause__, httpx2.ReadTimeout)
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_submission_timeout(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
+        )
+        responses.add(
+            responses.POST,
+            SUBMIT_URL,
+            body=httpx2.ReadTimeout("Zammad timed out"),
+        )
+
+        _, error = self.assert_zammad_failure()
+        self.assertIsInstance(error.__cause__, httpx2.ReadTimeout)
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_http_error_with_zammad_errors(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            status=503,
+            json={"errors": "Backend unavailable"},
+        )
+
+        report_error, error = self.assert_zammad_failure()
+        self.assertNotIn("Backend unavailable", str(error))
+        self.assertEqual(
+            report_error.call_args.kwargs["extra_log"],
+            "Zammad errors: 'Backend unavailable'",
+        )
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_http_error_with_json(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            status=503,
+            json={"detail": "Backend unavailable"},
+        )
+
+        self.assert_zammad_failure()
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_http_error_with_invalid_json(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            status=503,
+            body="<html>Unavailable</html>",
+        )
+
+        self.assert_zammad_failure()
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_api_error_is_not_exposed(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            json={"errors": "Secret internal detail"},
+        )
+
+        report_error, error = self.assert_zammad_failure()
+        self.assertNotIn("Secret internal detail", str(error))
+        self.assertEqual(
+            report_error.call_args.kwargs["extra_log"],
+            "Zammad errors: 'Secret internal detail'",
+        )
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_unexpected_json_type(self) -> None:
+        responses.add(responses.POST, CONFIG_URL, json=[])
+
+        self.assert_zammad_failure()
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_disabled_configuration(self) -> None:
+        responses.add(responses.POST, CONFIG_URL, json={"enabled": False})
+
+        self.assert_zammad_failure()
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_malformed_configuration(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            json={"enabled": True, "endpoint": SUBMIT_URL},
+        )
+
+        self.assert_zammad_failure()
+
+    @override_settings(ZAMMAD_URL=ZAMMAD_URL)
+    @responses.activate
+    def test_malformed_ticket(self) -> None:
+        responses.add(
+            responses.POST,
+            CONFIG_URL,
+            json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
+        )
+        responses.add(responses.POST, SUBMIT_URL, json={"ticket": {}})
+
+        self.assert_zammad_failure()

--- a/weblate/utils/zammad.py
+++ b/weblate/utils/zammad.py
@@ -4,39 +4,134 @@
 
 from __future__ import annotations
 
+from typing import Never
+
 import httpx2
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import gettext_lazy
 
 from .errors import report_error
 from .requests import JSON_RESPONSE_ERRORS, fetch_url
 
 FINGERPRINT = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASw"
 ERR_UNCONFIGURED = "ZAMMAD_URL is not configured!"
-ERR_TEMPORARY = "Customer care is currently unavailable."
+ERR_TEMPORARY = gettext_lazy("Customer care is currently unavailable.")
 
 
 class ZammadError(Exception):
     pass
 
 
-def process_zammad_response(response: httpx2.Response) -> dict:
+def _raise_zammad_error(
+    cause: str,
+    *,
+    error: BaseException | None = None,
+    extra_log: str | None = None,
+) -> Never:
+    report_error(
+        cause,
+        exception=error,
+        extra_log=extra_log,
+        message=error is None,
+    )
+    raise ZammadError(ERR_TEMPORARY) from error
+
+
+def _get_zammad_error_details(response: httpx2.Response) -> str | None:
     try:
         data = response.json()
-    except JSON_RESPONSE_ERRORS as error:
-        report_error("Zammad JSON response")
-        raise ZammadError(ERR_TEMPORARY) from error
+    except JSON_RESPONSE_ERRORS:
+        return None
+    if isinstance(data, dict) and "errors" in data:
+        return f"Zammad errors: {data['errors']!r}"
+    return None
 
-    if "errors" in data:
-        raise ZammadError(str(data["errors"]))
 
+def process_zammad_response(
+    response: httpx2.Response, *, context: str = "Zammad"
+) -> dict[str, object]:
     try:
         response.raise_for_status()
     except httpx2.HTTPError as error:
-        report_error("Zammad response status")
-        raise ZammadError(ERR_TEMPORARY) from error
+        _raise_zammad_error(
+            f"{context} response status",
+            error=error,
+            extra_log=_get_zammad_error_details(response),
+        )
+
+    try:
+        data = response.json()
+    except JSON_RESPONSE_ERRORS as error:
+        _raise_zammad_error(f"{context} JSON response", error=error)
+
+    if not isinstance(data, dict):
+        _raise_zammad_error(
+            f"{context} response schema",
+            extra_log=f"Expected an object, got {type(data).__name__}",
+        )
+
+    if "errors" in data:
+        _raise_zammad_error(
+            f"{context} API error",
+            extra_log=f"Zammad errors: {data['errors']!r}",
+        )
 
     return data
+
+
+def _fetch_zammad_response(
+    url: str, *, data: dict[str, str], context: str
+) -> dict[str, object]:
+    try:
+        response = fetch_url(
+            "POST",
+            url,
+            data=data,
+            raise_for_status=False,
+            timeout=10,
+        )
+    except (OSError, httpx2.HTTPError, httpx2.InvalidURL) as error:
+        _raise_zammad_error(f"{context} request", error=error)
+    return process_zammad_response(response, context=context)
+
+
+def _get_zammad_configuration(data: dict[str, object]) -> tuple[str, str]:
+    enabled = data.get("enabled")
+    if enabled is False:
+        _raise_zammad_error("Zammad form is disabled")
+    if enabled is not True:
+        _raise_zammad_error("Zammad form configuration schema")
+
+    endpoint = data.get("endpoint")
+    token = data.get("token")
+    if (
+        not isinstance(endpoint, str)
+        or not endpoint
+        or not isinstance(token, str)
+        or not token
+    ):
+        _raise_zammad_error("Zammad form configuration schema")
+    return endpoint, token
+
+
+def _get_zammad_ticket(data: dict[str, object]) -> tuple[str, str]:
+    ticket = data.get("ticket")
+    if not isinstance(ticket, dict):
+        _raise_zammad_error("Zammad ticket response schema")
+
+    ticket_id = ticket.get("id")
+    ticket_number = ticket.get("number")
+    if (
+        not isinstance(ticket_id, str | int)
+        or isinstance(ticket_id, bool)
+        or not str(ticket_id)
+        or not isinstance(ticket_number, str | int)
+        or isinstance(ticket_number, bool)
+        or not str(ticket_number)
+    ):
+        _raise_zammad_error("Zammad ticket response schema")
+    return str(ticket_id), str(ticket_number)
 
 
 def submit_zammad_ticket(
@@ -49,31 +144,29 @@ def submit_zammad_ticket(
 
     config_url = f"{zammad_url}/api/v1/form_config"
 
-    response = fetch_url(
-        "POST", config_url, data={"fingerprint": FINGERPRINT, "test": "true"}
+    data = _fetch_zammad_response(
+        config_url,
+        data={"fingerprint": FINGERPRINT, "test": "true"},
+        context="Zammad form configuration",
     )
-    data = process_zammad_response(response)
+    endpoint, token = _get_zammad_configuration(data)
 
-    if not data.get("enabled"):
-        raise ZammadError(ERR_TEMPORARY)
-
-    response = fetch_url(
-        "POST",
-        data["endpoint"],
+    data = _fetch_zammad_response(
+        endpoint,
         data={
             "fingerprint": FINGERPRINT,
             "test": "true",
-            "token": data["token"],
+            "token": token,
             "title": title,
             "name": name,
             "body": body,
             "email": email,
         },
-        timeout=10,
+        context="Zammad ticket submission",
     )
-    data = process_zammad_response(response)
+    ticket_id, ticket_number = _get_zammad_ticket(data)
 
     return (
-        f"{zammad_url}/#ticket/zoom/{data['ticket']['id']}",
-        str(data["ticket"]["number"]),
+        f"{zammad_url}/#ticket/zoom/{ticket_id}",
+        ticket_number,
     )

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -38,6 +38,7 @@ from weblate.utils.backup import BackupError, BorgResult
 from weblate.utils.data import data_path
 from weblate.utils.tests import http_mock as responses
 from weblate.utils.unittest import tempdir_setting
+from weblate.utils.zammad import ZammadError
 from weblate.wladmin.forms import ThemeColorField, ThemeColorWidget
 from weblate.wladmin.middleware import (
     CHECK_ATTEMPT_CACHE_KEY,
@@ -918,6 +919,31 @@ class AdminTest(ViewTestCase):
     def test_backup_page_hides_discovery_registration(self) -> None:
         response = self.client.get(reverse("manage-backups"))
         self.assertNotContains(response, "Register on weblate.org")
+
+    def test_support_form_handles_zammad_error(self) -> None:
+        SupportStatus.objects.create(
+            name="basic",
+            secret="paid-secret",
+            expiry=timezone.now() + timedelta(days=1),
+            enabled=True,
+        )
+
+        with patch(
+            "weblate.wladmin.views.submit_zammad_ticket",
+            side_effect=ZammadError("Customer care is currently unavailable."),
+        ):
+            response = self.client.post(
+                reverse("manage-support"),
+                {
+                    "subject": "Support request",
+                    "name": "Test user",
+                    "email": "test@example.com",
+                    "message": "Please help.",
+                },
+                follow=True,
+            )
+
+        self.assertContains(response, "Customer care is currently unavailable.")
 
     def test_workspaces(self) -> None:
         workspace = Workspace.objects.create(name="Test workspace")


### PR DESCRIPTION
Transport and malformed-response errors escaped inconsistently, allowing the management support form to return a server error. Normalize expected failures behind ZammadError while keeping diagnostics internal and user messaging stable.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
