### PR TITLE
fix(glossary): handle stale alert translations

### DIFF
--- a/weblate/glossary/tests.py
+++ b/weblate/glossary/tests.py
@@ -945,6 +945,20 @@ class GlossaryTest(ViewTestCase):
         self.assertTrue(self.user.has_perm("translation.delete", glossary))
         self.assertIn(removal_url, alert.render(self.user))
 
+    def test_unused_glossary_language_alert_missing_translation(self) -> None:
+        glossary = self.make_glossary_language_stale("de", "unused de")
+        update_alerts(self.glossary_component, {"UnusedGlossaryLanguage"})
+        alert = self.glossary_component.alert_set.get(name="UnusedGlossaryLanguage")
+        removal_url = f"{glossary.get_absolute_url()}#organize"
+
+        glossary.delete()
+        self.make_manager()
+        self.user.clear_permissions_cache()
+
+        rendered = alert.render(self.user)
+        self.assertIn("<td>de</td>", rendered)
+        self.assertNotIn(removal_url, rendered)
+
     def test_unused_glossary_language_alert_ignores_blank_local_glossary(self) -> None:
         self.make_glossary_language_stale("de")
 

--- a/weblate/templates/trans/alert/unusedglossarylanguage.html
+++ b/weblate/templates/trans/alert/unusedglossarylanguage.html
@@ -20,9 +20,11 @@
         <td>{{ occurrence.language }}</td>
         <td>{{ occurrence.language_code }}</td>
         <td>
-          {% perm "translation.delete" occurrence.translation as user_can_delete_translation %}
-          {% if user_can_delete_translation %}
-            <a href="{{ occurrence.translation.get_absolute_url }}#organize">{% translate "Remove" %}</a>
+          {% if occurrence.translation %}
+            {% perm "translation.delete" occurrence.translation as user_can_delete_translation %}
+            {% if user_can_delete_translation %}
+              <a href="{{ occurrence.translation.get_absolute_url }}#organize">{% translate "Remove" %}</a>
+            {% endif %}
           {% endif %}
         </td>
       </tr>


### PR DESCRIPTION
Stale glossary alert occurrences can outlive their referenced translation and pass an empty string to the permission checker. Guard the action and cover the stale-reference case.

Fixes WEBLATE-3AV6

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
