### PR TITLE
refactor(analytics): avoid inline Google Analytics script

### DIFF
--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -395,7 +395,6 @@ class CSPBuilder:
     def build_csp_google_analytics(self) -> None:
         # Google Analytics
         if settings.GOOGLE_ANALYTICS_ID:
-            self.directives["script-src"].add("'unsafe-inline'")
             self.directives["script-src"].add("www.google-analytics.com")
             self.directives["img-src"].add("www.google-analytics.com")
 

--- a/weblate/static/js/google-analytics.js
+++ b/weblate/static/js/google-analytics.js
@@ -1,0 +1,31 @@
+// Copyright © Michal Čihař <michal@weblate.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const tracker = document.getElementById("google-analytics-tracker");
+
+window.GoogleAnalyticsObject = "ga";
+if (typeof window.ga !== "function") {
+  const queue = [];
+  const ga = (...args) => {
+    queue.push(args);
+  };
+  ga.q = queue;
+  ga.l = Date.now();
+  window.ga = ga;
+}
+
+const analyticsScript = document.createElement("script");
+analyticsScript.async = true;
+analyticsScript.src = "https://www.google-analytics.com/analytics.js";
+document.head.append(analyticsScript);
+
+window.ga("create", tracker.dataset.trackingId, "auto");
+
+const pageView = {
+  dimension1: tracker.dataset.language,
+};
+if (tracker.dataset.project !== undefined) {
+  pageView.dimension2 = tracker.dataset.project;
+}
+window.ga("send", "pageview", pageView);

--- a/weblate/templates/footer.html
+++ b/weblate/templates/footer.html
@@ -1,4 +1,4 @@
-{% load i18n translations %}
+{% load i18n static translations %}
 
 <footer>
   <ul>
@@ -68,19 +68,9 @@
 {% endif %}
 
 {% if google_analytics_id %}
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '{{ google_analytics_id }}', 'auto');
-  ga('send', 'pageview', {
-  {% if project %}
-    'dimension2':  '{{ project.name }}',
-  {% endif %}
-    'dimension1':  '{{ LANGUAGE_CODE }}'
-  });
-
-  </script>
+  <script src="{% static 'js/google-analytics.js' %}"
+          id="google-analytics-tracker"
+          data-tracking-id="{{ google_analytics_id }}"
+          data-language="{{ LANGUAGE_CODE }}"
+          {% if project %}data-project="{{ project.name }}"{% endif %}></script>
 {% endif %}

--- a/weblate/trans/tests/test_basic_views.py
+++ b/weblate/trans/tests/test_basic_views.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from asgiref.sync import async_to_sync
 from django.core.cache import cache
+from django.templatetags.static import static
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -30,6 +31,20 @@ class BasicViewTest(FixtureTestCase):
     def test_about(self) -> None:
         response = self.client.get(reverse("about"))
         self.assertContains(response, "translate-toolkit")
+
+    @override_settings(GOOGLE_ANALYTICS_ID="UA-123")
+    def test_google_analytics(self) -> None:
+        response = self.client.get(reverse("about"))
+        self.assertContains(response, static("js/google-analytics.js"))
+        self.assertContains(response, 'data-tracking-id="UA-123"')
+        self.assertNotContains(response, "GoogleAnalyticsObject")
+        script_src = next(
+            directive
+            for directive in response["Content-Security-Policy"].split(";")
+            if directive.strip().startswith("script-src ")
+        )
+        self.assertIn("www.google-analytics.com", script_src)
+        self.assertNotIn("'unsafe-inline'", script_src)
 
     def test_keys(self) -> None:
         ensure_ssh_key()


### PR DESCRIPTION
Load the bootstrap from a static asset so enabling Google Analytics no longer weakens script-src with unsafe-inline.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
