### PR TITLE
fix(machinery): preserve literal HTML entities

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,6 +49,7 @@ Weblate 2026.8
 * REST API authorization now consistently protects internal accounts, restricted components, add-on configuration, component sharing, repository links, and review states.
 * :ref:`Project backup imports <projectbackup>` now validate restored data before creating project state, skip repository-linked components the importer cannot access, and no longer load archive-supplied Mercurial configuration or shared-repository indirection.
 * Rebuilding project translation memory no longer removes entries imported from files.
+* Literal HTML character references in source strings are now preserved by :ref:`mt-deepl`, :ref:`mt-google-translate-api-v3` and :ref:`mt-microsoft-translator` machine translation instead of being decoded into live markup.
 * Suggestion submission and rejection now reject excessively long suggestion text and rejection reasons.
 * Restricted components are now available on Hosted Weblate when the billing plan permits private projects.
 * Machine translation and translation memory AJAX lookups no longer disclose whether inaccessible unit IDs exist.

--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -33,6 +33,7 @@ from weblate.utils.docs import DocVersionsMixin
 from weblate.utils.errors import log_handled_exception, report_error
 from weblate.utils.forms import WeblateServiceURLField
 from weblate.utils.hash import calculate_dict_hash, calculate_hash, hash_to_checksum
+from weblate.utils.html import iter_html_entities
 from weblate.utils.outbound import is_allowlisted_hostname
 from weblate.utils.requests import (
     JSON_RESPONSE_ERRORS,
@@ -1547,6 +1548,42 @@ class GlossaryMachineTranslationMixin(MachineTranslation):
 class XMLMachineTranslationMixin(BatchMachineTranslation):
     highlight_syntax = True
     force_uncleanup = True
+
+    def get_highlights(
+        self, text: str, unit: Unit
+    ) -> Iterable[tuple[int, int, str, Highlight | Unit | None]]:
+        highlights = list(super().get_highlights(text, unit))
+
+        for entity_start, entity_end, entity_text in iter_html_entities(text):
+            entity = (entity_start, entity_end, entity_text, None)
+            overlapping = [
+                index
+                for index, (start, end, _highlight_text, _kind) in enumerate(highlights)
+                if entity_start < end and entity_end > start
+            ]
+            if overlapping:
+                first = overlapping[0]
+                last = overlapping[-1]
+                if any(
+                    start <= entity_start and end >= entity_end
+                    for start, end, _highlight_text, _kind in highlights[
+                        first : last + 1
+                    ]
+                ):
+                    continue
+                start = min(entity_start, highlights[first][0])
+                end = max(entity_end, highlights[last][1])
+                highlights[first : last + 1] = [(start, end, text[start:end], None)]
+                continue
+
+            for index, (start, _end, _highlight_text, _kind) in enumerate(highlights):
+                if entity_end <= start:
+                    highlights.insert(index, entity)
+                    break
+            else:
+                highlights.append(entity)
+
+        yield from highlights
 
     def unescape_text(self, text: str) -> str:
         """Unescaping of the text with replacements."""

--- a/weblate/machinery/microsoft.py
+++ b/weblate/machinery/microsoft.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+from bisect import insort
 from datetime import timedelta
+from operator import itemgetter
 from typing import TYPE_CHECKING, ClassVar
 
 from django.utils import timezone
@@ -198,18 +200,12 @@ class MicrosoftCognitiveTranslation(XMLMachineTranslationMixin, MachineTranslati
 
         for term in get_glossary_terms(unit, include_variants=False):
             for start, end in term.glossary_positions:
-                glossary_highlight = (start, end, text[start:end], term)
-                handled = False
-                for i, (h_start, _h_end, _h_text, _h_kind) in enumerate(result):
-                    if start < h_start:
-                        if end > h_start:
-                            # Skip as overlaps
-                            break
-                        # Insert before
-                        result.insert(i, glossary_highlight)
-                        handled = True
-                        break
-                if not handled and (not result or result[-1][1] < start):
-                    result.append(glossary_highlight)
+                if any(
+                    start < h_end and end > h_start
+                    for h_start, h_end, _h_text, _h_kind in result
+                ):
+                    # Skip as overlaps
+                    continue
+                insort(result, (start, end, text[start:end], term), key=itemgetter(0))
 
         yield from result

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from functools import partial
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, ClassVar, NoReturn, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 from urllib.parse import parse_qs, urlparse
@@ -1256,6 +1257,43 @@ class MicrosoftCognitiveTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(machine.map_language_code("fr_CA"), "fr-ca")
         self.assertEqual(machine.map_language_code("iu_Latn"), "iu-Latn")
 
+    def test_literal_entity_replacements(self) -> None:
+        machine = self.get_machine()
+        unit = make_unit(code="cs", source="Hello &lt;script&gt;.")
+        replaced = (
+            'Hello <span class="notranslate" id="6">&amp;amp;lt;</span>script'
+            '<span class="notranslate" id="16">&amp;amp;gt;</span>.'
+        )
+        replacements = {
+            '<span class="notranslate" id="6">&amp;amp;lt;</span>': "&amp;lt;",
+            '<span class="notranslate" id="16">&amp;amp;gt;</span>': "&amp;gt;",
+        }
+        self.assertEqual(
+            machine.cleanup_text(unit.source, unit),
+            (replaced, replacements),
+        )
+        self.assertEqual(unit.source, machine.uncleanup_text(replacements, replaced))
+
+    def test_glossary_term_overlapping_literal_entity(self) -> None:
+        """A glossary term inside a character reference must not be highlighted."""
+        machine = self.get_machine()
+        source = "The &copyright notice and &lt;b&gt; tag."
+        unit = make_unit(code="cs", source=source)
+        term = SimpleNamespace(glossary_positions=[(5, 14)], target="Copyright")
+
+        with patch(
+            "weblate.machinery.microsoft.get_glossary_terms",
+            return_value=[term],
+        ):
+            highlights = list(machine.get_highlights(source, unit))
+            replaced, replacements = machine.cleanup_text(source, unit)
+
+        self.assertEqual(
+            highlights,
+            [(4, 9, "&copy", None), (26, 30, "&lt;", None), (31, 35, "&gt;", None)],
+        )
+        self.assertEqual(source, machine.uncleanup_text(replacements, replaced))
+
     @patch(
         "weblate.utils.outbound.socket.getaddrinfo",
         return_value=[(0, 0, 0, "", ("127.0.0.1", 443))],
@@ -1518,6 +1556,26 @@ class GoogleV3TranslationTest(BaseMachineTranslationTest):
         replacements = {
             '<br translate="no">': "\n",
             '<span translate="no" id="7">%s</span>': "%s",
+        }
+        self.assertEqual(
+            machine_translation.cleanup_text(unit.source, unit),
+            (replaced, replacements),
+        )
+        self.assertEqual(
+            unit.source, machine_translation.uncleanup_text(replacements, replaced)
+        )
+
+    def test_literal_entity_replacements(self) -> None:
+        machine_translation = self.get_machine()
+        unit = make_unit(code="cs", source="Hello &lt;script&gt;.")
+        replaced = (
+            'Hello <span translate="no" id="6">&amp;amp;lt;</span>script'
+            '<span translate="no" id="16">&amp;amp;gt;</span>.'
+        )
+        replacements = {
+            '<span translate="no" id="6">&amp;amp;lt;</span>': "&amp;lt;",
+            '<span translate="no" id="16">&amp;amp;gt;</span>': "&amp;gt;",
+            '<br translate="no">': "\n",
         }
         self.assertEqual(
             machine_translation.cleanup_text(unit.source, unit),
@@ -2547,6 +2605,123 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         )
         self.assertEqual(translation[0][0]["source"], "Hello&world")
         self.assertEqual(translation[0][0]["text"], "Hallo&welt")
+
+    def mock_entity_normalizing_response(self) -> None:
+        def request_callback(request: httpx2.Request):
+            payload = load_request_json(request)
+            texts = cast("list[str]", payload["text"])
+            translated = texts[0].replace("Hello", "Hallo").replace("&amp;", "&")
+            return httpx2.Response(
+                200,
+                headers={},
+                text=json.dumps(
+                    {
+                        "translations": [
+                            {"detected_source_language": "EN", "text": translated}
+                        ]
+                    }
+                ),
+            )
+
+        self.mock_languages()
+        http_mock.register_callback(
+            "POST",
+            "https://api.deepl.com/v2/translate",
+            callback=request_callback,
+        )
+
+    @http_mock.activate
+    def test_literal_entities_preserved(self) -> None:
+        machine = self.MACHINE_CLS(self.get_configuration())
+        machine.delete_cache()
+        self.mock_entity_normalizing_response()
+
+        translation = self.assert_translate(
+            self.SUPPORTED,
+            "Hello &lt;script&gt;.",
+            1,
+            machine=machine,
+            unit_args={"flags": "safe-html"},
+        )
+        self.assertEqual(translation[0][0]["source"], "Hello &lt;script&gt;.")
+        self.assertEqual(translation[0][0]["text"], "Hallo &lt;script&gt;.")
+
+    @http_mock.activate
+    def test_literal_entity_variants_preserved(self) -> None:
+        machine = self.MACHINE_CLS(self.get_configuration())
+        machine.delete_cache()
+        self.mock_entity_normalizing_response()
+
+        source = "Hello &lt; &#60; &#x3C; &#X3C; &copy; &copy &unknown;."
+        translation = self.assert_translate(self.SUPPORTED, source, 1, machine=machine)
+        self.assertEqual(translation[0][0]["source"], source)
+        self.assertEqual(
+            translation[0][0]["text"],
+            "Hallo &lt; &#60; &#x3C; &#X3C; &copy; &copy &unknown;.",
+        )
+
+    def test_literal_entity_merges_with_overlapping_highlight(self) -> None:
+        """A highlight covering part of an entity is widened to cover all of it."""
+        machine = self.MACHINE_CLS(self.get_configuration())
+        source = "The &copy; is here"
+        unit = cast(
+            "Unit", make_unit(code="de", source=source, flags='placeholders:"y; is"')
+        )
+
+        self.assertEqual(
+            list(machine.get_highlights(source, unit)),
+            [(4, 13, "&copy; is", None)],
+        )
+        replaced, replacements = machine.cleanup_text(source, unit)
+        self.assertNotIn("&amp;cop", replaced)
+        self.assertEqual(source, machine.uncleanup_text(replacements, replaced))
+
+    @http_mock.activate
+    def test_literal_entities_with_xml_highlights(self) -> None:
+        machine = self.MACHINE_CLS(self.get_configuration())
+        machine.delete_cache()
+        self.mock_entity_normalizing_response()
+
+        source = '<b title="&copy;">Hello &lt;script&gt;.</b>'
+        translation = self.assert_translate(
+            self.SUPPORTED,
+            source,
+            1,
+            machine=machine,
+            unit_args={"flags": "xml-text"},
+        )
+        self.assertEqual(translation[0][0]["source"], source)
+        self.assertEqual(
+            translation[0][0]["text"],
+            '<b title="&copy;">Hallo &lt;script&gt;.</b>',
+        )
+
+    @http_mock.activate
+    def test_literal_entity_contains_existing_highlight(self) -> None:
+        machine = self.MACHINE_CLS(self.get_configuration())
+        machine.delete_cache()
+        self.mock_entity_normalizing_response()
+
+        source = "Hello &copy;."
+        translation = self.assert_translate(
+            self.SUPPORTED,
+            source,
+            1,
+            machine=machine,
+            unit_args={"flags": 'placeholders:"copy"'},
+        )
+        self.assertEqual(translation[0][0]["source"], source)
+        self.assertEqual(translation[0][0]["text"], "Hallo &copy;.")
+
+    def test_literal_entity_highlight_excludes_trailing_text(self) -> None:
+        machine = self.MACHINE_CLS(self.get_configuration())
+        source = "Hello a&notb."
+        unit = cast("Unit", make_unit(code="de", source=source))
+
+        self.assertEqual(
+            list(machine.get_highlights(source, unit)),
+            [(7, 11, "&not", None)],
+        )
 
     @http_mock.activate
     @patch("weblate.glossary.models.get_glossary_tsv", new=lambda _: "foo\tbar")

--- a/weblate/utils/html.py
+++ b/weblate/utils/html.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import re
 import threading
 from collections import defaultdict
+from html.entities import html5
 from html.parser import HTMLParser as StdHTMLParser
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -71,6 +72,31 @@ MD_SYNTAX = re.compile(
     re.VERBOSE,
 )
 MD_SYNTAX_GROUPS = 8
+
+HTML_ENTITY_CANDIDATE = re.compile(
+    r"&(?:#[0-9]+;?|#[xX][0-9a-fA-F]+;?|[^\t\n\f <&#;]{1,32};?)"
+)
+
+
+def iter_html_entities(text: str) -> Iterable[tuple[int, int, str]]:
+    """Yield character-reference spans consumed by html.unescape."""
+    for match in HTML_ENTITY_CANDIDATE.finditer(text):
+        entity = match.group()
+        if entity[1] == "#":
+            yield match.start(), match.end(), entity
+            continue
+
+        name = entity[1:]
+        if name in html5:
+            yield match.start(), match.end(), entity
+            continue
+
+        for length in range(len(name) - 1, 1, -1):
+            if name[:length] in html5:
+                end = match.start() + length + 1
+                yield match.start(), end, text[match.start() : end]
+                break
+
 
 AUTO_SAFE_HTML_START = re.compile(r"<(?=[!/?A-Za-z])")
 AUTO_SAFE_HTML_SEGMENT = re.compile(

--- a/weblate/utils/tests/test_html.py
+++ b/weblate/utils/tests/test_html.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from html import unescape
+
 from django.test import SimpleTestCase
 
 from weblate.checks.flags import Flags
@@ -14,6 +16,7 @@ from weblate.utils.html import (
     extract_html_attributes,
     extract_html_tags,
     is_auto_safe_html_source,
+    iter_html_entities,
     list_to_tuples,
     mail_quote_value,
 )
@@ -216,3 +219,52 @@ class TypeConversionTestCase(SimpleTestCase):
 
     def test_single_element_list(self) -> None:
         self.assertEqual(list(list_to_tuples(["only_one"])), [("only_one",)])
+
+
+class IterHTMLEntitiesTestCase(SimpleTestCase):
+    def test_named(self) -> None:
+        self.assertEqual(
+            list(iter_html_entities("a &lt; b &amp; c")),
+            [(2, 6, "&lt;"), (9, 14, "&amp;")],
+        )
+
+    def test_numeric(self) -> None:
+        self.assertEqual(
+            list(iter_html_entities("&#60; &#x3C; &#X3C;")),
+            [(0, 5, "&#60;"), (6, 12, "&#x3C;"), (13, 19, "&#X3C;")],
+        )
+
+    def test_missing_semicolon(self) -> None:
+        # Legacy references are decoded without the trailing semicolon
+        self.assertEqual(list(iter_html_entities("&copy 2026")), [(0, 5, "&copy")])
+
+    def test_longest_prefix(self) -> None:
+        # Only the recognized prefix is a reference, the rest is plain text
+        self.assertEqual(list(iter_html_entities("a&notb")), [(1, 5, "&not")])
+
+    def test_unknown(self) -> None:
+        for text in ("&unknown;", "R&D", "Tom & Jerry", "&", "&;", "&#", "&#x"):
+            with self.subTest(text=text):
+                self.assertEqual(list(iter_html_entities(text)), [])
+
+    def test_long_name(self) -> None:
+        # The longest name is 32 characters including the semicolon
+        longest = "&CounterClockwiseContourIntegral;"
+        self.assertEqual(list(iter_html_entities(longest)), [(0, 33, longest)])
+
+    def test_matches_unescape(self) -> None:
+        """Yielded spans are exactly what unescaping consumes."""
+        for text in (
+            "a &lt; b",
+            "&copy 2026",
+            "a&notb",
+            "&unknown;",
+            "R&D",
+            "&#60;&#x3C;",
+            "&amp;lt;",
+            "?a=1&notify=2",
+        ):
+            with self.subTest(text=text):
+                for start, end, entity in iter_html_entities(text):
+                    self.assertEqual(entity, text[start:end])
+                    self.assertNotEqual(unescape(entity), entity)


### PR DESCRIPTION
## Summary

- protect literal HTML character references as non-translatable spans for XML-based machine translation engines
- merge entity spans with existing highlights so a partial overlap cannot expose part of a reference
- preserve the existing unconditional unescape behaviour for raw ampersands
- skip glossary terms which overlap an existing highlight in the Azure AI Translator service

Fixes #21004.

## Root cause

XML-based machinery escapes source text before sending it to a provider and unescapes every returned result. That round trip is lossless only while the provider keeps the escaping level it was given, and HTML-mode providers renormalize it. When they do, an inert character reference in the source comes back one level decoded, and the unconditional unescape turns it into live markup.

With the `safe-html` flag set this becomes data loss rather than a quality problem: the sanitizer sees the now-live element and removes it together with everything after it, with no check firing and a success-shaped API response.

## Approach

Entity spans are protected through the existing non-translatable-span mechanism — the same one that already keeps units flagged `xml-text` intact. The spans recognized are exactly those Python unescaping consumes, including the recognized prefix of a legacy reference written without its semicolon, so nothing that would survive the round trip is touched and nothing that would be decoded is missed. Spans partially overlapping an existing highlight are merged with it, so a placeholder can no longer split a reference and leave half of it exposed.

The unconditional unescape is deliberately unchanged — it is what fixes #12936, and removing it would regress that. The narrower change is to stop pre-existing entity spans from entering the escape/unescape pair at all.

Applying protection where none existed before exposed a latent defect in the Azure AI Translator glossary path. Its insertion loop only compared a term against highlights starting after it, so a term matching inside a newly protected reference produced overlapping spans and duplicated characters on restore. Source `The &copyright notice and &lt;b&gt; tag.` with a `copyright` term restored as `The &copycopyright notice and ...`. The loop now skips any term overlapping an existing highlight. The same defect is reachable on `main` today with a plain placeholder, but this change makes it reachable for ordinary unflagged strings, so it is fixed here rather than deferred.

## Known behaviour

Protection preserves the reference but not the whitespace around it: a provider may return `&lt; script &gt;` where it was sent one protected span. This is a pre-existing property of the restore step and is byte-identical on `main` for units already flagged `xml-text`, across all three engines. It is not addressed here, because absorbing provider-inserted whitespace would change the signature of the shared cleanup and restore path and has not been validated against a live provider. In the regime the issue documents, the result is still strictly better: `main` restores live `<script>`, this restores the reference intact.

## Validation

- `uv run pytest weblate/machinery/tests.py weblate/utils/tests/test_html.py -q` — 906 passed, 50 skipped, 47 subtests passed
- `uv run pytest weblate/checks/ weblate/glossary/ -q` — 1465 passed, 498 skipped
- 18 new tests: 11 through the machinery layer, 7 covering the entity scanner directly. With the scanner present but the machinery change reverted, 10 of the 11 machinery tests fail. The eleventh asserts that units already flagged `xml-text` are unchanged, which is the intended result.
- reverting only the Azure AI Translator glossary change, with the rest of the patch applied, fails the two glossary overlap tests
- mypy reports 230 errors on the changed files, matching `main` exactly
- `ruff check` and `ruff format --check` clean
- live Google Cloud Translation v3 A/B covering escaped tags, mixed entities, and the raw-ampersand regression case
- differential fuzzing of the entity scanner against `html.unescape` over every HTML5 name with and without semicolon and trailing characters, numeric and hexadecimal references, malformed input, and non-Latin text — no divergence

Coverage spans DeepL, Google Cloud Translation v3 and Azure AI Translator, plus direct unit tests for the entity scanner in `weblate/utils/tests/test_html.py`.
