### PR TITLE
refactor(api): move ReDoc assets out of template

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -23,6 +23,7 @@ from django.core.files import File
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import DatabaseError
 from django.db.models import Q
+from django.templatetags.static import static
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -15851,4 +15852,16 @@ class OpenAPITest(APIBaseTest):
         )
 
     def test_redoc(self) -> None:
-        self.do_request("redoc")
+        response = self.do_request("redoc")
+        self.assertContains(response, f'data-schema-url="{reverse("api-schema")}"')
+        self.assertContains(response, "data-settings=")
+        self.assertContains(response, static("styles/redoc.css"))
+        self.assertContains(response, static("js/redoc.js"))
+        self.assertNotContains(response, "<style")
+        self.assertNotContains(response, "Redoc.init")
+        script_src = next(
+            directive
+            for directive in response["Content-Security-Policy"].split(";")
+            if directive.strip().startswith("script-src ")
+        )
+        self.assertNotIn("'unsafe-inline'", script_src)

--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -318,7 +318,7 @@ class CSPBuilder:
         self.build_csp_static_url()
         self.build_csp_cdn()
         self.build_csp_auth()
-        self.build_csp_redoc()
+        self.build_csp_api_docs()
 
     def apply_csp_settings(self) -> None:
         setting_names: dict[str, CSP_KIND] = {
@@ -356,13 +356,15 @@ class CSPBuilder:
 
         return domain
 
-    def build_csp_redoc(self) -> None:
+    def build_csp_api_docs(self) -> None:
         if self.request.resolver_match and self.request.resolver_match.view_name in {
             "redoc",
             "swagger",
         }:
-            self.directives["script-src"].add("'unsafe-inline'")
+            # ReDoc and Swagger render images using data URIs.
             self.directives["img-src"].add("data:")
+            if self.request.resolver_match.view_name == "swagger":
+                self.directives["script-src"].add("'unsafe-inline'")
 
     def build_csp_inline(self) -> None:
         if (

--- a/weblate/static/js/redoc.js
+++ b/weblate/static/js/redoc.js
@@ -1,0 +1,12 @@
+// Copyright © Michal Čihař <michal@weblate.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const redocContainer = document.getElementById("redoc-container");
+const redocSettings = JSON.parse(redocContainer.dataset.settings);
+
+window.Redoc.init(
+  redocContainer.dataset.schemaUrl,
+  redocSettings,
+  redocContainer,
+);

--- a/weblate/static/styles/redoc.css
+++ b/weblate/static/styles/redoc.css
@@ -1,0 +1,11 @@
+/*
+ * Copyright © Michal Čihař <michal@weblate.org>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/* ReDoc does not change outer page styles. */
+body {
+  margin: 0;
+  padding: 0;
+}

--- a/weblate/templates/drf_spectacular/redoc.html
+++ b/weblate/templates/drf_spectacular/redoc.html
@@ -13,22 +13,18 @@
       <meta name="description" content="{{ description }}" />
       <link rel="stylesheet" href="{% static 'weblate_fonts/source-code-pro.css' %}" />
       <link rel="stylesheet" href="{% static 'weblate_fonts/source-sans-3.css' %}" />
-      <style>
-      {# Redoc doesn't change outer page styles. #}
-      body { margin: 0; padding: 0; }
-      </style>
+      <link rel="stylesheet" href="{% static 'styles/redoc.css' %}" />
     {% endblock head %}
 
   </head>
   <body>
     {% block body %}
       {% if settings %}
-        <div id="redoc-container"></div>
+        <div id="redoc-container"
+             data-schema-url="{{ schema_url }}"
+             data-settings="{{ settings|force_escape }}"></div>
         <script src="{{ redoc_standalone }}"></script>
-        <script>
-      const redocSettings = {{ settings|safe }};
-      Redoc.init("{{ schema_url }}", redocSettings, document.getElementById('redoc-container'))
-        </script>
+        <script src="{% static 'js/redoc.js' %}"></script>
       {% else %}
         <redoc spec-url="{{ schema_url }}"></redoc>
         <script src="{{ redoc_standalone }}"></script>


### PR DESCRIPTION
Load ReDoc initialization and page styles from static assets so the API documentation no longer requires an inline-script CSP exception.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
