### PR TITLE
refactor(views): use async ORM for database-only endpoints

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -256,8 +256,8 @@ class Subscription(models.Model):
         return self.sign_id(self.pk)
 
     @classmethod
-    def get_by_signed_id(cls, signed_id: str) -> Subscription:
-        return cls.objects.get(
+    async def aget_by_signed_id(cls, signed_id: str) -> Subscription:
+        return await cls.objects.aget(
             pk=int(TimestampSigner().unsign(signed_id, max_age=cls.SIGNATURE_MAX_AGE))
         )
 

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -10,6 +10,7 @@ from time import sleep
 from types import SimpleNamespace
 from unittest import mock
 
+from asgiref.sync import async_to_sync
 from django.conf import settings
 from django.core import mail
 from django.test.utils import modify_settings, override_settings
@@ -1169,7 +1170,10 @@ class ProfileTest(FixtureTestCase):
         self.assertEqual(self.user.subscription_set.count(), 10)
 
         # Watch component
-        self.client.post(reverse("watch", kwargs=self.kw_component))
+        self.async_client.force_login(self.user)
+        async_to_sync(self.async_client.post)(
+            reverse("watch", kwargs=self.kw_component)
+        )
         self.assertEqual(self.user.profile.watched.count(), 1)
         # All project notifications should be muted
         self.assertEqual(

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -178,7 +178,7 @@ from weblate.utils.validators import (
     validate_profile_url,
 )
 from weblate.utils.version import USER_AGENT
-from weblate.utils.views import get_paginator, parse_path
+from weblate.utils.views import aparse_path, get_paginator
 from weblate.utils.zammad import ZammadError, submit_zammad_ticket
 
 if TYPE_CHECKING:
@@ -1516,21 +1516,21 @@ def userdata(request: AuthenticatedHttpRequest):
 
 @require_POST
 @login_required
-def watch(request: AuthenticatedHttpRequest, path):
+async def watch(request: AuthenticatedHttpRequest, path):
     user = request.user
-    redirect_obj = obj = parse_path(request, path, (Component, Project))
+    redirect_obj = obj = await aparse_path(request, path, (Component, Project))
     if isinstance(obj, Component):
         project = obj.project
 
         # Mute project level subscriptions
-        mute_real(
+        await amute_real(
             user, scope=NotificationScope.SCOPE_PROJECT, component=None, project=project
         )
         # Manually enable component level subscriptions
-        for default_subscription in user.subscription_set.filter(
+        async for default_subscription in user.subscription_set.filter(
             scope=NotificationScope.SCOPE_WATCHED
         ):
-            subscription, created = user.subscription_set.get_or_create(
+            subscription, created = await user.subscription_set.aget_or_create(
                 notification=default_subscription.notification,
                 scope=NotificationScope.SCOPE_COMPONENT,
                 component=obj,
@@ -1539,61 +1539,66 @@ def watch(request: AuthenticatedHttpRequest, path):
             )
             if not created and subscription.frequency != default_subscription.frequency:
                 subscription.frequency = default_subscription.frequency
-                subscription.save(update_fields=["frequency"])
+                await subscription.asave(update_fields=["frequency"])
 
         # Watch project
         obj = project
-    user.profile.watched.add(obj)
+    await user.profile.watched.aadd(obj)  # codespell:ignore aadd
     return redirect_next(request.GET.get("next"), redirect_obj)
 
 
 @require_POST
 @login_required
-def unwatch(request: AuthenticatedHttpRequest, path):
-    obj = parse_path(request, path, (Project,))
-    request.user.profile.watched.remove(obj)
-    request.user.subscription_set.filter(
+async def unwatch(request: AuthenticatedHttpRequest, path):
+    obj = await aparse_path(request, path, (Project,))
+    await request.user.profile.watched.aremove(obj)
+    await request.user.subscription_set.filter(
         Q(project=obj) | Q(component__project=obj)
-    ).delete()
+    ).adelete()
     return redirect_next(request.GET.get("next"), obj)
 
 
-def mute_real(user: User, **kwargs) -> None:
+async def amute_real(user: User, **kwargs) -> None:
     for notification_cls in NOTIFICATIONS:
         if notification_cls.ignore_watched:
             continue
         try:
-            subscription = user.subscription_set.get_or_create(
-                notification=notification_cls.get_name(),
-                defaults={"frequency": NotificationFrequency.FREQ_NONE},
-                **kwargs,
+            subscription = (
+                await user.subscription_set.aget_or_create(
+                    notification=notification_cls.get_name(),
+                    defaults={"frequency": NotificationFrequency.FREQ_NONE},
+                    **kwargs,
+                )
             )[0]
         except Subscription.MultipleObjectsReturned:
-            subscriptions = user.subscription_set.filter(
-                notification=notification_cls.get_name(), **kwargs
-            )
+            subscriptions = [
+                subscription
+                async for subscription in user.subscription_set.filter(
+                    notification=notification_cls.get_name(), **kwargs
+                )
+            ]
             # Remove extra subscriptions
             for subscription in subscriptions[1:]:
-                subscription.delete()
+                await subscription.adelete()
             subscription = subscriptions[0]
         if subscription.frequency != NotificationFrequency.FREQ_NONE:
             subscription.frequency = NotificationFrequency.FREQ_NONE
-            subscription.save(update_fields=["frequency"])
+            await subscription.asave(update_fields=["frequency"])
 
 
 @require_POST
 @login_required
-def mute(request: AuthenticatedHttpRequest, path):
-    obj = parse_path(request, path, (Component, Project))
+async def mute(request: AuthenticatedHttpRequest, path):
+    obj = await aparse_path(request, path, (Component, Project))
     if isinstance(obj, Component):
-        mute_real(
+        await amute_real(
             request.user,
             scope=NotificationScope.SCOPE_COMPONENT,
             component=obj,
             project=None,
         )
         return redirect(f"{reverse('profile')}?notify_component={obj.pk}#notifications")
-    mute_real(
+    await amute_real(
         request.user, scope=NotificationScope.SCOPE_PROJECT, component=None, project=obj
     )
     return redirect(f"{reverse('profile')}?notify_project={obj.pk}#notifications")
@@ -2013,9 +2018,12 @@ def social_complete(request: AuthenticatedHttpRequest, backend: str):
 
 @login_required
 @require_POST
-def subscribe(request: AuthenticatedHttpRequest):
+async def subscribe(request: AuthenticatedHttpRequest):
     if "onetime" in request.POST:
-        component = Component.objects.get(pk=request.POST["component"])
+        await request.user.aprepare_permissions()
+        component = await Component.objects.select_related("project").aget(
+            pk=request.POST["component"]
+        )
         request.user.check_access_component(component)
         subscription = Subscription(
             user=request.user,
@@ -2027,11 +2035,15 @@ def subscribe(request: AuthenticatedHttpRequest):
             onetime=True,
         )
         try:
-            subscription.full_clean(validate_unique=False, validate_constraints=False)
+            subscription.full_clean(
+                exclude={"user", "project", "component"},
+                validate_unique=False,
+                validate_constraints=False,
+            )
         except ValidationError:
             pass
         else:
-            Subscription.objects.update_or_create(
+            await Subscription.objects.aupdate_or_create(
                 user=subscription.user,
                 notification=subscription.notification,
                 scope=subscription.scope,
@@ -2047,10 +2059,10 @@ def subscribe(request: AuthenticatedHttpRequest):
 
 
 @login_not_required
-def unsubscribe(request: AuthenticatedHttpRequest):
+async def unsubscribe(request: AuthenticatedHttpRequest):
     if "i" in request.GET:
         try:
-            subscription = Subscription.get_by_signed_id(request.GET["i"])
+            subscription = await Subscription.aget_by_signed_id(request.GET["i"])
         except (BadSignature, SignatureExpired, Subscription.DoesNotExist):
             messages.error(
                 request,
@@ -2061,7 +2073,7 @@ def unsubscribe(request: AuthenticatedHttpRequest):
             )
         else:
             subscription.frequency = NotificationFrequency.FREQ_NONE
-            subscription.save(update_fields=["frequency"])
+            await subscription.asave(update_fields=["frequency"])
             messages.success(request, gettext("Notification settings adjusted."))
 
     return redirect_profile("#notifications")

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypedDict, cast
 
 import regex
 from appconf import AppConf
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.hashers import make_password
@@ -1049,6 +1050,19 @@ class User(AbstractBaseUser):
 
         # Generic permission
         return check_permission(self, perm, obj)
+
+    async def aprepare_permissions(self) -> None:
+        """Populate synchronous permission caches for async callers."""
+        if self.is_superuser:
+            return
+
+        def prepare() -> None:
+            _ = self._permissions
+            _ = self.global_permissions
+            _ = self.needs_project_filter
+            _ = self.needs_component_restrictions_filter
+
+        await sync_to_async(prepare, thread_sensitive=True)()
 
     def can_access_project(self, project):
         """Check access to given project."""

--- a/weblate/screenshots/models.py
+++ b/weblate/screenshots/models.py
@@ -131,12 +131,39 @@ class Screenshot(models.Model, UserDisplayMixin):
                 unit=unit,
             )
 
+    async def add_units_async(
+        self, units: Sequence[Unit], user: User | None = None
+    ) -> None:
+        """Asynchronously add units and create change events."""
+        if not units:
+            return
+        user_id = user.pk if user is not None else self.user_id
+        await self.units.aadd(*units)  # codespell:ignore aadd
+        for unit in units:
+            await self.change_set.acreate(
+                action=ActionEvents.SCREENSHOT_ADDED,
+                user_id=user_id,
+                target=self.name,
+                unit=unit,
+            )
+
     def remove_unit(self, unit: Unit, user: User | None = None) -> None:
         """Remove a unit from this screenshot and create a change event."""
         self.units.remove(unit)
         self.change_set.create(
             action=ActionEvents.SCREENSHOT_REMOVED,
             user=user or self.user,
+            target=self.name,
+            unit=unit,
+        )
+
+    async def aremove_unit(self, unit: Unit, user: User | None = None) -> None:
+        """Asynchronously remove a unit and create a change event."""
+        user_id = user.pk if user is not None else self.user_id
+        await self.units.aremove(unit)
+        await self.change_set.acreate(
+            action=ActionEvents.SCREENSHOT_REMOVED,
+            user_id=user_id,
             target=self.name,
             unit=unit,
         )

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -11,6 +11,7 @@ from shutil import copyfile, rmtree
 from unittest.mock import MagicMock, patch
 
 import httpx2
+from asgiref.sync import async_to_sync
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
@@ -544,6 +545,33 @@ class ViewTest(FixtureTestCase):
     def extract_pk(self, data):
         return int(data.split('data-pk="')[1].split('"')[0])
 
+    def test_async_source_changes_use_screenshot_owner(self) -> None:
+        screenshot = Screenshot.objects.create(
+            name="Owner",
+            translation=self.component.source_translation,
+            user=self.user,
+        )
+        unit = self.component.source_translation.unit_set.first()
+        if unit is None:
+            self.fail("Expected a source unit")
+
+        async def update_sources() -> None:
+            async_screenshot = await Screenshot.objects.aget(pk=screenshot.pk)
+            await async_screenshot.add_units_async([unit])
+            await async_screenshot.aremove_unit(unit)
+
+        async_to_sync(update_sources)()
+
+        changes = Change.objects.filter(screenshot=screenshot).order_by("pk")
+        self.assertEqual(
+            list(changes.values_list("action", "user_id")),
+            [
+                (ActionEvents.SCREENSHOT_ADDED, self.user.pk),
+                (ActionEvents.SCREENSHOT_REMOVED, self.user.pk),
+            ],
+        )
+        self.assertFalse(screenshot.units.filter(pk=unit.pk).exists())
+
     def test_source_manipulations(self) -> None:
         self.make_manager()
         self.do_upload()
@@ -568,11 +596,12 @@ class ViewTest(FixtureTestCase):
         )
 
         # Add found string
-        response = self.client.post(
+        self.async_client.force_login(self.user)
+        async_response = async_to_sync(self.async_client.post)(
             reverse("screenshot-js-add", kwargs={"pk": screenshot.pk}),
             {"source": source_pk},
         )
-        data = response.json()
+        data = async_response.json()
         self.assertEqual(data["responseCode"], 200)
         self.assertEqual(data["status"], True)
         self.assertEqual(screenshot.units.count(), 1)
@@ -591,7 +620,7 @@ class ViewTest(FixtureTestCase):
         self.assertContains(response, "Hello")
 
         # Remove added string
-        self.client.post(
+        async_to_sync(self.async_client.post)(
             reverse("screenshot-remove-source", kwargs={"pk": screenshot.pk}),
             {"source": source_pk},
         )

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -15,7 +15,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count
 from django.http import FileResponse, JsonResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import aget_object_or_404, get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -302,6 +302,57 @@ def add_sources(request: AuthenticatedHttpRequest, obj) -> dict[str, int | bool]
     }
 
 
+async def add_sources_async(
+    request: AuthenticatedHttpRequest, obj
+) -> dict[str, int | bool]:
+    sources = request.POST.getlist("source")
+    if not sources:
+        return {"status": False, "added": 0, "skipped": 0, "invalid": 0}
+
+    source_ids: list[int] = []
+    seen: set[int] = set()
+    skipped = 0
+    invalid = 0
+    for source in sources:
+        try:
+            source_id = int(source)
+        except ValueError:
+            invalid += 1
+            continue
+        if source_id in seen:
+            skipped += 1
+            continue
+        seen.add(source_id)
+        source_ids.append(source_id)
+
+    existing = {
+        pk
+        async for pk in obj.units.filter(pk__in=source_ids).values_list("pk", flat=True)
+    }
+    units = await obj.translation.unit_set.ain_bulk(source_ids)
+    units_to_add: list[Unit] = []
+    for source_id in source_ids:
+        unit = units.get(source_id)
+        if unit is None:
+            invalid += 1
+            continue
+        if source_id in existing:
+            skipped += 1
+            continue
+        units_to_add.append(unit)
+        existing.add(source_id)
+
+    await obj.add_units_async(units_to_add, user=request.user)
+    added = len(units_to_add)
+
+    return {
+        "status": added > 0,
+        "added": added,
+        "skipped": skipped,
+        "invalid": invalid,
+    }
+
+
 def try_add_source(request: AuthenticatedHttpRequest, obj) -> bool:
     return bool(add_sources(request, obj)["status"])
 
@@ -565,18 +616,31 @@ def get_screenshot(request: AuthenticatedHttpRequest, pk):
     return obj
 
 
+async def aget_screenshot(request: AuthenticatedHttpRequest, pk):
+    await request.user.aprepare_permissions()
+    obj = await aget_object_or_404(
+        Screenshot.objects.filter_access(request.user).select_related(
+            "translation__component__project"
+        ),
+        pk=pk,
+    )
+    if not request.user.has_perm("screenshot.edit", obj.translation.component):
+        raise PermissionDenied
+    return obj
+
+
 @require_POST
 @login_required
-def remove_source(request: AuthenticatedHttpRequest, pk):
-    obj = get_screenshot(request, pk)
+async def remove_source(request: AuthenticatedHttpRequest, pk):
+    obj = await aget_screenshot(request, pk)
 
     try:
-        unit = obj.translation.unit_set.get(pk=int(request.POST["source"]))
+        unit = await obj.translation.unit_set.aget(pk=int(request.POST["source"]))
     except (Unit.DoesNotExist, ValueError):
         messages.error(request, gettext("Invalid unit."))
         return redirect(obj)
 
-    obj.remove_unit(unit, user=request.user)
+    await obj.aremove_unit(unit, user=request.user)
 
     messages.success(request, gettext("Source has been removed."))
 
@@ -766,9 +830,11 @@ def ocr_search(request: AuthenticatedHttpRequest, pk):
 
 @login_required
 @require_POST
-def add_source(request: AuthenticatedHttpRequest, pk):
-    obj = get_screenshot(request, pk)
-    return JsonResponse(data={"responseCode": 200, **add_sources(request, obj)})
+async def add_source(request: AuthenticatedHttpRequest, pk):
+    obj = await aget_screenshot(request, pk)
+    return JsonResponse(
+        data={"responseCode": 200, **await add_sources_async(request, obj)}
+    )
 
 
 @login_required

--- a/weblate/trans/models/announcement.py
+++ b/weblate/trans/models/announcement.py
@@ -4,6 +4,10 @@
 
 """Announcement model."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
@@ -12,6 +16,21 @@ from django.utils.translation import gettext, gettext_lazy
 
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
+
+if TYPE_CHECKING:
+    from weblate.auth.models import User
+
+
+class AnnouncementChangeKwargs(TypedDict):
+    action: int
+    project_id: int | None
+    category_id: int | None
+    component_id: int | None
+    language_id: int | None
+    announcement_id: int
+    target: str
+    user: User | None
+
 
 ANNOUNCEMENT_SEVERITY_CHOICES = (
     ("info", gettext_lazy("Info (light blue)")),
@@ -22,6 +41,34 @@ ANNOUNCEMENT_SEVERITY_CHOICES = (
 
 
 class AnnouncementManager(models.Manager["Announcement"]):
+    @staticmethod
+    def _normalize_create_scope(kwargs) -> None:
+        has_category = (
+            kwargs.get("category") is not None or kwargs.get("category_id") is not None
+        )
+        has_component = (
+            kwargs.get("component") is not None
+            or kwargs.get("component_id") is not None
+        )
+        if has_category and not has_component:
+            kwargs.pop("project", None)
+            kwargs["project_id"] = None
+
+    @staticmethod
+    def _get_change_kwargs(
+        result, project_id: int | None, user: User | None
+    ) -> AnnouncementChangeKwargs:
+        return {
+            "action": ActionEvents.ANNOUNCEMENT,
+            "project_id": project_id,
+            "category_id": result.category_id,
+            "component_id": result.component_id,
+            "language_id": result.language_id,
+            "announcement_id": result.pk,
+            "target": result.message,
+            "user": user,
+        }
+
     @staticmethod
     def _category_filter(category):
         category_ids = []
@@ -113,25 +160,43 @@ class AnnouncementManager(models.Manager["Announcement"]):
 
     def create(self, user=None, **kwargs):
         # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models.category import Category
+
+        # ruff: ignore[import-outside-top-level]
         from weblate.trans.models.change import Change
 
-        if kwargs.get("category") is not None and kwargs.get("component") is None:
-            kwargs["project"] = None
+        self._normalize_create_scope(kwargs)
 
         result = super().create(**kwargs)
-        project = result.project
-        if project is None and result.category is not None:
-            project = result.category.project
+        project_id = result.project_id
+        if project_id is None and result.category_id is not None:
+            project_id = Category.objects.values_list("project_id", flat=True).get(
+                pk=result.category_id
+            )
 
         Change.objects.create(
-            action=ActionEvents.ANNOUNCEMENT,
-            project=project,
-            category=result.category,
-            component=result.component,
-            language=result.language,
-            announcement=result,
-            target=result.message,
-            user=user,
+            **self._get_change_kwargs(result, project_id, user),
+        )
+        return result
+
+    async def acreate(self, user=None, **kwargs):
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models.category import Category
+
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models.change import Change
+
+        self._normalize_create_scope(kwargs)
+
+        result = await super().acreate(**kwargs)
+        project_id = result.project_id
+        if project_id is None and result.category_id is not None:
+            project_id = await Category.objects.values_list(
+                "project_id", flat=True
+            ).aget(pk=result.category_id)
+
+        await Change.objects.acreate(
+            **self._get_change_kwargs(result, project_id, user),
         )
         return result
 

--- a/weblate/trans/tests/test_labels.py
+++ b/weblate/trans/tests/test_labels.py
@@ -7,6 +7,7 @@
 from typing import cast
 from unittest.mock import patch
 
+from asgiref.sync import async_to_sync
 from django.core.cache import cache
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -109,14 +110,13 @@ class LabelTest(FixtureTestCase):
     def test_delete(self) -> None:
         self.test_create()
         label = self.project.label_set.get()
-        response = self.client.post(
+        self.async_client.force_login(self.user)
+        response = async_to_sync(self.async_client.post)(
             reverse(
                 "label_delete", kwargs={"project": self.project.slug, "pk": label.pk}
             ),
-            follow=True,
         )
-        self.assertRedirects(response, self.labels_url)
-        self.assertNotContains(response, "Test label")
+        self.assertRedirects(response, self.labels_url, fetch_redirect_response=False)
         self.assertFalse(self.project.label_set.filter(name="Test label").exists())
 
     def test_assign(self) -> None:

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from asgiref.sync import async_to_sync
 from django.apps import apps
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.cache import cache
@@ -1455,6 +1456,38 @@ class AnnouncementTest(ModelTestCase):
             message="test component",
         )
         Announcement.objects.create(message="test global")
+
+    def test_async_create_with_foreign_key_ids(self) -> None:
+        category = self.create_category(self.component.project)
+
+        async def create_announcements():
+            category_announcement = await Announcement.objects.acreate(
+                category_id=category.pk,
+                language_id=self.czech.pk,
+                message="async category",
+            )
+            component_announcement = await Announcement.objects.acreate(
+                project_id=self.component.project_id,
+                component_id=self.component.pk,
+                language_id=self.czech.pk,
+                message="async component",
+            )
+            return category_announcement, component_announcement
+
+        category_announcement, component_announcement = async_to_sync(
+            create_announcements
+        )()
+
+        self.assertIsNone(category_announcement.project_id)
+        category_change = Change.objects.get(announcement=category_announcement)
+        self.assertEqual(category_change.project_id, category.project_id)
+        self.assertEqual(category_change.category_id, category.pk)
+        self.assertEqual(category_change.language_id, self.czech.pk)
+
+        component_change = Change.objects.get(announcement=component_announcement)
+        self.assertEqual(component_change.project_id, self.component.project_id)
+        self.assertEqual(component_change.component_id, self.component.pk)
+        self.assertEqual(component_change.language_id, self.czech.pk)
 
     def verify_filter(self, messages, count, message=None) -> None:
         """Verify whether messages have given count and first contains string."""

--- a/weblate/trans/views/labels.py
+++ b/weblate/trans/views/labels.py
@@ -8,14 +8,14 @@ from typing import TYPE_CHECKING
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import aget_object_or_404, get_object_or_404, redirect
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST
 
 from weblate.trans.forms import LabelForm
 from weblate.trans.models import Label, Project
 from weblate.trans.util import render
-from weblate.utils.views import parse_path
+from weblate.utils.views import aparse_path, parse_path
 
 if TYPE_CHECKING:
     from weblate.auth.models import AuthenticatedHttpRequest
@@ -78,14 +78,14 @@ def label_edit(request: AuthenticatedHttpRequest, project, pk):
 @login_required
 @never_cache
 @require_POST
-def label_delete(request: AuthenticatedHttpRequest, project, pk):
-    obj = parse_path(request, [project], (Project,))
+async def label_delete(request: AuthenticatedHttpRequest, project, pk):
+    obj = await aparse_path(request, [project], (Project,))
 
     if not request.user.has_perm("project.edit", obj):
         raise PermissionDenied
 
-    label = get_object_or_404(Label, pk=pk, project=obj)
+    label = await aget_object_or_404(Label, pk=pk, project=obj)
 
-    label.delete()
+    await label.adelete()
 
     return redirect("labels", project=project)

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -7,12 +7,13 @@ import os
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING
 
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.db import transaction
 from django.http import Http404, JsonResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import aget_object_or_404, redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext
@@ -61,7 +62,7 @@ from weblate.trans.util import redirect_param, render
 from weblate.utils import messages
 from weblate.utils.random import get_random_identifier
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
-from weblate.utils.views import parse_path, show_form_errors
+from weblate.utils.views import aparse_path, parse_path, show_form_errors
 from weblate.workspaces.forms import WorkspaceSettingsForm
 from weblate.workspaces.models import Workspace
 
@@ -453,18 +454,20 @@ def component_link_add(request: AuthenticatedHttpRequest, path):
 
 @login_required
 @require_POST
-def component_link_delete(request: AuthenticatedHttpRequest, path):
-    obj = parse_path(request, path, (Component,))
+async def component_link_delete(request: AuthenticatedHttpRequest, path):
+    obj = await aparse_path(request, path, (Component,))
     if not request.user.has_perm("component.edit", obj):
         raise PermissionDenied
 
     link_id = request.POST.get("link_id")
+    if link_id is None:
+        raise Http404
     try:
-        link = ComponentLink.objects.get(pk=link_id, component=obj)
+        link = await ComponentLink.objects.aget(pk=link_id, component=obj)
     except (ComponentLink.DoesNotExist, ValueError, TypeError) as e:
         raise Http404 from e
 
-    link.delete()
+    await link.adelete()
     return redirect_param(obj, "#sharing")
 
 
@@ -494,12 +497,12 @@ def component_link_categories(request: AuthenticatedHttpRequest, path):
 
 @login_required
 @require_POST
-def announcement(request: AuthenticatedHttpRequest, path):
-    obj = parse_path(
+async def announcement(request: AuthenticatedHttpRequest, path):
+    obj = await aparse_path(
         request, path, (ProjectLanguage, Translation, Component, Project, Category)
     )
 
-    if not request.user.has_perm("announcement.add", obj):
+    if not await sync_to_async(request.user.has_perm)("announcement.add", obj):
         raise PermissionDenied
 
     form = AnnouncementForm(request.POST)
@@ -524,7 +527,7 @@ def announcement(request: AuthenticatedHttpRequest, path):
     elif isinstance(obj, Project):
         scope["project"] = obj
 
-    Announcement.objects.create(
+    await Announcement.objects.acreate(
         user=request.user,
         **scope,
         **form.cleaned_data,
@@ -535,15 +538,24 @@ def announcement(request: AuthenticatedHttpRequest, path):
 
 @login_required
 @require_POST
-def announcement_delete(request: AuthenticatedHttpRequest, pk):
-    announcement = get_object_or_404(
-        Announcement.objects.filter_access(request.user), pk=pk
+async def announcement_delete(request: AuthenticatedHttpRequest, pk):
+    await request.user.aprepare_permissions()
+    announcement = await aget_object_or_404(
+        Announcement.objects.filter_access(request.user).select_related(
+            "category__project",
+            "component__project",
+            "language",
+            "project",
+        ),
+        pk=pk,
     )
 
-    if not request.user.has_perm("announcement.delete", announcement):
+    if not await sync_to_async(request.user.has_perm)(
+        "announcement.delete", announcement
+    ):
         raise PermissionDenied
 
-    announcement.delete()
+    await announcement.adelete()
     return JsonResponse({"responseStatus": 200})
 
 

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -17,6 +17,7 @@ from uuid import UUID
 from zipfile import ZipFile
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import EmptyPage, Paginator
 from django.http import (
     FileResponse,
@@ -24,7 +25,7 @@ from django.http import (
     HttpResponse,
     HttpResponseRedirect,
 )
-from django.shortcuts import get_object_or_404
+from django.shortcuts import aget_object_or_404, get_object_or_404
 from django.utils.cache import get_conditional_response
 from django.utils.http import http_date
 from django.utils.translation import activate, gettext, gettext_lazy, pgettext_lazy
@@ -403,6 +404,177 @@ def parse_path(
 
     check_type(Unit)
     return get_object_or_404(translation.unit_set, pk=int(unitid))
+
+
+async def _workspace_can_view(
+    request: AuthenticatedHttpRequest, workspace: Workspace
+) -> bool:
+    user = request.user
+    if await user.allowed_projects.filter(workspace=workspace).aexists():
+        return True
+    if any(
+        user.has_perm(permission, workspace)
+        for permission in (
+            "workspace.edit",
+            "workspace.add_project",
+            "workspace.edit_members",
+        )
+    ):
+        return True
+    if user.has_perm("management.use"):
+        return True
+    if "weblate.billing" in settings.INSTALLED_APPS:
+        with suppress(AttributeError, ObjectDoesNotExist):
+            return bool(user.has_perm("meta:billing.view", workspace.billing))
+    return False
+
+
+# ruff: ignore[complex-structure]
+async def aparse_path(
+    request: AuthenticatedHttpRequest | None,
+    path: list[str] | tuple[str, ...] | None,
+    types: tuple[type[Model | BaseURLMixin] | None, ...],
+):
+    if None in types and not path:
+        return None
+
+    allowed_types = {x for x in types if x is not None}
+    acting_user = request.user if request else None
+    if request is not None:
+        await request.user.aprepare_permissions()
+
+    def check_type(cls) -> None:
+        if cls not in allowed_types:
+            msg = f"Not supported object type: {cls}"
+            raise UnsupportedPathObjectError(msg)
+
+    if path is None:
+        msg = "Missing path"
+        raise UnsupportedPathObjectError(msg)
+
+    path = list(path)
+
+    # Workspace URL
+    if path[:2] == ["-", "workspace"]:
+        check_type(Workspace)
+        if len(path) != 3:
+            msg = "Invalid workspace path"
+            raise UnsupportedPathObjectError(msg)
+        try:
+            workspace_id = UUID(path[2])
+        except ValueError as error:
+            msg = "Invalid workspace id"
+            raise Http404(msg) from error
+        workspaces = (
+            Workspace.objects.select_related("billing")
+            if "weblate.billing" in settings.INSTALLED_APPS
+            else Workspace.objects.all()
+        )
+        workspace = await aget_object_or_404(workspaces, pk=workspace_id)
+        if request is not None and not await _workspace_can_view(request, workspace):
+            msg = "Access denied"
+            raise Http404(msg)
+        workspace.acting_user = acting_user
+        return workspace
+
+    # Language URL
+    if path[:2] == ["-", "-"] and len(path) == 3:
+        if path[2] == "-" and None in types:
+            return None
+        check_type(Language)
+        return await aget_object_or_404(Language, code=path[2])
+
+    # First level is always project
+    project = await aget_object_or_404(
+        Project.objects.select_related("workspace"), slug=path.pop(0)
+    )
+    if request is not None:
+        request.user.check_access(project)
+    project.acting_user = acting_user
+    if not path:
+        check_type(Project)
+        return project
+
+    # Project/language special case
+    if path[0] == "-" and len(path) == 2:
+        check_type(ProjectLanguage)
+        language = await aget_object_or_404(Language, code=path[1])
+        return ProjectLanguage(project, language)
+
+    if not allowed_types & {Component, Category, Translation, Unit}:
+        msg = "No remaining supported object type"
+        raise UnsupportedPathObjectError(msg)
+
+    # Component/category structure
+    current: Project | Category | Component = project
+    category_args = {"category": None}
+    while path:
+        slug = path.pop(0)
+
+        # Category/language special case
+        if slug == "-" and len(path) == 1:
+            language = await aget_object_or_404(Language, code=path[0])
+            check_type(CategoryLanguage)
+            if not isinstance(current, Category):
+                raise TypeError
+            return CategoryLanguage(current, language)
+
+        # Try component first
+        with suppress(Component.DoesNotExist):
+            current = await current.component_set.select_related("project").aget(
+                slug=slug, **category_args
+            )
+            if request is not None:
+                request.user.check_access_component(current)
+            current.acting_user = acting_user
+            break
+
+        # Try category
+        with suppress(Category.DoesNotExist):
+            current = (
+                await cast("Project | Category", current)
+                .category_set.select_related("project", "category")
+                .aget(slug=slug, **category_args)
+            )
+            current.acting_user = acting_user
+            category_args = {}
+            continue
+
+        # Nothing more to try
+        msg = f"Object {slug} not found in {current}"
+        raise Http404(msg)
+
+    # Nothing left, return current object
+    if not path:
+        if not isinstance(current, tuple(allowed_types)):
+            msg = f"Not supported object type: {current.__class__}"
+            raise UnsupportedPathObjectError(msg)
+        return current
+
+    if not allowed_types & {Translation, Unit}:
+        msg = "No remaining supported object type"
+        raise UnsupportedPathObjectError(msg)
+
+    translation = await aget_object_or_404(
+        cast("Component", current).translation_set.select_related("language", "plural"),
+        language__code=path.pop(0),
+    )
+    if not path:
+        check_type(Translation)
+        return translation
+
+    if len(path) > 1:
+        msg = f"Invalid path left: {'/'.join(path)}"
+        raise UnsupportedPathObjectError(msg)
+
+    unitid = path.pop(0)
+
+    if not unitid.isdigit():
+        msg = f"Invalid unit id: {unitid}"
+        raise Http404(msg)
+
+    check_type(Unit)
+    return await aget_object_or_404(translation.unit_set, pk=int(unitid))
 
 
 def parse_path_units(

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -17,7 +17,7 @@ from urllib.parse import quote, urlencode, urlparse
 
 import httpx2
 import jwt
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -128,9 +128,32 @@ def get_github_app_configurations() -> dict[str, GitHubAppCredentials]:
     return {row.hostname: row for row in rows}
 
 
+async def aget_github_app_configurations() -> dict[str, GitHubAppCredentials]:
+    """Asynchronously return configured GitHub apps keyed by hostname."""
+    try:
+        rows = [row async for row in GitHubAppCredentials.objects.all()]
+    except Exception:
+        # Database may not be migrated yet (e.g. during initial setup or
+        # when this is called outside a request).
+        return {}
+    return {row.hostname: row for row in rows}
+
+
 def get_github_app_settings(hostname: str | None = None) -> GitHubAppCredentials | None:
     """Return the configured Weblate GitHub app credentials for one host, if any."""
     configs = get_github_app_configurations()
+    if hostname is not None:
+        return configs.get(normalize_github_app_hostname(hostname))
+    if len(configs) == 1:
+        return next(iter(configs.values()))
+    return None
+
+
+async def aget_github_app_settings(
+    hostname: str | None = None,
+) -> GitHubAppCredentials | None:
+    """Asynchronously return GitHub app credentials for a host."""
+    configs = await aget_github_app_configurations()
     if hostname is not None:
         return configs.get(normalize_github_app_hostname(hostname))
     if len(configs) == 1:
@@ -660,6 +683,19 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
             queryset = queryset.filter(workspace=workspace)
         return queryset.order_by("workspace_id", "-created").first()
 
+    async def aget_for_installation(
+        self,
+        hostname: str,
+        installation_id: str | int,
+        *,
+        workspace: Workspace | None = None,
+    ) -> GitHubInstallation | None:
+        """Asynchronously return one installation by host and installation ID."""
+        queryset = self.filter_for_installation(hostname, installation_id)
+        if workspace is not None:
+            queryset = queryset.filter(workspace=workspace)
+        return await queryset.order_by("workspace_id", "-created").afirst()
+
     def get_for_repo(
         self,
         hostname: str,
@@ -712,7 +748,42 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
         installation.save()
         return installation
 
-    def upsert_pending_from_data(
+    async def aupsert_from_data(
+        self,
+        hostname: str,
+        installation_id: str | int,
+        data: dict,
+        *,
+        workspace: Workspace,
+        enabled: bool = True,
+    ) -> GitHubInstallation:
+        """Asynchronously create or update trusted installation metadata."""
+        hostname = normalize_github_app_hostname(hostname)
+        installation_id = normalize_github_installation_id(installation_id)
+        account = data.get("account") or {}
+        defaults: dict[str, object] = {"enabled": enabled}
+        if login := account.get("login"):
+            defaults["target_login"] = login
+        if target_type := account.get("type"):
+            defaults["target_type"] = target_type
+
+        installation = await self.filter(
+            hostname=hostname,
+            installation_id=installation_id,
+            workspace=workspace,
+        ).afirst()
+        if installation is None:
+            installation = self.model(
+                hostname=hostname,
+                installation_id=installation_id,
+                workspace=workspace,
+            )
+        for name, value in defaults.items():
+            setattr(installation, name, value)
+        await installation.asave()
+        return installation
+
+    async def aupsert_pending_from_data(
         self,
         hostname: str,
         installation_id: str | int,
@@ -721,15 +792,15 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
         workspace: Workspace,
         enabled: bool = True,
     ) -> tuple[GitHubInstallation, bool]:
-        """Create or update a workspace-scoped row before App API sync succeeds."""
+        """Asynchronously persist a row before App API sync succeeds."""
         hostname = normalize_github_app_hostname(hostname)
         installation_id = normalize_github_installation_id(installation_id)
         account = data.get("account") or {}
-        installation = self.filter(
+        installation = await self.filter(
             hostname=hostname,
             installation_id=installation_id,
             workspace=workspace,
-        ).first()
+        ).afirst()
         created = installation is None
         if installation is None:
             installation = self.model(
@@ -742,7 +813,7 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
             installation.target_login = login
         if target_type := account.get("type"):
             installation.target_type = target_type
-        installation.save()
+        await installation.asave()
         return installation, created
 
     async def sync_from_api(
@@ -755,7 +826,7 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
     ) -> GitHubInstallation:
         """Fetch installation metadata from GitHub and persist it."""
         hostname = normalize_github_app_hostname(hostname)
-        config = await sync_to_async(get_github_app_settings)(hostname)
+        config = await aget_github_app_settings(hostname)
         if config is None:
             msg = f"Weblate GitHub app is not configured for {hostname}"
             raise GitHubAppNotConfiguredError(msg)
@@ -766,7 +837,7 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
             installation_id,
             hostname,
         )
-        return await sync_to_async(self.upsert_from_data)(
+        return await self.aupsert_from_data(
             hostname,
             installation_id,
             data,
@@ -780,7 +851,7 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
         """Connect an existing GitHub installation to a Weblate workspace."""
         hostname = normalize_github_app_hostname(hostname)
 
-        installation = await sync_to_async(self.get_for_installation)(
+        installation = await self.aget_for_installation(
             hostname, installation_id, workspace=workspace
         )
         if installation is not None:
@@ -847,7 +918,10 @@ class GitHubInstallation(Installation):
         )
 
     async def refresh_repositories(self) -> list[dict]:
-        config = await sync_to_async(self._require_app_settings)()
+        config = await aget_github_app_settings(self.hostname)
+        if config is None:
+            msg = f"Weblate GitHub app is not configured for {self.hostname}"
+            raise GitHubAppNotConfiguredError(msg)
         repos = await get_app_repositories(
             config.app_id,
             config.private_key,
@@ -856,9 +930,7 @@ class GitHubInstallation(Installation):
         )
         self.repositories = repos
         self.repositories_updated = timezone.now()
-        await sync_to_async(self.save)(
-            update_fields=["repositories", "repositories_updated"]
-        )
+        await self.asave(update_fields=["repositories", "repositories_updated"])
         logger.info(
             "Refreshed %d repositories for connected GitHub account %s/%s",
             len(repos),

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -1327,11 +1327,16 @@ class GitHubInstallationViewTest(ViewTestCase):
             workspace=self.workspace,
         )
 
-        response = self.client.post(
-            reverse("manage-github-account-remove", kwargs={"pk": installation.pk})
+        self.async_client.force_login(self.user)
+        response = async_to_sync(self.async_client.post)(
+            reverse("manage-github-account-remove", kwargs={"pk": installation.pk}),
         )
 
-        self.assertRedirects(response, reverse("manage-github-accounts"))
+        self.assertRedirects(
+            response,
+            reverse("manage-github-accounts"),
+            fetch_redirect_response=False,
+        )
         self.assertFalse(GitHubInstallation.objects.filter(pk=installation.pk).exists())
 
     def test_remove_installation_rejects_get(self):

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -19,7 +19,7 @@ from django.core import signing
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.signing import BadSignature, SignatureExpired
 from django.http import HttpResponse, HttpResponseNotAllowed
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import aget_object_or_404, get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -47,6 +47,8 @@ from weblate.vcs.github import (
     GITHUB_APP_NAME_MAX_LENGTH,
     GitHubAppCredentials,
     GitHubInstallation,
+    aget_github_app_configurations,
+    aget_github_app_settings,
     build_github_app_manifest,
     exchange_github_app_manifest_code,
     exchange_github_user_code,
@@ -94,10 +96,35 @@ def _user_can_install_github_app(user) -> bool:
     return _installation_workspaces(user).exists()
 
 
+async def _auser_can_install_github_app(user) -> bool:
+    await user.aprepare_permissions()
+    return await _installation_workspaces(user).aexists()
+
+
 def _handle_missing_github_app_access(request, next_url: str) -> HttpResponse | None:
     if _user_can_install_github_app(request.user):
         return None
     if request.user.has_perm("management.use") and not Workspace.objects.exists():
+        messages.error(
+            request,
+            gettext(
+                "Create a workspace before connecting a GitHub account. "
+                "GitHub App connections are linked to workspaces."
+            ),
+        )
+        return redirect(next_url)
+    raise PermissionDenied
+
+
+async def _ahandle_missing_github_app_access(
+    request, next_url: str
+) -> HttpResponse | None:
+    if await _auser_can_install_github_app(request.user):
+        return None
+    if (
+        request.user.has_perm("management.use")
+        and not await Workspace.objects.aexists()
+    ):
         messages.error(
             request,
             gettext(
@@ -116,6 +143,18 @@ def _default_next_url(request, workspace: Workspace | None = None) -> str:
             f"{urlencode({'workspace': workspace.pk})}"
         )
     if _managed_workspaces(request.user).exists():
+        return reverse("github-app-repositories")
+    return reverse("manage-github-accounts")
+
+
+async def _adefault_next_url(request, workspace: Workspace | None = None) -> str:
+    if workspace is not None:
+        return (
+            f"{reverse('github-app-repositories')}?"
+            f"{urlencode({'workspace': workspace.pk})}"
+        )
+    await request.user.aprepare_permissions()
+    if await _managed_workspaces(request.user).aexists():
         return reverse("github-app-repositories")
     return reverse("manage-github-accounts")
 
@@ -143,8 +182,12 @@ def _get_managed_workspace(user, workspace_id) -> Workspace:
     return _get_workspace(_managed_workspaces(user), workspace_id)
 
 
-def _get_installation_workspace(user, workspace_id) -> Workspace:
-    return _get_workspace(_installation_workspaces(user), workspace_id)
+async def _aget_installation_workspace(user, workspace_id) -> Workspace:
+    await user.aprepare_permissions()
+    try:
+        return await _installation_workspaces(user).aget(pk=workspace_id)
+    except (Workspace.DoesNotExist, ValidationError, ValueError) as error:
+        raise PermissionDenied from error
 
 
 def _get_requested_workspace(request, workspaces) -> Workspace | None:
@@ -225,7 +268,9 @@ def _build_install_state(
     )
 
 
-def _load_install_state(request, state: str) -> dict[str, str]:
+def _load_install_state(
+    request, state: str, default_next_url: str | None = None
+) -> dict[str, str]:
     payload = signing.loads(
         state,
         salt=_GITHUB_APP_STATE_SALT,
@@ -244,7 +289,7 @@ def _load_install_state(request, state: str) -> dict[str, str]:
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),
     ):
-        next_url = _default_next_url(request)
+        next_url = default_next_url or _default_next_url(request)
 
     hostname = payload.get("host", "")
     if not isinstance(hostname, str):
@@ -289,15 +334,28 @@ def _get_workspace_install_url(
     )
 
 
-def _user_can_use_installation(user, installation: GitHubInstallation) -> bool:
+def _user_can_manage_installation(user, installation: GitHubInstallation) -> bool:
+    return _installation_workspaces(user).filter(pk=installation.workspace_id).exists()
+
+
+async def _auser_can_use_installation(user, installation: GitHubInstallation) -> bool:
+    await user.aprepare_permissions()
+    if user.has_perm("management.use"):
+        return True
     return (
-        user.has_perm("management.use")
-        or _managed_workspaces(user).filter(pk=installation.workspace_id).exists()
+        await _managed_workspaces(user).filter(pk=installation.workspace_id).aexists()
     )
 
 
-def _user_can_manage_installation(user, installation: GitHubInstallation) -> bool:
-    return _installation_workspaces(user).filter(pk=installation.workspace_id).exists()
+async def _auser_can_manage_installation(
+    user, installation: GitHubInstallation
+) -> bool:
+    await user.aprepare_permissions()
+    return (
+        await _installation_workspaces(user)
+        .filter(pk=installation.workspace_id)
+        .aexists()
+    )
 
 
 def _require_installation_access(request, installation: GitHubInstallation) -> None:
@@ -305,8 +363,15 @@ def _require_installation_access(request, installation: GitHubInstallation) -> N
         raise PermissionDenied
 
 
-def _require_installation_use(request, installation: GitHubInstallation) -> None:
-    if not _user_can_use_installation(request.user, installation):
+async def _arequire_installation_access(
+    request, installation: GitHubInstallation
+) -> None:
+    if not await _auser_can_manage_installation(request.user, installation):
+        raise PermissionDenied
+
+
+async def _arequire_installation_use(request, installation: GitHubInstallation) -> None:
+    if not await _auser_can_use_installation(request.user, installation):
         raise PermissionDenied
 
 
@@ -470,11 +535,11 @@ class GitHubInstallationDetailView(View):
 
 
 @login_required
-def remove_installation(request, pk):
+async def remove_installation(request, pk):
     if request.method != "POST":
         return HttpResponseNotAllowed(["POST"])
-    installation = get_object_or_404(GitHubInstallation, pk=pk)
-    _require_installation_access(request, installation)
+    installation = await aget_object_or_404(GitHubInstallation, pk=pk)
+    await _arequire_installation_access(request, installation)
     next_url = _get_redirect_url(
         request,
         (
@@ -484,7 +549,7 @@ def remove_installation(request, pk):
         ),
     )
     target = str(installation)
-    installation.delete()
+    await installation.adelete()
     messages.success(
         request,
         gettext("Removed connected GitHub account %(target)s.") % {"target": target},
@@ -493,13 +558,13 @@ def remove_installation(request, pk):
 
 
 @management_permission_required("management.configure")
-def remove_github_app(request, pk):
+async def remove_github_app(request, pk):
     """Delete the Weblate GitHub App credentials registered for one host."""
     if request.method != "POST":
         return HttpResponseNotAllowed(["POST"])
-    credentials = get_object_or_404(GitHubAppCredentials, pk=pk)
+    credentials = await aget_object_or_404(GitHubAppCredentials, pk=pk)
     hostname = credentials.hostname
-    if GitHubInstallation.objects.filter(hostname=hostname).exists():
+    if await GitHubInstallation.objects.filter(hostname=hostname).aexists():
         messages.error(
             request,
             gettext(
@@ -508,7 +573,7 @@ def remove_github_app(request, pk):
             % {"hostname": hostname},
         )
         return redirect("manage-github-accounts")
-    credentials.delete()
+    await credentials.adelete()
     messages.success(
         request,
         gettext("Removed Weblate GitHub App credentials for %(hostname)s.")
@@ -521,8 +586,8 @@ def remove_github_app(request, pk):
 async def refresh_repositories(request, pk):
     if request.method != "POST":
         return HttpResponseNotAllowed(["POST"])
-    installation = await sync_to_async(get_object_or_404)(GitHubInstallation, pk=pk)
-    await sync_to_async(_require_installation_access)(request, installation)
+    installation = await aget_object_or_404(GitHubInstallation, pk=pk)
+    await _arequire_installation_access(request, installation)
     next_url = _get_redirect_url(
         request,
         _get_installation_repository_url(installation),
@@ -628,7 +693,7 @@ async def _get_authorized_installation(
         return None
 
 
-def _get_update_callback_installation(
+async def _aget_update_callback_installation(
     request, installation_id: str
 ) -> GitHubInstallation | None:
     """
@@ -651,7 +716,8 @@ def _get_update_callback_installation(
     ):
         return None
 
-    configured_hosts = set(get_github_app_configurations())
+    await request.user.aprepare_permissions()
+    configured_hosts = set(await aget_github_app_configurations())
     if not configured_hosts:
         return None
 
@@ -664,10 +730,10 @@ def _get_update_callback_installation(
             workspace__in=_managed_workspaces(request.user)
         )
 
-    return (
+    return await (
         installations.select_related("workspace")
         .order_by("workspace__name", "target_login", "hostname")
-        .first()
+        .afirst()
     )
 
 
@@ -680,7 +746,7 @@ def _get_update_callback_next_url(request, installation: GitHubInstallation) -> 
 @login_required
 async def github_app_setup(request):
     """Finish connecting a GitHub account after GitHub redirects back."""
-    next_url = await sync_to_async(_default_next_url)(request)
+    next_url = await _adefault_next_url(request)
     installation_id = request.GET.get("installation_id", "").strip()
 
     # Handle GitHub's stateless ``setup_on_update`` callback before the stricter
@@ -688,7 +754,7 @@ async def github_app_setup(request):
     # signed ``state``. Signed callbacks fall through to the normal setup flow
     # below.
     if request.GET.get("setup_action") == "update" and not request.GET.get("state"):
-        installation = await sync_to_async(_get_update_callback_installation)(
+        installation = await _aget_update_callback_installation(
             request, installation_id
         )
         if installation:
@@ -696,11 +762,7 @@ async def github_app_setup(request):
                 request,
                 gettext("Connected GitHub account updated."),
             )
-            return redirect(
-                await sync_to_async(_get_update_callback_next_url)(
-                    request, installation
-                )
-            )
+            return redirect(_get_update_callback_next_url(request, installation))
         messages.error(
             request,
             gettext(
@@ -710,21 +772,22 @@ async def github_app_setup(request):
         )
         return redirect(next_url)
 
-    if response := await sync_to_async(_handle_missing_github_app_access)(
-        request, next_url
-    ):
+    if response := await _ahandle_missing_github_app_access(request, next_url):
         return response
 
     hostname = ""
     workspace = None
     try:
-        state = await sync_to_async(_load_install_state)(
-            request, request.GET.get("state", "")
+        state = _load_install_state(
+            request,
+            request.GET.get("state", ""),
+            default_next_url=next_url,
         )
         next_url = str(state["next"])
         hostname = str(state["host"])
-        workspace = await sync_to_async(_get_installation_workspace)(
-            request.user, state["workspace"]
+        workspace = await _aget_installation_workspace(
+            request.user,
+            state["workspace"],
         )
     except (BadSignature, SignatureExpired):
         messages.error(
@@ -751,7 +814,7 @@ async def github_app_setup(request):
         return redirect(next_url)
     installation_id = callback_form.cleaned_data["installation_id"]
 
-    config = await sync_to_async(get_github_app_settings)(hostname or None)
+    config = await aget_github_app_settings(hostname or None)
     if config is None:
         messages.error(
             request,
@@ -791,9 +854,10 @@ async def github_app_setup(request):
             ),
         )
         return redirect(next_url)
-    installation, is_new_install = await sync_to_async(
-        GitHubInstallation.objects.upsert_pending_from_data
-    )(
+    (
+        installation,
+        is_new_install,
+    ) = await GitHubInstallation.objects.aupsert_pending_from_data(
         config.hostname,
         installation_id,
         authorized_installation,
@@ -927,16 +991,16 @@ def github_app_repository_list(request):
 
 
 @login_required
-def github_app_import_repository(request, pk, repo_full_name):
+async def github_app_import_repository(request, pk, repo_full_name):
     """Import a repository selected from a connected GitHub account."""
-    configured_hosts = set(get_github_app_configurations())
-    installation = get_object_or_404(
+    configured_hosts = set(await aget_github_app_configurations())
+    installation = await aget_object_or_404(
         GitHubInstallation.objects.select_related("workspace"),
         pk=pk,
         enabled=True,
         hostname__in=configured_hosts,
     )
-    _require_installation_use(request, installation)
+    await _arequire_installation_use(request, installation)
 
     repository = None
     for entry in installation.repositories:
@@ -959,7 +1023,7 @@ def github_app_import_repository(request, pk, repo_full_name):
     project_id = request.GET.get("project", "").strip()
     if project_id:
         try:
-            selected_project = request.user.managed_projects.get(pk=project_id)
+            selected_project = await request.user.managed_projects.aget(pk=project_id)
         except (Project.DoesNotExist, ValueError) as error:
             raise PermissionDenied from error
         if selected_project.workspace_id != installation.workspace_id:
@@ -969,8 +1033,11 @@ def github_app_import_repository(request, pk, repo_full_name):
     category_id = request.GET.get("category", "").strip()
     if category_id:
         try:
-            selected_category = Category.objects.get(
-                pk=category_id, project__in=request.user.managed_projects
+            selected_category = await Category.objects.select_related(
+                "project__workspace"
+            ).aget(
+                pk=category_id,
+                project__in=request.user.managed_projects,
             )
         except (Category.DoesNotExist, ValueError) as error:
             raise PermissionDenied from error


### PR DESCRIPTION
Avoid blocking request handling on Django's synchronous view bridge for simple database-backed actions while preserving native synchronous callers and existing permission and audit behavior.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
