### PR TITLE
refactor(http): remove custom HTTPX2 tracing

### DIFF
--- a/weblate/utils/requests.py
+++ b/weblate/utils/requests.py
@@ -21,8 +21,6 @@ import httpx2
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext
-from opentelemetry import propagate
-from opentelemetry.trace import Span, SpanKind, Status, StatusCode
 
 from weblate.logger import LOGGER
 from weblate.utils.outbound import (
@@ -32,18 +30,15 @@ from weblate.utils.outbound import (
     validate_connected_peer,
     validate_outbound_url,
 )
-from weblate.utils.tracing import get_opentelemetry_tracer
 from weblate.utils.validators import validate_asset_url
 
 if TYPE_CHECKING:
     from collections.abc import (
         AsyncGenerator,
-        AsyncIterator,
         Callable,
         Generator,
         Iterator,
     )
-    from types import TracebackType
     from typing import Never
 
     from httpx2._types import AuthTypes
@@ -301,105 +296,6 @@ def _normalize_request_kwargs(kwargs: dict) -> dict:
     result.pop("verify", None)
     result.pop("cert", None)
     return result
-
-
-@contextmanager
-def trace_http_request(
-    request: httpx2.Request,
-) -> Generator[Span | None, None, None]:
-    tracer = get_opentelemetry_tracer()
-    if tracer is None:
-        yield None
-        return
-
-    attributes: dict[str, str | int] = {
-        "http.request.method": request.method,
-        "server.address": request.url.host,
-        "url.scheme": request.url.scheme,
-    }
-    if request.url.port is not None:
-        attributes["server.port"] = request.url.port
-    with tracer.start_as_current_span(
-        f"{request.method} {request.url.host}",
-        kind=SpanKind.CLIENT,
-        attributes=attributes,
-    ) as span:
-        propagate.inject(request.headers)
-        yield span
-
-
-def record_http_response(span: Span | None, response: httpx2.Response) -> None:
-    if span is None:
-        return
-    span.set_attribute("http.response.status_code", response.status_code)
-    if response.is_error:
-        span.set_status(Status(StatusCode.ERROR))
-
-
-class TracedStream:
-    """Keep a client span open until its response stream is consumed."""
-
-    def __init__(self, trace) -> None:
-        self.trace = trace
-
-    def _finish(
-        self,
-        exc_type: type[BaseException] | None = None,
-        exc_value: BaseException | None = None,
-        traceback: TracebackType | None = None,
-    ) -> None:
-        if self.trace is not None:
-            trace, self.trace = self.trace, None
-            trace.__exit__(exc_type, exc_value, traceback)
-
-
-class TracedSyncStream(TracedStream, httpx2.SyncByteStream):
-    """Synchronous traced response stream."""
-
-    def __init__(self, stream: httpx2.SyncByteStream, trace) -> None:
-        super().__init__(trace)
-        self.stream = stream
-
-    def __iter__(self) -> Iterator[bytes]:
-        try:
-            yield from self.stream
-        except BaseException as error:
-            self._finish(type(error), error, error.__traceback__)
-            raise
-        self._finish()
-
-    def close(self) -> None:
-        try:
-            self.stream.close()
-        except BaseException as error:
-            self._finish(type(error), error, error.__traceback__)
-            raise
-        self._finish()
-
-
-class TracedAsyncStream(TracedStream, httpx2.AsyncByteStream):
-    """Asynchronous traced response stream."""
-
-    def __init__(self, stream: httpx2.AsyncByteStream, trace) -> None:
-        super().__init__(trace)
-        self.stream = stream
-
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        try:
-            async for chunk in self.stream:
-                yield chunk
-        except BaseException as error:
-            self._finish(type(error), error, error.__traceback__)
-            raise
-        self._finish()
-
-    async def aclose(self) -> None:
-        try:
-            await self.stream.aclose()
-        except BaseException as error:
-            self._finish(type(error), error, error.__traceback__)
-            raise
-        self._finish()
 
 
 def _build_pinned_request(
@@ -677,12 +573,10 @@ def _validate_transport_response(
     response: httpx2.Response,
     *,
     request: httpx2.Request,
-    span: Span | None,
     validators: RedirectValidators | None,
     used_proxy: bool,
 ) -> None:
     response.request = request
-    record_http_response(span, response)
     if validators is not None:
         validators.validate_response(response, used_proxy=used_proxy)
 
@@ -705,33 +599,22 @@ class OutboundHTTPTransport(httpx2.BaseTransport):
             if outbound.validators is not None
             else ()
         )
-        trace = trace_http_request(request)
-        span = trace.__enter__()  # ruff: ignore[unnecessary-dunder-call]
-        response: httpx2.Response | None = None
+        routes = _route_outbound_request(
+            self.pool,
+            request,
+            connection_addresses,
+            proxy=outbound.proxy,
+        )
+        response = _send_request_with_fallback(routes)
         try:
-            routes = _route_outbound_request(
-                self.pool,
-                request,
-                connection_addresses,
-                proxy=outbound.proxy,
-            )
-            response = _send_request_with_fallback(routes)
             _validate_transport_response(
                 response,
                 request=request,
-                span=span,
                 validators=outbound.validators,
                 used_proxy=outbound.used_proxy,
             )
-            response.stream = TracedSyncStream(
-                cast("httpx2.SyncByteStream", response.stream), trace
-            )
-        except BaseException as error:
-            try:
-                if response is not None:
-                    response.close()
-            finally:
-                trace.__exit__(type(error), error, error.__traceback__)
+        except BaseException:
+            response.close()
             raise
         return response
 
@@ -753,33 +636,22 @@ class AsyncOutboundHTTPTransport(httpx2.AsyncBaseTransport):
     async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         outbound = _prepare_outbound_request(request)
         connection_addresses = await _validate_async_outbound_request(outbound)
-        trace = trace_http_request(request)
-        span = trace.__enter__()  # ruff: ignore[unnecessary-dunder-call]
-        response: httpx2.Response | None = None
+        routes = _route_outbound_request(
+            self.pool,
+            request,
+            connection_addresses,
+            proxy=outbound.proxy,
+        )
+        response = await _send_async_request_with_fallback(routes)
         try:
-            routes = _route_outbound_request(
-                self.pool,
-                request,
-                connection_addresses,
-                proxy=outbound.proxy,
-            )
-            response = await _send_async_request_with_fallback(routes)
             _validate_transport_response(
                 response,
                 request=request,
-                span=span,
                 validators=outbound.validators,
                 used_proxy=outbound.used_proxy,
             )
-            response.stream = TracedAsyncStream(
-                cast("httpx2.AsyncByteStream", response.stream), trace
-            )
-        except BaseException as error:
-            try:
-                if response is not None:
-                    await response.aclose()
-            finally:
-                trace.__exit__(type(error), error, error.__traceback__)
+        except BaseException:
+            await response.aclose()
             raise
         return response
 

--- a/weblate/utils/tests/test_requests.py
+++ b/weblate/utils/tests/test_requests.py
@@ -5,7 +5,6 @@
 import asyncio
 import os
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
 from threading import Event
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -15,7 +14,6 @@ from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-from weblate.utils import tracing
 from weblate.utils.requests import (
     PEER_IP_RESPONSE_ATTR,
     AsyncHTTPClient,
@@ -29,7 +27,6 @@ from weblate.utils.requests import (
     get_uri_error,
     open_asset_url,
     open_restricted_asset_url,
-    trace_http_request,
 )
 from weblate.utils.tests import http_mock as responses
 
@@ -118,72 +115,6 @@ class FetchURLTest(SimpleTestCase):
             responses.calls[0].request.body,
             b"source_branch=weblate",
         )
-
-    def test_http_client_buffers_response_inside_span(self) -> None:
-        events: list[str] = []
-        request = httpx2.Request("GET", "https://example.com/data")
-        response = httpx2.Response(
-            200,
-            request=request,
-            stream=TrackedSyncStream(events),
-        )
-
-        @contextmanager
-        def tracked_span(_request):
-            events.append("span-start")
-            try:
-                yield None
-            finally:
-                events.append("span-end")
-
-        client = HTTPClient(
-            httpx2.MockTransport(lambda _request: response),
-        )
-        with (
-            patch(
-                "weblate.utils.requests.trace_http_request",
-                side_effect=tracked_span,
-            ),
-            client,
-        ):
-            result = client.request("get", "https://example.com/data")
-
-        self.assertEqual(result.content, b"response-body")
-        self.assertEqual(events, ["span-start", "read", "span-end"])
-
-    def test_async_http_client_buffers_response_inside_span(self) -> None:
-        events: list[str] = []
-        request = httpx2.Request("GET", "https://example.com/data")
-        response = httpx2.Response(
-            200,
-            request=request,
-            stream=TrackedAsyncStream(events),
-        )
-
-        @contextmanager
-        def tracked_span(_request):
-            events.append("span-start")
-            try:
-                yield None
-            finally:
-                events.append("span-end")
-
-        client = AsyncHTTPClient(
-            httpx2.MockTransport(lambda _request: response),
-        )
-
-        async def make_request() -> httpx2.Response:
-            async with client:
-                return await client.request("get", "https://example.com/data")
-
-        with patch(
-            "weblate.utils.requests.trace_http_request",
-            side_effect=tracked_span,
-        ):
-            result = asyncio.run(make_request())
-
-        self.assertEqual(result.content, b"response-body")
-        self.assertEqual(events, ["span-start", "read", "span-end"])
 
     def test_http_client_does_not_read_streaming_redirect_body(self) -> None:
         events: list[str] = []
@@ -389,21 +320,6 @@ class FetchURLTest(SimpleTestCase):
             used_proxy=False,
         )
         validators.validate_request_url.assert_not_called()
-
-    def test_http_trace_uses_configured_tracer(self) -> None:
-        request = httpx2.Request("GET", "https://example.com/data")
-        span = MagicMock()
-        span_context = MagicMock()
-        span_context.__enter__.return_value = span
-        tracer = MagicMock()
-        tracer.start_as_current_span.return_value = span_context
-        tracing.configure_opentelemetry_tracer(tracer)
-        self.addCleanup(tracing.configure_opentelemetry_tracer, None)
-
-        with trace_http_request(request) as current_span:
-            self.assertIs(current_span, span)
-
-        tracer.start_as_current_span.assert_called_once()
 
 
 class OpenAssetURLTest(SimpleTestCase):
@@ -1148,113 +1064,6 @@ class FetchValidatedURLTest(SimpleTestCase):
             "xn--fa-hia.de",
         )
         mocked_getaddrinfo.assert_called_once_with("xn--fa-hia.de", None, type=1)
-
-    @responses.activate
-    @patch(
-        "weblate.utils.outbound.socket.getaddrinfo",
-        return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
-    )
-    def test_fetch_validated_url_injects_current_trace_before_pinning(
-        self, mocked_getaddrinfo
-    ) -> None:
-        responses.add(
-            responses.GET,
-            "https://public.example.com/source",
-            status=302,
-            headers={"Location": "/final"},
-        )
-        responses.add(
-            responses.GET,
-            "https://public.example.com/final",
-            status=200,
-            body=b"traced",
-        )
-        trace_headers = iter(
-            (
-                "00-00000000000000000000000000000001-0000000000000001-01",
-                "00-00000000000000000000000000000002-0000000000000002-01",
-            )
-        )
-
-        def inject(headers) -> None:
-            headers["traceparent"] = next(trace_headers)
-
-        tracer = MagicMock()
-        tracer.start_as_current_span.return_value.__enter__.return_value = MagicMock()
-        with (
-            patch(
-                "weblate.utils.requests.get_opentelemetry_tracer",
-                return_value=tracer,
-            ),
-            patch(
-                "weblate.utils.requests.propagate.inject",
-                side_effect=inject,
-            ),
-        ):
-            response = fetch_validated_url(
-                "get",
-                "https://public.example.com/source",
-                allow_private_targets=False,
-            )
-
-        self.assertEqual(response.content, b"traced")
-        self.assertEqual(
-            [call.request.headers["traceparent"] for call in responses.calls],
-            [
-                "00-00000000000000000000000000000001-0000000000000001-01",
-                "00-00000000000000000000000000000002-0000000000000002-01",
-            ],
-        )
-        self.assertEqual(mocked_getaddrinfo.call_count, 2)
-
-    @responses.activate
-    @patch(
-        "weblate.utils.requests.async_resolve_runtime_hostname",
-        new_callable=AsyncMock,
-        return_value=("93.184.216.34",),
-    )
-    def test_async_fetch_validated_url_injects_trace_before_pinning(
-        self, mocked_resolve
-    ) -> None:
-        responses.add(
-            responses.GET,
-            "https://public.example.com/source",
-            status=200,
-            body=b"async-traced",
-        )
-        trace_header = "00-00000000000000000000000000000001-0000000000000001-01"
-
-        def inject(headers) -> None:
-            headers["traceparent"] = trace_header
-
-        tracer = MagicMock()
-        tracer.start_as_current_span.return_value.__enter__.return_value = MagicMock()
-        with (
-            patch(
-                "weblate.utils.requests.get_opentelemetry_tracer",
-                return_value=tracer,
-            ),
-            patch(
-                "weblate.utils.requests.propagate.inject",
-                side_effect=inject,
-            ),
-        ):
-            response = asyncio.run(
-                async_fetch_validated_url(
-                    "get",
-                    "https://public.example.com/source",
-                    allow_private_targets=False,
-                )
-            )
-
-        self.assertEqual(response.content, b"async-traced")
-        self.assertEqual(
-            responses.calls[0].request.headers["traceparent"],
-            trace_header,
-        )
-        mocked_resolve.assert_awaited_once_with(
-            "public.example.com", allow_private_targets=False
-        )
 
     @responses.activate
     @patch(


### PR DESCRIPTION
Defer outbound HTTPX2 tracing until official OpenTelemetry instrumentation is available, avoiding a custom span and stream lifecycle implementation.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
