### PR TITLE
refactor(csp): avoid inline script on error page

### DIFF
--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -332,7 +332,9 @@ Build-time and configuration variants
    * - :setting:`CSP_SCRIPT_SRC`, :setting:`CSP_IMG_SRC`,
        :setting:`CSP_CONNECT_SRC`, :setting:`CSP_STYLE_SRC`,
        :setting:`CSP_FONT_SRC`, :setting:`CSP_FORM_SRC`
-     - Content Security Policy sources are configurable. *(documented)* (source: :doc:`/admin/config`)
+     - Content Security Policy sources are configurable. *(documented)*
+       (source: :doc:`/admin/config`) The default script policy permits inline
+       execution only on explicitly scoped compatibility paths. *(maintainer)*
      - Broadening sources can reduce browser-side containment for XSS or
        third-party content. *(maintainer)*
      - Deployments adding third-party sources accept that expanded browser

--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -384,7 +384,6 @@ class CSPBuilder:
             elif domain.endswith(".sentry.io"):
                 self.directives["script-src"].add("sentry.io")
                 self.directives["connect-src"].add("sentry.io")
-            self.directives["script-src"].add("'unsafe-inline'")
             self.directives["img-src"].add("data:")
 
     def build_csp_piwik(self) -> None:

--- a/weblate/static/js/sentry-feedback.js
+++ b/weblate/static/js/sentry-feedback.js
@@ -1,0 +1,18 @@
+// Copyright © Michal Čihař <michal@weblate.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const sentryFeedback = document.getElementById("sentry-feedback");
+
+window.Sentry.init({ dsn: sentryFeedback.dataset.dsn });
+
+const reportDialogOptions = {
+  eventId: sentryFeedback.dataset.eventId,
+};
+if (sentryFeedback.dataset.userName !== undefined) {
+  reportDialogOptions.user = {
+    name: sentryFeedback.dataset.userName,
+    email: sentryFeedback.dataset.userEmail,
+  };
+}
+window.Sentry.showReportDialog(reportDialogOptions);

--- a/weblate/templates/500.html
+++ b/weblate/templates/500.html
@@ -19,16 +19,11 @@
 
     {% if sentry_dsn %}
       <script src="{% static "js/vendor/sentry.js" %}"></script>
-
-      <script>
-      Sentry.init({ dsn: '{{ sentry_dsn|escapejs }}' });
-      Sentry.showReportDialog({
-        {% if request.user.is_authenticated %}
-          user: { name: "{{ user.full_name|escapejs }}", email: "{{ user.email|escapejs }}" },
-        {% endif %}
-        eventId: '{{ sentry_event_id|escapejs }}'
-      })
-      </script>
+      <script src="{% static 'js/sentry-feedback.js' %}"
+              id="sentry-feedback"
+              data-dsn="{{ sentry_dsn }}"
+              data-event-id="{{ sentry_event_id }}"
+              {% if request.user.is_authenticated %} data-user-name="{{ user.full_name }}" data-user-email="{{ user.email }}" {% endif %}></script>
     {% endif %}
 
   {% else %}

--- a/weblate/trans/tests/test_basic_views.py
+++ b/weblate/trans/tests/test_basic_views.py
@@ -18,6 +18,7 @@ from weblate.auth.models import User
 from weblate.trans.context_processors import weblate_context
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.views.about import FALLBACK_STATS, AboutView, DonateView
+from weblate.trans.views.error import server_error
 from weblate.utils.version import GIT_VERSION, VERSION
 from weblate.utils.version_display import (
     VERSION_DISPLAY_HIDE,
@@ -45,6 +46,31 @@ class BasicViewTest(FixtureTestCase):
         )
         self.assertIn("www.google-analytics.com", script_src)
         self.assertNotIn("'unsafe-inline'", script_src)
+
+    @override_settings(SENTRY_DSN="https://public@example.com/1")
+    @patch("weblate.trans.views.error.last_event_id", return_value="event-id")
+    def test_sentry_feedback(self, _last_event_id) -> None:
+        request = self.client.get(
+            reverse("about"), headers={"accept": "text/html"}
+        ).wsgi_request
+
+        response = server_error(request)
+
+        self.assertContains(response, static("js/vendor/sentry.js"), status_code=500)
+        self.assertContains(response, static("js/sentry-feedback.js"), status_code=500)
+        self.assertContains(
+            response,
+            'data-dsn="https://public@example.com/1"',
+            status_code=500,
+        )
+        self.assertContains(response, 'data-event-id="event-id"', status_code=500)
+        self.assertContains(response, 'data-user-name="Weblate Test"', status_code=500)
+        self.assertContains(
+            response,
+            'data-user-email="weblate@example.org"',
+            status_code=500,
+        )
+        self.assertNotContains(response, "Sentry.init", status_code=500)
 
     def test_keys(self) -> None:
         ensure_ssh_key()

--- a/weblate/utils/tests/test_middleware.py
+++ b/weblate/utils/tests/test_middleware.py
@@ -92,6 +92,21 @@ class CSPBuilderTest(TestCase):
     def setUp(self) -> None:
         self.factory = RequestFactory()
 
+    @override_settings(
+        SENTRY_DSN="https://public@o123.ingest.sentry.io/456",
+    )
+    def test_sentry_error_does_not_allow_inline_scripts(self) -> None:
+        request = self.factory.get("/")
+        request.resolver_match = None
+
+        builder = CSPBuilder(request, HttpResponse(status=500))
+
+        self.assertIn("o123.ingest.sentry.io", builder.directives["script-src"])
+        self.assertIn("sentry.io", builder.directives["script-src"])
+        self.assertIn("o123.ingest.sentry.io", builder.directives["connect-src"])
+        self.assertIn("sentry.io", builder.directives["connect-src"])
+        self.assertNotIn("'unsafe-inline'", builder.directives["script-src"])
+
     @override_settings(STATIC_URL="https://cdn.example.test/static/")
     def test_external_static_url_added_to_worker_src(self) -> None:
         request = self.factory.get("/")


### PR DESCRIPTION
Move Sentry feedback initialization into a static asset so 500 responses no longer need the unsafe-inline script policy.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
