### PR TITLE
fix: sorting on non-paginated lists

### DIFF
--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -512,6 +512,11 @@ class LanguagesViewTest(FixtureTestCase):
         response = self.client.get(reverse("languages"))
         self.assertContains(response, "Czech")
 
+    def test_languages_sortable(self) -> None:
+        """Client-side sorting must stay enabled for non-paginated listings."""
+        response = self.client.get(reverse("languages"))
+        self.assertContains(response, "sort table progress-table autocolspan")
+
     def test_language(self) -> None:
         response = self.client.get(reverse("show_language", kwargs={"lang": "cs"}))
         self.assertContains(response, "Czech")

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -1,7 +1,7 @@
 {% load humanize i18n icons permissions translations %}
 
 {% if objects or list_categories %}
-  <table class="{% if objects.paginator.num_pages <= 1 %}sort {% endif %}table progress-table autocolspan table-listing{% if show_workspace_details %} table-striped{% endif %}">
+  <table class="{% if not objects.paginator or objects.paginator.num_pages <= 1 %}sort {% endif %}table progress-table autocolspan table-listing{% if show_workspace_details %} table-striped{% endif %}">
     {% if not hide_details and not hide_header %}
       <thead class="sticky-header">
         <tr>

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -947,6 +947,46 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
             "inner",
         )
 
+    def test_table_sorting(self) -> None:
+        """Clicking sortable table headers reorders the rows client-side."""
+        # Load a page so that loader-bootstrap.js is loaded
+        with self.wait_for_page_load():
+            self.driver.get(f"{self.live_server_url}{reverse('languages')}")
+
+        result = self.driver.execute_script(
+            r"""
+            const table = document.createElement("table");
+            table.className = "sort";
+            table.innerHTML = `
+              <thead><tr>
+                <th class="sort-skip"></th>
+                <th class="sort-cell">Name</th>
+                <th class="number sort-cell"><span class="sort-icon"> </span>Count</th>
+              </tr></thead>
+              <tbody>
+                <tr id="9row-1"><td></td><th class="object-link">Beta</th><td class="number" data-value="30">30</td></tr>
+                <tr data-parent="9row-1"><td colspan="3">progress</td></tr>
+                <tr id="9row-2"><td></td><th class="object-link">Alpha</th><td class="number" data-value="10">10</td></tr>
+                <tr data-parent="9row-2"><td colspan="3">progress</td></tr>
+                <tr id="9row-3"><td></td><th class="object-link">Gamma</th><td class="number" data-value="20">20</td></tr>
+                <tr data-parent="9row-3"><td colspan="3">progress</td></tr>
+              </tbody>`;
+            document.body.appendChild(table);
+            loadTableSorting();
+            const header = table.querySelectorAll("thead th")[2];
+            const readNames = () => Array.from(
+                table.querySelectorAll("tbody tr[id] th.object-link")
+            ).map((el) => el.textContent.trim());
+            header.click();
+            const ascending = readNames();
+            header.click();
+            const descending = readNames();
+            return {ascending: ascending, descending: descending};
+            """
+        )
+        self.assertEqual(result["ascending"], ["Alpha", "Gamma", "Beta"])
+        self.assertEqual(result["descending"], ["Beta", "Gamma", "Alpha"])
+
     def test_hotkeys(self) -> None:
         """Test hotkeys functionality."""
         # Check that the hotkeys library is loaded and the filter is overridden by our wrapper.


### PR DESCRIPTION
the `sort` class was dropped from the list-objects template somehow which broke js sorting. Also adds regression tests to hopefully prevent sorting from breaking again
fixes #19724
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
