### PR TITLE
fix(billing): handle omitted count placeholders

### DIFF
--- a/weblate/billing/models.py
+++ b/weblate/billing/models.py
@@ -1010,11 +1010,14 @@ class Billing(models.Model):
                     queryset=Alert.objects.order_component(),
                 )
             )
-        yield LibreCheck(
-            len(components) > 0,
-            ngettext("Contains %d component", "Contains %d components", len(components))
-            % len(components),
+        component_count = len(components)
+        message = ngettext(
+            "Contains %d component", "Contains %d components", component_count
         )
+        # Ignore when format string is not present
+        with suppress(TypeError):
+            message %= component_count
+        yield LibreCheck(component_count > 0, message)
         for component in components:
             license_name = component.get_license_display()
             license_error = None

--- a/weblate/billing/tests.py
+++ b/weblate/billing/tests.py
@@ -515,6 +515,15 @@ class BillingTest(BaseTestCase):
         self.assertNotIn('data-bs-target="#libre-check-', content)
         self.assertNotIn("libre-check-", content)
 
+    def test_libre_checklist_translation_without_count_placeholder(self) -> None:
+        project = self.add_project()
+        self.add_component(project, "000000")
+
+        with translation.override("he"):
+            messages = [str(check) for check in self.billing.libre_general_checklist]
+
+        self.assertIn("מכיל רכיב אחד", messages)
+
     def test_limit_projects(self) -> None:
         self.assertTrue(self.billing.in_limits)
         self.add_project()


### PR DESCRIPTION
Some valid singular translations spell out the count and omit the numeric placeholder, which caused billing detail rendering to raise TypeError.

Fixes WEBLATE-3AV7

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
