### PR TITLE
fix(backups): filter Mercurial restore configuration

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,7 @@ Weblate 2026.8
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
 * :ref:`Project backup imports <projectbackup>` now validate restored data before creating project state and skip repository-linked components when the importer cannot access the target component.
+* Project backup restores no longer load Mercurial repository configuration or shared-repository indirection supplied by archives.
 * Suggestion submission and rejection now reject excessively long suggestion text and rejection reasons.
 * Restricted components are now available on Hosted Weblate when the billing plan permits private projects.
 * Machine translation and translation memory AJAX lookups no longer disclose whether inaccessible unit IDs exist.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -587,7 +587,9 @@ Security properties Weblate provides
    * - Repository, branch, path, and VCS inputs processed by Weblate must not
        become shell command execution. *(maintainer)*
      - VCS operations are invoked through Weblate-supported repository
-       workflows and configured credentials.
+       workflows and configured credentials. Project backup restores discard
+       archive-supplied repository-local Git and Mercurial configuration, Git
+       hooks, and Mercurial shared-repository indirection.
      - Command injection or arbitrary code execution as the Weblate user.
      - Security-critical.
    * - Private project data, user data, credentials, tokens, SSH keys, and 2FA

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from functools import partial
 from io import BytesIO
 from operator import itemgetter
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from shutil import copyfileobj
 from typing import (
     TYPE_CHECKING,
@@ -944,15 +944,24 @@ class ProjectBackup:
     @staticmethod
     def is_unsafe_vcs_path(path: str) -> bool:
         normalized = path.replace("\\", "/")
+        parts = PurePosixPath(normalized).parts
+        filename = parts[-1] if parts else ""
+        # Mercurial reads hgrc variants and can redirect configuration lookup
+        # through sharedpath.
+        unsafe_mercurial_path = (
+            len(parts) > 1
+            and parts[-2] == ".hg"
+            and (filename.startswith("hgrc") or filename == "sharedpath")
+        )
         return (
-            normalized.endswith(
+            unsafe_mercurial_path
+            or normalized.endswith(
                 (
                     "/.git",
                     "/.git/config",
                     "/.git/config.worktree",
                     "/.git/hooks",
                     "/.git/modules",
-                    "/.hg/hgrc",
                 )
             )
             # Hooks are executable content; Gerrit's commit-msg hook is recreated

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -1599,9 +1599,37 @@ class BackupsTest(ViewTestCase):
 
         self.assertTrue(os.path.isdir(project_path))
 
-    def test_restore_skips_git_hooks(self) -> None:
+    def test_unsafe_vcs_paths(self) -> None:
+        for path in (
+            "test/.hg/hgrc",
+            "test/.hg/hgrc-not-shared",
+            "test/.hg/hgrc-future",
+            "test/nested/.hg/hgrc",
+            "test/.hg/sharedpath",
+            "test\\.hg\\hgrc-not-shared",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(ProjectBackup.is_unsafe_vcs_path(path))
+
+        for path in (
+            "test/hgrc-not-shared",
+            "test/.hg/hgrc.d/example.rc",
+            "test/.hg/store/data/hgrc.i",
+            "test/.hg/store/sharedpath",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(ProjectBackup.is_unsafe_vcs_path(path))
+
+    def test_restore_skips_unsafe_vcs_files(self) -> None:
         backup = ProjectBackup()
         backup.backup_project(self.project)
+        unsafe_paths = (
+            ".git/hooks/post-checkout",
+            ".hg/hgrc",
+            ".hg/hgrc-not-shared",
+            ".hg/hgrc-future",
+            ".hg/sharedpath",
+        )
 
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:
             temp_name = temp_handle.name
@@ -1613,10 +1641,8 @@ class BackupsTest(ViewTestCase):
             ):
                 for item in source_zip.infolist():
                     target_zip.writestr(item, source_zip.read(item.filename))
-                target_zip.writestr(
-                    "vcs/test/.git/hooks/post-checkout",
-                    b"#!/bin/sh\nexit 1\n",
-                )
+                for path in unsafe_paths:
+                    target_zip.writestr(f"vcs/test/{path}", b"unsafe")
 
             restore = ProjectBackup(temp_name)
             restore.validate()
@@ -1626,11 +1652,11 @@ class BackupsTest(ViewTestCase):
             component = restored.component_set.get(slug="test")
             repository = component.repository
             assert isinstance(repository, GitRepository)
-            self.assertFalse(
-                os.path.exists(
-                    os.path.join(component.full_path, ".git", "hooks", "post-checkout")
-                )
-            )
+            for path in unsafe_paths:
+                with self.subTest(path=path):
+                    self.assertFalse(
+                        os.path.exists(os.path.join(component.full_path, path))
+                    )
             self.assertEqual(repository.get_config("remote.origin.url"), component.repo)
             self.assertEqual(
                 repository.get_config(f"branch.{component.branch}.remote"),


### PR DESCRIPTION
Mercurial loads additional repository-local configuration and shared-repository indirection from restored metadata. Filter those archive members to prevent attacker-supplied hooks from executing after restore.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
