### PR TITLE
fix(api): document autotranslate request schema

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2459,12 +2459,12 @@ Translations
     :type component: string
     :param language: Translation language code
     :type language: string
-    :<json string mode: Automatic translation mode
+    :<json string mode: Automatic translation mode - ``suggest``, ``translate``, ``fuzzy`` or ``approved``
     :<json string q: Automatic translation search string, see :ref:`search-strings`.
     :<json string auto_source: Automatic translation source - ``mt`` or ``others``
-    :<json string component: Turn on contribution to shared translation memory for the project to get access to additional components.
+    :<json string component: Source component, given as its numeric ID, or as a ``project/component`` path on instances offering many components. Leave blank to use all components sharing translation memory. Turn on contribution to shared translation memory for the project to get access to additional components.
     :<json array engines: Machine translation engines
-    :<json string threshold: Score threshold
+    :<json int threshold: Score threshold (1-100)
 
 .. http:get:: /api/translations/(string:project)/(string:component)/(string:language)/file/
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,7 @@ Weblate 2026.8
 * Category, project, and comment statistics now stay consistent after component topology and comment changes, and category metrics are collected correctly.
 * Mercurial repository filenames beginning with a dash are now handled safely.
 * URLs containing backslashes are now rejected as invalid.
+* The OpenAPI schema now documents the request body actually accepted by the automatic translation endpoint instead of the translation resource. See :http:post:`/api/translations/(string:project)/(string:component)/(string:language)/autotranslate/`.
 * Protected outbound HTTP and Git connections now bind to validated public addresses; protected Git operations fail closed when clients cannot enforce that binding.
 * Permanent same-host Git HTTP redirects are now validated and stored as canonical component repository URLs.
 * Self-service REST API e-mail changes are now restricted to verified addresses.

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -25523,7 +25523,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Translation'
+              $ref: '#/components/schemas/AutoTranslateRequest'
         required: true
       security:
       - tokenAuth: []
@@ -31867,6 +31867,51 @@ components:
           title: Component regular expression
           description: Regular expression which is used to match component slug.
           maxLength: 200
+    AutoSourceEnum:
+      enum:
+      - others
+      - mt
+      type: string
+      description: |-
+        * `others` - others
+        * `mt` - mt
+    AutoTranslateRequest:
+      type: object
+      properties:
+        mode:
+          allOf:
+          - $ref: '#/components/schemas/ModeEnum'
+          description: Automatic translation mode. Using `approved` requires reviews
+            to be enabled and the permission to approve translations.
+        q:
+          type: string
+          description: Search filter for strings to translate.
+        auto_source:
+          allOf:
+          - $ref: '#/components/schemas/AutoSourceEnum'
+          description: Source of the translations, either other components or machine
+            translation.
+        component:
+          type: string
+          description: Source component, given as its numeric ID, or as a `project/component`
+            path on instances offering many components. Leave blank to use all components
+            sharing translation memory. Only used when `auto_source` is `others`.
+        engines:
+          type: array
+          items:
+            type: string
+          description: Machine translation engines to use. Only used when `auto_source`
+            is `mt`.
+        threshold:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Score threshold for machine translation results.
+      required:
+      - auto_source
+      - mode
+      - q
+      - threshold
     Backup:
       type: object
       properties:
@@ -34283,6 +34328,18 @@ components:
       - units
       - units_translated
       - users
+    ModeEnum:
+      enum:
+      - suggest
+      - translate
+      - fuzzy
+      - approved
+      type: string
+      description: |-
+        * `suggest` - suggest
+        * `translate` - translate
+        * `fuzzy` - fuzzy
+        * `approved` - approved
     MonolingualUnit:
       type: object
       properties:

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -16428,6 +16428,54 @@ class OpenAPITest(APIBaseTest):
             request_schema, {"$ref": "#/components/schemas/Translation"}
         )
 
+    def test_autotranslate_schema_matches_runtime_behavior(self) -> None:
+        schema = self.get_schema()
+        operation = schema["paths"][
+            "/api/translations/{component__project__slug}/{component__slug}/{language__code}/autotranslate/"
+        ]["post"]
+
+        request_schema = operation["requestBody"]["content"]["application/json"][
+            "schema"
+        ]
+        self.assertEqual(
+            request_schema,
+            {"$ref": "#/components/schemas/AutoTranslateRequest"},
+        )
+
+        auto_translate_request = schema["components"]["schemas"]["AutoTranslateRequest"]
+        self.assertEqual(
+            set(auto_translate_request["properties"]),
+            {"mode", "q", "auto_source", "component", "engines", "threshold"},
+        )
+        self.assertEqual(
+            set(auto_translate_request["required"]),
+            {"mode", "q", "auto_source", "threshold"},
+        )
+        properties = auto_translate_request["properties"]
+        self.assertEqual(properties["q"]["type"], "string")
+        self.assertEqual(properties["component"]["type"], "string")
+        self.assertEqual(properties["engines"]["type"], "array")
+        self.assertEqual(properties["engines"]["items"], {"type": "string"})
+        self.assertEqual(properties["threshold"]["type"], "integer")
+        self.assertEqual(properties["threshold"]["minimum"], 1)
+        self.assertEqual(properties["threshold"]["maximum"], 100)
+        self.assertEqual(
+            properties["mode"]["allOf"],
+            [{"$ref": "#/components/schemas/ModeEnum"}],
+        )
+        self.assertEqual(
+            properties["auto_source"]["allOf"],
+            [{"$ref": "#/components/schemas/AutoSourceEnum"}],
+        )
+        self.assertEqual(
+            schema["components"]["schemas"]["ModeEnum"]["enum"],
+            ["suggest", "translate", "fuzzy", "approved"],
+        )
+        self.assertEqual(
+            schema["components"]["schemas"]["AutoSourceEnum"]["enum"],
+            ["others", "mt"],
+        )
+
     def test_string_state_enum_schema_names_are_stable(self) -> None:
         schema = self.get_schema()
         schemas = schema["components"]["schemas"]

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -425,6 +425,42 @@ USER_GROUP_REQUEST_SERIALIZER = inline_serializer(
     },
 )
 
+AUTOTRANSLATE_REQUEST_SERIALIZER = inline_serializer(
+    "AutoTranslateRequest",
+    fields={
+        "mode": serializers.ChoiceField(
+            choices=("suggest", "translate", "fuzzy", "approved"),
+            help_text="Automatic translation mode. Using `approved` requires "
+            "reviews to be enabled and the permission to approve translations.",
+        ),
+        "q": serializers.CharField(help_text="Search filter for strings to translate."),
+        "auto_source": serializers.ChoiceField(
+            choices=("others", "mt"),
+            help_text="Source of the translations, either other components or "
+            "machine translation.",
+        ),
+        "component": serializers.CharField(
+            required=False,
+            allow_blank=True,
+            help_text="Source component, given as its numeric ID, or as a "
+            "`project/component` path on instances offering many components. "
+            "Leave blank to use all components sharing translation memory. "
+            "Only used when `auto_source` is `others`.",
+        ),
+        "engines": serializers.ListField(
+            child=serializers.CharField(),
+            required=False,
+            help_text="Machine translation engines to use. Only used when "
+            "`auto_source` is `mt`.",
+        ),
+        "threshold": serializers.IntegerField(
+            min_value=1,
+            max_value=100,
+            help_text="Score threshold for machine translation results.",
+        ),
+    },
+)
+
 
 def parse_limit_language_codes(data: Mapping[str, object]) -> list[Language] | None:
     language_field_name = "limit_language_codes"
@@ -3606,7 +3642,11 @@ class TranslationViewSet(MultipleFieldViewSet, DestroyModelMixin, AnnouncementsM
 
         return self.get_paginated_response(serializer.data)
 
-    @extend_schema(description="Trigger automatic translation.", methods=["post"])
+    @extend_schema(
+        description="Trigger automatic translation.",
+        methods=["post"],
+        request=AUTOTRANSLATE_REQUEST_SERIALIZER,
+    )
     @action(detail=True, methods=["post"])
     def autotranslate(self, request: Request, **kwargs):
         translation = self.get_object()


### PR DESCRIPTION
## Summary

- document the request fields the autotranslate action actually accepts
- regenerate `docs/specs/openapi.yaml`
- align the prose documentation in `docs/api.rst` with the same shape

Fixes #20991.

## Root cause

The action validates its request body with `AutoForm`, a Django form rather than a serializer, which the schema generator cannot introspect. With no explicit request annotation it fell back to the resource serializer, so the published schema described the `Translation` object — `filename`, `revision`, `is_template`, `language_code` and around thirty other properties, none of which the endpoint reads, and none of the fields it does read. Any client generated from that schema was wrong.

## Approach

The action is annotated with an inline request serializer describing `AutoForm`'s fields, following the existing convention in `views.py` (`USER_GROUP_REQUEST_SERIALIZER`, `NEW_UNIT_REQUEST_SERIALIZER`).

The required set is `mode`, `q`, `auto_source` and `threshold`. Only `component` and `engines` carry `required=False` on the form, and Django ignores `initial` on a bound form, so the remaining four are required at runtime — confirmed by posting bodies with each field omitted in turn.

Two runtime constraints are not expressible in a static schema and are documented in `help_text` instead:

- `mode: approved` additionally requires reviews to be enabled and the permission to approve. Publishing the maximal enum matches the existing treatment of `NewUnitStateEnum`, which advertises the approved state unconditionally.
- `component` is a `ChoiceField` over component IDs on instances with few candidate components, and degrades to a free-form `project/component` path above that threshold. It is documented as a string, which makes no claim that every string validates.

## Validation

- `make -C docs update-openapi` run and the regenerated schema committed, so the `Verify OpenAPI spec is up to date` step passes. Without the regenerated file that step exits 1; the same command produces a byte-identical file on unpatched `main`, which confirms the local invocation matches CI.
- `spectacular --fail-on-warn --validate` exits 0 with empty stderr — no new schema warnings, no enum name collisions
- `uv run pytest weblate/api/tests.py::OpenAPITest -q` — 23 passed, 10 subtests passed
- the new test fails against unpatched `main` with `{'$ref': '.../Translation'} != {'$ref': '.../AutoTranslateRequest'}`
- `ruff check` and `ruff format --check` clean on the changed files
- rebased onto current `main`; merges cleanly
