### PR TITLE
feat(vcs): make GitHub App requests asynchronous

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,7 @@ Weblate 2026.8
 * Added opt-in :ref:`running-granian-asgi` deployment support, including :envvar:`WEBLATE_ASGI` for Docker containers.
 * Added opt-in :ref:`running-granian-asgi` deployment support.
 * Machine translation editor requests now use asynchronous HTTP for DeepL, LibreTranslate, ModernMT, OpenAI-compatible, Anthropic, and Ollama services on ASGI deployments.
+* GitHub App connection and repository refresh requests now use asynchronous HTTP on ASGI deployments.
 * Deployment checks now detect corrupted PostgreSQL relation statistics.
 * :ref:`Community diagnostics <alerts>` now show source-string screenshot coverage, recommend key translation-instruction topics, and distinguish inbound from outbound repository automation.
 

--- a/weblate/accounts/middleware.py
+++ b/weblate/accounts/middleware.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING
 
 from asgiref.sync import sync_to_async
@@ -38,6 +39,13 @@ def get_user(request: AuthenticatedHttpRequest):
     return request.weblate_cached_user
 
 
+async def aget_user(request: AuthenticatedHttpRequest):
+    """Return the user prepared by Weblate's authentication middleware."""
+    if hasattr(request, "weblate_cached_user"):
+        return request.weblate_cached_user
+    return await sync_to_async(get_user, thread_sensitive=True)(request)
+
+
 class AuthenticationMiddleware(OTPMiddleware):
     """
     Copy of django.contrib.auth.middleware.AuthenticationMiddleware.
@@ -67,6 +75,7 @@ class AuthenticationMiddleware(OTPMiddleware):
         # Django uses lazy object here, but we need the user in pretty
         # much every request, so there is no reason to delay this
         request.user = user = get_user(request)
+        request.auser = partial(aget_user, request)
         self._verify_user_sync(request, user)
 
         # Get language to use in this request

--- a/weblate/auth/decorators.py
+++ b/weblate/auth/decorators.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from functools import wraps
 from typing import TYPE_CHECKING
 
+from asgiref.sync import iscoroutinefunction, sync_to_async
 from django.core.exceptions import PermissionDenied
 
 if TYPE_CHECKING:
@@ -27,24 +28,43 @@ def check_management_access(
 
 def management_access(view: Callable):
     """Check management access decorator."""
+    if iscoroutinefunction(view):
+
+        @wraps(view)
+        async def async_wrapper(request: AuthenticatedHttpRequest, *args, **kwargs):
+            await sync_to_async(check_management_access, thread_sensitive=True)(request)
+            return await view(request, *args, **kwargs)
+
+        return async_wrapper
 
     @wraps(view)
-    def wrapper(request: AuthenticatedHttpRequest, *args, **kwargs):
+    def sync_wrapper(request: AuthenticatedHttpRequest, *args, **kwargs):
         check_management_access(request)
         return view(request, *args, **kwargs)
 
-    return wrapper
+    return sync_wrapper
 
 
 def management_permission_required(permission: str):
     """Check management access and a specific site-wide permission."""
 
     def decorator(view: Callable):
+        if iscoroutinefunction(view):
+
+            @wraps(view)
+            async def async_wrapper(request: AuthenticatedHttpRequest, *args, **kwargs):
+                await sync_to_async(check_management_access, thread_sensitive=True)(
+                    request, permission
+                )
+                return await view(request, *args, **kwargs)
+
+            return async_wrapper
+
         @wraps(view)
-        def wrapper(request: AuthenticatedHttpRequest, *args, **kwargs):
+        def sync_wrapper(request: AuthenticatedHttpRequest, *args, **kwargs):
             check_management_access(request, permission)
             return view(request, *args, **kwargs)
 
-        return wrapper
+        return sync_wrapper
 
     return decorator

--- a/weblate/trans/views/hooks.py
+++ b/weblate/trans/views/hooks.py
@@ -9,6 +9,7 @@ from functools import partial
 from typing import TYPE_CHECKING, ClassVar, NotRequired, TypedDict, cast
 from urllib.parse import quote, urlparse
 
+from asgiref.sync import async_to_sync
 from django.conf import settings
 from django.db.models import Q
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -474,7 +475,7 @@ def _refresh_github_installations(installations) -> None:
     if not installations:
         return
     try:
-        repositories = installations[0].refresh_repositories()
+        repositories = async_to_sync(installations[0].refresh_repositories)()
     except Exception:
         report_error("Failed to refresh connected GitHub account repositories")
         return

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -17,6 +17,7 @@ from urllib.parse import quote, urlencode, urlparse
 
 import httpx2
 import jwt
+from asgiref.sync import async_to_sync, sync_to_async
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -24,7 +25,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext, gettext_lazy
 
-from weblate.utils.requests import fetch_url
+from weblate.utils.requests import async_fetch_url
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.git import GithubRepository
 from weblate.vcs.models import Installation, InstallationProvider
@@ -228,13 +229,13 @@ def get_github_app_manifest_new_url(hostname: str, org: str | None = None) -> st
     return f"https://{hostname}/settings/apps/new"
 
 
-def exchange_github_app_manifest_code(
+async def exchange_github_app_manifest_code(
     code: str, hostname: str = "github.com"
 ) -> dict[str, object]:
     """Exchange a temporary manifest code for the created app's credentials."""
     code = quote(normalize_github_callback_code(code), safe="")
     api_base = get_github_api_base(normalize_github_app_hostname(hostname))
-    response = fetch_url(
+    response = await async_fetch_url(
         "post",
         f"{api_base}/app-manifests/{code}/conversions",
         headers={"Accept": "application/vnd.github.v3+json"},
@@ -303,7 +304,7 @@ def get_github_api_base(hostname: str) -> str:
     return f"https://{hostname}/api/v3"
 
 
-def get_installation_token(
+async def get_installation_token(
     app_id: str | int,
     private_key: str,
     installation_id: str | int,
@@ -312,7 +313,7 @@ def get_installation_token(
     """Return a cached installation access token for the given installation."""
     installation_id = normalize_github_installation_id(installation_id)
     cache_key = f"github-app-token:{hostname}:{installation_id}"
-    cached_token = cache.get(cache_key)
+    cached_token = await cache.aget(cache_key)
     if cached_token is not None:
         return cached_token
 
@@ -320,7 +321,7 @@ def get_installation_token(
     token = generate_jwt(app_id, private_key_pem)
 
     api_base = get_github_api_base(hostname)
-    response = fetch_url(
+    response = await async_fetch_url(
         "post",
         f"{api_base}/app/installations/{installation_id}/access_tokens",
         headers={
@@ -334,7 +335,7 @@ def get_installation_token(
     data = response.json()
 
     access_token = data["token"]
-    cache.set(cache_key, access_token, TOKEN_CACHE_TTL)
+    await cache.aset(cache_key, access_token, TOKEN_CACHE_TTL)
     logger.info(
         "Obtained Weblate GitHub app installation token for %s/%s",
         hostname,
@@ -343,7 +344,7 @@ def get_installation_token(
     return access_token
 
 
-def get_app_installation(
+async def get_app_installation(
     app_id: str | int,
     private_key: str,
     installation_id: str | int,
@@ -354,7 +355,7 @@ def get_app_installation(
     private_key_pem = validate_private_key(private_key)
     token = generate_jwt(app_id, private_key_pem)
     api_base = get_github_api_base(hostname)
-    response = fetch_url(
+    response = await async_fetch_url(
         "get",
         f"{api_base}/app/installations/{installation_id}",
         headers={
@@ -368,14 +369,14 @@ def get_app_installation(
     return response.json()
 
 
-def get_app_repositories(
+async def get_app_repositories(
     app_id: str | int,
     private_key: str,
     installation_id: str | int,
     hostname: str,
 ) -> list[dict]:
     """List repositories accessible to the installation, paginated."""
-    access_token = get_installation_token(
+    access_token = await get_installation_token(
         app_id, private_key, installation_id, hostname
     )
     api_base = get_github_api_base(hostname)
@@ -387,7 +388,7 @@ def get_app_repositories(
         "Accept": "application/vnd.github.v3+json",
     }
     while url:
-        response = fetch_url(
+        response = await async_fetch_url(
             "get", url, headers=headers, timeout=30, raise_for_status=False
         )
         response.raise_for_status()
@@ -500,9 +501,9 @@ def get_github_oauth_base(hostname: str) -> str:
     return "https://github.com" if hostname == "github.com" else f"https://{hostname}"
 
 
-def exchange_github_user_code(config: GitHubAppCredentials, code: str) -> str:
+async def exchange_github_user_code(config: GitHubAppCredentials, code: str) -> str:
     """Exchange an install-time OAuth ``code`` for a user-to-server access token."""
-    response = fetch_url(
+    response = await async_fetch_url(
         "post",
         f"{get_github_oauth_base(config.hostname)}/login/oauth/access_token",
         data={
@@ -523,12 +524,12 @@ def exchange_github_user_code(config: GitHubAppCredentials, code: str) -> str:
     return token
 
 
-def get_authenticated_github_user(
+async def get_authenticated_github_user(
     config: GitHubAppCredentials, user_token: str
 ) -> dict:
     """Return metadata for the authenticated GitHub user."""
     api_base = get_github_api_base(normalize_github_app_hostname(config.hostname))
-    response = fetch_url(
+    response = await async_fetch_url(
         "get",
         f"{api_base}/user",
         headers=_get_github_user_headers(user_token),
@@ -546,7 +547,7 @@ def _get_github_user_headers(user_token: str) -> dict[str, str]:
     }
 
 
-def _get_user_accessible_installation(
+async def _get_user_accessible_installation(
     config: GitHubAppCredentials, user_token: str, installation_id: str | int
 ) -> dict | None:
     """Return the user-visible installation metadata for ``installation_id``."""
@@ -555,7 +556,7 @@ def _get_user_accessible_installation(
     url: str | None = f"{api_base}/user/installations?per_page=100"
     headers = _get_github_user_headers(user_token)
     while url:
-        response = fetch_url(
+        response = await async_fetch_url(
             "get", url, headers=headers, timeout=30, raise_for_status=False
         )
         response.raise_for_status()
@@ -566,7 +567,7 @@ def _get_user_accessible_installation(
     return None
 
 
-def user_can_administer_org_installation(
+async def user_can_administer_org_installation(
     config: GitHubAppCredentials,
     user_token: str,
     org: str,
@@ -580,7 +581,7 @@ def user_can_administer_org_installation(
     )
     headers = _get_github_user_headers(user_token)
     while url:
-        response = fetch_url(
+        response = await async_fetch_url(
             "get", url, headers=headers, timeout=30, raise_for_status=False
         )
         try:
@@ -596,7 +597,7 @@ def user_can_administer_org_installation(
     return False
 
 
-def get_user_admin_installation(
+async def get_user_admin_installation(
     config: GitHubAppCredentials, user_token: str, installation_id: str | int
 ) -> dict | None:
     """
@@ -606,7 +607,7 @@ def get_user_admin_installation(
     installations need an additional owner/admin check before Weblate can bind
     the installation and mint installation tokens for all repositories.
     """
-    installation = _get_user_accessible_installation(
+    installation = await _get_user_accessible_installation(
         config, user_token, installation_id
     )
     if installation is None:
@@ -617,12 +618,12 @@ def get_user_admin_installation(
     target_type: str = account["type"].lower()
 
     if target_type == "user":
-        user = get_authenticated_github_user(config, user_token)
+        user = await get_authenticated_github_user(config, user_token)
         if user.get("login") == target_login:
             return installation
         return None
 
-    if target_type == "organization" and user_can_administer_org_installation(
+    if target_type == "organization" and await user_can_administer_org_installation(
         config, user_token, target_login, installation_id
     ):
         return installation
@@ -744,7 +745,7 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
         installation.save()
         return installation, created
 
-    def sync_from_api(
+    async def sync_from_api(
         self,
         hostname: str,
         installation_id: str | int,
@@ -754,18 +755,18 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
     ) -> GitHubInstallation:
         """Fetch installation metadata from GitHub and persist it."""
         hostname = normalize_github_app_hostname(hostname)
-        config = get_github_app_settings(hostname)
+        config = await sync_to_async(get_github_app_settings)(hostname)
         if config is None:
             msg = f"Weblate GitHub app is not configured for {hostname}"
             raise GitHubAppNotConfiguredError(msg)
 
-        data = get_app_installation(
+        data = await get_app_installation(
             config.app_id,
             config.private_key,
             installation_id,
             hostname,
         )
-        return self.upsert_from_data(
+        return await sync_to_async(self.upsert_from_data)(
             hostname,
             installation_id,
             data,
@@ -773,25 +774,25 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
             enabled=enabled,
         )
 
-    def connect_workspace(
+    async def connect_workspace(
         self, hostname: str, installation_id: str | int, workspace: Workspace
     ) -> tuple[GitHubInstallation, bool]:
         """Connect an existing GitHub installation to a Weblate workspace."""
         hostname = normalize_github_app_hostname(hostname)
 
-        installation = self.get_for_installation(
+        installation = await sync_to_async(self.get_for_installation)(
             hostname, installation_id, workspace=workspace
         )
         if installation is not None:
             return (
-                self.sync_from_api(
+                await self.sync_from_api(
                     hostname, installation_id, workspace=workspace, enabled=True
                 ),
                 False,
             )
 
         return (
-            self.sync_from_api(hostname, installation_id, workspace=workspace),
+            await self.sync_from_api(hostname, installation_id, workspace=workspace),
             True,
         )
 
@@ -838,16 +839,16 @@ class GitHubInstallation(Installation):
 
     def get_access_token(self) -> str:
         config = self._require_app_settings()
-        return get_installation_token(
+        return async_to_sync(get_installation_token)(
             config.app_id,
             config.private_key,
             self.installation_id,
             self.hostname,
         )
 
-    def refresh_repositories(self) -> list[dict]:
-        config = self._require_app_settings()
-        repos = get_app_repositories(
+    async def refresh_repositories(self) -> list[dict]:
+        config = await sync_to_async(self._require_app_settings)()
+        repos = await get_app_repositories(
             config.app_id,
             config.private_key,
             self.installation_id,
@@ -855,7 +856,9 @@ class GitHubInstallation(Installation):
         )
         self.repositories = repos
         self.repositories_updated = timezone.now()
-        self.save(update_fields=["repositories", "repositories_updated"])
+        await sync_to_async(self.save)(
+            update_fields=["repositories", "repositories_updated"]
+        )
         logger.info(
             "Refreshed %d repositories for connected GitHub account %s/%s",
             len(repos),

--- a/weblate/vcs/tests/test_github_models.py
+++ b/weblate/vcs/tests/test_github_models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from base64 import b64decode
 from unittest.mock import patch
 
+from asgiref.sync import async_to_sync
 from django.core.cache import cache
 from django.test import TestCase
 
@@ -211,7 +212,7 @@ class TestGitHubInstallationManager(TestCase):
     @responses.activate
     def test_installation_token_rejects_malformed_installation_id(self):
         with self.assertRaises(ValueError):
-            get_installation_token(
+            async_to_sync(get_installation_token)(
                 "99999",
                 SETTINGS_PRIVATE_KEY,
                 "67890/access_tokens",
@@ -229,7 +230,7 @@ class TestGitHubInstallationManager(TestCase):
             json={"id": 99},
         )
 
-        exchange_github_app_manifest_code(
+        async_to_sync(exchange_github_app_manifest_code)(
             "../installations/67890/access_tokens?x=1", "github.com"
         )
 
@@ -248,7 +249,7 @@ class TestGitHubInstallationManager(TestCase):
             },
         )
 
-        installation = GitHubInstallation.objects.sync_from_api(
+        installation = async_to_sync(GitHubInstallation.objects.sync_from_api)(
             "github.com", "24680", workspace=_make_workspace("sync-workspace")
         )
 
@@ -258,7 +259,7 @@ class TestGitHubInstallationManager(TestCase):
 
     def test_sync_from_api_requires_credentials(self):
         with self.assertRaises(GitHubAppNotConfiguredError):
-            GitHubInstallation.objects.sync_from_api(
+            async_to_sync(GitHubInstallation.objects.sync_from_api)(
                 "github.com",
                 "24680",
                 workspace=_make_workspace("sync-missing-workspace"),
@@ -279,9 +280,9 @@ class TestGitHubInstallationManager(TestCase):
             },
         )
 
-        installation, created = GitHubInstallation.objects.connect_workspace(
-            "github.com", "67890", self.installation.workspace
-        )
+        installation, created = async_to_sync(
+            GitHubInstallation.objects.connect_workspace
+        )("github.com", "67890", self.installation.workspace)
 
         self.assertFalse(created)
         self.assertEqual(installation.pk, self.installation.pk)

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from typing import cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
+from asgiref.sync import async_to_sync
 from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.test import TestCase
@@ -1276,12 +1277,17 @@ class GitHubInstallationViewTest(ViewTestCase):
                 ]
             },
         )
-        response = self.client.post(
+        self.async_client.force_login(self.user)
+        response = async_to_sync(self.async_client.post)(
             reverse("manage-github-account-refresh", kwargs={"pk": installation.pk}),
             {"next": reverse("github-app-repositories")},
         )
 
-        self.assertRedirects(response, reverse("github-app-repositories"))
+        self.assertRedirects(
+            response,
+            reverse("github-app-repositories"),
+            fetch_redirect_response=False,
+        )
         installation.refresh_from_db()
         self.assertEqual(installation.repositories, [repo])
         self.assertIsNotNone(installation.repositories_updated)

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core import signing
@@ -517,19 +518,21 @@ def remove_github_app(request, pk):
 
 
 @login_required
-def refresh_repositories(request, pk):
+async def refresh_repositories(request, pk):
     if request.method != "POST":
         return HttpResponseNotAllowed(["POST"])
-    installation = get_object_or_404(GitHubInstallation, pk=pk)
-    _require_installation_access(request, installation)
+    installation = await sync_to_async(get_object_or_404)(GitHubInstallation, pk=pk)
+    await sync_to_async(_require_installation_access)(request, installation)
     next_url = _get_redirect_url(
         request,
         _get_installation_repository_url(installation),
     )
     try:
-        repos = installation.refresh_repositories()
+        repos = await installation.refresh_repositories()
     except Exception:
-        report_error("Failed to refresh connected GitHub account repositories")
+        await sync_to_async(report_error)(
+            "Failed to refresh connected GitHub account repositories"
+        )
         messages.error(
             request,
             gettext("Failed to refresh repositories from GitHub."),
@@ -604,7 +607,9 @@ def github_app_install(request):
     return redirect(install_url)
 
 
-def _get_authorized_installation(request, config, code, installation_id) -> dict | None:
+async def _get_authorized_installation(
+    request, config, code, installation_id
+) -> dict | None:
     """
     Return the installation when the current user controls it via OAuth.
 
@@ -614,10 +619,12 @@ def _get_authorized_installation(request, config, code, installation_id) -> dict
     if not code:
         return None
     try:
-        user_token = exchange_github_user_code(config, code)
-        return get_user_admin_installation(config, user_token, installation_id)
+        user_token = await exchange_github_user_code(config, code)
+        return await get_user_admin_installation(config, user_token, installation_id)
     except Exception:
-        report_error("Failed to verify GitHub installation ownership")
+        await sync_to_async(report_error)(
+            "Failed to verify GitHub installation ownership"
+        )
         return None
 
 
@@ -671,9 +678,9 @@ def _get_update_callback_next_url(request, installation: GitHubInstallation) -> 
 
 
 @login_required
-def github_app_setup(request):
+async def github_app_setup(request):
     """Finish connecting a GitHub account after GitHub redirects back."""
-    next_url = _default_next_url(request)
+    next_url = await sync_to_async(_default_next_url)(request)
     installation_id = request.GET.get("installation_id", "").strip()
 
     # Handle GitHub's stateless ``setup_on_update`` callback before the stricter
@@ -681,13 +688,19 @@ def github_app_setup(request):
     # signed ``state``. Signed callbacks fall through to the normal setup flow
     # below.
     if request.GET.get("setup_action") == "update" and not request.GET.get("state"):
-        installation = _get_update_callback_installation(request, installation_id)
+        installation = await sync_to_async(_get_update_callback_installation)(
+            request, installation_id
+        )
         if installation:
             messages.success(
                 request,
                 gettext("Connected GitHub account updated."),
             )
-            return redirect(_get_update_callback_next_url(request, installation))
+            return redirect(
+                await sync_to_async(_get_update_callback_next_url)(
+                    request, installation
+                )
+            )
         messages.error(
             request,
             gettext(
@@ -697,16 +710,22 @@ def github_app_setup(request):
         )
         return redirect(next_url)
 
-    if response := _handle_missing_github_app_access(request, next_url):
+    if response := await sync_to_async(_handle_missing_github_app_access)(
+        request, next_url
+    ):
         return response
 
     hostname = ""
     workspace = None
     try:
-        state = _load_install_state(request, request.GET.get("state", ""))
+        state = await sync_to_async(_load_install_state)(
+            request, request.GET.get("state", "")
+        )
         next_url = str(state["next"])
         hostname = str(state["host"])
-        workspace = _get_installation_workspace(request.user, state["workspace"])
+        workspace = await sync_to_async(_get_installation_workspace)(
+            request.user, state["workspace"]
+        )
     except (BadSignature, SignatureExpired):
         messages.error(
             request,
@@ -732,7 +751,7 @@ def github_app_setup(request):
         return redirect(next_url)
     installation_id = callback_form.cleaned_data["installation_id"]
 
-    config = get_github_app_settings(hostname or None)
+    config = await sync_to_async(get_github_app_settings)(hostname or None)
     if config is None:
         messages.error(
             request,
@@ -747,7 +766,7 @@ def github_app_setup(request):
         )
         return redirect(next_url)
 
-    if not check_rate_limit("github_setup", request):
+    if not await sync_to_async(check_rate_limit)("github_setup", request):
         messages.error(
             request,
             gettext(
@@ -759,7 +778,7 @@ def github_app_setup(request):
         return redirect(next_url)
 
     code = callback_form.cleaned_data.get("code", "")
-    authorized_installation = _get_authorized_installation(
+    authorized_installation = await _get_authorized_installation(
         request, config, code, installation_id
     )
     if authorized_installation is None:
@@ -772,23 +791,30 @@ def github_app_setup(request):
             ),
         )
         return redirect(next_url)
-    installation, is_new_install = GitHubInstallation.objects.upsert_pending_from_data(
+    installation, is_new_install = await sync_to_async(
+        GitHubInstallation.objects.upsert_pending_from_data
+    )(
         config.hostname,
         installation_id,
         authorized_installation,
         workspace=workspace,
         enabled=True,
     )
-    apply_pending_github_installation_event(config.hostname, installation_id)
+    await sync_to_async(apply_pending_github_installation_event)(
+        config.hostname, installation_id
+    )
     try:
-        installation, synced_is_new_install = (
-            GitHubInstallation.objects.connect_workspace(
-                config.hostname, installation_id, workspace
-            )
+        (
+            installation,
+            synced_is_new_install,
+        ) = await GitHubInstallation.objects.connect_workspace(
+            config.hostname, installation_id, workspace
         )
         is_new_install = is_new_install or synced_is_new_install
     except Exception:
-        report_error("Failed to connect GitHub account to workspace")
+        await sync_to_async(report_error)(
+            "Failed to connect GitHub account to workspace"
+        )
         messages.warning(
             request,
             gettext(
@@ -800,9 +826,11 @@ def github_app_setup(request):
         return redirect(next_url)
 
     try:
-        installation.refresh_repositories()
+        await installation.refresh_repositories()
     except Exception:
-        report_error("Failed to refresh connected GitHub account repositories")
+        await sync_to_async(report_error)(
+            "Failed to refresh connected GitHub account repositories"
+        )
         messages.warning(
             request,
             gettext(
@@ -1185,7 +1213,7 @@ def github_app_register_submit(request):
 
 
 @management_permission_required("management.configure")
-def github_app_register_callback(request):
+async def github_app_register_callback(request):
     """Exchange a temporary manifest code for the App's credentials."""
     accounts_url = reverse("manage-github-accounts")
     callback_form = GitHubAppRegisterCallbackForm(request.GET)
@@ -1212,9 +1240,9 @@ def github_app_register_callback(request):
         return redirect(accounts_url)
 
     try:
-        data = exchange_github_app_manifest_code(code, hostname)
+        data = await exchange_github_app_manifest_code(code, hostname)
     except Exception:
-        report_error("Failed to exchange GitHub App manifest code")
+        await sync_to_async(report_error)("Failed to exchange GitHub App manifest code")
         messages.error(
             request,
             gettext(
@@ -1245,7 +1273,7 @@ def github_app_register_callback(request):
         )
         return redirect(accounts_url)
 
-    credentials, created = GitHubAppCredentials.objects.update_or_create(
+    credentials, created = await GitHubAppCredentials.objects.aupdate_or_create(
         hostname=hostname,
         defaults={
             "app_id": app_id,


### PR DESCRIPTION
GitHub App callbacks and repository refreshes can wait on several provider requests, tying up ASGI workers. Use one async HTTP interface while adapting the remaining synchronous VCS and webhook boundaries.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
