### PR TITLE
fix(api): improve OpenMetrics conformance

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3276,6 +3276,11 @@ Metrics
 
        Metrics can now be exposed in OpenMetrics compatible format with ``?format=openmetrics``.
 
+    .. versionchanged:: 2026.8
+
+       OpenMetrics responses now include ``HELP`` and ``TYPE`` metadata and use
+       the versioned OpenMetrics content type.
+
     :>json int units: Number of units
     :>json int units_translated: Number of translated units
     :>json int users: Number of users
@@ -3292,7 +3297,8 @@ Metrics
     :>json string version: Running Weblate version, included when :setting:`VERSION_DISPLAY` is ``show`` or ``soft``
 
     In OpenMetrics format, the version is exposed as ``weblate_info{version="..."} 1``
-    when :setting:`VERSION_DISPLAY` is ``show`` or ``soft``.
+    when :setting:`VERSION_DISPLAY` is ``show`` or ``soft``. All metrics are
+    exposed as gauges.
 
 Search
 +++++++

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.8
 
 .. rubric:: Improvements
 
+* OpenMetrics API responses now include metric metadata and a versioned content type.
 * Added grouped project and workspace :guilabel:`Diagnostics` views with state, severity, category, and actionable-by-user filters.
 * Component diagnostics now record dismissal ownership, reopen after relevant changes, and notify only project maintainers who can act on warnings and errors.
 * :ref:`Add-on activity logs <addon-activity-logging>` now distinguish pending, successful, failed, and skipped executions and explain why an add-on was skipped.

--- a/weblate/api/renderers.py
+++ b/weblate/api/renderers.py
@@ -5,52 +5,79 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
 
 from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework_csv.renderers import CSVRenderer
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+OpenMetricsMetricType = Literal[
+    "counter",
+    "gauge",
+    "histogram",
+    "gaugehistogram",
+    "summary",
+    "info",
+    "stateset",
+    "unknown",
+]
 
 
 @dataclass(frozen=True)
 class OpenMetricsSample:
     value: int | float
-    labels: dict[str, str]
+    labels: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class OpenMetricsMetric:
+    name: str
+    help_text: str
+    metric_type: OpenMetricsMetricType
+    samples: tuple[OpenMetricsSample, ...]
 
 
 def format_openmetrics_label(value: str) -> str:
     return value.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
 
 
+def format_openmetrics_help(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("\n", "\\n")
+
+
 class OpenMetricsRenderer(BaseRenderer):
     media_type = "application/openmetrics-text"
+    response_content_type = "application/openmetrics-text; version=1.0.0; charset=utf-8"
     format = "openmetrics"
     charset = "utf-8"
     render_style = "text"
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        result = []
-        for key, value in data.items():
-            if isinstance(value, str):
-                # Strings not supported
+        result: list[str] = []
+        for metric in data:
+            if not isinstance(metric, OpenMetricsMetric):
                 continue
-            if isinstance(value, (int, float)):
-                result.append(f"{key} {value}")
-            elif isinstance(value, OpenMetricsSample):
+            result.extend(
+                (
+                    f"# HELP {metric.name} {format_openmetrics_help(metric.help_text)}",
+                    f"# TYPE {metric.name} {metric.metric_type}",
+                )
+            )
+            for sample in metric.samples:
                 labels = ",".join(
                     f'{label}="{format_openmetrics_label(label_value)}"'
-                    for label, label_value in value.labels.items()
+                    for label, label_value in sample.labels.items()
                 )
                 result.append(
-                    f"{key}{{{labels}}} {value.value}"
+                    f"{metric.name}{{{labels}}} {sample.value}"
                     if labels
-                    else f"{key} {value.value}"
+                    else f"{metric.name} {sample.value}"
                 )
-            elif isinstance(value, dict):
-                # Celery queues
-                for queue, stat in value.items():
-                    result.append(f'{key}{{queue="{queue}"}} {stat}')
 
         result.append("# EOF")
-        return "\n".join(result)
+        return "\n".join(result) + "\n"
 
 
 class FlatBaseRenderer(BaseRenderer):

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -12778,8 +12778,51 @@ class MetricsAPITest(APIBaseTest):
     def test_metrics_openmetrics(self) -> None:
         self.authenticate()
         response = self.client.get(reverse("api:metrics"), {"format": "openmetrics"})
+        self.assertEqual(
+            response["Content-Type"],
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
+        self.assertContains(
+            response,
+            "# HELP units Number of translation units.\n# TYPE units gauge\nunits ",
+        )
+        self.assertContains(
+            response,
+            "# HELP celery_queues Number of tasks in each Celery queue.\n"
+            "# TYPE celery_queues gauge",
+        )
+        self.assertContains(
+            response,
+            "# HELP weblate_info Weblate build information.\n# TYPE weblate_info gauge",
+        )
         self.assertContains(response, f'weblate_info{{version="{GIT_VERSION}"}} 1')
-        self.assertContains(response, "# EOF")
+        self.assertTrue(response.content.endswith(b"# EOF\n"))
+
+    @override_settings(VERSION_DISPLAY=VERSION_DISPLAY_SOFT, HIDE_VERSION=False)
+    def test_metrics_openmetrics_accept_header(self) -> None:
+        self.authenticate()
+        response = self.client.get(
+            reverse("api:metrics"),
+            headers={"accept": "application/openmetrics-text"},
+        )
+        self.assertEqual(
+            response["Content-Type"],
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
+        self.assertContains(response, "# TYPE projects gauge")
+
+    @patch(
+        "weblate.utils.celery.get_queue_stats",
+        return_value={'queue"\\\n': 7},
+    )
+    def test_metrics_openmetrics_escapes_labels(self, mock_queues) -> None:
+        self.authenticate()
+        response = self.client.get(reverse("api:metrics"), {"format": "openmetrics"})
+        mock_queues.assert_called_once_with()
+        self.assertContains(
+            response,
+            r'celery_queues{queue="queue\"\\\n"} 7',
+        )
 
     def test_metrics_csv(self) -> None:
         self.authenticate()

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -199,7 +199,12 @@ from weblate.utils.version_display import show_metrics_version
 from weblate.utils.views import download_translation_file, zip_download
 from weblate.workspaces.models import Workspace
 
-from .renderers import FlatJsonRenderer, OpenMetricsRenderer, OpenMetricsSample
+from .renderers import (
+    FlatJsonRenderer,
+    OpenMetricsMetric,
+    OpenMetricsRenderer,
+    OpenMetricsSample,
+)
 
 if TYPE_CHECKING:
     from django.db.models import Model
@@ -4277,6 +4282,46 @@ class CategoryViewSet(viewsets.ModelViewSet, ReportsMixin, AnnouncementsMixin):
         return Response(serializer.data)
 
 
+OPENMETRICS_METRIC_HELP = (
+    ("units", "Number of translation units."),
+    ("units_translated", "Number of translated translation units."),
+    ("users", "Number of users."),
+    ("changes", "Number of recorded changes."),
+    ("projects", "Number of projects."),
+    ("components", "Number of components."),
+    ("translations", "Number of translations."),
+    ("languages", "Number of configured languages."),
+    ("checks", "Number of triggered quality checks."),
+    ("configuration_errors", "Number of active configuration errors."),
+    ("suggestions", "Number of pending suggestions."),
+)
+
+
+def get_openmetrics_data(data: Mapping[str, object]) -> list[OpenMetricsMetric]:
+    result = [
+        OpenMetricsMetric(
+            name=name,
+            help_text=help_text,
+            metric_type="gauge",
+            samples=(OpenMetricsSample(value=cast("int", data[name]), labels={}),),
+        )
+        for name, help_text in OPENMETRICS_METRIC_HELP
+    ]
+    queues = cast("Mapping[str, int]", data["celery_queues"])
+    result.append(
+        OpenMetricsMetric(
+            name="celery_queues",
+            help_text="Number of tasks in each Celery queue.",
+            metric_type="gauge",
+            samples=tuple(
+                OpenMetricsSample(value=value, labels={"queue": queue})
+                for queue, value in queues.items()
+            ),
+        )
+    )
+    return result
+
+
 class Metrics(APIView):
     """Metrics view for monitoring."""
 
@@ -4290,12 +4335,25 @@ class Metrics(APIView):
         stats = GlobalStats()
         serializer = self.serializer_class(stats)
         data = dict(serializer.data)
-        if request.accepted_renderer.format == "openmetrics" and show_metrics_version(
-            settings.VERSION_DISPLAY
-        ):
-            data["weblate_info"] = OpenMetricsSample(
-                value=1,
-                labels={"version": GIT_VERSION},
+        if request.accepted_renderer.format == "openmetrics":
+            metrics = get_openmetrics_data(data)
+            if show_metrics_version(settings.VERSION_DISPLAY):
+                metrics.append(
+                    OpenMetricsMetric(
+                        name="weblate_info",
+                        help_text="Weblate build information.",
+                        metric_type="gauge",
+                        samples=(
+                            OpenMetricsSample(
+                                value=1,
+                                labels={"version": GIT_VERSION},
+                            ),
+                        ),
+                    )
+                )
+            return Response(
+                metrics,
+                content_type=OpenMetricsRenderer.response_content_type,
             )
         return Response(data)
 


### PR DESCRIPTION
Expose metric metadata, properly escaped labels, and a versioned content type so Prometheus clients can reliably consume the metrics endpoint without changing existing metric names.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
