### PR TITLE
fix(checks): optimize inconsistent batch queries

### DIFF
--- a/weblate/checks/consistency.py
+++ b/weblate/checks/consistency.py
@@ -111,12 +111,26 @@ class ConsistencyCheck(TargetCheck, BatchCheckMixin):
 
     def check_component(self, component: Component) -> Iterable[Unit]:
         # ruff: ignore[import-outside-top-level]
-        from weblate.trans.models import Unit
+        from weblate.trans.models import Translation, Unit
 
-        units = Unit.objects.filter(
-            translation__component__project=component.project,
-            translation__component__allow_translation_propagation=True,
-        )
+        translation_ids_by_plural: dict[int, list[int]] = defaultdict(list)
+        for translation_id, plural_id in Translation.objects.filter(
+            component__project=component.project,
+            component__allow_translation_propagation=True,
+        ).values_list("id", "plural_id"):
+            translation_ids_by_plural[plural_id].append(translation_id)
+
+        # A single translation cannot contain different targets for one id_hash.
+        translation_ids = [
+            translation_id
+            for plural_translation_ids in translation_ids_by_plural.values()
+            if len(plural_translation_ids) > 1
+            for translation_id in plural_translation_ids
+        ]
+        if not translation_ids:
+            return []
+
+        units = Unit.objects.filter(translation_id__in=translation_ids)
 
         # List strings with different targets
         # Limit this to 100 strings, otherwise the resulting query is way too complex
@@ -124,23 +138,29 @@ class ConsistencyCheck(TargetCheck, BatchCheckMixin):
             units.values("id_hash", "translation__plural_id")
             .annotate(min_target=Min("target"), max_target=Max("target"))
             .filter(min_target__lt=F("max_target"))
-            .order_by("id_hash")[:100]
+            .order_by("id_hash", "translation__plural_id")[:100]
         )
 
         if not matches:
             return []
 
+        id_hashes_by_plural: dict[int, list[int]] = defaultdict(list)
+        for match in matches:
+            id_hashes_by_plural[match["translation__plural_id"]].append(
+                match["id_hash"]
+            )
+
         return (
-            units.filter(
+            Unit.objects.filter(
                 reduce(
-                    lambda x, y: (
-                        x
-                        | (
-                            Q(id_hash=y["id_hash"])
-                            & Q(translation__plural_id=y["translation__plural_id"])
+                    lambda query, item: (
+                        query
+                        | Q(
+                            translation_id__in=translation_ids_by_plural[item[0]],
+                            id_hash__in=item[1],
                         )
                     ),
-                    matches,
+                    id_hashes_by_plural.items(),
                     Q(),
                 )
             )

--- a/weblate/checks/tests/test_consistency_checks.py
+++ b/weblate/checks/tests/test_consistency_checks.py
@@ -315,3 +315,30 @@ class ConsistencyCheckTest(ComponentTestCase):
         self.assertNotIn("COUNT(DISTINCT", sql)
         self.assertIn("MIN(", sql)
         self.assertIn("MAX(", sql)
+
+        aggregate_sql = next(
+            query["sql"].upper() for query in queries if "MIN(" in query["sql"].upper()
+        )
+        self.assertNotIn('"TRANS_COMPONENT"', aggregate_sql)
+        self.assertIn('"TRANS_UNIT"."TRANSLATION_ID" IN', aggregate_sql)
+
+        unit_sql = next(
+            query["sql"].upper()
+            for query in queries
+            if '"TRANS_UNIT"."TRANSLATION_ID" IN' in query["sql"].upper()
+            and '"TRANS_UNIT"."ID_HASH" IN' in query["sql"].upper()
+            and "MIN(" not in query["sql"].upper()
+        )
+        self.assertNotIn('"TRANS_COMPONENT"', unit_sql)
+        self.assertNotIn('"TRANS_TRANSLATION"', unit_sql)
+
+    def test_consistency_skips_singleton_plurals(self) -> None:
+        check = ConsistencyCheck()
+        self.other.allow_translation_propagation = False
+        self.other.save(update_fields=["allow_translation_propagation"])
+
+        with CaptureQueriesContext(connection) as queries:
+            self.assertEqual(check.check_component(self.component), [])
+
+        sql = "\n".join(query["sql"].upper() for query in queries)
+        self.assertNotIn("MIN(", sql)


### PR DESCRIPTION
The batch consistency check scanned and grouped every propagating unit in a project, then repeated project joins to fetch up to 100 matching keys. On large projects these queries accounted for most of finalize_component_checks.

Preselect translation IDs by plural, omit singleton plural groups that cannot be inconsistent, and use the existing translation/id_hash index for the final lookup. This reduces database work while preserving exact target comparison.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
