### PR TITLE
fix(machinery): preserve Anthropic base URL paths

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -40,6 +40,7 @@ Weblate 2026.8
 .. rubric:: Bug fixes
 
 * :ref:`Disabling password authentication <site-wide-user-management>` from site-wide user management now regenerates the user's personal API key by default.
+* :ref:`mt-anthropic` machine translation now preserves the path component of a custom base URL, so API gateways which serve the messages endpoint below a path prefix are reachable.
 * Category, project, and comment statistics now stay consistent after component topology and comment changes, and category metrics are collected correctly.
 * Mercurial repository filenames beginning with a dash are now handled safely.
 * URLs containing backslashes are now rejected as invalid.

--- a/weblate/machinery/anthropic.py
+++ b/weblate/machinery/anthropic.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from typing import ClassVar
-from urllib.parse import urljoin
 
 from .base import MachineryRateLimitError
 from .forms import AnthropicMachineryForm
@@ -22,7 +21,7 @@ class AnthropicTranslation(BaseLLMTranslation):
 
     name = "Anthropic"
     trusted_error_hosts: ClassVar[set[str]] = {"api.anthropic.com"}
-    end_point = "/v1/messages"
+    end_point = "v1/messages"
     settings_form = AnthropicMachineryForm
     version_added = "5.16"
 
@@ -93,10 +92,15 @@ class AnthropicTranslation(BaseLLMTranslation):
         }
 
     def get_chat_url(self) -> str:
-        return urljoin(
-            self.settings.get("base_url") or "https://api.anthropic.com",
-            self.end_point,
-        )
+        base_url = (
+            self.settings.get("base_url") or "https://api.anthropic.com"
+        ).rstrip("/")
+        # The endpoint carries the API version, so strip it from the base URL
+        # to accept configurations which spell it out there as well.
+        version = self.end_point.partition("/")[0]
+        if base_url.endswith(f"/{version}"):
+            base_url = base_url[: -len(version) - 1]
+        return self.join_api_url(base_url, self.end_point)
 
     @staticmethod
     def parse_chat_response(response_data) -> str | None:

--- a/weblate/machinery/llm.py
+++ b/weblate/machinery/llm.py
@@ -13,6 +13,7 @@ from collections import Counter, defaultdict
 from itertools import chain
 from operator import itemgetter
 from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, TypeGuard
+from urllib.parse import urljoin
 
 from asgiref.sync import sync_to_async
 from django.utils.html import strip_tags
@@ -273,6 +274,10 @@ class BaseLLMTranslation(BatchMachineTranslation):
 
     def is_supported(self, source_language, target_language) -> bool:
         return True
+
+    @staticmethod
+    def join_api_url(base_url: str, path: str) -> str:
+        return urljoin(f"{base_url.rstrip('/')}/", path)
 
     @staticmethod
     def format_prompt_text(text: str) -> str:

--- a/weblate/machinery/openai.py
+++ b/weblate/machinery/openai.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from typing import ClassVar
-from urllib.parse import quote, urljoin
+from urllib.parse import quote
 
 from django.core.cache import cache
 
@@ -23,10 +23,6 @@ class BaseOpenAITranslation(BaseLLMTranslation):
 
     def get_chat_completions_url(self) -> str:
         raise NotImplementedError
-
-    @staticmethod
-    def join_api_url(base_url: str, path: str) -> str:
-        return urljoin(f"{base_url.rstrip('/')}/", path)
 
     def check_failure(self, response) -> None:
         if response.status_code == 429:

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -7614,10 +7614,10 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
             },
         )
 
-    def mock_response(self) -> None:
+    def mock_response(self, url: str = "https://api.anthropic.com/v1/messages") -> None:
         http_mock.register(
             "POST",
-            "https://api.anthropic.com/v1/messages",
+            url,
             status_code=200,
             json={
                 "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
@@ -7673,6 +7673,32 @@ class AnthropicTranslationTest(BaseMachineTranslationTest):
         )
 
         machine = self.MACHINE_CLS({**self.CONFIGURATION, "base_url": ""})
+        self.assert_translate(
+            self.SUPPORTED,
+            self.SOURCE_BLANK,
+            self.EXPECTED_LEN,
+            machine=machine,
+        )
+
+    @http_mock.activate
+    def test_base_url_path_is_preserved(self) -> None:
+        self.mock_response("https://gateway.example/api/v1/messages")
+        machine = self.MACHINE_CLS(
+            {**self.CONFIGURATION, "base_url": "https://gateway.example/api"}
+        )
+        self.assert_translate(
+            self.SUPPORTED,
+            self.SOURCE_BLANK,
+            self.EXPECTED_LEN,
+            machine=machine,
+        )
+
+    @http_mock.activate
+    def test_base_url_with_version(self) -> None:
+        self.mock_response("https://gateway.example/api/v1/messages")
+        machine = self.MACHINE_CLS(
+            {**self.CONFIGURATION, "base_url": "https://gateway.example/api/v1"}
+        )
         self.assert_translate(
             self.SUPPORTED,
             self.SOURCE_BLANK,


### PR DESCRIPTION
## Summary

- preserve path prefixes in custom Anthropic base URLs
- share the existing `join_api_url` helper between the OpenAI and Anthropic services
- accept base URLs which already spell out the API version

Fixes #20992.

## Root cause

`end_point` started with `/`, so `urljoin` treated it as an absolute path and discarded any path component of a custom `base_url`. A gateway configured as `https://openrouter.ai/api` was called at `https://openrouter.ai/v1/messages`, which does not serve the API, and the failure surfaced as a JSON parsing error that gives no hint the URL was wrong.

## Approach

`end_point` becomes relative and is joined onto a normalized base, which is what `openai.py` already did through its `join_api_url` static method. That helper moves from `BaseOpenAITranslation` to `BaseLLMTranslation` so both services share one implementation. The OpenAI classes already inherit from `BaseLLMTranslation`, so no call sites change.

Correcting the join changes the result for a `base_url` which itself ends in the endpoint's version segment. `https://api.anthropic.com/v1` resolved correctly before, by accident of the bug, and a plain fix would start sending requests to `/v1/v1/messages`. Since `end_point` carries the version, a duplicate trailing segment is stripped from the base. Only the exact segment the endpoint supplies is stripped, so an unrelated path such as `https://gateway.example/v2` is left intact rather than silently rewritten.

| `base_url` | before | after |
| --- | --- | --- |
| unset | `https://api.anthropic.com/v1/messages` | unchanged |
| `https://api.anthropic.com` | `https://api.anthropic.com/v1/messages` | unchanged |
| `https://api.anthropic.com/v1` | `https://api.anthropic.com/v1/messages` | unchanged |
| `https://openrouter.ai/api` | `https://openrouter.ai/v1/messages` | `https://openrouter.ai/api/v1/messages` |
| `https://gateway.example/x/y/` | `https://gateway.example/v1/messages` | `https://gateway.example/x/y/v1/messages` |

`ollama.py` builds its URL the same way and has the same defect. It is left out of this change to keep the patch focused, and can follow separately.

## Validation

- `uv run pytest weblate/machinery/tests.py -q` — 861 passed, 50 skipped, 26 subtests passed
- LLM engine subset (Anthropic, OpenAI, Azure OpenAI, Mistral, Ollama) — 558 passed, 14 skipped
- both new tests fail against unpatched `main`, confirming they exercise the defect:

  ```
  FAILED AnthropicTranslationTest::test_base_url_path_is_preserved
  FAILED AnthropicTranslationTest::test_base_url_with_version
  FAILED AnthropicCustomModelTranslationTest::test_base_url_path_is_preserved
  FAILED AnthropicCustomModelTranslationTest::test_base_url_with_version
  ```

- `ruff check` and `ruff format --check` clean on the changed files
- mypy reports no new errors relative to `main`
- rebased onto current `main`; merges cleanly
