### PR TITLE
checks: make Kashida check less aggressive

### DIFF
--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -606,12 +606,13 @@ class KashidaCheck(TargetCheck):
     description = gettext_lazy("The decorative kashida letters should not be used.")
 
     kashida_regex = (
-        # Allow kashida after certain letters
-        "(?<![\u0628\u0643\u0644])"
+        # Allow kashida after certain letters, only if sandwiched between actual letters
+        r"(?<=\p{sc=Arab})(?<![\u0640\ufcf2\ufcf3\ufcf4\ufe71\ufe77\ufe79\ufe7b\ufe7d\ufe7f])"
         # List of kashida letters to check
-        "[\u0640\ufcf2\ufcf3\ufcf4\ufe71\ufe77\ufe79\ufe7b\ufe7d\ufe7f]"
+        r"[\u0640\ufcf2\ufcf3\ufcf4\ufe71\ufe77\ufe79\ufe7b\ufe7d\ufe7f]+"
+        r"(?=\p{sc=Arab})(?![\u0640\ufcf2\ufcf3\ufcf4\ufe71\ufe77\ufe79\ufe7b\ufe7d\ufe7f])"
     )
-    kashida_re = re.compile(kashida_regex)
+    kashida_re = regex.compile(kashida_regex)
 
     def check_single(self, source: str, target: str, unit: Unit):
         return self.kashida_re.search(target)

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -588,7 +588,6 @@ class KashidaCheckTest(CheckTestCase):
         self.do_test(False, ("string", "ــ٘ـ", ""))
 
 
-
 class PunctuationSpacingCheckTest(CheckTestCase):
     check = PunctuationSpacingCheck()
     default_lang = "fr"

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -572,11 +572,21 @@ class KashidaCheckTest(CheckTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.test_good_matching = ("string", "string", "")
+        self.test_good_matching = ("string", "مـ", "")
         self.test_good_ignore = ("string", "بـ:", "")
-        self.test_failure_1 = ("string", "string\u0640", "")
-        self.test_failure_2 = ("string", "string\ufe79", "")
-        self.test_failure_3 = ("string", "string\ufe7f", "")
+        self.test_failure_1 = ("string", "صـــفــــحـــــے", "")
+        self.test_failure_2 = ("string", "صـف", "")
+        self.test_failure_3 = ("string", "بـالبيت", "")
+
+    def test_kashida_abbreviation(self) -> None:
+        # Single and multiple kashidas at end of abbreviation/word should be allowed
+        self.do_test(False, ("string", "اتـ", ""))
+        self.do_test(False, ("string", "مــ", ""))
+
+    def test_kashida_combining_mark(self) -> None:
+        # Kashidas holding combining marks should be allowed
+        self.do_test(False, ("string", "ــ٘ـ", ""))
+
 
 
 class PunctuationSpacingCheckTest(CheckTestCase):


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->

Fixes #8228

## Summary

This change makes `KashidaCheck` less aggressive by warning only when Kashida (Tatweel) is used for decorative stretching within Arabic-script words.

Valid uses of Kashida described in the issue are now allowed, including:

- Abbreviations ending with Kashida (for example, `مـ` and `اتـ`)
- Kashida used as a holder for combining marks (for example, `ــ٘ـ`)
- Standalone preposition placeholders such as `بـ:`

Decorative stretching within words continues to be reported.

## Changes

- Updated the Kashida matching logic in `weblate/checks/chars.py` to use Unicode-aware matching for Arabic-script text.
- Added regression tests in `weblate/checks/tests/test_chars_checks.py` covering the valid and invalid cases described in the issue.

## Testing

- Added regression tests covering the reported scenarios.
