### PR TITLE
fix(accounts): rotate API token when disabling password

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -190,11 +190,18 @@ users at once by pasting whitespace-separated e-mail addresses. All
 invitations created in one bulk action use the selected team, and site-wide
 bulk invites also apply the selected superuser flag.
 
+.. _site-wide-user-management:
+
 Site-wide user management is controlled by the global ``user.edit``
 permission. Unlike project access management, this is a trusted administrative
 permission which allows editing user accounts across the whole instance,
 including assigning site-wide teams and granting superuser status to the
 managed account, even the caller's own account.
+
+Site administrators can also disable password authentication for a user. The
+:guilabel:`Regenerate API key` option is enabled by default so that the current
+personal API key stops working. Clear it only when the current API key should
+remain active.
 
 Bulk invitations are processed individually. Invalid addresses and addresses
 with an already pending invitation are skipped while valid invitations are

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,7 @@ Weblate 2026.8
 
 .. rubric:: Bug fixes
 
+* :ref:`Disabling password authentication <site-wide-user-management>` from site-wide user management now regenerates the user's personal API key by default.
 * Category, project, and comment statistics now stay consistent after component topology and comment changes, and category metrics are collected correctly.
 * Mercurial repository filenames beginning with a dash are now handled safely.
 * Protected outbound HTTP requests now bind connections to validated public addresses.

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -671,7 +671,7 @@ class AuditLog(models.Model):
         ):
             failures = AuditLog.objects.get_after(self.user, "login", "failed-auth")
             if failures.count() >= settings.AUTH_LOCK_ATTEMPTS:
-                lock_user(self.user, "locked", request)
+                lock_user(self.user, "locked", request, regenerate_api_key=False)
                 return True
 
         elif (
@@ -683,7 +683,7 @@ class AuditLog(models.Model):
                 self.user, "twofactor-login", "twofactor-failed"
             )
             if failures.count() >= settings.AUTH_LOCK_ATTEMPTS:
-                lock_user(self.user, "locked", request)
+                lock_user(self.user, "locked", request, regenerate_api_key=False)
                 return True
 
         elif self.activity == "reset-request":

--- a/weblate/accounts/tests/test_utils.py
+++ b/weblate/accounts/tests/test_utils.py
@@ -14,6 +14,7 @@ from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.test.utils import override_settings
 from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from rest_framework.authtoken.models import Token
 
 from weblate.accounts.models import format_private_commit_data
 from weblate.accounts.pipeline import slugify_username
@@ -28,6 +29,7 @@ from weblate.accounts.utils import (
     SESSION_EXPIRY_SCOPE_SAML,
     adjust_session_expiry,
     get_session_expiry_refresh_seconds,
+    lock_user,
 )
 from weblate.auth.models import User
 from weblate.utils.validators import EmailValidator, validate_username
@@ -41,6 +43,26 @@ class PipelineTest(SimpleTestCase):
         self.assertEqual(slugify_username(" zkouska "), "zkouska")
         self.assertEqual(slugify_username("ahoj - ahoj"), "ahoj-ahoj")
         self.assertEqual(slugify_username("..test"), "test")
+
+
+class LockUserTest(TestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.old_token = self.user.auth_token.key
+
+    def test_regenerate_api_key(self) -> None:
+        lock_user(self.user, "admin-locked")
+
+        token = Token.objects.get(user=self.user)
+        self.assertNotEqual(token.key, self.old_token)
+        self.assertFalse(Token.objects.filter(key=self.old_token).exists())
+
+    def test_keep_api_key(self) -> None:
+        lock_user(self.user, "locked", regenerate_api_key=False)
+
+        self.assertEqual(Token.objects.get(user=self.user).key, self.old_token)
 
 
 class SessionExpiryTest(TestCase):

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -641,8 +641,10 @@ class ViewTest(RepoTestCase):
     def test_login_ratelimit(self, login=False) -> None:
         if login:
             self.test_login()
+            user = User.objects.get(username="testuser")
         else:
-            self.get_user()
+            user = self.get_user()
+        old_token = user.auth_token.key
 
         # Use auth attempts
         for _unused in range(5):
@@ -656,6 +658,7 @@ class ViewTest(RepoTestCase):
             reverse("login"), {"username": "testuser", "password": "testpassword"}
         )
         self.assertContains(response, "Please try again.")
+        self.assertEqual(Token.objects.get(user=user).key, old_token)
 
     @override_settings(RATELIMIT_ATTEMPTS=10, AUTH_LOCK_ATTEMPTS=5)
     def test_login_ratelimit_login(self) -> None:
@@ -1306,6 +1309,44 @@ class EditUserTest(FixtureTestCase):
 
         response = self.client.get(target.get_absolute_url())
         self.assertContains(response, "No language limit")
+
+    def test_disable_password_regenerates_api_key(self) -> None:
+        target = User.objects.create_user(
+            username="password-reset-target", password="testpassword"
+        )
+        old_token = target.auth_token.key
+
+        response = self.client.get(target.get_absolute_url())
+        self.assertContains(response, 'name="regenerate_api_key"')
+        self.assertContains(response, "checked")
+
+        response = self.client.post(
+            target.get_absolute_url(),
+            {"disable_password": "1", "regenerate_api_key": "on"},
+        )
+
+        self.assertRedirects(response, f"{target.get_absolute_url()}#edit")
+        target.refresh_from_db()
+        self.assertFalse(target.has_usable_password())
+        self.assertTrue(target.is_active)
+        token = Token.objects.get(user=target)
+        self.assertNotEqual(token.key, old_token)
+        self.assertFalse(Token.objects.filter(key=old_token).exists())
+
+    def test_disable_password_keeps_api_key(self) -> None:
+        target = User.objects.create_user(
+            username="password-reset-target", password="testpassword"
+        )
+        old_token = target.auth_token.key
+
+        response = self.client.post(
+            target.get_absolute_url(), {"disable_password": "1"}
+        )
+
+        self.assertRedirects(response, f"{target.get_absolute_url()}#edit")
+        target.refresh_from_db()
+        self.assertFalse(target.has_usable_password())
+        self.assertEqual(Token.objects.get(user=target).key, old_token)
 
 
 class AdminUserRevertTest(FixtureTestCase):

--- a/weblate/accounts/utils.py
+++ b/weblate/accounts/utils.py
@@ -150,9 +150,13 @@ def lock_user(
     user: User,
     reason: Literal["locked", "admin-locked"],
     request: AuthenticatedHttpRequest | None = None,
+    *,
+    regenerate_api_key: bool = True,
 ) -> None:
     user.set_unusable_password()
     user.save(update_fields=["password"])
+    if regenerate_api_key:
+        reset_api_token(user)
     AuditLog.objects.create(user, request, reason)
 
 

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -847,7 +847,11 @@ class UserPage(UpdateView):
             return HttpResponseRedirect(f"{self.get_success_url()}#edit")
 
         if "disable_password" in request.POST:
-            lock_user(user, "admin-locked")
+            lock_user(
+                user,
+                "admin-locked",
+                regenerate_api_key="regenerate_api_key" in request.POST,
+            )
             return HttpResponseRedirect(f"{self.get_success_url()}#edit")
 
         user.store_audit_state()

--- a/weblate/templates/accounts/user.html
+++ b/weblate/templates/accounts/user.html
@@ -445,7 +445,19 @@
               <div class="card-header text-bg-danger">
                 <h4 class="card-title">{% translate "Password reset" %}</h4>
               </div>
-              <div class="card-body">{% translate "Disables password authentication for the user." %}</div>
+              <div class="card-body">
+                <p>{% translate "Disables password authentication for the user." %}</p>
+                <div class="form-check">
+                  <input class="form-check-input"
+                         type="checkbox"
+                         name="regenerate_api_key"
+                         id="regenerate_api_key_{{ page_user.id }}"
+                         aria-describedby="regenerate_api_key_help_{{ page_user.id }}"
+                         checked />
+                  <label class="form-check-label" for="regenerate_api_key_{{ page_user.id }}">{% translate "Regenerate API key" %}</label>
+                  <div class="form-text" id="regenerate_api_key_help_{{ page_user.id }}">{% translate "Leave enabled to revoke the current API key and generate a new one." %}</div>
+                </div>
+              </div>
               <div class="card-footer">
                 <input type="submit"
                        name="disable_password"


### PR DESCRIPTION
Regenerate a user's personal API token by default when password authentication is disabled. This invalidates the previous DRF token so it cannot continue authenticating after an administrator-triggered password reset. Expose a default-enabled administrator opt-out matching the existing password-change flow. 