### PR TITLE
fix(github): support legacy app webhooks

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -264,9 +264,10 @@ GitHub. Components imported from the connected GitHub account also use the App
 for repository access and pull requests, without inviting the Hosted Weblate
 :guilabel:`weblate` GitHub user.
 
-The `Hosted Weblate legacy app`_ is kept for existing webhook-only setups. Use
-it only when you need the legacy app to deliver GitHub notifications to Hosted
-Weblate.
+The `Hosted Weblate legacy app`_ is kept for existing webhook-only setups. Its
+deliveries use the generic GitHub webhook URL and are authenticated using a
+separate webhook secret configured by the Hosted Weblate operator. Use it only
+when you need the legacy app to deliver GitHub notifications to Hosted Weblate.
 
 .. _Hosted Weblate legacy app: https://github.com/apps/hosted-weblate-legacy
 

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1071,6 +1071,30 @@ List for credentials for GitHub servers.
 
 .. _Creating a GitHub personal access token: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 
+.. setting:: GITHUB_LEGACY_APP_WEBHOOK_SECRET
+
+GITHUB_LEGACY_APP_WEBHOOK_SECRET
+--------------------------------
+
+.. versionadded:: 2026.8
+
+Webhook secret for a legacy GitHub App which delivers events to the generic
+GitHub webhook URL, ``/hooks/github/``.
+
+App webhook deliveries to the generic URL are rejected when this setting is
+empty or their ``X-Hub-Signature-256`` does not match. Ordinary repository
+webhooks are unaffected. GitHub Apps registered through Weblate use their
+per-App webhook URLs and do not use this setting.
+
+.. code-block:: python
+
+   GITHUB_LEGACY_APP_WEBHOOK_SECRET = "your-webhook-secret"
+
+.. seealso::
+
+   * :ref:`code-hosting-github-notifications`
+   * :ref:`code-hosting-github-app-webhook`
+
 .. setting:: BITBUCKETSERVER_CREDENTIALS
 
 BITBUCKETSERVER_CREDENTIALS

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1453,8 +1453,15 @@ Or the path to a file containing the Python dictionary:
 
        :ref:`Configuring code-hosting credentials in Docker <docker-vcs-config>`
 
-GitHub Apps are registered through the in-app manifest flow and stored in the
-database, so there are no GitHub App environment variables to configure. See
+.. envvar:: WEBLATE_GITHUB_LEGACY_APP_WEBHOOK_SECRET
+
+   .. versionadded:: 2026.8
+
+   Configures :setting:`GITHUB_LEGACY_APP_WEBHOOK_SECRET`. The ``_FILE``
+   variant can be used to load the secret from a file.
+
+GitHub Apps registered through the in-app manifest flow are stored in the
+database and do not need environment variables. See
 :ref:`code-hosting-github-notifications`.
 
 .. envvar:: WEBLATE_GITLAB_USERNAME

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,6 +49,7 @@ Weblate 2026.8
 * Restricted components are now available on Hosted Weblate when the billing plan permits private projects.
 * Machine translation and translation memory AJAX lookups no longer disclose whether inaccessible unit IDs exist.
 * :ref:`RSS feeds <rss>` no longer disclose change history from inaccessible projects or restricted components.
+* Authenticated legacy GitHub App webhooks can again trigger repository updates through the :ref:`generic GitHub webhook endpoint <code-hosting-github-notifications>`.
 
 .. rubric:: Compatibility
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -186,10 +186,13 @@ repository state, background tasks, outbound requests, and rendered UI.
        application actions. *(documented)* (source: :doc:`/api`, :doc:`/admin/access`)
    * - Webhook sender to Weblate
      - Public forge notifications can schedule repository synchronization
-       where hooks are enabled. GitHub App webhooks additionally authenticate
-       with a per-app URL token and GitHub signature
-       verification before processing. *(documented)* (source: :ref:`hooks`,
-       :ref:`project-enable_hooks`, :ref:`code-hosting-github-app-webhook`)
+       where hooks are enabled. Registered GitHub App webhooks additionally
+       authenticate with a per-app URL token and GitHub signature verification.
+       Opt-in legacy GitHub App deliveries to the generic GitHub webhook URL
+       authenticate with a separately configured secret. *(documented)*
+       (source: :ref:`hooks`, :ref:`project-enable_hooks`,
+       :ref:`code-hosting-github-app-webhook`,
+       :setting:`GITHUB_LEGACY_APP_WEBHOOK_SECRET`)
    * - Weblate to database/datastore
      - Permission-checked application state becomes persistent data and queued
        work. *(documented)* (source: :doc:`/admin/install`)

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -256,6 +256,11 @@ TEMPLATES = [
 # Please see the documentation for more details.
 GITHUB_CREDENTIALS = get_env_credentials("GITHUB")
 
+# Webhook secret for a legacy GitHub App delivering to /hooks/github/.
+GITHUB_LEGACY_APP_WEBHOOK_SECRET = get_env_str(
+    "WEBLATE_GITHUB_LEGACY_APP_WEBHOOK_SECRET", ""
+)
+
 # Azure DevOps username, token, and organization for sending pull requests.
 # Please see the documentation for more details.
 AZURE_DEVOPS_CREDENTIALS = get_env_credentials("AZURE_DEVOPS")

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -211,6 +211,9 @@ TEMPLATES = [
 # Please see the documentation for more details.
 GITHUB_CREDENTIALS = {}
 
+# Webhook secret for a legacy GitHub App delivering to /hooks/github/.
+GITHUB_LEGACY_APP_WEBHOOK_SECRET = ""
+
 # Azure DevOps username and token for sending pull requests.
 # Please see the documentation for more details.
 AZURE_DEVOPS_CREDENTIALS = {}

--- a/weblate/trans/views/hooks.py
+++ b/weblate/trans/views/hooks.py
@@ -881,8 +881,20 @@ def github_hook_helper(data: dict, request: Request | None) -> HandlerResponse |
     if request:
         event = request.headers.get("x-github-event", "")
         if data.get("installation"):
-            msg = "GitHub App webhooks must use the per-App hook URL"
-            raise PermissionDenied(msg)
+            signature = request.headers.get("x-hub-signature-256", "")
+            secret = getattr(settings, "GITHUB_LEGACY_APP_WEBHOOK_SECRET", "")
+            if not secret:
+                LOGGER.warning(
+                    "Rejected legacy GitHub App webhook because no secret is configured"
+                )
+                msg = "Invalid legacy GitHub App webhook signature"
+                raise PermissionDenied(msg)
+            if not verify_webhook_signature(request.body, signature, secret):
+                LOGGER.warning(
+                    "Rejected legacy GitHub App webhook with invalid signature"
+                )
+                msg = "Invalid legacy GitHub App webhook signature"
+                raise PermissionDenied(msg)
         if event != "push":
             return None
 

--- a/weblate/vcs/tests/test_github_hooks.py
+++ b/weblate/vcs/tests/test_github_hooks.py
@@ -10,6 +10,7 @@ import json
 from datetime import timedelta
 
 from django.core.cache import cache
+from django.test import override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
 
@@ -475,13 +476,25 @@ class TestGitHubAppHooks(ViewTestCase):
         response = self._post("push", data)
         self.assertIn(response.status_code, (200, 202))
 
-    def _legacy_post(self, event_type, data):
+    def _legacy_post(
+        self,
+        event_type,
+        data,
+        *,
+        secret: str | None = None,
+        signature: str | None = None,
+    ):
         body = json.dumps(data)
+        headers = {"X-Github-Event": event_type}
+        if signature is not None:
+            headers["X-Hub-Signature-256"] = signature
+        elif secret is not None:
+            headers["X-Hub-Signature-256"] = sign_webhook_payload(body, secret)
         return self.client.post(
             self.LEGACY_WEBHOOK_URL,
             data=body,
             content_type="application/json",
-            headers={"X-Github-Event": event_type},
+            headers=headers,
         )
 
     def test_push_event_without_app_configured(self):
@@ -501,7 +514,7 @@ class TestGitHubAppHooks(ViewTestCase):
         self.assertIn(response.status_code, (200, 202))
 
     def test_app_delivery_rejected_on_generic_endpoint(self):
-        """GitHub App deliveries must use the per-App endpoint."""
+        """App deliveries are rejected unless a legacy secret is configured."""
         data = {
             "ref": "refs/heads/main",
             "installation": {"id": 12345, "app_id": 99999},
@@ -516,6 +529,86 @@ class TestGitHubAppHooks(ViewTestCase):
         }
         response = self._post("push", data, url=self.LEGACY_WEBHOOK_URL)
         self.assertEqual(response.status_code, 403)
+
+    @override_settings(GITHUB_LEGACY_APP_WEBHOOK_SECRET="legacy-secret")
+    def test_legacy_app_push_with_valid_signature(self):
+        """A signed legacy App push updates ordinary Git components."""
+        data = {
+            "ref": f"refs/heads/{self.component.branch}",
+            "installation": {"id": 12345},
+            "repository": {
+                "name": "local-repo",
+                "owner": {"login": "test-org"},
+                "url": "https://github.com/test-org/local-repo",
+                "clone_url": self.component.repo,
+            },
+        }
+
+        response = self._legacy_post("push", data, secret="legacy-secret")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            self.component.change_set.filter(action=ActionEvents.HOOK).exists()
+        )
+
+    @override_settings(GITHUB_LEGACY_APP_WEBHOOK_SECRET="legacy-secret")
+    def test_legacy_app_push_rejects_invalid_signatures(self):
+        data = {
+            "ref": "refs/heads/main",
+            "installation": {"id": 12345},
+            "repository": {
+                "name": "test-repo",
+                "owner": {"login": "test-org"},
+                "url": "https://github.com/test-org/test-repo",
+                "clone_url": "https://github.com/test-org/test-repo.git",
+            },
+        }
+        signatures = (
+            {"secret": None},
+            {"secret": "wrong-secret"},
+            {"signature": "invalid"},
+        )
+
+        for signature in signatures:
+            with self.subTest(signature=signature):
+                response = self._legacy_post("push", data, **signature)
+                self.assertEqual(response.status_code, 403)
+
+    @override_settings(GITHUB_LEGACY_APP_WEBHOOK_SECRET="legacy-secret")
+    def test_legacy_app_push_excludes_github_app_components(self):
+        self.component.vcs = "github-app"
+        self.component.save(update_fields=["vcs"])
+        data = {
+            "ref": f"refs/heads/{self.component.branch}",
+            "installation": {"id": 12345},
+            "repository": {
+                "name": "local-repo",
+                "owner": {"login": "test-org"},
+                "url": "https://github.com/test-org/local-repo",
+                "clone_url": self.component.repo,
+            },
+        }
+
+        response = self._legacy_post("push", data, secret="legacy-secret")
+
+        self.assertEqual(response.status_code, 202)
+        self.assertFalse(
+            self.component.change_set.filter(action=ActionEvents.HOOK).exists()
+        )
+
+    @override_settings(GITHUB_LEGACY_APP_WEBHOOK_SECRET="legacy-secret")
+    def test_legacy_app_non_push_event_is_ignored(self):
+        installation = self._create_installation()
+        data = {
+            "action": "deleted",
+            "installation": {"id": 12345, "app_id": 99999, "account": {}},
+        }
+
+        response = self._legacy_post("installation", data, secret="legacy-secret")
+
+        self.assertEqual(response.status_code, 201)
+        installation.refresh_from_db()
+        self.assertTrue(installation.enabled)
 
     def test_signed_integration_hook_runs_repository_update(self):
         self.project.workspace = self.workspace


### PR DESCRIPTION
The Hosted Weblate legacy app still delivers signed pushes to the generic endpoint. Allow deployments to verify those deliveries with a dedicated secret without weakening per-App webhook routing.

Fixes #20788

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
