### PR TITLE
doc: fix link to admin docs for checks

### DIFF
--- a/docs/admin/translating.rst
+++ b/docs/admin/translating.rst
@@ -76,7 +76,7 @@ using the ``priority`` flag.
 
 .. seealso::
 
-   :ref:`checks`
+   :ref:`custom-checks`
 
 .. _additional-flags:
 


### PR DESCRIPTION
There it is described that `priority:N` is the format to be used for the flag.

Related: https://github.com/WeblateOrg/weblate/commit/d13805f5280d6d698e3d715bb3ddc866caf3e3c0