### PR TITLE
feat(api): add project metrics endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1311,6 +1311,29 @@ Projects
 
        Returned attributes are described in :ref:`api-statistics`.
 
+.. http:get:: /api/projects/(string:project)/metrics/
+
+    .. versionadded:: 2026.8
+
+    Returns translation metrics for the project components visible to the
+    caller. Components are identified by their project-relative path and the
+    result is grouped by component and language. When multiple components have
+    the same project-relative path, ``@`` and the component ID are appended to
+    each colliding path.
+
+    The OpenMetrics representation exposes ``weblate_translation_info`` and
+    ``weblate_*`` gauges compatible with the project translation statistics.
+    Strings containing suggestions use
+    ``weblate_strings_with_suggestions`` to distinguish them from the
+    server-wide ``weblate_suggestions`` object count.
+    The CSV representation contains one row for each component, language, and
+    numeric metric.
+
+    :param project: Project URL slug
+    :type project: string
+    :query string format: Response format; use ``openmetrics`` or ``csv`` for
+       monitoring and tabular output.
+
 .. http:get:: /api/projects/(string:project)/categories/
 
    .. versionadded:: 5.0
@@ -3299,6 +3322,12 @@ Metrics
     In OpenMetrics format, the version is exposed as ``weblate_info{version="..."} 1``
     when :setting:`VERSION_DISPLAY` is ``show`` or ``soft``. All metrics are
     exposed as gauges.
+
+Project metrics expose translation statistics for each visible component and
+language at :http:get:`/api/projects/(string:project)/metrics/`. They include
+translated, total, fuzzy, failing-check, and approved string, word, and
+character counts; suggestions; comments; and translated and approved
+percentages.
 
 Search
 +++++++

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Weblate 2026.8
 .. rubric:: New features
 
 * Workspaces now provide aggregate translation statistics and historical metrics.
+* Added :ref:`project-level translation metrics <monitoring-translation-progress>` in JSON, CSV, and OpenMetrics formats.
 * :ref:`Workspaces <workspaces>` now provide a permission-filtered :guilabel:`My workspaces` list, archive downloads, and management of workspace translation memory.
 * Added API endpoints for listing, adding, accepting, rejecting, and voting on translation suggestions.
 * :doc:`Translation reports </devel/reporting>` are now generated in the background, stored for later download, available at workspace scope, and include translator work analysis.

--- a/docs/devel/integration.rst
+++ b/docs/devel/integration.rst
@@ -63,6 +63,24 @@ the translations so that they match your codebase.
    * :ref:`continuous-translation`
    * :ref:`vcs-repos`
 
+.. _monitoring-translation-progress:
+
+Monitoring translation progress
++++++++++++++++++++++++++++++++
+
+Use the project metrics endpoint to track translation progress from external
+integrations. It returns statistics for all visible components and languages
+in a single request and supports JSON, CSV, and OpenMetrics formats.
+
+The OpenMetrics representation can be scraped by Prometheus-compatible
+monitoring systems without polling the statistics endpoint for each
+translation.
+
+.. seealso::
+
+   * :http:get:`/api/projects/(string:project)/metrics/`
+   * :ref:`api-statistics`
+
 .. _adding-new-strings:
 
 Adding new strings

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -48,6 +48,15 @@ Scope and intended use
      - Browser views, forms, session endpoints, :doc:`/api`
      - Database, datastore, e-mail, logs, uploaded files
      - In scope. *(documented)* (source: :doc:`/api`, :doc:`/admin/install`)
+   * - Project translation metrics
+     - :http:get:`/api/projects/(string:project)/metrics/` in JSON, CSV, and
+       OpenMetrics formats
+     - Database and statistics-cache reads, including possible lazy cache
+       population
+     - In scope as a read-only public API. Unauthenticated callers can query
+       public projects; private projects and restricted components remain
+       permission-filtered. *(documented)* (source: :doc:`/api`,
+       :doc:`/admin/access`)
    * - Stored translation reports
      - Report forms and :http:get:`/api/reports/` endpoints
      - Database snapshots and background tasks
@@ -214,6 +223,12 @@ Reachability preconditions:
 * A web UI or API finding is in model only when reachable by an unauthenticated
   client, authenticated user, or project-scoped token through documented
   routes, forms, or API endpoints. *(maintainer)*
+* A project-metrics finding is in model when the response includes a project
+  or component the caller cannot access, or exposes data beyond the documented
+  component and language identifiers, aggregate translation statistics, and
+  statistics update timestamps. Unauthenticated access to these aggregates for
+  public projects is intentional. *(documented)* (source: :doc:`/api`,
+  :doc:`/admin/access`)
 * An authorization finding is in model only when it crosses a documented
   permission, team, project, component, language, glossary, token, or site-wide
   boundary. *(documented)* (source: :doc:`/admin/access`)
@@ -489,6 +504,12 @@ Size and rate assumptions:
   created by that attempt. *(documented)* (source: :ref:`projectbackup`)
 * API and selected web actions are expected to be protected by configured rate
   limits. *(documented)* (source: :doc:`/api`, :doc:`/admin/config`)
+* Project metrics response size and request work scale with the number of
+  visible components and translations and with statistics-cache state. Cache
+  misses can calculate and store translation statistics. The endpoint relies
+  on standard API rate limits and deployment sizing rather than a separate
+  fixed project-size limit. *(documented)* (source: :doc:`/api`,
+  :doc:`/admin/config`)
 * Repository size, number of projects, number of components, and worker
   capacity are deployment-sizing concerns unless a single in-scope input
   bypasses documented limits or permissions. *(maintainer)*

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -18396,6 +18396,249 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse400'
           description: The request was invalid or could not be parsed.
+  /api/projects/{slug}/metrics/:
+    get:
+      operationId: api_projects_metrics_retrieve
+      description: Return translation metrics for a project.
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+          - openmetrics
+      - in: path
+        name: slug
+        schema:
+          type: string
+          title: URL slug
+          description: Name used in URLs and filenames.
+        required: true
+      tags:
+      - projects
+      - metrics
+      security:
+      - tokenAuth: []
+      - bearerAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse400'
+          description: The request was invalid or could not be parsed.
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: Authentication credentials were missing or invalid.
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse403'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
+          description: The authenticated user does not have permission for this operation.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: The requested resource was not found or is not accessible.
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: The HTTP method is not allowed for this resource.
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: The requested response media type is not available.
+        '423':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse423'
+          description: The resource is locked.
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: The API request rate limit was exceeded.
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: An unexpected server error occurred.
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      translated:
+                        type: integer
+                      translated_words:
+                        type: integer
+                      translated_chars:
+                        type: integer
+                      total:
+                        type: integer
+                      total_words:
+                        type: integer
+                      total_chars:
+                        type: integer
+                      fuzzy:
+                        type: integer
+                      fuzzy_words:
+                        type: integer
+                      fuzzy_chars:
+                        type: integer
+                      failing:
+                        type: integer
+                      failing_words:
+                        type: integer
+                      failing_chars:
+                        type: integer
+                      approved:
+                        type: integer
+                      approved_words:
+                        type: integer
+                      approved_chars:
+                        type: integer
+                      suggestions:
+                        type: integer
+                      comments:
+                        type: integer
+                      translated_percent:
+                        type: number
+                      translated_words_percent:
+                        type: number
+                      translated_chars_percent:
+                        type: number
+                      approved_percent:
+                        type: number
+                      approved_words_percent:
+                        type: number
+                      approved_chars_percent:
+                        type: number
+                    required:
+                    - name
+                    - translated
+                    - translated_words
+                    - translated_chars
+                    - total
+                    - total_words
+                    - total_chars
+                    - fuzzy
+                    - fuzzy_words
+                    - fuzzy_chars
+                    - failing
+                    - failing_words
+                    - failing_chars
+                    - approved
+                    - approved_words
+                    - approved_chars
+                    - suggestions
+                    - comments
+                    - translated_percent
+                    - translated_words_percent
+                    - translated_chars_percent
+                    - approved_percent
+                    - approved_words_percent
+                    - approved_chars_percent
+            text/csv:
+              schema:
+                type: string
+            application/openmetrics-text:
+              schema:
+                type: string
+          description: Successful response.
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/projects/{slug}/reports/:
     get:
       operationId: api_projects_reports_list
@@ -35501,6 +35744,10 @@ components:
           type: string
           format: uri
           readOnly: true
+        metrics_url:
+          type: string
+          format: uri
+          readOnly: true
         categories_url:
           type: string
           format: uri
@@ -35886,6 +36133,10 @@ components:
           type: string
           format: uri
           readOnly: true
+        metrics_url:
+          type: string
+          format: uri
+          readOnly: true
         categories_url:
           type: string
           format: uri
@@ -36125,6 +36376,7 @@ components:
       - lock_url
       - locked
       - machinery_settings
+      - metrics_url
       - name
       - reports_url
       - repository_url

--- a/weblate/api/docs.py
+++ b/weblate/api/docs.py
@@ -45,6 +45,8 @@ WILDCARD_MEDIA_TYPE = "*/*"
 CSV_MEDIA_TYPE = "text/csv"
 OPENMETRICS_MEDIA_TYPE = "application/openmetrics-text"
 METRICS_PATH = "/api/metrics/"
+PROJECT_METRICS_PATH = "/api/projects/{slug}/metrics/"
+METRICS_PATHS = {METRICS_PATH, PROJECT_METRICS_PATH}
 USER_GROUPS_PATH = "/api/users/{username}/groups/"
 CHANGES_PATH = "/api/changes/"
 UNSUPPORTED_MEDIA_TYPE_RESPONSE_CODE = "415"
@@ -277,7 +279,7 @@ def _simplify_response_media_types(path: str, method: str, operation: dict) -> N
         if not isinstance(content, dict):
             continue
 
-        if path == METRICS_PATH and method == "get" and status_code == "200":
+        if path in METRICS_PATHS and method == "get" and status_code == "200":
             if CSV_MEDIA_TYPE in content:
                 content[CSV_MEDIA_TYPE]["schema"] = {"type": "string"}
             if OPENMETRICS_MEDIA_TYPE in content:
@@ -289,7 +291,7 @@ def _simplify_response_media_types(path: str, method: str, operation: dict) -> N
 
 
 def _simplify_format_parameter(path: str, method: str, operation: dict) -> None:
-    if path == METRICS_PATH and method == "get":
+    if path in METRICS_PATHS and method == "get":
         return
 
     parameters = operation.get("parameters")

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -1246,6 +1246,9 @@ class ProjectSerializer(serializers.ModelSerializer[Project]):
     statistics_url = serializers.HyperlinkedIdentityField(
         view_name="api:project-statistics", lookup_field="slug"
     )
+    metrics_url = serializers.HyperlinkedIdentityField(
+        view_name="api:project-metrics", lookup_field="slug"
+    )
     categories_url = serializers.HyperlinkedIdentityField(
         view_name="api:project-categories", lookup_field="slug"
     )
@@ -1283,6 +1286,7 @@ class ProjectSerializer(serializers.ModelSerializer[Project]):
             "components_list_url",
             "repository_url",
             "statistics_url",
+            "metrics_url",
             "categories_url",
             "changes_list_url",
             "languages_url",

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import csv
 import operator
 import os
 import tempfile
@@ -9,7 +10,7 @@ import zipfile
 from contextlib import nullcontext
 from copy import copy
 from datetime import UTC, date, datetime, timedelta
-from io import BytesIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -39,7 +40,7 @@ from weblate.addons.consistency import LanguageConsistencyAddon
 from weblate.addons.gettext import XgettextAddon
 from weblate.addons.git import GitSquashAddon
 from weblate.addons.models import Addon
-from weblate.api.docs import DOCS_OPENAPI_ALL_VCS_CHOICES_ENV
+from weblate.api.docs import DOCS_OPENAPI_ALL_VCS_CHOICES_ENV, METRICS_PATHS
 from weblate.api.serializers import (
     CommentSerializer,
     ComponentSerializer,
@@ -3050,6 +3051,10 @@ class ProjectAPITest(APIBaseTest):
             reverse("api:project-detail", kwargs=self.project_kwargs)
         )
         self.assertEqual(response.data["slug"], "test")
+        self.assertEqual(
+            response.data["metrics_url"],
+            "http://example.com/api/projects/test/metrics/",
+        )
 
     def test_repo_ops(self) -> None:
         for operation in RepoOperations.values:
@@ -3206,6 +3211,265 @@ class ProjectAPITest(APIBaseTest):
     def test_statistics(self) -> None:
         request = self.do_request("api:project-statistics", self.project_kwargs)
         self.assertEqual(request.data["total"], 16)
+
+    def test_metrics(self) -> None:
+        response = self.do_request("api:project-metrics", self.project_kwargs)
+
+        translation = self.component.translation_set.select_related("language").get(
+            language__code="cs"
+        )
+        metrics = response.data["test"]["cs"]
+        self.assertEqual(metrics["name"], translation.language.name)
+        self.assertEqual(metrics["total"], translation.stats.all)
+        self.assertEqual(metrics["translated"], translation.stats.translated)
+        self.assertEqual(metrics["failing_words"], translation.stats.allchecks_words)
+        self.assertEqual(
+            metrics["translated_percent"], translation.stats.translated_percent
+        )
+        self.assertEqual(
+            set(metrics),
+            {
+                "name",
+                "translated",
+                "translated_words",
+                "translated_chars",
+                "total",
+                "total_words",
+                "total_chars",
+                "fuzzy",
+                "fuzzy_words",
+                "fuzzy_chars",
+                "failing",
+                "failing_words",
+                "failing_chars",
+                "approved",
+                "approved_words",
+                "approved_chars",
+                "suggestions",
+                "comments",
+                "translated_percent",
+                "translated_words_percent",
+                "translated_chars_percent",
+                "approved_percent",
+                "approved_words_percent",
+                "approved_chars_percent",
+            },
+        )
+
+    def test_metrics_anonymous(self) -> None:
+        response = self.do_request(
+            "api:project-metrics", self.project_kwargs, authenticated=False
+        )
+
+        self.assertIn("test", response.data)
+
+    def test_metrics_component_path(self) -> None:
+        category = self.create_category(self.project)
+        Component.objects.filter(pk=self.component.pk).update(category=category)
+
+        response = self.do_request("api:project-metrics", self.project_kwargs)
+
+        self.assertIn("test-category/test", response.data)
+        self.assertNotIn("test", response.data)
+
+    def test_metrics_shared_component_path(self) -> None:
+        source_category = self.create_category(self.project)
+        Component.objects.filter(pk=self.component.pk).update(category=source_category)
+        project = self.create_project(name="Shared", slug="shared")
+        category = Category.objects.create(
+            name="Target category", slug="target-category", project=project
+        )
+        ComponentLink.objects.create(
+            component=self.component, project=project, category=category
+        )
+
+        response = self.do_request("api:project-metrics", {"slug": project.slug})
+
+        self.assertIn("target-category/test", response.data)
+        self.assertNotIn("test-category/test", response.data)
+        self.assertNotIn("test", response.data)
+        self.assertIn("cs", response.data["target-category/test"])
+
+    def test_metrics_disambiguates_component_path(self) -> None:
+        project = self.create_project(name="Collision", slug="collision")
+        with self.captureOnCommitCallbacks(execute=True):
+            owned_component = self.create_po(project=project)
+        ComponentLink.objects.create(component=self.component, project=project)
+
+        response = self.do_request("api:project-metrics", {"slug": project.slug})
+
+        own_path = f"test@{owned_component.pk}"
+        shared_path = f"test@{self.component.pk}"
+        self.assertNotIn("test", response.data)
+        self.assertTrue({own_path, shared_path} <= set(response.data))
+        self.assertIn("cs", response.data[own_path])
+        self.assertIn("cs", response.data[shared_path])
+
+        response = self.do_request(
+            "api:project-metrics",
+            {"slug": project.slug},
+            request={"format": "csv"},
+        )
+        csv_components = {
+            row["component"]
+            for row in csv.DictReader(StringIO(response.content.decode()))
+        }
+        self.assertTrue({own_path, shared_path} <= csv_components)
+
+        response = self.do_request(
+            "api:project-metrics",
+            {"slug": project.slug},
+            request={"format": "openmetrics"},
+        )
+        self.assertContains(response, f'component="{own_path}",language="cs"')
+        self.assertContains(response, f'component="{shared_path}",language="cs"')
+
+    def test_metrics_csv(self) -> None:
+        response = self.do_request(
+            "api:project-metrics",
+            self.project_kwargs,
+            request={"format": "csv"},
+        )
+
+        rows = list(csv.DictReader(StringIO(response.content.decode())))
+        translation_rows = [
+            row
+            for row in rows
+            if row["component"] == "test" and row["language"] == "cs"
+        ]
+        self.assertEqual(len(translation_rows), 23)
+        translated = next(
+            row for row in translation_rows if row["metric"] == "translated"
+        )
+        self.assertEqual(translated["name"], "Czech")
+        self.assertEqual(
+            translated["value"],
+            str(
+                self.component.translation_set.get(language__code="cs").stats.translated
+            ),
+        )
+
+    def test_metrics_openmetrics(self) -> None:
+        translation = self.component.translation_set.get(language__code="cs")
+        _ = translation.stats.all
+        translation.stats.store("stats_timestamp", 1234.5)
+        translation.stats.save(update_parents=False)
+
+        response = self.do_request(
+            "api:project-metrics",
+            self.project_kwargs,
+            request={"format": "openmetrics"},
+        )
+
+        self.assertEqual(
+            response["Content-Type"],
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
+        self.assertContains(
+            response,
+            "# HELP weblate_translated Number of translated strings.\n"
+            "# TYPE weblate_translated gauge\n",
+        )
+        self.assertContains(
+            response,
+            'weblate_translation_info{component="test",language="cs",name="Czech"} 1',
+        )
+        self.assertContains(
+            response,
+            'weblate_translated{component="test",language="cs"} ',
+        )
+        self.assertContains(
+            response,
+            "# HELP weblate_failing Number of strings with failing checks.",
+        )
+        self.assertContains(
+            response,
+            "# HELP weblate_strings_with_suggestions "
+            "Number of strings with suggestions.",
+        )
+        self.assertNotContains(response, "# HELP weblate_suggestions ")
+        self.assertContains(
+            response,
+            "# HELP weblate_comments Number of strings with unresolved comments.",
+        )
+        self.assertContains(
+            response,
+            "# HELP weblate_last_update_timestamp "
+            "Unix timestamp of last statistics update.",
+        )
+        self.assertContains(
+            response,
+            'weblate_last_update_timestamp{component="test",language="cs"} 1234.5',
+        )
+        self.assertTrue(response.content.endswith(b"# EOF\n"))
+
+    def test_metrics_openmetrics_accept_header(self) -> None:
+        response = self.do_request(
+            "api:project-metrics",
+            self.project_kwargs,
+            headers={"accept": "application/openmetrics-text"},
+        )
+
+        self.assertEqual(
+            response["Content-Type"],
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
+        self.assertContains(response, "# TYPE weblate_total gauge")
+
+    def test_metrics_openmetrics_escapes_language_name(self) -> None:
+        language = Language.objects.get(code="cs")
+        language.name = 'Czech"\\\n'
+        language.save(update_fields=["name"])
+
+        response = self.do_request(
+            "api:project-metrics",
+            self.project_kwargs,
+            request={"format": "openmetrics"},
+        )
+
+        self.assertContains(response, r'name="Czech\"\\\n"')
+
+    def test_metrics_restricted_component(self) -> None:
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        self.user.clear_permissions_cache()
+
+        response = self.do_request("api:project-metrics", self.project_kwargs)
+        self.assertNotIn("test", response.data)
+
+        response = self.do_request(
+            "api:project-metrics", self.project_kwargs, superuser=True
+        )
+        self.assertIn("test", response.data)
+
+    def test_metrics_private_project(self) -> None:
+        private_component = self.create_acl()
+
+        self.do_request(
+            "api:project-metrics",
+            {"slug": private_component.project.slug},
+            code=404,
+            authenticated=False,
+        )
+
+    def test_metrics_empty_project(self) -> None:
+        project = self.create_project(name="Empty", slug="empty")
+        kwargs = {"slug": project.slug}
+
+        response = self.do_request("api:project-metrics", kwargs)
+        self.assertEqual(response.data, {})
+
+        response = self.do_request(
+            "api:project-metrics", kwargs, request={"format": "csv"}
+        )
+        self.assertEqual(response.content, b"")
+
+        response = self.do_request(
+            "api:project-metrics", kwargs, request={"format": "openmetrics"}
+        )
+        self.assertContains(response, "# TYPE weblate_translation_info gauge")
+        self.assertContains(response, "# TYPE weblate_last_update_timestamp gauge")
+        self.assertTrue(response.content.endswith(b"# EOF\n"))
 
     def test_languages(self) -> None:
         request = self.do_request("api:project-languages", self.project_kwargs)
@@ -15687,7 +15951,7 @@ class OpenAPITest(APIBaseTest):
                 if method not in {"delete", "get", "patch", "post", "put"}:
                     continue
 
-                if path != "/api/metrics/":
+                if path not in METRICS_PATHS:
                     self.assertFalse(
                         any(
                             parameter["name"] == "format" and parameter["in"] == "query"
@@ -15706,7 +15970,7 @@ class OpenAPITest(APIBaseTest):
                 for status_code, response in operation.get("responses", {}).items():
                     content = response.get("content", {})
                     if (
-                        path == "/api/metrics/"
+                        path in METRICS_PATHS
                         and method == "get"
                         and status_code == "200"
                     ):

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os.path
+from collections import Counter
 from collections.abc import Mapping
 from contextlib import suppress
 from typing import TYPE_CHECKING, TypedDict, cast
@@ -193,7 +194,12 @@ from weblate.utils.state import (
     STATE_NEEDS_REWRITING,
     STATE_TRANSLATED,
 )
-from weblate.utils.stats import GlobalStats, ProjectLanguage, prefetch_stats
+from weblate.utils.stats import (
+    GlobalStats,
+    ProjectLanguage,
+    iter_prefetch_stats,
+    prefetch_stats,
+)
 from weblate.utils.version import GIT_VERSION
 from weblate.utils.version_display import show_metrics_version
 from weblate.utils.views import download_translation_file, zip_download
@@ -294,6 +300,119 @@ REPORT_RST_RESPONSE = OpenApiResponse(
     response=OpenApiTypes.STR,
     description="Rendered reStructuredText report.",
 )
+
+PROJECT_METRIC_DEFINITIONS = (
+    ("translated", "translated", "Number of translated strings.", "integer"),
+    ("translated_words", "translated_words", "Number of translated words.", "integer"),
+    (
+        "translated_chars",
+        "translated_chars",
+        "Number of translated characters.",
+        "integer",
+    ),
+    ("total", "all", "Total number of strings.", "integer"),
+    ("total_words", "all_words", "Total number of words.", "integer"),
+    ("total_chars", "all_chars", "Total number of characters.", "integer"),
+    ("fuzzy", "fuzzy", "Number of fuzzy strings.", "integer"),
+    ("fuzzy_words", "fuzzy_words", "Number of fuzzy words.", "integer"),
+    ("fuzzy_chars", "fuzzy_chars", "Number of fuzzy characters.", "integer"),
+    (
+        "failing",
+        "allchecks",
+        "Number of strings with failing checks.",
+        "integer",
+    ),
+    (
+        "failing_words",
+        "allchecks_words",
+        "Number of words with failing checks.",
+        "integer",
+    ),
+    (
+        "failing_chars",
+        "allchecks_chars",
+        "Number of characters with failing checks.",
+        "integer",
+    ),
+    ("approved", "approved", "Number of approved strings.", "integer"),
+    ("approved_words", "approved_words", "Number of approved words.", "integer"),
+    ("approved_chars", "approved_chars", "Number of approved characters.", "integer"),
+    (
+        "suggestions",
+        "suggestions",
+        "Number of strings with suggestions.",
+        "integer",
+    ),
+    (
+        "comments",
+        "comments",
+        "Number of strings with unresolved comments.",
+        "integer",
+    ),
+    (
+        "translated_percent",
+        "translated_percent",
+        "Percentage of translated strings.",
+        "number",
+    ),
+    (
+        "translated_words_percent",
+        "translated_words_percent",
+        "Percentage of translated words.",
+        "number",
+    ),
+    (
+        "translated_chars_percent",
+        "translated_chars_percent",
+        "Percentage of translated characters.",
+        "number",
+    ),
+    (
+        "approved_percent",
+        "approved_percent",
+        "Percentage of approved strings.",
+        "number",
+    ),
+    (
+        "approved_words_percent",
+        "approved_words_percent",
+        "Percentage of approved words.",
+        "number",
+    ),
+    (
+        "approved_chars_percent",
+        "approved_chars_percent",
+        "Percentage of approved characters.",
+        "number",
+    ),
+)
+
+PROJECT_OPENMETRICS_NAMES = {
+    "suggestions": "strings_with_suggestions",
+}
+
+PROJECT_METRIC_VALUE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        **{
+            name: {"type": value_type}
+            for name, _source, _help_text, value_type in PROJECT_METRIC_DEFINITIONS
+        },
+    },
+    "required": [
+        "name",
+        *(name for name, _source, _help_text, _type in PROJECT_METRIC_DEFINITIONS),
+    ],
+}
+
+PROJECT_METRICS_RESPONSE_SCHEMA = {
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": PROJECT_METRIC_VALUE_SCHEMA,
+    },
+}
 
 USER_GROUP_REQUEST_SERIALIZER = inline_serializer(
     "UserGroupRequest",
@@ -1917,6 +2036,30 @@ class ProjectViewSet(
         serializer = StatisticsSerializer(obj, context={"request": request})
 
         return Response(serializer.data)
+
+    @extend_schema(
+        description="Return translation metrics for a project.",
+        methods=["get"],
+        tags=["projects", "metrics"],
+        responses=OpenApiResponse(response=PROJECT_METRICS_RESPONSE_SCHEMA),
+    )
+    @action(
+        detail=True,
+        methods=["get"],
+        renderer_classes=(*api_settings.DEFAULT_RENDERER_CLASSES, OpenMetricsRenderer),
+    )
+    def metrics(self, request: Request, **kwargs):
+        project = self.get_object()
+        data, timestamps = get_project_metrics_data(project, self.request.user)
+
+        if request.accepted_renderer.format == "openmetrics":
+            return Response(
+                get_project_openmetrics_data(data, timestamps),
+                content_type=OpenMetricsRenderer.response_content_type,
+            )
+        if request.accepted_renderer.format == "csv":
+            return Response(get_project_metrics_csv_data(data))
+        return Response(data)
 
     @extend_schema(
         description="Return statistics for all languages within a project.",
@@ -4295,6 +4438,139 @@ OPENMETRICS_METRIC_HELP = (
     ("configuration_errors", "Number of active configuration errors."),
     ("suggestions", "Number of pending suggestions."),
 )
+
+
+def get_project_metrics_data(
+    project: Project, user: User
+) -> tuple[
+    dict[str, dict[str, dict[str, int | float | str]]],
+    dict[str, dict[str, int | float]],
+]:
+    result: dict[str, dict[str, dict[str, int | float | str]]] = {}
+    timestamps: dict[str, dict[str, int | float]] = {}
+    components = list(project.get_child_components_access(user))
+    component_paths = {
+        component.pk: "/".join(component.get_url_path()[1:])
+        for component in components
+        if component.pk is not None
+    }
+    for link in ComponentLink.objects.filter(
+        project=project, component_id__in=component_paths
+    ).select_related(
+        "component",
+        "category",
+        "category__category",
+        "category__category__category",
+    ):
+        component_paths[link.component_id] = "/".join(
+            (
+                *(
+                    link.category.get_url_path()[1:]
+                    if link.category is not None
+                    else ()
+                ),
+                link.component.slug,
+            )
+        )
+
+    path_counts = Counter(component_paths.values())
+    component_paths = {
+        component_id: (f"{path}@{component_id}" if path_counts[path] > 1 else path)
+        for component_id, path in component_paths.items()
+    }
+    translations = (
+        Translation.objects.filter(component_id__in=component_paths).prefetch().order()
+    )
+    for translation in iter_prefetch_stats(translations):
+        component = component_paths[translation.component_id]
+        values: dict[str, int | float | str] = {
+            "name": translation.language.name,
+        }
+        values.update(
+            {
+                name: cast("int | float", getattr(translation.stats, source))
+                for name, source, _help_text, _type in PROJECT_METRIC_DEFINITIONS
+            }
+        )
+        result.setdefault(component, {})[translation.language.code] = values
+        timestamps.setdefault(component, {})[translation.language.code] = cast(
+            "int | float", translation.stats.stats_timestamp
+        )
+    return result, timestamps
+
+
+def get_project_metrics_csv_data(
+    data: Mapping[str, Mapping[str, Mapping[str, int | float | str]]],
+) -> list[dict[str, int | float | str]]:
+    return [
+        {
+            "component": component,
+            "language": language,
+            "name": values["name"],
+            "metric": metric,
+            "value": values[metric],
+        }
+        for component, languages in data.items()
+        for language, values in languages.items()
+        for metric, _source, _help_text, _type in PROJECT_METRIC_DEFINITIONS
+    ]
+
+
+def get_project_openmetrics_data(
+    data: Mapping[str, Mapping[str, Mapping[str, int | float | str]]],
+    timestamps: Mapping[str, Mapping[str, int | float]],
+) -> list[OpenMetricsMetric]:
+    result = [
+        OpenMetricsMetric(
+            name="weblate_translation_info",
+            help_text="Translation information.",
+            metric_type="gauge",
+            samples=tuple(
+                OpenMetricsSample(
+                    value=1,
+                    labels={
+                        "component": component,
+                        "language": language,
+                        "name": cast("str", values["name"]),
+                    },
+                )
+                for component, languages in data.items()
+                for language, values in languages.items()
+            ),
+        )
+    ]
+    result.extend(
+        OpenMetricsMetric(
+            name=f"weblate_{PROJECT_OPENMETRICS_NAMES.get(metric, metric)}",
+            help_text=help_text,
+            metric_type="gauge",
+            samples=tuple(
+                OpenMetricsSample(
+                    value=cast("int | float", values[metric]),
+                    labels={"component": component, "language": language},
+                )
+                for component, languages in data.items()
+                for language, values in languages.items()
+            ),
+        )
+        for metric, _source, help_text, _type in PROJECT_METRIC_DEFINITIONS
+    )
+    result.append(
+        OpenMetricsMetric(
+            name="weblate_last_update_timestamp",
+            help_text="Unix timestamp of last statistics update.",
+            metric_type="gauge",
+            samples=tuple(
+                OpenMetricsSample(
+                    value=timestamp,
+                    labels={"component": component, "language": language},
+                )
+                for component, languages in timestamps.items()
+                for language, timestamp in languages.items()
+            ),
+        )
+    )
+    return result
 
 
 def get_openmetrics_data(data: Mapping[str, object]) -> list[OpenMetricsMetric]:

--- a/weblate/templates/data.html
+++ b/weblate/templates/data.html
@@ -96,6 +96,28 @@
     {% endif %}
   {% endwith %}
 
+  {% url 'api:project-metrics' slug=object.slug as metrics_url %}
+  <h3>
+    {% translate "Metrics" %}
+    {% documentation_icon 'devel/integration' 'monitoring-translation-progress' %}
+  </h3>
+
+  <p>
+    {% blocktranslate %}Project translation metrics provide statistics for all visible components and languages in a single request.{% endblocktranslate %}
+  </p>
+
+  <ul>
+    <li>
+      <a href="{{ metrics_url }}">{% translate "JSON metrics" %}</a>
+    </li>
+    <li>
+      <a href="{{ metrics_url }}?format=csv">{% translate "CSV metrics" %}</a>
+    </li>
+    <li>
+      <a href="{{ metrics_url }}?format=openmetrics">{% translate "OpenMetrics metrics" %}</a>
+    </li>
+  </ul>
+
   {% if hooks_enabled and project.enable_hooks %}
     <h3>
       {% translate "Notification hooks" %}

--- a/weblate/trans/tests/test_exports.py
+++ b/weblate/trans/tests/test_exports.py
@@ -31,3 +31,9 @@ class ExportsViewTest(FixtureTestCase):
     def test_data(self) -> None:
         response = self.client.get(reverse("data_project", kwargs=self.kw_project))
         self.assertContains(response, "Test")
+        metrics_url = reverse(
+            "api:project-metrics", kwargs={"slug": self.kw_project["project"]}
+        )
+        self.assertContains(response, f'href="{metrics_url}"')
+        self.assertContains(response, f'href="{metrics_url}?format=csv"')
+        self.assertContains(response, f'href="{metrics_url}?format=openmetrics"')


### PR DESCRIPTION
Expose component and language statistics in JSON, CSV, and OpenMetrics formats to replace monitoring clients that fan out across many translation API requests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
