### PR TITLE
fix(checks): clarify source length warning

### DIFF
--- a/docs/snippets/checks-autogenerated.rst
+++ b/docs/snippets/checks-autogenerated.rst
@@ -2612,7 +2612,7 @@ Consider using named variables instead to allow translators to reorder them.
 Source string length
 ~~~~~~~~~~~~~~~~~~~~
 
-:Summary: Source string is too long to fit into the configured maximum length.
+:Summary: Source string is close to or exceeds the configured maximum length for translations.
 :Scope: source strings
 :Check class: ``weblate.checks.source.SourceMaxLengthCheck``
 :Check identifier: ``source-max-length``

--- a/weblate/checks/source.py
+++ b/weblate/checks/source.py
@@ -61,7 +61,8 @@ class SourceMaxLengthCheck(SourceCheck):
     check_id = "source-max-length"
     name = gettext_lazy("Source string length")
     description = gettext_lazy(
-        "Source string is too long to fit into the configured maximum length."
+        "Source string is close to or exceeds the configured maximum length for "
+        "translations."
     )
 
     def check_source_unit(self, sources: list[str], unit: Unit) -> bool:


### PR DESCRIPTION
The check can trigger before the source exceeds the configured limit to reserve room for translation expansion, so the previous wording incorrectly implied that the source itself did not fit.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
