### PR TITLE
fix(stats): handle outdated cached values

### DIFF
--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -103,6 +103,18 @@ SOURCE_KEYS = frozenset(
     )
 )
 
+# TODO: Remove after stats cache versioning prevents pre-5.2 values from
+# surviving supported staged upgrades.
+OUTDATED_STATS_KEYS = {
+    "unapproved",
+    "unapproved_chars",
+    "unapproved_words",
+    "recent_changes",
+    "monthly_changes",
+    "total_changes",
+    "stats_timestamp",
+}
+
 SOURCE_MAP = {
     "source_chars": "all_chars",
     "source_words": "all_words",
@@ -340,6 +352,10 @@ class BaseStats:
             # Handle source_* keys as virtual on translation level for easier aggregation
             if name.startswith("source_"):
                 return self._data[SOURCE_MAP[name]]
+            # These keys used to be calculated on demand and can be missing
+            # from cached stats that survived a staged upgrade.
+            if name in OUTDATED_STATS_KEYS:
+                return 0
             raise
 
     def __getattr__(self, name: str):

--- a/weblate/utils/tests/test_stats.py
+++ b/weblate/utils/tests/test_stats.py
@@ -41,6 +41,22 @@ class StubObject:
 
 
 class StatsPrefetchTest(SimpleTestCase):
+    def test_aggregate_outdated_stats(self) -> None:
+        stats = StubStats(1)
+        stats.set_data({"all": 1})
+
+        for key in (
+            "unapproved",
+            "unapproved_chars",
+            "unapproved_words",
+            "recent_changes",
+            "monthly_changes",
+            "total_changes",
+            "stats_timestamp",
+        ):
+            with self.subTest(key=key):
+                self.assertEqual(stats.aggregate_get(key), 0)
+
     def test_prefetch_is_bounded_and_preserves_order(self) -> None:
         count = 2 * STATS_PREFETCH_CHUNK_SIZE + 1
         objects = [StubObject(identifier) for identifier in range(count)]


### PR DESCRIPTION
Statistics cached by Weblate versions before 5.2 can survive supported staged upgrades. Restore the compatibility fallback so aggregating them does not raise a KeyError.

Closes #21024

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
