### PR TITLE
fix(memory): preserve uploads during rebuild

### DIFF
--- a/docs/admin/memory.rst
+++ b/docs/admin/memory.rst
@@ -105,6 +105,9 @@ Translation memory status
 
 Translation memory entries can have two different statuses: **active** and **pending**.
 Pending entries are included in suggestions, but with a quality penalty applied.
+Depending on the configured score threshold, the penalty can exclude even exact
+matches from suggestions and automatic translation. Entries imported from
+translation memory files are stored as active.
 If :ref:`autoclean-tm` is enabled, matching pending entries are removed when a
 translation becomes active.
 
@@ -173,7 +176,7 @@ translation memory are enabled for the project, with a link to the project
 workflow settings when the user can edit the project.
 
 Translation memory files can be imported on the same page. Uploaded files are
-stored in the selected scope:
+processed during the request, stored as active, and added to the selected scope:
 
 * Personal uploads are available in your personal translation memory.
 * Project uploads are available in the selected project's translation memory.
@@ -209,9 +212,10 @@ uploaded entries, and download uploaded, shared, or all entries as JSON or TMX.
 .. versionadded:: 4.12
 
 The project translation memory view also allows rebuilding parts of or the
-entire project translation memory. Existing entries for the selected component
-or project are deleted, and the memory is populated again from the current
-translations in the background.
+entire project translation memory. Automatically generated entries for the
+selected component or project are deleted, and the memory is populated again
+from the current translations in the background. Entries imported from files
+are preserved.
 
 Management interface
 ++++++++++++++++++++

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,7 @@ Weblate 2026.8
 * Expanded :ref:`change-actions` documentation with detailed event semantics and improved OpenAPI schema accuracy.
 * Improved matrix view loading performance when displaying multiple languages.
 * Translation memory management pages now load origin summaries with a single database aggregation.
+* Translation memory management shows active and pending entry counts and reports the number of entries processed during import.
 * Dashboard component list tabs now load without processing unrelated component lists.
 * Category pages now load recent history and shared component listings more efficiently.
 * Static assets now use content-hashed filenames, and CAPTCHA JavaScript is loaded only when needed.
@@ -49,6 +50,7 @@ Weblate 2026.8
 * Self-service REST API e-mail changes are now restricted to verified addresses.
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
 * :ref:`Project backup imports <projectbackup>` now validate restored data before creating project state and skip repository-linked components when the importer cannot access the target component.
+* Rebuilding project translation memory no longer removes entries imported from files.
 * Project backup restores no longer load Mercurial repository configuration or shared-repository indirection supplied by archives.
 * Suggestion submission and rejection now reject excessively long suggestion text and rejection reasons.
 * Restricted components are now available on Hosted Weblate when the billing plan permits private projects.

--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -530,7 +530,7 @@ class MemoryManager(models.Manager["Memory"]):
         user: User | None = None,
         project: Project | None = None,
         from_file: bool = True,
-    ):
+    ) -> int:
         origin = os.path.basename(fileobj.name).lower()
         name, extension = os.path.splitext(origin)
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -3079,6 +3079,85 @@ class MemoryViewTest(FixtureTestCase):
 
         self.assertContains(response, "Uploaded translation file is too big.")
 
+    def test_upload_reports_active_entry(self) -> None:
+        unit = self.get_unit()
+        target = "Uploaded active translation"
+        handle = BytesIO(
+            json.dumps(
+                [
+                    {
+                        "source_language": "en",
+                        "target_language": "cs",
+                        "source": unit.source,
+                        "target": target,
+                        "origin": "Uploaded",
+                        "context": unit.context,
+                        "category": CATEGORY_FILE,
+                    }
+                ]
+            ).encode()
+        )
+        handle.name = "active.json"
+
+        response = self.client.post(
+            reverse("memory-upload"),
+            {"file": handle},
+            follow=True,
+        )
+
+        self.assertContains(response, "Processed 1 active translation memory entry.")
+        memory = Memory.objects.filter_type(user=self.user).get(target=target)
+        self.assertEqual(memory.status, Memory.STATUS_ACTIVE)
+        results = WeblateMemory({}).search(unit, unit.source, self.user)
+        result = next(result for result in results if result["text"] == target)
+        self.assertEqual(result["quality"], 100)
+
+    def test_status_counts(self) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        for status in (Memory.STATUS_ACTIVE, Memory.STATUS_PENDING):
+            memory = Memory.objects.create(
+                source_language=source_language,
+                target_language=target_language,
+                source=f"Status count source {status}",
+                target=f"Status count target {status}",
+                origin="status-count",
+                status=status,
+            )
+            MemoryScope.objects.create(
+                memory=memory,
+                scope=MemoryScope.SCOPE_USER,
+                user=self.user,
+            )
+
+        unrelated = Memory.objects.create(
+            source_language=source_language,
+            target_language=target_language,
+            source="Unrelated status count source",
+            target="Unrelated status count target",
+            origin="status-count",
+            status=Memory.STATUS_PENDING,
+        )
+        MemoryScope.objects.create(
+            memory=unrelated,
+            scope=MemoryScope.SCOPE_GLOBAL_FILE,
+        )
+
+        response = self.client.get(reverse("memory"))
+
+        entries = Memory.objects.filter_type(user=self.user)
+        self.assertEqual(response.context["num_entries"], entries.count())
+        self.assertEqual(
+            response.context["active_entries"],
+            entries.filter(status=Memory.STATUS_ACTIVE).count(),
+        )
+        self.assertEqual(
+            response.context["pending_entries"],
+            entries.filter(status=Memory.STATUS_PENDING).count(),
+        )
+        self.assertContains(response, "Active entries")
+        self.assertContains(response, "Pending entries")
+
     def test_memory(
         self, match="Number of your entries", fail=False, prefix: str = "", **kwargs
     ) -> None:
@@ -3104,7 +3183,9 @@ class MemoryViewTest(FixtureTestCase):
         if fail:
             self.assertContains(response, "Permission Denied", status_code=403)
         else:
-            self.assertContains(response, "File processed")
+            self.assertContains(
+                response, "Processed 2 active translation memory entries."
+            )
 
         # Test download
         response = self.client.get(reverse(f"{prefix}memory-download", **kwargs))
@@ -3163,7 +3244,8 @@ class MemoryViewTest(FixtureTestCase):
                 self.assertContains(response, "Permission Denied", status_code=403)
             else:
                 self.assertContains(
-                    response, "Entries were deleted and the translation memory"
+                    response,
+                    "Translation memory entries created from current translations",
                 )
                 self.assertEqual(4, Memory.objects.count())
                 with self.captureOnCommitCallbacks(execute=True):
@@ -3173,7 +3255,8 @@ class MemoryViewTest(FixtureTestCase):
                         follow=True,
                     )
                 self.assertContains(
-                    response, "Entries were deleted and the translation memory"
+                    response,
+                    "Translation memory entries created from current translations",
                 )
                 self.assertEqual(4, Memory.objects.count())
 
@@ -3216,7 +3299,9 @@ class MemoryViewTest(FixtureTestCase):
         if fail:
             self.assertContains(response, "Permission Denied", status_code=403)
         else:
-            self.assertContains(response, "File processed")
+            self.assertContains(
+                response, "Processed 2 active translation memory entries."
+            )
 
     def test_memory_project(self) -> None:
         self.test_memory("Number of entries for Test", True, kwargs=self.kw_project)
@@ -3259,10 +3344,85 @@ class MemoryViewTest(FixtureTestCase):
                 follow=True,
             )
 
-        self.assertContains(response, "Entries were deleted and the translation memory")
+        self.assertContains(
+            response, "Translation memory entries created from current translations"
+        )
         self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
         mocked_import.assert_called_once_with(
             project_id=self.project.id, component_id=self.component.id
+        )
+
+    def test_rebuild_preserves_uploaded_entries(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        response = self.client.get(reverse("memory", kwargs=self.kw_project))
+        initial_rebuild_count = response.context["rebuild_entries_count"]
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        file_memory = Memory.objects.create(
+            source_language=source_language,
+            target_language=target_language,
+            source="Uploaded rebuild source",
+            target="Uploaded rebuild target",
+            origin="uploaded.tmx",
+            legacy_project=self.project,
+            legacy_from_file=True,
+            status=Memory.STATUS_ACTIVE,
+        )
+        compacted_memory = Memory.objects.create(
+            source_language=source_language,
+            target_language=target_language,
+            source="Compacted rebuild source",
+            target="Compacted rebuild target",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=compacted_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        MemoryScope.objects.create(
+            memory=compacted_memory,
+            scope=MemoryScope.SCOPE_PROJECT_FILE,
+            project=self.project,
+        )
+
+        response = self.client.get(reverse("memory", kwargs=self.kw_project))
+        rebuild_count = response.context["rebuild_entries_count"]
+        self.assertEqual(rebuild_count, initial_rebuild_count + 1)
+        self.assertContains(
+            response,
+            f"Rebuilding in the background will replace {rebuild_count} "
+            "translation memory "
+            f"{'entry' if rebuild_count == 1 else 'entries'}",
+        )
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs=self.kw_project),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(response, "Uploaded entries were preserved.")
+        self.assertTrue(Memory.objects.filter(pk=file_memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=compacted_memory.pk).exists())
+        self.assertFalse(
+            MemoryScope.objects.filter(
+                memory=compacted_memory,
+                scope=MemoryScope.SCOPE_PROJECT,
+                project=self.project,
+            ).exists()
+        )
+        self.assertTrue(
+            MemoryScope.objects.filter(
+                memory=compacted_memory,
+                scope=MemoryScope.SCOPE_PROJECT_FILE,
+                project=self.project,
+            ).exists()
+        )
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id, component_id=None
         )
 
     def test_global_memory_superuser(self) -> None:

--- a/weblate/memory/views.py
+++ b/weblate/memory/views.py
@@ -13,7 +13,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
-from django.utils.translation import gettext
+from django.utils.translation import gettext, ngettext
 from django.views.generic.base import TemplateView
 
 from weblate.lang.models import Language
@@ -146,10 +146,14 @@ class RebuildView(MemoryFormView):
             except ObjectDoesNotExist as error:
                 raise PermissionDenied from error
         # Delete private entries
-        entries = Memory.objects.filter_type(**self.objects)
+        entries = Memory.objects.filter_type(**self.objects).exclude(
+            legacy_from_file=True
+        )
         if origin:
             entries = entries.filter(origin=origin)
-        entries.using("default").delete_scope(get_scope_delete_query(self.objects))
+        entries.using("default").delete_scope(
+            Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
+        )
         # Delete possible shared entries
         if origin:
             slugs = [origin]
@@ -169,8 +173,9 @@ class RebuildView(MemoryFormView):
         messages.success(
             self.request,
             gettext(
-                "Entries were deleted and the translation memory will be "
-                "rebuilt in the background."
+                "Translation memory entries created from current translations "
+                "were deleted and will be rebuilt in the background. Uploaded "
+                "entries were preserved."
             ),
         )
         return super().form_valid(form)
@@ -184,7 +189,7 @@ class UploadView(MemoryFormView):
         if not check_perm(self.request.user, "memory.edit", self.objects):
             raise PermissionDenied
         try:
-            Memory.objects.import_file(
+            count = Memory.objects.import_file(
                 request=self.request,
                 fileobj=form.cleaned_data["file"],
                 source_language=form.cleaned_data["source_language"],
@@ -193,7 +198,12 @@ class UploadView(MemoryFormView):
             )
             messages.success(
                 self.request,
-                gettext("File processed, the entries will appear shortly."),
+                ngettext(
+                    "Processed %(count)d active translation memory entry.",
+                    "Processed %(count)d active translation memory entries.",
+                    count,
+                )
+                % {"count": count},
             )
         except MemoryImportError as error:
             messages.error(self.request, str(error))
@@ -218,6 +228,34 @@ class MemoryView(TemplateView):
     @cached_property
     def entries(self):
         return Memory.objects.filter_type(**self.objects)
+
+    @cached_property
+    def component_slugs(self) -> set[str]:
+        return {
+            component.full_slug
+            for component in self.objects["project"].component_set.prefetch()
+        }
+
+    def get_rebuild_entries(self):
+        project = self.objects["project"]
+        scope_query = Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
+        if self.component_slugs:
+            scope_query |= Q(
+                scope__in=(MemoryScope.SCOPE_SHARED, MemoryScope.SCOPE_WORKSPACE),
+                source_project=project,
+                memory__origin__in=self.component_slugs,
+            )
+        return Memory.objects.using(self.entries.db).filter_scope(scope_query)
+
+    @cached_property
+    def rebuild_counts(self) -> dict[str, int]:
+        return {
+            entry["origin"]: entry["id__count"]
+            for entry in self.get_rebuild_entries()
+            .values("origin")
+            .order_by("origin")
+            .annotate(Count("id"))
+        }
 
     def get_origins(self):
         def get_url(slug: str) -> str:
@@ -249,22 +287,20 @@ class MemoryView(TemplateView):
         for entry in result:
             entry["url"] = get_url(entry["origin"])
         if "project" in self.objects:
-            slugs = {
-                component.full_slug
-                for component in self.objects["project"].component_set.prefetch()
-            }
             existing = {entry["origin"] for entry in result}
             for entry in result:
-                entry["can_rebuild"] = entry["origin"] in slugs
+                entry["can_rebuild"] = entry["origin"] in self.component_slugs
+                entry["rebuild_count"] = self.rebuild_counts.get(entry["origin"], 0)
             # Add missing ones
             result.extend(
                 {
                     "origin": missing,
                     "id__count": 0,
                     "can_rebuild": True,
+                    "rebuild_count": self.rebuild_counts.get(missing, 0),
                     "url": get_url(missing),
                 }
-                for missing in slugs - existing
+                for missing in self.component_slugs - existing
             )
         return from_file + result
 
@@ -296,7 +332,14 @@ class MemoryView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update(self.objects)
-        context["num_entries"] = self.entries.count()
+        status_counts = self.entries.aggregate(
+            total=Count("id"),
+            active=Count("id", filter=Q(status=Memory.STATUS_ACTIVE)),
+            pending=Count("id", filter=Q(status=Memory.STATUS_PENDING)),
+        )
+        context["num_entries"] = status_counts["total"]
+        context["active_entries"] = status_counts["active"]
+        context["pending_entries"] = status_counts["pending"]
         context["entries_origin"] = self.get_origins()
         context["entries_languages"] = self.get_languages()
         context["total_entries"] = Metric.objects.get_current_metric(
@@ -309,6 +352,7 @@ class MemoryView(TemplateView):
             context["delete_url"] = self.get_url("memory-delete")
             if "project" in self.objects:
                 context["rebuild_url"] = self.get_url("memory-rebuild")
+                context["rebuild_entries_count"] = sum(self.rebuild_counts.values())
         if check_perm(user, "memory.edit", self.objects):
             context["upload_form"] = UploadForm()
         if "from_file" in self.objects:

--- a/weblate/templates/memory/index.html
+++ b/weblate/templates/memory/index.html
@@ -103,8 +103,7 @@
                               aria-label="{% translate "Close" %}"></button>
                     </div>
                     <div class="modal-body">
-                      {% blocktranslate count count=num_entries %}This will permanently delete {{ count }} entry from the translation memory.{% plural %}This will permanently delete {{ count }} entries from the translation memory.{% endblocktranslate %}
-                      {% translate "Memory will be then populated with the current translations." %}
+                      {% blocktranslate count count=rebuild_entries_count %}Rebuilding in the background will replace {{ count }} translation memory entry created from current translations. Uploaded translation memory entries will be preserved.{% plural %}Rebuilding in the background will replace {{ count }} translation memory entries created from current translations. Uploaded translation memory entries will be preserved.{% endblocktranslate %}
                     </div>
                     <div class="modal-footer">
                       <input type="submit" class="btn btn-warning" value="{% translate "Rebuild" %}" />
@@ -118,6 +117,18 @@
             </form>
           {% endif %}
         </td>
+      </tr>
+      <tr>
+        <th>{% translate "Active entries" %}</th>
+        <td></td>
+        <td class="number">{{ active_entries|intcomma }}</td>
+        <td></td>
+      </tr>
+      <tr>
+        <th>{% translate "Pending entries" %}</th>
+        <td></td>
+        <td class="number">{{ pending_entries|intcomma }}</td>
+        <td></td>
       </tr>
       {% for item in entries_origin %}
         <tr>
@@ -193,8 +204,7 @@
                                 aria-label="{% translate "Close" %}"></button>
                       </div>
                       <div class="modal-body">
-                        {% blocktranslate count count=item.id__count %}This will permanently delete {{ count }} entry from the translation memory.{% plural %}This will permanently delete {{ count }} entries from the translation memory.{% endblocktranslate %}
-                        {% translate "Memory will be then populated with the current translations." %}
+                        {% blocktranslate count count=item.rebuild_count %}Rebuilding in the background will replace {{ count }} translation memory entry created from current translations. Uploaded translation memory entries will be preserved.{% plural %}Rebuilding in the background will replace {{ count }} translation memory entries created from current translations. Uploaded translation memory entries will be preserved.{% endblocktranslate %}
                       </div>
                       <div class="modal-footer">
                         <input type="submit" class="btn btn-warning" value="{% translate "Rebuild" %}" />


### PR DESCRIPTION
Rebuilds should replace generated memory without deleting manually imported data. Show accurate rebuild, import, and status counts so administrators can assess the impact of these operations.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
