### PR TITLE
fix(docs): validate GHSA identifiers

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -17,6 +17,7 @@ from sphinx.util.nodes import split_explicit_title
 simple_option_desc_re = re.compile(r"([-_a-zA-Z0-9]+)(\s*.*?)(?=,\s+(?:/|-|--)|$)")
 
 GHSSA_URL = "https://github.com/WeblateOrg/weblate/security/advisories/{}"
+GHSA_RE = re.compile(r"GHSA(?:-[23456789cfghjmpqrvwx]{4}){3}")
 PYPI_URL = "https://pypi.org/project/{}/"
 
 
@@ -30,6 +31,11 @@ class WeblateCommandLiteral(literal):
 # ruff: ignore[mutable-argument-default]
 def ghsa_link(name, rawtext, text, lineno, inliner, options={}, content=[]):
     fullname = f"GHSA-{text}"
+    if not GHSA_RE.fullmatch(fullname):
+        msg = inliner.reporter.error(
+            f"Invalid GitHub Security Advisory identifier: {fullname}", line=lineno
+        )
+        return [inliner.problematic(rawtext, rawtext, msg)], [msg]
     url = GHSSA_URL.format(fullname)
     node = nodes.reference(rawtext, fullname, refuri=url, **options)
     return [node], []

--- a/docs/_ext/test_djangodocs.py
+++ b/docs/_ext/test_djangodocs.py
@@ -1,0 +1,52 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for Weblate documentation Sphinx plugins."""
+
+from unittest.mock import Mock
+
+import pytest
+from djangodocs import GHSSA_URL, ghsa_link
+from docutils import nodes
+
+
+def test_ghsa_link() -> None:
+    identifier = "r52j-4vjp-q949"
+
+    result, messages = ghsa_link("ghsa", f":ghsa:`{identifier}`", identifier, 1, Mock())
+
+    assert messages == []
+    assert len(result) == 1
+    assert isinstance(result[0], nodes.reference)
+    assert result[0].astext() == f"GHSA-{identifier}"
+    assert result[0]["refuri"] == GHSSA_URL.format(f"GHSA-{identifier}")
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "",
+        "r52j-4vjp",
+        "r52j-4vjp-q94",
+        "r52j-4vjp-q949-extra",
+        "R52J-4VJP-Q949",
+        "abcd-1234-efgh",
+    ],
+)
+def test_ghsa_link_invalid(identifier: str) -> None:
+    rawtext = f":ghsa:`{identifier}`"
+    message = object()
+    problematic = object()
+    inliner = Mock()
+    inliner.reporter.error.return_value = message
+    inliner.problematic.return_value = problematic
+
+    result, messages = ghsa_link("ghsa", rawtext, identifier, 42, inliner)
+
+    assert result == [problematic]
+    assert messages == [message]
+    inliner.reporter.error.assert_called_once_with(
+        f"Invalid GitHub Security Advisory identifier: GHSA-{identifier}", line=42
+    )
+    inliner.problematic.assert_called_once_with(rawtext, rawtext, message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -677,6 +677,7 @@ max-complexity = 16  # TODO: should be lower
 [tool.ruff.lint.per-file-ignores]
 "ci/migrate-scripts/*.py" = ["INP001", "S101"]
 "docs/_ext/*.py" = ["INP001"]
+"docs/_ext/test_*.py" = ["S101"]
 "docs/conf.py" = ["ERA001", "INP001"]
 "fuzzing/targets.py" = ["PLC0415"]
 "scripts/*" = ["T201", "T203"]


### PR DESCRIPTION
Reject malformed advisory IDs during Sphinx builds so incomplete security advisory links cannot be published.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
