### PR TITLE
refactor(http): adopt native HTTPX2 client interface

### DIFF
--- a/weblate/accounts/tests/test_avatars.py
+++ b/weblate/accounts/tests/test_avatars.py
@@ -16,7 +16,7 @@ from weblate.accounts import avatar
 from weblate.accounts.apps import check_avatars
 from weblate.auth.models import User
 from weblate.trans.tests.test_views import FixtureTestCase
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 
 TEST_URL = (
     "https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=identicon&s=32"
@@ -44,13 +44,13 @@ class AvatarTest(FixtureTestCase):
             "https://cdn.example.com/static/api-32.png",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_avatar(self) -> None:
         image = Image.new("RGB", (32, 32))
         storage = BytesIO()
         image.save(storage, "PNG")
         imagedata = storage.getvalue()
-        responses.add(responses.GET, TEST_URL, body=imagedata)
+        http_mock.register("GET", TEST_URL, content=imagedata)
         # Real user
         response = self.client.get(
             reverse("user_avatar", kwargs={"user": self.user.username, "size": 32})
@@ -64,9 +64,9 @@ class AvatarTest(FixtureTestCase):
         self.assert_png(response)
         self.assertEqual(response.content, imagedata)
 
-    @responses.activate
+    @http_mock.activate
     def test_avatar_error(self) -> None:
-        responses.add(responses.GET, TEST_URL, status=503)
+        http_mock.register("GET", TEST_URL, status_code=503)
         # Choose different username to avoid using cache
         self.user.username = "test2"
         self.user.save()
@@ -86,13 +86,13 @@ class AvatarTest(FixtureTestCase):
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0].id, "weblate.E018")
 
-    @responses.activate
+    @http_mock.activate
     def test_avatar_rejects_unsupported_size_before_fetch(self) -> None:
         response = self.client.get(
             reverse("user_avatar", kwargs={"user": self.user.username, "size": 999})
         )
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
     def test_anonymous_avatar(self) -> None:
         anonymous = User.objects.get(username="anonymous")

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -82,7 +82,7 @@ from weblate.utils.state import (
     STATE_READONLY,
     STATE_TRANSLATED,
 )
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.utils.unittest import tempdir_setting
 from weblate.vcs.base import Repository, RepositoryError
 
@@ -173,20 +173,17 @@ if TYPE_CHECKING:
     from weblate.trans.models import (
         Project,
     )
-    from weblate.utils.tests.http_mock import PreparedRequest
 
 
 def get_webhook_request_data(
-    request: PreparedRequest,
-) -> tuple[bytes | str, dict[str, str]]:
+    request: httpx2.Request,
+) -> tuple[bytes, dict[str, str]]:
     """Return the concrete body and string headers prepared by the HTTP client."""
-    body = request.body
-    assert isinstance(body, (bytes, str))
     headers: dict[str, str] = {}
     for key, value in request.headers.items():
         assert isinstance(value, str)
         headers[key] = value
-    return body, headers
+    return request.content, headers
 
 
 class GettextUtilityTest(SimpleTestCase):
@@ -8352,7 +8349,7 @@ class CDNJSAddonTest(ViewTestCase):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
-    @responses.activate
+    @http_mock.activate
     def test_form_rejects_private_remote_file_before_request(
         self, mocked_getaddrinfo
     ) -> None:
@@ -8371,7 +8368,7 @@ class CDNJSAddonTest(ViewTestCase):
         self.assertFalse(form.is_valid())
 
         mocked_getaddrinfo.assert_called_once_with("private.example.com", None, type=1)
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         self.assertIn("internal or non-public address", str(form.errors["files"]))
 
     @tempdir_setting("LOCALIZE_CDN_PATH")
@@ -8601,7 +8598,7 @@ class CDNJSAddonTest(ViewTestCase):
         alert = self.component.alert_set.get(name="CDNAddonError")
         self.assertIn("domain is not allowed", alert.details["occurrences"][0]["error"])
 
-    @responses.activate
+    @http_mock.activate
     @tempdir_setting("LOCALIZE_CDN_PATH")
     @override_settings(
         LOCALIZE_CDN_URL="http://localhost/", ALLOWED_ASSET_DOMAINS=[".allowed.com"]
@@ -8620,17 +8617,17 @@ class CDNJSAddonTest(ViewTestCase):
             Unit.objects.filter(translation__component=self.component).count(), 8
         )
 
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://cdn.allowed.com/messages.html",
-            status=302,
+            status_code=302,
             headers={"Location": "https://blocked.example.com/messages.html"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://blocked.example.com/messages.html",
-            status=200,
-            body="<html><body><div class='l10n'>Blocked</div></body></html>",
+            status_code=200,
+            text="<html><body><div class='l10n'>Blocked</div></body></html>",
         )
 
         self.create_addon(
@@ -8650,10 +8647,10 @@ class CDNJSAddonTest(ViewTestCase):
         self.assertIn("domain is not allowed", alert.details["occurrences"][0]["error"])
         self.assertNotIn(
             "https://blocked.example.com/messages.html",
-            [call.request.url for call in responses.calls],
+            [call.request.url for call in http_mock.calls],
         )
 
-    @responses.activate
+    @http_mock.activate
     @tempdir_setting("LOCALIZE_CDN_PATH")
     @override_settings(LOCALIZE_CDN_URL="http://localhost/")
     @patch(
@@ -8666,11 +8663,11 @@ class CDNJSAddonTest(ViewTestCase):
         self.assertEqual(
             Unit.objects.filter(translation__component=self.component).count(), 8
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/messages.html",
-            status=200,
-            body="<html><body><div class='l10n'>Private</div></body></html>",
+            status_code=200,
+            text="<html><body><div class='l10n'>Private</div></body></html>",
         )
 
         self.create_addon(
@@ -8687,13 +8684,13 @@ class CDNJSAddonTest(ViewTestCase):
             Unit.objects.filter(translation__component=self.component).count(), 8
         )
         self.assertGreaterEqual(mocked_getaddrinfo.call_count, 1)
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         alert = self.component.alert_set.get(name="CDNAddonError")
         self.assertIn(
             "internal or non-public address", alert.details["occurrences"][0]["error"]
         )
 
-    @responses.activate
+    @http_mock.activate
     @tempdir_setting("LOCALIZE_CDN_PATH")
     @override_settings(LOCALIZE_CDN_URL="http://localhost/")
     @patch("weblate.utils.requests._get_response_peer_ip", return_value="93.184.216.34")
@@ -8713,17 +8710,17 @@ class CDNJSAddonTest(ViewTestCase):
         self.assertEqual(
             Unit.objects.filter(translation__component=self.component).count(), 8
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/messages.html",
-            status=302,
+            status_code=302,
             headers={"Location": "https://private.example.com/messages.html"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/messages.html",
-            status=200,
-            body="<html><body><div class='l10n'>Private</div></body></html>",
+            status_code=200,
+            text="<html><body><div class='l10n'>Private</div></body></html>",
         )
 
         self.create_addon(
@@ -8747,10 +8744,10 @@ class CDNJSAddonTest(ViewTestCase):
         )
         self.assertNotIn(
             "https://private.example.com/messages.html",
-            [call.request.url for call in responses.calls],
+            [call.request.url for call in http_mock.calls],
         )
 
-    @responses.activate
+    @http_mock.activate
     @tempdir_setting("LOCALIZE_CDN_PATH")
     @override_settings(
         LOCALIZE_CDN_URL="http://localhost/",
@@ -8766,11 +8763,11 @@ class CDNJSAddonTest(ViewTestCase):
         self.assertEqual(
             Unit.objects.filter(translation__component=self.component).count(), 8
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/messages.html",
-            status=200,
-            body="<html><body><div class='l10n'>Allowed private</div></body></html>",
+            status_code=200,
+            text="<html><body><div class='l10n'>Allowed private</div></body></html>",
         )
 
         self.create_addon(
@@ -9198,19 +9195,30 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.addon_configuration["event_filter"] = CHANGE_EVENT_FILTER_CUSTOM
 
     def count_requests(self) -> int:
-        return len(responses.calls)
+        return len(http_mock.calls)
 
     def reset_calls(self) -> None:
-        responses.calls.reset()
+        http_mock.calls.clear()
 
     def do_translation_added_test(
-        self, response_code=None, expected_calls: int = 1, **responses_kwargs
+        self,
+        response_code: int = 200,
+        expected_calls: int = 1,
+        *,
+        content: bytes | None = None,
+        exception: BaseException | None = None,
     ) -> None:
         """Install addon, edit unit and assert outgoing calls."""
         self.WEBHOOK_CLS.create(configuration=self.addon_configuration)
-        if response_code:
-            responses_kwargs |= {"status": response_code}
-        responses.add(responses.POST, self.WEBHOOK_URL, **responses_kwargs)
+        if exception is None:
+            http_mock.register(
+                "POST",
+                self.WEBHOOK_URL,
+                status_code=response_code,
+                content=content,
+            )
+        else:
+            http_mock.register_exception("POST", self.WEBHOOK_URL, exception)
 
         with self.captureOnCommitCallbacks(execute=True):
             self.edit_unit(
@@ -9223,7 +9231,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
             )  # triggers ActionEvents.STRING_REMOVE event
         self.assertEqual(self.count_requests(), expected_calls)
 
-    @responses.activate
+    @http_mock.activate
     def test_bulk_changes(self) -> None:
         """Test bulk change create via the propagate() method."""
         # create another component in project with same units as self.component
@@ -9237,14 +9245,14 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
             configuration=self.addon_configuration, project=self.project
         )
         self.component.drop_addons_cache()
-        responses.add(responses.POST, self.WEBHOOK_URL, status=200)
+        http_mock.register("POST", self.WEBHOOK_URL, status_code=200)
 
         # create translation for unit and similar units across project
         with self.captureOnCommitCallbacks(execute=True):
             self.change_unit("Nazdar svete!\n", "Hello, world!\n", "cs")
         self.assertEqual(self.count_requests(), 2)
 
-    @responses.activate
+    @http_mock.activate
     def test_translation_added(self) -> None:
         """Test translation added and translation edited action change."""
         self.addon_configuration["events"].append(ActionEvents.CHANGE)
@@ -9254,13 +9262,13 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
             self.edit_unit("Hello, world!\n", "Nazdar svete edit!\n")
         self.assertEqual(self.count_requests(), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_all_events(self) -> None:
         """Test processing every change action without event filtering."""
         self.addon_configuration["event_filter"] = CHANGE_EVENT_FILTER_ALL
         self.do_translation_added_test(response_code=200, expected_calls=2)
 
-    @responses.activate
+    @http_mock.activate
     def test_content_events(self) -> None:
         """Test processing translation content events preset."""
         self.assertIn(ActionEvents.NEW, ACTIONS_CONTENT)
@@ -9269,7 +9277,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.addon_configuration["events"] = []
         self.do_translation_added_test(response_code=200)
 
-    @responses.activate
+    @http_mock.activate
     def test_announcement(self) -> None:
         """Test project and site wide events."""
         self.addon_configuration["events"].append(ActionEvents.ANNOUNCEMENT)
@@ -9277,7 +9285,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.WEBHOOK_CLS.create(
             configuration=self.addon_configuration, project=self.project
         )
-        responses.add(responses.POST, self.WEBHOOK_URL, status=200)
+        http_mock.register("POST", self.WEBHOOK_URL, status_code=200)
 
         self.reset_calls()
         with self.captureOnCommitCallbacks(execute=True):
@@ -9293,7 +9301,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         # Both site-wide and project-wide add-ons should receive this
         self.assertEqual(self.count_requests(), 2)
 
-    @responses.activate
+    @http_mock.activate
     def test_component_scopes(self) -> None:
         """Test webhook addon installed at component level."""
         secondary_url = f"{self.WEBHOOK_URL}-2"
@@ -9307,8 +9315,8 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.WEBHOOK_CLS.create(configuration=config1, component=component1)
         self.WEBHOOK_CLS.create(configuration=config2, component=component2)
 
-        resp1 = responses.post(self.WEBHOOK_URL, status=200)
-        resp2 = responses.post(secondary_url, status=200)
+        resp1 = http_mock.register("POST", self.WEBHOOK_URL, status_code=200)
+        resp2 = http_mock.register("POST", secondary_url, status_code=200)
         translation1 = self.get_translation()
         translation2 = component2.translation_set.get(language__code="cs")
 
@@ -9330,7 +9338,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.assertEqual(len(resp1.calls), 1)
         self.assertEqual(len(resp2.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_project_scopes(self) -> None:
         """Test webhook addon installed at project level."""
         secondary_url = f"{self.WEBHOOK_URL}-2"
@@ -9351,8 +9359,8 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.WEBHOOK_CLS.create(configuration=config_a, project=project_a)
         self.WEBHOOK_CLS.create(configuration=config_b, project=project_b)
 
-        resp_a = responses.post(self.WEBHOOK_URL, status=200)
-        resp_b = responses.post(secondary_url, status=200)
+        resp_a = http_mock.register("POST", self.WEBHOOK_URL, status_code=200)
+        resp_b = http_mock.register("POST", secondary_url, status_code=200)
 
         translation_a1 = component_a1.translation_set.get(language__code="cs")
         translation_a2 = component_a2.translation_set.get(language__code="cs")
@@ -9380,7 +9388,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         self.assertEqual(len(resp_a.calls), 2)
         self.assertEqual(len(resp_b.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_site_wide_scope(self) -> None:
         """Test webhook addon installed site-wide."""
         project_b = self.create_project(name="Test 2", slug="project2")
@@ -9389,7 +9397,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         )
 
         self.WEBHOOK_CLS.create(configuration=self.addon_configuration)
-        responses.add(responses.POST, self.WEBHOOK_URL, status=200)
+        http_mock.register("POST", self.WEBHOOK_URL, status_code=200)
 
         translation_a1 = self.get_translation()
         translation_b1 = component_b1.translation_set.get(language__code="cs")
@@ -9404,7 +9412,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
 
         self.assertEqual(self.count_requests(), 2)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
@@ -9413,7 +9421,7 @@ class BaseWebhookTests(_WebhookTestsTypingBase):
         """Test connection error when during message delivery."""
         request = httpx2.Request("POST", self.WEBHOOK_URL)
         self.do_translation_added_test(
-            body=httpx2.ConnectError("Connection failed", request=request)
+            exception=httpx2.ConnectError("Connection failed", request=request)
         )
 
 
@@ -9428,18 +9436,18 @@ class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):
         "events": [],
     }
 
-    @responses.activate
+    @http_mock.activate
     def test_invalid_response(self) -> None:
         """Test invalid response from client."""
         self.do_translation_added_test(response_code=301)
 
-    @responses.activate
+    @http_mock.activate
     def test_webhook_signature_prefix(self) -> None:
         """Test webhook signature features."""
         self.addon_configuration["secret"] = "whsec_secret-string"
         self.do_translation_added_test(response_code=200)
 
-        wh_request = responses.calls[0].request
+        wh_request = http_mock.calls[0].request
         body, headers = get_webhook_request_data(wh_request)
         wh_utils = Webhook("whsec_secret-string")
         wh_utils.verify(body, headers)
@@ -9453,13 +9461,13 @@ class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):
             wh_utils = Webhook("public-string")
             wh_utils.verify(body, headers)
 
-    @responses.activate
+    @http_mock.activate
     def test_webhook_signature(self) -> None:
         """Test webhook signature features."""
         self.addon_configuration["secret"] = "secret-string"
         self.do_translation_added_test(response_code=200)
 
-        wh_request = responses.calls[0].request
+        wh_request = http_mock.calls[0].request
         body, wh_headers = get_webhook_request_data(wh_request)
         wh_utils = Webhook("secret-string")
 
@@ -9700,7 +9708,7 @@ class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):
 
         self.assertContains(response, "Installed 1 add-on")
 
-    @responses.activate
+    @http_mock.activate
     def test_jsonschema_error(self) -> None:
         """Test payload schema validation error."""
         with patch(
@@ -9709,7 +9717,7 @@ class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):
         ):
             self.do_translation_added_test(expected_calls=0)
 
-    @responses.activate
+    @http_mock.activate
     def test_category_in_payload(self) -> None:
         """Test webhook payload includes category field when available."""
         self.project.add_user(self.user, "Administration")
@@ -9735,7 +9743,7 @@ class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):
         self.component.category = sub_category
         self.component.save()
 
-        responses.add(responses.POST, "https://example.com/webhooks", status=200)
+        http_mock.register("POST", "https://example.com/webhooks", status_code=200)
         with self.captureOnCommitCallbacks(execute=True):
             self.client.post(
                 reverse("rename", kwargs={"path": self.component.get_url_path()}),
@@ -9747,12 +9755,12 @@ class WebhooksAddonTest(BaseWebhookTests, ViewTestCase):
                 },
             )
 
-        request_body = json.loads(cast("bytes", responses.calls[0].request.body))
+        request_body = json.loads(http_mock.calls[0].request.content)
         self.assertIn("child-category", request_body["category"])
         self.assertIn("parent-category", request_body["category"])
         self.assertIn("sub-category", request_body["category"])
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 80))],
@@ -9786,10 +9794,12 @@ class SlackWebhooksAddonsTest(BaseWebhookTests, ViewTestCase):
         "events": [str(ActionEvents.NEW)],
     }
 
-    @responses.activate
+    @http_mock.activate
     def test_invalid_response(self) -> None:
         """Test invalid response from client."""
-        self.do_translation_added_test(response_code=410, body=b"channel_is_archived")
+        self.do_translation_added_test(
+            response_code=410, content=b"channel_is_archived"
+        )
 
 
 class FedoraMessagingPEMBlockTest(SimpleTestCase):

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -101,7 +101,7 @@ from weblate.utils.state import (
     STATE_NEEDS_REWRITING,
     STATE_TRANSLATED,
 )
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.utils.version import GIT_VERSION
 from weblate.utils.version_display import VERSION_DISPLAY_HIDE, VERSION_DISPLAY_SOFT
 from weblate.vcs.base import RepositoryError, RepositoryLock
@@ -5331,7 +5331,7 @@ class ProjectAPITest(APIBaseTest):
         )
         self.assertEqual(len(response.data["results"]), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.utils.requests._get_response_peer_ip", return_value="93.184.216.34")
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -107,7 +107,7 @@ from weblate.trans.tests.test_views import (
 from weblate.trans.tests.utils import get_test_file
 from weblate.trans.util import join_plural
 from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 
 from .types import SourceLanguageChoices
 
@@ -118,7 +118,6 @@ if TYPE_CHECKING:
         BatchMachineTranslation,
         SettingsDict,
     )
-    from weblate.utils.tests.http_mock import PreparedRequest
 
 HTTPError = httpx2.HTTPStatusError
 
@@ -348,26 +347,19 @@ LIBRETRANSLATE_LANG_RESPONSE = [
 ]
 
 
-def load_request_json(request: PreparedRequest) -> dict[str, object]:
-    body = request.body or "{}"
-    if not isinstance(body, (str, bytes, bytearray)):
-        msg = f"Unexpected request body: {body!r}"
-        raise TypeError(msg)
-    payload = json.loads(body)
+def load_request_json(request: httpx2.Request) -> dict[str, object]:
+    payload = json.loads(request.content or b"{}")
     if not isinstance(payload, dict):
         msg = f"Expected a JSON object, got: {payload!r}"
         raise TypeError(msg)
     return payload
 
 
-def get_request_url(request: PreparedRequest) -> str:
-    if request.url is None:
-        msg = "Prepared request has no URL"
-        raise ValueError(msg)
-    return request.url
+def get_request_url(request: httpx2.Request) -> str:
+    return str(request.url)
 
 
-def get_request_params(request: PreparedRequest) -> dict[str, str]:
+def get_request_params(request: httpx2.Request) -> dict[str, str]:
     return {
         key: values[-1]
         for key, values in parse_qs(urlparse(get_request_url(request)).query).items()
@@ -377,7 +369,7 @@ def get_request_params(request: PreparedRequest) -> dict[str, str]:
 def get_translate_payloads(url: str) -> list[dict[str, object]]:
     return [
         load_request_json(call.request)
-        for call in responses.calls
+        for call in http_mock.calls
         if call.request.url == url
     ]
 
@@ -421,7 +413,7 @@ class BaseMachineTranslationTest(TestCase):
         machine.cache_translations = use_cache
         return machine
 
-    @responses.activate
+    @http_mock.activate
     def test_validate_settings(self) -> None:
         self.mock_response()
         machine = self.get_machine()
@@ -431,7 +423,7 @@ class BaseMachineTranslationTest(TestCase):
         machine = self.get_machine()
         self.assertEqual(machine.map_language_code("en_devel"), self.ENGLISH)
 
-    @responses.activate
+    @http_mock.activate
     def test_support(self, machine_translation=None) -> None:
         self.mock_response()
         if machine_translation is None:
@@ -505,19 +497,19 @@ class BaseMachineTranslationTest(TestCase):
     def mock_error(self) -> None:
         self.skipTest("Not tested")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_empty(self) -> None:
         self.mock_empty()
         self.assert_translate(self.SUPPORTED, self.SOURCE_BLANK, 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_translate(self, **kwargs) -> None:
         self.mock_response()
         self.assert_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, **kwargs
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_batch(self, machine=None) -> None:
         self.mock_response()
         if machine is None:
@@ -536,13 +528,13 @@ class BaseMachineTranslationTest(TestCase):
         self.assertGreater(unit2.machinery["quality"][0], -1)
         self.assertIn("translation", unit2.machinery)
 
-    @responses.activate
+    @http_mock.activate
     def test_error(self) -> None:
         self.mock_error()
         with self.assertRaises(MachineTranslationError):
             self.assert_translate(self.SUPPORTED, self.SOURCE_BLANK, 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_clean(self) -> None:
         if not self.CONFIGURATION or self.MACHINE_CLS.settings_form is None:
             return
@@ -1066,22 +1058,20 @@ class GlosbeTranslationTest(BaseMachineTranslationTest):
     def mock_empty(self) -> None:
         response = copy(GLOSBE_JSON)
         response["tuc"] = []
-        responses.add(responses.GET, "https://glosbe.com/gapi/translate", json=response)
+        http_mock.register("GET", "https://glosbe.com/gapi/translate", json=response)
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET, "https://glosbe.com/gapi/translate", json=GLOSBE_JSON
-        )
+        http_mock.register("GET", "https://glosbe.com/gapi/translate", json=GLOSBE_JSON)
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://glosbe.com/gapi/translate",
             json=GLOSBE_JSON,
-            status=429,
+            status_code=429,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_ratelimit(self) -> None:
         """Test rate limit response handling."""
         # This raises an exception
@@ -1092,7 +1082,7 @@ class GlosbeTranslationTest(BaseMachineTranslationTest):
             self.SUPPORTED, self.SOURCE_TRANSLATED, 0, machine=machine
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_ratelimit_set(self) -> None:
         """Test manual setting of rate limit."""
         machine = self.MACHINE_CLS(self.get_configuration())
@@ -1120,21 +1110,21 @@ class MyMemoryTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET, "https://mymemory.translated.net/api/get", json=MYMEMORY_JSON
+        http_mock.register(
+            "GET", "https://mymemory.translated.net/api/get", json=MYMEMORY_JSON
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_non_json_error_response_falls_back_to_http_error(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://mymemory.translated.net/api/get",
-            body=(
+            text=(
                 "<html><head><title>403 Forbidden</title></head><body>"
                 "<center><h1>403 Forbidden</h1></center></body></html>"
             ),
-            content_type="text/html",
-            status=403,
+            headers={"Content-Type": "text/html"},
+            status_code=403,
         )
 
         with self.assertRaises(MachineTranslationError) as raised:
@@ -1160,16 +1150,16 @@ class ApertiumAPYTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "http://apertium.example.com/listPairs",
             json={
                 "responseStatus": 200,
                 "responseData": [{"sourceLanguage": "eng", "targetLanguage": "spa"}],
             },
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "http://apertium.example.com/translate",
             json={
                 "responseData": {"translatedText": "Mundial"},
@@ -1178,18 +1168,18 @@ class ApertiumAPYTranslationTest(BaseMachineTranslationTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_validate_settings(self) -> None:
         self.mock_response()
         machine = self.get_machine()
         machine.validate_settings()
-        self.assertEqual(len(responses.calls), 2)
-        call_2 = responses.calls[1]
+        self.assertEqual(len(http_mock.calls), 2)
+        call_2 = http_mock.calls[1]
         params = get_request_params(call_2.request)
         self.assertIn("langpair", params)
         self.assertEqual("eng|spa", params["langpair"])
 
-    @responses.activate
+    @http_mock.activate
     def test_translations_cache(self) -> None:
         self.mock_response()
         machine = self.MACHINE_CLS(self.get_configuration())
@@ -1197,14 +1187,14 @@ class ApertiumAPYTranslationTest(BaseMachineTranslationTest):
         self.assert_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
-        self.assertEqual(len(responses.calls), 2)
-        responses.reset()
+        self.assertEqual(len(http_mock.calls), 2)
+        http_mock.reset()
         # New instance should use cached languages and translations
         machine = self.MACHINE_CLS(self.get_configuration())
         self.assert_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
 
 class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
@@ -1224,36 +1214,36 @@ class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_token_response(self, url: str) -> None:
-        def request_callback(request: PreparedRequest):
-            self.assertEqual(urlparse(request.url).query, "")
+        def request_callback(request: httpx2.Request):
+            self.assertEqual(request.url.query, b"")
             self.assertEqual(request.headers["Ocp-Apim-Subscription-Key"], "KEY")
-            return 200, {}, "TOKEN"
+            return httpx2.Response(200, headers={}, text="TOKEN")
 
-        responses.add_callback(responses.POST, url, callback=request_callback)
+        http_mock.register_callback("POST", url, callback=request_callback)
 
     def mock_response(self) -> None:
         self.mock_token_response(
             "https://api.cognitive.microsoft.com/sts/v1.0/issueToken"
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.cognitive.microsofttranslator.com/languages?api-version=3.0",
             json=MS_SUPPORTED_LANG_RESP,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.cognitive.microsofttranslator.com/"
             "translate?api-version=3.0&from=en&to=cs&category=general&textType=html",
             json=MICROSOFT_RESPONSE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.cognitive.microsofttranslator.com/"
             "translate?api-version=3.0&from=en&to=de&category=general&textType=html",
             json=MICROSOFT_RESPONSE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.cognitive.microsofttranslator.com/"
             "translate?api-version=3.0&from=en&to=de&category=&textType=html",
             json=MICROSOFT_RESPONSE,
@@ -1270,7 +1260,7 @@ class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
-    @responses.activate
+    @http_mock.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_validation_blocks_private_base_url_resolution_before_request(
         self, mocked_getaddrinfo
@@ -1287,7 +1277,7 @@ class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
         mocked_getaddrinfo.assert_called_once_with(
             "api.cognitive.microsofttranslator.com", None, type=1
         )
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         self.assertIn("internal or non-public address", str(form.non_field_errors()))
 
 
@@ -1303,42 +1293,42 @@ class MicrosoftCognitiveTranslationRegionTest(MicrosoftCognitiveTranslationTest)
         self.mock_token_response(
             "https://westeurope.api.cognitive.microsoft.com/sts/v1.0/issueToken"
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.cognitive.microsofttranslator.com/languages?api-version=3.0",
             json=MS_SUPPORTED_LANG_RESP,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.cognitive.microsofttranslator.com/"
             "translate?api-version=3.0&from=en&to=cs&category=general&textType=html",
             json=MICROSOFT_RESPONSE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.cognitive.microsofttranslator.com/"
             "translate?api-version=3.0&from=en&to=de&category=general&textType=html",
             json=MICROSOFT_RESPONSE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.cognitive.microsofttranslator.com/"
             "translate?api-version=3.0&from=en&to=de&category=&textType=html",
             json=MICROSOFT_RESPONSE,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_validate_settings_uses_regional_token_host(self) -> None:
         self.mock_response()
         self.get_machine().validate_settings()
 
-        token_call = responses.calls[0]
+        token_call = http_mock.calls[0]
         self.assertEqual(
             token_call.request.url,
             "https://westeurope.api.cognitive.microsoft.com/sts/v1.0/issueToken",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_region_rejects_url_delimiters_before_request(self) -> None:
         form = self.MACHINE_CLS.settings_form(
             self.MACHINE_CLS,
@@ -1348,10 +1338,10 @@ class MicrosoftCognitiveTranslationRegionTest(MicrosoftCognitiveTranslationTest)
 
         self.assertFalse(form.is_valid())
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         self.assertIn("valid Azure region name", str(form.errors["region"]))
 
-    @responses.activate
+    @http_mock.activate
     def test_regional_host_string_payload_raises_error(self) -> None:
         machine = self.MACHINE_CLS(
             {
@@ -1362,13 +1352,13 @@ class MicrosoftCognitiveTranslationRegionTest(MicrosoftCognitiveTranslationTest)
         self.mock_token_response(
             "https://westeurope.api.cognitive.microsoft.com/sts/v1.0/issueToken"
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api-eur.cognitive.microsofttranslator.com/languages?api-version=3.0",
             json=MS_SUPPORTED_LANG_RESP,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api-eur.cognitive.microsofttranslator.com/"
             "translate?api-version=3.0&from=en&to=cs&category=general&textType=html",
             json="Regional host error",
@@ -1389,17 +1379,19 @@ class GoogleTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(responses.GET, f"{GOOGLE_API_ROOT}languages", body="", status=500)
-        responses.add(responses.POST, GOOGLE_API_ROOT, body="", status=500)
+        http_mock.register(
+            "GET", f"{GOOGLE_API_ROOT}languages", text="", status_code=500
+        )
+        http_mock.register("POST", GOOGLE_API_ROOT, text="", status_code=500)
 
     def mock_response(self) -> None:
-        def languages_callback(request: PreparedRequest):
-            self.assertEqual(urlparse(request.url).query, "")
+        def languages_callback(request: httpx2.Request):
+            self.assertEqual(request.url.query, b"")
             self.assertEqual(request.headers["X-Goog-Api-Key"], "KEY")
-            return (
+            return httpx2.Response(
                 200,
-                {},
-                json.dumps(
+                headers={},
+                text=json.dumps(
                     {
                         "data": {
                             "languages": [
@@ -1412,8 +1404,8 @@ class GoogleTranslationTest(BaseMachineTranslationTest):
                 ),
             )
 
-        def translate_callback(request: PreparedRequest):
-            self.assertEqual(urlparse(request.url).query, "")
+        def translate_callback(request: httpx2.Request):
+            self.assertEqual(request.url.query, b"")
             self.assertEqual(request.headers["X-Goog-Api-Key"], "KEY")
             payload = load_request_json(request)
             self.assertEqual(payload["source"], "en")
@@ -1421,24 +1413,26 @@ class GoogleTranslationTest(BaseMachineTranslationTest):
             self.assertIn(payload["q"], {self.SOURCE_TRANSLATED, "test"})
             self.assertEqual(payload["format"], "text")
             self.assertNotIn("key", payload)
-            return (
+            return httpx2.Response(
                 200,
-                {},
-                json.dumps({"data": {"translations": [{"translatedText": "svet"}]}}),
+                headers={},
+                text=json.dumps(
+                    {"data": {"translations": [{"translatedText": "svet"}]}}
+                ),
             )
 
-        responses.add_callback(
-            responses.GET,
+        http_mock.register_callback(
+            "GET",
             f"{GOOGLE_API_ROOT}languages",
             callback=languages_callback,
         )
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             GOOGLE_API_ROOT,
             callback=translate_callback,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_ratelimit_set(self) -> None:
         """Test manual setting of rate limit."""
         machine = self.MACHINE_CLS(self.get_configuration())
@@ -1749,26 +1743,26 @@ class TMServerTranslationTest(BaseMachineTranslationTest):
     }
 
     def mock_empty(self) -> None:
-        responses.add(responses.GET, f"{AMAGAMA_LIVE}/languages/", body="", status=404)
-        responses.add(responses.GET, f"{AMAGAMA_LIVE}/en/cs/unit/Hello", json=[])
+        http_mock.register(
+            "GET", f"{AMAGAMA_LIVE}/languages/", text="", status_code=404
+        )
+        http_mock.register("GET", f"{AMAGAMA_LIVE}/en/cs/unit/Hello", json=[])
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             f"{AMAGAMA_LIVE}/languages/",
             json={"sourceLanguages": ["en"], "targetLanguages": ["cs"]},
         )
-        responses.add(
-            responses.GET, f"{AMAGAMA_LIVE}/en/cs/unit/Hello", json=AMAGAMA_JSON
-        )
-        responses.add(
-            responses.GET, f"{AMAGAMA_LIVE}/en/de/unit/test", json=AMAGAMA_JSON
-        )
+        http_mock.register("GET", f"{AMAGAMA_LIVE}/en/cs/unit/Hello", json=AMAGAMA_JSON)
+        http_mock.register("GET", f"{AMAGAMA_LIVE}/en/de/unit/test", json=AMAGAMA_JSON)
 
     def mock_error(self) -> None:
-        responses.add(responses.GET, f"{AMAGAMA_LIVE}/languages/", body="", status=404)
-        responses.add(
-            responses.GET, f"{AMAGAMA_LIVE}/en/cs/unit/Hello", body="", status=500
+        http_mock.register(
+            "GET", f"{AMAGAMA_LIVE}/languages/", text="", status_code=404
+        )
+        http_mock.register(
+            "GET", f"{AMAGAMA_LIVE}/en/cs/unit/Hello", text="", status_code=500
         )
 
 
@@ -1783,39 +1777,39 @@ class YandexTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://translate.yandex.net/api/v1.5/tr.json/getLangs",
             json={"code": 401},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://translate.yandex.net/api/v1.5/tr.json/translate",
             json={"code": 400, "message": "Invalid request"},
         )
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://translate.yandex.net/api/v1.5/tr.json/getLangs",
             json={"langs": {"en": "English", "cs": "Czech"}},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://translate.yandex.net/api/v1.5/tr.json/translate",
             json={"code": 200, "lang": "en-cs", "text": ["svet"]},
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_error_message(self) -> None:
         message = "Invalid test request"
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://translate.yandex.net/api/v1.5/tr.json/getLangs",
             json={"langs": {"en": "English", "cs": "Czech"}},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://translate.yandex.net/api/v1.5/tr.json/translate",
             json={"code": 400, "message": message},
         )
@@ -1834,20 +1828,20 @@ class YandexV2TranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://translate.api.cloud.yandex.net/translate/v2/languages",
             json={"code": 401},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://translate.api.cloud.yandex.net/translate/v2/translate",
             json={"code": 400, "message": "Invalid request"},
         )
 
     def mock_response(self) -> None:
-        def translate_callback(request: PreparedRequest):
-            self.assertEqual(urlparse(request.url).query, "")
+        def translate_callback(request: httpx2.Request):
+            self.assertEqual(request.url.query, b"")
             self.assertEqual(request.headers["Authorization"], "Api-Key KEY")
             payload = load_request_json(request)
             self.assertEqual(payload["sourceLanguageCode"], "en")
@@ -1856,16 +1850,16 @@ class YandexV2TranslationTest(BaseMachineTranslationTest):
             assert isinstance(texts, list)
             self.assertEqual(len(texts), 1)
             self.assertIn(texts[0], {self.SOURCE_TRANSLATED, "test"})
-            return (
+            return httpx2.Response(
                 200,
-                {},
-                json.dumps(
+                headers={},
+                text=json.dumps(
                     {"translations": [{"text": "svet", "detectedLanguageCode": "en"}]}
                 ),
             )
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://translate.api.cloud.yandex.net/translate/v2/languages",
             json={
                 "languages": [
@@ -1874,17 +1868,17 @@ class YandexV2TranslationTest(BaseMachineTranslationTest):
                 ]
             },
         )
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://translate.api.cloud.yandex.net/translate/v2/translate",
             callback=translate_callback,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_error_message(self) -> None:
         message = "Invalid test request"
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://translate.api.cloud.yandex.net/translate/v2/languages",
             json={
                 "languages": [
@@ -1893,8 +1887,8 @@ class YandexV2TranslationTest(BaseMachineTranslationTest):
                 ]
             },
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://translate.api.cloud.yandex.net/translate/v2/translate",
             json={"code": 400, "message": message},
         )
@@ -1917,28 +1911,28 @@ class YoudaoTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST, "https://openapi.youdao.com/api", json={"errorCode": 1}
+        http_mock.register(
+            "POST", "https://openapi.youdao.com/api", json={"errorCode": 1}
         )
 
     def mock_response(self) -> None:
-        def request_callback(request: PreparedRequest):
-            self.assertEqual(urlparse(request.url).query, "")
-            body = parse_qs(
-                request.body.decode()
-                if isinstance(request.body, bytes)
-                else str(request.body)
-            )
+        def request_callback(request: httpx2.Request):
+            self.assertEqual(request.url.query, b"")
+            body = parse_qs(request.content.decode())
             self.assertEqual(body["appKey"], ["id"])
             self.assertIn(body["q"][0], {self.SOURCE_TRANSLATED, "test"})
             self.assertIn(body["_from"][0], {"EN", "en"})
             self.assertEqual(body["to"], ["de"])
             self.assertIn("salt", body)
             self.assertIn("sign", body)
-            return 200, {}, json.dumps({"errorCode": 0, "translation": ["hello"]})
+            return httpx2.Response(
+                200,
+                headers={},
+                text=json.dumps({"errorCode": 0, "translation": ["hello"]}),
+            )
 
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://openapi.youdao.com/api",
             callback=request_callback,
         )
@@ -1954,11 +1948,11 @@ class NeteaseSightTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(responses.POST, NETEASE_API_ROOT, json={"success": "false"})
+        http_mock.register("POST", NETEASE_API_ROOT, json={"success": "false"})
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             NETEASE_API_ROOT,
             json={
                 "success": "true",
@@ -1980,50 +1974,46 @@ class BaiduTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST, BAIDU_API, json={"error_code": 1, "error_msg": "Error"}
+        http_mock.register(
+            "POST", BAIDU_API, json={"error_code": 1, "error_msg": "Error"}
         )
 
     def mock_response(self) -> None:
-        def request_callback(request: PreparedRequest):
-            self.assertEqual(urlparse(request.url).query, "")
-            body = parse_qs(
-                request.body.decode()
-                if isinstance(request.body, bytes)
-                else str(request.body)
-            )
+        def request_callback(request: httpx2.Request):
+            self.assertEqual(request.url.query, b"")
+            body = parse_qs(request.content.decode())
             self.assertEqual(body["appid"], ["id"])
             self.assertIn(body["q"][0], {self.SOURCE_TRANSLATED, "test"})
             self.assertEqual(body["from"], ["en"])
             self.assertIn(body["to"][0], {"cs", "de"})
             self.assertIn("salt", body)
             self.assertIn("sign", body)
-            return (
+            return httpx2.Response(
                 200,
-                {},
-                json.dumps({"trans_result": [{"src": "hello", "dst": "hallo"}]}),
+                headers={},
+                text=json.dumps({"trans_result": [{"src": "hello", "dst": "hallo"}]}),
             )
 
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             BAIDU_API,
             callback=request_callback,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_ratelimit(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             BAIDU_API,
             json={"error_code": "54003", "error_msg": "Error"},
         )
         with self.assertRaises(MachineryRateLimitError):
             self.assert_translate(self.SUPPORTED, self.SOURCE_TRANSLATED, 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_bug(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             BAIDU_API,
             json={"error_code": "bug", "error_msg": "Error"},
         )
@@ -2045,34 +2035,38 @@ class SystranTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_response(self) -> None:
-        def supported_languages_callback(request: PreparedRequest):
-            self.assertEqual(urlparse(request.url).query, "")
+        def supported_languages_callback(request: httpx2.Request):
+            self.assertEqual(request.url.query, b"")
             self.assertEqual(request.headers["Authorization"], "Key key")
-            return 200, {}, json.dumps(SYSTRAN_LANGUAGE_JSON)
+            return httpx2.Response(
+                200, headers={}, text=json.dumps(SYSTRAN_LANGUAGE_JSON)
+            )
 
-        def translate_callback(request: PreparedRequest):
+        def translate_callback(request: httpx2.Request):
             query = parse_qs(urlparse(get_request_url(request)).query)
             self.assertEqual(request.headers["Authorization"], "Key key")
             self.assertNotIn("key", query)
             self.assertEqual(query["source"], ["en"])
             self.assertIn(query["target"][0], {"cs", "de"})
             self.assertIn(query["input"][0], {self.SOURCE_TRANSLATED, "test"})
-            return 200, {}, json.dumps({"outputs": [{"output": "ahoj"}]})
+            return httpx2.Response(
+                200, headers={}, text=json.dumps({"outputs": [{"output": "ahoj"}]})
+            )
 
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api-translate.systran.net/translation/apiVersion",
             json={"version": "2.11.0"},
         )
 
-        responses.add_callback(
-            responses.GET,
+        http_mock.register_callback(
+            "GET",
             "https://api-translate.systran.net/translation/supportedLanguages",
             callback=supported_languages_callback,
         )
 
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api-translate.systran.net/translation/text/translate",
             callback=translate_callback,
         )
@@ -2093,16 +2087,16 @@ class SAPTranslationHubTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.GET, "http://sth.example.com/v1/languages", body="", status=500
+        http_mock.register(
+            "GET", "http://sth.example.com/v1/languages", text="", status_code=500
         )
-        responses.add(
-            responses.POST, "http://sth.example.com/v1/translate", body="", status=500
+        http_mock.register(
+            "POST", "http://sth.example.com/v1/translate", text="", status_code=500
         )
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "http://sth.example.com/v1/languages",
             json={
                 "languages": [
@@ -2111,14 +2105,14 @@ class SAPTranslationHubTest(BaseMachineTranslationTest):
                     {"id": "de", "name": "German", "bcp-47-code": "de"},
                 ]
             },
-            status=200,
+            status_code=200,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "http://sth.example.com/v1/translate",
             json=SAPTRANSLATIONHUB_JSON,
-            status=200,
-            content_type="text/json",
+            status_code=200,
+            headers={"Content-Type": "text/json"},
         )
 
 
@@ -2146,39 +2140,39 @@ class ModernMTTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.GET, "https://api.modernmt.com/languages", body="", status=500
+        http_mock.register(
+            "GET", "https://api.modernmt.com/languages", text="", status_code=500
         )
-        responses.add(
-            responses.GET, "https://api.modernmt.com/translate", body="", status=500
+        http_mock.register(
+            "GET", "https://api.modernmt.com/translate", text="", status_code=500
         )
 
     def mock_languages(self) -> None:
         """Set up mock responses for languages list from ModernMT API."""
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.modernmt.com/translate/languages",
             json={
                 "data": ["en", "sr", "cs", "it", "ja"],
                 "status": 200,
             },
-            status=200,
+            status_code=200,
         )
 
     def mock_response(self) -> None:
         """Set up mock responses for ModernMT API."""
         self.mock_languages()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.modernmt.com/translate",
             json=MODERNMT_RESPONSE,
-            status=200,
-            content_type="text/json",
+            status_code=200,
+            headers={"Content-Type": "text/json"},
         )
 
         self.mock_list_glossaries()
 
-    @responses.activate
+    @http_mock.activate
     def test_async_translate(self) -> None:
         self.mock_response()
         self.assert_async_translate(
@@ -2195,8 +2189,8 @@ class ModernMTTest(BaseMachineTranslationTest):
             }
             for glossary_id, glossary_name, glossary_date in id_name_date
         ]
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.modernmt.com/memories",
             json={
                 "status": 200,
@@ -2207,8 +2201,8 @@ class ModernMTTest(BaseMachineTranslationTest):
     def mock_create_glossary(self, glossary_id: int, glossary_name: str) -> None:
         """Set up mock responses for creating glossary in ModernMT."""
         # creating the memory
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.modernmt.com/memories",
             json={
                 "status": 200,
@@ -2221,8 +2215,8 @@ class ModernMTTest(BaseMachineTranslationTest):
         )
 
         # storing content in memory as glossary
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             f"https://api.modernmt.com/memories/{glossary_id}/glossary",
             json={
                 "status": 200,
@@ -2244,20 +2238,20 @@ class ModernMTTest(BaseMachineTranslationTest):
             )
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_glossary(self, fail_delete_glossary: bool = False) -> None:
         """Test that glossary is used in translation request when available."""
 
-        def translate_request_callback(request: PreparedRequest):
+        def translate_request_callback(request: httpx2.Request):
             """Check 'glossaries' included in request params."""
             self.assertIn("glossaries", get_request_params(request))
-            return (200, {}, json.dumps(MODERNMT_RESPONSE))
+            return httpx2.Response(200, headers={}, text=json.dumps(MODERNMT_RESPONSE))
 
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
 
-        responses.add_callback(
-            responses.GET,
+        http_mock.register_callback(
+            "GET",
             "https://api.modernmt.com/translate",
             callback=translate_request_callback,
         )
@@ -2278,15 +2272,15 @@ class ModernMTTest(BaseMachineTranslationTest):
         # return current list of glossaries
         self.mock_list_glossaries(*[(37784, "weblate:1:en:it:9e250d830c11d70f", None)])
 
-        def delete_glossary_callback(request: PreparedRequest, expected_id: int):
+        def delete_glossary_callback(request: httpx2.Request, expected_id: int):
             """Check that the stale glossary is being deleted."""
             self.assertTrue(
                 get_request_url(request).endswith(f"memories/{expected_id}")
             )
-            return (200, {}, "{}")
+            return httpx2.Response(200, headers={}, text="{}")
 
-        responses.add_callback(
-            responses.DELETE,
+        http_mock.register_callback(
+            "DELETE",
             re.compile(r"https://api.modernmt.com/memories/(\d+)"),
             callback=partial(delete_glossary_callback, expected_id=37784),
         )
@@ -2302,20 +2296,22 @@ class ModernMTTest(BaseMachineTranslationTest):
             )
 
         if fail_delete_glossary:
-            responses.delete(
-                re.compile(r"https://api.modernmt.com/memories/(\d+)"), status=404
+            http_mock.register(
+                "DELETE",
+                re.compile(r"https://api.modernmt.com/memories/(\d+)"),
+                status_code=404,
             )
         else:
             # stale glossary delete
-            responses.add_callback(
-                responses.DELETE,
+            http_mock.register_callback(
+                "DELETE",
                 re.compile(r"https://api.modernmt.com/memories/(\d+)"),
                 callback=partial(delete_glossary_callback, expected_id=37785),
             )
 
             # oldest glossary delete
-            responses.add_callback(
-                responses.DELETE,
+            http_mock.register_callback(
+                "DELETE",
                 re.compile(r"https://api.modernmt.com/memories/(\d+)"),
                 callback=partial(delete_glossary_callback, expected_id=37782),
             )
@@ -2386,17 +2382,17 @@ class ModernMTTest(BaseMachineTranslationTest):
     def test_glossary_with_delete_fail(self) -> None:
         self.test_glossary(fail_delete_glossary=True)
 
-    @responses.activate
+    @http_mock.activate
     def test_context_vector(self) -> None:
         """Test that context vector is sent with the request when configured."""
 
-        def request_callback(request: PreparedRequest):
+        def request_callback(request: httpx2.Request):
             """Check 'context_vector' included in request body."""
             self.assertIn("context_vector", get_request_params(request))
-            return (200, {}, json.dumps(MODERNMT_RESPONSE))
+            return httpx2.Response(200, headers={}, text=json.dumps(MODERNMT_RESPONSE))
 
-        responses.add_callback(
-            responses.GET,
+        http_mock.register_callback(
+            "GET",
             "https://api.modernmt.com/translate",
             callback=request_callback,
         )
@@ -2409,7 +2405,7 @@ class ModernMTTest(BaseMachineTranslationTest):
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_clean_custom(self) -> None:
         """Check that validation of context_vector settings works."""
         self.mock_response()
@@ -2456,26 +2452,26 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/languages",
-            status=500,
+            status_code=500,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.deepl.com/v2/translate",
-            status=500,
+            status_code=500,
         )
 
     @staticmethod
     def mock_languages() -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/languages?resource=translate_text",
             json=DEEPL_LANG_RESPONSE,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/languages?resource=glossary",
             json=DEEPL_LANG_RESPONSE,
         )
@@ -2484,33 +2480,33 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
     # pylint: disable-next=arguments-differ
     def mock_response(cls) -> None:
         cls.mock_languages()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.deepl.com/v2/translate",
             json=DEEPL_RESPONSE,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_async_translate(self) -> None:
         self.mock_response()
         self.assert_async_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_formality(self) -> None:
         expected_formality = "more"
 
-        def request_callback(request: PreparedRequest):
+        def request_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertEqual(payload["formality"], expected_formality)
-            return (200, {}, json.dumps(DEEPL_RESPONSE))
+            return httpx2.Response(200, headers={}, text=json.dumps(DEEPL_RESPONSE))
 
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
         self.mock_languages()
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api.deepl.com/v2/translate",
             callback=request_callback,
         )
@@ -2528,20 +2524,20 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
             "DE@INFORMAL", self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_escaping(self) -> None:
-        def request_callback(request: PreparedRequest):
+        def request_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertIn("formality", payload)
             response = DEEPL_RESPONSE.copy()
             response["translations"][0]["text"] = "Hallo&amp;welt"
-            return (200, {}, json.dumps(response))
+            return httpx2.Response(200, headers={}, text=json.dumps(response))
 
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
         self.mock_languages()
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api.deepl.com/v2/translate",
             callback=request_callback,
         )
@@ -2552,15 +2548,15 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(translation[0][0]["source"], "Hello&world")
         self.assertEqual(translation[0][0]["text"], "Hallo&welt")
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.glossary.models.get_glossary_tsv", new=lambda _: "foo\tbar")
     def test_glossary(self) -> None:
-        def request_callback(request: PreparedRequest):
+        def request_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertIn("glossary_id", payload)
-            return (200, {}, json.dumps(DEEPL_RESPONSE))
+            return httpx2.Response(200, headers={}, text=json.dumps(DEEPL_RESPONSE))
 
-        def glossary_create_callback(request: PreparedRequest):
+        def glossary_create_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertEqual(
                 payload,
@@ -2576,28 +2572,28 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
                     ],
                 },
             )
-            return (200, {}, "{}")
+            return httpx2.Response(200, headers={}, text="{}")
 
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
         self.mock_languages()
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api.deepl.com/v2/translate",
             callback=request_callback,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/glossaries",
             json={"glossaries": []},
         )
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api.deepl.com/v3/glossaries",
             callback=glossary_create_callback,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/glossaries",
             json={
                 "glossaries": [
@@ -2616,7 +2612,7 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         # Fetch from service
         self.assert_translate(self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN)
 
-    @responses.activate
+    @http_mock.activate
     def test_glossary_languages_ignores_legacy_cache(self) -> None:
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
@@ -2629,31 +2625,31 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
             {("EN", "DE"), ("EN", "FR"), ("DE", "EN")},
             24 * 3600,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/languages?resource=glossary",
             json=DEEPL_LANG_RESPONSE,
         )
 
         self.assertTrue(machine.is_glossary_supported("EN", "DE"))
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
         self.assertIsNotNone(cache.get(new_cache_key))
         self.assertEqual(
             cache.get(old_cache_key), {("EN", "DE"), ("EN", "FR"), ("DE", "EN")}
         )
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.glossary.models.get_glossary_tsv", new=lambda _: "foo\tbar")
     def test_glossary_with_regional_target(self) -> None:
-        def request_callback(request: PreparedRequest):
+        def request_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertEqual(payload["target_lang"], "PT-BR")
             self.assertEqual(
                 payload["glossary_id"], "def3a26b-3e84-45b3-84ae-0c0aaf3525f7"
             )
-            return (200, {}, json.dumps(DEEPL_RESPONSE))
+            return httpx2.Response(200, headers={}, text=json.dumps(DEEPL_RESPONSE))
 
-        def glossary_create_callback(request: PreparedRequest):
+        def glossary_create_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertEqual(
                 payload,
@@ -2669,28 +2665,28 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
                     ],
                 },
             )
-            return (200, {}, "{}")
+            return httpx2.Response(200, headers={}, text="{}")
 
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
         self.mock_languages()
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api.deepl.com/v2/translate",
             callback=request_callback,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/glossaries",
             json={"glossaries": []},
         )
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api.deepl.com/v3/glossaries",
             callback=glossary_create_callback,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.deepl.com/v3/glossaries",
             json={
                 "glossaries": [
@@ -2708,12 +2704,12 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         )
         self.assert_translate("PT-BR", self.SOURCE_TRANSLATED, self.EXPECTED_LEN)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.glossary.models.get_glossary_tsv", new=lambda _: "foo\tbar")
     def test_glossary_updates_stale_glossary(self) -> None:
         """Test handling of glossary update scenario."""
 
-        def glossary_replace_callback(request: PreparedRequest):
+        def glossary_replace_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertEqual(
                 payload,
@@ -2724,9 +2720,9 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
                     "entries_format": "tsv",
                 },
             )
-            return (200, {}, "{}")
+            return httpx2.Response(200, headers={}, text="{}")
 
-        def glossary_rename_callback(request: PreparedRequest):
+        def glossary_rename_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertEqual(
                 payload,
@@ -2734,7 +2730,7 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
                     "name": "weblate:1:EN:DE:9e250d830c11d70f",
                 },
             )
-            return (200, {}, "{}")
+            return httpx2.Response(200, headers={}, text="{}")
 
         with patch(
             "weblate.machinery.deepl.DeepLTranslation.glossary_count_limit",
@@ -2742,7 +2738,8 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         ):
             self.mock_languages()
             # list glossaries to find matching name
-            responses.get(
+            http_mock.register(
+                "GET",
                 "https://api.deepl.com/v3/glossaries",
                 json={
                     "glossaries": [
@@ -2759,19 +2756,20 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
                 },
             )
             # replace stale glossary dictionary
-            responses.add_callback(
-                responses.PUT,
+            http_mock.register_callback(
+                "PUT",
                 "https://api.deepl.com/v3/glossaries/8f54a21b-475f-42c2-bf8d-1a0a9f6543e2/dictionaries",
                 callback=glossary_replace_callback,
             )
             # rename stale glossary to the new checksum
-            responses.add_callback(
-                responses.PATCH,
+            http_mock.register_callback(
+                "PATCH",
                 "https://api.deepl.com/v3/glossaries/8f54a21b-475f-42c2-bf8d-1a0a9f6543e2",
                 callback=glossary_rename_callback,
             )
             # list glossaries with new entry
-            responses.get(
+            http_mock.register(
+                "GET",
                 "https://api.deepl.com/v3/glossaries",
                 json={
                     "glossaries": [
@@ -2788,12 +2786,14 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
                 },
             )
 
-            responses.post("https://api.deepl.com/v2/translate", json=DEEPL_RESPONSE)
+            http_mock.register(
+                "POST", "https://api.deepl.com/v2/translate", json=DEEPL_RESPONSE
+            )
             self.assert_translate(
                 self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
             )
             calls = [
-                (call.request.method, call.request.url) for call in responses.calls
+                (call.request.method, str(call.request.url)) for call in http_mock.calls
             ]
             replace_call = (
                 "PUT",
@@ -2805,20 +2805,20 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
             )
             self.assertLess(calls.index(replace_call), calls.index(rename_call))
             self.assertFalse(
-                any(call.request.method == "DELETE" for call in responses.calls)
+                any(call.request.method == "DELETE" for call in http_mock.calls)
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_replacements(self) -> None:
-        def request_callback(request: PreparedRequest):
+        def request_callback(request: httpx2.Request):
             payload = load_request_json(request)
             self.assertEqual(
                 payload["text"], ['Hello, <x id="7"></x>! &lt;&lt;foo&gt;&gt;']
             )
-            return (
+            return httpx2.Response(
                 200,
-                {},
-                json.dumps(
+                headers={},
+                text=json.dumps(
                     {
                         "translations": [
                             {
@@ -2833,8 +2833,8 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
         self.mock_languages()
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             "https://api.deepl.com/v2/translate",
             callback=request_callback,
         )
@@ -2848,7 +2848,7 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         )
         self.assertEqual(translation[0][0]["text"], "Hallo, %s! <<foo>>")
 
-    @responses.activate
+    @http_mock.activate
     def test_cache(self) -> None:
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
@@ -2857,24 +2857,24 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         self.assert_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
-        self.assertEqual(len(responses.calls), 3)
+        self.assertEqual(len(http_mock.calls), 3)
         self.assertEqual(
-            [(call.request.method, call.request.url) for call in responses.calls],
+            [(call.request.method, call.request.url) for call in http_mock.calls],
             [
                 ("GET", "https://api.deepl.com/v3/languages?resource=translate_text"),
                 ("GET", "https://api.deepl.com/v3/languages?resource=glossary"),
                 ("POST", "https://api.deepl.com/v2/translate"),
             ],
         )
-        responses.reset()
+        http_mock.reset()
         # Fetch from cache
         machine = self.MACHINE_CLS(self.get_configuration())
         self.assert_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_api_url(self) -> None:
         test_cases = (
             {
@@ -2974,7 +2974,7 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
                 with self.assertRaises(MachineTranslationError):
                     _ = machine.api_base_url
 
-    @responses.activate
+    @http_mock.activate
     def test_languages_map(self) -> None:
         machine = self.MACHINE_CLS(self.get_configuration())
         self.mock_languages()
@@ -3006,33 +3006,33 @@ class LibreTranslateTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.get_api_url("translate"),
             json=LIBRETRANSLATE_TRANS_ERROR_RESPONSE,
-            status=403,
+            status_code=403,
         )
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             self.get_api_url("languages"),
             json=LIBRETRANSLATE_LANG_RESPONSE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.get_api_url("translate"),
             json=LIBRETRANSLATE_TRANS_RESPONSE,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_async_translate(self) -> None:
         self.mock_response()
         self.assert_async_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_chinese(self) -> None:
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
@@ -3044,7 +3044,7 @@ class LibreTranslateTranslationTest(BaseMachineTranslationTest):
             "zh_Hans", self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_result_content(self) -> None:
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
@@ -3054,7 +3054,7 @@ class LibreTranslateTranslationTest(BaseMachineTranslationTest):
         )
         self.assertEqual(translation[0][0]["text"], "¡Hola, Mundo!")
 
-    @responses.activate
+    @http_mock.activate
     def test_uses_batched_query(self) -> None:
         machine = self.get_machine()
         self.mock_response()
@@ -3066,7 +3066,7 @@ class LibreTranslateTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(len(payloads), 1)
         self.assertEqual(payloads[0]["q"], [self.SOURCE_TRANSLATED])
 
-    @responses.activate
+    @http_mock.activate
     def test_cache(self) -> None:
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
@@ -3075,14 +3075,14 @@ class LibreTranslateTranslationTest(BaseMachineTranslationTest):
         self.assert_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
-        self.assertEqual(len(responses.calls), 2)
-        responses.reset()
+        self.assertEqual(len(http_mock.calls), 2)
+        http_mock.reset()
         # Fetch from cache
         machine = self.MACHINE_CLS(self.get_configuration())
         self.assert_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN, machine=machine
         )
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
 
 class LTEngineTranslationTest(BaseMachineTranslationTest):
@@ -3106,26 +3106,26 @@ class LTEngineTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(self.MACHINE_CLS.batch_size, 1)
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.get_api_url("translate"),
             json=LIBRETRANSLATE_TRANS_ERROR_RESPONSE,
-            status=403,
+            status_code=403,
         )
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             self.get_api_url("languages"),
             json=LIBRETRANSLATE_LANG_RESPONSE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.get_api_url("translate"),
             json=LIBRETRANSLATE_SINGLE_TRANS_RESPONSE,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_result_content(self) -> None:
         machine = self.MACHINE_CLS(self.get_configuration())
         machine.delete_cache()
@@ -3135,7 +3135,7 @@ class LTEngineTranslationTest(BaseMachineTranslationTest):
         )
         self.assertEqual(translation[0][0]["text"], "¡Hola, Mundo!")
 
-    @responses.activate
+    @http_mock.activate
     def test_uses_scalar_query(self) -> None:
         machine = self.get_machine()
         self.mock_response()
@@ -3147,21 +3147,21 @@ class LTEngineTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(len(payloads), 1)
         self.assertEqual(payloads[0]["q"], self.SOURCE_TRANSLATED)
 
-    @responses.activate
+    @http_mock.activate
     def test_uses_scalar_query_for_batch(self) -> None:
         machine = self.get_machine()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             self.get_api_url("languages"),
             json=LIBRETRANSLATE_LANG_RESPONSE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.get_api_url("translate"),
             json={"translatedText": "¡Hola, Mundo!"},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.get_api_url("translate"),
             json={"translatedText": "¡Adiós, Mundo!"},
         )
@@ -3517,19 +3517,19 @@ class AlibabaTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.API_URL,
             json={
                 "Code": "InvalidAccessKeyId.NotFound",
                 "Message": "Specified access key is not found.",
             },
-            status=400,
+            status_code=400,
         )
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             self.API_URL,
             json={
                 "RequestId": "14E447CA-B93B-4526-ACD7-42AE13CC2AF6",
@@ -3538,17 +3538,12 @@ class AlibabaTranslationTest(BaseMachineTranslationTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_signed_request(self) -> None:
-        def request_callback(request: PreparedRequest):
+        def request_callback(request: httpx2.Request):
             url = urlparse(get_request_url(request))
             query = parse_qs(url.query, keep_blank_values=True)
-            body_content = (
-                request.body.decode()
-                if isinstance(request.body, bytes)
-                else str(request.body)
-            )
-            body = parse_qs(body_content, keep_blank_values=True)
+            body = parse_qs(request.content.decode(), keep_blank_values=True)
 
             self.assertEqual(url.scheme, "https")
             self.assertEqual(url.netloc, "mt.cn-hangzhou.aliyuncs.com")
@@ -3567,10 +3562,10 @@ class AlibabaTranslationTest(BaseMachineTranslationTest):
             self.assertEqual(query["SignatureNonce"], ["nonce"])
             self.assertEqual(query["Timestamp"], ["2016-02-23T12:46:24Z"])
             self.assertEqual(query["Signature"], ["CFsUjxmfcBDHRL3x66DjpEQ+hJc="])
-            return (
+            return httpx2.Response(
                 200,
-                {},
-                json.dumps(
+                headers={},
+                text=json.dumps(
                     {
                         "RequestId": "14E447CA-B93B-4526-ACD7-42AE13CC2AF6",
                         "Data": {"Translated": "Hello"},
@@ -3579,8 +3574,8 @@ class AlibabaTranslationTest(BaseMachineTranslationTest):
                 ),
             )
 
-        responses.add_callback(
-            responses.POST,
+        http_mock.register_callback(
+            "POST",
             self.API_URL,
             callback=request_callback,
         )
@@ -3595,7 +3590,7 @@ class AlibabaTranslationTest(BaseMachineTranslationTest):
                 self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_error_message(self) -> None:
         self.mock_error()
         with self.assertRaisesRegex(
@@ -3813,8 +3808,8 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
     @staticmethod
     def mock_models() -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.openai.com/v1/models",
             json={
                 "object": "list",
@@ -3831,8 +3826,8 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
     def mock_response(self, content: str = '["Ahoj světe"]') -> None:
         self.mock_models()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.openai.com/v1/chat/completions",
             json={
                 "id": "chatcmpl-123",
@@ -3858,7 +3853,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_async_translate(self) -> None:
         self.mock_response()
         self.assert_async_translate(
@@ -3878,7 +3873,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         )
         self.assertIn("Prefer structured objects when", PROMPT)
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_traces_resolved_model_breadcrumb(self) -> None:
         self.mock_response()
         machine = self.get_machine()
@@ -4985,7 +4980,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         self.assertEqual(unit1.machinery["translation"], ["Archive as noun"])
         self.assertEqual(unit2.machinery["translation"], ["Archive as verb"])
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_invalid_json_string_quotes(self) -> None:
         source = "Synthetic source string for malformed JSON recovery."
         self.mock_response('["Préfixe "citation" suffixe"]')
@@ -5001,7 +4996,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             'Préfixe "citation" suffixe',
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_invalid_json_string_quotes_before_colon(self) -> None:
         source = "Synthetic source string for malformed JSON recovery."
         self.mock_response('["Bouton "Enregistrer": conserve les modifications"]')
@@ -5017,7 +5012,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             'Bouton "Enregistrer": conserve les modifications',
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_invalid_json_string_quotes_before_brace(self) -> None:
         source = "Synthetic source string for malformed JSON recovery."
         self.mock_response('["Utiliser "}" pour fermer"]')
@@ -5033,7 +5028,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             'Utiliser "}" pour fermer',
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_invalid_structured_json_string_quotes(self) -> None:
         source = "Synthetic source string for structured JSON recovery."
         self.mock_response(
@@ -5051,7 +5046,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             'Préfixe "citation" suffixe',
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_invalid_structured_json_string_quotes_before_colon(
         self,
     ) -> None:
@@ -5071,7 +5066,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             'Bouton "Enregistrer": conserve les modifications',
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_invalid_structured_json_string_quotes_before_brace(
         self,
     ) -> None:
@@ -5091,7 +5086,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             'Utiliser "}" pour fermer',
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_invalid_structured_json_string_quote_at_end(
         self,
     ) -> None:
@@ -5111,7 +5106,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             'Synthetic terminal quote"',
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_structured_json_code_fence(self) -> None:
         source = "Synthetic source string for fenced JSON recovery."
         self.mock_response(
@@ -5129,7 +5124,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Synthetic fenced translation",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_truncated_structured_json_container(self) -> None:
         self.mock_response(
             '[{"parts":[{"type":"text","text":"Genel Müdür"}]},'
@@ -5145,7 +5140,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
         self.assertEqual(translation["CEO"][0]["text"], "Genel Müdür")
         self.assertEqual(translation["CEO Since"][0]["text"], "CEO'dan beri")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_missing_structured_part_object_close(self) -> None:
         source = "Synthetic source string for missing object close recovery."
         response = (
@@ -5161,7 +5156,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Synthetic missing object close translation.",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_uses_llm_placeholder_syntax(self) -> None:
         machine = self.get_machine()
 
@@ -5901,7 +5896,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Utiliser @@PH4@@ pour le code.",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_repairs_escaped_placeholders(self) -> None:
         source = "List filtered by responses to custom field @@PH44@@."
         self.mock_response(
@@ -5919,7 +5914,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Liste filtree selon les responses au champ personnalise @@PH44@@.",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_placeholderizes_existing_translation(self) -> None:
         machine = self.get_machine()
         existing_translation = "Bonjour, %s! <<foo>>"
@@ -6026,7 +6021,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Articles: @@PH8@@.",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_omits_unmappable_existing_translation(self) -> None:
         machine = self.get_machine()
         broken_translation = "Bonjour tout le monde! <<foo>>"
@@ -6054,7 +6049,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         self.assertEqual(translation[0][0]["text"], "Bonjour %s! <<foo>>")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_maps_reordered_distinct_placeholders(self) -> None:
         machine = self.get_machine()
 
@@ -6085,7 +6080,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Items: %d, value: %s.",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_maps_reordered_distinct_structured_placeholders(self) -> None:
         machine = self.get_machine()
 
@@ -6128,7 +6123,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Items: %d, value: %s.",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_accepts_split_text_around_reordered_structured_placeholder(
         self,
     ) -> None:
@@ -6366,7 +6361,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             "Entre {other.name} et ${user.name}",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_reordered_structured_markup_placeholders(self) -> None:
         machine = self.get_machine()
 
@@ -6407,7 +6402,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "rst-text"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_reordered_structured_escaped_markup_placeholders(
         self,
     ) -> None:
@@ -6448,7 +6443,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": 'placeholders:r"&lt;[a-z/]+&gt;", xml-text'},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_reordered_structured_bbcode_placeholders(self) -> None:
         machine = self.get_machine()
 
@@ -6487,7 +6482,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "bbcode-text"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_structured_placeholder_moved_outside_markup(
         self,
     ) -> None:
@@ -6528,7 +6523,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "bbcode-text, python-format"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_structured_text_moved_inside_markup(self) -> None:
         machine = self.get_machine()
 
@@ -6568,7 +6563,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": 'placeholders:r"&lt;[a-z/]+&gt;", xml-text'},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_reordered_structured_translatable_markup_wrappers(
         self,
     ) -> None:
@@ -6616,7 +6611,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "rst-text"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_unmappable_rst_markup(self) -> None:
         self.mock_response('["Voir :ref:`branche-cible`."]')  # codespell:ignore
 
@@ -6628,7 +6623,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "rst-text"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_unmappable_single_highlight(self) -> None:
         self.mock_response('["Hello, `friend`!"]')
 
@@ -6640,7 +6635,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "python-format"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_placeholder_mismatch(self) -> None:
         self.mock_response('["Synthetic source string without placeholder."]')
 
@@ -6651,7 +6646,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 [("Synthetic source string with @@PH44@@ placeholder.", None)],
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_literal_placeholder_repair_mismatch(self) -> None:
         self.mock_response('["@@PH5@@"]')
 
@@ -6663,7 +6658,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "python-format"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_recovers_spaced_placeholder_syntax(self) -> None:
         self.mock_response('["Bonjour @@PH7@ @! <<foo>>"]')
 
@@ -6676,7 +6671,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         self.assertEqual(translation[0][0]["text"], "Bonjour %s! <<foo>>")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_drops_trailing_empty_extra_reply(self) -> None:
         self.mock_response('["**Konfigurēt paziņojumus**:", ""]')
 
@@ -6689,7 +6684,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         self.assertEqual(translation[0][0]["text"], "**Konfigurēt paziņojumus**:")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_drops_trailing_empty_extra_structured_reply(self) -> None:
         self.mock_response(
             json.dumps(
@@ -6708,7 +6703,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         self.assertEqual(translation["One"][0]["text"], "Premier")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_recovers_extra_rst_closing_placeholder(self) -> None:
         machine = self.get_machine()
         source = (
@@ -6752,7 +6747,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             translation[0][0]["text"],
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_restores_placeholder_before_literal_at(self) -> None:
         machine = self.get_machine()
 
@@ -6781,7 +6776,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         self.assertEqual(translation[0][0]["text"], "%s@example.com")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_accepts_adjacent_placeholders(self) -> None:
         machine = self.get_machine()
 
@@ -6809,7 +6804,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
 
         self.assertEqual(translation[0][0]["text"], "%s%s")
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_placeholder_with_trailing_at(self) -> None:
         self.mock_response('["Bonjour @@PH7@@@! <<foo>>"]')
 
@@ -6821,7 +6816,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "python-format"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_legacy_placeholder_syntax(self) -> None:
         self.mock_response('["Synthetic source string with [X44X] placeholder."]')
 
@@ -6832,7 +6827,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 [("Synthetic source string with @@PH44@@ placeholder.", None)],
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_missing_comma_between_items(self) -> None:
         self.mock_response('["Premier" "Deuxieme", "Troisieme"]')
 
@@ -6843,7 +6838,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 [("One", None), ("Two", None)],
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_non_empty_extra_reply(self) -> None:
         self.mock_response('["Premier", "Deuxieme"]')
 
@@ -6854,7 +6849,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 [("One", None)],
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_rejects_extra_structured_metadata_reply(self) -> None:
         self.mock_response(
             json.dumps(
@@ -6872,7 +6867,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 [("One", None)],
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_ignores_trailing_metadata_reply(self) -> None:
         self.mock_response(
             json.dumps(
@@ -6928,7 +6923,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
                 unit_args={"flags": "rst-text"},
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_blank_reply_reports_single_exception_event(self) -> None:
         machine = self.get_machine()
         handled_cause = f"machinery[{machine.name}]: Blank assistant reply"
@@ -6954,7 +6949,7 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             MachineTranslationError,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_parse_error_reports_single_exception_event(self) -> None:
         machine = self.get_machine()
         handled_cause = (
@@ -6988,14 +6983,14 @@ class OpenAITranslationTest(BaseMachineTranslationTest):
             MachineTranslationError,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_still_rejects_unrepairable_json(self) -> None:
         self.mock_response('["Ahoj světe')
 
         with self.assertRaises(MachineTranslationError):
             self.assert_translate(self.SUPPORTED, self.SOURCE_TRANSLATED, 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_translate_chains_repaired_json_decode_error(self) -> None:
         self.mock_response('["Ahoj "svete"]')
 
@@ -7197,8 +7192,8 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
     }
 
     def mock_response(self, content: str = '["Ahoj světe"]') -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://custom.example.com/models",
             json={
                 "object": "list",
@@ -7212,8 +7207,8 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
                 ],
             },
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://custom.example.com/chat/completions",
             json={
                 "id": "chatcmpl-123",
@@ -7239,7 +7234,7 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_clean_custom(self) -> None:
         self.mock_response()
         settings = self.CONFIGURATION.copy()
@@ -7263,7 +7258,7 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
-    @responses.activate
+    @http_mock.activate
     def test_runtime_url_validation(self, mocked_getaddrinfo) -> None:
         machine = self.MACHINE_CLS(self.CONFIGURATION.copy())
         machine.delete_cache()
@@ -7273,9 +7268,9 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
             machine.get_model()
 
         mocked_getaddrinfo.assert_called_once()
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         side_effect=OSError("Name or service not known"),
@@ -7286,8 +7281,8 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
         machine = self.MACHINE_CLS(self.CONFIGURATION.copy())
         machine.delete_cache()
         machine.settings["_project"] = Mock()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://custom.example.com/models",
             json={
                 "object": "list",
@@ -7316,7 +7311,7 @@ class OpenAICustomTranslationTest(OpenAITranslationTest):
             self.assertEqual(machine.get_model(), self.TRACE_MODEL)
 
         mocked_getaddrinfo.assert_not_called()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
 
 class MistralTranslationTest(OpenAITranslationTest):
@@ -7331,8 +7326,8 @@ class MistralTranslationTest(OpenAITranslationTest):
 
     @staticmethod
     def mock_models() -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.mistral.ai/v1/models",
             json={
                 "object": "list",
@@ -7349,8 +7344,8 @@ class MistralTranslationTest(OpenAITranslationTest):
 
     def mock_response(self, content: str = '["Ahoj světe"]') -> None:
         self.mock_models()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.mistral.ai/v1/chat/completions",
             json={
                 "id": "chatcmpl-123",
@@ -7388,8 +7383,8 @@ class MistralCustomTranslationTest(OpenAICustomTranslationTest):
     TRACE_MODEL: ClassVar[str] = "ministral-3b-latest"
 
     def mock_response(self, content: str = '["Ahoj světe"]') -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://custom.example.com/models",
             json={
                 "object": "list",
@@ -7403,8 +7398,8 @@ class MistralCustomTranslationTest(OpenAICustomTranslationTest):
                 ],
             },
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://custom.example.com/chat/completions",
             json={
                 "id": "chatcmpl-123",
@@ -7442,8 +7437,8 @@ class AzureOpenAITranslationTest(OpenAITranslationTest):
     TRACE_MODEL: ClassVar[str] = "my-deployment"
 
     def mock_response(self, content: str = '["Ahoj světe"]') -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://my-instance.openai.azure.com/openai/deployments/my-deployment/chat/completions?api-version=2024-06-01",
             json={
                 "id": "chatcmpl-123",
@@ -7469,7 +7464,7 @@ class AzureOpenAITranslationTest(OpenAITranslationTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         side_effect=OSError("Name or service not known"),
@@ -7498,7 +7493,7 @@ class AzureOpenAITranslationTest(OpenAITranslationTest):
             )
 
         mocked_getaddrinfo.assert_not_called()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
 
 class OllamaTranslationTest(BaseMachineTranslationTest):
@@ -7518,18 +7513,18 @@ class OllamaTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "http://localhost:11434/api/chat",
-            status=404,
+            status_code=404,
             json={"error": "the model failed to generate a response"},
         )
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "http://localhost:11434/api/chat",
-            status=200,
+            status_code=200,
             json={
                 "model": "itzune/latxa:8b",
                 "created_at": "2025-11-29T21:25:08.441817763Z",
@@ -7548,7 +7543,7 @@ class OllamaTranslationTest(BaseMachineTranslationTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_async_translate(self) -> None:
         self.mock_response()
         self.assert_async_translate(
@@ -7565,10 +7560,10 @@ class OllamaRemoteModelTranslationTest(OllamaTranslationTest):
     }
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "http://localhost:11434/api/chat",
-            status=200,
+            status_code=200,
             json={
                 "model": "minimax-m2:cloud",
                 "remote_model": "minimax-m2",
@@ -7606,10 +7601,10 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
         self.skipTest("Not tested")
 
     def mock_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.anthropic.com/v1/messages",
-            status=400,
+            status_code=400,
             json={
                 "type": "error",
                 "error": {
@@ -7620,10 +7615,10 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
         )
 
     def mock_response(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.anthropic.com/v1/messages",
-            status=200,
+            status_code=200,
             json={
                 "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
                 "type": "message",
@@ -7644,19 +7639,19 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_async_translate(self) -> None:
         self.mock_response()
         self.assert_async_translate(
             self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_empty_base_url_uses_default(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.anthropic.com/v1/messages",
-            status=200,
+            status_code=200,
             json={
                 "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
                 "type": "message",
@@ -7685,12 +7680,12 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
             machine=machine,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_error_non_json(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.anthropic.com/v1/messages",
-            status=200,
+            status_code=200,
             json={
                 "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
                 "type": "message",
@@ -7713,12 +7708,12 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
         with self.assertRaises(MachineTranslationError):
             self.assert_translate(self.SUPPORTED, self.SOURCE_BLANK, 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_error_wrong_type(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.anthropic.com/v1/messages",
-            status=200,
+            status_code=200,
             json={
                 "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
                 "type": "message",
@@ -7741,12 +7736,12 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
         with self.assertRaises(MachineTranslationError):
             self.assert_translate(self.SUPPORTED, self.SOURCE_BLANK, 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_response_skips_thinking_blocks(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.anthropic.com/v1/messages",
-            status=200,
+            status_code=200,
             json={
                 "content": [
                     {"type": "thinking", "thinking": ""},
@@ -7775,7 +7770,7 @@ class AnthropicCustomModelTranslationTest(AnthropicTranslationTest):
         "style": "",
     }
 
-    @responses.activate
+    @http_mock.activate
     def test_clean_custom(self) -> None:
         self.mock_response()
         settings = self.CONFIGURATION.copy()
@@ -8648,7 +8643,7 @@ class MachineryValidationTest(TestCase):
         self.assertNotIn("site-wide", str(form.errors["__all__"]))
         self.assertNotIn("allowlisted", str(form.errors["__all__"]))
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_ollama_rejects_private_url_before_request(self) -> None:
         form = OllamaTranslation.settings_form(
@@ -8664,10 +8659,10 @@ class MachineryValidationTest(TestCase):
 
         self.assertFalse(form.is_valid())
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         self.assertIn("internal or non-public address", str(form.errors["__all__"]))
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_anthropic_rejects_private_url_before_request(self) -> None:
         form = AnthropicTranslation.settings_form(
@@ -8685,7 +8680,7 @@ class MachineryValidationTest(TestCase):
 
         self.assertFalse(form.is_valid())
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         self.assertIn("internal or non-public address", str(form.errors["__all__"]))
 
     def test_check_failure_hides_response_body(self) -> None:
@@ -8864,7 +8859,7 @@ class MachineryValidationTest(TestCase):
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
     )
-    @responses.activate
+    @http_mock.activate
     @override_settings(OFFER_HOSTING=False)
     def test_project_validation_uses_runtime_url_guard(
         self, mocked_getaddrinfo
@@ -8878,7 +8873,7 @@ class MachineryValidationTest(TestCase):
         self.assertFalse(form.is_valid())
 
         mocked_getaddrinfo.assert_called()
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         self.assertIn(
             "internal or non-public address",
             str(form.non_field_errors()),
@@ -8980,7 +8975,7 @@ class CommandTest(FixtureComponentTestCase):
                 stderr=output,
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_install_valid_form(self) -> None:
         output = StringIO()
         DeepLTranslationTest.mock_response()

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -41,7 +41,7 @@ from weblate.trans.tests.test_models import RepoTestCase
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.tests.utils import create_test_user, get_test_file
 from weblate.utils.docs import get_doc_url
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 
 TEST_SCREENSHOT = get_test_file("screenshot.png")
 PUBLIC_TEST_ADDRESS = "93.184.216.34"
@@ -132,7 +132,7 @@ class TesseractDataTest(SimpleTestCase):
         fetch_url.assert_called_with(
             "GET",
             "https://example.com/eng",
-            allow_redirects=True,
+            follow_redirects=True,
             timeout=TESSERACT_DOWNLOAD_TIMEOUT,
         )
         self.assertEqual([call.args for call in sleep.call_args_list], [(1,), (2,)])
@@ -1039,7 +1039,7 @@ class ViewTest(FixtureTestCase):
         )
         self.assertEqual(screenshot.units.count(), 0)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value=PUBLIC_TEST_ADDRESS,
@@ -1051,11 +1051,11 @@ class ViewTest(FixtureTestCase):
     def test_upload_with_image_url(self, _mocked_getaddrinfo, _mocked_get_peer) -> None:
         data = Path(TEST_SCREENSHOT).read_bytes()
         image_url = "https://example.com/test-image.png?signature=test#preview"
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://example.com/test-image.png?signature=test",
-            content_type="image/png",
-            body=data,
+            headers={"Content-Type": "image/png"},
+            content=data,
         )
 
         self.make_manager()
@@ -1066,7 +1066,7 @@ class ViewTest(FixtureTestCase):
         assert image_name is not None
         self.assertTrue(image_name.endswith(".png"))
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value=PUBLIC_TEST_ADDRESS,
@@ -1078,11 +1078,11 @@ class ViewTest(FixtureTestCase):
     def test_upload_with_image_url_invalid_extension(
         self, _mocked_getaddrinfo, _mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://example.com/test-image.html",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         self.make_manager()
@@ -1093,7 +1093,7 @@ class ViewTest(FixtureTestCase):
         self.assertContains(response, "File extension")
         self.assertEqual(Screenshot.objects.count(), 0)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value=PUBLIC_TEST_ADDRESS,
@@ -1110,11 +1110,11 @@ class ViewTest(FixtureTestCase):
         old_filename = screenshot.image.file.name
 
         data = Path(TEST_SCREENSHOT).read_bytes()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://example.com/test-image.png",
-            content_type="image/png",
-            body=data,
+            headers={"Content-Type": "image/png"},
+            content=data,
         )
 
         self.client.post(
@@ -1129,7 +1129,7 @@ class ViewTest(FixtureTestCase):
         self.assertNotEqual(screenshot.image.name, old_name)
         self.assertNotEqual(screenshot.image.file.name, old_filename)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value=PUBLIC_TEST_ADDRESS,
@@ -1143,16 +1143,16 @@ class ViewTest(FixtureTestCase):
     ) -> None:
         """Test handling of image download failures."""
         self.make_manager()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://example.com/missing-image.png",
-            content_type="text/html",
-            status=301,
+            headers={"Content-Type": "text/html"},
+            status_code=301,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register_exception(
+            "GET",
             "https://example.com/broken-image.png",
-            body=httpx2.ConnectError(
+            exception=httpx2.ConnectError(
                 "Network error",
                 request=httpx2.Request("GET", "https://example.com/broken-image.png"),
             ),
@@ -1170,7 +1170,7 @@ class ViewTest(FixtureTestCase):
         )
         self.assertContains(response, "Unable to download image from the provided URL.")
 
-    @responses.activate
+    @http_mock.activate
     def test_no_image_or_url_validation(self) -> None:
         """Test validation when neither image nor URL is provided."""
         self.make_manager()
@@ -1179,14 +1179,14 @@ class ViewTest(FixtureTestCase):
             response, "You need to provide either image file or image URL."
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_both_image_and_url_provided(self) -> None:
         """Test that providing both image file and URL prioritizes the file."""
         self.make_manager()
         self.do_upload(image_url="https://example.com/should-be-ignored.png")
         self.assertEqual(Screenshot.objects.count(), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value=PUBLIC_TEST_ADDRESS,
@@ -1200,17 +1200,17 @@ class ViewTest(FixtureTestCase):
     ) -> None:
         self.make_manager()
         # Mock a non-image content type
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://example.com/not-an-image.png",
-            content_type="text/html",
+            headers={"Content-Type": "text/html"},
         )
         response = self.do_upload(
             image="", image_url="https://example.com/not-an-image.png"
         )
         self.assertContains(response, "Unsupported image type")
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_SIZE=1)
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
@@ -1225,18 +1225,18 @@ class ViewTest(FixtureTestCase):
     ) -> None:
         self.make_manager()
         # Mock a too big image
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://example.com/big-image.png",
-            content_type="image/png",
-            body=b"x" * (settings.ALLOWED_ASSET_SIZE + 1),
+            headers={"Content-Type": "image/png"},
+            content=b"x" * (settings.ALLOWED_ASSET_SIZE + 1),
         )
         response = self.do_upload(
             image="", image_url="https://example.com/big-image.png"
         )
         self.assertContains(response, "Image is too big")
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value=PUBLIC_TEST_ADDRESS,
@@ -1250,18 +1250,18 @@ class ViewTest(FixtureTestCase):
     ) -> None:
         self.make_manager()
         # Mock a non-image content
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://example.com/invalid-image.png",
-            content_type="image/png",
-            body=b"x",
+            headers={"Content-Type": "image/png"},
+            content=b"x",
         )
         response = self.do_upload(
             image="", image_url="https://example.com/invalid-image.png"
         )
         self.assertContains(response, "Upload a valid image.")
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     def test_disallowed_image_url_domain(self) -> None:
         """Test validation when image URL domain is not allowed."""
@@ -1271,7 +1271,7 @@ class ViewTest(FixtureTestCase):
         )
         self.assertContains(response, "URL domain is not allowed.")
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
@@ -1286,17 +1286,17 @@ class ViewTest(FixtureTestCase):
     ) -> None:
         """Reject redirects leaving the allowed asset domains."""
         self.make_manager()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://images.allowed.com/redirect-image.png",
-            status=302,
+            status_code=302,
             headers={"Location": "https://proof.example.com/final-image.png"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://proof.example.com/final-image.png",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         response = self.do_upload(
@@ -1306,7 +1306,7 @@ class ViewTest(FixtureTestCase):
         self.assertContains(response, "URL domain is not allowed.")
         self.assertEqual(Screenshot.objects.count(), 0)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
@@ -1321,17 +1321,17 @@ class ViewTest(FixtureTestCase):
     ) -> None:
         """Allow redirects that stay within the allowed asset domains."""
         self.make_manager()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://images.allowed.com/redirect-image.png",
-            status=302,
+            status_code=302,
             headers={"Location": "https://cdn.allowed.com/final-image.png"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://cdn.allowed.com/final-image.png",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         response = self.do_upload(
@@ -1342,7 +1342,7 @@ class ViewTest(FixtureTestCase):
         self.assertContains(response, screenshot.name)
         self.assertEqual(screenshot.image.size, Path(TEST_SCREENSHOT).stat().st_size)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1350,11 +1350,11 @@ class ViewTest(FixtureTestCase):
     )
     def test_image_url_private_target(self, mocked_getaddrinfo) -> None:
         self.make_manager()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/test-image.png",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         response = self.do_upload(
@@ -1364,9 +1364,9 @@ class ViewTest(FixtureTestCase):
         self.assertContains(response, "internal or non-public address")
         self.assertEqual(Screenshot.objects.count(), 0)
         mocked_getaddrinfo.assert_called_once_with("private.example.com", None, type=1)
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
@@ -1386,17 +1386,17 @@ class ViewTest(FixtureTestCase):
 
         mocked_getaddrinfo.side_effect = getaddrinfo
         self.make_manager()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/redirect-image.png",
-            status=302,
+            status_code=302,
             headers={"Location": "https://private.example.com/final-image.png"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/final-image.png",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         response = self.do_upload(
@@ -1409,10 +1409,10 @@ class ViewTest(FixtureTestCase):
         mocked_get_peer.assert_called_once()
         self.assertEqual(
             ["https://public.example.com/redirect-image.png"],
-            [call.request.url for call in responses.calls],
+            [call.request.url for call in http_mock.calls],
         )
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
@@ -1424,11 +1424,11 @@ class ViewTest(FixtureTestCase):
     )
     def test_image_url_private_peer(self, mocked_getaddrinfo, mocked_get_peer) -> None:
         self.make_manager()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/test-image.png",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         response = self.do_upload(
@@ -1439,9 +1439,9 @@ class ViewTest(FixtureTestCase):
         self.assertEqual(Screenshot.objects.count(), 0)
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(
         ALLOWED_ASSET_DOMAINS=["*"], ASSET_PRIVATE_ALLOWLIST=["private.example.com"]
     )
@@ -1451,11 +1451,11 @@ class ViewTest(FixtureTestCase):
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
         self.make_manager()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/test-image.png",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         response = self.do_upload(
@@ -1467,7 +1467,7 @@ class ViewTest(FixtureTestCase):
         mocked_getaddrinfo.assert_not_called()
         mocked_get_peer.assert_not_called()
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1482,11 +1482,11 @@ class ViewTest(FixtureTestCase):
         old_name = screenshot.name
         old_image_name = screenshot.image.name
         old_filename = screenshot.image.file.name
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/test-image.png",
-            content_type="image/png",
-            body=Path(TEST_SCREENSHOT).read_bytes(),
+            headers={"Content-Type": "image/png"},
+            content=Path(TEST_SCREENSHOT).read_bytes(),
         )
 
         response = self.client.post(
@@ -1504,7 +1504,7 @@ class ViewTest(FixtureTestCase):
         self.assertEqual(screenshot.image.name, old_image_name)
         self.assertEqual(screenshot.image.file.name, old_filename)
         mocked_getaddrinfo.assert_called_once_with("private.example.com", None, type=1)
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
 
 class ScreenshotVCSTest(APITestCase, RepoTestCase):

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -189,7 +189,7 @@ def download_tesseract_data(url: str, full_name: str) -> None:
                     response = fetch_url(
                         "GET",
                         url,
-                        allow_redirects=True,
+                        follow_redirects=True,
                         timeout=TESSERACT_DOWNLOAD_TIMEOUT,
                     )
             except httpx2.HTTPError as error:

--- a/weblate/utils/requests.py
+++ b/weblate/utils/requests.py
@@ -7,12 +7,11 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
 from time import monotonic
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
 import httpx2
@@ -50,9 +49,9 @@ class TestTransport:
 _TEST_TRANSPORT = TestTransport()
 PEER_IP_RESPONSE_ATTR = "_weblate_peer_ip"
 ORIGINAL_URL_REQUEST_EXTENSION = "weblate_original_url"
-VALIDATORS_REQUEST_EXTENSION = "weblate_redirect_validators"
 JSON_RESPONSE_ERRORS = (json.JSONDecodeError, UnicodeDecodeError)
 ADDRESS_FALLBACK_DELAY = 0.25
+MAX_REDIRECTS = 5
 
 
 def set_test_transport(transport: httpx2.MockTransport | None) -> None:
@@ -209,25 +208,6 @@ def _validate_response_peer(
     )
 
 
-def _normalize_request_kwargs(kwargs: dict) -> dict:
-    result = kwargs.copy()
-    data = result.get("data")
-    if isinstance(data, str | bytes) and "files" not in result:
-        result["content"] = result.pop("data")
-    elif isinstance(data, Mapping):
-        # Match Requests form encoding, which omitted mapping entries with null
-        # values instead of sending them as empty fields.
-        result["data"] = {
-            key: value for key, value in data.items() if value is not None
-        }
-    # Requests accepted this argument per request. HTTPX2 transport selection is
-    # handled centrally instead.
-    result.pop("proxies", None)
-    result.pop("verify", None)
-    result.pop("cert", None)
-    return result
-
-
 def _build_pinned_request(
     request: httpx2.Request, connection_address: str
 ) -> httpx2.Request:
@@ -315,7 +295,6 @@ class OutboundRequest:
 
     url: str
     proxy: str | None
-    validators: RedirectValidators | None
 
     @property
     def used_proxy(self) -> bool:
@@ -327,19 +306,16 @@ def _prepare_outbound_request(request: httpx2.Request) -> OutboundRequest:
     return OutboundRequest(
         url=request_url,
         proxy=get_environment_proxy(request_url),
-        validators=cast(
-            "RedirectValidators | None",
-            request.extensions.get(VALIDATORS_REQUEST_EXTENSION),
-        ),
     )
 
 
 async def _validate_async_outbound_request(
     outbound: OutboundRequest,
+    validators: RedirectValidators | None,
 ) -> tuple[str, ...]:
-    if outbound.validators is None:
+    if validators is None:
         return ()
-    return await outbound.validators.validate_async_request_url(
+    return await validators.validate_async_request_url(
         outbound.url,
         used_proxy=outbound.used_proxy,
     )
@@ -514,7 +490,13 @@ def _validate_transport_response(
 class OutboundHTTPTransport(httpx2.BaseTransport):
     """Validate and route every synchronous HTTPX2 request hop."""
 
-    def __init__(self, transport: httpx2.BaseTransport | None = None) -> None:
+    def __init__(
+        self,
+        transport: httpx2.BaseTransport | None = None,
+        *,
+        validators: RedirectValidators | None = None,
+    ) -> None:
+        self.validators = validators
         self.pool = OutboundTransportPool(
             transport,
             lambda proxy: httpx2.HTTPTransport(proxy=proxy, trust_env=True),
@@ -523,10 +505,10 @@ class OutboundHTTPTransport(httpx2.BaseTransport):
     def handle_request(self, request: httpx2.Request) -> httpx2.Response:
         outbound = _prepare_outbound_request(request)
         connection_addresses = (
-            outbound.validators.validate_request_url(
+            self.validators.validate_request_url(
                 outbound.url, used_proxy=outbound.used_proxy
             )
-            if outbound.validators is not None
+            if self.validators is not None
             else ()
         )
         routes = _route_outbound_request(
@@ -540,7 +522,7 @@ class OutboundHTTPTransport(httpx2.BaseTransport):
             _validate_transport_response(
                 response,
                 request=request,
-                validators=outbound.validators,
+                validators=self.validators,
                 used_proxy=outbound.used_proxy,
             )
         except BaseException:
@@ -557,7 +539,13 @@ class OutboundHTTPTransport(httpx2.BaseTransport):
 class AsyncOutboundHTTPTransport(httpx2.AsyncBaseTransport):
     """Validate and route every asynchronous HTTPX2 request hop."""
 
-    def __init__(self, transport: httpx2.AsyncBaseTransport | None = None) -> None:
+    def __init__(
+        self,
+        transport: httpx2.AsyncBaseTransport | None = None,
+        *,
+        validators: RedirectValidators | None = None,
+    ) -> None:
+        self.validators = validators
         self.pool = OutboundTransportPool(
             transport,
             lambda proxy: httpx2.AsyncHTTPTransport(proxy=proxy, trust_env=True),
@@ -565,7 +553,9 @@ class AsyncOutboundHTTPTransport(httpx2.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         outbound = _prepare_outbound_request(request)
-        connection_addresses = await _validate_async_outbound_request(outbound)
+        connection_addresses = await _validate_async_outbound_request(
+            outbound, self.validators
+        )
         routes = _route_outbound_request(
             self.pool,
             request,
@@ -577,7 +567,7 @@ class AsyncOutboundHTTPTransport(httpx2.AsyncBaseTransport):
             _validate_transport_response(
                 response,
                 request=request,
-                validators=outbound.validators,
+                validators=self.validators,
                 used_proxy=outbound.used_proxy,
             )
         except BaseException:
@@ -591,26 +581,50 @@ class AsyncOutboundHTTPTransport(httpx2.AsyncBaseTransport):
         self.pool.clear()
 
 
+def create_http_client(
+    *,
+    transport: httpx2.BaseTransport | None = None,
+    validators: RedirectValidators | None = None,
+    max_redirects: int = MAX_REDIRECTS,
+) -> httpx2.Client:
+    """Create a synchronous HTTPX2 client using Weblate's outbound transport."""
+    return httpx2.Client(
+        headers=_prepare_headers(None),
+        transport=OutboundHTTPTransport(transport, validators=validators),
+        trust_env=False,
+        follow_redirects=False,
+        max_redirects=max_redirects,
+    )
+
+
+def create_async_http_client(
+    *,
+    transport: httpx2.AsyncBaseTransport | None = None,
+    validators: RedirectValidators | None = None,
+    max_redirects: int = MAX_REDIRECTS,
+) -> httpx2.AsyncClient:
+    """Create an asynchronous HTTPX2 client using Weblate's outbound transport."""
+    return httpx2.AsyncClient(
+        headers=_prepare_headers(None),
+        transport=AsyncOutboundHTTPTransport(transport, validators=validators),
+        trust_env=False,
+        follow_redirects=False,
+        max_redirects=max_redirects,
+    )
+
+
 def _build_client_request(
     client: httpx2.Client | httpx2.AsyncClient,
     method: str,
     url: str,
     *,
-    headers: dict[str, str] | None,
-    timeout: float,
-    validators: RedirectValidators | None,
-    kwargs: dict[str, Any],
+    kwargs: dict,
 ) -> tuple[httpx2.Request, AuthTypes | None]:
-    request_kwargs = _normalize_request_kwargs(kwargs)
+    request_kwargs = kwargs.copy()
     request_auth = request_kwargs.pop("auth", None)
-    extensions = dict(request_kwargs.pop("extensions", {}) or {})
-    extensions[VALIDATORS_REQUEST_EXTENSION] = validators
     request = client.build_request(
         method,
         url,
-        headers=_prepare_headers(headers),
-        timeout=timeout,
-        extensions=extensions,
         **request_kwargs,
     )
     return request, request_auth
@@ -642,7 +656,6 @@ def _send_with_redirects(
     request: httpx2.Request,
     *,
     auth: AuthTypes | None,
-    max_redirects: int,
 ) -> httpx2.Response:
     history: list[httpx2.Response] = []
     while True:
@@ -653,7 +666,9 @@ def _send_with_redirects(
             follow_redirects=False,
         )
         try:
-            next_request = _next_streaming_redirect(response, history, max_redirects)
+            next_request = _next_streaming_redirect(
+                response, history, client.max_redirects
+            )
         except BaseException:
             response.close()
             raise
@@ -669,7 +684,6 @@ async def _async_send_with_redirects(
     request: httpx2.Request,
     *,
     auth: AuthTypes | None,
-    max_redirects: int,
 ) -> httpx2.Response:
     history: list[httpx2.Response] = []
     while True:
@@ -680,7 +694,9 @@ async def _async_send_with_redirects(
             follow_redirects=False,
         )
         try:
-            next_request = _next_streaming_redirect(response, history, max_redirects)
+            next_request = _next_streaming_redirect(
+                response, history, client.max_redirects
+            )
         except BaseException:
             await response.aclose()
             raise
@@ -691,188 +707,64 @@ async def _async_send_with_redirects(
         auth = None
 
 
-class HTTPClient:
-    """Synchronous HTTPX2 client using Weblate's outbound transport."""
-
-    def __init__(self, transport: httpx2.BaseTransport | None = None) -> None:
-        self.client = httpx2.Client(
-            transport=OutboundHTTPTransport(transport),
-            trust_env=False,
-            follow_redirects=False,
-        )
-
-    def __enter__(self) -> Self:
-        return self
-
-    def __exit__(self, *args) -> None:
-        self.close()
-
-    def close(self) -> None:
-        self.client.close()
-
-    def request(
-        self,
-        method: str,
-        url: str,
-        *,
-        headers: dict[str, str] | None = None,
-        timeout: float = 5,
-        allow_redirects: bool = True,
-        stream: bool = False,
-        max_redirects: int = 5,
-        validators: RedirectValidators | None = None,
-        **kwargs,
-    ) -> httpx2.Response:
-        request, request_auth = _build_client_request(
-            self.client,
-            method,
-            url,
-            headers=headers,
-            timeout=timeout,
-            validators=validators,
-            kwargs=kwargs,
-        )
-        if allow_redirects:
-            response = _send_with_redirects(
-                self.client,
-                request,
-                auth=request_auth,
-                max_redirects=max_redirects,
-            )
-            if stream:
-                return response
-            try:
-                response.read()
-            except BaseException:
-                response.close()
-                raise
-            return response
-        return self.client.send(
-            request,
-            stream=stream,
-            auth=request_auth,
-            follow_redirects=False,
-        )
-
-
-class AsyncHTTPClient:
-    """Asynchronous HTTPX2 client using Weblate's outbound transport."""
-
-    def __init__(self, transport: httpx2.AsyncBaseTransport | None = None) -> None:
-        self.client = httpx2.AsyncClient(
-            transport=AsyncOutboundHTTPTransport(transport),
-            trust_env=False,
-            follow_redirects=False,
-        )
-
-    async def __aenter__(self) -> Self:
-        return self
-
-    async def __aexit__(self, *args) -> None:
-        await self.aclose()
-
-    async def aclose(self) -> None:
-        await self.client.aclose()
-
-    async def request(
-        self,
-        method: str,
-        url: str,
-        *,
-        headers: dict[str, str] | None = None,
-        timeout: float = 5,  # ruff: ignore[async-function-with-timeout]
-        allow_redirects: bool = True,
-        stream: bool = False,
-        max_redirects: int = 5,
-        validators: RedirectValidators | None = None,
-        **kwargs,
-    ) -> httpx2.Response:
-        request, request_auth = _build_client_request(
-            self.client,
-            method,
-            url,
-            headers=headers,
-            timeout=timeout,
-            validators=validators,
-            kwargs=kwargs,
-        )
-        if allow_redirects:
-            response = await _async_send_with_redirects(
-                self.client,
-                request,
-                auth=request_auth,
-                max_redirects=max_redirects,
-            )
-            if stream:
-                return response
-            try:
-                await response.aread()
-            except BaseException:
-                await response.aclose()
-                raise
-            return response
-        return await self.client.send(
-            request,
-            stream=stream,
-            auth=request_auth,
-            follow_redirects=False,
-        )
-
-
-def _request_with_redirects(
-    method: str,
-    url: str,
-    **kwargs,
-) -> httpx2.Response:
-    with HTTPClient() as client:
-        return client.request(method, url, **kwargs)
-
-
-async def _async_request_with_redirects(
-    method: str,
-    url: str,
-    **kwargs,
-) -> httpx2.Response:
-    async with AsyncHTTPClient() as client:
-        return await client.request(method, url, **kwargs)
-
-
-def _validated_request_with_redirects(
+def _request(
     method: str,
     url: str,
     *,
-    allow_private_targets: bool = False,
-    private_allowlist: list[str] | tuple[str, ...] = (),
+    validators: RedirectValidators | None = None,
+    follow_redirects: bool = True,
     **kwargs,
 ) -> httpx2.Response:
-    return _request_with_redirects(
-        method,
-        url,
-        validators=RuntimeRedirectValidators(
-            allow_private_targets=allow_private_targets,
-            private_allowlist=private_allowlist,
-        ),
-        **kwargs,
-    )
+    with create_http_client(validators=validators) as client:
+        request, request_auth = _build_client_request(
+            client, method, url, kwargs=kwargs
+        )
+        response = (
+            _send_with_redirects(client, request, auth=request_auth)
+            if follow_redirects
+            else client.send(
+                request,
+                stream=True,
+                auth=request_auth,
+                follow_redirects=False,
+            )
+        )
+        try:
+            response.read()
+        except BaseException:
+            response.close()
+            raise
+        return response
 
 
-async def _async_validated_request_with_redirects(
+async def _async_request(
     method: str,
     url: str,
     *,
-    allow_private_targets: bool = False,
-    private_allowlist: list[str] | tuple[str, ...] = (),
+    validators: RedirectValidators | None = None,
+    follow_redirects: bool = True,
     **kwargs,
 ) -> httpx2.Response:
-    return await _async_request_with_redirects(
-        method,
-        url,
-        validators=RuntimeRedirectValidators(
-            allow_private_targets=allow_private_targets,
-            private_allowlist=private_allowlist,
-        ),
-        **kwargs,
-    )
+    async with create_async_http_client(validators=validators) as client:
+        request, request_auth = _build_client_request(
+            client, method, url, kwargs=kwargs
+        )
+        response = (
+            await _async_send_with_redirects(client, request, auth=request_auth)
+            if follow_redirects
+            else await client.send(
+                request,
+                stream=True,
+                auth=request_auth,
+                follow_redirects=False,
+            )
+        )
+        try:
+            await response.aread()
+        except BaseException:
+            await response.aclose()
+            raise
+        return response
 
 
 def fetch_url(
@@ -880,9 +772,10 @@ def fetch_url(
     url: str,
     *,
     raise_for_status: bool = True,
+    follow_redirects: bool = True,
     **kwargs,
 ) -> httpx2.Response:
-    response = _request_with_redirects(method, url, stream=False, **kwargs)
+    response = _request(method, url, follow_redirects=follow_redirects, **kwargs)
     if raise_for_status:
         response.raise_for_status()
     return response
@@ -893,9 +786,12 @@ async def async_fetch_url(
     url: str,
     *,
     raise_for_status: bool = True,
+    follow_redirects: bool = True,
     **kwargs,
 ) -> httpx2.Response:
-    response = await _async_request_with_redirects(method, url, stream=False, **kwargs)
+    response = await _async_request(
+        method, url, follow_redirects=follow_redirects, **kwargs
+    )
     if raise_for_status:
         response.raise_for_status()
     return response
@@ -906,16 +802,19 @@ def fetch_validated_url(
     url: str,
     *,
     raise_for_status: bool = True,
+    follow_redirects: bool = True,
     allow_private_targets: bool = False,
     private_allowlist: list[str] | tuple[str, ...] = (),
     **kwargs,
 ) -> httpx2.Response:
-    response = _validated_request_with_redirects(
+    response = _request(
         method,
         url,
-        stream=False,
-        allow_private_targets=allow_private_targets,
-        private_allowlist=private_allowlist,
+        validators=RuntimeRedirectValidators(
+            allow_private_targets=allow_private_targets,
+            private_allowlist=private_allowlist,
+        ),
+        follow_redirects=follow_redirects,
         **kwargs,
     )
     if raise_for_status:
@@ -928,21 +827,53 @@ async def async_fetch_validated_url(
     url: str,
     *,
     raise_for_status: bool = True,
+    follow_redirects: bool = True,
     allow_private_targets: bool = False,
     private_allowlist: list[str] | tuple[str, ...] = (),
     **kwargs,
 ) -> httpx2.Response:
-    response = await _async_validated_request_with_redirects(
+    response = await _async_request(
         method,
         url,
-        stream=False,
-        allow_private_targets=allow_private_targets,
-        private_allowlist=private_allowlist,
+        validators=RuntimeRedirectValidators(
+            allow_private_targets=allow_private_targets,
+            private_allowlist=private_allowlist,
+        ),
+        follow_redirects=follow_redirects,
         **kwargs,
     )
     if raise_for_status:
         response.raise_for_status()
     return response
+
+
+@contextmanager
+def _open_url(
+    method: str,
+    url: str,
+    *,
+    validators: RedirectValidators | None = None,
+    follow_redirects: bool = True,
+    **kwargs,
+) -> Generator[httpx2.Response, None, None]:
+    with create_http_client(validators=validators) as client:
+        request, request_auth = _build_client_request(
+            client, method, url, kwargs=kwargs
+        )
+        response = (
+            _send_with_redirects(client, request, auth=request_auth)
+            if follow_redirects
+            else client.send(
+                request,
+                stream=True,
+                auth=request_auth,
+                follow_redirects=False,
+            )
+        )
+        try:
+            yield response
+        finally:
+            response.close()
 
 
 @contextmanager
@@ -955,52 +886,39 @@ def open_restricted_asset_url(
     private_allowlist: list[str] | tuple[str, ...] = (),
     **kwargs,
 ) -> Generator[httpx2.Response, None, None]:
-    with HTTPClient() as client:
-        response = client.request(
-            method,
-            url,
-            stream=True,
-            validators=RestrictedAssetRedirectValidators(
-                allow_private_targets=allow_private_targets,
-                private_allowlist=private_allowlist,
-            ),
-            **kwargs,
-        )
-        try:
-            if raise_for_status and not response.is_success:
-                raise ValidationError(
-                    gettext(
-                        "Unable to download asset from the provided URL (HTTP status code: %(code)s)."
-                    ),
-                    code="download_failed",
-                    params={"code": response.status_code},
-                )
-            yield response
-        finally:
-            response.close()
+    with _open_url(
+        method,
+        url,
+        validators=RestrictedAssetRedirectValidators(
+            allow_private_targets=allow_private_targets,
+            private_allowlist=private_allowlist,
+        ),
+        **kwargs,
+    ) as response:
+        if raise_for_status and not response.is_success:
+            raise ValidationError(
+                gettext(
+                    "Unable to download asset from the provided URL (HTTP status code: %(code)s)."
+                ),
+                code="download_failed",
+                params={"code": response.status_code},
+            )
+        yield response
 
 
 def _probe_validated_url(
     url: str,
     *,
     timeout: float = 5,
-    max_redirects: int = 5,
     validators: RedirectValidators,
 ) -> None:
-    with HTTPClient() as client:
-        response = client.request(
-            "get",
-            url,
-            timeout=timeout,
-            allow_redirects=True,
-            stream=True,
-            max_redirects=max_redirects,
-            validators=validators,
-        )
-        try:
-            response.raise_for_status()
-        finally:
-            response.close()
+    with _open_url(
+        "get",
+        url,
+        timeout=timeout,
+        validators=validators,
+    ) as response:
+        response.raise_for_status()
 
 
 def _uri_error_cache_key(

--- a/weblate/utils/tests/http_mock.py
+++ b/weblate/utils/tests/http_mock.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Small responses-compatible HTTPX2 mock used by the existing test suite."""
+"""HTTPX2 mock transport helpers for the test suite."""
 
 from __future__ import annotations
 
 import json as json_module
 import re
-from collections import UserList
 from dataclasses import dataclass, field
 from functools import wraps
 from typing import TYPE_CHECKING
@@ -25,70 +24,50 @@ from weblate.utils.requests import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-GET = "GET"
-POST = "POST"
-PUT = "PUT"
-PATCH = "PATCH"
-DELETE = "DELETE"
-HEAD = "HEAD"
-OPTIONS = "OPTIONS"
-
 type ResponseHeaders = dict[str, str] | list[tuple[str, str]] | None
+type RequestMatcher = Callable[[httpx2.Request], tuple[bool, str]]
+type ResponseCallback = Callable[[httpx2.Request], httpx2.Response]
+
+_TRANSPORT_URL_REQUEST_EXTENSION = "weblate.transport_url"
 
 
-class Calls(UserList):
-    def reset(self) -> None:
-        self.clear()
+class _Unset:
+    pass
 
 
-class PreparedRequest:
-    """Requests-shaped view of an HTTPX2 request for legacy callbacks."""
-
-    def __init__(self, request: httpx2.Request) -> None:
-        self._request = request
-        self.extensions = dict(request.extensions)
-        request_url = request.extensions.get(
-            ORIGINAL_URL_REQUEST_EXTENSION, request.url
-        )
-        self.method = request.method
-        self.url = str(request_url.copy_with(fragment=None))
-        self.transport_url = str(request.url.copy_with(fragment=None))
-        self.headers = request.headers
-        self.body = request.content or None
-        self.path_url = request_url.raw_path.decode("ascii")
+_UNSET = _Unset()
 
 
 @dataclass
 class Call:
-    request: PreparedRequest
+    request: httpx2.Request
     response: httpx2.Response | BaseException
 
 
 @dataclass
-class Registration:
+class Route:
     method: str
     url: str | re.Pattern[str]
-    body: str | bytes | BaseException = b""
-    json: object | None = None
-    status: int = 200
+    status_code: int = 200
     headers: ResponseHeaders = None
-    callback: (
-        Callable[[PreparedRequest], tuple[int, ResponseHeaders, object]] | None
-    ) = None
-    match: list[Callable[[PreparedRequest], tuple[bool, str]]] = field(
-        default_factory=list
-    )
-    calls: Calls = field(default_factory=Calls)
+    content: bytes | None = None
+    text: str | None = None
+    json: object = _UNSET
+    callback: ResponseCallback | None = None
+    exception: BaseException | None = None
+    match: list[RequestMatcher] = field(default_factory=list)
+    calls: list[Call] = field(default_factory=list)
 
-    def matches(self, request: PreparedRequest) -> bool:
+    def matches(self, request: httpx2.Request) -> bool:
+        request_url = str(request.url)
         if self.method != request.method:
             return False
         if isinstance(self.url, re.Pattern):
-            if self.url.search(request.url) is None:
+            if self.url.search(request_url) is None:
                 return False
-        elif self.url != request.url:
+        elif self.url != request_url:
             registered = urlsplit(self.url)
-            requested = urlsplit(request.url)
+            requested = urlsplit(request_url)
             if registered.query or self.url != urlunsplit(
                 (requested.scheme, requested.netloc, requested.path, "", "")
             ):
@@ -96,26 +75,11 @@ class Registration:
         return all(matcher(request)[0] for matcher in self.match)
 
     def respond(
-        self, request: PreparedRequest, original: httpx2.Request
+        self, request: httpx2.Request, transport_request: httpx2.Request
     ) -> httpx2.Response:
         try:
-            if self.callback is not None:
-                status, headers, body = self.callback(request)
-                response = _build_response(
-                    original,
-                    status=status,
-                    headers=headers,
-                    body=body,
-                )
-            else:
-                response = _build_response(
-                    original,
-                    status=self.status,
-                    headers=self.headers,
-                    body=self.body,
-                    json=self.json,
-                )
-        except Exception as error:
+            response = self._get_response(request, transport_request)
+        except BaseException as error:
             call = Call(request=request, response=error)
             calls.append(call)
             self.calls.append(call)
@@ -125,49 +89,70 @@ class Registration:
         self.calls.append(call)
         return response
 
-
-calls = Calls()
-_registrations: list[Registration] = []
-
-
-class Matchers:
-    @staticmethod
-    def json_params_matcher(expected: object, *, strict_match: bool = True):
-        def match(request: PreparedRequest) -> tuple[bool, str]:
-            try:
-                actual = json_module.loads(request.body or b"null")
-            except (json_module.JSONDecodeError, UnicodeDecodeError) as error:
-                return False, f"request body is not valid JSON: {error}"
-            if (
-                not strict_match
-                and isinstance(actual, dict)
-                and isinstance(expected, dict)
-            ):
-                actual = _filter_mapping(actual, expected)
-            return (
-                actual == expected,
-                f"JSON body {actual!r} does not match {expected!r}",
+    def _get_response(
+        self, request: httpx2.Request, transport_request: httpx2.Request
+    ) -> httpx2.Response:
+        if self.exception is not None:
+            raise self.exception
+        if self.callback is not None:
+            response = self.callback(request)
+            if not isinstance(response, httpx2.Response):
+                msg = "HTTP mock callbacks must return an httpx2.Response"
+                raise TypeError(msg)
+        else:
+            response = _build_response(
+                transport_request,
+                status_code=self.status_code,
+                headers=self.headers,
+                content=self.content,
+                text=self.text,
+                json=self.json,
             )
-
-        return match
-
-    @staticmethod
-    def header_matcher(expected: dict[str, str]):
-        def match(request: PreparedRequest) -> tuple[bool, str]:
-            actual = {
-                name: request.headers.get(name)
-                for name in expected
-                if name in request.headers
-            }
-            return (
-                actual == expected,
-                f"headers {actual!r} do not match {expected!r}",
-            )
-
-        return match
+        response.request = transport_request
+        setattr(response, PEER_IP_RESPONSE_ATTR, "93.184.216.34")
+        return response
 
 
-matchers = Matchers()
+calls: list[Call] = []
+_routes: list[Route] = []
+
+
+def json_params_matcher(
+    expected: object, *, strict_match: bool = True
+) -> RequestMatcher:
+    def match(request: httpx2.Request) -> tuple[bool, str]:
+        try:
+            actual = json_module.loads(request.content or b"null")
+        except (json_module.JSONDecodeError, UnicodeDecodeError) as error:
+            return False, f"request body is not valid JSON: {error}"
+        if not strict_match and isinstance(actual, dict) and isinstance(expected, dict):
+            actual = _filter_mapping(actual, expected)
+        return (
+            actual == expected,
+            f"JSON body {actual!r} does not match {expected!r}",
+        )
+
+    return match
+
+
+def header_matcher(expected: dict[str, str]) -> RequestMatcher:
+    def match(request: httpx2.Request) -> tuple[bool, str]:
+        actual = {
+            name: request.headers.get(name)
+            for name in expected
+            if name in request.headers
+        }
+        return (
+            actual == expected,
+            f"headers {actual!r} do not match {expected!r}",
+        )
+
+    return match
+
+
+def get_transport_url(request: httpx2.Request) -> httpx2.URL:
+    """Return the URL passed to the transport after address pinning."""
+    return request.extensions[_TRANSPORT_URL_REQUEST_EXTENSION]
 
 
 def _filter_mapping(actual: dict, expected: dict) -> dict:
@@ -184,63 +169,82 @@ def _filter_mapping(actual: dict, expected: dict) -> dict:
 def _build_response(
     request: httpx2.Request,
     *,
-    status: int,
-    headers: ResponseHeaders = None,
-    body: object = b"",
-    json: object | None = None,
+    status_code: int,
+    headers: ResponseHeaders,
+    content: bytes | None,
+    text: str | None,
+    json: object,
 ) -> httpx2.Response:
-    if isinstance(body, BaseException):
-        raise body
-    if json is not None:
-        response = httpx2.Response(
-            status,
+    if json is not _UNSET:
+        if json is None:
+            result_headers = httpx2.Headers(headers)
+            result_headers.setdefault("Content-Type", "application/json")
+            return httpx2.Response(
+                status_code,
+                headers=result_headers,
+                content=b"null",
+                request=request,
+            )
+        return httpx2.Response(
+            status_code,
             headers=headers,
             json=json,
             request=request,
         )
-    elif isinstance(body, bytes):
-        response = httpx2.Response(
-            status,
+    if text is not None:
+        return httpx2.Response(
+            status_code,
             headers=headers,
-            content=body,
+            text=text,
             request=request,
         )
-    elif body is not None:
-        response = httpx2.Response(
-            status,
-            headers=headers,
-            text=str(body),
-            request=request,
-        )
-    else:
-        response = httpx2.Response(status, headers=headers, request=request)
-    setattr(response, PEER_IP_RESPONSE_ATTR, "93.184.216.34")
-    return response
+    return httpx2.Response(
+        status_code,
+        headers=headers,
+        content=content,
+        request=request,
+    )
+
+
+def _logical_request(request: httpx2.Request) -> httpx2.Request:
+    transport_url = request.url.copy_with(fragment=None)
+    logical_url = request.extensions.get(
+        ORIGINAL_URL_REQUEST_EXTENSION, request.url
+    ).copy_with(fragment=None)
+    extensions = dict(request.extensions)
+    extensions[_TRANSPORT_URL_REQUEST_EXTENSION] = transport_url
+    return httpx2.Request(
+        request.method,
+        logical_url,
+        headers=request.headers,
+        content=request.content,
+        extensions=extensions,
+    )
 
 
 def _handler(request: httpx2.Request) -> httpx2.Response:
-    prepared = PreparedRequest(request)
+    logical_request = _logical_request(request)
     matches = [
-        (index, registration)
-        for index, registration in enumerate(_registrations)
-        if registration.matches(prepared)
+        (index, route)
+        for index, route in enumerate(_routes)
+        if route.matches(logical_request)
     ]
     if not matches:
         msg = f"Connection refused: {request.method} {request.url}"
         error = httpx2.ConnectError(msg, request=request)
-        calls.append(Call(request=prepared, response=error))
+        calls.append(Call(request=logical_request, response=error))
         raise error
-    index, registration = matches[0]
+    index, route = matches[0]
     if len(matches) > 1:
-        _registrations.pop(index)
-        if registration.calls:
-            registration = matches[1][1]
-    return registration.respond(prepared, request)
+        _routes.pop(index)
+        if route.calls:
+            route = matches[1][1]
+    return route.respond(logical_request, request)
 
 
 def reset() -> None:
-    _registrations.clear()
-    calls.reset()
+    _routes.clear()
+    calls.clear()
 
 
 def activate(function):
@@ -267,76 +271,109 @@ def activate(function):
     return async_wrapper if function.__code__.co_flags & 0x80 else wrapper
 
 
-def add(
+def _validate_response_body(
+    *, content: bytes | None, text: str | None, json: object
+) -> None:
+    supplied = sum((content is not None, text is not None, json is not _UNSET))
+    if supplied > 1:
+        msg = "Only one of content, text, or json can be supplied"
+        raise TypeError(msg)
+
+
+def register(
     method: str,
     url: str | re.Pattern[str],
-    body: str | bytes | BaseException = b"",
     *,
-    json: object | None = None,
-    status: int = 200,
-    headers: dict[str, str] | list[tuple[str, str]] | None = None,
-    content_type: str | None = None,
-    match: list[Callable[[PreparedRequest], tuple[bool, str]]] | None = None,
-    **_kwargs,
-) -> Registration:
-    result_headers = dict(headers or {})
-    if content_type is not None:
-        result_headers["Content-Type"] = content_type
-    registration = Registration(
+    status_code: int = 200,
+    headers: ResponseHeaders = None,
+    content: bytes | None = None,
+    text: str | None = None,
+    json: object = _UNSET,
+    match: list[RequestMatcher] | None = None,
+) -> Route:
+    _validate_response_body(content=content, text=text, json=json)
+    route = Route(
         method=method.upper(),
         url=url,
-        body=body,
+        status_code=status_code,
+        headers=headers,
+        content=content,
+        text=text,
         json=json,
-        status=status,
-        headers=result_headers,
         match=list(match or ()),
     )
-    _registrations.append(registration)
-    return registration
+    _routes.append(route)
+    return route
 
 
-def add_callback(
+def register_callback(
     method: str,
     url: str | re.Pattern[str],
+    callback: ResponseCallback,
     *,
-    callback,
-    match=None,
-    **kwargs,
-) -> Registration:
-    registration = add(method, url, match=match, **kwargs)
-    registration.callback = callback
-    return registration
+    match: list[RequestMatcher] | None = None,
+) -> Route:
+    route = Route(
+        method=method.upper(),
+        url=url,
+        callback=callback,
+        match=list(match or ()),
+    )
+    _routes.append(route)
+    return route
 
 
-def remove(method: str, url: str | re.Pattern[str]) -> None:
-    _registrations[:] = [
-        registration
-        for registration in _registrations
-        if not (registration.method == method.upper() and registration.url == url)
+def register_exception(
+    method: str,
+    url: str | re.Pattern[str],
+    exception: BaseException,
+    *,
+    match: list[RequestMatcher] | None = None,
+) -> Route:
+    route = Route(
+        method=method.upper(),
+        url=url,
+        exception=exception,
+        match=list(match or ()),
+    )
+    _routes.append(route)
+    return route
+
+
+def unregister(method: str, url: str | re.Pattern[str]) -> None:
+    _routes[:] = [
+        route
+        for route in _routes
+        if not (route.method == method.upper() and route.url == url)
     ]
 
 
-def replace(method: str, url: str | re.Pattern[str], **kwargs) -> Registration:
-    remove(method, url)
-    return add(method, url, **kwargs)
+def replace(
+    method: str,
+    url: str | re.Pattern[str],
+    *,
+    status_code: int = 200,
+    headers: ResponseHeaders = None,
+    content: bytes | None = None,
+    text: str | None = None,
+    json: object = _UNSET,
+    match: list[RequestMatcher] | None = None,
+) -> Route:
+    unregister(method, url)
+    return register(
+        method,
+        url,
+        status_code=status_code,
+        headers=headers,
+        content=content,
+        text=text,
+        json=json,
+        match=match,
+    )
 
 
 def assert_call_count(url: str, count: int) -> None:
-    actual = sum(call.request.url == url for call in calls)
+    actual = sum(str(call.request.url) == url for call in calls)
     if actual != count:
         msg = f"Expected {url!r} to be called {count} times, called {actual} times."
         raise AssertionError(msg)
-
-
-def get(url, **kwargs) -> Registration:
-    return add(GET, url, **kwargs)
-
-
-def post(url, **kwargs) -> Registration:
-    return add(POST, url, **kwargs)
-
-
-def delete(*args, **kwargs):
-    if len(args) == 2:
-        return remove(args[0], args[1])
-    return add(DELETE, args[0], **kwargs)

--- a/weblate/utils/tests/test_http_mock.py
+++ b/weblate/utils/tests/test_http_mock.py
@@ -1,0 +1,111 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import httpx2
+from django.test import SimpleTestCase
+
+from weblate.utils.requests import fetch_url
+from weblate.utils.tests import http_mock
+
+
+class HTTPMockTest(SimpleTestCase):
+    @http_mock.activate
+    def test_native_callback_and_recorded_request(self) -> None:
+        def callback(request: httpx2.Request) -> httpx2.Response:
+            self.assertEqual(request.method, "POST")
+            self.assertEqual(str(request.url), "https://example.com/callback")
+            self.assertEqual(request.content, b"request body")
+            return httpx2.Response(201, json={"result": "created"})
+
+        http_mock.register_callback(
+            "POST",
+            "https://example.com/callback",
+            callback,
+        )
+
+        response = fetch_url(
+            "post",
+            "https://example.com/callback",
+            content=b"request body",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {"result": "created"})
+        self.assertIsInstance(http_mock.calls[0].request, httpx2.Request)
+        self.assertIs(http_mock.calls[0].response, response)
+
+    @http_mock.activate
+    def test_response_payload_validation_and_json_null(self) -> None:
+        with self.assertRaisesRegex(TypeError, "Only one"):
+            http_mock.register(
+                "GET",
+                "https://example.com/invalid",
+                content=b"content",
+                text="text",
+            )
+        http_mock.register(
+            "GET",
+            "https://example.com/null",
+            json=None,
+        )
+
+        response = fetch_url("get", "https://example.com/null")
+
+        self.assertEqual(response.content, b"null")
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+
+    @http_mock.activate
+    def test_route_sequence_replacement_and_removal(self) -> None:
+        url = "https://example.com/sequence"
+        first = http_mock.register("GET", url, text="first")
+        second = http_mock.register("GET", url, text="second")
+
+        self.assertEqual(fetch_url("get", url).text, "first")
+        self.assertEqual(fetch_url("get", url).text, "second")
+        self.assertEqual(len(first.calls), 1)
+        self.assertEqual(len(second.calls), 1)
+
+        http_mock.replace("GET", url, text="replacement")
+        self.assertEqual(fetch_url("get", url).text, "replacement")
+
+        http_mock.unregister("GET", url)
+        with self.assertRaises(httpx2.ConnectError):
+            fetch_url("get", url)
+
+    @http_mock.activate
+    def test_registered_exception_is_recorded(self) -> None:
+        error = httpx2.ConnectTimeout("timed out")
+        http_mock.register_exception(
+            "GET",
+            "https://example.com/timeout",
+            error,
+        )
+
+        with self.assertRaises(httpx2.ConnectTimeout):
+            fetch_url("get", "https://example.com/timeout")
+
+        self.assertIs(http_mock.calls[0].response, error)
+
+    @http_mock.activate
+    def test_native_request_matchers(self) -> None:
+        url = "https://example.com/match"
+        http_mock.register(
+            "POST",
+            url,
+            text="matched",
+            match=[
+                http_mock.json_params_matcher({"key": "value"}),
+                http_mock.header_matcher({"X-Test": "expected"}),
+            ],
+        )
+        http_mock.register("POST", url, text="fallback")
+
+        response = fetch_url(
+            "post",
+            url,
+            json={"key": "value"},
+            headers={"X-Test": "expected"},
+        )
+
+        self.assertEqual(response.text, "matched")

--- a/weblate/utils/tests/test_requests.py
+++ b/weblate/utils/tests/test_requests.py
@@ -4,8 +4,6 @@
 
 import asyncio
 import os
-from concurrent.futures import ThreadPoolExecutor
-from threading import Event
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx2
@@ -17,17 +15,17 @@ from django.test.utils import override_settings
 from weblate.utils.outbound import get_environment_proxy
 from weblate.utils.requests import (
     PEER_IP_RESPONSE_ATTR,
-    AsyncHTTPClient,
-    HTTPClient,
     _get_response_peer_ip,
     _validate_response_peer,
+    async_fetch_url,
     async_fetch_validated_url,
+    create_async_http_client,
     fetch_url,
     fetch_validated_url,
     get_uri_error,
     open_restricted_asset_url,
 )
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 
 
 class TrackedSyncStream(httpx2.SyncByteStream):
@@ -89,29 +87,7 @@ class FetchURLTest(SimpleTestCase):
         ):
             self.assertIsNone(get_environment_proxy("https://example.com/source"))
 
-    @responses.activate
-    def test_fetch_url_omits_null_form_values(self) -> None:
-        responses.add(
-            responses.POST,
-            "https://gitlab.example.com/merge_requests",
-            status=201,
-        )
-
-        fetch_url(
-            "post",
-            "https://gitlab.example.com/merge_requests",
-            data={
-                "source_branch": "weblate",
-                "target_project_id": None,
-            },
-        )
-
-        self.assertEqual(
-            responses.calls[0].request.body,
-            b"source_branch=weblate",
-        )
-
-    def test_http_client_does_not_read_streaming_redirect_body(self) -> None:
+    def test_fetch_url_does_not_read_redirect_body(self) -> None:
         events: list[str] = []
 
         def handle_request(request):
@@ -123,23 +99,18 @@ class FetchURLTest(SimpleTestCase):
                 )
             return httpx2.Response(200, content=b"final-response")
 
-        client = HTTPClient(httpx2.MockTransport(handle_request))
-        with client:
-            response = client.request(
-                "get",
-                "https://example.com/redirect",
-                stream=True,
-            )
-            try:
-                self.assertEqual(response.read(), b"final-response")
-                self.assertEqual(len(response.history), 1)
-                self.assertTrue(response.history[0].is_closed)
-            finally:
-                response.close()
+        with patch(
+            "weblate.utils.requests._TEST_TRANSPORT.transport",
+            httpx2.MockTransport(handle_request),
+        ):
+            response = fetch_url("get", "https://example.com/redirect")
 
+        self.assertEqual(response.content, b"final-response")
+        self.assertEqual(len(response.history), 1)
+        self.assertTrue(response.history[0].is_closed)
         self.assertEqual(events, ["close"])
 
-    def test_async_http_client_does_not_read_streaming_redirect_body(self) -> None:
+    def test_async_fetch_url_does_not_read_redirect_body(self) -> None:
         events: list[str] = []
 
         def handle_request(request):
@@ -151,28 +122,24 @@ class FetchURLTest(SimpleTestCase):
                 )
             return httpx2.Response(200, content=b"final-response")
 
-        client = AsyncHTTPClient(httpx2.MockTransport(handle_request))
-
         async def make_request() -> httpx2.Response:
-            async with client:
-                response = await client.request(
-                    "get",
-                    "https://example.com/redirect",
-                    stream=True,
-                )
-                try:
-                    self.assertEqual(await response.aread(), b"final-response")
-                    self.assertEqual(len(response.history), 1)
-                    self.assertTrue(response.history[0].is_closed)
-                    return response
-                finally:
-                    await response.aclose()
+            return await async_fetch_url(
+                "get",
+                "https://example.com/redirect",
+            )
 
-        asyncio.run(make_request())
+        with patch(
+            "weblate.utils.requests._TEST_TRANSPORT.transport",
+            httpx2.MockTransport(handle_request),
+        ):
+            response = asyncio.run(make_request())
 
+        self.assertEqual(response.content, b"final-response")
+        self.assertEqual(len(response.history), 1)
+        self.assertTrue(response.history[0].is_closed)
         self.assertEqual(events, ["close"])
 
-    def test_http_client_limits_streaming_redirects(self) -> None:
+    def test_fetch_url_limits_redirects(self) -> None:
         events: list[str] = []
 
         def handle_request(_request):
@@ -182,109 +149,36 @@ class FetchURLTest(SimpleTestCase):
                 stream=TrackedRedirectSyncStream(events),
             )
 
-        client = HTTPClient(httpx2.MockTransport(handle_request))
         with (
-            client,
+            patch(
+                "weblate.utils.requests._TEST_TRANSPORT.transport",
+                httpx2.MockTransport(handle_request),
+            ),
             self.assertRaises(httpx2.TooManyRedirects),
         ):
-            client.request(
-                "get",
-                "https://example.com/redirect",
-                stream=True,
-                max_redirects=1,
-            )
+            fetch_url("get", "https://example.com/redirect")
 
-        self.assertEqual(events, ["close", "close"])
+        self.assertEqual(events, ["close"] * 6)
 
-    def test_http_client_keeps_redirect_limit_request_local(self) -> None:
-        short_started = Event()
-        long_started = Event()
-        short_finished = Event()
+    @http_mock.activate
+    def test_fetch_url_does_not_follow_redirects_when_disabled(self) -> None:
+        http_mock.register(
+            "GET",
+            "https://example.com/redirect",
+            status_code=302,
+            headers={"Location": "/final"},
+        )
 
-        def handle_request(request):
-            if request.url.path == "/short":
-                short_started.set()
-                if not long_started.wait(5):
-                    msg = "Long request did not start."
-                    raise RuntimeError(msg)
-                return httpx2.Response(302, headers={"Location": "/short-final"})
-            if request.url.path == "/long":
-                long_started.set()
-                if not short_finished.wait(5):
-                    msg = "Short request did not finish."
-                    raise RuntimeError(msg)
-            return httpx2.Response(200)
+        response = fetch_url(
+            "get",
+            "https://example.com/redirect",
+            follow_redirects=False,
+            raise_for_status=False,
+        )
 
-        client = HTTPClient(httpx2.MockTransport(handle_request))
-
-        def request_short_url() -> httpx2.Response:
-            try:
-                return client.request(
-                    "get",
-                    "https://example.com/short",
-                    max_redirects=0,
-                )
-            finally:
-                short_finished.set()
-
-        with client, ThreadPoolExecutor(max_workers=2) as executor:
-            short_result = executor.submit(request_short_url)
-            self.assertTrue(short_started.wait(5))
-            long_result = executor.submit(
-                client.request,
-                "get",
-                "https://example.com/long",
-                max_redirects=2,
-            )
-
-            with self.assertRaises(httpx2.TooManyRedirects):
-                short_result.result(timeout=5)
-            self.assertEqual(long_result.result(timeout=5).status_code, 200)
-
-    def test_async_http_client_keeps_redirect_limit_request_local(self) -> None:
-        async def run_requests() -> None:
-            short_started = asyncio.Event()
-            long_started = asyncio.Event()
-            short_finished = asyncio.Event()
-
-            async def handle_request(request):
-                if request.url.path == "/short":
-                    short_started.set()
-                    await asyncio.wait_for(long_started.wait(), timeout=5)
-                    return httpx2.Response(302, headers={"Location": "/short-final"})
-                if request.url.path == "/long":
-                    long_started.set()
-                    await asyncio.wait_for(short_finished.wait(), timeout=5)
-                return httpx2.Response(200)
-
-            client = AsyncHTTPClient(httpx2.MockTransport(handle_request))
-
-            async def request_short_url() -> httpx2.Response:
-                try:
-                    return await client.request(
-                        "get",
-                        "https://example.com/short",
-                        max_redirects=0,
-                    )
-                finally:
-                    short_finished.set()
-
-            async with client:
-                short_result = asyncio.create_task(request_short_url())
-                await asyncio.wait_for(short_started.wait(), timeout=5)
-                long_result = asyncio.create_task(
-                    client.request(
-                        "get",
-                        "https://example.com/long",
-                        max_redirects=2,
-                    )
-                )
-
-                with self.assertRaises(httpx2.TooManyRedirects):
-                    await short_result
-                self.assertEqual((await long_result).status_code, 200)
-
-        asyncio.run(run_requests())
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.history, [])
+        self.assertEqual(len(http_mock.calls), 1)
 
     def test_async_http_client_uses_async_validator(self) -> None:
         request = httpx2.Request("GET", "https://example.com/data")
@@ -295,8 +189,9 @@ class FetchURLTest(SimpleTestCase):
         )
         validators = MagicMock()
         validators.validate_async_request_url = AsyncMock(return_value=())
-        client = AsyncHTTPClient(
-            httpx2.MockTransport(lambda _request: response),
+        client = create_async_http_client(
+            transport=httpx2.MockTransport(lambda _request: response),
+            validators=validators,
         )
 
         async def make_request() -> httpx2.Response:
@@ -304,7 +199,6 @@ class FetchURLTest(SimpleTestCase):
                 return await client.request(
                     "get",
                     "https://example.com/data",
-                    validators=validators,
                 )
 
         result = asyncio.run(make_request())
@@ -318,20 +212,53 @@ class FetchURLTest(SimpleTestCase):
 
 
 class OpenRestrictedAssetURLBehaviorTest(SimpleTestCase):
-    @responses.activate
+    def test_open_restricted_asset_url_does_not_read_redirect_body(self) -> None:
+        events: list[str] = []
+
+        def handle_request(request):
+            if request.url.path == "/redirect":
+                return httpx2.Response(
+                    302,
+                    headers={"Location": "/final"},
+                    stream=TrackedRedirectSyncStream(events),
+                )
+            return httpx2.Response(200, content=b"final-response")
+
+        with (
+            patch(
+                "weblate.utils.requests._TEST_TRANSPORT.transport",
+                httpx2.MockTransport(handle_request),
+            ),
+            patch(
+                "weblate.utils.requests.RestrictedAssetRedirectValidators.validate_request_url",
+                return_value=(),
+            ),
+            open_restricted_asset_url(
+                "get",
+                "https://example.com/redirect",
+                allow_private_targets=True,
+            ) as response,
+        ):
+            self.assertEqual(response.read(), b"final-response")
+            self.assertEqual(len(response.history), 1)
+            self.assertTrue(response.history[0].is_closed)
+
+        self.assertEqual(events, ["close"])
+
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     def test_open_restricted_asset_url_follows_allowed_redirect(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://images.allowed.com/redirect-image.png",
-            status=302,
+            status_code=302,
             headers={"Location": "https://cdn.allowed.com/final-image.png"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://cdn.allowed.com/final-image.png",
-            status=200,
-            body=b"image-data",
+            status_code=200,
+            content=b"image-data",
         )
 
         with open_restricted_asset_url(
@@ -341,26 +268,26 @@ class OpenRestrictedAssetURLBehaviorTest(SimpleTestCase):
         ) as response:
             self.assertEqual(response.content, b"image-data")
 
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(http_mock.calls), 2)
         self.assertEqual(
-            responses.calls[1].request.url,
+            http_mock.calls[1].request.url,
             "https://cdn.allowed.com/final-image.png",
         )
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     def test_open_restricted_asset_url_blocks_disallowed_redirect(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://images.allowed.com/redirect-image.png",
-            status=302,
+            status_code=302,
             headers={"Location": "https://proof.example.com/final-image.png"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://proof.example.com/final-image.png",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with (
@@ -373,29 +300,29 @@ class OpenRestrictedAssetURLBehaviorTest(SimpleTestCase):
         ):
             pass
 
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
         self.assertEqual(
-            responses.calls[0].request.url,
+            http_mock.calls[0].request.url,
             "https://images.allowed.com/redirect-image.png",
         )
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     def test_open_restricted_asset_url_preserves_redirect_cookies(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://images.allowed.com/redirect-image.png",
-            status=302,
+            status_code=302,
             headers={
                 "Location": "https://cdn.allowed.com/final-image.png",
                 "Set-Cookie": "asset-token=allowed; Domain=.allowed.com; Path=/",
             },
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://cdn.allowed.com/final-image.png",
-            status=200,
-            body=b"image-data",
+            status_code=200,
+            content=b"image-data",
         )
 
         with open_restricted_asset_url(
@@ -406,19 +333,19 @@ class OpenRestrictedAssetURLBehaviorTest(SimpleTestCase):
             self.assertEqual(response.content, b"image-data")
 
         self.assertEqual(
-            responses.calls[1].request.headers["Cookie"],
+            http_mock.calls[1].request.headers["Cookie"],
             "asset-token=allowed",
         )
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     def test_open_restricted_asset_url_raises_validation_error_for_http_status(
         self,
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://images.allowed.com/missing-image.png",
-            status=404,
+            status_code=404,
         )
 
         with (
@@ -434,15 +361,15 @@ class OpenRestrictedAssetURLBehaviorTest(SimpleTestCase):
         ):
             pass
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     def test_open_restricted_asset_url_raises_validation_error_for_redirect_status(
         self,
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://images.allowed.com/redirect-image.png",
-            status=301,
+            status_code=301,
         )
 
         with (
@@ -460,7 +387,7 @@ class OpenRestrictedAssetURLBehaviorTest(SimpleTestCase):
 
 
 class OpenRestrictedAssetURLTest(SimpleTestCase):
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -469,11 +396,11 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
     def test_open_restricted_asset_url_blocks_private_target(
         self, mocked_getaddrinfo
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/messages.html",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with (
@@ -486,9 +413,9 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
             pass
 
         mocked_getaddrinfo.assert_called_once_with("private.example.com", None, type=1)
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch("weblate.utils.requests._get_response_peer_ip", return_value="93.184.216.34")
     @patch(
@@ -501,17 +428,17 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
     def test_open_restricted_asset_url_blocks_private_redirect(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/messages.html",
-            status=302,
+            status_code=302,
             headers={"Location": "https://private.example.com/messages.html"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/messages.html",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with (
@@ -526,9 +453,9 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
 
         self.assertEqual(mocked_getaddrinfo.call_count, 2)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch("weblate.utils.requests._get_response_peer_ip", return_value="127.0.0.1")
     @patch(
@@ -538,11 +465,11 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
     def test_open_restricted_asset_url_blocks_private_peer_after_public_dns(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/messages.html",
-            status=200,
-            body=b"should-not-be-read",
+            status_code=200,
+            content=b"should-not-be-read",
         )
 
         with (
@@ -557,9 +484,9 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
 
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch("weblate.utils.requests._get_response_peer_ip", return_value=None)
     @patch(
@@ -569,11 +496,11 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
     def test_open_restricted_asset_url_blocks_missing_peer_after_public_dns(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/messages.html",
-            status=200,
-            body=b"connection-close-response",
+            status_code=200,
+            content=b"connection-close-response",
         )
 
         with (
@@ -588,9 +515,9 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
 
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=["*"])
     @patch("weblate.utils.requests._get_response_peer_ip")
     @patch(
@@ -600,11 +527,11 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
     def test_open_restricted_asset_url_allows_allowlisted_private_target(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/messages.html",
-            status=200,
-            body=b"allowlisted-private-target",
+            status_code=200,
+            content=b"allowlisted-private-target",
         )
 
         with open_restricted_asset_url(
@@ -617,19 +544,19 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
 
         mocked_getaddrinfo.assert_not_called()
         mocked_get_peer.assert_not_called()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(ALLOWED_ASSET_DOMAINS=[".allowed.com"])
     @patch("weblate.utils.outbound.socket.getaddrinfo")
     def test_open_restricted_asset_url_blocks_disallowed_asset_domain(
         self, mocked_getaddrinfo
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://blocked.example.com/messages.html",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with (
@@ -643,25 +570,25 @@ class OpenRestrictedAssetURLTest(SimpleTestCase):
             pass
 
         mocked_getaddrinfo.assert_not_called()
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
 
 class GetUriErrorTest(SimpleTestCase):
     def setUp(self) -> None:
         cache.clear()
 
-    @responses.activate
+    @http_mock.activate
     def test_get_uri_error_allows_internal_host_by_default(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://gitlab.intranet.example/project",
-            status=200,
-            body=b"ok",
+            status_code=200,
+            content=b"ok",
         )
 
         self.assertIsNone(get_uri_error("https://gitlab.intranet.example/project"))
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value="93.184.216.34",
@@ -676,17 +603,17 @@ class GetUriErrorTest(SimpleTestCase):
     def test_get_uri_error_blocks_private_redirect(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=302,
+            status_code=302,
             headers={"Location": "https://private.example.com/final"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/final",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         expected_error = (
@@ -702,9 +629,9 @@ class GetUriErrorTest(SimpleTestCase):
 
         self.assertEqual(mocked_getaddrinfo.call_count, 2)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         return_value="93.184.216.34",
@@ -719,17 +646,17 @@ class GetUriErrorTest(SimpleTestCase):
     def test_get_uri_error_cache_is_scoped_by_private_target_policy(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=302,
+            status_code=302,
             headers={"Location": "https://private.example.com/final"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/final",
-            status=200,
-            body=b"private-target",
+            status_code=200,
+            content=b"private-target",
         )
 
         expected_error = (
@@ -747,7 +674,7 @@ class GetUriErrorTest(SimpleTestCase):
 
         self.assertEqual(mocked_getaddrinfo.call_count, 2)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 3)
+        self.assertEqual(len(http_mock.calls), 3)
 
     @patch("weblate.utils.requests._probe_validated_url")
     def test_get_uri_error_flattens_validation_error(self, mocked_probe) -> None:
@@ -760,7 +687,7 @@ class GetUriErrorTest(SimpleTestCase):
 
 
 class FetchValidatedURLTest(SimpleTestCase):
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         side_effect=[
@@ -775,11 +702,11 @@ class FetchValidatedURLTest(SimpleTestCase):
         self, mocked_getaddrinfo
     ) -> None:
         url = "https://public.example.com:8443/source"
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             url,
-            status=200,
-            body=b"pinned",
+            status_code=200,
+            content=b"pinned",
         )
 
         response = fetch_validated_url(
@@ -791,20 +718,20 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertEqual(response.content, b"pinned")
         self.assertEqual(str(response.url), url)
         self.assertEqual(
-            responses.calls[0].request.transport_url,
+            str(http_mock.get_transport_url(http_mock.calls[0].request)),
             "https://93.184.216.34:8443/source",
         )
         self.assertEqual(
-            responses.calls[0].request.headers["Host"],
+            http_mock.calls[0].request.headers["Host"],
             "public.example.com:8443",
         )
         self.assertEqual(
-            responses.calls[0].request.extensions["sni_hostname"],
+            http_mock.calls[0].request.extensions["sni_hostname"],
             "public.example.com",
         )
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[
@@ -816,16 +743,16 @@ class FetchValidatedURLTest(SimpleTestCase):
         self, mocked_getaddrinfo
     ) -> None:
         url = "https://public.example.com/source"
-        responses.add(
-            responses.GET,
+        http_mock.register_exception(
+            "GET",
             url,
-            body=httpx2.ConnectError("IPv6 route unavailable"),
+            exception=httpx2.ConnectError("IPv6 route unavailable"),
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             url,
-            status=200,
-            body=b"fallback",
+            status_code=200,
+            content=b"fallback",
         )
 
         with patch(
@@ -840,19 +767,22 @@ class FetchValidatedURLTest(SimpleTestCase):
 
         self.assertEqual(response.content, b"fallback")
         self.assertEqual(
-            [call.request.transport_url for call in responses.calls],
+            [
+                str(http_mock.get_transport_url(call.request))
+                for call in http_mock.calls
+            ],
             [
                 "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
                 "https://93.184.216.34/source",
             ],
         )
         self.assertEqual(
-            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [call.request.extensions["timeout"]["connect"] for call in http_mock.calls],
             [0.25, 0.25],
         )
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[
@@ -864,21 +794,21 @@ class FetchValidatedURLTest(SimpleTestCase):
         self, mocked_getaddrinfo
     ) -> None:
         url = "https://public.example.com/source"
-        responses.add(
-            responses.GET,
+        http_mock.register_exception(
+            "GET",
             url,
-            body=httpx2.ConnectTimeout("IPv6 probe timed out"),
+            exception=httpx2.ConnectTimeout("IPv6 probe timed out"),
         )
-        responses.add(
-            responses.GET,
+        http_mock.register_exception(
+            "GET",
             url,
-            body=httpx2.ConnectTimeout("IPv4 probe timed out"),
+            exception=httpx2.ConnectTimeout("IPv4 probe timed out"),
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             url,
-            status=200,
-            body=b"slow-fallback",
+            status_code=200,
+            content=b"slow-fallback",
         )
 
         with patch(
@@ -893,7 +823,10 @@ class FetchValidatedURLTest(SimpleTestCase):
 
         self.assertEqual(response.content, b"slow-fallback")
         self.assertEqual(
-            [call.request.transport_url for call in responses.calls],
+            [
+                str(http_mock.get_transport_url(call.request))
+                for call in http_mock.calls
+            ],
             [
                 "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
                 "https://93.184.216.34/source",
@@ -901,12 +834,12 @@ class FetchValidatedURLTest(SimpleTestCase):
             ],
         )
         self.assertEqual(
-            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [call.request.extensions["timeout"]["connect"] for call in http_mock.calls],
             [0.25, 0.25, 4.75],
         )
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests.async_resolve_runtime_hostname",
         new_callable=AsyncMock,
@@ -916,11 +849,11 @@ class FetchValidatedURLTest(SimpleTestCase):
         self, mocked_resolve
     ) -> None:
         url = "https://public.example.com/source"
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             url,
-            status=200,
-            body=b"async-pinned",
+            status_code=200,
+            content=b"async-pinned",
         )
 
         response = asyncio.run(
@@ -934,14 +867,14 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertEqual(response.content, b"async-pinned")
         self.assertEqual(str(response.url), url)
         self.assertEqual(
-            responses.calls[0].request.transport_url,
+            str(http_mock.get_transport_url(http_mock.calls[0].request)),
             "https://93.184.216.34/source",
         )
         mocked_resolve.assert_awaited_once_with(
             "public.example.com", allow_private_targets=False
         )
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests.async_resolve_runtime_hostname",
         new_callable=AsyncMock,
@@ -950,11 +883,11 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_async_fetch_validated_url_blocks_private_target_by_default(
         self, mocked_resolve
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/source",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with self.assertRaises(ValidationError):
@@ -968,9 +901,9 @@ class FetchValidatedURLTest(SimpleTestCase):
         mocked_resolve.assert_awaited_once_with(
             "private.example.com", allow_private_targets=False
         )
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests.async_resolve_runtime_hostname",
         new_callable=AsyncMock,
@@ -983,16 +916,16 @@ class FetchValidatedURLTest(SimpleTestCase):
         self, mocked_resolve
     ) -> None:
         url = "https://public.example.com/source"
-        responses.add(
-            responses.GET,
+        http_mock.register_exception(
+            "GET",
             url,
-            body=httpx2.ConnectTimeout("IPv6 route timed out"),
+            exception=httpx2.ConnectTimeout("IPv6 route timed out"),
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             url,
-            status=200,
-            body=b"async-fallback",
+            status_code=200,
+            content=b"async-fallback",
         )
 
         with patch(
@@ -1009,21 +942,24 @@ class FetchValidatedURLTest(SimpleTestCase):
 
         self.assertEqual(response.content, b"async-fallback")
         self.assertEqual(
-            [call.request.transport_url for call in responses.calls],
+            [
+                str(http_mock.get_transport_url(call.request))
+                for call in http_mock.calls
+            ],
             [
                 "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
                 "https://93.184.216.34/source",
             ],
         )
         self.assertEqual(
-            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [call.request.extensions["timeout"]["connect"] for call in http_mock.calls],
             [0.25, 0.25],
         )
         mocked_resolve.assert_awaited_once_with(
             "public.example.com", allow_private_targets=False
         )
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests.async_resolve_runtime_hostname",
         new_callable=AsyncMock,
@@ -1036,21 +972,21 @@ class FetchValidatedURLTest(SimpleTestCase):
         self, mocked_resolve
     ) -> None:
         url = "https://public.example.com/source"
-        responses.add(
-            responses.GET,
+        http_mock.register_exception(
+            "GET",
             url,
-            body=httpx2.ConnectTimeout("IPv6 probe timed out"),
+            exception=httpx2.ConnectTimeout("IPv6 probe timed out"),
         )
-        responses.add(
-            responses.GET,
+        http_mock.register_exception(
+            "GET",
             url,
-            body=httpx2.ConnectTimeout("IPv4 probe timed out"),
+            exception=httpx2.ConnectTimeout("IPv4 probe timed out"),
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             url,
-            status=200,
-            body=b"async-slow-fallback",
+            status_code=200,
+            content=b"async-slow-fallback",
         )
 
         with patch(
@@ -1067,7 +1003,10 @@ class FetchValidatedURLTest(SimpleTestCase):
 
         self.assertEqual(response.content, b"async-slow-fallback")
         self.assertEqual(
-            [call.request.transport_url for call in responses.calls],
+            [
+                str(http_mock.get_transport_url(call.request))
+                for call in http_mock.calls
+            ],
             [
                 "https://[2606:2800:220:1:248:1893:25c8:1946]/source",
                 "https://93.184.216.34/source",
@@ -1075,24 +1014,24 @@ class FetchValidatedURLTest(SimpleTestCase):
             ],
         )
         self.assertEqual(
-            [call.request.extensions["timeout"]["connect"] for call in responses.calls],
+            [call.request.extensions["timeout"]["connect"] for call in http_mock.calls],
             [0.25, 0.25, 4.75],
         )
         mocked_resolve.assert_awaited_once_with(
             "public.example.com", allow_private_targets=False
         )
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
     )
     def test_fetch_validated_url_uses_idna_sni_name(self, mocked_getaddrinfo) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://xn--fa-hia.de/source",
-            status=200,
-            body=b"idna",
+            status_code=200,
+            content=b"idna",
         )
 
         response = fetch_validated_url(
@@ -1103,12 +1042,12 @@ class FetchValidatedURLTest(SimpleTestCase):
 
         self.assertEqual(response.content, b"idna")
         self.assertEqual(
-            responses.calls[0].request.extensions["sni_hostname"],
+            http_mock.calls[0].request.extensions["sni_hostname"],
             "xn--fa-hia.de",
         )
         mocked_getaddrinfo.assert_called_once_with("xn--fa-hia.de", None, type=1)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("93.184.216.34", 443))],
@@ -1116,17 +1055,17 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_keeps_logical_url_for_relative_redirect(
         self, mocked_getaddrinfo
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=302,
+            status_code=302,
             headers={"Location": "/final"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/final",
-            status=200,
-            body=b"redirected",
+            status_code=200,
+            content=b"redirected",
         )
 
         response = fetch_validated_url(
@@ -1142,7 +1081,10 @@ class FetchValidatedURLTest(SimpleTestCase):
             ["https://public.example.com/source"],
         )
         self.assertEqual(
-            [call.request.transport_url for call in responses.calls],
+            [
+                str(http_mock.get_transport_url(call.request))
+                for call in http_mock.calls
+            ],
             [
                 "https://93.184.216.34/source",
                 "https://93.184.216.34/final",
@@ -1150,29 +1092,29 @@ class FetchValidatedURLTest(SimpleTestCase):
         )
         self.assertEqual(mocked_getaddrinfo.call_count, 2)
 
-    @responses.activate
+    @http_mock.activate
     def test_fetch_validated_url_strips_auth_on_cross_origin_redirect(self) -> None:
         recorded_headers: list[dict[str, str]] = []
 
         def redirect(request):
             recorded_headers.append(dict(request.headers))
-            return (
+            return httpx2.Response(
                 302,
-                {"Location": "https://other.example.com/final"},
-                b"",
+                headers={"Location": "https://other.example.com/final"},
+                content=b"",
             )
 
         def final(request):
             recorded_headers.append(dict(request.headers))
-            return 200, {}, b"ok"
+            return httpx2.Response(200, headers={}, content=b"ok")
 
-        responses.add_callback(
-            responses.GET,
+        http_mock.register_callback(
+            "GET",
             "https://public.example.com/source",
             callback=redirect,
         )
-        responses.add_callback(
-            responses.GET,
+        http_mock.register_callback(
+            "GET",
             "https://other.example.com/final",
             callback=final,
         )
@@ -1182,7 +1124,7 @@ class FetchValidatedURLTest(SimpleTestCase):
             "https://public.example.com/source",
             headers={"Authorization": "Bearer secret"},
             auth=("user", "pass"),
-            allow_redirects=True,
+            follow_redirects=True,
             allow_private_targets=True,
         )
 
@@ -1190,29 +1132,29 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertIn("authorization", recorded_headers[0])
         self.assertNotIn("authorization", recorded_headers[1])
 
-    @responses.activate
+    @http_mock.activate
     def test_fetch_validated_url_preserves_delete_method_on_301_redirect(self) -> None:
-        recorded_calls: list[tuple[str, bytes | None]] = []
+        recorded_calls: list[tuple[str, bytes]] = []
 
         def redirect(request):
-            recorded_calls.append((request.method, request.body))
-            return (
+            recorded_calls.append((request.method, request.content))
+            return httpx2.Response(
                 301,
-                {"Location": "https://public.example.com/final"},
-                b"",
+                headers={"Location": "https://public.example.com/final"},
+                content=b"",
             )
 
         def final(request):
-            recorded_calls.append((request.method, request.body))
-            return 200, {}, b"ok"
+            recorded_calls.append((request.method, request.content))
+            return httpx2.Response(200, headers={}, content=b"ok")
 
-        responses.add_callback(
-            responses.DELETE,
+        http_mock.register_callback(
+            "DELETE",
             "https://public.example.com/source",
             callback=redirect,
         )
-        responses.add_callback(
-            responses.DELETE,
+        http_mock.register_callback(
+            "DELETE",
             "https://public.example.com/final",
             callback=final,
         )
@@ -1220,9 +1162,9 @@ class FetchValidatedURLTest(SimpleTestCase):
         fetch_validated_url(
             "delete",
             "https://public.example.com/source",
-            allow_redirects=True,
+            follow_redirects=True,
             allow_private_targets=True,
-            data=b"payload",
+            content=b"payload",
         )
 
         self.assertEqual(
@@ -1230,7 +1172,7 @@ class FetchValidatedURLTest(SimpleTestCase):
             [("DELETE", b"payload"), ("DELETE", b"payload")],
         )
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
@@ -1238,11 +1180,11 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_blocks_private_target_by_default(
         self, mocked_getaddrinfo
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with self.assertRaises(ValidationError):
@@ -1252,9 +1194,9 @@ class FetchValidatedURLTest(SimpleTestCase):
             )
 
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.utils.requests._get_response_peer_ip", return_value="93.184.216.34")
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1266,17 +1208,17 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_blocks_private_redirect(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=302,
+            status_code=302,
             headers={"Location": "https://private.example.com/final"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example.com/final",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with self.assertRaises(ValidationError):
@@ -1288,9 +1230,9 @@ class FetchValidatedURLTest(SimpleTestCase):
 
         self.assertEqual(mocked_getaddrinfo.call_count, 2)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.utils.requests._get_response_peer_ip", return_value="127.0.0.1")
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1299,11 +1241,11 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_blocks_private_peer_after_public_dns(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with self.assertRaises(ValidationError):
@@ -1315,9 +1257,9 @@ class FetchValidatedURLTest(SimpleTestCase):
 
         mocked_getaddrinfo.assert_called_once_with("public.example.com", None, type=1)
         mocked_get_peer.assert_called_once()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.utils.requests._get_response_peer_ip", return_value="127.0.0.1")
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1326,11 +1268,11 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_allows_allowlisted_private_target(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example/source",
-            status=200,
-            body=b"allowlisted-private-target",
+            status_code=200,
+            content=b"allowlisted-private-target",
         )
 
         response = fetch_validated_url(
@@ -1343,9 +1285,9 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertEqual(response.content, b"allowlisted-private-target")
         mocked_getaddrinfo.assert_not_called()
         mocked_get_peer.assert_not_called()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch(
         "weblate.utils.requests._get_response_peer_ip",
         side_effect=["93.184.216.34", "127.0.0.1"],
@@ -1360,17 +1302,17 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_allows_redirect_to_allowlisted_private_target(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=302,
+            status_code=302,
             headers={"Location": "https://private.example/final"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://private.example/final",
-            status=200,
-            body=b"allowlisted-private-redirect",
+            status_code=200,
+            content=b"allowlisted-private-redirect",
         )
 
         response = fetch_validated_url(
@@ -1383,9 +1325,9 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertEqual(response.content, b"allowlisted-private-redirect")
         self.assertEqual(mocked_getaddrinfo.call_count, 1)
         self.assertEqual(mocked_get_peer.call_count, 1)
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(http_mock.calls), 2)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.utils.requests._get_response_peer_ip")
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1394,11 +1336,11 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_skips_peer_validation_through_proxy(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=200,
-            body=b"fetched-via-proxy",
+            status_code=200,
+            content=b"fetched-via-proxy",
         )
 
         with patch.dict(
@@ -1419,9 +1361,9 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertEqual(response.content, b"fetched-via-proxy")
         mocked_getaddrinfo.assert_not_called()
         mocked_get_peer.assert_not_called()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.utils.requests._get_response_peer_ip")
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1430,11 +1372,11 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_allows_proxy_resolved_hostname(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://public.example.com/source",
-            status=200,
-            body=b"resolved-by-proxy",
+            status_code=200,
+            content=b"resolved-by-proxy",
         )
 
         with patch.dict(
@@ -1455,9 +1397,9 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertEqual(response.content, b"resolved-by-proxy")
         mocked_getaddrinfo.assert_not_called()
         mocked_get_peer.assert_not_called()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     @patch("weblate.utils.requests._get_response_peer_ip")
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
@@ -1466,11 +1408,11 @@ class FetchValidatedURLTest(SimpleTestCase):
     def test_fetch_validated_url_allows_allowlisted_hostname_through_proxy(
         self, mocked_getaddrinfo, mocked_get_peer
     ) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "http://ollama/api/tags",
-            status=200,
-            body=b'{"models":[]}',
+            status_code=200,
+            content=b'{"models":[]}',
         )
 
         with patch.dict(
@@ -1492,15 +1434,15 @@ class FetchValidatedURLTest(SimpleTestCase):
         self.assertEqual(response.content, b'{"models":[]}')
         mocked_getaddrinfo.assert_not_called()
         mocked_get_peer.assert_not_called()
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_fetch_validated_url_blocks_localhost_alias_through_proxy(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "http://localhost./source",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with (
@@ -1521,15 +1463,15 @@ class FetchValidatedURLTest(SimpleTestCase):
                 allow_private_targets=False,
             )
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_fetch_validated_url_blocks_shorthand_loopback_through_proxy(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "http://127.1/source",
-            status=200,
-            body=b"should-not-be-fetched",
+            status_code=200,
+            content=b"should-not-be-fetched",
         )
 
         with (
@@ -1550,7 +1492,7 @@ class FetchValidatedURLTest(SimpleTestCase):
                 allow_private_targets=False,
             )
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
     @patch("weblate.utils.requests._get_response_peer_ip", return_value=None)
     def test_http_request_fails_when_peer_ip_is_unavailable(

--- a/weblate/utils/tests/test_version.py
+++ b/weblate/utils/tests/test_version.py
@@ -14,7 +14,7 @@ from packaging.version import Version
 
 from weblate.trans.tests.utils import get_test_file
 from weblate.utils.docs import get_doc_url
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.utils.version import (
     PYPI,
     VERSION,
@@ -49,24 +49,24 @@ class VersionTest(SimpleTestCase):
     @staticmethod
     def mock_pypi() -> None:
         test_file = Path(get_test_file("pypi.json"))
-        responses.add(responses.GET, PYPI, body=test_file.read_text(encoding="utf-8"))
+        http_mock.register("GET", PYPI, text=test_file.read_text(encoding="utf-8"))
 
-    @responses.activate
+    @http_mock.activate
     def test_download(self) -> None:
         self.mock_pypi()
         data = download_version_info()
         self.assertEqual(len(data), 47)
 
-    @responses.activate
+    @http_mock.activate
     def test_get(self) -> None:
         self.mock_pypi()
         data = get_version_info()
         self.assertEqual(len(data), 47)
-        responses.replace(responses.GET, PYPI, body="")
+        http_mock.replace("GET", PYPI, text="")
         data = get_version_info()
         self.assertEqual(len(data), 47)
 
-    @responses.activate
+    @http_mock.activate
     def test_latest(self) -> None:
         self.mock_pypi()
         latest = get_latest_version()

--- a/weblate/utils/tests/test_zammad.py
+++ b/weblate/utils/tests/test_zammad.py
@@ -11,7 +11,7 @@ import httpx2
 from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import override_settings
 
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.utils.zammad import ZammadError, submit_zammad_ticket
 
 ZAMMAD_URL = "https://example.com"
@@ -39,23 +39,23 @@ class ZammadTest(TestCase):
         return report_error, raised.exception
 
     def mock_zammad(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
             json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
         )
-        responses.add(
-            responses.POST, SUBMIT_URL, json={"ticket": {"id": 123, "number": 4123}}
+        http_mock.register(
+            "POST", SUBMIT_URL, json={"ticket": {"id": 123, "number": 4123}}
         )
 
     @override_settings(ZAMMAD_URL=None)
-    @responses.activate
+    @http_mock.activate
     def test_unconfigured(self) -> None:
         with self.assertRaises(ImproperlyConfigured):
             submit_zammad_ticket(**TICKET_DATA)
 
     @override_settings(ZAMMAD_URL=None)
-    @responses.activate
+    @http_mock.activate
     def test_unconfigured_override(self) -> None:
         self.mock_zammad()
         self.assertEqual(
@@ -67,7 +67,7 @@ class ZammadTest(TestCase):
         )
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_configured(self) -> None:
         self.mock_zammad()
         self.assertEqual(
@@ -76,82 +76,82 @@ class ZammadTest(TestCase):
         )
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_invalid_json_encoding(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
-            body=b"\xff",
-            content_type="application/json",
+            content=b"\xff",
+            headers={"Content-Type": "application/json"},
         )
 
         self.assert_zammad_failure()
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_configuration_connection_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register_exception(
+            "POST",
             CONFIG_URL,
-            body=httpx2.ConnectError("Zammad unavailable"),
+            exception=httpx2.ConnectError("Zammad unavailable"),
         )
 
         _, error = self.assert_zammad_failure()
         self.assertIsInstance(error.__cause__, httpx2.ConnectError)
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_submission_connection_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
             json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register_exception(
+            "POST",
             SUBMIT_URL,
-            body=httpx2.ConnectError("Zammad unavailable"),
+            exception=httpx2.ConnectError("Zammad unavailable"),
         )
 
         _, error = self.assert_zammad_failure()
         self.assertIsInstance(error.__cause__, httpx2.ConnectError)
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_configuration_timeout(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register_exception(
+            "POST",
             CONFIG_URL,
-            body=httpx2.ReadTimeout("Zammad timed out"),
+            exception=httpx2.ReadTimeout("Zammad timed out"),
         )
 
         _, error = self.assert_zammad_failure()
         self.assertIsInstance(error.__cause__, httpx2.ReadTimeout)
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_submission_timeout(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
             json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register_exception(
+            "POST",
             SUBMIT_URL,
-            body=httpx2.ReadTimeout("Zammad timed out"),
+            exception=httpx2.ReadTimeout("Zammad timed out"),
         )
 
         _, error = self.assert_zammad_failure()
         self.assertIsInstance(error.__cause__, httpx2.ReadTimeout)
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_http_error_with_zammad_errors(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
-            status=503,
+            status_code=503,
             json={"errors": "Backend unavailable"},
         )
 
@@ -163,34 +163,34 @@ class ZammadTest(TestCase):
         )
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_http_error_with_json(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
-            status=503,
+            status_code=503,
             json={"detail": "Backend unavailable"},
         )
 
         self.assert_zammad_failure()
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_http_error_with_invalid_json(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
-            status=503,
-            body="<html>Unavailable</html>",
+            status_code=503,
+            text="<html>Unavailable</html>",
         )
 
         self.assert_zammad_failure()
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_api_error_is_not_exposed(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
             json={"errors": "Secret internal detail"},
         )
@@ -203,24 +203,24 @@ class ZammadTest(TestCase):
         )
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_unexpected_json_type(self) -> None:
-        responses.add(responses.POST, CONFIG_URL, json=[])
+        http_mock.register("POST", CONFIG_URL, json=[])
 
         self.assert_zammad_failure()
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_disabled_configuration(self) -> None:
-        responses.add(responses.POST, CONFIG_URL, json={"enabled": False})
+        http_mock.register("POST", CONFIG_URL, json={"enabled": False})
 
         self.assert_zammad_failure()
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_malformed_configuration(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
             json={"enabled": True, "endpoint": SUBMIT_URL},
         )
@@ -228,13 +228,13 @@ class ZammadTest(TestCase):
         self.assert_zammad_failure()
 
     @override_settings(ZAMMAD_URL=ZAMMAD_URL)
-    @responses.activate
+    @http_mock.activate
     def test_malformed_ticket(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             CONFIG_URL,
             json={"enabled": True, "endpoint": SUBMIT_URL, "token": "token"},
         )
-        responses.add(responses.POST, SUBMIT_URL, json={"ticket": {}})
+        http_mock.register("POST", SUBMIT_URL, json={"ticket": {}})
 
         self.assert_zammad_failure()

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -55,8 +55,8 @@ from weblate.utils.lock import WeblateLock, WeblateLockTimeoutError
 from weblate.utils.render import render_template
 from weblate.utils.requests import (
     JSON_RESPONSE_ERRORS,
-    HTTPClient,
     RedirectValidators,
+    create_http_client,
     fetch_url,
 )
 from weblate.utils.tracing import start_span
@@ -335,24 +335,21 @@ def _perform_git_probe(
     environment: dict[str, str] | None,
 ) -> tuple[int, str | None, str]:
     """Perform one Git smart-HTTP probe using the shared HTTP client."""
-    with HTTPClient() as client:
-        response = client.request(
+    with (
+        create_http_client(validators=GitProbeRedirectValidators(target)) as client,
+        client.stream(
             "GET",
             _build_git_probe_url(repository_url),
             headers=_get_git_probe_headers(repository_url, environment),
             timeout=20,
-            allow_redirects=False,
-            stream=True,
-            validators=GitProbeRedirectValidators(target),
+            follow_redirects=False,
+        ) as response,
+    ):
+        return (
+            response.status_code,
+            response.headers.get("Location"),
+            response.headers.get("Content-Type", ""),
         )
-        try:
-            return (
-                response.status_code,
-                response.headers.get("Location"),
-                response.headers.get("Content-Type", ""),
-            )
-        finally:
-            response.close()
 
 
 class GitCredentials(TypedDict):
@@ -3498,8 +3495,9 @@ class GitLabRepository(GitMergeRequestBase):
             "target_branch": origin_branch,
             "title": title,
             "description": description,
-            "target_project_id": target_project_id,
         }
+        if target_project_id is not None:
+            request["target_project_id"] = target_project_id
         try:
             response_data, response, error = self.request(
                 "post", credentials, pr_url, data=request

--- a/weblate/vcs/tests/test_github_hooks.py
+++ b/weblate/vcs/tests/test_github_hooks.py
@@ -17,7 +17,7 @@ from rest_framework.test import APIClient
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Component
 from weblate.trans.tests.test_views import ViewTestCase
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.vcs.github import (
     GitHubAppCredentials,
     GitHubInstallation,
@@ -125,18 +125,18 @@ class TestGitHubAppHooks(ViewTestCase):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(GitHubInstallation.objects.get(installation_id="12345").enabled)
 
-    @responses.activate
+    @http_mock.activate
     def test_installation_created_syncs_existing_row(self):
         """``created`` updates rows owned by the setup flow; never auto-creates."""
         cache.clear()
         self._create_installation(target_login="placeholder")
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/12345/access_tokens",
             json={"token": "ghs_test"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/installation/repositories?per_page=100",
             json={
                 "repositories": [
@@ -182,7 +182,7 @@ class TestGitHubAppHooks(ViewTestCase):
             ["test-org/synced-repo"],
         )
         self.assertEqual(
-            [call.request.method for call in responses.calls], ["POST", "GET"]
+            [call.request.method for call in http_mock.calls], ["POST", "GET"]
         )
 
     def test_installation_created_without_row_is_pending(self):

--- a/weblate/vcs/tests/test_github_models.py
+++ b/weblate/vcs/tests/test_github_models.py
@@ -14,7 +14,7 @@ from django.core.cache import cache
 from django.test import TestCase
 
 from weblate.trans.models import Component, Project
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.vcs.base import RepositoryError
 from weblate.vcs.github import (
     GitHubAppCredentials,
@@ -209,7 +209,7 @@ class TestGitHubInstallationManager(TestCase):
             with self.subTest(code=code), self.assertRaises(ValueError):
                 normalize_github_callback_code(code)
 
-    @responses.activate
+    @http_mock.activate
     def test_installation_token_rejects_malformed_installation_id(self):
         with self.assertRaises(ValueError):
             async_to_sync(get_installation_token)(
@@ -219,12 +219,12 @@ class TestGitHubInstallationManager(TestCase):
                 "github.com",
             )
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_manifest_code_quotes_code_path_segment(self):
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app-manifests/"
             "..%2Finstallations%2F67890%2Faccess_tokens%3Fx%3D1/conversions",
             json={"id": 99},
@@ -234,13 +234,13 @@ class TestGitHubInstallationManager(TestCase):
             "../installations/67890/access_tokens?x=1", "github.com"
         )
 
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_sync_from_api(self):
         _make_credentials()
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/app/installations/24680",
             json={
                 "id": 24680,
@@ -255,7 +255,7 @@ class TestGitHubInstallationManager(TestCase):
 
         self.assertEqual(installation.target_login, "synced-org")
         self.assertEqual(installation.app_id, "99999")
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
     def test_sync_from_api_requires_credentials(self):
         with self.assertRaises(GitHubAppNotConfiguredError):
@@ -265,13 +265,13 @@ class TestGitHubInstallationManager(TestCase):
                 workspace=_make_workspace("sync-missing-workspace"),
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_connect_workspace_reenables_existing_installation(self):
         _make_credentials()
         self.installation.enabled = False
         self.installation.save(update_fields=["enabled"])
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/app/installations/67890",
             json={
                 "id": 67890,
@@ -287,14 +287,14 @@ class TestGitHubInstallationManager(TestCase):
         self.assertFalse(created)
         self.assertEqual(installation.pk, self.installation.pk)
         self.assertTrue(installation.enabled)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_auth_environment_uses_installation_token(self):
         _make_credentials()
         cache.clear()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
@@ -305,9 +305,9 @@ class TestGitHubInstallationManager(TestCase):
 
         _assert_no_github_app_auth_args(self, args)
         _assert_github_app_auth_environment(self, environment)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
         self.assertEqual(
-            responses.calls[0].request.url,
+            http_mock.calls[0].request.url,
             "https://api.github.com/app/installations/67890/access_tokens",
         )
 
@@ -330,7 +330,7 @@ class TestGitHubInstallationManager(TestCase):
 
         self.assertEqual(component.branch, "")
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_auth_environment_requires_workspace(self):
         repository = GithubAppRepository(".", branch="main", local=True)
 
@@ -339,9 +339,9 @@ class TestGitHubInstallationManager(TestCase):
         ):
             repository.get_auth_environment()
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_auth_environment_require_installation(self):
         _make_credentials()
         cache.clear()
@@ -352,18 +352,18 @@ class TestGitHubInstallationManager(TestCase):
         ):
             repository.get_auth_environment()
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_auth_environment_token_failure_raises_repository_error(
         self,
     ):
         _make_credentials()
         cache.clear()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/67890/access_tokens",
-            status=500,
+            status_code=500,
         )
         repository = self._make_app_repository()
 
@@ -372,9 +372,9 @@ class TestGitHubInstallationManager(TestCase):
         ):
             repository.get_auth_environment()
 
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_auth_args_malformed_installation_id_raises_repository_error(
         self,
     ):
@@ -388,9 +388,9 @@ class TestGitHubInstallationManager(TestCase):
         ):
             repository.get_auth_environment()
 
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_instance_auth_requires_workspace(self):
         component = self._make_component(has_workspace=False)
         repository = GithubAppRepository(
@@ -405,18 +405,18 @@ class TestGitHubInstallationManager(TestCase):
             RepositoryError, "GitHub App components require a project with a workspace"
         ):
             repository.get_credentials_by_hostname("api.github.com")
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_instance_auth_token_failure_raises_repository_error(
         self,
     ):
         _make_credentials()
         cache.clear()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/67890/access_tokens",
-            status=500,
+            status_code=500,
         )
         component = self._make_component()
         repository = GithubAppRepository(
@@ -428,14 +428,14 @@ class TestGitHubInstallationManager(TestCase):
         ):
             repository.get_credentials_by_hostname("api.github.com")
 
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_clone_uses_installation_token(self):
         _make_credentials()
         cache.clear()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
@@ -452,14 +452,14 @@ class TestGitHubInstallationManager(TestCase):
         self.assertIn("clone", clone_args)
         _assert_no_github_app_auth_args(self, clone_args)
         _assert_github_app_auth_environment(self, environment)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_push_uses_installation_token_environment(self):
         _make_credentials()
         cache.clear()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
@@ -477,16 +477,16 @@ class TestGitHubInstallationManager(TestCase):
         self.assertIn("push", push_args)
         _assert_no_github_app_auth_args(self, push_args)
         _assert_github_app_auth_environment(self, environment)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_remote_compatibility_deepen_uses_installation_token(
         self,
     ):
         _make_credentials()
         cache.clear()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
@@ -511,14 +511,14 @@ class TestGitHubInstallationManager(TestCase):
         self.assertIn(f"--deepen={repository.remote_compatibility_deepen}", deepen_args)
         _assert_no_github_app_auth_args(self, deepen_args)
         _assert_github_app_auth_environment(self, environment)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_github_repository_remote_compatibility_uses_installation_token(self):
         _make_credentials()
         cache.clear()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/67890/access_tokens",
             json={"token": "ghs_test"},
         )
@@ -544,4 +544,4 @@ class TestGitHubInstallationManager(TestCase):
         self.assertIn("fetch", fetch_args)
         _assert_no_github_app_auth_args(self, fetch_args)
         _assert_github_app_auth_environment(self, environment)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -21,7 +21,7 @@ from weblate.auth.models import Group, Permission, Role, User
 from weblate.trans.models import Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.site import get_site_url
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.vcs.github import (
     GITHUB_APP_MANIFEST_EVENTS,
     GITHUB_APP_MANIFEST_PERMISSIONS,
@@ -117,8 +117,8 @@ class GitHubInstallationViewTest(ViewTestCase):
             if hostname == "github.com"
             else f"https://{hostname}/api/v3"
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             f"{oauth_base}/login/oauth/access_token",
             json={"access_token": token, "token_type": "bearer"},
         )
@@ -133,8 +133,8 @@ class GitHubInstallationViewTest(ViewTestCase):
                 for i in accessible_ids
             ]
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             f"{api_base}/user/installations?per_page=100",
             json={"installations": installation_rows},
         )
@@ -157,8 +157,8 @@ class GitHubInstallationViewTest(ViewTestCase):
             if str(installation.get("id")) in managed_ids:
                 rows.append(installation)
         for org, rows in org_rows.items():
-            responses.add(
-                responses.GET,
+            http_mock.register(
+                "GET",
                 f"{api_base}/orgs/{org}/installations?per_page=100",
                 json={"installations": rows},
             )
@@ -173,18 +173,18 @@ class GitHubInstallationViewTest(ViewTestCase):
             repositories = [_repo_entry("test-org/repo1")]
         if account is None:
             account = {"login": "test-org", "type": "Organization"}
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/app/installations/12345",
             json={"id": 12345, "account": account},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/12345/access_tokens",
             json={"token": "ghs_test"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/installation/repositories?per_page=100",
             json={"repositories": repositories},
         )
@@ -535,7 +535,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             "/github-apps/weblate-enterprise-app/installations/select_target",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_connects_installation(self):
         repositories = [_repo_entry("test-org/repo1", default_branch="stable")]
         next_url = "/create/component/#github"
@@ -558,7 +558,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertEqual(connected.repositories, repositories)
         self.assertIsNotNone(connected.repositories_updated)
         self.assertEqual(
-            [(call.request.method, call.request.url) for call in responses.calls],
+            [(call.request.method, call.request.url) for call in http_mock.calls],
             [
                 ("POST", "https://github.com/login/oauth/access_token"),
                 ("GET", "https://api.github.com/user/installations?per_page=100"),
@@ -578,7 +578,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             ],
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_connects_personal_installation_for_account_owner(self):
         repositories = [_repo_entry("octocat/repo1", default_branch="stable")]
         next_url = "/create/component/#github"
@@ -590,8 +590,8 @@ class GitHubInstallationViewTest(ViewTestCase):
                 {"id": 12345, "account": {"login": "octocat", "type": "User"}}
             ]
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/user",
             json={"login": "octocat"},
         )
@@ -612,7 +612,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertEqual(connected.target_type, "User")
         self.assertEqual(connected.repositories, repositories)
         self.assertEqual(
-            [(call.request.method, call.request.url) for call in responses.calls],
+            [(call.request.method, call.request.url) for call in http_mock.calls],
             [
                 ("POST", "https://github.com/login/oauth/access_token"),
                 ("GET", "https://api.github.com/user/installations?per_page=100"),
@@ -629,7 +629,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             ],
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_persists_pending_installation_when_api_not_ready(self):
         next_url = "/create/component/#github"
         install_url = self._start_install(next_url)
@@ -691,7 +691,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertIn("might still be pending", response_messages[0])
         self.assertIn("Try connecting the account again later", response_messages[0])
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_applies_pending_installation_webhook(self):
         repositories = [_repo_entry("test-org/repo1", default_branch="stable")]
         PendingInstallation.objects.create(
@@ -733,7 +733,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             ).exists()
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_ignores_stale_pending_installation_webhook(self):
         pending = PendingInstallation.objects.create(
             provider=InstallationProvider.GITHUB,
@@ -867,7 +867,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         ]
         self.assertEqual(response_messages, ["Connected GitHub account updated."])
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_update_with_state_runs_full_setup(self):
         # An update callback that carries a signed Weblate state is a
         # Weblate-initiated install flow and must run the full setup (OAuth
@@ -896,7 +896,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertEqual(connected.repositories, repositories)
         self.assertIsNotNone(connected.repositories_updated)
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_rejects_malformed_installation_id(self):
         install_url = self._start_install("/create/component/#github")
         state = parse_qs(urlparse(install_url).query)["state"][0]
@@ -912,7 +912,7 @@ class GitHubInstallationViewTest(ViewTestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertFalse(GitHubInstallation.objects.exists())
-        self.assertEqual(len(responses.calls), 0)
+        self.assertEqual(len(http_mock.calls), 0)
         response_messages = [
             str(message) for message in get_messages(response.wsgi_request)
         ]
@@ -920,7 +920,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             response_messages, ["GitHub did not return a valid installation ID."]
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_rejects_foreign_installation_id(self):
         # The attacker holds a valid signed state for their own workspace and a
         # valid OAuth code for *their* GitHub account, then swaps in another
@@ -942,14 +942,14 @@ class GitHubInstallationViewTest(ViewTestCase):
         # Ownership is rejected before any App-level token is minted: only the
         # OAuth exchange and the user-installations lookup are called.
         self.assertEqual(
-            [(call.request.method, call.request.url) for call in responses.calls],
+            [(call.request.method, call.request.url) for call in http_mock.calls],
             [
                 ("POST", "https://github.com/login/oauth/access_token"),
                 ("GET", "https://api.github.com/user/installations?per_page=100"),
             ],
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_rejects_personal_installation_for_non_owner(self):
         install_url = self._start_install("/create/component/#github")
         state = parse_qs(urlparse(install_url).query)["state"][0]
@@ -959,8 +959,8 @@ class GitHubInstallationViewTest(ViewTestCase):
                 {"id": 12345, "account": {"login": "octocat", "type": "User"}}
             ]
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/user",
             json={"login": "repo-collaborator"},
         )
@@ -974,7 +974,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             GitHubInstallation.objects.filter(installation_id="12345").exists()
         )
         self.assertEqual(
-            [(call.request.method, call.request.url) for call in responses.calls],
+            [(call.request.method, call.request.url) for call in http_mock.calls],
             [
                 ("POST", "https://github.com/login/oauth/access_token"),
                 ("GET", "https://api.github.com/user/installations?per_page=100"),
@@ -982,7 +982,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             ],
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_rejects_org_installation_without_admin_access(self):
         # ``GET /user/installations`` can list organization installations where
         # the user merely has repository access. Weblate must require the
@@ -1001,7 +1001,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             GitHubInstallation.objects.filter(installation_id="12345").exists()
         )
         self.assertEqual(
-            [(call.request.method, call.request.url) for call in responses.calls],
+            [(call.request.method, call.request.url) for call in http_mock.calls],
             [
                 ("POST", "https://github.com/login/oauth/access_token"),
                 ("GET", "https://api.github.com/user/installations?per_page=100"),
@@ -1012,13 +1012,13 @@ class GitHubInstallationViewTest(ViewTestCase):
             ],
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_setup_rejects_when_code_exchange_fails(self):
         install_url = self._start_install("/create/component/#github")
         state = parse_qs(urlparse(install_url).query)["state"][0]
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://github.com/login/oauth/access_token",
             json={"error": "bad_verification_code"},
         )
@@ -1252,7 +1252,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertContains(response, "test-org/active")
         self.assertNotContains(response, "test-org/archived")
 
-    @responses.activate
+    @http_mock.activate
     def test_refresh_repositories_updates_installation(self):
         installation = GitHubInstallation.objects.create(
             installation_id="12345",
@@ -1262,13 +1262,13 @@ class GitHubInstallationViewTest(ViewTestCase):
         )
         repo = _repo_entry("test-org/repo1", default_branch="stable")
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/12345/access_tokens",
             json={"token": "ghs_test"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/installation/repositories?per_page=100",
             json={
                 "repositories": [
@@ -1292,7 +1292,7 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertEqual(installation.repositories, [repo])
         self.assertIsNotNone(installation.repositories_updated)
         self.assertEqual(
-            [(call.request.method, call.request.url) for call in responses.calls],
+            [(call.request.method, call.request.url) for call in http_mock.calls],
             [
                 (
                     "POST",
@@ -1391,13 +1391,13 @@ class GitHubAppAccessControlTest(ViewTestCase):
         )
 
     def _mock_setup_api(self, repositories: list[dict]) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://github.com/login/oauth/access_token",
             json={"access_token": "ghu_user", "token_type": "bearer"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/user/installations?per_page=100",
             json={
                 "installations": [
@@ -1408,8 +1408,8 @@ class GitHubAppAccessControlTest(ViewTestCase):
                 ]
             },
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/orgs/test-org/installations?per_page=100",
             json={
                 "installations": [
@@ -1420,21 +1420,21 @@ class GitHubAppAccessControlTest(ViewTestCase):
                 ]
             },
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/app/installations/12345",
             json={
                 "id": 12345,
                 "account": {"login": "test-org", "type": "Organization"},
             },
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app/installations/12345/access_tokens",
             json={"token": "ghs_test"},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.github.com/installation/repositories?per_page=100",
             json={"repositories": repositories},
         )
@@ -1489,7 +1489,7 @@ class GitHubAppAccessControlTest(ViewTestCase):
             GitHubInstallation.objects.filter(installation_id="12345").exists()
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_workspace_member_can_import_repo_linked_by_other_user(self):
         repo = _repo_entry("test-org/repo1", default_branch="stable")
 
@@ -1704,10 +1704,10 @@ class GitHubAppManifestViewTest(TestCase):
         manifest = json.loads(response.context["manifest_json"])
         self.assertEqual(manifest["name"], "Acme Translate (testserver)")
 
-    @responses.activate
+    @http_mock.activate
     def test_register_callback_stores_credentials(self):
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app-manifests/tempcode123/conversions",
             json=MANIFEST_RESPONSE,
         )
@@ -1721,9 +1721,9 @@ class GitHubAppManifestViewTest(TestCase):
         )
 
         self.assertRedirects(response, reverse("manage-github-accounts"))
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(http_mock.calls), 1)
         self.assertEqual(
-            responses.calls[0].request.url,
+            http_mock.calls[0].request.url,
             "https://api.github.com/app-manifests/tempcode123/conversions",
         )
         credentials = GitHubAppCredentials.objects.get(hostname="github.com")
@@ -1734,10 +1734,10 @@ class GitHubAppManifestViewTest(TestCase):
         self.assertEqual(credentials.client_secret, "manifest-client-secret")
         self.assertIn("manifest", credentials.private_key)
 
-    @responses.activate
+    @http_mock.activate
     def test_register_callback_quotes_code_path_segment(self):
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app-manifests/"
             "..%2Finstallations%2F123%2Faccess_tokens/conversions",
             json=MANIFEST_RESPONSE,
@@ -1756,15 +1756,15 @@ class GitHubAppManifestViewTest(TestCase):
         self.assertRedirects(response, reverse("manage-github-accounts"))
         self.assertTrue(GitHubAppCredentials.objects.exists())
         self.assertEqual(
-            responses.calls[0].request.url,
+            http_mock.calls[0].request.url,
             "https://api.github.com/app-manifests/"
             "..%2Finstallations%2F123%2Faccess_tokens/conversions",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_register_callback_updates_existing(self):
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app-manifests/tempcode123/conversions",
             json=MANIFEST_RESPONSE,
         )
@@ -1789,7 +1789,7 @@ class GitHubAppManifestViewTest(TestCase):
         self.assertEqual(credentials.app_slug, "weblate-auto")
         self.assertEqual(GitHubAppCredentials.objects.count(), 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_register_callback_reject(self):
         response = self.client.get(reverse("github-app-register-callback"))
 
@@ -1804,8 +1804,8 @@ class GitHubAppManifestViewTest(TestCase):
         self.assertRedirects(response, reverse("manage-github-accounts"))
         self.assertFalse(GitHubAppCredentials.objects.exists())
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/app-manifests/x/conversions",
             json={"id": 99},  # missing pem/slug/secret
         )

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -35,8 +35,7 @@ from weblate.trans.models import Component, Project
 from weblate.trans.tests.utils import RepoTestMixin, TempDirMixin
 from weblate.utils.files import REPO_TEMP_DIRNAME
 from weblate.utils.render import render_template
-from weblate.utils.tests import http_mock as responses
-from weblate.utils.tests.http_mock import matchers
+from weblate.utils.tests import http_mock
 from weblate.utils.zip import ZipSafetyLimits
 from weblate.vcs import git as git_module
 from weblate.vcs.base import (
@@ -1279,16 +1278,16 @@ class RepositoryRemotePinningTest(SimpleTestCase):
         self.assertEqual(environment["GIT_LFS_SKIP_PUSH"], "1")
         self.assertEqual(environment["GIT_LFS_SKIP_SMUDGE"], "1")
 
-    @responses.activate
+    @http_mock.activate
     def test_git_redirect_probe_uses_smart_http_and_validated_address(self) -> None:
         probe_url = (
             "https://user:secret@git.example/owner/repo/"
             "info/refs?service=git-upload-pack"
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             probe_url,
-            status=301,
+            status_code=301,
             headers={
                 "Location": "/owner/repo.git/info/refs?service=git-upload-pack",
             },
@@ -1319,10 +1318,10 @@ class RepositoryRemotePinningTest(SimpleTestCase):
                 "",
             ),
         )
-        self.assertEqual(len(responses.calls), 1)
-        request = responses.calls[0].request
+        self.assertEqual(len(http_mock.calls), 1)
+        request = http_mock.calls[0].request
         self.assertEqual(
-            request.transport_url,
+            str(http_mock.get_transport_url(request)),
             "https://user:secret@93.184.216.34/owner/repo/"
             "info/refs?service=git-upload-pack",
         )
@@ -2656,41 +2655,41 @@ class VCSGiteaTest(VCSGitUpstreamTest):
 
         This function will mock request responses for both fork and PRs
         """
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks",
             json={
                 "ssh_url": "git@gitea.io:test/test.git",
                 "clone_url": "https://gitea.io/test/test.git",
             },
-            match=[matchers.header_matcher({"Content-Type": "application/json"})],
+            match=[http_mock.header_matcher({"Content-Type": "application/json"})],
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/pulls",
             json=pr_response,
-            status=pr_status,
-            match=[matchers.header_matcher({"Content-Type": "application/json"})],
+            status_code=pr_status,
+            match=[http_mock.header_matcher({"Content-Type": "application/json"})],
         )
 
     def mock_pull_request_response(self, pr_response, pr_status=200) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/pulls",
             json=pr_response,
-            status=pr_status,
-            match=[matchers.header_matcher({"Content-Type": "application/json"})],
+            status_code=pr_status,
+            match=[http_mock.header_matcher({"Content-Type": "application/json"})],
         )
 
     def assert_pr_head(self, head: str) -> None:
         pr_calls = [
             call
-            for call in responses.calls
+            for call in http_mock.calls
             if call.request.url
             == "https://try.gitea.io/api/v1/repos/WeblateOrg/test/pulls"
         ]
         self.assertEqual(len(pr_calls), 1)
-        request = json.loads(pr_calls[0].request.body or "{}")
+        request = json.loads(pr_calls[0].request.content or b"{}")
         self.assertEqual(request["head"], head)
         self.assertEqual(request["base"], self._remote_branch)
 
@@ -2774,7 +2773,7 @@ class VCSGiteaTest(VCSGitUpstreamTest):
                 "https://try.gitea.io/api/v1/repos/WeblateOrg/test",
             )
 
-    @responses.activate
+    @http_mock.activate
     def test_push(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -2790,7 +2789,7 @@ class VCSGiteaTest(VCSGitUpstreamTest):
         super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_push_reconfigures_stale_fork_remote(self) -> None:
         self.repo.config_update(
             ('remote "test"', "pushurl", "git@github.com:test/test.git")
@@ -2804,24 +2803,24 @@ class VCSGiteaTest(VCSGitUpstreamTest):
 
             super().test_push("")
 
-        responses.assert_call_count(
+        http_mock.assert_call_count(
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks", 1
         )
         self.assertEqual(
             self.repo.get_config("remote.test.pushURL"), "git@gitea.io:test/test.git"
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_existing_fork_configures_fork_remote(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks",
             json={"message": "repository is already forked by user"},
-            status=409,
-            match=[matchers.header_matcher({"Content-Type": "application/json"})],
+            status_code=409,
+            match=[http_mock.header_matcher({"Content-Type": "application/json"})],
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://try.gitea.io/api/v1/repos/test/test",
             json={
                 "fork": True,
@@ -2841,25 +2840,25 @@ class VCSGiteaTest(VCSGitUpstreamTest):
         mocked_push.assert_called_once_with(
             self.repo.get_credentials(), self._remote_branch, "weblate-test-test"
         )
-        responses.assert_call_count(
+        http_mock.assert_call_count(
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks", 1
         )
-        responses.assert_call_count("https://try.gitea.io/api/v1/repos/test/test", 1)
+        http_mock.assert_call_count("https://try.gitea.io/api/v1/repos/test/test", 1)
         self.assertEqual(
             self.repo.get_config("remote.test.pushURL"), "git@gitea.io:test/test.git"
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_same_name_non_fork_rejected(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks",
             json={"message": "repository is already forked by user"},
-            status=409,
-            match=[matchers.header_matcher({"Content-Type": "application/json"})],
+            status_code=409,
+            match=[http_mock.header_matcher({"Content-Type": "application/json"})],
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://try.gitea.io/api/v1/repos/test/test",
             json={
                 "fork": False,
@@ -2878,15 +2877,15 @@ class VCSGiteaTest(VCSGitUpstreamTest):
             super().test_push("")
 
         mocked_push.assert_not_called()
-        responses.assert_call_count(
+        http_mock.assert_call_count(
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks", 1
         )
-        responses.assert_call_count("https://try.gitea.io/api/v1/repos/test/test", 1)
-        responses.assert_call_count(
+        http_mock.assert_call_count("https://try.gitea.io/api/v1/repos/test/test", 1)
+        http_mock.assert_call_count(
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/pulls", 0
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_empty_push_url_with_push_branch_uses_upstream_branch(self) -> None:
         self.repo.component.push = ""
         self.repo.component.push_branch = "upstream-branch"
@@ -2896,12 +2895,12 @@ class VCSGiteaTest(VCSGitUpstreamTest):
 
         super().test_push(self.repo.component.push_branch)
 
-        responses.assert_call_count(
+        http_mock.assert_call_count(
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks", 0
         )
         self.assert_pr_head("upstream-branch")
 
-    @responses.activate
+    @http_mock.activate
     def test_push_url_with_push_branch_uses_upstream_branch(self) -> None:
         self.repo.component.push = "https://try.gitea.io/WeblateOrg/test.git"
         self.repo.component.push_branch = "upstream-branch"
@@ -2911,12 +2910,12 @@ class VCSGiteaTest(VCSGitUpstreamTest):
 
         super().test_push(self.repo.component.push_branch)
 
-        responses.assert_call_count(
+        http_mock.assert_call_count(
             "https://try.gitea.io/api/v1/repos/WeblateOrg/test/forks", 0
         )
         self.assert_pr_head("upstream-branch")
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_error(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -2933,7 +2932,7 @@ class VCSGiteaTest(VCSGitUpstreamTest):
             super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_exists(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -2995,32 +2994,32 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
 
         This function will mock request responses for PRs
         """
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories/test/pullrequests",
             json=pr_response,
-            status=pr_status,
+            status_code=pr_status,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories",
             json={
                 "sshUrl": "git@ssh.dev.azure.com:v3/organization/WeblateOrg/test",
                 "remoteUrl": "https://dev.azure.com/v3/organization/WeblateOrg/test.git",
             },
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories/test",
             json={"id": "repo-id", "project": {"id": "org-id"}},
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://dev.azure.com/organization/_apis/projects/WeblateOrg",
             json={"id": "proj-id"},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://dev.azure.com/organization/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1",
             json={
                 "dataProviders": {
@@ -3030,8 +3029,8 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
                 }
             },
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories/test/forks/org-id",
             json={"value": []},
         )
@@ -3110,7 +3109,7 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
             "https://summanv.visualstudio.com/Lancelot/_apis/git/repositories/GoSuite",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_error(self, branch: str = "") -> None:
         # Mock PR to return error
         self.mock_responses(pr_status=403, pr_response={"message": "Some error"})
@@ -3118,7 +3117,7 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
         with self.assertRaises(RepositoryError):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_exists(self, branch: str = "") -> None:
         # Check that it doesn't raise error when pull request already exists
         self.mock_responses(
@@ -3140,30 +3139,31 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
             }
         }
     )
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_work_item_refs(self, branch: str = "") -> None:
         # Mock PR to return success
         response = {"url": "https://example.com"}
         self.mock_responses(response)
-        responses.remove(
-            responses.POST,
+        http_mock.unregister(
+            "POST",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories/test/pullrequests",
         )
-        responses.post(
+        http_mock.register(
+            "POST",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories/test/pullrequests",
             match=[
-                matchers.json_params_matcher(
+                http_mock.json_params_matcher(
                     {"workItemRefs": [{"id": "1111"}, {"id": "2222"}]},
                     strict_match=False,
                 )
             ],
             json=response,
-            status=201,
+            status_code=201,
         )
 
         super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_push(self, branch: str = "") -> None:
         self.mock_responses(
             pr_response={
@@ -3172,27 +3172,27 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
         )
         super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_fork_repository_already_exists(self, branch: str = "") -> None:
         # Mock PR to return success
         repositories_url = (
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories"
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             repositories_url,
             json={
                 "message": "TF400948: A Git repository with the name already exists."
             },
-            status=409,
+            status_code=409,
         )
         self.mock_responses({"url": f"{repositories_url}/test/pullRequests/1"})
 
         super().test_push(branch)
 
-        responses.assert_call_count(repositories_url, 2)
+        http_mock.assert_call_count(repositories_url, 2)
 
-    @responses.activate
+    @http_mock.activate
     def test_push_where_finds_existing_fork(self, branch: str = "") -> None:
         repositories_url = (
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories"
@@ -3203,8 +3203,8 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
 
         fork_url = f"{repositories_url}/test/forks/org-id"
 
-        responses.replace(
-            responses.GET,
+        http_mock.replace(
+            "GET",
             fork_url,
             json={
                 "value": [
@@ -3219,9 +3219,9 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
 
         super().test_push(branch)
 
-        responses.assert_call_count(repositories_url, 0)
+        http_mock.assert_call_count(repositories_url, 0)
 
-    @responses.activate
+    @http_mock.activate
     def test_push_when_remote_fork_is_deleted(self, branch: str = "") -> None:
         self.mock_responses(
             pr_response={
@@ -3240,20 +3240,21 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
                 remote_op="none",
             )
 
-        responses.post(
+        http_mock.register(
+            "POST",
             "https://this.does.not.exist/org/proj/_apis/git/repositories/repo",
             json={"message": "Not found"},
-            status=404,
+            status_code=404,
         )
 
         super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_fork_parent_repo_not_found(self, branch: str = "") -> None:
         self.mock_responses(pr_response={})
 
-        responses.replace(
-            responses.GET,
+        http_mock.replace(
+            "GET",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories/test",
             json={"message": "Not found"},
         )
@@ -3261,12 +3262,12 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
         with self.assertRaises(RepositoryError):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_creating_fork_fails(self, branch: str = "") -> None:
         self.mock_responses(pr_response={})
 
-        responses.replace(
-            responses.POST,
+        http_mock.replace(
+            "POST",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories",
             json={"message": "Some error"},
         )
@@ -3274,7 +3275,7 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
         with self.assertRaises(RepositoryError):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_getting_organization_id_fails(self, branch: str = "") -> None:
         self.mock_responses(
             pr_response={
@@ -3282,8 +3283,8 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
             }
         )
 
-        responses.replace(
-            responses.POST,
+        http_mock.replace(
+            "POST",
             "https://dev.azure.com/organization/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1",
             json={"message": "Some error"},
         )
@@ -3291,7 +3292,7 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
         with self.assertRaises(RepositoryError):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_getting_existing_forks_fails(self, branch: str = "") -> None:
         self.mock_responses(
             pr_response={
@@ -3299,23 +3300,23 @@ class VCSAzureDevOpsTest(VCSGitUpstreamTest):
             }
         )
 
-        responses.replace(
-            responses.GET,
+        http_mock.replace(
+            "GET",
             "https://dev.azure.com/organization/WeblateOrg/_apis/git/repositories/test/forks/org-id",
             json={"message": "Some error"},
-            status=418,
+            status_code=418,
         )
 
         with self.assertRaises(RepositoryError):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_fails_when_token_is_considered_invalid(self, branch: str = "") -> None:
-        responses.add(
-            method=responses.GET,
+        http_mock.register(
+            method="GET",
             url=re.compile(r".*"),
-            body="<html><head>Sign in please</head><body></body></html>",
-            status=203,
+            text="<html><head>Sign in please</head><body></body></html>",
+            status_code=203,
         )
 
         with self.assertRaises(RepositoryError) as cm:
@@ -3345,8 +3346,8 @@ class VCSGitHubTest(VCSGitUpstreamTest):
 
         This function will mock request responses for both fork and PRs
         """
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.github.com/repos/WeblateOrg/test/forks",
             json={
                 "ssh_url": "git@github.com:test/test.git",
@@ -3354,23 +3355,31 @@ class VCSGitHubTest(VCSGitUpstreamTest):
                 "url": "https://api.github.com/repos/test/test",
             },
         )
-        responses.add(
-            responses.PUT,
+        http_mock.register(
+            "PUT",
             "https://api.github.com/repos/test/test/actions/permissions",
-            status=204,
+            status_code=204,
         )
-        kwargs: dict[str, object] = {"status": pr_status}
         if pr_body is None:
-            kwargs["json"] = pr_response or {}
+            http_mock.register(
+                "POST",
+                "https://api.github.com/repos/WeblateOrg/test/pulls",
+                status_code=pr_status,
+                json=pr_response or {},
+            )
         else:
-            kwargs["body"] = pr_body
-            if pr_content_type is not None:
-                kwargs["content_type"] = pr_content_type
-        responses.add(
-            responses.POST,
-            "https://api.github.com/repos/WeblateOrg/test/pulls",
-            **kwargs,
-        )
+            headers = (
+                {"Content-Type": pr_content_type}
+                if pr_content_type is not None
+                else None
+            )
+            http_mock.register(
+                "POST",
+                "https://api.github.com/repos/WeblateOrg/test/pulls",
+                status_code=pr_status,
+                text=pr_body,
+                headers=headers,
+            )
 
     def test_api_url_github_com(self) -> None:
         self.repo.component.repo = "https://github.com/WeblateOrg/test.git"
@@ -3449,7 +3458,7 @@ class VCSGitHubTest(VCSGitUpstreamTest):
             "https://self-hosted-ghes.com/api/v3/repos/WeblateOrg/test.github.io",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_push(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -3465,7 +3474,7 @@ class VCSGitHubTest(VCSGitUpstreamTest):
         super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_error(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -3482,7 +3491,7 @@ class VCSGitHubTest(VCSGitUpstreamTest):
             super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_empty_server_error(self) -> None:
         with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork") as mocked_push:
             mocked_push.return_value = ""
@@ -3499,7 +3508,7 @@ class VCSGitHubTest(VCSGitUpstreamTest):
         self.assertIn("Please retry later.", message)
         self.assertNotIn("JSONDecodeError", message)
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_html_server_error(self) -> None:
         with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork") as mocked_push:
             mocked_push.return_value = ""
@@ -3520,11 +3529,11 @@ class VCSGitHubTest(VCSGitUpstreamTest):
         self.assertIn("Please retry later.", message)
         self.assertNotIn("<html>", message)
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_client_errors_do_not_suggest_retry(self) -> None:
         for status in (401, 403, 404, 422):
             with self.subTest(status=status):
-                responses.reset()
+                http_mock.reset()
                 with patch(
                     "weblate.vcs.git.GitMergeRequestBase.push_to_fork"
                 ) as mocked_push:
@@ -3545,7 +3554,7 @@ class VCSGitHubTest(VCSGitUpstreamTest):
                 self.assertIn("Some error", message)
                 self.assertNotIn("Please retry later.", message)
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_exists(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -3594,8 +3603,8 @@ class VCSGitLabTest(VCSGitUpstreamTest):
         if repo_state == 409:
             # Response to mock existing of repo with duplicate name
             # In case repo name already taken, append number at the end
-            responses.add(
-                responses.POST,
+            http_mock.register(
+                "POST",
                 "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/fork",
                 json={
                     "message": {
@@ -3603,10 +3612,10 @@ class VCSGitLabTest(VCSGitUpstreamTest):
                         "path": ["has already been taken"],
                     }
                 },
-                status=409,
+                status_code=409,
             )
-            responses.add(
-                responses.POST,
+            http_mock.register(
+                "POST",
                 "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/fork",
                 json={
                     "ssh_url_to_repo": "git@gitlab.com:test/test-6184.git",
@@ -3615,17 +3624,17 @@ class VCSGitLabTest(VCSGitUpstreamTest):
                 },
             )
         elif repo_state == 403:
-            responses.add(
-                responses.POST,
+            http_mock.register(
+                "POST",
                 "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/fork",
                 json={
                     "message": "error",
                 },
-                status=403,
+                status_code=403,
             )
         else:
-            responses.add(
-                responses.POST,
+            http_mock.register(
+                "POST",
                 "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/fork",
                 json={
                     "ssh_url_to_repo": "git@gitlab.com:test/test.git",
@@ -3634,8 +3643,8 @@ class VCSGitLabTest(VCSGitUpstreamTest):
                 },
             )
         # Mock GET responses to get forks for the repo
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/forks?owned=True",
             json=get_forks or [],
         )
@@ -3643,39 +3652,39 @@ class VCSGitLabTest(VCSGitUpstreamTest):
     def mock_pr_responses(self, pr_response, pr_status) -> None:
         # PR response in case fork is create with a suffix due to duplicate
         # repo name
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://gitlab.com/api/v4/projects/test%2Ftest-6184/merge_requests",
             json=pr_response,
-            status=pr_status,
+            status_code=pr_status,
         )
 
         # In case the remote is origin, we send the PR to itself
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/merge_requests",
             json=pr_response,
-            status=pr_status,
+            status_code=pr_status,
         )
 
         # General PR response
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://gitlab.com/api/v4/projects/test%2Ftest/merge_requests",
             json=pr_response,
-            status=pr_status,
+            status_code=pr_status,
         )
 
     def mock_configure_fork_features(self) -> None:
-        responses.add(
-            responses.PUT,
+        http_mock.register(
+            "PUT",
             "https://gitlab.com/api/v4/projects/20227391",
             json={"web_url": "https://gitlab.com/test/test"},
         )
 
     def mock_get_project_id(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest",
             json={"id": 20227391},
         )
@@ -3757,6 +3766,50 @@ class VCSGitLabTest(VCSGitUpstreamTest):
             ("https", "bot", "glpat", "gitlab.com", "path", "group/repo"),
         )
 
+    def test_pull_request_target_project_form_value(self) -> None:
+        credentials = self.repo.get_credentials()
+        response = MagicMock(status_code=201)
+        request_result = (
+            {"web_url": "https://gitlab.com/WeblateOrg/test/-/merge_requests/1"},
+            response,
+            "",
+        )
+
+        with patch.object(
+            self.repo, "request", return_value=request_result
+        ) as mocked_request:
+            self.repo.create_pull_request(
+                credentials,
+                "main",
+                "origin",
+                "weblate",
+            )
+
+        self.assertNotIn("target_project_id", mocked_request.call_args.kwargs["data"])
+
+        with (
+            patch.object(self.repo, "get_target_project_id", return_value=20227391),
+            patch.object(
+                self.repo,
+                "get_forked_url",
+                return_value="https://gitlab.com/api/v4/projects/test%2Ftest",
+            ),
+            patch.object(
+                self.repo, "request", return_value=request_result
+            ) as mocked_request,
+        ):
+            self.repo.create_pull_request(
+                credentials,
+                "main",
+                "test",
+                "weblate",
+            )
+
+        self.assertEqual(
+            mocked_request.call_args.kwargs["data"]["target_project_id"],
+            20227391,
+        )
+
     @override_settings(
         GITLAB_CREDENTIALS={
             "gitlab.example.com": {"username": "test", "token": "token"}
@@ -3811,7 +3864,7 @@ class VCSGitLabTest(VCSGitUpstreamTest):
             },
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_push(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -3830,7 +3883,7 @@ class VCSGitLabTest(VCSGitUpstreamTest):
         super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_existing_fork(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -3859,11 +3912,11 @@ class VCSGitLabTest(VCSGitUpstreamTest):
 
         # Test that the POST request to create a new fork was not called
         call_count = len(
-            [1 for call in responses.calls if call.request.method == "POST"]
+            [1 for call in http_mock.calls if call.request.method == "POST"]
         )
         self.assertEqual(call_count, 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_fork_listing_non_json_server_error(self, branch: str = "") -> None:
         """Test fork discovery with non-JSON server errors."""
         fork_list_url = (
@@ -3877,16 +3930,28 @@ class VCSGitLabTest(VCSGitUpstreamTest):
             (b"\xff", "application/json"),
         ):
             with self.subTest(body=body):
-                responses.reset()
-                response_kwargs: dict[str, object] = {
-                    "body": body,
-                    "status": 502,
-                }
-                if content_type is not None:
-                    response_kwargs["content_type"] = content_type
-                responses.add(responses.GET, fork_list_url, **response_kwargs)
-                responses.add(
-                    responses.POST,
+                http_mock.reset()
+                headers = (
+                    {"Content-Type": content_type} if content_type is not None else None
+                )
+                if isinstance(body, bytes):
+                    http_mock.register(
+                        "GET",
+                        fork_list_url,
+                        status_code=502,
+                        content=body,
+                        headers=headers,
+                    )
+                else:
+                    http_mock.register(
+                        "GET",
+                        fork_list_url,
+                        status_code=502,
+                        text=body,
+                        headers=headers,
+                    )
+                http_mock.register(
+                    "POST",
                     fork_create_url,
                     json={
                         "ssh_url_to_repo": "git@gitlab.com:test/test.git",
@@ -3913,13 +3978,13 @@ class VCSGitLabTest(VCSGitUpstreamTest):
                 self.assertNotIn("<html>", message)
                 fork_create_calls = [
                     call
-                    for call in responses.calls
+                    for call in http_mock.calls
                     if call.request.method == "POST"
                     and call.request.url == fork_create_url
                 ]
                 self.assertEqual(fork_create_calls, [])
 
-    @responses.activate
+    @http_mock.activate
     def test_push_duplicate_repo_name(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -3942,11 +4007,11 @@ class VCSGitLabTest(VCSGitUpstreamTest):
         # Test that the POST request to create a new fork was called again to
         # create different repo name
         call_count = len(
-            [1 for call in responses.calls if call.request.method == "POST"]
+            [1 for call in http_mock.calls if call.request.method == "POST"]
         )
         self.assertEqual(call_count, 3)
 
-    @responses.activate
+    @http_mock.activate
     def test_push_rejected(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -3970,20 +4035,20 @@ class VCSGitLabTest(VCSGitUpstreamTest):
         # Test that the POST request to create a new fork was called again to
         # create different repo name
         call_count = len(
-            [1 for call in responses.calls if call.request.method == "POST"]
+            [1 for call in http_mock.calls if call.request.method == "POST"]
         )
         self.assertEqual(call_count, 1)
 
-    @responses.activate
+    @http_mock.activate
     def test_get_target_project_id_auth_error(self) -> None:
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest",
             json={
                 "error": "invalid_token",
                 "error_description": "Token is expired.",
             },
-            status=401,
+            status_code=401,
         )
 
         with (
@@ -4001,7 +4066,7 @@ class VCSGitLabTest(VCSGitUpstreamTest):
             extra_log="401: invalid_token, Token is expired.",
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_error(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4017,7 +4082,7 @@ class VCSGitLabTest(VCSGitUpstreamTest):
             super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_exists(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4125,32 +4190,32 @@ class VCSPagureTest(VCSGitUpstreamTest):
 
     def mock_responses(self, pr_response: dict, existing_response: dict) -> None:
         """Mock response helper function."""
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://pagure.io/api/0/fork",
             json=pr_response,
-            status=200,
+            status_code=200,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://pagure.io/api/0/fork/test/testrepo/pull-request/new",
             json={"id": 1},
-            status=200,
+            status_code=200,
         )
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://pagure.io/api/0/testrepo/pull-requests",
             json=existing_response,
-            status=200,
+            status_code=200,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://pagure.io/api/0/testrepo/pull-request/new",
             json={"id": 1},
-            status=200,
+            status_code=200,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_push(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4168,7 +4233,7 @@ class VCSPagureTest(VCSGitUpstreamTest):
         super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_existing_fork(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4191,11 +4256,11 @@ class VCSPagureTest(VCSGitUpstreamTest):
 
         # Test that the POST request to create a new fork was not called
         call_count = len(
-            [1 for call in responses.calls if call.request.method == "POST"]
+            [1 for call in http_mock.calls if call.request.method == "POST"]
         )
         self.assertEqual(call_count, 2)
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_existing_request(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4219,7 +4284,7 @@ class VCSPagureTest(VCSGitUpstreamTest):
         # Test that the POST request to create a new fork and pull request were
         # not called
         call_count = len(
-            [1 for call in responses.calls if call.request.method == "POST"]
+            [1 for call in http_mock.calls if call.request.method == "POST"]
         )
         self.assertEqual(call_count, 1)
 
@@ -4783,21 +4848,21 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         else:
             body = self._bb_api_error_stub
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             f"{self._bbhost}/rest/api/1.0/projects/bb_pk/repos/bb_repo",
             json=body,
-            status=status,
+            status_code=status,
         )
 
     def mock_repo_response(self, status: int) -> None:
         body = {"id": 111} if status == 200 else self._bb_api_error_stub
 
-        responses.add(  # get remote repo id
-            responses.GET,
+        http_mock.register(  # get remote repo id
+            "GET",
             f"{self._bbhost}/rest/api/1.0/projects/bb_pk/repos/bb_repo",
             json=body,
-            status=status,
+            status_code=status,
         )
 
     def mock_repo_forks_response(self, status: int, pages: int = 0) -> None:
@@ -4822,20 +4887,20 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
                 page_body = {"values": [{"origin": fork_stub}], "isLastPage": False}
 
                 params = f"limit=1000&start={pages}"
-                responses.add(  # get remote repo id
-                    responses.GET,
+                http_mock.register(  # get remote repo id
+                    "GET",
                     f"{self._bbhost}/{path}?{params}",
                     json=page_body,
-                    status=status,
+                    status_code=status,
                 )
                 pages -= 1
 
         params = f"limit=1000&start={pages}"
-        responses.add(  # add actual relevant response
-            responses.GET,
+        http_mock.register(  # add actual relevant response
+            "GET",
             f"{self._bbhost}/{path}?{params}",
             json=body,
-            status=status,
+            status_code=status,
         )
 
     def mock_reviewer_response(self, status, branch: str = "") -> None:
@@ -4850,11 +4915,11 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
             branch = "weblate-test-test"
         params = "targetRepoId=111&sourceRepoId=222"
         params += f"&targetRefId=main&sourceRefId={branch}"
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             f"{self._bbhost}/{path}?{params}",
             json=body,
-            status=status,
+            status_code=status,
         )
 
     def mock_pr_response(self, status) -> None:
@@ -4869,11 +4934,11 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         else:
             body = self._bb_api_error_stub
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             f"{self._bbhost}/rest/api/1.0/projects/bb_pk/repos/bb_repo/pull-requests",
             json=body,
-            status=status,
+            status_code=status,
         )
 
     def test_api_url(self) -> None:
@@ -4914,7 +4979,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
             self.repo.get_headers(stub_credentials)["Authorization"], "Bearer bbs_token"
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_default_reviewers_repo_error(self) -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4934,7 +4999,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         )
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_default_reviewers_error(self) -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4956,7 +5021,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         )
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_push(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4973,7 +5038,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_existing_pr(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -4990,7 +5055,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_push_pr_error_response(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -5008,7 +5073,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
             super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_existing_fork(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -5026,7 +5091,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
         super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_create_fork_unexpected_fail(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -5041,7 +5106,7 @@ class VCSBitbucketServerTest(VCSGitUpstreamTest):
             super().test_push(branch)
         mock_push_to_fork.stop()
 
-    @responses.activate
+    @http_mock.activate
     def test_existing_fork_not_found(self, branch: str = "") -> None:
         # Patch push_to_fork() function because we don't want to actually
         # make a git push request
@@ -5084,19 +5149,19 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
             - list default reviewers
             - create a pull request
         """
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/forks",
             json={
                 "values": [],
                 "pagelen": 10,
                 "page": 1,
             },
-            status=200,
+            status_code=200,
         )
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/forks",
             json={
                 "type": "repository",
@@ -5122,11 +5187,11 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                 },
                 "owner": {"username": "test-workspace"},
             },
-            status=200,
+            status_code=200,
         )
 
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/effective-default-reviewers",
             json={
                 "values": [
@@ -5142,11 +5207,11 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                 "pagelen": 10,
                 "page": 1,
             },
-            status=200,
+            status_code=200,
         )
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/pullrequests",
             json={
                 "type": "pullrequest",
@@ -5156,29 +5221,29 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                 "state": "OPEN",
                 "destination": {"branch": {"name": "main"}},
             },
-            status=200,
+            status_code=200,
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_push(self, branch: str = "") -> None:
         """Test push to bitbucket cloud."""
         self.mock_responses()
         with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork", return_value=""):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_http(self, branch: str = "") -> None:
         """Test push to bitbucket cloud with HTTP repo link."""
         self.mock_responses()
         with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork", return_value=""):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_push_with_missing_permission(self, branch: str = "") -> None:
         """Test push with missing permission for App Password."""
         self.mock_responses()
-        responses.replace(
-            responses.POST,
+        http_mock.replace(
+            "POST",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/pullrequests",
             json={
                 "type": "error",
@@ -5198,7 +5263,7 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
         ):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_pull_request_non_json_server_error(self, branch: str = "") -> None:
         """Test pull request creation with non-JSON server errors."""
         for body, content_type in (
@@ -5207,19 +5272,31 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
             (b"\xff", "application/json"),
         ):
             with self.subTest(body=body):
-                responses.reset()
+                http_mock.reset()
                 self.mock_responses()
-                response_kwargs: dict[str, object] = {
-                    "body": body,
-                    "status": 502,
-                }
-                if content_type is not None:
-                    response_kwargs["content_type"] = content_type
-                responses.replace(
-                    responses.POST,
-                    "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/pullrequests",
-                    **response_kwargs,
+                headers = (
+                    {"Content-Type": content_type} if content_type is not None else None
                 )
+                pull_request_url = (
+                    "https://api.bitbucket.org/2.0/repositories/"
+                    "WeblateOrg/test/pullrequests"
+                )
+                if isinstance(body, bytes):
+                    http_mock.replace(
+                        "POST",
+                        pull_request_url,
+                        status_code=502,
+                        content=body,
+                        headers=headers,
+                    )
+                else:
+                    http_mock.replace(
+                        "POST",
+                        pull_request_url,
+                        status_code=502,
+                        text=body,
+                        headers=headers,
+                    )
 
                 with (
                     self.assertRaises(RepositoryError) as error,
@@ -5239,15 +5316,15 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                 self.assertIn("Please retry later.", message)
                 self.assertNotIn("<html>", message)
 
-    @responses.activate
+    @http_mock.activate
     def test_fork_non_json_server_error(self, branch: str = "") -> None:
         """Test fork creation with a non-JSON server error."""
         self.mock_responses()
-        responses.replace(
-            responses.POST,
+        http_mock.replace(
+            "POST",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/forks",
-            body="",
-            status=502,
+            text="",
+            status_code=502,
         )
 
         with (
@@ -5261,13 +5338,13 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
         self.assertIn("502 Bad Gateway", message)
         self.assertIn("Please retry later.", message)
 
-    @responses.activate
+    @http_mock.activate
     def test_default_reviewers_error(self, branch: str = "") -> None:
         """Test default reviewers error, push expected to be successful."""
         self.mock_responses()
 
-        responses.replace(
-            responses.GET,
+        http_mock.replace(
+            "GET",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/effective-default-reviewers",
             json={
                 "type": "error",
@@ -5275,7 +5352,7 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                     "message": "Some unexpected error.",
                 },
             },
-            status=400,
+            status_code=400,
         )
         credentials = {
             "url": "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test",
@@ -5284,13 +5361,13 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
         }
         self.assertEqual(self.repo.get_default_reviewers_uuids(credentials), [])
 
-    @responses.activate
+    @http_mock.activate
     def test_paginated_reviewers_list(self, branch: str = "") -> None:
         """Test the 'build_full_paginated_result' with default reviewers list."""
         self.mock_responses()
 
-        responses.replace(
-            responses.GET,
+        http_mock.replace(
+            "GET",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/effective-default-reviewers",
             json={
                 "values": [
@@ -5307,11 +5384,11 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                 "page": 1,
                 "next": "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/effective-default-reviewers?page=2",
             },
-            status=200,
+            status_code=200,
         )
 
-        responses.add(
-            responses.GET,
+        http_mock.register(
+            "GET",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/effective-default-reviewers?page=2",
             json={
                 "values": [
@@ -5327,7 +5404,7 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                 "pagelen": 1,
                 "page": 2,
             },
-            status=200,
+            status_code=200,
         )
 
         credentials = {
@@ -5340,31 +5417,31 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
             ["reviewer-uuid-1", "reviewer-uuid-2"],
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_push_nothing_to_merge(self, branch: str = "") -> None:
         """Test push to bitbucket cloud with no changes to be merged."""
         self.mock_responses()
 
-        responses.replace(
-            responses.POST,
+        http_mock.replace(
+            "POST",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/pullrequests",
             json={
                 "type": "error",
                 "error": {"message": "There are no changes to be pulled"},
             },
-            status=400,
+            status_code=400,
         )
 
         with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork", return_value=""):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_fork_already_exists(self, branch: str = "") -> None:
         """Test push to bitbucket cloud with HTTP repo link."""
         self.mock_responses()
 
-        responses.replace(
-            responses.GET,
+        http_mock.replace(
+            "GET",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/forks",
             json={
                 "values": [
@@ -5389,17 +5466,17 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                 "pagelen": 10,
                 "page": 1,
             },
-            status=200,
+            status_code=200,
         )
 
         with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork", return_value=""):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_fork_name_already_taken(self, branch: str = "") -> None:
         """Test push to bitbucket cloud with HTTP repo link."""
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/forks",
             json={
                 "type": "error",
@@ -5410,18 +5487,18 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                     },
                 },
             },
-            status=400,
+            status_code=400,
         )
         self.mock_responses()
         with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork", return_value=""):
             super().test_push(branch)
 
-    @responses.activate
+    @http_mock.activate
     def test_fork_error(self, branch: str = "") -> None:
         """Test push to bitbucket cloud with HTTP repo link."""
         self.mock_responses()
-        responses.replace(
-            responses.POST,
+        http_mock.replace(
+            "POST",
             "https://api.bitbucket.org/2.0/repositories/WeblateOrg/test/forks",
             json={
                 "type": "error",
@@ -5430,7 +5507,7 @@ class VCSBitbucketCloudTest(VCSGitUpstreamTest):
                     "fields": {"name": ["Unknown error not related to name."]},
                 },
             },
-            status=400,
+            status_code=400,
         )
         with (
             self.assertRaises(RepositoryError),

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -36,7 +36,7 @@ from weblate.trans.tests.utils import get_test_file
 from weblate.utils.apps import check_data_writable
 from weblate.utils.backup import BackupError, BorgResult
 from weblate.utils.data import data_path
-from weblate.utils.tests import http_mock as responses
+from weblate.utils.tests import http_mock
 from weblate.utils.unittest import tempdir_setting
 from weblate.utils.zammad import ZammadError
 from weblate.wladmin.forms import ThemeColorField, ThemeColorWidget
@@ -69,11 +69,7 @@ TEST_BACKENDS = ("weblate.accounts.auth.WeblateUserBackend",)
 
 
 def get_response_call_body(index: int) -> str:
-    request_body = responses.calls[index].request.body
-    if isinstance(request_body, bytes):
-        return request_body.decode()
-    assert isinstance(request_body, str)
-    return request_body
+    return http_mock.calls[index].request.content.decode()
 
 
 @contextmanager
@@ -1690,13 +1686,13 @@ class AdminTest(ViewTestCase):
     def test_send_test_email_error(self) -> None:
         self.test_send_test_email("Could not send test e-mail")
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(SITE_TITLE="Test Weblate")
     def test_activation_wrong(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            status=404,
+            status_code=404,
         )
         response = self.client.post(
             reverse("manage-activate"), {"secret": "123456"}, follow=True
@@ -1705,13 +1701,13 @@ class AdminTest(ViewTestCase):
         self.assertFalse(SupportStatus.objects.exists())
         self.assertFalse(BackupService.objects.exists())
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(SITE_TITLE="Test Weblate")
     def test_activation_error(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            status=500,
+            status_code=500,
         )
         response = self.client.post(
             reverse("manage-activate"), {"secret": "123456"}, follow=True
@@ -1720,13 +1716,13 @@ class AdminTest(ViewTestCase):
         self.assertFalse(SupportStatus.objects.exists())
         self.assertFalse(BackupService.objects.exists())
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(SITE_TITLE="Test Weblate")
     def test_activation_community(self) -> None:
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            body=json.dumps(
+            text=json.dumps(
                 {
                     "name": "community",
                     "backup_repository": "",
@@ -1846,7 +1842,7 @@ class AdminTest(ViewTestCase):
         self.assertContains(response, "Invalid activation state.")
         self.assertFalse(SupportStatus.objects.exists())
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(
         ENABLE_HTTPS=True,
         SITE_DOMAIN="instance.example",
@@ -1868,15 +1864,15 @@ class AdminTest(ViewTestCase):
         )
         self.assertFalse(SupportStatus.objects.exists())
 
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://weblate.example/api/support/activation/",
             json={"secret": "secret-123"},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            body=json.dumps(
+            text=json.dumps(
                 {
                     "name": "community",
                     "backup_repository": "",
@@ -1913,7 +1909,7 @@ class AdminTest(ViewTestCase):
         self.assertContains(response, "Missing activation code.")
         self.assertFalse(SupportStatus.objects.exists())
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(
         ENABLE_HTTPS=True,
         SITE_DOMAIN="instance.example",
@@ -1923,15 +1919,15 @@ class AdminTest(ViewTestCase):
     def test_discovery_callback_exchanges_code(self) -> None:
         response = self.client.post(reverse("manage-discovery-register"))
         state = parse_qs(urlparse(response["Location"]).query)["state"][0]
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://weblate.example/api/support/activation/",
             json={"secret": "secret-123"},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            body=json.dumps(
+            text=json.dumps(
                 {
                     "name": "community",
                     "backup_repository": "",
@@ -1975,7 +1971,7 @@ class AdminTest(ViewTestCase):
         self.assertNotIn("discoverable", refresh_body)
         self.assertNotIn("public_projects", refresh_body)
 
-    @responses.activate
+    @http_mock.activate
     def test_support_refresh_includes_discoverable_projects(self) -> None:
         Project.objects.update(access_control=Project.ACCESS_PRIVATE)
         Project.objects.create(
@@ -1996,10 +1992,10 @@ class AdminTest(ViewTestCase):
             web="https://private.example/",
             access_control=Project.ACCESS_PRIVATE,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            body=json.dumps(
+            text=json.dumps(
                 {
                     "name": "community",
                     "backup_repository": "",
@@ -2063,7 +2059,7 @@ class AdminTest(ViewTestCase):
         self.assertNotContains(response, "internal detail")
         self.assertFalse(SupportStatus.objects.exists())
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(
         ENABLE_HTTPS=True,
         SITE_DOMAIN="instance.example",
@@ -2082,10 +2078,10 @@ class AdminTest(ViewTestCase):
             "expires": (timezone.now() + DISCOVERY_REGISTRATION_STATE_AGE).timestamp(),
         }
         session.save()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://weblate.example/api/support/activation/",
-            status=500,
+            status_code=500,
         )
 
         response = self.client.get(
@@ -2098,7 +2094,7 @@ class AdminTest(ViewTestCase):
         self.assertTrue(old_status.enabled)
         self.assertEqual(SupportStatus.objects.get_current(), old_status)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(
         ENABLE_HTTPS=True,
         SITE_DOMAIN="instance.example",
@@ -2119,15 +2115,15 @@ class AdminTest(ViewTestCase):
             "expires": (timezone.now() + DISCOVERY_REGISTRATION_STATE_AGE).timestamp(),
         }
         session.save()
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             "https://weblate.example/api/support/activation/",
             json={"secret": "discovery-secret"},
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            body=json.dumps(
+            text=json.dumps(
                 {
                     "name": "community",
                     "backup_repository": "",
@@ -2157,7 +2153,7 @@ class AdminTest(ViewTestCase):
             SupportStatus.objects.filter(secret="discovery-secret").exists()
         )
 
-    @responses.activate
+    @http_mock.activate
     def test_activation_unlink_disables_discovery_remotely(self) -> None:
         SupportStatus.objects.create(
             name="community",
@@ -2166,10 +2162,10 @@ class AdminTest(ViewTestCase):
             discoverable=True,
             enabled=True,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            body=json.dumps(
+            text=json.dumps(
                 {
                     "name": "community",
                     "backup_repository": "",
@@ -2190,7 +2186,7 @@ class AdminTest(ViewTestCase):
         self.assertNotIn("public_projects", unlink_body)
         self.assertFalse(SupportStatus.objects.filter(enabled=True).exists())
 
-    @responses.activate
+    @http_mock.activate
     def test_activation_unlink_disables_locally_on_discovery_error(self) -> None:
         status = SupportStatus.objects.create(
             name="community",
@@ -2199,10 +2195,10 @@ class AdminTest(ViewTestCase):
             discoverable=True,
             enabled=True,
         )
-        responses.add(
-            responses.POST,
+        http_mock.register(
+            "POST",
             get_support_url(),
-            status=500,
+            status_code=500,
         )
 
         response = self.client.post(
@@ -2215,14 +2211,14 @@ class AdminTest(ViewTestCase):
         self.assertFalse(status.enabled)
         self.assertFalse(status.discoverable)
 
-    @responses.activate
+    @http_mock.activate
     @override_settings(SITE_TITLE="Test Weblate")
     def test_activation_hosted(self) -> None:
         with TemporaryDirectory() as tempdir:
-            responses.add(
-                responses.POST,
+            http_mock.register(
+                "POST",
                 get_support_url(),
-                body=json.dumps(
+                text=json.dumps(
                     {
                         "name": "hosted",
                         "backup_repository": tempdir,
@@ -2249,11 +2245,11 @@ class AdminTest(ViewTestCase):
             self.assertTrue(status.discoverable)
 
             # Use different payload for second registration
-            responses.delete(responses.POST, get_support_url())
-            responses.add(
-                responses.POST,
+            http_mock.unregister("POST", get_support_url())
+            http_mock.register(
+                "POST",
                 get_support_url(),
-                body=json.dumps(
+                text=json.dumps(
                     {
                         "name": "hosted",
                         "backup_repository": tempdir,


### PR DESCRIPTION
Remove the obsolete Requests-shaped compatibility layer now that outbound HTTP uses HTTPX2. Native clients reduce duplication while preserving unread redirect bodies and SSRF address pinning.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
