### PR TITLE
fix(vcs): defer repository error localization

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,7 +29,7 @@ Weblate 2026.8
 * Static assets now use content-hashed filenames, and CAPTCHA JavaScript is loaded only when needed.
 * :ref:`mt-aws` machine translation now supports configuring formality, brevity, and profanity masking.
 * Improved :ref:`screenshots` OCR reliability and error reporting when downloading recognition data.
-* Repository failure alerts now link directly to component version control settings for users who can edit them.
+* Repository failure alerts now link directly to component version control settings for users who can edit them, keep technical errors in English, and localize actionable diagnoses for each viewer, including GitHub pull request restrictions.
 * Celery workers now prefetch fewer tasks by default to reduce memory usage and improve task distribution.
 * Improved the recommended :ref:`running-granian` configuration and Docker container worker resilience for Weblate's WSGI workload.
 * Deployment checks now detect corrupted PostgreSQL relation statistics.

--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -62,7 +62,8 @@ class GitSquashAddon(
             repository.ensure_no_interrupted_operation()
         except RepositoryError as error:
             component.add_alert(
-                "RepositoryOperationFailure", error=component.error_text(error)
+                "RepositoryOperationFailure",
+                **component.get_repository_alert_details(error),
             )
             raise
 

--- a/weblate/templates/trans/alert/common-repo.html
+++ b/weblate/templates/trans/alert/common-repo.html
@@ -24,6 +24,16 @@
   </p>
 {% endif %}
 
+{% if analysis.github_pull_request_creation_restricted %}
+  <p>
+    {% if analysis.github_pull_request_creation_restricted_username %}
+      {% blocktranslate with username=analysis.github_pull_request_creation_restricted_username %}The GitHub repository allows only collaborators to create pull requests. Ask a repository maintainer to allow pull requests from all users or add <code>{{ username }}</code> as a collaborator.{% endblocktranslate %}
+    {% else %}
+      {% translate "The GitHub repository allows only collaborators to create pull requests. Ask a repository maintainer to allow pull requests from all users." %}
+    {% endif %}
+  </p>
+{% endif %}
+
 {% if analysis.temporary %}
   <p>{% translate "The upstream repository could not be temporarily accessed. Please try it again later." %}</p>
 {% endif %}

--- a/weblate/trans/alerts/vcs.py
+++ b/weblate/trans/alerts/vcs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext, gettext_lazy
 
 from weblate.trans.actions import ActionEvents
 from weblate.trans.alerts.base import (
@@ -22,13 +22,21 @@ from weblate.trans.hooks.matching import (
     repo_matches_exact_repos,
 )
 from weblate.vcs.base import (
-    is_ssh_host_key_mismatch_error,
-    is_ssh_host_key_verification_error,
+    RepositoryDiagnosis,
+    RepositoryDiagnosisCode,
+    RepositoryStructuredError,
+    format_stored_repository_error,
+    get_repository_error_diagnoses,
 )
 
 if TYPE_CHECKING:
     from weblate.auth.models import User
     from weblate.trans.models.component import Component
+
+
+def normalize_repository_error_fingerprint(error: str) -> str:
+    """Normalize legacy repository URL redaction in alert identities."""
+    return error.replace("repository URL", "...")
 
 
 class RepositoryAlert(BaseAlert):
@@ -49,17 +57,59 @@ class RepositoryErrorAlert(ErrorAlert):
     category = AlertCategory.VCS
     repository_permissions: tuple[str, ...] = ()
 
+    def __init__(
+        self,
+        instance,
+        error: str | RepositoryStructuredError,
+        diagnoses: list[RepositoryDiagnosis] | None = None,
+    ) -> None:
+        self.stored_error = error
+        canonical_error = format_stored_repository_error(error)
+        super().__init__(instance, canonical_error)
+        self.diagnoses = (
+            get_repository_error_diagnoses(canonical_error)
+            if diagnoses is None
+            else diagnoses
+        )
+
+    def get_context(self, user: User) -> dict[str, Any]:
+        result = super().get_context(user)
+        result["error"] = format_stored_repository_error(self.stored_error, gettext)
+        return result
+
+    def has_diagnosis(self, code: RepositoryDiagnosisCode) -> bool:
+        """Return whether the alert contains a diagnosis code."""
+        return any(diagnosis.get("code") == code for diagnosis in self.diagnoses)
+
+    def get_diagnosis_params(
+        self, code: RepositoryDiagnosisCode
+    ) -> dict[str, str] | None:
+        """Return parameters for the first matching diagnosis."""
+        for diagnosis in self.diagnoses:
+            if diagnosis.get("code") == code:
+                return diagnosis.get("params", {})
+        return None
+
     def get_analysis(self) -> dict[str, Any]:
-        normalized = self.error.lower()
         return {
-            "redirect": (
-                "returned error: 301" in normalized
-                or "returned error: 308" in normalized
-                or "http redirect" in normalized
-                or "permanently redirects" in normalized
-                or "repository url redirects" in normalized
-            )
+            "redirect": self.has_diagnosis("repository_redirect"),
         }
+
+    @classmethod
+    def get_dismissal_context(
+        cls, _component: Component, details: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Exclude diagnosis metadata from the repository failure identity."""
+        identity_details = {
+            key: value
+            for key, value in details.items()
+            if key not in {"diagnoses", "error"}
+        }
+        if error := details.get("error"):
+            identity_details["error"] = normalize_repository_error_fingerprint(
+                format_stored_repository_error(error)
+            )
+        return {"details": identity_details}
 
     @classmethod
     def can_user_act_for(
@@ -196,45 +246,18 @@ class RepositoryOperationFailure(RepositoryErrorAlert):
 class BaseGitFailure(RepositoryErrorAlert):
     category = AlertCategory.VCS
     link_wide = True
-    behind_messages = (
-        "The tip of your current branch is behind its remote counterpart",
-        "fetch first",
-    )
-    terminal_message = "terminal prompts disabled"
-    not_found_messages = (
-        "Repository not found.",
-        "HTTP Error 404: Not Found",
-        "Repository was archived so is read-only",
-        "does not appear to be a git repository",
-    )
-    temporary_messages = (
-        "Empty reply from server",
-        "no suitable response from remote hg",
-        "cannot lock ref",
-        "Too many retries",
-        "Connection timed out",
-    )
-    permission_messages = (
-        "denied to",
-        "The repository exists, but forking is disabled.",
-        "protected branch hook declined",
-        "GH006:",
-    )
-    gerrit_messages = (
-        "is not registered in your account, and you lack 'forge",
-        "prohibited by Gerrit",
-    )
 
     def get_analysis(self) -> dict[str, Any]:
         analysis = super().get_analysis()
-        terminal_disabled = self.terminal_message in self.error
+        github_pull_request_params = self.get_diagnosis_params(
+            "github_pull_request_creation_restricted"
+        )
+        terminal_disabled = self.has_diagnosis("missing_credentials")
         repo_suggestion = None
         force_push_suggestion = False
         component = self.instance.component
-        host_key_mismatch = is_ssh_host_key_mismatch_error(self.error)
-        host_key = (
-            is_ssh_host_key_verification_error(self.error) and not host_key_mismatch
-        )
+        host_key_mismatch = self.has_diagnosis("ssh_host_key_mismatch")
+        host_key = self.has_diagnosis("ssh_host_key_unverified")
         host_key_message = None
         if host_key_mismatch:
             host_key_message = component.get_ssh_host_key_mismatch_error_message()
@@ -248,7 +271,7 @@ class BaseGitFailure(RepositoryErrorAlert):
             elif component.repo.startswith("https://github.com/"):
                 repo_suggestion = f"git@github.com:{component.repo[19:]}"
 
-        behind = any(message in self.error for message in self.behind_messages)
+        behind = self.has_diagnosis("branch_behind")
         if behind:
             force_push_suggestion = (
                 component.vcs == "git"
@@ -263,15 +286,17 @@ class BaseGitFailure(RepositoryErrorAlert):
             "repo_suggestion": repo_suggestion,
             "force_push_suggestion": force_push_suggestion,
             "host_key_message": host_key_message,
-            "not_found": any(
-                message in self.error for message in self.not_found_messages
+            "not_found": self.has_diagnosis("repository_not_found"),
+            "permission": self.has_diagnosis("repository_permission"),
+            "gerrit": self.has_diagnosis("gerrit_permission"),
+            "temporary": self.has_diagnosis("temporary_failure"),
+            "github_pull_request_creation_restricted": (
+                github_pull_request_params is not None
             ),
-            "permission": any(
-                message in self.error for message in self.permission_messages
-            ),
-            "gerrit": any(message in self.error for message in self.gerrit_messages),
-            "temporary": any(
-                message in self.error for message in self.temporary_messages
+            "github_pull_request_creation_restricted_username": (
+                github_pull_request_params.get("username")
+                if github_pull_request_params
+                else None
             ),
         }
 

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -173,11 +173,16 @@ from weblate.utils.validators import (
     validate_slug,
 )
 from weblate.vcs.base import (
+    RepositoryAlertDetails,
+    RepositoryDiagnosis,
     RepositoryError,
+    RepositoryInternalError,
     RepositoryRecoveryEvent,
     RepositoryRedirectError,
     RepositoryRestrictedPathError,
+    RepositoryStructuredError,
     RepositorySymlinkError,
+    get_repository_error_diagnoses,
     is_ssh_host_key_mismatch_error,
     is_ssh_host_key_verification_error,
     should_auto_add_ssh_host_key,
@@ -2527,10 +2532,62 @@ class Component(  # ruff: ignore[too-many-public-methods]
     def error_text(self, error: RepositoryError) -> str:
         """Return text message for a RepositoryError."""
         return sanitize_backend_error_message(
-            error.get_message(),
+            error.get_message(gettext),
             repo_urls=(self.repo, self.push),
             extra_paths=(self.full_path,),
         )
+
+    def get_repository_alert_details(
+        self, error: RepositoryError
+    ) -> RepositoryAlertDetails:
+        """Build persistent, locale-independent repository alert details."""
+        error_text = sanitize_backend_error_message(
+            error.get_message(),
+            repo_urls=(self.repo, self.push),
+            extra_paths=(self.full_path,),
+            url_placeholder="...",
+        )
+        stored_error: str | RepositoryStructuredError
+        if isinstance(error, RepositoryInternalError):
+            stored_error = error.get_stored_error()
+            if params := stored_error.get("params"):
+                stored_error["params"] = {
+                    key: sanitize_backend_error_message(
+                        value,
+                        repo_urls=(self.repo, self.push),
+                        extra_paths=(self.full_path,),
+                        url_placeholder="...",
+                    )
+                    for key, value in params.items()
+                }
+        else:
+            stored_error = error_text
+        diagnoses: list[RepositoryDiagnosis] = []
+        seen: set[tuple[str, tuple[tuple[str, str], ...]]] = set()
+        for diagnosis in [
+            *error.diagnoses,
+            *get_repository_error_diagnoses(error_text),
+        ]:
+            params = diagnosis.get("params", {})
+            key = (diagnosis["code"], tuple(sorted(params.items())))
+            if key in seen:
+                continue
+            seen.add(key)
+            if params:
+                diagnosis = {
+                    "code": diagnosis["code"],
+                    "params": {
+                        key: sanitize_backend_error_message(
+                            value,
+                            repo_urls=(self.repo, self.push),
+                            extra_paths=(self.full_path,),
+                            url_placeholder="...",
+                        )
+                        for key, value in params.items()
+                    },
+                }
+            diagnoses.append(diagnosis)
+        return {"error": stored_error, "diagnoses": diagnoses}
 
     @staticmethod
     def get_ssh_host_key_error_message() -> str:
@@ -2670,7 +2727,9 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 self.handle_update_error(error_text, retry)
                 return self.update_remote_branch(True, False, user=user)
             if self.id:
-                self.add_alert("UpdateFailure", error=error_text)
+                self.add_alert(
+                    "UpdateFailure", **self.get_repository_alert_details(error)
+                )
             return False
 
         for line in self.repository.last_output.splitlines():
@@ -2981,7 +3040,9 @@ class Component(  # ruff: ignore[too-many-public-methods]
                         "error_text": error_text,
                     },
                 )
-                self.add_alert("PushFailure", error=error_text)
+                self.add_alert(
+                    "PushFailure", **self.get_repository_alert_details(error)
+                )
                 return False
             self.delete_alert("RepositoryChanges")
             self.delete_alert("PushFailure")
@@ -3892,11 +3953,12 @@ class Component(  # ruff: ignore[too-many-public-methods]
         """Surface failed recovery from interrupted repository operations."""
         if self._state.adding:
             return
+        details: RepositoryAlertDetails
         if isinstance(error, RepositoryError):
-            error_text = self.error_text(error)
+            details = self.get_repository_alert_details(error)
         else:
-            error_text = str(error)
-        self.add_alert("RepositoryOperationFailure", error=error_text)
+            details = {"error": str(error), "diagnoses": []}
+        self.add_alert("RepositoryOperationFailure", **details)
 
     @perform_on_link
     @contextmanager
@@ -4004,7 +4066,9 @@ class Component(  # ruff: ignore[too-many-public-methods]
                         author=user,
                         details=details,
                     )
-                    self.add_alert("MergeFailure", error=error_text)
+                    self.add_alert(
+                        "MergeFailure", **self.get_repository_alert_details(error)
+                    )
 
                 # Reset repo back
                 method_func(abort=True)
@@ -5782,7 +5846,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 project=self.project,
                 skip_error_reporting=not settings.DEBUG,
             )
-            self.add_alert("MergeFailure", error=self.error_text(error))
+            self.add_alert("MergeFailure", **self.get_repository_alert_details(error))
             return 0
 
     def _get_count_repo_outgoing(self, retry: bool = True):
@@ -5798,7 +5862,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 project=self.project,
                 skip_error_reporting=not settings.DEBUG,
             )
-            self.add_alert("PushFailure", error=error_text)
+            self.add_alert("PushFailure", **self.get_repository_alert_details(error))
             return 0
 
     @property
@@ -5836,7 +5900,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 project=self.project,
                 skip_error_reporting=not settings.DEBUG,
             )
-            self.add_alert("PushFailure", error=error_text)
+            self.add_alert("PushFailure", **self.get_repository_alert_details(error))
             return False
 
     @property

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -643,7 +643,9 @@ def repository_alerts(threshold: int = settings.REPOSITORY_ALERT_THRESHOLD) -> N
             update_repository_alerts(component, threshold)
         except RepositoryError as error:
             report_error("Could not check repository status", project=component.project)
-            component.add_alert("MergeFailure", error=component.error_text(error))
+            component.add_alert(
+                "MergeFailure", **component.get_repository_alert_details(error)
+            )
 
 
 def update_repository_alerts(component: Component, threshold: int) -> None:

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -21,6 +21,7 @@ from django.test import SimpleTestCase, override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.translation import override as translation_override
 
 from weblate.addons.gettext import MsgmergeAddon, SphinxAddon, XgettextAddon
 from weblate.addons.models import Addon
@@ -40,6 +41,7 @@ from weblate.trans.models import (
 )
 from weblate.trans.models.alert import Alert
 from weblate.trans.tests.test_views import ViewTestCase
+from weblate.vcs.base import RepositoryError, RepositoryInternalError
 from weblate.vcs.models import VCS_REGISTRY
 from weblate.workspaces.models import Workspace
 
@@ -786,6 +788,96 @@ class AlertTest(ViewTestCase):
             ).count(),
             1,
         )
+
+    def test_repository_diagnoses_do_not_reopen_dismissed_alert(self) -> None:
+        error = "Repository not found."
+        self.component.add_alert("UpdateFailure", error=error)
+        alert = self.component.alert_set.get(name="UpdateFailure")
+        alert.dismissed_at = timezone.now()
+        alert.dismissed_by = self.user
+        alert.dismissal_fingerprint = alert.obj.get_dismissal_fingerprint(
+            self.component, alert.details
+        )
+        alert.save(
+            update_fields=(
+                "dismissed_at",
+                "dismissed_by",
+                "dismissal_fingerprint",
+            )
+        )
+
+        self.component.add_alert(
+            "UpdateFailure",
+            error=error,
+            diagnoses=[{"code": "repository_not_found"}],
+        )
+
+        alert.refresh_from_db()
+        self.assertIsNotNone(alert.dismissed_at)
+        self.assertEqual(alert.details["diagnoses"], [{"code": "repository_not_found"}])
+        self.assertFalse(
+            self.component.change_set.filter(
+                action=ActionEvents.ALERT_REOPENED, alert=alert
+            ).exists()
+        )
+
+    def test_repository_url_redaction_does_not_reopen_dismissed_alert(self) -> None:
+        self.component.add_alert(
+            "UpdateFailure", error="fatal: failed to access repository URL (128)"
+        )
+        alert = self.component.alert_set.get(name="UpdateFailure")
+        alert.dismissed_at = timezone.now()
+        alert.dismissed_by = self.user
+        alert.dismissal_fingerprint = alert.obj.get_dismissal_fingerprint(
+            self.component, alert.details
+        )
+        alert.save(
+            update_fields=(
+                "dismissed_at",
+                "dismissed_by",
+                "dismissal_fingerprint",
+            )
+        )
+
+        self.component.add_alert(
+            "UpdateFailure", error="fatal: failed to access ... (128)", diagnoses=[]
+        )
+
+        alert.refresh_from_db()
+        self.assertIsNotNone(alert.dismissed_at)
+        self.assertFalse(
+            self.component.change_set.filter(
+                action=ActionEvents.ALERT_REOPENED, alert=alert
+            ).exists()
+        )
+
+    def test_repository_error_is_stored_structured_and_rendered_for_user(
+        self,
+    ) -> None:
+        error = RepositoryInternalError(0, "repository_url_invalid")
+
+        with translation_override("fr"):
+            # spellchecker:off
+            self.assertEqual(
+                self.component.error_text(error),
+                "Saisissez une URL valide.",  # codespell:ignore valide
+            )
+            # spellchecker:on
+            details = self.component.get_repository_alert_details(error)
+            self.component.add_alert("UpdateFailure", **details)
+
+        alert = self.component.alert_set.get(name="UpdateFailure")
+        self.assertEqual(
+            alert.details["error"],
+            {"code": "repository_url_invalid", "retcode": 0},
+        )
+        with translation_override("fr"):
+            # spellchecker:off
+            self.assertEqual(
+                alert.obj.get_context(self.user)["error"],
+                "Saisissez une URL valide.",  # codespell:ignore valide
+            )
+            # spellchecker:on
 
     def test_legacy_dismissal_reopens_on_first_refresh(self) -> None:
         self.component.add_alert("BrokenProjectURL", error="failure")
@@ -1887,6 +1979,233 @@ class RepositoryAlertTemplateTest(SimpleTestCase):
         )
 
         self.assertEqual(alert.get_analysis()["host_key_message"], "host key changed")
+
+    def test_repository_alert_uses_structured_diagnoses(self) -> None:
+        component = SimpleNamespace(
+            get_ssh_host_key_mismatch_error_message=lambda: "host key changed",
+            get_ssh_host_key_error_message=lambda: "host key missing",
+            push="",
+            repo="",
+            vcs="git",
+            merge_style="merge",
+            push_branch="",
+        )
+        alert = UpdateFailure(
+            cast("Alert", SimpleNamespace(component=component)),
+            "Repository not found.",
+            diagnoses=[],
+        )
+
+        self.assertFalse(alert.get_analysis()["not_found"])
+
+    def test_repository_alert_legacy_diagnosis_fallback(self) -> None:
+        component = SimpleNamespace(
+            get_ssh_host_key_mismatch_error_message=lambda: "host key changed",
+            get_ssh_host_key_error_message=lambda: "host key missing",
+            push="",
+            repo="",
+            vcs="git",
+            merge_style="merge",
+            push_branch="",
+        )
+        alert = UpdateFailure(
+            cast("Alert", SimpleNamespace(component=component)),
+            "Repository not found.",
+        )
+
+        self.assertTrue(alert.get_analysis()["not_found"])
+
+    def test_repository_diagnosis_is_localized_when_rendered(self) -> None:
+        analysis = {
+            "not_found": True,
+            "github_pull_request_creation_restricted": False,
+            "github_pull_request_creation_restricted_username": None,
+        }
+
+        with translation_override("fr"):
+            rendered = render_to_string(
+                "trans/alert/common-repo.html", {"analysis": analysis}
+            )
+
+        self.assertIn("n’a pas été trouvé. Veuillez vérifier", rendered)
+
+    def test_github_pull_request_diagnosis_renders_username(self) -> None:
+        rendered = render_to_string(
+            "trans/alert/common-repo.html",
+            {
+                "analysis": {
+                    "github_pull_request_creation_restricted": True,
+                    "github_pull_request_creation_restricted_username": (
+                        "<integration>"
+                    ),
+                }
+            },
+        )
+
+        self.assertIn(
+            "allow pull requests from all users or add "
+            "<code>&lt;integration&gt;</code> as a collaborator",
+            rendered,
+        )
+
+    def test_github_app_pull_request_diagnosis_omits_username(self) -> None:
+        rendered = render_to_string(
+            "trans/alert/common-repo.html",
+            {
+                "analysis": {
+                    "github_pull_request_creation_restricted": True,
+                    "github_pull_request_creation_restricted_username": None,
+                }
+            },
+        )
+
+        self.assertIn(
+            "Ask a repository maintainer to allow pull requests from all users",
+            rendered,
+        )
+        self.assertNotIn("x-access-token", rendered)
+
+    def test_repository_alert_details_store_structured_error_and_diagnoses(
+        self,
+    ) -> None:
+        component = SimpleNamespace(
+            repo="https://example.com/repository",
+            push="",
+            full_path=Path.cwd() / "repository",
+        )
+        error = RepositoryInternalError(
+            1,
+            "repository_fork_not_found",
+            params={"hostname": "example.com", "username": "weblate"},
+            diagnoses=(
+                {
+                    "code": "github_pull_request_creation_restricted",
+                    "params": {"username": "weblate"},
+                },
+            ),
+        )
+
+        details = Component.get_repository_alert_details(  # type: ignore[arg-type]
+            component, error
+        )
+
+        self.assertEqual(
+            details["error"],
+            {
+                "code": "repository_fork_not_found",
+                "retcode": 1,
+                "params": {"hostname": "example.com", "username": "weblate"},
+            },
+        )
+        self.assertEqual(
+            details["diagnoses"],
+            [
+                {
+                    "code": "github_pull_request_creation_restricted",
+                    "params": {"username": "weblate"},
+                },
+                {"code": "repository_not_found"},
+            ],
+        )
+
+    def test_repository_alert_details_keep_external_error_text(self) -> None:
+        component = SimpleNamespace(
+            repo="https://user:super-secret-token@example.com/repository",
+            push="",
+            full_path=Path.cwd() / "repository",
+        )
+
+        with translation_override("fr"):
+            details = Component.get_repository_alert_details(  # type: ignore[arg-type]
+                component,
+                RepositoryError(128, f"fatal: failed to access {component.repo}"),
+            )
+
+        self.assertEqual(details["error"], "fatal: failed to access ... (128)")
+
+    def test_repository_alert_details_sanitize_structured_params(self) -> None:
+        component = SimpleNamespace(
+            repo="https://user:super-secret-token@example.com/repository",
+            push="",
+            full_path=Path.cwd() / "repository",
+        )
+        error = RepositoryInternalError(
+            0,
+            "repository_redirect_probe_failed",
+            params={
+                "error": (
+                    f"Failed to access {component.repo} from "
+                    f"{component.full_path}/private"
+                )
+            },
+        )
+
+        with translation_override("fr"):
+            details = Component.get_repository_alert_details(  # type: ignore[arg-type]
+                component, error
+            )
+
+        assert isinstance(details["error"], dict)
+        stored_detail = details["error"]["params"]["error"]
+        self.assertEqual(stored_detail, "Failed to access ... from .../private")
+        self.assertNotIn("super-secret-token", stored_detail)
+
+    def test_structured_repository_alert_error_is_localized_when_rendered(
+        self,
+    ) -> None:
+        details = {
+            "error": {"code": "repository_url_invalid", "retcode": 0},
+            "diagnoses": [],
+        }
+        instance = SimpleNamespace(
+            component=SimpleNamespace(), details=details, timestamp=None
+        )
+        alert = RepositoryErrorAlert(cast("Alert", instance), **details)
+        user = SimpleNamespace()
+
+        self.assertEqual(alert.get_context(user)["error"], "Enter a valid URL.")
+        with translation_override("fr"):
+            # spellchecker:off
+            self.assertEqual(
+                alert.get_context(user)["error"],
+                "Saisissez une URL valide.",  # codespell:ignore valide
+            )
+            # spellchecker:on
+
+    def test_structured_repository_error_preserves_legacy_fingerprint(self) -> None:
+        legacy_details = {"error": "Enter a valid URL.", "diagnoses": []}
+        structured_details = {
+            "error": {"code": "repository_url_invalid", "retcode": 0},
+            "diagnoses": [],
+        }
+
+        self.assertEqual(
+            RepositoryErrorAlert.get_dismissal_fingerprint(
+                SimpleNamespace(), legacy_details
+            ),
+            RepositoryErrorAlert.get_dismissal_fingerprint(
+                SimpleNamespace(), structured_details
+            ),
+        )
+
+    def test_repository_url_redaction_preserves_legacy_fingerprint(self) -> None:
+        legacy_details = {
+            "error": "fatal: failed to access repository URL (128)",
+            "diagnoses": [],
+        }
+        current_details = {
+            "error": "fatal: failed to access ... (128)",
+            "diagnoses": [],
+        }
+
+        self.assertEqual(
+            RepositoryErrorAlert.get_dismissal_fingerprint(
+                SimpleNamespace(), legacy_details
+            ),
+            RepositoryErrorAlert.get_dismissal_fingerprint(
+                SimpleNamespace(), current_details
+            ),
+        )
 
     def test_common_repo_renders_host_key_mismatch_message(self) -> None:
         rendered = render_to_string(

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -3438,13 +3438,16 @@ class ComponentHostKeyHandlingTest(SimpleTestCase):
         )
 
     def test_repo_needs_push_host_key_mismatch_skips_tofu_retry(self) -> None:
+        error = RepositoryError(255, HOST_KEY_MISMATCH_ERROR)
         component = SimpleNamespace(
-            repository=Mock(
-                needs_push=Mock(
-                    side_effect=RepositoryError(255, HOST_KEY_MISMATCH_ERROR)
-                )
-            ),
+            repository=Mock(needs_push=Mock(side_effect=error)),
             error_text=Mock(return_value=HOST_KEY_MISMATCH_ERROR),
+            get_repository_alert_details=Mock(
+                return_value={
+                    "error": HOST_KEY_MISMATCH_ERROR,
+                    "diagnoses": [{"code": "ssh_host_key_mismatch"}],
+                }
+            ),
             add_alert=Mock(),
             add_ssh_host_key=Mock(),
             push_branch="main",
@@ -3457,8 +3460,11 @@ class ComponentHostKeyHandlingTest(SimpleTestCase):
             )
 
         component.add_ssh_host_key.assert_not_called()
+        component.get_repository_alert_details.assert_called_once_with(error)
         component.add_alert.assert_called_once_with(
-            "PushFailure", error=HOST_KEY_MISMATCH_ERROR
+            "PushFailure",
+            error=HOST_KEY_MISMATCH_ERROR,
+            diagnoses=[{"code": "ssh_host_key_mismatch"}],
         )
         mocked_report.assert_called_once()
 

--- a/weblate/trans/tests/test_remote.py
+++ b/weblate/trans/tests/test_remote.py
@@ -324,6 +324,11 @@ class MultiRepoTest(ViewTestCase):
         self.assertEqual(change.details["error"], "fetch failed (1)")
         self.assertEqual(change.details["previous_remote_revision"], "old-remote")
         self.assertIn("fetch failed", change.get_details_display())
+        alert = self.component2.alert_set.get(name="UpdateFailure")
+        self.assertEqual(
+            alert.details,
+            {"error": "fetch failed (1)", "diagnoses": []},
+        )
 
     def test_remote_update_history_failure_skips_validation(self) -> None:
         """Test repository validation does not record failed update history."""

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -192,10 +192,12 @@ def sanitize_backend_error_message(
     *,
     repo_urls: Iterable[str | None] = (),
     extra_paths: Iterable[os.PathLike[str] | str | None] = (),
+    url_placeholder: str | None = None,
 ) -> str:
     """Strip internal transport and filesystem details from backend errors."""
     result = str(text)
-    url_placeholder = gettext("repository URL")
+    if url_placeholder is None:
+        url_placeholder = gettext("repository URL")
 
     for repo_url in repo_urls:
         if repo_url:

--- a/weblate/utils/outbound.py
+++ b/weblate/utils/outbound.py
@@ -302,7 +302,9 @@ def resolve_runtime_hostname(
         )
     except OSError as error:
         raise ValidationError(
-            gettext("Could not resolve the URL domain: {}").format(error)
+            gettext("Could not resolve the URL domain: {}").format(error),
+            code="url_unresolved_with_error",
+            params={"error": str(error)},
         ) from error
 
     return _validate_runtime_addresses(
@@ -326,7 +328,9 @@ async def async_resolve_runtime_hostname(
         )
     except OSError as error:
         raise ValidationError(
-            gettext("Could not resolve the URL domain: {}").format(error)
+            gettext("Could not resolve the URL domain: {}").format(error),
+            code="url_unresolved_with_error",
+            params={"error": str(error)},
         ) from error
 
     return _validate_runtime_addresses(
@@ -352,7 +356,9 @@ def _prepare_runtime_hostname(
         return idna_encode(normalized, uts46=True).decode("ascii"), ()
     except (IDNAError, UnicodeError) as error:
         raise ValidationError(
-            gettext("Could not resolve the URL domain: {}").format(error)
+            gettext("Could not resolve the URL domain: {}").format(error),
+            code="url_unresolved_with_error",
+            params={"error": str(error)},
         ) from error
 
 
@@ -366,7 +372,9 @@ def _validate_runtime_addresses(
             validate_runtime_ip(address, allow_private_targets=allow_private_targets)
             result.append(address)
     if not result:
-        raise ValidationError(gettext("Could not resolve the URL domain."))
+        raise ValidationError(
+            gettext("Could not resolve the URL domain."), code="url_unresolved"
+        )
     return tuple(result)
 
 

--- a/weblate/utils/validators.py
+++ b/weblate/utils/validators.py
@@ -921,7 +921,10 @@ def resolve_repo_hostname(
     policy_hostname = policy_hostname or hostname
     if settings.VCS_ALLOW_HOSTS and policy_hostname not in settings.VCS_ALLOW_HOSTS:
         raise ValidationError(
-            gettext("Fetching VCS repository from %s is not allowed.") % policy_hostname
+            gettext("Fetching VCS repository from %s is not allowed.")
+            % policy_hostname,
+            code="repository_host_not_allowed",
+            params={"hostname": policy_hostname},
         )
     allow_private_targets = (
         policy_hostname in settings.VCS_ALLOW_HOSTS or not settings.VCS_RESTRICT_PRIVATE
@@ -951,7 +954,10 @@ def resolve_repo_url(
         if os.path.isabs(url) or url.startswith(("./", "../")):
             if "file" not in settings.VCS_ALLOW_SCHEMES:
                 raise ValidationError(
-                    gettext("Fetching VCS repository using %s is not allowed.") % "file"
+                    gettext("Fetching VCS repository using %s is not allowed.")
+                    % "file",
+                    code="repository_scheme_not_allowed",
+                    params={"scheme": "file"},
                 )
             return None
         # assume all links without schema are ssh links
@@ -960,7 +966,9 @@ def resolve_repo_url(
             parsed = urlparse(normalized_url)
         except ValueError as error:
             raise ValidationError(
-                gettext("Could not parse URL: {}").format(error)
+                gettext("Could not parse URL: {}").format(error),
+                code="url_parse_failed",
+                params={"error": str(error)},
             ) from error
 
     # Allow Weblate internal URLs
@@ -970,7 +978,9 @@ def resolve_repo_url(
     # Filter out schemes early
     if parsed.scheme not in settings.VCS_ALLOW_SCHEMES:
         raise ValidationError(
-            gettext("Fetching VCS repository using %s is not allowed.") % parsed.scheme
+            gettext("Fetching VCS repository using %s is not allowed.") % parsed.scheme,
+            code="repository_scheme_not_allowed",
+            params={"scheme": parsed.scheme},
         )
 
     # URL validation using for http (the URL validator is too strict to handle others)
@@ -983,14 +993,16 @@ def resolve_repo_url(
     if parsed.scheme == "file":
         if hostname is None:
             return None
-        raise ValidationError(gettext("Could not parse URL."))
+        raise ValidationError(gettext("Could not parse URL."), code="url_parse_invalid")
 
     if hostname is None:
-        raise ValidationError(gettext("Could not parse URL."))
+        raise ValidationError(gettext("Could not parse URL."), code="url_parse_invalid")
 
     if settings.VCS_ALLOW_HOSTS and hostname not in settings.VCS_ALLOW_HOSTS:
         raise ValidationError(
-            gettext("Fetching VCS repository from %s is not allowed.") % hostname
+            gettext("Fetching VCS repository from %s is not allowed.") % hostname,
+            code="repository_host_not_allowed",
+            params={"hostname": hostname},
         )
 
     allow_private_targets = (
@@ -1001,7 +1013,9 @@ def resolve_repo_url(
         explicit_port = None if implicit_ssh else parsed.port
     except ValueError as error:
         raise ValidationError(
-            gettext("Could not parse URL: {}").format(error)
+            gettext("Could not parse URL: {}").format(error),
+            code="url_parse_failed",
+            params={"error": str(error)},
         ) from error
     port = explicit_port
     if port is None:

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -32,7 +32,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import gettext, gettext_lazy
+from django.utils.translation import gettext_lazy, gettext_noop
 from packaging.version import Version
 
 from weblate.trans.util import path_separator
@@ -51,7 +51,7 @@ from weblate.utils.outbound import get_environment_proxy
 from weblate.vcs.ssh import SSH_WRAPPER
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterator
+    from collections.abc import Callable, Generator, Iterable, Iterator
 
     import httpx2
     from django_stubs_ext import StrOrPromise
@@ -127,6 +127,281 @@ class CommitInfo(TypedDict):
 
 
 type RemoteOperation = Literal["none", "pull", "push"]
+type RepositoryDiagnosisCode = Literal[
+    "branch_behind",
+    "gerrit_permission",
+    "github_pull_request_creation_restricted",
+    "missing_credentials",
+    "repository_not_found",
+    "repository_permission",
+    "repository_redirect",
+    "ssh_host_key_mismatch",
+    "ssh_host_key_unverified",
+    "temporary_failure",
+]
+type RepositoryErrorCode = Literal[
+    "api_error",
+    "api_error_retry",
+    "api_request_failed",
+    "api_request_failed_retry",
+    "api_request_failed_with_error",
+    "api_request_failed_with_error_retry",
+    "github_app_branch_required",
+    "github_app_installation_invalid",
+    "github_app_installation_missing",
+    "github_app_installation_missing_for_host",
+    "github_app_token_failed",
+    "github_app_workspace_required",
+    "gitlab_project_failed",
+    "gitlab_project_failed_unknown",
+    "pull_request_listing_failed",
+    "pull_request_listing_failed_retry",
+    "repository_fork_failed",
+    "repository_fork_not_found",
+    "repository_fork_failed_retry",
+    "repository_fork_failed_with_error",
+    "repository_fork_failed_with_error_retry",
+    "repository_interrupted_operation",
+    "repository_recovery_failed",
+    "repository_redirect",
+    "repository_redirect_credentials",
+    "repository_redirect_cross_host",
+    "repository_redirect_insecure",
+    "repository_redirect_invalid",
+    "repository_redirect_invalid_hostname",
+    "repository_redirect_loop",
+    "repository_redirect_missing_address",
+    "repository_redirect_missing_target",
+    "repository_redirect_not_smart_http",
+    "repository_redirect_probe_failed",
+    "repository_redirect_query_changed",
+    "repository_redirect_target_invalid",
+    "repository_redirect_target_unverified",
+    "repository_redirect_too_many",
+    "repository_redirect_unsupported_scheme",
+    "repository_remote_branch_shallow",
+    "repository_remote_branch_unrelated",
+    "repository_ssh_destination_unresolved",
+    "repository_ssh_destination_unresolved_with_error",
+    "repository_unsupported_interrupted_operation",
+    "repository_url_backend_unsupported",
+    "repository_url_host_not_allowed",
+    "repository_url_invalid",
+    "repository_url_parse_invalid",
+    "repository_url_parse_failed",
+    "repository_url_private_target",
+    "repository_url_scheme_not_allowed",
+    "repository_url_unresolved",
+    "repository_url_unresolved_with_error",
+]
+
+
+class RepositoryDiagnosis(TypedDict):
+    """Machine-readable diagnosis for a repository error."""
+
+    code: RepositoryDiagnosisCode
+    params: NotRequired[dict[str, str]]
+
+
+class RepositoryStructuredError(TypedDict):
+    """Machine-readable repository error stored in an alert."""
+
+    code: RepositoryErrorCode
+    retcode: int
+    params: NotRequired[dict[str, str]]
+
+
+class RepositoryAlertDetails(TypedDict):
+    """Persistent details for a repository failure alert."""
+
+    error: str | RepositoryStructuredError
+    diagnoses: list[RepositoryDiagnosis]
+
+
+REPOSITORY_ERROR_MESSAGES: dict[RepositoryErrorCode, str] = {
+    "api_error": gettext_noop("%(detail)s"),
+    "api_error_retry": gettext_noop("%(detail)s Please retry later."),
+    "api_request_failed": gettext_noop(
+        "%(service)s API request failed while creating a pull request: %(status)s"
+    ),
+    "api_request_failed_retry": gettext_noop(
+        "%(service)s API request failed while creating a pull request: %(status)s Please retry later."
+    ),
+    "api_request_failed_with_error": gettext_noop(
+        "%(service)s API request failed while creating a pull request (%(status)s): %(error)s"
+    ),
+    "api_request_failed_with_error_retry": gettext_noop(
+        "%(service)s API request failed while creating a pull request (%(status)s): %(error)s Please retry later."
+    ),
+    "github_app_branch_required": gettext_noop(
+        "GitHub App repositories must be imported with a branch."
+    ),
+    "github_app_installation_invalid": gettext_noop(
+        "Invalid GitHub App installation ID."
+    ),
+    "github_app_installation_missing": gettext_noop(
+        "No Weblate GitHub app installation available."
+    ),
+    "github_app_installation_missing_for_host": gettext_noop(
+        "No Weblate GitHub app installation available for %(hostname)s"
+    ),
+    "github_app_token_failed": gettext_noop(
+        "Could not obtain GitHub App access token: %(error)s"
+    ),
+    "github_app_workspace_required": gettext_noop(
+        "GitHub App components require a project with a workspace."
+    ),
+    "gitlab_project_failed": gettext_noop(
+        "Could not get GitLab project (%(status)s): %(error)s"
+    ),
+    "gitlab_project_failed_unknown": gettext_noop(
+        "Could not get GitLab project (%(status)s): Unknown error"
+    ),
+    "pull_request_listing_failed": gettext_noop(
+        "Pull request listing failed: %(error)s"
+    ),
+    "pull_request_listing_failed_retry": gettext_noop(
+        "Pull request listing failed: %(error)s Please retry later."
+    ),
+    "repository_fork_failed": gettext_noop("Could not fork repository at %(hostname)s"),
+    "repository_fork_failed_retry": gettext_noop(
+        "Could not fork repository at %(hostname)s. Please retry later."
+    ),
+    "repository_fork_failed_with_error": gettext_noop(
+        "Could not fork repository at %(hostname)s: %(error)s"
+    ),
+    "repository_fork_failed_with_error_retry": gettext_noop(
+        "Could not fork repository at %(hostname)s: %(error)s Please retry later."
+    ),
+    "repository_fork_not_found": gettext_noop(
+        "Could not fork repository at %(hostname)s: Repository not found. "
+        "Check whether exists and user '%(username)s' has access to it."
+    ),
+    "repository_interrupted_operation": gettext_noop(
+        "Repository has an interrupted Git %(operation)s operation."
+    ),
+    "repository_recovery_failed": gettext_noop(
+        "Could not recover interrupted Git %(operation)s operation."
+    ),
+    "repository_redirect": gettext_noop(
+        "The repository URL permanently redirects to a canonical URL."
+    ),
+    "repository_redirect_credentials": gettext_noop(
+        "The repository HTTP redirect contains credentials and was rejected."
+    ),
+    "repository_redirect_cross_host": gettext_noop(
+        "The repository URL redirects to a different host. Automatic cross-host redirects are disabled for security; update the repository URL manually."
+    ),
+    "repository_redirect_insecure": gettext_noop(
+        "The repository URL redirects from HTTPS to an insecure URL and was rejected."
+    ),
+    "repository_redirect_invalid": gettext_noop(
+        "The repository returned an invalid HTTP redirect."
+    ),
+    "repository_redirect_invalid_hostname": gettext_noop(
+        "The repository returned an HTTP redirect with an invalid hostname."
+    ),
+    "repository_redirect_loop": gettext_noop(
+        "The repository HTTP redirect contains a loop."
+    ),
+    "repository_redirect_missing_address": gettext_noop(
+        "The repository redirect target has no validated address."
+    ),
+    "repository_redirect_missing_target": gettext_noop(
+        "The repository returned a permanent HTTP redirect without a target URL."
+    ),
+    "repository_redirect_not_smart_http": gettext_noop(
+        "The repository HTTP redirect does not point to a Git smart HTTP endpoint."
+    ),
+    "repository_redirect_probe_failed": gettext_noop(
+        "Could not probe the repository HTTP redirect: %(error)s"
+    ),
+    "repository_redirect_query_changed": gettext_noop(
+        "The repository HTTP redirect unexpectedly changed the URL query."
+    ),
+    "repository_redirect_target_invalid": gettext_noop(
+        "The repository HTTP redirect target could not be validated."
+    ),
+    "repository_redirect_target_unverified": gettext_noop(
+        "The repository HTTP redirect target could not be verified as a Git repository."
+    ),
+    "repository_redirect_too_many": gettext_noop(
+        "The repository returned too many HTTP redirects."
+    ),
+    "repository_redirect_unsupported_scheme": gettext_noop(
+        "The repository URL redirects to an unsupported URL scheme."
+    ),
+    "repository_remote_branch_shallow": gettext_noop(
+        "Remote branch could not be verified against the shallow existing repository."
+    ),
+    "repository_remote_branch_unrelated": gettext_noop(
+        "Remote branch does not share common history with the existing repository."
+    ),
+    "repository_ssh_destination_unresolved": gettext_noop(
+        "Could not determine the effective SSH destination."
+    ),
+    "repository_ssh_destination_unresolved_with_error": gettext_noop(
+        "Could not determine the effective SSH destination: %(error)s"
+    ),
+    "repository_unsupported_interrupted_operation": gettext_noop(
+        "Unsupported interrupted Git operation: %(operation)s"
+    ),
+    "repository_url_backend_unsupported": gettext_noop(
+        "This VCS backend cannot safely connect to this URL while private address restrictions are enabled."
+    ),
+    "repository_url_host_not_allowed": gettext_noop(
+        "Fetching VCS repository from %(hostname)s is not allowed."
+    ),
+    "repository_url_invalid": gettext_noop("Enter a valid URL."),
+    "repository_url_parse_invalid": gettext_noop("Could not parse URL."),
+    "repository_url_parse_failed": gettext_noop("Could not parse URL: %(error)s"),
+    "repository_url_private_target": gettext_noop(
+        "This URL is prohibited because it points to an internal or non-public address."
+    ),
+    "repository_url_scheme_not_allowed": gettext_noop(
+        "Fetching VCS repository using %(scheme)s is not allowed."
+    ),
+    "repository_url_unresolved": gettext_noop("Could not resolve the URL domain."),
+    "repository_url_unresolved_with_error": gettext_noop(
+        "Could not resolve the URL domain: %(error)s"
+    ),
+}
+
+
+REPOSITORY_REDIRECT_MESSAGES = (
+    "returned error: 301",
+    "returned error: 308",
+    "http redirect",
+    "permanently redirects",
+    "repository url redirects",
+)
+REPOSITORY_BEHIND_MESSAGES = (
+    "The tip of your current branch is behind its remote counterpart",
+    "fetch first",
+)
+REPOSITORY_NOT_FOUND_MESSAGES = (
+    "Repository not found.",
+    "HTTP Error 404: Not Found",
+    "Repository was archived so is read-only",
+    "does not appear to be a git repository",
+)
+REPOSITORY_TEMPORARY_MESSAGES = (
+    "Empty reply from server",
+    "no suitable response from remote hg",
+    "cannot lock ref",
+    "Too many retries",
+    "Connection timed out",
+)
+REPOSITORY_PERMISSION_MESSAGES = (
+    "denied to",
+    "The repository exists, but forking is disabled.",
+    "protected branch hook declined",
+    "GH006:",
+)
+REPOSITORY_GERRIT_PERMISSION_MESSAGES = (
+    "is not registered in your account, and you lack 'forge",
+    "prohibited by Gerrit",
+)
 
 
 @dataclass(slots=True)
@@ -229,11 +504,18 @@ class RepositoryLock:
 class RepositoryError(Exception):
     """Error while working with a repository."""
 
-    def __init__(self, retcode: int, message: str) -> None:
+    def __init__(
+        self,
+        retcode: int,
+        message: str,
+        *,
+        diagnoses: Iterable[RepositoryDiagnosis] = (),
+    ) -> None:
         super().__init__(message)
         self.retcode = retcode
+        self.diagnoses = list(diagnoses)
 
-    def get_message(self):
+    def get_message(self, translator: Callable[[str], str] | None = None) -> str:
         if self.retcode != 0:
             return f"{self.args[0]} ({self.retcode})"
         return self.args[0]
@@ -242,10 +524,60 @@ class RepositoryError(Exception):
         return self.get_message()
 
 
+class RepositoryInternalError(RepositoryError):
+    """Structured error for failures generated by Weblate itself."""
+
+    def __init__(
+        self,
+        retcode: int,
+        code: RepositoryErrorCode,
+        *,
+        params: dict[str, str] | None = None,
+        diagnoses: Iterable[RepositoryDiagnosis] = (),
+    ) -> None:
+        self.code = code
+        self.params = params or {}
+        super().__init__(retcode, code, diagnoses=diagnoses)
+
+    def get_message(self, translator: Callable[[str], str] | None = None) -> str:
+        template = REPOSITORY_ERROR_MESSAGES[self.code]
+        if translator is not None:
+            template = translator(template)
+        message = template % self.params
+        if self.retcode != 0:
+            return f"{message} ({self.retcode})"
+        return message
+
+    def get_stored_error(self) -> RepositoryStructuredError:
+        """Return a JSON-safe structured representation for persistent storage."""
+        result: RepositoryStructuredError = {
+            "code": self.code,
+            "retcode": self.retcode,
+        }
+        if self.params:
+            result["params"] = self.params
+        return result
+
+
+def format_stored_repository_error(
+    error: str | RepositoryStructuredError,
+    translator: Callable[[str], str] | None = None,
+) -> str:
+    """Format a raw or structured repository error for a consumer."""
+    if isinstance(error, str):
+        return error
+    structured = RepositoryInternalError(
+        error["retcode"],
+        error["code"],
+        params=error.get("params"),
+    )
+    return structured.get_message(translator)
+
+
 class RepositoryCommandError(RepositoryError):
     """Error raised by the underlying VCS command."""
 
-    def get_message(self):
+    def get_message(self, translator: Callable[[str], str] | None = None) -> str:
         if self.retcode < 0:
             signum = -self.retcode
             with suppress(ValueError):
@@ -265,14 +597,14 @@ class RepositoryCommandError(RepositoryError):
                 if message:
                     return f"{message}\n\n{hint} ({self.retcode})"
                 return f"{hint} ({self.retcode})"
-        return super().get_message()
+        return super().get_message(translator)
 
 
-class RepositoryValidationError(RepositoryError):
+class RepositoryValidationError(RepositoryInternalError):
     """Error raised when repository configuration violates runtime policy."""
 
 
-class RepositoryRedirectError(RepositoryError):
+class RepositoryRedirectError(RepositoryInternalError):
     """A repository URL permanently redirects to a validated canonical URL."""
 
     def __init__(
@@ -283,7 +615,8 @@ class RepositoryRedirectError(RepositoryError):
     ) -> None:
         super().__init__(
             0,
-            gettext("The repository URL permanently redirects to a canonical URL."),
+            "repository_redirect",
+            diagnoses=({"code": "repository_redirect"},),
         )
         self.original_url = original_url
         self.canonical_url = canonical_url
@@ -311,6 +644,33 @@ def is_ssh_host_key_mismatch_error(errormessage: str) -> bool:
         or "possible dns spoofing detected" in normalized
         or ("host key for" in normalized and "has changed" in normalized)
     )
+
+
+def get_repository_error_diagnoses(error: str) -> list[RepositoryDiagnosis]:
+    """Classify a repository error into stable machine-readable diagnoses."""
+    diagnoses: list[RepositoryDiagnosis] = []
+    normalized = error.lower()
+
+    if any(message in normalized for message in REPOSITORY_REDIRECT_MESSAGES):
+        diagnoses.append({"code": "repository_redirect"})
+    if "terminal prompts disabled" in error:
+        diagnoses.append({"code": "missing_credentials"})
+    if any(message in error for message in REPOSITORY_BEHIND_MESSAGES):
+        diagnoses.append({"code": "branch_behind"})
+    if is_ssh_host_key_mismatch_error(error):
+        diagnoses.append({"code": "ssh_host_key_mismatch"})
+    elif is_ssh_host_key_verification_error(error):
+        diagnoses.append({"code": "ssh_host_key_unverified"})
+    if any(message in error for message in REPOSITORY_NOT_FOUND_MESSAGES):
+        diagnoses.append({"code": "repository_not_found"})
+    if any(message in error for message in REPOSITORY_PERMISSION_MESSAGES):
+        diagnoses.append({"code": "repository_permission"})
+    if any(message in error for message in REPOSITORY_GERRIT_PERMISSION_MESSAGES):
+        diagnoses.append({"code": "gerrit_permission"})
+    if any(message in error for message in REPOSITORY_TEMPORARY_MESSAGES):
+        diagnoses.append({"code": "temporary_failure"})
+
+    return diagnoses
 
 
 def should_auto_add_ssh_host_key(errormessage: str) -> bool:
@@ -756,7 +1116,50 @@ class Repository:
                 proxy_url=get_environment_proxy(url),
             )
         except ValidationError as error:
-            raise RepositoryValidationError(0, "; ".join(error.messages)) from error
+            validation_error = error.error_list[0]
+            error_codes: dict[
+                str | None, tuple[RepositoryErrorCode, tuple[str, ...]]
+            ] = {
+                "invalid": ("repository_url_invalid", ()),
+                "private_target": ("repository_url_private_target", ()),
+                "repository_host_not_allowed": (
+                    "repository_url_host_not_allowed",
+                    ("hostname",),
+                ),
+                "repository_scheme_not_allowed": (
+                    "repository_url_scheme_not_allowed",
+                    ("scheme",),
+                ),
+                "ssh_destination_unresolved": (
+                    "repository_ssh_destination_unresolved",
+                    (),
+                ),
+                "ssh_destination_unresolved_with_error": (
+                    "repository_ssh_destination_unresolved_with_error",
+                    ("error",),
+                ),
+                "url_parse_failed": ("repository_url_parse_failed", ("error",)),
+                "url_parse_invalid": ("repository_url_parse_invalid", ()),
+                "url_unresolved": ("repository_url_unresolved", ()),
+                "url_unresolved_with_error": (
+                    "repository_url_unresolved_with_error",
+                    ("error",),
+                ),
+            }
+            code, param_names = error_codes.get(
+                validation_error.code, ("repository_url_invalid", ())
+            )
+            validation_params = validation_error.params or {}
+            params = {
+                name: str(validation_params[name])
+                for name in param_names
+                if name in validation_params
+            }
+            raise RepositoryValidationError(
+                0,
+                code,
+                params=params,
+            ) from error
         if (
             target is not None
             and target.requires_pinning
@@ -764,9 +1167,7 @@ class Repository:
         ):
             raise RepositoryValidationError(
                 0,
-                gettext(
-                    "This VCS backend cannot safely connect to this URL while private address restrictions are enabled."
-                ),
+                "repository_url_backend_unsupported",
             )
         return target
 

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -71,9 +71,12 @@ from weblate.utils.zip import (
 from weblate.vcs.base import (
     Repository,
     RepositoryCommandError,
+    RepositoryDiagnosis,
     RepositoryError,
+    RepositoryInternalError,
     RepositoryRecoveryEvent,
     RepositoryRedirectError,
+    RepositoryValidationError,
 )
 from weblate.vcs.gpg import get_gpg_sign_key
 from weblate.vcs.ssh import SSH_WRAPPER, resolve_ssh_destination
@@ -89,6 +92,7 @@ if TYPE_CHECKING:
     from weblate.utils.validators import ResolvedRepositoryURL
     from weblate.vcs.base import (
         RawCommitInfo,
+        RepositoryErrorCode,
     )
 
 LOCK_ERROR = re.compile(r"Unable to create '([^']*\.git/[^']*\.lock)': File exists")
@@ -123,10 +127,7 @@ class GitProbeRedirectValidators(RedirectValidators):
         if used_proxy or not self.target.requires_pinning:
             return ()
         if not self.target.addresses:
-            raise RepositoryError(
-                0,
-                gettext("The repository redirect target has no validated address."),
-            )
+            raise RepositoryInternalError(0, "repository_redirect_missing_address")
         return self.target.addresses
 
 
@@ -139,11 +140,8 @@ def _normalize_redirect_hostname(hostname: str) -> str:
         try:
             return idna_encode(normalized, uts46=True).decode("ascii").lower()
         except (IDNAError, UnicodeError) as error:
-            raise RepositoryError(
-                0,
-                gettext(
-                    "The repository returned an HTTP redirect with an invalid hostname."
-                ),
+            raise RepositoryInternalError(
+                0, "repository_redirect_invalid_hostname"
             ) from error
 
 
@@ -190,54 +188,28 @@ def _repository_url_from_probe_redirect(
     try:
         location_parsed = urlparse(location)
     except ValueError as error:
-        raise RepositoryError(
-            0, gettext("The repository returned an invalid HTTP redirect.")
-        ) from error
+        raise RepositoryInternalError(0, "repository_redirect_invalid") from error
     if location_parsed.username is not None:
-        raise RepositoryError(
-            0,
-            gettext(
-                "The repository HTTP redirect contains credentials and was rejected."
-            ),
-        )
+        raise RepositoryInternalError(0, "repository_redirect_credentials")
 
     redirected_probe = urllib.parse.urljoin(probe_url, location)
     try:
         parsed = urlparse(redirected_probe)
         port = parsed.port
     except ValueError as error:
-        raise RepositoryError(
-            0, gettext("The repository returned an invalid HTTP redirect.")
-        ) from error
+        raise RepositoryInternalError(0, "repository_redirect_invalid") from error
     if not parsed.hostname or not parsed.path.endswith("/info/refs"):
-        raise RepositoryError(
-            0,
-            gettext(
-                "The repository HTTP redirect does not point to a Git smart HTTP endpoint."
-            ),
-        )
+        raise RepositoryInternalError(0, "repository_redirect_not_smart_http")
 
     source_parsed = urlparse(source_url)
     if _normalize_redirect_hostname(parsed.hostname) != _normalize_redirect_hostname(
         source_parsed.hostname or ""
     ):
-        raise RepositoryError(
-            0,
-            gettext(
-                "The repository URL redirects to a different host. Automatic cross-host redirects are disabled for security; update the repository URL manually."
-            ),
-        )
+        raise RepositoryInternalError(0, "repository_redirect_cross_host")
     if source_parsed.scheme == "https" and parsed.scheme != "https":
-        raise RepositoryError(
-            0,
-            gettext(
-                "The repository URL redirects from HTTPS to an insecure URL and was rejected."
-            ),
-        )
+        raise RepositoryInternalError(0, "repository_redirect_insecure")
     if parsed.scheme not in {"http", "https"}:
-        raise RepositoryError(
-            0, gettext("The repository URL redirects to an unsupported URL scheme.")
-        )
+        raise RepositoryInternalError(0, "repository_redirect_unsupported_scheme")
 
     query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
     query_without_service = [
@@ -250,10 +222,7 @@ def _repository_url_from_probe_redirect(
         keep_blank_values=True,
     )
     if query_without_service != source_query:
-        raise RepositoryError(
-            0,
-            gettext("The repository HTTP redirect unexpectedly changed the URL query."),
-        )
+        raise RepositoryInternalError(0, "repository_redirect_query_changed")
     host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
     netloc = host if port is None else f"{host}:{port}"
     result = urlunparse(
@@ -323,9 +292,10 @@ def _request_git_probe(
     try:
         return _perform_git_probe(repository_url, target, environment)
     except httpx2.HTTPError as error:
-        raise RepositoryError(
+        raise RepositoryInternalError(
             0,
-            gettext("Could not probe the repository HTTP redirect: %s") % error,
+            "repository_redirect_probe_failed",
+            params={"error": str(error)},
         ) from error
 
 
@@ -370,7 +340,7 @@ class GitCredentials(TypedDict):
     github_app: NotRequired[bool]
 
 
-class GitAPIRequestError(RepositoryError):
+class GitAPIRequestError(RepositoryInternalError):
     """Error raised for failed hosting API responses without parsed errors."""
 
     def __init__(
@@ -379,10 +349,11 @@ class GitAPIRequestError(RepositoryError):
         self.response = response
         self.response_data = response_data
         self.error = error
-        message = error or f"{response.status_code} {response.reason_phrase}".strip()
-        if 500 <= response.status_code <= 599:
-            message = gettext("%(message)s Please retry later.") % {"message": message}
-        super().__init__(0, message)
+        detail = error or f"{response.status_code} {response.reason_phrase}".strip()
+        code: RepositoryErrorCode = (
+            "api_error_retry" if 500 <= response.status_code <= 599 else "api_error"
+        )
+        super().__init__(0, code, params={"detail": detail})
 
 
 class GitRepository(Repository):
@@ -605,11 +576,8 @@ class GitRepository(Repository):
         for _redirect_count in range(GIT_REDIRECT_LIMIT + 1):
             if status_code in {301, 308}:
                 if location is None:
-                    raise RepositoryError(
-                        0,
-                        gettext(
-                            "The repository returned a permanent HTTP redirect without a target URL."
-                        ),
+                    raise RepositoryInternalError(
+                        0, "repository_redirect_missing_target"
                     ) from error
                 next_url = _repository_url_from_probe_redirect(
                     current_url,
@@ -618,17 +586,14 @@ class GitRepository(Repository):
                 )
                 identity = _strip_url_credentials(next_url)
                 if identity in seen:
-                    raise RepositoryError(
-                        0, gettext("The repository HTTP redirect contains a loop.")
+                    raise RepositoryInternalError(
+                        0, "repository_redirect_loop"
                     ) from error
                 seen.add(identity)
                 validated_target = cls.validate_remote_url(next_url)
                 if validated_target is None:
-                    raise RepositoryError(
-                        0,
-                        gettext(
-                            "The repository HTTP redirect target could not be validated."
-                        ),
+                    raise RepositoryInternalError(
+                        0, "repository_redirect_target_invalid"
                     ) from error
                 current_target = validated_target
                 current_url = next_url
@@ -651,16 +616,11 @@ class GitRepository(Repository):
                     initial_status,
                 ) from error
 
-            raise RepositoryError(
-                0,
-                gettext(
-                    "The repository HTTP redirect target could not be verified as a Git repository."
-                ),
+            raise RepositoryInternalError(
+                0, "repository_redirect_target_unverified"
             ) from error
 
-        raise RepositoryError(
-            0, gettext("The repository returned too many HTTP redirects.")
-        ) from error
+        raise RepositoryInternalError(0, "repository_redirect_too_many") from error
 
     @staticmethod
     def cleanup_stale_lock(lock: Path) -> bool:
@@ -797,10 +757,11 @@ class GitRepository(Repository):
     def ensure_no_interrupted_operation(self) -> None:
         operation = self.get_interrupted_operation()
         if operation is not None:
-            msg = gettext(
-                "Repository has an interrupted Git %(operation)s operation."
-            ) % {"operation": operation}
-            raise RepositoryError(1, msg)
+            raise RepositoryInternalError(
+                1,
+                "repository_interrupted_operation",
+                params={"operation": operation},
+            )
 
     def abort_interrupted_operation(self, operation: str) -> None:
         match operation:
@@ -817,10 +778,11 @@ class GitRepository(Repository):
                 if self.needs_commit():
                     self.execute(["reset", "--hard"], remote_op="none")
             case _:
-                msg = gettext(
-                    "Unsupported interrupted Git operation: %(operation)s"
-                ) % {"operation": operation}
-                raise RepositoryError(1, msg)
+                raise RepositoryInternalError(
+                    1,
+                    "repository_unsupported_interrupted_operation",
+                    params={"operation": operation},
+                )
         self.clean_revision_cache()
 
     def recover_lock_session(self) -> list[RepositoryRecoveryEvent]:
@@ -831,10 +793,11 @@ class GitRepository(Repository):
         while operation := self.get_interrupted_operation():
             self.abort_interrupted_operation(operation)
             if self.get_interrupted_operation() is not None:
-                msg = gettext(
-                    "Could not recover interrupted Git %(operation)s operation."
-                ) % {"operation": operation}
-                raise RepositoryError(1, msg)
+                raise RepositoryInternalError(
+                    1,
+                    "repository_recovery_failed",
+                    params={"operation": operation},
+                )
             recovery_events.append(
                 RepositoryRecoveryEvent(
                     operation=operation,
@@ -998,12 +961,9 @@ class GitRepository(Repository):
                     ):
                         return
                     if self.is_shallow():
-                        raise RepositoryError(
+                        raise RepositoryValidationError(
                             0,
-                            gettext(
-                                "Remote branch could not be verified against the "
-                                "shallow existing repository."
-                            ),
+                            "repository_remote_branch_shallow",
                         )
             finally:
                 with suppress(RepositoryError):
@@ -1013,11 +973,9 @@ class GitRepository(Repository):
                         merge_err=False,
                     )
 
-        raise RepositoryError(
+        raise RepositoryValidationError(
             0,
-            gettext(
-                "Remote branch does not share common history with the existing repository."
-            ),
+            "repository_remote_branch_unrelated",
         )
 
     def _clone(self, source: str, target: str, branch: str) -> None:
@@ -2299,22 +2257,16 @@ class GitMergeRequestBase(GitForcePushRepository):
         self, error: GitAPIRequestError, credentials: GitCredentials
     ) -> NoReturn:
         report_error("Could not fork repository", message=True)
-        raise RepositoryError(
-            0,
-            self.get_fork_failed_message(error.error, credentials, error.response),
+        raise self.get_fork_failed_error(
+            error.error, credentials, error.response
         ) from error
 
-    def add_api_retry_guidance(self, message: str, response: httpx2.Response) -> str:
-        if 500 <= response.status_code <= 599:
-            return gettext("%(message)s Please retry later.") % {"message": message}
-        return message
-
-    def get_fork_failed_message(
+    def get_fork_failed_error(
         self,
         error: str,
         credentials: GitCredentials,
         response: httpx2.Response,
-    ) -> str:
+    ) -> RepositoryInternalError:
         hostname = credentials["hostname"]
         username = credentials["username"]
         try:
@@ -2326,17 +2278,25 @@ class GitMergeRequestBase(GitForcePushRepository):
             level=logging.WARNING,
         )
         if response.status_code == 404:
-            error = f"Repository not found. Check whether exists and user '{username}' has access to it."
-        if error.strip():
-            message = f"Could not fork repository at {hostname}: {error}"
-        elif not response.is_success:
-            message = (
-                f"Could not fork repository at {hostname}: "
-                f"{self.get_response_status_message(response)}"
+            return RepositoryInternalError(
+                0,
+                "repository_fork_not_found",
+                params={"hostname": hostname, "username": username},
             )
+        if not error.strip() and not response.is_success:
+            error = self.get_response_status_message(response)
+        retry = 500 <= response.status_code <= 599
+        if error.strip():
+            code: RepositoryErrorCode = (
+                "repository_fork_failed_with_error_retry"
+                if retry
+                else "repository_fork_failed_with_error"
+            )
+            params = {"hostname": hostname, "error": error}
         else:
-            message = f"Could not fork repository at {hostname}"
-        return self.add_api_retry_guidance(message, response)
+            code = "repository_fork_failed_retry" if retry else "repository_fork_failed"
+            params = {"hostname": hostname}
+        return RepositoryInternalError(0, code, params=params)
 
     def create_pull_request(
         self,
@@ -2563,31 +2523,41 @@ class GitMergeRequestBase(GitForcePushRepository):
             self.get_response_error_message(response, response_data),
         )
 
-    def get_api_request_failure_message(
-        self, response: httpx2.Response, action: str, error: str
-    ) -> str:
+    def get_api_request_failure_error(
+        self,
+        response: httpx2.Response,
+        error: str,
+        *,
+        retcode: int = 0,
+        diagnoses: list[RepositoryDiagnosis] | None = None,
+    ) -> RepositoryInternalError:
         status = response.status_code
         status_text = f"{status} {response.reason_phrase}".strip()
         error = error.strip()
+        retry = 500 <= status <= 599
         if error:
-            message = gettext(
-                "%(service)s API request failed while %(action)s "
-                "(%(status)s): %(error)s"
-            ) % {
+            code: RepositoryErrorCode = (
+                "api_request_failed_with_error_retry"
+                if retry
+                else "api_request_failed_with_error"
+            )
+            params = {
                 "service": self.api_service_name,
-                "action": action,
                 "status": status_text,
                 "error": error,
             }
         else:
-            message = gettext(
-                "%(service)s API request failed while %(action)s: %(status)s"
-            ) % {
+            code = "api_request_failed_retry" if retry else "api_request_failed"
+            params = {
                 "service": self.api_service_name,
-                "action": action,
                 "status": status_text,
             }
-        return self.add_api_retry_guidance(message, response)
+        return RepositoryInternalError(
+            retcode,
+            code,
+            params=params,
+            diagnoses=diagnoses or (),
+        )
 
     def failed_pull_request(
         self,
@@ -2595,6 +2565,8 @@ class GitMergeRequestBase(GitForcePushRepository):
         pr_url: str,
         response: httpx2.Response,
         data: dict,
+        *,
+        diagnoses: list[RepositoryDiagnosis] | None = None,
     ) -> NoReturn:
         status_code = response.status_code
         response_detail: object = data
@@ -2606,11 +2578,11 @@ class GitMergeRequestBase(GitForcePushRepository):
             level=logging.WARNING,
         )
         report_error("Could not create pull request", message=True)
-        raise RepositoryError(
-            -1,
-            self.get_api_request_failure_message(
-                response, gettext("creating a pull request"), error
-            ),
+        raise self.get_api_request_failure_error(
+            response,
+            error,
+            retcode=-1,
+            diagnoses=diagnoses,
         )
 
     @classmethod
@@ -2735,9 +2707,7 @@ class AzureDevOpsRepository(GitMergeRequestBase):
 
         if "project" not in response_data:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error, credentials, response)
-            )
+            raise self.get_fork_failed_error(error, credentials, response)
 
         found_fork = self.__find_fork(credentials)
 
@@ -2772,9 +2742,7 @@ class AzureDevOpsRepository(GitMergeRequestBase):
 
         if "sshUrl" not in response_data or "remoteUrl" not in response_data:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error, credentials, response)
-            )
+            raise self.get_fork_failed_error(error, credentials, response)
 
         self.configure_fork_remote(
             response_data["sshUrl"], response_data["remoteUrl"], credentials
@@ -2880,9 +2848,7 @@ class AzureDevOpsRepository(GitMergeRequestBase):
 
         if response.status_code != 200:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error, credentials, response)
-            )
+            raise self.get_fork_failed_error(error, credentials, response)
 
         return response_data["value"]
 
@@ -2911,8 +2877,8 @@ class AzureDevOpsRepository(GitMergeRequestBase):
             return data_providers[org_property]["organizations"][0]["id"]
         except (KeyError, IndexError) as error:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error_message, credentials, response)
+            raise self.get_fork_failed_error(
+                error_message, credentials, response
             ) from error
 
 
@@ -2992,13 +2958,41 @@ class GithubRepository(GitMergeRequestBase):
         response_data, response, error = self.request("post", credentials, fork_url)
         if "ssh_url" not in response_data:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error, credentials, response)
-            )
+            raise self.get_fork_failed_error(error, credentials, response)
         self.configure_fork_features(credentials, response_data["url"])
         self.configure_fork_remote(
             response_data["ssh_url"], response_data["clone_url"], credentials
         )
+
+    def get_pull_request_failure_diagnoses(
+        self,
+        credentials: GitCredentials,
+        response: httpx2.Response,
+    ) -> list[RepositoryDiagnosis]:
+        """Provide an actionable diagnosis for GitHub pull request failures."""
+        if response.status_code != 404:
+            return []
+
+        try:
+            repository_data, repository_response, _repository_error = self.request(
+                "get", credentials, credentials["url"]
+            )
+        except RepositoryError:
+            return []
+
+        if (
+            repository_response.is_success
+            and repository_data.get("pull_request_creation_policy")
+            == "collaborators_only"
+        ):
+            diagnosis: RepositoryDiagnosis = {
+                "code": "github_pull_request_creation_restricted"
+            }
+            if not credentials.get("github_app"):
+                diagnosis["params"] = {"username": credentials["username"]}
+            return [diagnosis]
+
+        return []
 
     def create_pull_request(
         self,
@@ -3048,8 +3042,8 @@ class GithubRepository(GitMergeRequestBase):
                 return
 
             if "Validation Failed" in error_text:
-                for error in response_data["errors"]:
-                    if error.get("field") == "head" and retry_fork:
+                for response_error in response_data["errors"]:
+                    if response_error.get("field") == "head" and retry_fork:
                         # This most likely indicates that Weblate repository has moved
                         # and we should create a fresh fork.
                         self.create_fork(credentials)
@@ -3062,7 +3056,14 @@ class GithubRepository(GitMergeRequestBase):
                         )
                         return
 
-            self.failed_pull_request(error_message, pr_url, response, response_data)
+            diagnoses = self.get_pull_request_failure_diagnoses(credentials, response)
+            self.failed_pull_request(
+                error_message,
+                pr_url,
+                response,
+                response_data,
+                diagnoses=diagnoses,
+            )
 
 
 class GiteaRepository(GitMergeRequestBase):
@@ -3142,9 +3143,7 @@ class GiteaRepository(GitMergeRequestBase):
             self.validate_existing_fork(response_data, credentials)
         if "ssh_url" not in response_data:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error, credentials, response)
-            )
+            raise self.get_fork_failed_error(error, credentials, response)
         self.configure_fork_remote(
             response_data["ssh_url"], response_data["clone_url"], credentials
         )
@@ -3372,16 +3371,19 @@ class GitLabRepository(GitMergeRequestBase):
             "get", credentials, credentials["url"]
         )
         if "id" not in response_data:
-            detail = error or response.reason_phrase or gettext("Unknown error")
+            detail = error or response.reason_phrase
             report_error(
                 "Could not get GitLab project",
                 message=True,
-                extra_log=f"{response.status_code}: {detail}",
+                extra_log=f"{response.status_code}: {detail or 'Unknown error'}",
             )
-            raise RepositoryError(
+            raise RepositoryInternalError(
                 0,
-                gettext("Could not get GitLab project (%(status)s): %(error)s")
-                % {"status": response.status_code, "error": detail},
+                "gitlab_project_failed" if detail else "gitlab_project_failed_unknown",
+                params={
+                    "status": str(response.status_code),
+                    **({"error": detail} if detail else {}),
+                },
             )
         return response_data["id"]
 
@@ -3425,9 +3427,7 @@ class GitLabRepository(GitMergeRequestBase):
         response_data, response, error = self.request("get", credentials, get_fork_url)
         if error:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error, credentials, response)
-            )
+            raise self.get_fork_failed_error(error, credentials, response)
         for fork in response_data:
             # Since owned=True returns forks from both the user's repo and the forks
             # in all the groups owned by the user, hence we need the below logic
@@ -3457,9 +3457,7 @@ class GitLabRepository(GitMergeRequestBase):
                 or "http_url_to_repo" not in forked_repo
             ):
                 report_error("Could not fork repository", message=True)
-                raise RepositoryError(
-                    0, self.get_fork_failed_message(error, credentials, response)
-                )
+                raise self.get_fork_failed_error(error, credentials, response)
 
         self.configure_fork_features(credentials, forked_repo["_links"]["self"])
 
@@ -3552,9 +3550,7 @@ class PagureRepository(GitMergeRequestBase):
         error_text = error or ""
         if '" cloned to "' not in error_text and "already exists" not in error_text:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error, credentials, response)
-            )
+            raise self.get_fork_failed_error(error, credentials, response)
 
         self.configure_fork_remote(
             f"ssh://git@{credentials['hostname']}/forks/{credentials['username']}/{credentials['slug']}.git",
@@ -3595,16 +3591,19 @@ class PagureRepository(GitMergeRequestBase):
             )
         except GitAPIRequestError as error:
             response = error.response
-            error_message = self.add_api_retry_guidance(
-                self.get_response_status_message(response), response
-            )
+            error_message = self.get_response_status_message(response)
             response_data = {}
 
         if error_message:
             report_error("Pull request listing failed", message=True)
-            raise RepositoryError(
+            raise RepositoryInternalError(
                 0,
-                f"Pull request listing failed: {error_message}",
+                (
+                    "pull_request_listing_failed_retry"
+                    if 500 <= response.status_code <= 599
+                    else "pull_request_listing_failed"
+                ),
+                params={"error": error_message},
             )
 
         if response_data["total_requests"] > 0:
@@ -3711,9 +3710,7 @@ class BitbucketServerRepository(GitMergeRequestBase):
 
         if not ssh_url or not http_url:
             report_error("Could not fork repository", message=True)
-            raise RepositoryError(
-                0, self.get_fork_failed_message(error_message, credentials, response)
-            )
+            raise self.get_fork_failed_error(error_message, credentials, response)
 
         self.configure_fork_remote(ssh_url, http_url, credentials)
 
@@ -3960,9 +3957,7 @@ class BitbucketCloudRepository(GitMergeRequestBase):
 
             if response_data.get("type") == "error" or error:
                 report_error("Could not fork repository", message=True)
-                raise RepositoryError(
-                    0, self.get_fork_failed_message(error, credentials, response)
-                )
+                raise self.get_fork_failed_error(error, credentials, response)
 
             forked_repo = response_data
 

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -26,7 +26,7 @@ from django.utils import timezone
 from django.utils.translation import gettext, gettext_lazy
 
 from weblate.utils.requests import async_fetch_url
-from weblate.vcs.base import RepositoryError
+from weblate.vcs.base import RepositoryInternalError
 from weblate.vcs.git import GithubRepository
 from weblate.vcs.models import Installation, InstallationProvider
 
@@ -1044,9 +1044,7 @@ class GithubAppRepository(GithubRepository):
             or self.component.project_id is None
             or self.component.project.workspace_id is None
         ):
-            raise RepositoryError(
-                0, gettext("GitHub App components require a project with a workspace.")
-            )
+            raise RepositoryInternalError(0, "github_app_workspace_required")
         return self.component.project.workspace
 
     def push(self, branch: str) -> None:
@@ -1084,11 +1082,15 @@ class GithubAppRepository(GithubRepository):
         except GitHubAppNotConfiguredError:
             return None
         except ValueError as error:
-            msg = gettext("Invalid GitHub App installation ID.")
-            raise RepositoryError(0, msg) from error
+            raise RepositoryInternalError(
+                0, "github_app_installation_invalid"
+            ) from error
         except httpx2.HTTPError as error:
-            msg = gettext("Could not obtain GitHub App access token: %s") % error
-            raise RepositoryError(0, msg) from error
+            raise RepositoryInternalError(
+                0,
+                "github_app_token_failed",
+                params={"error": str(error)},
+            ) from error
 
         return {
             "username": "x-access-token",
@@ -1102,9 +1104,7 @@ class GithubAppRepository(GithubRepository):
             repo, workspace=workspace
         )
         if app_creds is None:
-            raise RepositoryError(
-                0, gettext("No Weblate GitHub app installation available.")
-            )
+            raise RepositoryInternalError(0, "github_app_installation_missing")
 
         environment = super()._get_auth_environment(repo)
         environment.update(
@@ -1114,23 +1114,17 @@ class GithubAppRepository(GithubRepository):
 
     def get_auth_environment(self) -> dict[str, str]:
         if self.component is None:
-            raise RepositoryError(
-                0, gettext("GitHub App components require a project with a workspace.")
-            )
+            raise RepositoryInternalError(0, "github_app_workspace_required")
         return self._get_auth_environment(self.component.repo)
 
     @classmethod
     def get_remote_branch(cls, _repo: str) -> str:
-        raise RepositoryError(
-            0, gettext("GitHub App repositories must be imported with a branch.")
-        )
+        raise RepositoryInternalError(0, "github_app_branch_required")
 
     def _resolve_github_app_token(self, _hostname: str) -> dict[str, str] | None:
         """Resolve an installation access token for the parsed repository."""
         if self.component is None:
-            raise RepositoryError(
-                0, gettext("GitHub App components require a project with a workspace.")
-            )
+            raise RepositoryInternalError(0, "github_app_workspace_required")
         workspace = self._get_component_workspace()
         return GithubAppRepository._resolve_github_app_credentials_for_repo(
             self.component.repo, workspace=workspace
@@ -1139,7 +1133,9 @@ class GithubAppRepository(GithubRepository):
     def get_credentials_by_hostname(self, hostname: str) -> dict[str, str]:
         app_creds = self._resolve_github_app_token(hostname)
         if app_creds is None:
-            raise RepositoryError(
-                0, f"No Weblate GitHub app installation available for {hostname}"
+            raise RepositoryInternalError(
+                0,
+                "github_app_installation_missing_for_host",
+                params={"hostname": hostname},
             )
         return app_creds

--- a/weblate/vcs/ssh.py
+++ b/weblate/vcs/ssh.py
@@ -607,16 +607,21 @@ def resolve_ssh_destination(
         detail = (error.stderr or error.stdout or "").strip()
         if not detail:
             raise ValidationError(
-                gettext("Could not determine the effective SSH destination.")
+                gettext("Could not determine the effective SSH destination."),
+                code="ssh_destination_unresolved",
             ) from error
+        detail = cleanup_error_message(detail)
         raise ValidationError(
-            gettext("Could not determine the effective SSH destination: %s")
-            % cleanup_error_message(detail)
+            gettext("Could not determine the effective SSH destination: %s") % detail,
+            code="ssh_destination_unresolved_with_error",
+            params={"error": detail},
         ) from error
     except OSError as error:
+        detail = cleanup_error_message(str(error))
         raise ValidationError(
-            gettext("Could not determine the effective SSH destination: %s")
-            % cleanup_error_message(str(error))
+            gettext("Could not determine the effective SSH destination: %s") % detail,
+            code="ssh_destination_unresolved_with_error",
+            params={"error": detail},
         ) from error
 
     configuration: dict[str, str] = {}
@@ -629,17 +634,20 @@ def resolve_ssh_destination(
     effective_port = configuration.get("port")
     if not effective_hostname or not effective_port:
         raise ValidationError(
-            gettext("Could not determine the effective SSH destination.")
+            gettext("Could not determine the effective SSH destination."),
+            code="ssh_destination_unresolved",
         )
     try:
         parsed_port = int(effective_port)
     except ValueError as error:
         raise ValidationError(
-            gettext("Could not determine the effective SSH destination.")
+            gettext("Could not determine the effective SSH destination."),
+            code="ssh_destination_unresolved",
         ) from error
     if not 0 < parsed_port <= 65535:
         raise ValidationError(
-            gettext("Could not determine the effective SSH destination.")
+            gettext("Could not determine the effective SSH destination."),
+            code="ssh_destination_unresolved",
         )
     return effective_hostname, parsed_port
 

--- a/weblate/vcs/tests/test_ssh.py
+++ b/weblate/vcs/tests/test_ssh.py
@@ -4,12 +4,14 @@
 
 import os
 import shutil
+import subprocess  # ruff: ignore[suspicious-subprocess-import]
 from pathlib import Path
 from time import time
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -131,6 +133,47 @@ class SSHTest(TestCase):
                 "--",
                 "git.example",
             ],
+        )
+
+    def test_resolve_effective_destination_failure_with_detail(self) -> None:
+        process_error = subprocess.CalledProcessError(
+            255,
+            ["ssh", "-G"],
+            stderr="Invalid SSH configuration",
+        )
+        with (
+            patch.object(SSH_WRAPPER, "create"),
+            patch("weblate.vcs.ssh.subprocess.run", side_effect=process_error),
+            self.assertRaises(ValidationError) as raised,
+        ):
+            resolve_ssh_destination("git.example", "git", None)
+
+        self.assertEqual(raised.exception.code, "ssh_destination_unresolved_with_error")
+        self.assertEqual(
+            raised.exception.params, {"error": "Invalid SSH configuration"}
+        )
+        self.assertEqual(
+            raised.exception.messages,
+            [
+                "Could not determine the effective SSH destination: Invalid SSH configuration"
+            ],
+        )
+
+    def test_resolve_effective_destination_failure_without_detail(self) -> None:
+        with (
+            patch.object(SSH_WRAPPER, "create"),
+            patch(
+                "weblate.vcs.ssh.subprocess.run",
+                return_value=SimpleNamespace(stdout=""),
+            ),
+            self.assertRaises(ValidationError) as raised,
+        ):
+            resolve_ssh_destination("git.example", "git", None)
+
+        self.assertEqual(raised.exception.code, "ssh_destination_unresolved")
+        self.assertEqual(
+            raised.exception.messages,
+            ["Could not determine the effective SSH destination."],
         )
 
     def test_allow_admin_ssh_proxy_routing(self) -> None:

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -29,6 +29,8 @@ from django.core.cache import cache
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
+from django.utils.translation import gettext
+from django.utils.translation import override as translation_override
 
 from weblate.trans import defaults
 from weblate.trans.models import Component, Project
@@ -46,6 +48,7 @@ from weblate.vcs.base import (
     RepositorySymlinkError,
     RepositoryValidationError,
     get_config_check_cache_key,
+    get_repository_error_diagnoses,
     is_ssh_host_key_mismatch_error,
     is_ssh_host_key_verification_error,
     parse_commit_date,
@@ -275,6 +278,117 @@ class RepositoryTest(SimpleTestCase):
         error = RepositoryError(-1, "Can not switch subversion URL")
 
         self.assertEqual(str(error), "Can not switch subversion URL (-1)")
+
+    def test_repository_error_diagnoses(self) -> None:
+        cases = (
+            ("The requested URL returned error: 301", "repository_redirect"),
+            ("fatal: terminal prompts disabled", "missing_credentials"),
+            ("rejected: fetch first", "branch_behind"),
+            ("Repository not found.", "repository_not_found"),
+            ("push denied to user", "repository_permission"),
+            ("push prohibited by Gerrit", "gerrit_permission"),
+            ("Connection timed out", "temporary_failure"),
+            ("Host key verification failed", "ssh_host_key_unverified"),
+            (
+                (
+                    "REMOTE HOST IDENTIFICATION HAS CHANGED!\n"
+                    "Host key verification failed."
+                ),
+                "ssh_host_key_mismatch",
+            ),
+        )
+        for message, expected in cases:
+            with self.subTest(message=message):
+                self.assertIn(
+                    expected,
+                    {
+                        diagnosis["code"]
+                        for diagnosis in get_repository_error_diagnoses(message)
+                    },
+                )
+
+    def test_repository_redirect_error_is_not_localized(self) -> None:
+        with translation_override("fr"):
+            error = RepositoryRedirectError(
+                "https://example.com/old",
+                "https://example.com/new",
+                301,
+            )
+
+        self.assertEqual(
+            error.get_message(),
+            "The repository URL permanently redirects to a canonical URL.",
+        )
+        self.assertEqual(error.diagnoses, [{"code": "repository_redirect"}])
+
+    def test_repository_validation_error_is_structured(self) -> None:
+        with (
+            translation_override("fr"),
+            self.assertRaises(RepositoryValidationError) as raised,
+        ):
+            GitRepository.validate_remote_url("https://exa mple.com")
+
+        self.assertEqual(raised.exception.code, "repository_url_invalid")
+        self.assertEqual(raised.exception.params, {})
+        self.assertEqual(raised.exception.get_message(), "Enter a valid URL.")
+        with translation_override("fr"):
+            # spellchecker:off
+            self.assertEqual(
+                raised.exception.get_message(gettext),
+                "Saisissez une URL valide.",  # codespell:ignore valide
+            )
+            # spellchecker:on
+
+    @override_settings(VCS_ALLOW_SCHEMES={"https"})
+    def test_eager_repository_validation_error_is_structured(self) -> None:
+        with (
+            translation_override("fr"),
+            self.assertRaises(RepositoryValidationError) as raised,
+        ):
+            GitRepository.validate_remote_url("ftp://example.com/repository")
+
+        self.assertEqual(raised.exception.code, "repository_url_scheme_not_allowed")
+        self.assertEqual(raised.exception.params, {"scheme": "ftp"})
+        self.assertEqual(
+            raised.exception.get_message(),
+            "Fetching VCS repository using ftp is not allowed.",
+        )
+        self.assertEqual(
+            raised.exception.get_message(lambda message: f"Translated: {message}"),
+            "Translated: Fetching VCS repository using ftp is not allowed.",
+        )
+
+    @override_settings(
+        VCS_ALLOW_HOSTS=set(),
+        VCS_ALLOW_SCHEMES={"ssh"},
+        VCS_RESTRICT_PRIVATE=True,
+    )
+    def test_ssh_destination_validation_error_is_structured(self) -> None:
+        process_error = subprocess.CalledProcessError(
+            255,
+            ["ssh", "-G"],
+            stderr="Invalid SSH configuration",
+        )
+        with (
+            translation_override("fr"),
+            patch.object(SSH_WRAPPER, "create"),
+            patch("weblate.vcs.ssh.subprocess.run", side_effect=process_error),
+            self.assertRaises(RepositoryValidationError) as raised,
+        ):
+            GitRepository.validate_remote_url("ssh://git@git.example/repository")
+
+        self.assertEqual(
+            raised.exception.code,
+            "repository_ssh_destination_unresolved_with_error",
+        )
+        self.assertEqual(
+            raised.exception.params,
+            {"error": "Invalid SSH configuration"},
+        )
+        self.assertEqual(
+            raised.exception.get_message(),
+            "Could not determine the effective SSH destination: Invalid SSH configuration",
+        )
 
     def test_popen_retry_does_not_duplicate_command(self) -> None:
         failed_process = subprocess.CompletedProcess(
@@ -2296,12 +2410,20 @@ class VCSGitTest(TestCase, RepoTestMixin, TempDirMixin):
         with tempfile.TemporaryDirectory() as tempdir:
             self.create_unrelated_git_repository(tempdir)
 
-            with self.assertRaisesRegex(
-                RepositoryError, "does not share common history"
-            ):
+            with self.assertRaises(RepositoryValidationError) as raised:
                 self.repo.validate_remote_compatibility(
                     self.format_local_path(tempdir), self._remote_branch
                 )
+
+        self.assertEqual(raised.exception.code, "repository_remote_branch_unrelated")
+        self.assertEqual(
+            raised.exception.get_message(),
+            "Remote branch does not share common history with the existing repository.",
+        )
+        with translation_override("cs"):
+            self.assertNotEqual(
+                raised.exception.get_message(gettext), raised.exception.get_message()
+            )
 
     def test_validate_remote_compatibility_rejects_inconclusive_shallow_history(
         self,
@@ -2314,12 +2436,21 @@ class VCSGitTest(TestCase, RepoTestMixin, TempDirMixin):
         with tempfile.TemporaryDirectory() as tempdir:
             self.create_unrelated_git_repository(tempdir)
 
-            with self.assertRaisesRegex(
-                RepositoryError, "could not be verified against the shallow"
-            ):
+            with self.assertRaises(RepositoryValidationError) as raised:
                 self.repo.validate_remote_compatibility(
                     self.format_local_path(tempdir), self._remote_branch
                 )
+
+        self.assertEqual(raised.exception.code, "repository_remote_branch_shallow")
+        self.assertEqual(
+            raised.exception.get_message(),
+            "Remote branch could not be verified against the shallow existing "
+            "repository.",
+        )
+        with translation_override("cs"):
+            self.assertNotEqual(
+                raised.exception.get_message(gettext), raised.exception.get_message()
+            )
 
     def test_validate_remote_compatibility_allows_shallow_fork(self) -> None:
         if self._class is not GitRepository:
@@ -3340,6 +3471,7 @@ class VCSGitHubTest(VCSGitUpstreamTest):
         pr_status: int = 200,
         pr_body: str | None = None,
         pr_content_type: str | None = None,
+        pull_request_creation_policy: str = "all",
     ) -> None:
         """
         Mock response helper function.
@@ -3359,6 +3491,13 @@ class VCSGitHubTest(VCSGitUpstreamTest):
             "PUT",
             "https://api.github.com/repos/test/test/actions/permissions",
             status_code=204,
+        )
+        http_mock.register(
+            "GET",
+            "https://api.github.com/repos/WeblateOrg/test",
+            json={
+                "pull_request_creation_policy": pull_request_creation_policy,
+            },
         )
         if pr_body is None:
             http_mock.register(
@@ -3553,6 +3692,85 @@ class VCSGitHubTest(VCSGitUpstreamTest):
                 self.assertIn(str(status), message)
                 self.assertIn("Some error", message)
                 self.assertNotIn("Please retry later.", message)
+                self.assertEqual(error.exception.diagnoses, [])
+
+    @http_mock.activate
+    def test_pull_request_creation_restricted(self) -> None:
+        with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork") as mocked_push:
+            mocked_push.return_value = ""
+            self.mock_responses(
+                pr_status=404,
+                pr_response={"message": "Not Found"},
+                pull_request_creation_policy="collaborators_only",
+            )
+
+            with self.assertRaises(RepositoryError) as error:
+                super().test_push("")
+
+        message = error.exception.get_message()
+        self.assertIn("404 Not Found", message)
+        self.assertEqual(
+            error.exception.diagnoses,
+            [
+                {
+                    "code": "github_pull_request_creation_restricted",
+                    "params": {"username": "test"},
+                }
+            ],
+        )
+        http_mock.assert_call_count("https://api.github.com/repos/WeblateOrg/test", 1)
+
+    @http_mock.activate
+    def test_pull_request_creation_policy_not_queried_for_other_errors(self) -> None:
+        with patch("weblate.vcs.git.GitMergeRequestBase.push_to_fork") as mocked_push:
+            mocked_push.return_value = ""
+            self.mock_responses(
+                pr_status=403,
+                pr_response={"message": "Forbidden"},
+                pull_request_creation_policy="collaborators_only",
+            )
+
+            with self.assertRaises(RepositoryError) as error:
+                super().test_push("")
+
+        self.assertEqual(error.exception.diagnoses, [])
+        http_mock.assert_call_count("https://api.github.com/repos/WeblateOrg/test", 0)
+
+    def test_pull_request_creation_policy_lookup_failure(self) -> None:
+        repository = SimpleNamespace(
+            request=MagicMock(side_effect=RepositoryError(0, "API failed"))
+        )
+
+        diagnoses = GithubRepository.get_pull_request_failure_diagnoses(
+            repository,  # type: ignore[arg-type]
+            {"url": "https://api.github.com/repos/WeblateOrg/test"},
+            SimpleNamespace(status_code=404),  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(diagnoses, [])
+
+    def test_pull_request_creation_restricted_for_github_app(self) -> None:
+        credentials = self.repo.get_credentials()
+        credentials["github_app"] = True
+        credentials["username"] = "x-access-token"
+        with patch.object(
+            self.repo,
+            "request",
+            return_value=(
+                {"pull_request_creation_policy": "collaborators_only"},
+                SimpleNamespace(is_success=True),
+                "",
+            ),
+        ):
+            diagnoses = self.repo.get_pull_request_failure_diagnoses(
+                credentials,
+                SimpleNamespace(status_code=404),  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(
+            diagnoses,
+            [{"code": "github_pull_request_creation_restricted"}],
+        )
 
     @http_mock.activate
     def test_pull_request_exists(self, branch: str = "") -> None:


### PR DESCRIPTION
Repository failures are shown in localized forms and persisted for alerts viewed in other locales. Emit stable codes and parameters from VCS backends so consumers choose localization while stored diagnostics remain locale-neutral and actionable.



<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
