### PR TITLE
fix: honor documented HTTP proxy settings

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -105,8 +105,8 @@ trusted when deciding whether remote provider error details or response bodies
 can be shown to the user. Matching hosts are also exempt from private-target
 restrictions. For direct connections, Weblate does not resolve, pin, or verify
 the peer address of matching hosts. Only add hosts or domains whose network
-destinations are trusted. When an HTTP(S) proxy is used, the proxy is trusted
-to resolve the destination hostname.
+destinations are trusted. When a configured :ref:`http-proxy` is used, the
+proxy is trusted to resolve the destination hostname.
 
 .. setting:: ALLOWED_ASSET_SIZE
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -639,11 +639,13 @@ Client protocol
    * :envvar:`WEBLATE_IP_PROXY_HEADER`
    * :envvar:`WEBLATE_IP_PROXY_OFFSET`
 
+.. _http-proxy:
+
 HTTP proxy
 ++++++++++
 
-Weblate does execute VCS commands and those accept proxy configuration from
-environment. The recommended approach is to define proxy settings in
+Weblate supports per-protocol HTTP proxy configuration for outbound HTTP
+requests and Git repositories. Define the proxy environment variables in
 :file:`settings.py`:
 
 .. code-block:: python
@@ -651,11 +653,15 @@ environment. The recommended approach is to define proxy settings in
    import os
 
    os.environ["http_proxy"] = "http://proxy.example.com:8080"
-   os.environ["HTTPS_PROXY"] = "http://proxy.example.com:8080"
+   os.environ["https_proxy"] = "http://proxy.example.com:8080"
+
+Only ``http_proxy`` and ``https_proxy`` are supported. Generic and bypass
+variables such as ``all_proxy`` and ``no_proxy``, operating-system proxy
+configuration, and VCS-specific proxy configuration are not supported.
 
 .. seealso::
 
-   `Proxy Environment Variables <https://everything.curl.dev/usingcurl/proxies/env.html>`_
+   `Proxy environment variables <https://everything.curl.dev/usingcurl/proxies/env.html>`_
 
 .. _configuration:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -61,6 +61,7 @@ Weblate 2026.8
 * django-compressor is no longer used, and the ``COMPRESS_*`` settings have been removed.
 * Legal document styling is now provided through an overridable template instead of Weblate's global stylesheet. See :ref:`legal-customization`.
 * When :setting:`VCS_RESTRICT_PRIVATE` is enabled, Mercurial and Subversion repository hosts must be explicitly included in :setting:`VCS_ALLOW_HOSTS`; Git over HTTPS and SSH enforces connection address pinning without an allowlist entry.
+* Outbound HTTP proxy configuration is limited to the per-protocol environment variables documented in :ref:`http-proxy`.
 * Git SSH validates configured ``HostName`` and ``Port`` destinations before connecting; administrator SSH configuration remains trusted, and :setting:`SSH_EXTRA_ARGS` can override connection routing and address pinning.
 * Git LFS object transfers are unsupported and disabled for Weblate-managed repositories; LFS-tracked files remain pointer files.
 * The project and component ``credits`` REST API endpoints and their ``credits_url`` response fields have been replaced by scoped ``reports`` endpoints and ``reports_url``. Credits report generation is now asynchronous; clients need to submit a ``credits`` report, follow the returned task URL, and fetch the completed report. See :http:post:`/api/reports/`.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -359,18 +359,18 @@ Build-time and configuration variants
        :setting:`PROJECT_WEB_RESTRICT_PRIVATE`,
        :setting:`WEBHOOK_RESTRICT_PRIVATE`, :setting:`VCS_RESTRICT_PRIVATE`)
        Protected direct HTTP requests are bound to addresses approved by
-       runtime validation; configured proxies are trusted infrastructure and
-       resolve their destination hosts.
+       runtime validation; configured per-protocol HTTP proxies are trusted
+       infrastructure and resolve their destination hosts.
        Protected Git HTTPS and SSH operations are bound to addresses approved
        by runtime validation. Protected SSH operations validate the effective
        ``HostName`` and ``Port``. Trusted administrator SSH configuration can
        alter routing, and :setting:`SSH_EXTRA_ARGS` can override connection
        binding. Permanent same-host Git HTTP redirects are probed without
        automatic redirect following. Every direct destination is independently
-       validated and bound before use; configured HTTP proxies use the shared
-       trusted outbound routing. Git LFS object transfers are disabled and
-       outside the supported VCS integration surface. VCS clients without
-       connection binding require an explicit trusted-host exemption.
+       validated and bound before use; configured per-protocol HTTP proxies use
+       the shared trusted outbound routing. Git LFS object transfers are
+       disabled and outside the supported VCS integration surface. VCS clients
+       without connection binding require an explicit trusted-host exemption.
        *(maintainer)*
      - Allowlist settings and privileged configuration can intentionally expand
        reachability. Fedora Messaging broker URLs are site-administrator
@@ -614,7 +614,8 @@ Security properties Weblate provides
        exemption applies. Direct protected HTTP requests and Git HTTPS and SSH
        operations retain address binding, VCS restrictions remain enabled,
        and VCS backends without binding use only explicitly trusted hosts.
-       Configured proxies remain trusted routing infrastructure.
+       Configured per-protocol HTTP proxies remain trusted routing
+       infrastructure.
      - A user-configurable screenshot URL, remote HTML URL, project website or
        repository browser URL, outbound webhook URL, or VCS URL reaches an
        internal or non-public target despite default controls.

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -282,28 +282,8 @@ In case you don't provide credentials in the URL and the repository requires it,
 Using proxy
 +++++++++++
 
-If you need to access HTTP/HTTPS VCS repositories using a proxy server,
-configure the VCS to use it.
-
-This can be done using the ``http_proxy``, ``https_proxy``, and ``all_proxy``
-environment variables, (as described in the `cURL documentation <https://curl.se/docs/>`_)
-or by enforcing it in the VCS configuration, for example:
-
-.. code-block:: sh
-
-    git config --global http.proxy http://user:password@proxy.example.com:80
-
-.. note::
-
-    The proxy configuration needs to be done under user running Weblate (see
-    also :ref:`file-permissions`) and with ``HOME=$DATA_DIR/home`` (see
-    :setting:`DATA_DIR`), otherwise Git executed by Weblate will not use it.
-
-.. seealso::
-
-    * `The cURL manpage <https://curl.se/docs/manpage.html>`_
-    * `Git config documentation <https://git-scm.com/docs/git-config>`_
-
+If you need to access Git repositories over HTTPS using a proxy server,
+configure the per-protocol environment variables described in :ref:`http-proxy`.
 
 .. _vcs-git:
 

--- a/weblate/utils/commands.py
+++ b/weblate/utils/commands.py
@@ -94,7 +94,6 @@ def get_clean_env(
         "http_proxy",
         "https_proxy",
         "HTTPS_PROXY",
-        "NO_PROXY",
         # below two are needed for openshift3 deployment,
         # where nss_wrapper is used
         # more on the topic on below link:

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -9,6 +9,7 @@ import socket
 from asyncio import get_running_loop
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
+from urllib.request import getproxies_environment
 
 from django.core.exceptions import ValidationError
 from django.http.request import validate_host
@@ -42,6 +43,14 @@ _NON_PUBLIC_SPECIAL_USE_PREFIXES: tuple[
     ipaddress.IPv6Network("5f00::/16"),  # IPv6 Segment Routing
     ipaddress.IPv6Network("2001:20::/28"),  # ORCHIDv2
 )
+
+
+def get_environment_proxy(url: str) -> str | None:
+    """Return the per-protocol environment proxy configured for a URL."""
+    scheme = urlparse(url).scheme
+    if scheme not in {"http", "https"}:
+        return None
+    return getproxies_environment().get(scheme)
 
 
 def _parse_ip(value: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:

--- a/weblate/utils/requests.py
+++ b/weblate/utils/requests.py
@@ -11,11 +11,9 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
-from ipaddress import ip_address, ip_network
 from time import monotonic
 from typing import TYPE_CHECKING, Any, Self, cast
 from urllib.parse import urlparse
-from urllib.request import getproxies, proxy_bypass
 
 import httpx2
 from django.core.cache import cache
@@ -25,6 +23,7 @@ from django.utils.translation import gettext
 from weblate.logger import LOGGER
 from weblate.utils.outbound import (
     async_resolve_runtime_hostname,
+    get_environment_proxy,
     is_allowlisted_hostname,
     resolve_runtime_hostname,
     validate_connected_peer,
@@ -161,48 +160,6 @@ def _prepare_headers(headers: dict[str, str] | None) -> dict[str, str]:
     return {**headers, **agent} if headers is not None else agent
 
 
-def _matches_no_proxy(hostname: str, port: int | None, no_proxy: str) -> bool:
-    no_proxy_hosts = (host for host in no_proxy.replace(" ", "").split(",") if host)
-    try:
-        address = ip_address(hostname)
-    except ValueError:
-        host_with_port = hostname if port is None else f"{hostname}:{port}"
-        for host in no_proxy_hosts:
-            host = host.lstrip(".").lower()
-            if host in {hostname, host_with_port}:
-                return True
-            suffix = f".{host}"
-            if hostname.endswith(suffix) or host_with_port.endswith(suffix):
-                return True
-    else:
-        for host in no_proxy_hosts:
-            try:
-                if address in ip_network(host, strict=False):
-                    return True
-            except ValueError:
-                if hostname == host:
-                    return True
-    return False
-
-
-def _get_proxy(url: str) -> str | None:
-    parsed = urlparse(url)
-    if not parsed.hostname:
-        return None
-    proxies = getproxies()
-    if (no_proxy := proxies.get("no")) and _matches_no_proxy(
-        parsed.hostname, parsed.port, no_proxy
-    ):
-        return None
-    if proxy_bypass(parsed.hostname):
-        return None
-    return proxies.get(parsed.scheme) or proxies.get("all")
-
-
-def _request_uses_proxy(url: str) -> bool:
-    return _get_proxy(url) is not None
-
-
 def validate_request_url(
     url: str,
     *,
@@ -212,7 +169,7 @@ def validate_request_url(
     RuntimeRedirectValidators(
         allow_private_targets=allow_private_targets,
         private_allowlist=private_allowlist,
-    ).validate_request_url(url, used_proxy=_request_uses_proxy(url))
+    ).validate_request_url(url, used_proxy=get_environment_proxy(url) is not None)
 
 
 def _get_response_peer_ip(response: httpx2.Response) -> str | None:
@@ -369,7 +326,7 @@ def _prepare_outbound_request(request: httpx2.Request) -> OutboundRequest:
     request_url = str(request.url)
     return OutboundRequest(
         url=request_url,
-        proxy=_get_proxy(request_url),
+        proxy=get_environment_proxy(request_url),
         validators=cast(
             "RedirectValidators | None",
             request.extensions.get(VALIDATORS_REQUEST_EXTENSION),

--- a/weblate/utils/tests/test_commands.py
+++ b/weblate/utils/tests/test_commands.py
@@ -201,6 +201,24 @@ class RuntimeCommandTests(SimpleTestCase):
 
         self.assertNotIn("FONTCONFIG_FILE", env)
 
+    def test_get_clean_env_only_preserves_per_protocol_proxies(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "http_proxy": "http://http-proxy.example:8080",
+                "https_proxy": "http://https-proxy.example:8080",
+                "all_proxy": "http://generic-proxy.example:8080",
+                "no_proxy": "*",
+            },
+            clear=True,
+        ):
+            env = get_clean_env()
+
+        self.assertEqual(env["http_proxy"], "http://http-proxy.example:8080")
+        self.assertEqual(env["https_proxy"], "http://https-proxy.example:8080")
+        self.assertNotIn("all_proxy", env)
+        self.assertNotIn("no_proxy", env)
+
     def test_get_clean_env_includes_runtime_and_venv_paths(self) -> None:
         with (
             patch("weblate.utils.commands.sys.executable", "/runtime/bin/python"),

--- a/weblate/utils/tests/test_requests.py
+++ b/weblate/utils/tests/test_requests.py
@@ -14,11 +14,11 @@ from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
+from weblate.utils.outbound import get_environment_proxy
 from weblate.utils.requests import (
     PEER_IP_RESPONSE_ATTR,
     AsyncHTTPClient,
     HTTPClient,
-    _get_proxy,
     _get_response_peer_ip,
     _validate_response_peer,
     async_fetch_validated_url,
@@ -59,39 +59,35 @@ class TrackedRedirectAsyncStream(TrackedAsyncStream):
 
 
 class FetchURLTest(SimpleTestCase):
-    @patch(
-        "weblate.utils.requests.getproxies",
-        return_value={
-            "https": "http://proxy.example:8080",
-            "no": "example.com:8443",
-        },
-    )
-    @patch("weblate.utils.requests.proxy_bypass", return_value=False)
-    def test_get_proxy_honors_no_proxy_port(
-        self, mocked_proxy_bypass, mocked_getproxies
-    ) -> None:
-        self.assertIsNone(_get_proxy("https://example.com:8443/source"))
-        self.assertEqual(
-            _get_proxy("https://example.com:443/source"),
-            "http://proxy.example:8080",
-        )
+    def test_environment_proxy_uses_per_protocol_environment(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "http_proxy": "http://http-proxy.example:8080",
+                "https_proxy": "http://https-proxy.example:8080",
+                "all_proxy": "http://generic-proxy.example:8080",
+                "ftp_proxy": "http://ftp-proxy.example:8080",
+                "no_proxy": "*",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                get_environment_proxy("http://example.com/source"),
+                "http://http-proxy.example:8080",
+            )
+            self.assertEqual(
+                get_environment_proxy("https://example.com/source"),
+                "http://https-proxy.example:8080",
+            )
+            self.assertIsNone(get_environment_proxy("ftp://example.com/source"))
 
-    @patch(
-        "weblate.utils.requests.getproxies",
-        return_value={
-            "https": "http://proxy.example:8080",
-            "no": "10.0.0.0/8",
-        },
-    )
-    @patch("weblate.utils.requests.proxy_bypass", return_value=False)
-    def test_get_proxy_honors_no_proxy_cidr(
-        self, mocked_proxy_bypass, mocked_getproxies
-    ) -> None:
-        self.assertIsNone(_get_proxy("https://10.1.2.3/source"))
-        self.assertEqual(
-            _get_proxy("https://192.0.2.1/source"),
-            "http://proxy.example:8080",
-        )
+    def test_environment_proxy_does_not_use_all_proxy(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"all_proxy": "http://generic-proxy.example:8080"},
+            clear=True,
+        ):
+            self.assertIsNone(get_environment_proxy("https://example.com/source"))
 
     @responses.activate
     def test_fetch_url_omits_null_form_values(self) -> None:

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -910,7 +910,6 @@ class RepoURLValidationTestCase(SimpleTestCase):
         self.assertIsNotNone(target)
         assert target is not None
         self.assertEqual(target.hostname, "example.com")
-        self.assertEqual(target.connection_hostname, "example.com")
         self.assertEqual(target.port, 443)
         self.assertEqual(target.addresses, ("93.184.216.34", "2001:4860:4860::8888"))
         self.assertTrue(target.requires_pinning)
@@ -1099,6 +1098,38 @@ class RepoURLValidationTestCase(SimpleTestCase):
 
         self.assertIn("Could not resolve the URL domain", str(error.exception))
         mocked_getaddrinfo.assert_called_once_with("unresolved.example", None, type=1)
+
+    @patch(
+        "weblate.utils.outbound.socket.getaddrinfo",
+        side_effect=OSError("Name or service not known"),
+    )
+    def test_proxy_resolves_repository_hostname(self, mocked_getaddrinfo) -> None:
+        with (
+            override_settings(VCS_ALLOW_SCHEMES={"https", "ssh"}),
+            patch.dict(
+                os.environ,
+                {"https_proxy": "http://proxy.example:8080"},
+                clear=True,
+            ),
+        ):
+            validate_repo_url("https://unresolved.example/repo.git")
+
+        mocked_getaddrinfo.assert_not_called()
+
+    def test_proxy_rejects_private_repository_address(self) -> None:
+        with (
+            override_settings(VCS_ALLOW_SCHEMES={"https", "ssh"}),
+            patch.dict(
+                os.environ,
+                {"https_proxy": "http://proxy.example:8080"},
+                clear=True,
+            ),
+            self.assertRaisesMessage(
+                ValidationError,
+                "internal or non-public address",
+            ),
+        ):
+            validate_repo_url("https://127.0.0.1/repo.git")
 
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",

--- a/weblate/utils/validators.py
+++ b/weblate/utils/validators.py
@@ -42,6 +42,7 @@ from weblate.utils.data import data_dir
 from weblate.utils.errors import report_error
 from weblate.utils.files import is_unsafe_path, is_vcs_metadata_path, read_file_bytes
 from weblate.utils.outbound import (
+    get_environment_proxy,
     is_allowlisted_hostname,
     resolve_runtime_hostname,
     validate_outbound_hostname,
@@ -903,16 +904,14 @@ def validate_fedora_messaging_url(value: str) -> None:
 
 @dataclass(frozen=True, slots=True)
 class ResolvedRepositoryURL:
-    """Validated repository URL and addresses approved for connecting."""
+    """Validated repository URL and approved outbound route."""
 
-    url: str
-    normalized_url: str
     scheme: str
     hostname: str
-    connection_hostname: str
     port: int | None
     addresses: tuple[str, ...]
     requires_pinning: bool
+    proxy_url: str | None
 
 
 def resolve_repo_hostname(
@@ -942,8 +941,9 @@ def resolve_repo_url(
     *,
     ssh_destination_resolver: Callable[[str, str | None, int | None], tuple[str, int]]
     | None = None,
+    proxy_url: str | None = None,
 ) -> ResolvedRepositoryURL | None:
-    """Validate a repository URL and retain its approved DNS resolution."""
+    """Validate a repository URL and retain its approved outbound route."""
     normalized_url = url
     parsed = urlparse(normalized_url)
     implicit_ssh = not parsed.scheme
@@ -1017,20 +1017,25 @@ def resolve_repo_url(
             hostname, parsed.username, explicit_port
         )
 
-    addresses = resolve_repo_hostname(
-        connection_hostname,
-        policy_hostname=hostname,
-    )
+    if proxy_url is None:
+        addresses = resolve_repo_hostname(
+            connection_hostname,
+            policy_hostname=hostname,
+        )
+    else:
+        validate_outbound_hostname(
+            hostname,
+            allow_private_targets=allow_private_targets,
+        )
+        addresses = ()
 
     return ResolvedRepositoryURL(
-        url=url,
-        normalized_url=normalized_url,
         scheme=parsed.scheme,
         hostname=hostname,
-        connection_hostname=connection_hostname,
         port=port,
         addresses=addresses,
         requires_pinning=not allow_private_targets,
+        proxy_url=proxy_url,
     )
 
 
@@ -1040,7 +1045,11 @@ def validate_repo_url(url: str) -> None:
         resolve_ssh_destination,
     )
 
-    resolve_repo_url(url, ssh_destination_resolver=resolve_ssh_destination)
+    resolve_repo_url(
+        url,
+        ssh_destination_resolver=resolve_ssh_destination,
+        proxy_url=get_environment_proxy(url),
+    )
 
 
 @deconstructible

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -47,6 +47,7 @@ from weblate.utils.files import (
     remove_tree,
 )
 from weblate.utils.lock import WeblateLock
+from weblate.utils.outbound import get_environment_proxy
 from weblate.vcs.ssh import SSH_WRAPPER
 
 if TYPE_CHECKING:
@@ -752,6 +753,7 @@ class Repository:
             target = resolve_repo_url(
                 url,
                 ssh_destination_resolver=cls.get_ssh_destination_resolver(),
+                proxy_url=get_environment_proxy(url),
             )
         except ValidationError as error:
             raise RepositoryValidationError(0, "; ".join(error.messages)) from error

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -57,7 +57,6 @@ from weblate.utils.requests import (
     JSON_RESPONSE_ERRORS,
     HTTPClient,
     RedirectValidators,
-    _get_proxy,
     fetch_url,
 )
 from weblate.utils.tracing import start_span
@@ -299,6 +298,22 @@ def _get_git_probe_headers(
     return headers
 
 
+def _with_git_http_proxy(
+    environment: dict[str, str] | None,
+    proxy: str,
+) -> dict[str, str]:
+    """Configure Git's proxy without exposing it in command arguments."""
+    result = dict(environment or {})
+    try:
+        index = int(result.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        index = 0
+    result["GIT_CONFIG_COUNT"] = str(index + 1)
+    result[f"GIT_CONFIG_KEY_{index}"] = "http.proxy"
+    result[f"GIT_CONFIG_VALUE_{index}"] = proxy
+    return result
+
+
 def _request_git_probe(
     repository_url: str,
     target: ResolvedRepositoryURL,
@@ -475,35 +490,39 @@ class GitRepository(Repository):
             return args, environment
 
         if target.scheme in {"http", "https"}:
-            resolve_options: list[str] = []
-            proxy = _get_proxy(target.url)
-            proxy_environment = environment
+            proxy = target.proxy_url
             if proxy is not None:
-                proxy_environment = dict(environment or {})
-                proxy_environment[f"{target.scheme}_proxy"] = proxy
-            elif target.requires_pinning:
-                try:
-                    ip_address(target.hostname)
-                except ValueError:
-                    resolve_hostname = idna_encode(target.hostname, uts46=True).decode(
-                        "ascii"
-                    )
-                    addresses = ",".join(
-                        f"[{address}]" if ":" in address else address
-                        for address in target.addresses
-                    )
-                    resolve_options = [
-                        "-c",
-                        f"http.curloptResolve={resolve_hostname}:{target.port}:{addresses}",
-                    ]
+                environment = _with_git_http_proxy(
+                    environment,
+                    proxy,
+                )
+                connection_options: list[str] = []
+            else:
+                connection_options = ["-c", "http.proxy="]
+                if target.requires_pinning:
+                    try:
+                        ip_address(target.hostname)
+                    except ValueError:
+                        resolve_hostname = idna_encode(
+                            target.hostname, uts46=True
+                        ).decode("ascii")
+                        addresses = ",".join(
+                            f"[{address}]" if ":" in address else address
+                            for address in target.addresses
+                        )
+                        connection_options = [
+                            *connection_options,
+                            "-c",
+                            f"http.curloptResolve={resolve_hostname}:{target.port}:{addresses}",
+                        ]
             return (
                 [
-                    *resolve_options,
+                    *connection_options,
                     "-c",
                     "http.followRedirects=false",
                     *args,
                 ],
-                proxy_environment,
+                environment,
             )
 
         if target.scheme == "ssh" and target.requires_pinning:

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -1300,7 +1300,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
 
         with (
             patch(
-                "weblate.utils.requests._get_proxy",
+                "weblate.utils.requests.get_environment_proxy",
                 return_value=None,
             ),
             patch("weblate.utils.version.USER_AGENT", "Weblate/test"),
@@ -1503,7 +1503,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                     (0, 0, 0, "", ("2001:4860:4860::8888", 443, 0, 0)),
                 ],
             ),
-            patch("weblate.vcs.git._get_proxy", return_value=None),
+            patch("weblate.vcs.base.get_environment_proxy", return_value=None),
             patch.object(
                 GitRepository,
                 "_popen",
@@ -1515,8 +1515,10 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         self.assertEqual(branch, "main")
         args = popen.call_args.args[0]
         self.assertEqual(
-            args[:4],
+            args[:6],
             [
+                "-c",
+                "http.proxy=",
                 "-c",
                 "http.curloptResolve=git.example:443:93.184.216.34,[2001:4860:4860::8888]",
                 "-c",
@@ -1533,13 +1535,13 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         with (
             patch.dict(
                 os.environ,
-                {"ALL_PROXY": "http://proxy.example:8080"},
+                {"https_proxy": "http://proxy.example:8080"},
                 clear=True,
             ),
             patch(
                 "weblate.utils.outbound.socket.getaddrinfo",
-                return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
-            ),
+                side_effect=OSError("Name or service not known"),
+            ) as getaddrinfo,
             patch.object(
                 GitRepository,
                 "_popen",
@@ -1549,6 +1551,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
             branch = GitRepository.get_remote_branch("https://git.example/repo.git")
 
         self.assertEqual(branch, "main")
+        getaddrinfo.assert_not_called()
         args = popen.call_args.args[0]
         self.assertNotIn(
             "http.curloptResolve=git.example:443:93.184.216.34",
@@ -1559,11 +1562,44 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         environment = popen.call_args.kwargs["environment"]
         self.assertEqual(
             environment,
-            {"https_proxy": "http://proxy.example:8080"},
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "http.proxy",
+                "GIT_CONFIG_VALUE_0": "http://proxy.example:8080",
+            },
         )
         self.assertEqual(
-            GitRepository._getenv(environment)["https_proxy"],  # ruff: ignore[private-member-access]
+            GitRepository._getenv(environment)[  # ruff: ignore[private-member-access]
+                "GIT_CONFIG_VALUE_0"
+            ],
             "http://proxy.example:8080",
+        )
+
+    def test_https_proxy_preserves_command_authentication(self) -> None:
+        authentication = {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.extraHeader",
+            "GIT_CONFIG_VALUE_0": "Authorization: Basic secret",
+        }
+        target = SimpleNamespace(
+            scheme="https",
+            proxy_url="http://proxy.example:8080",
+        )
+
+        _args, environment = GitRepository.prepare_remote_command(
+            ["fetch"],
+            authentication,
+            target,  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(
+            environment,
+            {
+                **authentication,
+                "GIT_CONFIG_COUNT": "2",
+                "GIT_CONFIG_KEY_1": "http.proxy",
+                "GIT_CONFIG_VALUE_1": "http://proxy.example:8080",
+            },
         )
 
     @override_settings(
@@ -1577,7 +1613,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                 "weblate.utils.outbound.socket.getaddrinfo",
                 return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
             ) as getaddrinfo,
-            patch("weblate.vcs.git._get_proxy", return_value=None),
+            patch("weblate.vcs.base.get_environment_proxy", return_value=None),
             patch.object(
                 GitRepository,
                 "_popen",
@@ -1604,7 +1640,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         ):
             with (
                 self.subTest(url=url),
-                patch("weblate.vcs.git._get_proxy", return_value=None),
+                patch("weblate.vcs.base.get_environment_proxy", return_value=None),
                 patch.object(
                     GitRepository,
                     "_popen",
@@ -1618,7 +1654,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                 any(arg.startswith("http.curloptResolve=") for arg in args)
             )
             self.assertIn("http.followRedirects=false", args)
-            self.assertNotIn("http.proxy=", args)
+            self.assertIn("http.proxy=", args)
 
     @override_settings(
         VCS_ALLOW_HOSTS=set(),
@@ -1632,7 +1668,7 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                 "weblate.utils.outbound.socket.getaddrinfo",
                 return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
             ) as getaddrinfo,
-            patch("weblate.vcs.git._get_proxy", return_value=None),
+            patch("weblate.vcs.base.get_environment_proxy", return_value=None),
             patch.object(GitRepository, "validate_branch_name", return_value="main"),
             patch.object(GitRepository, "_popen", return_value="") as popen,
         ):


### PR DESCRIPTION
Keep outbound validation and Git transport on the same proxy route so proxy-side DNS works reliably. Limit support to per-protocol environment variables to keep behavior predictable and the implementation focused.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
