### PR TITLE
fix(auth): explain workflow permission denials

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -101,6 +101,7 @@ from weblate.utils.state import (
     STATE_EMPTY,
     STATE_NEEDS_CHECKING,
     STATE_NEEDS_REWRITING,
+    STATE_READONLY,
     STATE_TRANSLATED,
 )
 from weblate.utils.tests import http_mock
@@ -8519,7 +8520,8 @@ class ComponentAPITest(APIBaseTest):
 
         self.assertEqual(
             response.data["errors"][0]["detail"],
-            "Direct editing is restricted for this language. Add a suggestion instead.",
+            "Only privileged users can edit strings directly in this language because "
+            "of its translation workflow. Add a suggestion instead.",
         )
         perform.assert_not_called()
         self.assertFalse(target.translation_set.filter(language_code="fa").exists())
@@ -12820,6 +12822,46 @@ class SuggestionAPITest(APIBaseTest):
             code=404,
         )
 
+    def test_add_suggestion_disabled_by_workflow(self) -> None:
+        unit = self._get_unit()
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=unit.translation.language,
+            enable_suggestions=False,
+        )
+
+        response = self._add_suggestion(unit, "Navrh", code=403)
+
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "Suggestions are turned off for this language. Ask a project administrator "
+            "to enable them.",
+        )
+        self.assertFalse(unit.suggestion_set.exists())
+
+    def test_add_suggestion_readonly(self) -> None:
+        unit = self._get_unit()
+        original_state = unit.state
+        Unit.objects.filter(pk=unit.pk).update(state=STATE_READONLY)
+
+        response = self._add_suggestion(unit, "Navrh", code=403)
+
+        self.assertEqual(
+            response.data["errors"][0]["detail"], "The string is read-only."
+        )
+        self.assertFalse(unit.suggestion_set.exists())
+
+        Unit.objects.filter(pk=unit.pk).update(state=original_state)
+        unit.translation.check_flags = "read-only"
+        unit.translation.save(update_fields=["check_flags"])
+
+        response = self._add_suggestion(unit, "Navrh", code=403)
+
+        self.assertEqual(
+            response.data["errors"][0]["detail"], "The translation is read-only."
+        )
+        self.assertFalse(unit.suggestion_set.exists())
+
     def test_list_unit_suggestions(self) -> None:
         unit = self._get_unit()
         self._add_suggestion(unit, "Navrh 1")
@@ -12950,12 +12992,16 @@ class SuggestionAPITest(APIBaseTest):
         response = self._add_suggestion(unit, "Navrh")
         suggestion_id = response.data["id"]
         # missing unit.review permission
-        self.do_request(
+        response = self.do_request(
             "api:suggestion-accept",
             kwargs={"pk": suggestion_id},
             method="post",
             request={"approve": True},
             code=403,
+        )
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "Translation reviews are turned off.",
         )
 
         # missing suggestion.accept permission
@@ -12968,6 +13014,30 @@ class SuggestionAPITest(APIBaseTest):
             code=403,
             authenticated=False,
         )
+
+    def test_accept_suggestion_restricted_by_workflow(self) -> None:
+        unit = self._get_unit()
+        response = self._add_suggestion(unit, "Navrh")
+        suggestion_id = response.data["id"]
+        WorkflowSetting.objects.create(
+            project=self.project,
+            language=unit.translation.language,
+            restrict_direct_editing=True,
+        )
+
+        response = self.do_request(
+            "api:suggestion-accept",
+            kwargs={"pk": suggestion_id},
+            method="post",
+            code=403,
+        )
+
+        self.assertEqual(
+            response.data["errors"][0]["detail"],
+            "Only privileged users can edit strings directly in this language because "
+            "of its translation workflow. Add a suggestion instead.",
+        )
+        self.assertTrue(Suggestion.objects.filter(pk=suggestion_id).exists())
 
     def test_accept_suggestion_approve(self) -> None:
         unit = self._get_unit()
@@ -13033,12 +13103,15 @@ class SuggestionAPITest(APIBaseTest):
         )
 
         # Voting disabled on translation.
-        self.do_request(
+        response = self.do_request(
             "api:suggestion-vote",
             kwargs={"pk": suggestion.pk},
             method="post",
             request={"value": 1},
             code=403,
+        )
+        self.assertEqual(
+            response.data["errors"][0]["detail"], "Suggestion voting is disabled."
         )
 
         self.component.suggestion_voting = True

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -3964,8 +3964,11 @@ class UnitViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelM
         user = request.user
 
         if request.method == "POST":
-            if not user.has_perm("suggestion.add", unit):
-                self.permission_denied(request)
+            suggestion_permission = user.has_perm("suggestion.add", unit)
+            if not suggestion_permission:
+                self.permission_denied(
+                    request, getattr(suggestion_permission, "reason", None)
+                )
 
             serializer = SuggestionSerializer(
                 data=request.data,
@@ -4057,11 +4060,16 @@ class SuggestionViewSet(viewsets.ReadOnlyModelViewSet, DestroyModelMixin):
         serializer.is_valid(raise_exception=True)
         approve = serializer.validated_data["approve"]
 
-        if not user.has_perm("suggestion.accept", unit):
-            self.permission_denied(request)
+        accept_permission = user.has_perm("suggestion.accept", unit)
+        if not accept_permission:
+            self.permission_denied(request, getattr(accept_permission, "reason", None))
 
-        if approve and not user.has_perm("unit.review", unit):
-            self.permission_denied(request)
+        if approve:
+            review_permission = user.has_perm("unit.review", unit)
+            if not review_permission:
+                self.permission_denied(
+                    request, getattr(review_permission, "reason", None)
+                )
 
         suggestion.accept(
             request,
@@ -4081,8 +4089,9 @@ class SuggestionViewSet(viewsets.ReadOnlyModelViewSet, DestroyModelMixin):
         unit = suggestion.unit
         user = request.user
 
-        if not user.has_perm("suggestion.vote", unit):
-            self.permission_denied(request)
+        vote_permission = user.has_perm("suggestion.vote", unit)
+        if not vote_permission:
+            self.permission_denied(request, getattr(vote_permission, "reason", None))
 
         serializer = SuggestionVoteRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -236,10 +236,17 @@ def check_direct_editing(
     if obj.enable_suggestions:
         return Denied(
             gettext(
-                "Direct editing is restricted for this language. Add a suggestion instead."
+                "Only privileged users can edit strings directly in this language "
+                "because of its translation workflow. Add a suggestion instead."
             )
         )
-    return Denied(gettext("Direct editing is restricted for this language."))
+    return Denied(
+        gettext(
+            "Only privileged users can edit strings directly in this language "
+            "because of its translation workflow. Ask a project administrator for "
+            "access."
+        )
+    )
 
 
 def check_permission(
@@ -741,9 +748,18 @@ def check_suggestion_add(
     obj: Unit | Translation | ProjectLanguage | CategoryLanguage,
 ) -> bool | PermissionResult:
     if isinstance(obj, Unit):
+        if obj.readonly:
+            return Denied(gettext("The string is read-only."))
         obj = obj.translation
-    if not obj.enable_suggestions or obj.is_readonly:
-        return False
+    if obj.is_readonly:
+        return Denied(gettext("The translation is read-only."))
+    if not obj.enable_suggestions:
+        return Denied(
+            gettext(
+                "Suggestions are turned off for this language. Ask a project "
+                "administrator to enable them."
+            )
+        )
     # Check contributor license agreement
     if (
         not user.is_bot

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -256,11 +256,7 @@
                 </button>
 
                 {% if unit.translation.enable_suggestions %}
-                  <button class="btn btn-warning btn-spaced"
-                          type="submit"
-                          name="suggest"
-                          {% if project_locked or not user_can_suggest or unit.readonly %}disabled="disabled"{% endif %}
-                          {% if not user_can_suggest %} title="{% translate "Insufficient privileges for adding suggestions." %}" {% elif project_locked %} title="{% translate "This translation is currently locked." %}" {% elif unit.readonly %} title="{% translate "Read-only" %}" {% endif %}>
+                  <button class="btn btn-warning btn-spaced" type="submit" name="suggest" {% if project_locked or not user_can_suggest or unit.readonly %}disabled="disabled"{% endif %} {% if not user_can_suggest %} title="{% if user_can_suggest.reason %}{{ user_can_suggest.reason }}{% else %}{% translate "You do not have permission to add suggestions." %}{% endif %}" {% elif project_locked %} title="{% translate "This translation is currently locked." %}" {% elif unit.readonly %} title="{% translate "Read-only" %}" {% endif %}>
                     {% translate "Suggest" %}
                   </button>
                 {% endif %}

--- a/weblate/trans/tests/test_suggestions.py
+++ b/weblate/trans/tests/test_suggestions.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from weblate.auth.results import Denied
 from weblate.trans.models import Suggestion, WorkflowSetting
 from weblate.trans.tests.test_views import ViewTestCase
+from weblate.utils.state import STATE_READONLY
 
 
 class SuggestionsTest(ViewTestCase):
@@ -234,7 +235,8 @@ class SuggestionsTest(ViewTestCase):
         self.assertIsInstance(permission, Denied)
         self.assertEqual(
             permission.reason,
-            "Direct editing is restricted for this language. Add a suggestion instead.",
+            "Only privileged users can edit strings directly in this language because "
+            "of its translation workflow. Add a suggestion instead.",
         )
         self.assertTrue(self.user.has_perm("suggestion.add", unit))
 
@@ -245,6 +247,7 @@ class SuggestionsTest(ViewTestCase):
         )
         self.assertContains(response, "Translation suggestions can be made.")
         self.assertNotContains(response, "Translations can be made directly.")
+        self.assertContains(self.client.get(unit.get_absolute_url()), permission.reason)
 
         self.add_suggestion_1()
         self.assertEqual(unit.suggestion_set.count(), 1)
@@ -266,9 +269,17 @@ class SuggestionsTest(ViewTestCase):
         permission = self.user.has_perm("unit.edit", unit)
         self.assertIsInstance(permission, Denied)
         self.assertEqual(
-            permission.reason, "Direct editing is restricted for this language."
+            permission.reason,
+            "Only privileged users can edit strings directly in this language because "
+            "of its translation workflow. Ask a project administrator for access.",
         )
-        self.assertFalse(self.user.has_perm("suggestion.add", unit))
+        suggestion_permission = self.user.has_perm("suggestion.add", unit)
+        self.assertIsInstance(suggestion_permission, Denied)
+        self.assertEqual(
+            suggestion_permission.reason,
+            "Suggestions are turned off for this language. Ask a project administrator "
+            "to enable them.",
+        )
 
         response = self.client.get(self.translation_url)
         self.assertContains(
@@ -277,6 +288,37 @@ class SuggestionsTest(ViewTestCase):
         )
         self.assertContains(response, "Translation suggestions are turned off.")
         self.assertNotContains(response, "Translations can be made directly.")
+        self.assertContains(self.client.get(unit.get_absolute_url()), permission.reason)
+
+        response = self.edit_unit(
+            "Hello, world!\n", "Nazdar svete!\n", suggest="yes", follow=True
+        )
+        self.assertContains(response, suggestion_permission.reason)
+        self.assertEqual(unit.suggestion_set.count(), 0)
+
+    def test_suggestion_readonly_denials(self) -> None:
+        unit = self.get_unit()
+        original_state = unit.state
+        unit.state = STATE_READONLY
+        unit.save(update_fields=["state"])
+
+        permission = self.user.has_perm("suggestion.add", unit)
+        self.assertIsInstance(permission, Denied)
+        self.assertEqual(permission.reason, "The string is read-only.")
+
+        response = self.client.get(unit.get_absolute_url())
+        self.assertContains(response, 'title="The string is read-only."')
+
+        unit.state = original_state
+        unit.save(update_fields=["state"])
+        translation = unit.translation
+        translation.check_flags = "read-only"
+        translation.save(update_fields=["check_flags"])
+        unit = self.get_unit()
+
+        permission = self.user.has_perm("suggestion.add", unit)
+        self.assertIsInstance(permission, Denied)
+        self.assertEqual(permission.reason, "The translation is read-only.")
 
     def test_restrict_direct_editing_allows_voting(self) -> None:
         WorkflowSetting.objects.create(

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -804,10 +804,13 @@ def perform_suggestion(unit, form, request: AuthenticatedHttpRequest):
         messages.error(request, gettext("Your suggestion is empty!"))
         # Stay on same entry
         return False
-    if not request.user.has_perm("suggestion.add", unit):
+    suggestion_permission = request.user.has_perm("suggestion.add", unit)
+    if not suggestion_permission:
         # Need privilege to add
         messages.error(
-            request, gettext("You don't have privileges to add suggestions!")
+            request,
+            getattr(suggestion_permission, "reason", "")
+            or gettext("You do not have permission to add suggestions."),
         )
         # Stay on same entry
         return False
@@ -1003,11 +1006,21 @@ def check_suggest_permissions(
     """Check permission for suggestion handling."""
     user = request.user
     if mode in {"accept", "accept_edit", "accept_approve"}:
-        if not user.has_perm("suggestion.accept", unit) or (
-            mode == "accept_approve" and not user.has_perm("unit.review", unit)
+        accept_permission = user.has_perm("suggestion.accept", unit)
+        if not accept_permission:
+            messages.error(
+                request,
+                getattr(accept_permission, "reason", "")
+                or gettext("You do not have permission to accept suggestions."),
+            )
+            return False
+        if mode == "accept_approve" and not (
+            review_permission := user.has_perm("unit.review", unit)
         ):
             messages.error(
-                request, gettext("You do not have privilege to accept suggestions!")
+                request,
+                getattr(review_permission, "reason", "")
+                or gettext("You do not have permission to approve translations."),
             )
             return False
     elif mode in {"delete", "spam"}:


### PR DESCRIPTION
Make workflow restrictions discoverable by returning and displaying actionable denial reasons. Enforce read-only suggestion checks server-side so disabled editor controls cannot be bypassed.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
