### PR TITLE
feat(workflows): restrict direct editing per language

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.8
 * Added :guilabel:`Use keywords exclusively` option to :ref:`addon-weblate.gettext.xgettext`, allowing projects to disable xgettext default keywords and rely only on a custom keyword.
 * Added API support for reading and updating :ref:`user-profile` preferences. See :ref:`api-users` endpoint.
 * Added :ref:`check-max-lines` and :ref:`check-asciidoc-markup` quality checks for limiting the number of translation lines and validating AsciiDoc strings.
+* Added :ref:`workflow-language-restrictions`, including per-language control for restricting direct translation editing to privileged users.
 * Added support for legacy Qt Linguist TS version 1 files. See :ref:`qtling`.
 * Weblate is now available in Lao language.
 

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -32741,7 +32741,7 @@ components:
           description: Whether to allow translation suggestions at all.
         suggestion_voting:
           type: boolean
-          description: Users can only vote for suggestions and can’t make direct translations.
+          description: Allows users to vote on suggestions.
         suggestion_autoaccept:
           type: integer
           maximum: 32767
@@ -35502,7 +35502,7 @@ components:
           description: Whether to allow translation suggestions at all.
         suggestion_voting:
           type: boolean
-          description: Users can only vote for suggestions and can’t make direct translations.
+          description: Allows users to vote on suggestions.
         suggestion_autoaccept:
           type: integer
           maximum: 32767
@@ -37264,7 +37264,7 @@ components:
           description: Whether to allow translation suggestions at all.
         suggestion_voting:
           type: boolean
-          description: Users can only vote for suggestions and can’t make direct translations.
+          description: Allows users to vote on suggestions.
         suggestion_autoaccept:
           type: integer
           maximum: 32767

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -40,6 +40,65 @@ The first existing setting applies:
    Please be careful when using site-wide override as that applies to all
    projects (unless they have own overrides for a given language).
 
+.. _workflow-language-restrictions:
+
+Limiting translation languages
+++++++++++++++++++++++++++++++
+
+Several settings can limit translation languages. They address different
+stages of the translation lifecycle and can be combined:
+
+Control requests for languages that do not exist yet
+    Configure :ref:`project-new-lang` at workspace, project, or component level.
+    Components can inherit this setting. You can let users contact maintainers,
+    point them to translation instructions, create the language file
+    automatically, or disable adding new translations.
+
+    Project admins can still add a translation when Weblate can create its
+    file. For components that do not inherit the project setting, change
+    :ref:`component-new_lang` individually or automate the changes using
+    :http:patch:`/api/components/(string:project)/(string:component)/`.
+
+Limit which translation files Weblate discovers
+    Configure :ref:`component-language_regex` on each component. For example,
+    ``^(de|en|fr)$`` limits the component to translation files whose language
+    code is ``de``, ``en``, or ``fr``. The filter applies while scanning the
+    component file mask; it does not change permissions for translations that
+    are already present.
+
+Grant translation access only for selected languages
+    Use :ref:`language-scoped teams <custom-acl>` when different users should be
+    able to translate different languages. A team can only grant permissions,
+    so remove any broader translation permission that would otherwise apply to
+    the same users.
+
+Restrict direct editing of an existing language
+    Open the language settings in the project, enable
+    :guilabel:`Customize translation workflow for this language in this project`,
+    and turn on :guilabel:`Restrict direct editing`.
+
+    Users with the :guilabel:`Edit string when suggestions are enforced`
+    permission can continue editing directly. Other users can add suggestions
+    when :guilabel:`Turn on suggestions` is enabled. Turn off suggestions as
+    well to make the language editable only by privileged users.
+
+    The restriction can also be configured site-wide while
+    :ref:`changing-languages`. A project-language customization takes
+    precedence over the site-wide language setting.
+
+Use suggestion voting
+    Turn on :guilabel:`Suggestion voting` to let users vote on suggestions.
+    Voting alone does not restrict direct editing. A positive
+    :guilabel:`Automatically accept suggestions` threshold also requires users
+    without the :guilabel:`Edit string when suggestions are enforced`
+    permission to submit suggestions. Use :guilabel:`Restrict direct editing`
+    when this restriction should not depend on automatic acceptance.
+
+.. seealso::
+
+   * :ref:`component-new_lang`
+   * :ref:`component-language_regex`
+   * :ref:`custom-acl`
 
 Translation access
 ------------------

--- a/weblate/addons/autotranslate.py
+++ b/weblate/addons/autotranslate.py
@@ -155,6 +155,7 @@ class AutoTranslateAddon(
                 translation_id=translation_id,
                 activity_log_id=activity_log_id,
                 activity_log_task_count=activity_log_task_count,
+                enforce_permissions=False,
             )
         else:
             auto_translate_component.delay_on_commit(
@@ -167,6 +168,7 @@ class AutoTranslateAddon(
                 source_component_id=source_component_id,
                 user_id=task_user_id,
                 activity_log_id=activity_log_id,
+                enforce_permissions=False,
             )
         return AddonEventOutcome.pending()
 

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -54,7 +54,7 @@ from weblate.addons.forms import (
     SphinxExtractPotForm,
     XgettextExtractPotForm,
 )
-from weblate.auth.models import Group, Permission, Role
+from weblate.auth.models import Group, Permission, Role, User
 from weblate.lang.models import Language
 from weblate.trans.actions import ACTIONS_CONTENT, ActionEvents
 from weblate.trans.exceptions import FileParseError
@@ -7484,6 +7484,7 @@ class AutoTranslateAddonTest(ComponentTestCase):
             source_component_id=None,
             user_id=None,
             activity_log_id=None,
+            enforce_permissions=False,
         )
         self.assertEqual(outcome, AddonEventOutcome.pending())
 
@@ -7581,6 +7582,7 @@ class AutoTranslateAddonTest(ComponentTestCase):
             source_component_id=None,
             user_id=None,
             activity_log_id=123,
+            enforce_permissions=False,
         )
 
     def test_auto_others_component_uses_addon_user(self) -> None:
@@ -7611,6 +7613,7 @@ class AutoTranslateAddonTest(ComponentTestCase):
             source_component_id=None,
             user_id=addon.user.id,
             activity_log_id=None,
+            enforce_permissions=False,
         )
 
     def test_auto_change_event_normalizes_blank_component(self) -> None:
@@ -7649,6 +7652,7 @@ class AutoTranslateAddonTest(ComponentTestCase):
             translation_id=self.translation.id,
             activity_log_id=None,
             activity_log_task_count=2,
+            enforce_permissions=False,
         )
 
     def test_auto_change_event_passes_fanout_task_count(self) -> None:
@@ -7880,8 +7884,7 @@ class AutoTranslateAddonTest(ComponentTestCase):
         self.assertIn("First task failed", rendered)
         self.assertIn("Second task succeeded", rendered)
 
-    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    def test_auto_change_event(self) -> None:
+    def assert_auto_change_event(self, change_user: User | None) -> None:
         component_1 = self.create_po_new_base(name="Component 1", project=self.project)
         component_1.allow_translation_propagation = False
         component_1.save()
@@ -7915,8 +7918,8 @@ class AutoTranslateAddonTest(ComponentTestCase):
         with self.captureOnCommitCallbacks(execute=True):
             Comment.objects.create(unit=unit_2, comment="Foo")
         change = unit_2.change_set.latest("timestamp")
-        change.user = None
-        change.author = None
+        change.user = change_user
+        change.author = change_user
         change.save(update_fields=["user", "author"])
 
         with self.captureOnCommitCallbacks(execute=True):
@@ -7924,17 +7927,26 @@ class AutoTranslateAddonTest(ComponentTestCase):
 
         unit_2 = translation_2.unit_set.get(source="one")
         self.assertEqual(unit_2.target, "jeden")
+        expected_author = change_user or addon.user
         self.assertEqual(
             unit_2.change_set.get(action=ActionEvents.AUTO).author,
-            addon.user,
+            expected_author,
         )
         self.assertTrue(
             PendingUnitChange.objects.filter(
                 unit=unit_2,
-                author=addon.user,
+                author=expected_author,
                 automatically_translated=True,
             ).exists()
         )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_auto_change_event(self) -> None:
+        self.assert_auto_change_event(None)
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_auto_change_event_uses_triggering_user(self) -> None:
+        self.assert_auto_change_event(self.user)
 
 
 class AddonConfigurationUnitTest(SimpleTestCase):
@@ -7983,6 +7995,7 @@ class AddonConfigurationUnitTest(SimpleTestCase):
             translation_id=2,
             activity_log_id=None,
             activity_log_task_count=None,
+            enforce_permissions=False,
         )
 
     def test_trigger_autotranslate_normalizes_blank_component_for_component_task(
@@ -8018,6 +8031,7 @@ class AddonConfigurationUnitTest(SimpleTestCase):
             source_component_id=None,
             user_id=None,
             activity_log_id=None,
+            enforce_permissions=False,
         )
 
     def test_get_configuration_normalizes_legacy_filter_configuration(self) -> None:

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -81,6 +81,7 @@ from weblate.trans.models import (
     Suggestion,
     Translation,
     Unit,
+    WorkflowSetting,
 )
 from weblate.trans.models.component import ComponentQuerySet
 from weblate.trans.tests.utils import (
@@ -8472,6 +8473,79 @@ class ComponentAPITest(APIBaseTest):
             },
         )
 
+    def test_create_translation_from_component_restrict_direct_editing(self) -> None:
+        target = self.create_po_new_base(name="target", project=self.component.project)
+        source = self.create_po_new_base(name="source", project=self.component.project)
+        language = Language.objects.get(code="fa")
+        source_translation = source.add_new_language(language, None)
+        self.assertIsNotNone(source_translation)
+        WorkflowSetting.objects.create(
+            project=target.project,
+            language=language,
+            restrict_direct_editing=True,
+        )
+        self.grant_perm_to_user(
+            "translation.auto",
+            group_name="Target automatic translation",
+            component=target,
+        )
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Target component editing",
+            component=target,
+        )
+        self.grant_perm_to_user(
+            "component.edit",
+            group_name="Source component editing",
+            component=source,
+        )
+        self.user.clear_permissions_cache()
+
+        self.assertTrue(self.user.has_perm("translation.auto", target))
+        with patch.object(AutoTranslate, "perform") as perform:
+            response = self.do_request(
+                "api:component-translations",
+                {"project__slug": target.project.slug, "slug": target.slug},
+                method="post",
+                code=403,
+                format="json",
+                request={
+                    "language_code": "fa",
+                    "from_component": [source.full_slug],
+                },
+            )
+
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "Direct editing is restricted for this language. Add a suggestion instead.",
+        )
+        perform.assert_not_called()
+        self.assertFalse(target.translation_set.filter(language_code="fa").exists())
+
+        self.grant_perm_to_user(
+            "unit.override",
+            group_name="Target workflow override",
+            component=target,
+        )
+        self.user.clear_permissions_cache()
+        with patch.object(
+            AutoTranslate, "perform", return_value="Automatic translation completed"
+        ) as perform:
+            self.do_request(
+                "api:component-translations",
+                {"project__slug": target.project.slug, "slug": target.slug},
+                method="post",
+                code=201,
+                format="json",
+                request={
+                    "language_code": "fa",
+                    "from_component": [source.full_slug],
+                },
+            )
+
+        perform.assert_called_once()
+        self.assertTrue(target.translation_set.filter(language_code="fa").exists())
+
     def test_create_translation_from_component_allows_shared_tm_source_without_edit(
         self,
     ) -> None:
@@ -11196,6 +11270,55 @@ class TranslationAPITest(APIBaseTest):
 
     def test_autotranslate_json(self) -> None:
         self.test_autotranslate("json")
+
+    def test_autotranslate_restrict_direct_editing(self) -> None:
+        translation = Translation.objects.get(**self.translation_kwargs)
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=translation.language,
+            restrict_direct_editing=True,
+        )
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Restricted automatic translation",
+            language_selection=SELECTION_ALL,
+        )
+        group.components.add(self.component)
+        group.roles.add(
+            Role.objects.get(name="Translate"),
+            Role.objects.get(name="Automatic translation"),
+        )
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+
+        translation = Translation.objects.get(pk=translation.pk)
+        self.assertTrue(self.user.has_perm("translation.auto", translation))
+        self.assertFalse(self.user.has_perm("meta:unit.direct_edit", translation))
+        self.assertTrue(self.user.has_perm("suggestion.add", translation))
+
+        request = {
+            "q": "state:<translated",
+            "auto_source": "others",
+            "threshold": "100",
+        }
+        with patch.object(
+            AutoTranslate, "perform", return_value="Automatic translation completed"
+        ) as perform:
+            self.do_request(
+                "api:translation-autotranslate",
+                self.translation_kwargs,
+                method="post",
+                request={"mode": "translate", **request},
+                code=403,
+            )
+            self.do_request(
+                "api:translation-autotranslate",
+                self.translation_kwargs,
+                method="post",
+                request={"mode": "suggest", **request},
+                code=200,
+            )
+        perform.assert_called_once()
 
     def test_add_monolingual(self) -> None:
         component = self.create_acl()

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -142,7 +142,7 @@ from weblate.machinery.models import validate_service_configuration
 from weblate.memory.models import Memory, MemoryScope
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
-from weblate.trans.autotranslate import AutoTranslate
+from weblate.trans.autotranslate import AutoTranslate, check_auto_translate_permission
 from weblate.trans.backups import list_backups
 from weblate.trans.exceptions import (
     FailedCommitError,
@@ -2808,6 +2808,18 @@ class ComponentViewSet(
                 message = f"Could not add {language_code!r}!"
                 raise ValidationError({"language_code": message}) from error
 
+            if source_components:
+                auto_permission = check_auto_translate_permission(
+                    request.user,
+                    Translation(component=obj, language=language),
+                    "translate",
+                )
+                if not auto_permission:
+                    self.permission_denied(
+                        request,
+                        getattr(auto_permission, "reason", "Can not auto translate"),
+                    )
+
             translation = obj.add_new_language(language, request)
             if translation is None:
                 storage = get_messages(request)
@@ -3613,6 +3625,15 @@ class TranslationViewSet(MultipleFieldViewSet, DestroyModelMixin, AnnouncementsM
                     else:
                         errors[field.name] = str(error)
             raise ValidationError(errors)
+
+        auto_permission = check_auto_translate_permission(
+            request.user, translation, autoform.cleaned_data["mode"]
+        )
+        if not auto_permission:
+            self.permission_denied(
+                request,
+                getattr(auto_permission, "reason", "Can not auto translate"),
+            )
 
         auto = AutoTranslate(
             user=get_request_user(request),

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -213,6 +213,35 @@ def get_glossary_permission_denial(permission: str) -> str:
     return ""
 
 
+@register_perm("meta:unit.direct_edit")
+def check_direct_editing(
+    user: User,
+    permission: str,
+    obj: Unit
+    | Translation
+    | ProjectLanguage
+    | CategoryLanguage
+    | Component
+    | Category
+    | Project,
+) -> bool | PermissionResult:
+    if isinstance(obj, Unit):
+        obj = obj.translation
+    if not isinstance(obj, Translation | ProjectLanguage | CategoryLanguage):
+        return True
+    if not obj.restrict_direct_editing:
+        return True
+    if check_permission(user, "unit.override", obj):
+        return True
+    if obj.enable_suggestions:
+        return Denied(
+            gettext(
+                "Direct editing is restricted for this language. Add a suggestion instead."
+            )
+        )
+    return Denied(gettext("Direct editing is restricted for this language."))
+
+
 def check_permission(
     user: User,
     permission: str,
@@ -343,6 +372,7 @@ def check_can_edit(
     | Project,
     *,
     is_vote: bool = False,
+    direct_edit: bool = True,
     allow_limited_without_language: bool | None = None,
 ) -> bool | PermissionResult:
     translation = component = None
@@ -441,6 +471,13 @@ def check_can_edit(
         and not check_permission(user, "unit.template", obj)
     ):
         return Denied(gettext("You do not have permission to edit source strings."))
+
+    if direct_edit and not (
+        direct_edit_permission := check_direct_editing(
+            user, "meta:unit.direct_edit", obj
+        )
+    ):
+        return direct_edit_permission
 
     # Special checks for voting
     if is_vote and translation and not translation.suggestion_voting:
@@ -680,7 +717,12 @@ def check_autotranslate(
         or translation.is_readonly
     ):
         return False
-    return check_can_edit(user, permission, translation)
+    return check_can_edit(
+        user,
+        permission,
+        translation,
+        direct_edit=permission != "translation.auto",
+    )
 
 
 @register_perm("suggestion.vote")
@@ -689,7 +731,7 @@ def check_suggestion_vote(
 ) -> bool | PermissionResult:
     if isinstance(obj, Unit):
         obj = obj.translation
-    return check_can_edit(user, permission, obj, is_vote=True)
+    return check_can_edit(user, permission, obj, is_vote=True, direct_edit=False)
 
 
 @register_perm("suggestion.add")
@@ -931,15 +973,21 @@ def check_upload(
             )
         if obj.component.is_glossary:
             permission = "glossary.upload"
-        return check_can_edit(user, permission, obj) and (
+        return check_can_edit(user, permission, obj, direct_edit=False) and (
             # Normal upload
             check_edit_approved(user, "unit.edit", obj)
             # Suggestion upload
             or check_suggestion_add(user, "suggestion.add", obj)
             # Add upload
-            or check_suggestion_add(user, "unit.add", obj)
+            or (
+                check_direct_editing(user, "meta:unit.direct_edit", obj)
+                and check_suggestion_add(user, "unit.add", obj)
+            )
             # Source upload
-            or obj.is_source
+            or (
+                obj.is_source
+                and check_direct_editing(user, "meta:unit.direct_edit", obj)
+            )
         )
 
     return _has_upload_child(user, obj)

--- a/weblate/lang/tests.py
+++ b/weblate/lang/tests.py
@@ -613,12 +613,14 @@ class LanguagesViewTest(FixtureTestCase):
                 "direction": "ltr",
                 "population": 10,
                 "workflow-enable": 1,
+                "workflow-restrict_direct_editing": 1,
                 "workflow-translation_review": 1,
                 "workflow-suggestion_autoaccept": 0,
             },
         )
         self.assertRedirects(response, reverse("show_language", kwargs={"lang": "xx"}))
-        self.assertTrue(language.workflowsetting_set.exists())
+        workflow_settings = language.workflowsetting_set.get()
+        self.assertTrue(workflow_settings.restrict_direct_editing)
         response = self.client.post(
             reverse("edit-language", kwargs={"pk": language.pk}),
             {

--- a/weblate/templates/snippets/info.html
+++ b/weblate/templates/snippets/info.html
@@ -93,7 +93,19 @@
               <td colspan="2" class="full-cell">
                 <ul>
                   {% get_workflow_flags translation component as workflow_flags %}
-                  {% if workflow_flags.suggestion_voting and workflow_flags.suggestion_autoaccept %}
+                  {% if workflow_flags.restrict_direct_editing %}
+                    <li>{% translate "Direct translation editing is restricted to privileged users." %}</li>
+                    {% if workflow_flags.enable_suggestions %}
+                      <li>{% translate "Translation suggestions can be made." %}</li>
+                    {% else %}
+                      <li>{% translate "Translation suggestions are turned off." %}</li>
+                    {% endif %}
+                    {% if workflow_flags.suggestion_voting and workflow_flags.suggestion_autoaccept %}
+                      <li>
+                        {% blocktranslate count count=workflow_flags.suggestion_autoaccept %}Suggestions with one vote are automatically accepted as translations.{% plural %}Suggestions are automatically accepted as translations once they have {{ count }} votes.{% endblocktranslate %}
+                      </li>
+                    {% endif %}
+                  {% elif workflow_flags.suggestion_voting and workflow_flags.suggestion_autoaccept %}
                     <li>{% translate "Translations can only be done through suggestions." %}</li>
                     <li>
                       {% blocktranslate count count=workflow_flags.suggestion_autoaccept %}Suggestions with one vote are automatically accepted as translations.{% plural %}Suggestions are automatically accepted as translations once they have {{ count }} votes.{% endblocktranslate %}

--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -21,6 +21,7 @@ from weblate.trans.actions import ActionEvents
 from weblate.trans.models import (
     Category,
     Component,
+    Project,
     Suggestion,
     SuggestionAddResult,
     Translation,
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from weblate.auth.models import User
+    from weblate.auth.results import PermissionResult
     from weblate.machinery.base import BatchMachineTranslation, UnitMemoryResultDict
     from weblate.utils.state import StringState
 
@@ -90,6 +92,21 @@ def fetch_machinery_matches(
         for unit in units
         if unit.machinery and any(unit.machinery["quality"])
     }
+
+
+def check_auto_translate_permission(
+    user: User | None, translation: Translation, mode: str
+) -> bool | PermissionResult:
+    # Add-on users identify generated changes rather than authorize the operation.
+    if user is None or (user.is_bot and user.username.startswith("addon:")):
+        return True
+    if not (permission := user.has_perm("translation.auto", translation)):
+        return permission
+    if mode == "suggest":
+        if not translation.restrict_direct_editing:
+            return True
+        return user.has_perm("suggestion.add", translation)
+    return user.has_perm("meta:unit.direct_edit", translation)
 
 
 class BaseAutoTranslate:
@@ -529,6 +546,7 @@ class BatchAutoTranslate(BaseAutoTranslate):
         component_wide: bool = False,
         unit_ids: list[int] | None = None,
         allow_non_shared_tm_source_components: bool = False,
+        enforce_permissions: bool = True,
     ) -> None:
         super().__init__(
             user=user,
@@ -542,23 +560,29 @@ class BatchAutoTranslate(BaseAutoTranslate):
         )
         self._task_meta: dict[str, Any] = {}
         self.workspace_source_component_ids: dict[int, list[int]] | None = None
-        self.check_translation_permissions = False
+        self.enforce_permissions = enforce_permissions
 
         match obj:
             case Translation():
                 self.translations = [obj]
                 self._task_meta = {"translation": obj.pk}
             case Component():
-                self.translations = obj.translation_set.exclude_source()
+                self.translations = obj.translation_set.select_related(
+                    "language"
+                ).exclude_source()
                 self._task_meta = {"component": obj.pk}
             case Category():
-                self.translations = Translation.objects.filter(
-                    component__category=obj
-                ).exclude_source()
+                self.translations = (
+                    Translation.objects.filter(component__category=obj)
+                    .select_related("language", "component", "component__project")
+                    .exclude_source()
+                )
                 self._task_meta = {"category": obj.pk}
             case ProjectLanguage():
                 self.translations = list(
-                    obj.action_translation_set.exclude_source().prefetch()
+                    obj.action_translation_set.select_related("language")
+                    .exclude_source()
+                    .prefetch()
                 )
                 self._task_meta = {
                     "project": obj.project.pk,
@@ -570,7 +594,7 @@ class BatchAutoTranslate(BaseAutoTranslate):
                     components = components.filter_access(user)
                 self.translations = (
                     Translation.objects.filter(component__in=components)
-                    .select_related("component", "component__project")
+                    .select_related("language", "component", "component__project")
                     .exclude_source()
                 )
                 source_component_ids: dict[int, list[int]] = {}
@@ -582,19 +606,44 @@ class BatchAutoTranslate(BaseAutoTranslate):
                     )
                 self.workspace_source_component_ids = source_component_ids
                 self.allow_non_shared_tm_source_components = True
-                self.check_translation_permissions = True
                 self._task_meta = {"workspace": str(obj.pk)}
             case _:  # pragma: no cover
                 msg = "Unsupported object type for BatchAutoTranslate"
                 raise ValueError(msg)
-        self.progress_steps = (
-            self.translations.count()
-            if isinstance(self.translations, QuerySet)
-            else len(self.translations)
-        )
+        self._preload_workflow_settings()
+        self.progress_steps = len(self.translations)
+
+    def _preload_workflow_settings(self) -> None:
+        self.translations = list(self.translations)
+        projects: dict[int, Project] = {}
+        project_languages: dict[int, dict[int, ProjectLanguage]] = {}
+
+        for translation in self.translations:
+            project = translation.component.project
+            project = projects.setdefault(project.pk, project)
+            languages = project_languages.setdefault(project.pk, {})
+            if translation.language_id not in languages:
+                languages[translation.language_id] = ProjectLanguage(
+                    project, translation.language
+                )
+
+        for project_id, languages in project_languages.items():
+            projects[project_id].project_languages.preload_workflow_settings(
+                languages.values()
+            )
+
+        for translation in self.translations:
+            translation.__dict__["workflow_settings"] = project_languages[
+                translation.component.project_id
+            ][translation.language_id].workflow_settings
 
     def get_task_meta(self) -> dict[str, Any]:
         return self._task_meta
+
+    def _can_process_translation(self, translation: Translation) -> bool:
+        return not self.enforce_permissions or bool(
+            check_auto_translate_permission(self.user, translation, self.mode)
+        )
 
     def perform(
         self,
@@ -620,11 +669,7 @@ class BatchAutoTranslate(BaseAutoTranslate):
                     ).append(component_id)
 
         for pos, translation in enumerate(self.translations, start=1):
-            if (
-                self.check_translation_permissions
-                and self.user is not None
-                and not self.user.has_perm("translation.auto", translation)
-            ):
+            if not self._can_process_translation(translation):
                 self.set_progress(pos)
                 continue
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -4648,6 +4648,7 @@ class WorkflowSettingForm(FieldDocsMixin, forms.ModelForm):
         # ruff: ignore[mutable-class-default]
         fields = [
             "translation_review",
+            "restrict_direct_editing",
             "enable_suggestions",
             "suggestion_voting",
             "suggestion_autoaccept",
@@ -4699,6 +4700,7 @@ class WorkflowSettingForm(FieldDocsMixin, forms.ModelForm):
             ),
             Div(
                 Field("translation_review"),
+                Field("restrict_direct_editing"),
                 Field("enable_suggestions"),
                 Field("suggestion_voting"),
                 Field("suggestion_autoaccept"),

--- a/weblate/trans/migrations/0097_workflowsetting_restrict_direct_editing.py
+++ b/weblate/trans/migrations/0097_workflowsetting_restrict_direct_editing.py
@@ -1,0 +1,44 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0096_change_recent_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="workflowsetting",
+            name="restrict_direct_editing",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "Only users with the “Edit string when suggestions are enforced” "
+                    "permission can make direct changes."
+                ),
+                verbose_name="Restrict direct editing",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="component",
+            name="suggestion_voting",
+            field=models.BooleanField(
+                default=False,
+                help_text="Allows users to vote on suggestions.",
+                verbose_name="Suggestion voting",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="workflowsetting",
+            name="suggestion_voting",
+            field=models.BooleanField(
+                default=False,
+                help_text="Allows users to vote on suggestions.",
+                verbose_name="Suggestion voting",
+            ),
+        ),
+    ]

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -774,9 +774,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
     suggestion_voting = models.BooleanField(
         verbose_name=gettext_lazy("Suggestion voting"),
         default=False,
-        help_text=gettext_lazy(
-            "Users can only vote for suggestions and can’t make direct translations."
-        ),
+        help_text=gettext_lazy("Allows users to vote on suggestions."),
     )
     # This should match definition in WorkflowSetting
     suggestion_autoaccept = models.PositiveSmallIntegerField(

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -1606,6 +1606,12 @@ class Translation(
         return self.component.enable_suggestions
 
     @property
+    def restrict_direct_editing(self) -> bool:
+        if self.workflow_settings is not None:
+            return self.workflow_settings.restrict_direct_editing
+        return False
+
+    @property
     def suggestion_voting(self):
         if self.workflow_settings is not None:
             return self.workflow_settings.suggestion_voting

--- a/weblate/trans/models/workflow.py
+++ b/weblate/trans/models/workflow.py
@@ -31,13 +31,19 @@ class WorkflowSetting(models.Model):
         default=True,
         help_text=gettext_lazy("Whether to allow translation suggestions at all."),
     )
+    restrict_direct_editing = models.BooleanField(
+        verbose_name=gettext_lazy("Restrict direct editing"),
+        default=False,
+        help_text=gettext_lazy(
+            "Only users with the “Edit string when suggestions are enforced” "
+            "permission can make direct changes."
+        ),
+    )
     # This should match definition in Component
     suggestion_voting = models.BooleanField(
         verbose_name=gettext_lazy("Suggestion voting"),
         default=False,
-        help_text=gettext_lazy(
-            "Users can only vote for suggestions and can’t make direct translations."
-        ),
+        help_text=gettext_lazy("Allows users to vote on suggestions."),
     )
     # This should match definition in Component
     suggestion_autoaccept = models.PositiveSmallIntegerField(

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -985,6 +985,7 @@ def auto_translate(
     workspace_id: str | None = None,
     activity_log_id: int | None = None,
     activity_log_task_count: int | None = None,
+    enforce_permissions: bool = True,
 ) -> dict[str, Any]:
     result: dict[str, Any] = {"warnings": []}
     user = User.objects.get(pk=user_id) if user_id else None
@@ -1017,6 +1018,7 @@ def auto_translate(
             mode=mode,
             component_wide=component_wide,
             unit_ids=unit_ids,
+            enforce_permissions=enforce_permissions,
         )
         try:
             message = auto.perform(
@@ -1060,6 +1062,7 @@ def auto_translate_component(
     source_component_id: int | None = None,
     user_id: int | None = None,
     activity_log_id: int | None = None,
+    enforce_permissions: bool = True,
 ) -> dict[str, Any]:
     component_obj = Component.objects.get(pk=component_id)
     user = User.objects.get(pk=user_id) if user_id else None
@@ -1069,6 +1072,7 @@ def auto_translate_component(
         q=q,
         mode=mode,
         component_wide=True,
+        enforce_permissions=enforce_permissions,
     )
     message = auto.perform(
         auto_source=auto_source,

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -1589,12 +1589,14 @@ def get_workflow_flags(translation: Translation | None, component: Component):
             "suggestion_voting": translation.suggestion_voting,
             "suggestion_autoaccept": translation.suggestion_autoaccept,
             "enable_suggestions": translation.enable_suggestions,
+            "restrict_direct_editing": translation.restrict_direct_editing,
             "translation_review": translation.enable_review,
         }
     return {
         "suggestion_voting": component.suggestion_voting,
         "suggestion_autoaccept": component.suggestion_autoaccept,
         "enable_suggestions": component.enable_suggestions,
+        "restrict_direct_editing": False,
         "translation_review": component.project.translation_review,
     }
 

--- a/weblate/trans/tests/test_autotranslate.py
+++ b/weblate/trans/tests/test_autotranslate.py
@@ -21,8 +21,17 @@ from weblate.configuration.models import Setting, SettingCategory
 from weblate.lang.models import Language, Plural
 from weblate.machinery.dummy import DummyTranslation
 from weblate.trans.actions import ActionEvents
+from weblate.trans.autotranslate import BatchAutoTranslate
 from weblate.trans.forms import AutoForm
-from weblate.trans.models import Change, Component, PendingUnitChange, Project, Unit
+from weblate.trans.models import (
+    Change,
+    Component,
+    PendingUnitChange,
+    Project,
+    Translation,
+    Unit,
+    WorkflowSetting,
+)
 from weblate.trans.tasks import auto_translate, auto_translate_component
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.state import STATE_APPROVED, STATE_READONLY, STATE_TRANSLATED
@@ -114,9 +123,16 @@ class AutoTranslationTest(ViewTestCase):
         )
 
     def perform_auto(
-        self, expected=1, expected_count=None, path_params=None, success=True, **kwargs
+        self,
+        expected=1,
+        expected_count=None,
+        path_params=None,
+        success=True,
+        prepare_source=True,
+        **kwargs,
     ) -> None:
-        self.make_different()
+        if prepare_source:
+            self.make_different()
         if path_params is None:
             path_params = {"path": [*self.component2.get_url_path(), "cs"]}
         url = reverse("auto_translation", kwargs=path_params)
@@ -162,6 +178,87 @@ class AutoTranslationTest(ViewTestCase):
     def test_different(self) -> None:
         """Test for automatic translation with different content."""
         self.perform_auto()
+
+    def restrict_direct_editing(self) -> Translation:
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Restricted automatic translation",
+            language_selection=SELECTION_ALL,
+        )
+        group.components.add(self.component2)
+        group.roles.add(
+            Role.objects.get(name="Translate"),
+            Role.objects.get(name="Automatic translation"),
+        )
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+
+        translation = self.component2.translation_set.get(language_code="cs")
+        WorkflowSetting.objects.create(
+            project=translation.component.project,
+            language=translation.language,
+            restrict_direct_editing=True,
+        )
+        return Translation.objects.get(component=self.component2, language_code="cs")
+
+    def test_restrict_direct_editing_blocks_automatic_translation(self) -> None:
+        self.make_different()
+        translation = self.restrict_direct_editing()
+
+        self.assertTrue(self.user.has_perm("translation.auto", translation))
+        self.perform_auto(expected=0, prepare_source=False)
+
+    def test_restrict_direct_editing_allows_automatic_suggestions(self) -> None:
+        self.make_different()
+        translation = self.restrict_direct_editing()
+
+        self.assertTrue(self.user.has_perm("translation.auto", translation))
+        self.assertTrue(self.user.has_perm("suggestion.add", translation))
+        self.perform_auto(mode="suggest", prepare_source=False)
+
+    def test_restrict_direct_editing_in_component_batch(self) -> None:
+        self.make_different()
+        self.make_different("de")
+        translation = self.restrict_direct_editing()
+        german = self.component2.translation_set.get(language_code="de")
+        initial_german_translated = german.stats.translated
+
+        self.perform_auto(
+            expected=1,
+            expected_count=0,
+            path_params={"path": self.component2.get_url_path()},
+            prepare_source=False,
+        )
+
+        translation = Translation.objects.get(pk=translation.pk)
+        german = Translation.objects.get(pk=german.pk)
+        self.assertEqual(translation.stats.translated, 0)
+        self.assertEqual(german.stats.translated, initial_german_translated + 1)
+
+    def test_batch_preloads_workflow_settings(self) -> None:
+        translation = self.component2.translation_set.get(language_code="cs")
+        setting = WorkflowSetting.objects.create(
+            project=translation.component.project,
+            language=translation.language,
+            restrict_direct_editing=True,
+        )
+
+        auto = BatchAutoTranslate(
+            self.component2,
+            user=self.user,
+            q="state:<translated",
+            mode="translate",
+        )
+
+        self.assertGreater(len(auto.translations), 1)
+        with self.assertNumQueries(0):
+            workflow_settings = [item.workflow_settings for item in auto.translations]
+            restrictions = [item.restrict_direct_editing for item in auto.translations]
+        self.assertIn(setting, workflow_settings)
+        self.assertIn(True, restrictions)
+        self.assertIn(False, restrictions)
 
     def test_readonly_empty_target_source_candidate(self) -> None:
         """Skip source candidates with empty targets even when read-only."""

--- a/weblate/trans/tests/test_files.py
+++ b/weblate/trans/tests/test_files.py
@@ -23,6 +23,8 @@ from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 from openpyxl import load_workbook
 
+from weblate.auth.data import SELECTION_ALL
+from weblate.auth.models import Group, Permission, Role
 from weblate.auth.results import Denied
 from weblate.formats.helpers import NamedBytesIO, format_csv_id_hash
 from weblate.formats.ttkit import CSVFormat
@@ -37,9 +39,11 @@ from weblate.trans.models import (
     PendingUnitChange,
     Project,
     Translation,
+    WorkflowSetting,
 )
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import get_optional_path, get_test_file
+from weblate.trans.util import check_upload_method_permissions
 from weblate.trans.views.files import can_download_workspace
 from weblate.utils.data import data_dir
 from weblate.utils.state import STATE_READONLY
@@ -113,6 +117,60 @@ class UploadFormPermissionTest(ViewTestCase):
 
         choices = [choice[0] for choice in form.fields["conflicts"].choices]
         self.assertIn("replace-approved", choices)
+
+
+class RestrictedDirectEditingUploadTest(ViewTestCase):
+    def add_project_role(self, role: Role) -> None:
+        group = Group.objects.create(
+            name=f"Restricted upload {role.name}",
+            language_selection=SELECTION_ALL,
+        )
+        group.projects.add(self.project)
+        group.roles.add(role)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+
+    def restrict_language(self, translation: Translation) -> Translation:
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=translation.language,
+            restrict_direct_editing=True,
+        )
+        return Translation.objects.get(pk=translation.pk)
+
+    def test_direct_and_suggestion_upload(self) -> None:
+        translation = self.restrict_language(self.translation)
+
+        self.assertTrue(self.user.has_perm("upload.perform", translation))
+        self.assertFalse(
+            check_upload_method_permissions(self.user, translation, "translate")
+        )
+        self.assertTrue(
+            check_upload_method_permissions(self.user, translation, "suggest")
+        )
+
+    def test_replace_upload(self) -> None:
+        role = Role.objects.create(name="Replace upload")
+        role.permissions.add(Permission.objects.get(codename="component.edit"))
+        self.add_project_role(role)
+        self.assertTrue(
+            check_upload_method_permissions(self.user, self.translation, "replace")
+        )
+
+        translation = self.restrict_language(self.translation)
+
+        self.assertFalse(
+            check_upload_method_permissions(self.user, translation, "replace")
+        )
+
+    def test_source_upload(self) -> None:
+        self.add_project_role(Role.objects.get(name="Edit source"))
+        source = self.get_translation("en")
+        self.assertTrue(check_upload_method_permissions(self.user, source, "source"))
+
+        source = self.restrict_language(source)
+
+        self.assertFalse(check_upload_method_permissions(self.user, source, "source"))
 
 
 class ImportBaseTest(ViewTestCase):

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -25,6 +25,7 @@ from weblate.trans.models import (
     PendingUnitChange,
     Translation,
     Unit,
+    WorkflowSetting,
 )
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.ratelimit import reset_rate_limit
@@ -1001,6 +1002,46 @@ class BulkEditTest(ViewTestCase):
         self.assertEqual(updated, 0)
         self.unit.refresh_from_db()
         self.assertEqual(self.unit.state, STATE_FUZZY)
+
+    def test_bulk_edit_skips_restricted_language(self) -> None:
+        limited_user = User.objects.create_user(
+            "restricted-bulk", "restricted-bulk@example.com", "restricted-bulk"
+        )
+        group = Group.objects.create(
+            name="Restricted bulk", language_selection=SELECTION_ALL
+        )
+        group.roles.add(
+            Role.objects.get(name="Translate"), Role.objects.get(name="Bulk editing")
+        )
+        group.components.add(self.component)
+        limited_user.groups.add(group)
+        limited_user.clear_permissions_cache()
+        self.assertTrue(limited_user.has_perm("unit.edit", self.unit))
+        self.assertTrue(limited_user.has_perm("unit.bulk_edit", self.unit))
+
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=self.translation.language,
+            restrict_direct_editing=True,
+        )
+        unit = Unit.objects.get(pk=self.unit.pk)
+
+        updated = bulk_perform(
+            limited_user,
+            Unit.objects.filter(pk=unit.pk),
+            query="state:needs-editing",
+            target_state=STATE_TRANSLATED,
+            add_flags="",
+            remove_flags="",
+            add_labels=self.project.label_set.none(),
+            remove_labels=self.project.label_set.none(),
+            project=self.project,
+            components=[self.component],
+        )
+
+        self.assertEqual(updated, 0)
+        unit.refresh_from_db()
+        self.assertEqual(unit.state, STATE_FUZZY)
 
     def test_bulk_edit_requires_review_permission_to_approve(self) -> None:
         self.project.translation_review = True

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -31,6 +31,7 @@ from weblate.trans.models import (
     Project,
     Translation,
     Unit,
+    WorkflowSetting,
 )
 from weblate.trans.models.component import ComponentQuerySet
 from weblate.trans.tests.test_views import ViewTestCase
@@ -961,14 +962,27 @@ class SettingsTest(ViewTestCase):
         self.assertContains(response, "Settings")
         response = self.client.post(
             url,
-            {"workflow-enable": 1, "workflow-suggestion_autoaccept": 0},
+            {
+                "workflow-enable": 1,
+                "workflow-restrict_direct_editing": 1,
+                "workflow-suggestion_autoaccept": 0,
+            },
             follow=True,
         )
         self.assertContains(response, "Settings saved")
-        self.assertIsNotNone(
+        workflow_settings = (
             Project.objects.get(pk=self.project.pk)
             .project_languages[self.translation.language]
             .workflow_settings
+        )
+        self.assertIsNotNone(workflow_settings)
+        self.assertTrue(workflow_settings.restrict_direct_editing)
+        self.assertTrue(
+            WorkflowSetting.objects.filter(
+                project=self.project,
+                language=self.translation.language,
+                restrict_direct_editing=True,
+            ).exists()
         )
         response = self.client.post(
             url, {"workflow-suggestion_autoaccept": 0}, follow=True

--- a/weblate/trans/tests/test_suggestions.py
+++ b/weblate/trans/tests/test_suggestions.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
+from weblate.auth.results import Denied
 from weblate.trans.models import Suggestion, WorkflowSetting
 from weblate.trans.tests.test_views import ViewTestCase
 
@@ -214,6 +215,75 @@ class SuggestionsTest(ViewTestCase):
             project=self.project,
             language=self.translation.language,
             enable_suggestions=True,
+            suggestion_voting=True,
+            suggestion_autoaccept=0,
+        )
+
+        self.assert_vote()
+
+    def test_restrict_direct_editing(self) -> None:
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=self.translation.language,
+            enable_suggestions=True,
+            restrict_direct_editing=True,
+        )
+        unit = self.get_unit()
+
+        permission = self.user.has_perm("unit.edit", unit)
+        self.assertIsInstance(permission, Denied)
+        self.assertEqual(
+            permission.reason,
+            "Direct editing is restricted for this language. Add a suggestion instead.",
+        )
+        self.assertTrue(self.user.has_perm("suggestion.add", unit))
+
+        response = self.client.get(self.translation_url)
+        self.assertContains(
+            response,
+            "Direct translation editing is restricted to privileged users.",
+        )
+        self.assertContains(response, "Translation suggestions can be made.")
+        self.assertNotContains(response, "Translations can be made directly.")
+
+        self.add_suggestion_1()
+        self.assertEqual(unit.suggestion_set.count(), 1)
+        self.assertFalse(self.get_unit().translated)
+
+        self.project.add_user(self.user, "Administration")
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("unit.edit", unit))
+
+    def test_restrict_direct_editing_without_suggestions(self) -> None:
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=self.translation.language,
+            enable_suggestions=False,
+            restrict_direct_editing=True,
+        )
+        unit = self.get_unit()
+
+        permission = self.user.has_perm("unit.edit", unit)
+        self.assertIsInstance(permission, Denied)
+        self.assertEqual(
+            permission.reason, "Direct editing is restricted for this language."
+        )
+        self.assertFalse(self.user.has_perm("suggestion.add", unit))
+
+        response = self.client.get(self.translation_url)
+        self.assertContains(
+            response,
+            "Direct translation editing is restricted to privileged users.",
+        )
+        self.assertContains(response, "Translation suggestions are turned off.")
+        self.assertNotContains(response, "Translations can be made directly.")
+
+    def test_restrict_direct_editing_allows_voting(self) -> None:
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=self.translation.language,
+            enable_suggestions=True,
+            restrict_direct_editing=True,
             suggestion_voting=True,
             suggestion_autoaccept=0,
         )

--- a/weblate/trans/tests/test_workflowsetting.py
+++ b/weblate/trans/tests/test_workflowsetting.py
@@ -4,6 +4,8 @@
 
 """Test for categories."""
 
+from weblate.auth.data import SELECTION_ALL
+from weblate.auth.models import Group, Role
 from weblate.lang.models import Language
 from weblate.trans.models import (
     Category,
@@ -20,25 +22,33 @@ class WorkflowSettingsTestCase(FixtureComponentTestCase):
     def assert_workflow(self, **kwargs) -> None:
         self.assertFalse(self.translation.enable_review)
         self.assertTrue(self.translation.enable_suggestions)
+        self.assertFalse(self.translation.restrict_direct_editing)
 
         workflowsetting = WorkflowSetting.objects.create(
-            translation_review=True, enable_suggestions=False, **kwargs
+            translation_review=True,
+            enable_suggestions=False,
+            restrict_direct_editing=True,
+            **kwargs,
         )
         translation = Translation.objects.get(pk=self.translation.pk)
         self.assertFalse(translation.enable_review)
         self.assertFalse(translation.enable_suggestions)
+        self.assertTrue(translation.restrict_direct_editing)
 
         self.project.translation_review = True
         self.project.save()
         translation = Translation.objects.get(pk=translation.pk)
         self.assertTrue(translation.enable_review)
         self.assertFalse(translation.enable_suggestions)
+        self.assertTrue(translation.restrict_direct_editing)
 
         workflowsetting.translation_review = False
+        workflowsetting.restrict_direct_editing = False
         workflowsetting.save()
         translation = Translation.objects.get(pk=translation.pk)
         self.assertFalse(translation.enable_review)
         self.assertFalse(translation.enable_suggestions)
+        self.assertFalse(translation.restrict_direct_editing)
 
     def test_project(self) -> None:
         self.assert_workflow(project=self.project, language=self.translation.language)
@@ -105,6 +115,82 @@ class WorkflowSettingsTestCase(FixtureComponentTestCase):
                         self.assertEqual(project_language.enable_review, expected)
                         self.assertEqual(category_language.enable_review, expected)
                         self.assertEqual(category_language.stats.has_review, expected)
+
+    def test_language_wrappers_restrict_direct_editing(self) -> None:
+        category = Category.objects.create(
+            project=self.project,
+            name="Restricted workflow wrappers",
+            slug="restricted-workflow-wrappers",
+        )
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+
+        project_language = ProjectLanguage(self.project, self.translation.language)
+        category_language = CategoryLanguage(category, self.translation.language)
+        self.assertFalse(project_language.restrict_direct_editing)
+        self.assertFalse(category_language.restrict_direct_editing)
+
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=self.translation.language,
+            restrict_direct_editing=True,
+        )
+
+        project_language = ProjectLanguage(self.project, self.translation.language)
+        category_language = CategoryLanguage(category, self.translation.language)
+        self.assertTrue(project_language.restrict_direct_editing)
+        self.assertTrue(category_language.restrict_direct_editing)
+
+    def test_restrict_direct_editing_permissions(self) -> None:
+        category = Category.objects.create(
+            project=self.project,
+            name="Restricted workflow permissions",
+            slug="restricted-workflow-permissions",
+        )
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+
+        group = Group.objects.create(
+            name="Workflow actions", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        group.roles.add(
+            Role.objects.get(name="Automatic translation"),
+            Role.objects.get(name="Bulk editing"),
+        )
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+
+        project_language = ProjectLanguage(self.project, self.translation.language)
+        category_language = CategoryLanguage(category, self.translation.language)
+        for obj in (self.translation, project_language, category_language):
+            with self.subTest(obj=obj):
+                self.assertTrue(self.user.has_perm("unit.edit", obj))
+                self.assertTrue(self.user.has_perm("translation.auto", obj))
+                self.assertTrue(self.user.has_perm("unit.bulk_edit", obj))
+
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=self.translation.language,
+            restrict_direct_editing=True,
+        )
+
+        translation = Translation.objects.get(pk=self.translation.pk)
+        project_language = ProjectLanguage(self.project, translation.language)
+        category_language = CategoryLanguage(category, translation.language)
+        for obj in (translation, project_language, category_language):
+            with self.subTest(obj=obj):
+                self.assertFalse(self.user.has_perm("unit.edit", obj))
+                self.assertTrue(self.user.has_perm("translation.auto", obj))
+                self.assertFalse(self.user.has_perm("unit.bulk_edit", obj))
+
+        self.project.add_user(self.user, "Administration")
+        self.user.clear_permissions_cache()
+        for obj in (translation, project_language, category_language):
+            with self.subTest(obj=obj):
+                self.assertTrue(self.user.has_perm("unit.edit", obj))
+                self.assertTrue(self.user.has_perm("translation.auto", obj))
+                self.assertTrue(self.user.has_perm("unit.bulk_edit", obj))
 
     def test_shared_category_source_language_review(self) -> None:
         project = Project.objects.create(

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -434,9 +434,13 @@ def check_upload_method_permissions(
     if method == "approve":
         return user.has_perm("unit.review", translation)
     if method == "replace":
-        return bool(translation.filename) and (
-            user.has_perm("component.edit", translation)
-            or user.has_perms(["unit.add", "unit.delete", "unit.edit"], translation)
+        return (
+            bool(translation.filename)
+            and user.has_perm("meta:unit.direct_edit", translation)
+            and (
+                user.has_perm("component.edit", translation)
+                or user.has_perms(["unit.add", "unit.delete", "unit.edit"], translation)
+            )
         )
     msg = f"Invalid method: {method}"
     raise ValueError(msg)

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -1204,6 +1204,12 @@ class ProjectLanguage(BaseURLMixin, TranslationChecklistMixin):
         return True
 
     @property
+    def restrict_direct_editing(self) -> bool:
+        if self.workflow_settings is not None:
+            return self.workflow_settings.restrict_direct_editing
+        return False
+
+    @property
     def is_readonly(self) -> bool:
         return False
 
@@ -1388,6 +1394,12 @@ class CategoryLanguage(BaseURLMixin, TranslationChecklistMixin):
         return any(
             translation.enable_suggestions for translation in self.translation_set
         )
+
+    @property
+    def restrict_direct_editing(self) -> bool:
+        if self.workflow_settings is not None:
+            return self.workflow_settings.restrict_direct_editing
+        return False
 
     @property
     def is_readonly(self) -> bool:


### PR DESCRIPTION
Projects need to keep selected languages open for suggestions while limiting direct changes to trusted users. Add an explicit language-scoped workflow restriction so this no longer depends on enabling suggestion auto-acceptance.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
