### PR TITLE
docs: update external documentation links

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -507,7 +507,7 @@ This can be done in :guilabel:`Webhooks` under repository :guilabel:`Settings`.
 
 .. seealso::
 
-   * `Webhooks in Gitea manual <https://docs.gitea.io/en-us/webhooks/>`_
+   * `Webhooks in Gitea manual <https://docs.gitea.com/usage/repository/webhooks>`_
    * :http:post:`/hooks/gitea/`
    * :ref:`hosted-push`
 
@@ -547,7 +547,7 @@ repository, while the :guilabel:`Gitea` backend creates pull requests.
 To create pull requests, select :guilabel:`Gitea` as
 :ref:`component-vcs` and configure :setting:`GITEA_CREDENTIALS`.
 
-.. _Gitea API: https://docs.gitea.io/en-us/api-usage/
+.. _Gitea API: https://docs.gitea.com/development/api-usage
 
 .. _code-hosting-bitbucket:
 

--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -997,7 +997,7 @@ List for credentials for Gitea servers.
    * :ref:`code-hosting-gitea-pull-requests`
    * `Creating a Gitea personal access token`_
 
-.. _Creating a Gitea personal access token: https://docs.gitea.io/en-us/api-usage
+.. _Creating a Gitea personal access token: https://docs.gitea.com/development/api-usage
 
 .. setting:: GITLAB_CREDENTIALS
 

--- a/docs/admin/deployments.rst
+++ b/docs/admin/deployments.rst
@@ -22,7 +22,7 @@ Weblate Cloudron Package
 
 `Cloudron <https://www.cloudron.io/>`_ is a platform for self-hosting web applications.
 Weblate installed with Cloudron will be automatically kept up-to-date.
-The package is maintained by the Cloudron team at their `Weblate package repo <https://git.cloudron.io/cloudron/weblate-app>`_.
+The package is maintained by the Cloudron team; see the `Weblate package documentation <https://docs.cloudron.io/packages/weblate/>`_.
 
 .. image:: /images/cloudron.png
    :alt: Install Weblate with Cloudron

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3554,7 +3554,7 @@ update individual repositories; see
 
         :ref:`Gitea notifications <code-hosting-gitea-notifications>`
             For instruction on setting up Gitea integration
-        https://docs.gitea.io/en-us/webhooks/
+        https://docs.gitea.com/usage/repository/webhooks
             Generic information about Gitea Webhooks
         :setting:`ENABLE_HOOKS`
             For enabling hooks for whole Weblate


### PR DESCRIPTION
Gitea reorganized its documentation, while Cloudron's repository rejects automated link checks. Point to the current public pages so link checking succeeds.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
