### PR TITLE
fix(backups): match VCS metadata case-insensitively

### DIFF
--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -944,7 +944,8 @@ class ProjectBackup:
     @staticmethod
     def is_unsafe_vcs_path(path: str) -> bool:
         normalized = path.replace("\\", "/")
-        parts = PurePosixPath(normalized).parts
+        casefolded = normalized.casefold()
+        parts = PurePosixPath(casefolded).parts
         filename = parts[-1] if parts else ""
         # Mercurial reads hgrc variants and can redirect configuration lookup
         # through sharedpath.
@@ -955,7 +956,7 @@ class ProjectBackup:
         )
         return (
             unsafe_mercurial_path
-            or normalized.endswith(
+            or casefolded.endswith(
                 (
                     "/.git",
                     "/.git/config",
@@ -966,8 +967,8 @@ class ProjectBackup:
             )
             # Hooks are executable content; Gerrit's commit-msg hook is recreated
             # by git-review when needed.
-            or "/.git/hooks/" in normalized
-            or "/.git/modules/" in normalized
+            or "/.git/hooks/" in casefolded
+            or "/.git/modules/" in casefolded
         )
 
     @classmethod

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -1607,6 +1607,12 @@ class BackupsTest(ViewTestCase):
             "test/nested/.hg/hgrc",
             "test/.hg/sharedpath",
             "test\\.hg\\hgrc-not-shared",
+            "test/.HG/HGRC-NOT-SHARED",
+            "test/.Hg/HgRc-Future",
+            "test/.HG/SHAREDPATH",
+            "test/.GIT/CONFIG",
+            "test/.GiT/HOOKS/pre-commit",
+            "test/.GIT/MODULES/submodule/config",
         ):
             with self.subTest(path=path):
                 self.assertTrue(ProjectBackup.is_unsafe_vcs_path(path))
@@ -1616,6 +1622,9 @@ class BackupsTest(ViewTestCase):
             "test/.hg/hgrc.d/example.rc",
             "test/.hg/store/data/hgrc.i",
             "test/.hg/store/sharedpath",
+            "test/.HG/store/data/HGRC.i",
+            "test/.GITISH/HOOKS/pre-commit",
+            "test/.git/hooks-backup/pre-commit",
         ):
             with self.subTest(path=path):
                 self.assertFalse(ProjectBackup.is_unsafe_vcs_path(path))
@@ -1629,6 +1638,10 @@ class BackupsTest(ViewTestCase):
             ".hg/hgrc-not-shared",
             ".hg/hgrc-future",
             ".hg/sharedpath",
+            ".HG/HGRC-NOT-SHARED",
+            ".Hg/SharedPath",
+            ".GIT/HOOKS/pre-commit",
+            ".GiT/CONFIG",
         )
 
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:


### PR DESCRIPTION
Case-insensitive filesystems resolve mixed-case Git and Mercurial metadata as their lowercase security-sensitive paths. Case-fold denylist comparisons to prevent crafted backup members from bypassing restore filtering.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
