### PR TITLE
fix(auth): enforce repository-wide VCS permissions

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -479,6 +479,12 @@ the following rules:
   those languages. Project-wide, component-wide and global permissions from that
   team are not granted for that member.
 
+- The VCS permissions to commit, push, reset, and update are evaluated for the
+  whole repository. A member needs component-wide permission on the component
+  owning the repository and every component linked to it. This also applies
+  when linked components are in other projects. A per-member language limit
+  therefore cannot grant these permissions.
+
 .. hint::
 
    Use :guilabel:`Language selection` or :guilabel:`Project selection`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1102,6 +1102,10 @@ Projects
     only an overall summary for all repositories for the project. To get more detailed
     status use :http:get:`/api/components/(string:project)/(string:component)/repository/`.
 
+    Repository status requires component-wide permission on every component
+    sharing the affected repositories. This includes linked components in other
+    projects.
+
     :param project: Project URL slug
     :type project: string
     :>json boolean needs_commit: whether there are any pending changes to commit
@@ -1123,6 +1127,9 @@ Projects
 
     Performs given operation on the VCS repository.
 
+    Repository operations require component-wide permission on every component
+    sharing the affected repositories. This includes linked components in other
+    projects.
 
     :param project: Project URL slug
     :type project: string
@@ -1965,8 +1972,9 @@ Components
 
     The response is same as for :http:get:`/api/projects/(string:project)/repository/`.
 
-    For a linked repository, permission is checked on the source component that
-    owns the repository.
+    Repository status requires component-wide permission on the component that
+    owns the repository and every component linked to it, including components
+    in other projects.
 
     :param project: Project URL slug
     :type project: string
@@ -1985,8 +1993,9 @@ Components
 
     See :http:post:`/api/projects/(string:project)/repository/` for documentation.
 
-    For a linked repository, permission is checked on the source component that
-    owns the repository.
+    Repository operations require component-wide permission on the component
+    that owns the repository and every component linked to it, including
+    components in other projects.
 
     :param project: Project URL slug
     :type project: string
@@ -2523,9 +2532,10 @@ Translations
 
     The response is same as for :http:get:`/api/components/(string:project)/(string:component)/repository/`.
 
-    For a linked repository, permission is checked on the source component that
-    owns the repository. For an unlinked repository, permission can be limited
-    to the requested language.
+    Repository status requires component-wide permission on the component that
+    owns the repository and every component linked to it, including components
+    in other projects. A permission limited to the requested language is not
+    sufficient.
 
     :param project: Project URL slug
     :type project: string
@@ -2540,10 +2550,10 @@ Translations
 
     See :http:post:`/api/projects/(string:project)/repository/` for documentation.
 
-    Repository operations affect the entire component and therefore require
-    component-wide permission on the component that owns the repository. A
-    permission limited to the requested language is sufficient for viewing
-    unlinked repository status, but not for performing an operation.
+    Repository operations require component-wide permission on the component
+    that owns the repository and every component linked to it, including
+    components in other projects. A permission limited to the requested
+    language is not sufficient.
 
     :param project: Project URL slug
     :type project: string

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Weblate 2026.8.1
 .. rubric:: Bug fixes
 
 * Large language model machine translation services no longer fail when the optional persona and style settings are absent from the stored configuration, as happens when the service is installed through the REST API.
+* Repository actions now require permission on every component sharing the affected repository, including linked components in other projects.
 
 .. rubric:: Compatibility
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -604,7 +604,9 @@ Security properties Weblate provides
        :doc:`/admin/auth`)
      - Permission assignments match the intended trust relationship.
        Team-level enforced 2FA is satisfied by human users before
-       team-derived permissions apply.
+       team-derived permissions apply. Permissions for VCS actions cover every
+       component sharing an affected repository, including linked components
+       in other projects.
      - User or token can read or mutate data outside assigned scope.
      - Security-critical when private data or privileged mutation is exposed.
    * - Project-scoped API tokens are limited by assigned project/team

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -6585,7 +6585,7 @@ class ComponentAPITest(APIBaseTest):
         self.assertTrue(response.data["result"])
         do_update.assert_called_once()
 
-    def test_linked_repo_operation_requires_source_permission(self) -> None:
+    def test_linked_repo_operation_requires_all_component_permissions(self) -> None:
         linked_component = self.create_link_existing(
             name="Linked repository operation",
             slug="linked-repository-operation",
@@ -6603,7 +6603,7 @@ class ComponentAPITest(APIBaseTest):
         )
         self.user.clear_permissions_cache()
 
-        self.assertTrue(self.user.has_perm("vcs.update", linked_component))
+        self.assertFalse(self.user.has_perm("vcs.update", linked_component))
         self.assertFalse(self.user.has_perm("vcs.update", self.component))
         self.do_request(
             "api:component-repository",
@@ -6620,14 +6620,13 @@ class ComponentAPITest(APIBaseTest):
             )
         do_update.assert_not_called()
 
-        self.user.groups.remove(Group.objects.get(name=child_group_name))
         self.grant_perm_to_user(
             "vcs.update",
             group_name="Linked source repository access",
             component=self.component,
         )
         self.user.clear_permissions_cache()
-        self.assertFalse(self.user.has_perm("vcs.update", linked_component))
+        self.assertTrue(self.user.has_perm("vcs.update", linked_component))
         self.assertTrue(self.user.has_perm("vcs.update", self.component))
         self.do_request(
             "api:component-repository",
@@ -11073,13 +11072,13 @@ class TranslationAPITest(APIBaseTest):
 
         translation = self.component.translation_set.get(language_code="cs")
         for permission in permissions:
-            self.assertTrue(self.user.has_perm(permission, translation))
+            self.assertFalse(self.user.has_perm(permission, translation))
             self.assertFalse(self.user.has_perm(permission, self.component))
 
         self.do_request(
             "api:translation-repository",
             self.translation_kwargs,
-            code=200,
+            code=403,
         )
         for operation in RepoOperations.values:
             self.do_request(

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -662,28 +662,11 @@ class DownloadViewSet(viewsets.ReadOnlyModelViewSet):
 class WeblateViewSet(DownloadViewSet):
     """Allow to skip content negotiation for certain requests."""
 
-    @staticmethod
-    def get_repository_permission_obj(
-        obj: Project | Component | Translation, *, component_scope: bool
-    ) -> Project | Component | Translation:
-        component = obj.component if isinstance(obj, Translation) else obj
-        if (
-            isinstance(component, Component)
-            and component.linked_component_id is not None
-        ):
-            linked_component = component.linked_component
-            if linked_component is None:
-                msg = "Linked component ID exists without a linked component"
-                raise RuntimeError(msg)
-            return linked_component
-        return component if component_scope else obj
-
     @transaction.atomic
     def repository_operation(self, request: Request, obj, operation: str):
         permission, method, args, kwargs, takes_request = REPO_OPERATIONS[operation]
 
-        permission_obj = self.get_repository_permission_obj(obj, component_scope=True)
-        if not request.user.has_perm(permission, permission_obj):
+        if not request.user.has_perm(permission, obj):
             raise PermissionDenied
 
         obj.acting_user = request.user
@@ -724,8 +707,7 @@ class WeblateViewSet(DownloadViewSet):
 
             return Response(data)
 
-        permission_obj = self.get_repository_permission_obj(obj, component_scope=False)
-        if not request.user.has_perm("meta:vcs.status", permission_obj):
+        if not request.user.has_perm("meta:vcs.status", obj):
             raise PermissionDenied
 
         data = {

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -44,6 +44,18 @@ if TYPE_CHECKING:
 
 SPECIALS: dict[str, Callable[[User, str, Model], bool | PermissionResult]] = {}
 UPLOAD_SCOPE_PERMISSIONS = frozenset({"glossary.upload", "upload.perform"})
+REPOSITORY_PERMISSIONS = ("vcs.push", "vcs.commit", "vcs.reset", "vcs.update")
+type PermissionObject = (
+    Unit
+    | Translation
+    | CategoryLanguage
+    | Component
+    | ProjectLanguage
+    | Category
+    | Project
+    | ComponentList
+    | Workspace
+)
 
 
 @dataclass(frozen=True)
@@ -252,15 +264,7 @@ def check_direct_editing(
 def check_permission(
     user: User,
     permission: str,
-    obj: Unit
-    | Translation
-    | CategoryLanguage
-    | Component
-    | ProjectLanguage
-    | Category
-    | Project
-    | ComponentList
-    | Workspace,
+    obj: PermissionObject,
     *,
     allow_limited_without_language: bool = False,
 ) -> bool:
@@ -347,6 +351,78 @@ def check_permission(
         ) and check_enforced_2fa(user, obj.component.project)
     msg = f"Permission {permission} does not support: {obj.__class__}: {obj!r}"
     raise TypeError(msg)
+
+
+def get_repository_permission_components(
+    obj: Translation | Component | Project,
+) -> list[Component]:
+    """Return all components affected by repository operations on an object."""
+    cache_key = "_repository_permission_components"
+    cached = obj.__dict__.get(cache_key)
+    if cached is not None:
+        return cached
+
+    if isinstance(obj, Translation):
+        component = obj.component
+        owner_ids = {component.linked_component_id or component.pk}
+    elif isinstance(obj, Component):
+        owner_ids = {obj.linked_component_id or obj.pk}
+    elif isinstance(obj, Project):
+        owner_ids = {
+            linked_component_id or component_id
+            for component_id, linked_component_id in obj.component_set.values_list(
+                "pk", "linked_component_id"
+            )
+        }
+    else:
+        msg = f"Repository permission does not support: {obj.__class__}: {obj!r}"
+        raise TypeError(msg)
+
+    components = list(
+        Component.objects.filter(
+            Q(pk__in=owner_ids) | Q(linked_component_id__in=owner_ids)
+        )
+        .select_related("project")
+        .only(
+            "id",
+            "restricted",
+            "project_id",
+            "project__id",
+            "project__access_control",
+            "project__enforced_2fa",
+        )
+    )
+    obj.__dict__[cache_key] = components
+    return components
+
+
+def _check_repository_permission(
+    user: User,
+    permission: str,
+    components: Iterable[Component],
+) -> bool:
+    return all(
+        check_permission(user, permission, component) for component in components
+    )
+
+
+@register_perm(*REPOSITORY_PERMISSIONS)
+def check_repository_permission(
+    user: User,
+    permission: str,
+    obj: PermissionObject,
+) -> bool:
+    """Check permission on every component sharing an affected repository."""
+    if user.is_superuser:
+        return True
+    if not isinstance(obj, Translation | Component | Project):
+        return check_permission(user, permission, obj)
+    permission_obj = obj.component if isinstance(obj, Translation) else obj
+    if not check_permission(user, permission, permission_obj):
+        return False
+    return _check_repository_permission(
+        user, permission, get_repository_permission_components(obj)
+    )
 
 
 @register_perm("comment.resolve", "comment.delete", "suggestion.delete")
@@ -1058,11 +1134,20 @@ def check_possibly_global(
 def check_repository_status(
     user: User, permission: str, obj: Translation | Component | Project
 ) -> bool | PermissionResult:
-    return (
-        check_permission(user, "vcs.push", obj)
-        or check_permission(user, "vcs.commit", obj)
-        or check_permission(user, "vcs.reset", obj)
-        or check_permission(user, "vcs.update", obj)
+    if user.is_superuser:
+        return True
+    permission_obj = obj.component if isinstance(obj, Translation) else obj
+    allowed_permissions = tuple(
+        repository_permission
+        for repository_permission in REPOSITORY_PERMISSIONS
+        if check_permission(user, repository_permission, permission_obj)
+    )
+    if not allowed_permissions:
+        return False
+    components = get_repository_permission_components(obj)
+    return any(
+        _check_repository_permission(user, repository_permission, components)
+        for repository_permission in allowed_permissions
     )
 
 

--- a/weblate/auth/tests/test_models.py
+++ b/weblate/auth/tests/test_models.py
@@ -337,6 +337,108 @@ class ModelTest(FixtureComponentTestCase):
         self.assertTrue(self.user.can_access_project(self.project))
         self.assertTrue(self.user.has_perm("unit.edit", self.translation))
 
+    def test_repository_permissions_cover_linked_components(self) -> None:
+        linked = self.create_link_existing(
+            name="Repository permission child",
+            slug="repository-permission-child",
+        )
+        permissions = ("vcs.commit", "vcs.push", "vcs.reset", "vcs.update")
+        role = Role.objects.create(name="Repository permissions")
+        role.permissions.add(*Permission.objects.filter(codename__in=permissions))
+
+        child_group = Group.objects.create(
+            name="Repository child", language_selection=SELECTION_ALL
+        )
+        child_group.components.add(linked)
+        child_group.roles.add(role)
+        self.user.groups.add(child_group)
+        self.user.clear_permissions_cache()
+
+        for permission in permissions:
+            with self.subTest(permission=permission, scope="child-only"):
+                self.assertFalse(self.user.has_perm(permission, linked))
+                self.assertFalse(self.user.has_perm(permission, self.component))
+                self.assertFalse(self.user.has_perm(permission, self.translation))
+        self.assertFalse(self.user.has_perm("meta:vcs.status", linked))
+
+        owner_group = Group.objects.create(
+            name="Repository owner", language_selection=SELECTION_ALL
+        )
+        owner_group.components.add(self.component)
+        owner_group.roles.add(role)
+        self.user.groups.add(owner_group)
+        self.user.clear_permissions_cache()
+
+        for permission in permissions:
+            with self.subTest(permission=permission, scope="complete"):
+                self.assertTrue(self.user.has_perm(permission, linked))
+                self.assertTrue(self.user.has_perm(permission, self.component))
+                self.assertTrue(self.user.has_perm(permission, self.translation))
+        self.assertTrue(self.user.has_perm("meta:vcs.status", linked))
+
+    def test_repository_permission_scope_query_is_cached(self) -> None:
+        linked_components = [
+            self.create_link_existing(
+                name=f"Repository query child {index}",
+                slug=f"repository-query-child-{index}",
+                filemask=f"repository-query-{index}/*.po",
+            )
+            for index in range(10)
+        ]
+        role = Role.objects.create(name="Repository query permissions")
+        role.permissions.add(Permission.objects.get(codename="vcs.reset"))
+        group = Group.objects.create(
+            name="Repository query components", language_selection=SELECTION_ALL
+        )
+        group.components.add(self.component, *linked_components)
+        group.roles.add(role)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+        _ = self.user.profile
+        _ = self.user.component_permissions
+
+        component = self.component.__class__.objects.select_related("project").get(
+            pk=self.component.pk
+        )
+        with self.assertNumQueries(1):
+            self.assertTrue(self.user.has_perm("vcs.reset", component))
+        with self.assertNumQueries(0):
+            self.assertTrue(self.user.has_perm("vcs.reset", component))
+
+    def test_project_repository_permission_covers_cross_project_links(self) -> None:
+        other_project = Project.objects.create(
+            name="Repository child project",
+            slug="repository-child-project",
+            web="https://example.com/child",
+        )
+        linked = self.create_link_existing(
+            name="Cross-project repository child",
+            slug="cross-project-repository-child",
+            project=other_project,
+        )
+        role = Role.objects.create(name="Project repository permission")
+        role.permissions.add(Permission.objects.get(codename="vcs.reset"))
+        self.group.roles.add(role)
+        self.user.groups.add(self.group)
+        self.user.clear_permissions_cache()
+
+        self.assertFalse(self.user.has_perm("vcs.reset", self.project))
+        self.assertFalse(self.user.has_perm("vcs.reset", self.component))
+        self.assertFalse(self.user.has_perm("vcs.reset", linked))
+
+        child_group = Group.objects.create(
+            name="Cross-project repository permission",
+            language_selection=SELECTION_ALL,
+        )
+        child_group.components.add(linked)
+        child_group.roles.add(role)
+        self.user.groups.add(child_group)
+        self.user.clear_permissions_cache()
+
+        self.assertTrue(self.user.has_perm("vcs.reset", self.project))
+        self.assertTrue(self.user.has_perm("vcs.reset", self.component))
+        self.assertTrue(self.user.has_perm("vcs.reset", linked))
+
     def test_componentlist(self) -> None:
         # Add user to group of power users
         self.user.groups.add(self.group)

--- a/weblate/trans/tests/test_git_views.py
+++ b/weblate/trans/tests/test_git_views.py
@@ -10,6 +10,9 @@ from django.contrib.messages import get_messages
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from weblate.auth.data import SELECTION_ALL
+from weblate.auth.models import Group, Permission, Role, TeamMembership
+from weblate.lang.models import Language
 from weblate.trans.models import Component, PendingUnitChange, Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import get_optional_path
@@ -153,6 +156,80 @@ class GitNoChangeProjectTest(ViewTestCase):
         ):
             response = self.client.get(self.get_test_url("git_status"))
         self.assertContains(response, "Repository status")
+
+
+class RepositoryPermissionScopeTest(ViewTestCase):
+    def grant_permission(
+        self,
+        permission: str,
+        *,
+        component: Component | None = None,
+        project: Project | None = None,
+        language: Language | None = None,
+    ) -> None:
+        group = Group.objects.create(
+            name=f"Repository scope {permission} {Group.objects.count()}",
+            language_selection=SELECTION_ALL,
+        )
+        if component is not None:
+            group.components.add(component)
+        if project is not None:
+            group.projects.add(project)
+        role = Role.objects.create(
+            name=f"Repository scope {permission} {Role.objects.count()}"
+        )
+        role.permissions.add(Permission.objects.get(codename=permission))
+        group.roles.add(role)
+        self.user.groups.add(group)
+        if language is not None:
+            TeamMembership.objects.get(user=self.user, group=group).limit_languages.add(
+                language
+            )
+        self.user.clear_permissions_cache()
+
+    def test_language_limited_reset_and_cleanup_are_denied(self) -> None:
+        self.user.groups.clear()
+        translation = self.get_translation("cs")
+        self.grant_permission(
+            "vcs.reset",
+            project=self.project,
+            language=Language.objects.get(code="cs"),
+        )
+
+        self.assertFalse(self.user.has_perm("vcs.reset", translation))
+        self.assertFalse(self.user.has_perm("meta:vcs.status", translation))
+        for view_name in (
+            "reset",
+            "cleanup",
+            "file_sync",
+            "file_scan",
+            "remove_duplicate_units",
+            "cleanup_unused",
+            "remove_obsolete_units",
+        ):
+            with self.subTest(view_name=view_name):
+                response = self.client.post(
+                    reverse(view_name, kwargs={"path": translation.get_url_path()})
+                )
+                self.assertEqual(response.status_code, 403)
+
+    def test_linked_child_reset_requires_owner_permission(self) -> None:
+        self.user.groups.clear()
+        other_project = self.create_project(name="Other", slug="other")
+        linked = self.create_link_existing(
+            name="Linked repository permission",
+            slug="linked-repository-permission",
+            project=other_project,
+        )
+        self.grant_permission("vcs.reset", component=linked)
+
+        self.assertFalse(self.user.has_perm("vcs.reset", linked))
+        with patch.object(Component, "do_reset", autospec=True) as reset:
+            response = self.client.post(
+                reverse("reset", kwargs={"path": linked.get_url_path()})
+            )
+        self.assertEqual(response.status_code, 403)
+        reset.assert_not_called()
 
 
 class GitNoChangeComponentTest(GitNoChangeProjectTest):


### PR DESCRIPTION
Repository actions affect the owner and every linked component, including across projects. Require component-wide permission for the full repository scope so narrow grants cannot mutate unrelated translation state.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
