### PR TITLE
fix(screenshots): restore clipboard paste button

### DIFF
--- a/weblate/screenshots/forms.py
+++ b/weblate/screenshots/forms.py
@@ -7,12 +7,12 @@ from typing import Any, ClassVar, NoReturn, cast
 from urllib.parse import unquote, urlsplit
 
 import httpx2
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Field, Layout
 from django import forms
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.forms.forms import BaseForm
-from django.template.loader import render_to_string
-from django.utils.html import format_html
 from django.utils.http import urlencode
 from django.utils.translation import gettext, gettext_lazy
 
@@ -109,13 +109,6 @@ class ScreenshotImageValidationMixin(BaseForm):
         )
 
 
-class ScreenshotInput(forms.FileInput):
-    def render(self, name, value, attrs=None, renderer=None, **kwargs):
-        rendered_input = super().render(name, value, attrs, renderer, **kwargs)
-        paste_button = render_to_string("screenshots/snippets/paste-button.html")
-        return format_html("{}{}", rendered_input, paste_button)
-
-
 class ScreenshotEditForm(forms.ModelForm, ScreenshotImageValidationMixin):
     """Screenshot editing."""
 
@@ -130,11 +123,19 @@ class ScreenshotEditForm(forms.ModelForm, ScreenshotImageValidationMixin):
         model = Screenshot
         fields = ("name", "image", "image_url", "repository_filename")
         # ruff: ignore[mutable-class-default]
-        widgets = {
-            "image": ScreenshotInput,
-        }
-        # ruff: ignore[mutable-class-default]
         field_classes = {"image": AssetImageField}
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.disable_csrf = True
+        self.helper.form_tag = False
+        self.helper.layout = Layout(
+            "name",
+            Field("image", template="screenshots/snippets/image-field.html"),
+            "image_url",
+            "repository_filename",
+        )
 
     def clean(self):
         cleaned_data = super().clean()
@@ -162,7 +163,6 @@ class ScreenshotForm(forms.ModelForm, ScreenshotImageValidationMixin):
         # ruff: ignore[mutable-class-default]
         widgets = {
             "translation": SortedSelect,
-            "image": ScreenshotInput,
         }
         # ruff: ignore[mutable-class-default]
         field_classes = {
@@ -187,6 +187,16 @@ class ScreenshotForm(forms.ModelForm, ScreenshotImageValidationMixin):
         translation_field.initial = component.source_translation
         translation_field.empty_label = None
         self.fields["image"].required = False
+        self.helper = FormHelper(self)
+        self.helper.disable_csrf = True
+        self.helper.form_tag = False
+        self.helper.layout = Layout(
+            "name",
+            "repository_filename",
+            Field("image", template="screenshots/snippets/image-field.html"),
+            "image_url",
+            "translation",
+        )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -21,6 +21,7 @@ from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
 from django.utils import timezone
+from lxml import html
 from PIL import Image
 from rest_framework.test import APITestCase
 
@@ -201,6 +202,26 @@ class ViewTest(FixtureTestCase):
             response, get_doc_url("user/search", "search-screenshots", user=self.user)
         )
 
+    def test_list_paste_button(self) -> None:
+        self.make_manager()
+        response = self.client.get(reverse("screenshots", kwargs=self.kw_component))
+        self.assertContains(response, 'id="paste-screenshot-btn"')
+        document = html.fromstring(response.content)
+        container = document.get_element_by_id("screenshot-form-container")
+        form = container.xpath("ancestor::form[1]")[0]
+        self.assertEqual(
+            len(form.xpath('.//input[@name="csrfmiddlewaretoken"]')),
+            1,
+        )
+        button = document.get_element_by_id("paste-screenshot-btn")
+        self.assertEqual(button.get("class"), "btn btn-outline-secondary")
+        parent = button.getparent()
+        assert parent is not None
+        self.assertEqual(parent.get("class"), "input-group")
+        previous = button.getprevious()
+        assert previous is not None
+        self.assertEqual(previous.get("id"), "id_image")
+
     def do_upload(self, **kwargs):
         with open(TEST_SCREENSHOT, "rb") as handle:
             data = {
@@ -351,6 +372,14 @@ class ViewTest(FixtureTestCase):
             response, get_doc_url("user/search", "search-boolean", user=self.user)
         )
         self.assertContains(response, 'id="screenshots-toggle-selection"')
+        self.assertContains(response, 'id="paste-screenshot-btn"')
+        form = html.fromstring(response.content).get_element_by_id(
+            "screenshot-form-container"
+        )
+        self.assertEqual(
+            len(form.xpath('.//input[@name="csrfmiddlewaretoken"]')),
+            1,
+        )
 
     @override_settings(ALLOWED_ASSET_SIZE=1)
     def test_edit_metadata_with_existing_oversized_image(self) -> None:

--- a/weblate/static/js/screenshots/clipboard-paste.js
+++ b/weblate/static/js/screenshots/clipboard-paste.js
@@ -8,58 +8,66 @@ document.addEventListener("DOMContentLoaded", () => {
   if (pasteScreenshotBtn === null) {
     return;
   }
+  const screenshotForm = document.getElementById("screenshot-form-container");
   // The file input to store the screenshot file
-  const screenshotFileInput = document.querySelector(
-    "#screenshot-form-container input#id_image",
-  );
-
-  // Check if the browser supports the Clipboard API
-  if (!navigator.clipboard?.read) {
+  const screenshotFileInput = screenshotForm?.querySelector("input#id_image");
+  if (screenshotForm === null || screenshotFileInput === null) {
     pasteScreenshotBtn.remove();
     return;
   }
 
+  const setScreenshotImage = (blob, type) => {
+    const fileName = `screenshot_${Date.now()}.${type.split("/")[1]}`;
+    const imageFile = new File([blob], fileName, { type: type });
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(imageFile);
+    screenshotFileInput.files = dataTransfer.files;
+    screenshotFileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    showInfo("success", gettext("Image Pasted!"));
+  };
+
+  const showPasteInstructions = () => {
+    showInfo("info", gettext("Press Ctrl+V or Command+V to paste an image."));
+  };
+
+  screenshotForm.addEventListener("paste", (event) => {
+    const clipboardItems = event.clipboardData?.items;
+    if (clipboardItems === undefined) {
+      return;
+    }
+    const imageItem = Array.from(clipboardItems).find(
+      (item) => item.kind === "file" && item.type.startsWith("image/"),
+    );
+    const imageFile = imageItem?.getAsFile();
+    if (imageFile === null || imageFile === undefined) {
+      return;
+    }
+    event.preventDefault();
+    setScreenshotImage(imageFile, imageItem.type);
+  });
+
   pasteScreenshotBtn.addEventListener("click", async (e) => {
     e.preventDefault();
+    if (!navigator.clipboard?.read) {
+      showPasteInstructions();
+      return;
+    }
     try {
       // Read clipboard content
       const clipboardItems = await navigator.clipboard.read();
-      let imageFound = false;
       for (const clipboardItem of clipboardItems) {
         // Find the image in the clipboard
-        for (const type of clipboardItem.types) {
-          if (type.startsWith("image/")) {
-            // Convert the image data to a file data
-            const blob = await clipboardItem.getType(type);
-            const reader = new FileReader();
-            reader.onload = (_event) => {
-              if (screenshotFileInput !== null) {
-                // Load the file data into the form input
-                const fileName = `screenshot_${Date.now()}.${type.split("/")[1]}`;
-                const imageFile = new File([blob], fileName, { type: type });
-                const dataTransfer = new DataTransfer();
-                dataTransfer.items.add(imageFile);
-                screenshotFileInput.files = dataTransfer.files;
-                // Inform paste success
-                showInfo("success", gettext("Image Pasted!"));
-              } else {
-                showInfo("danger", gettext("Something went wrong!"));
-              }
-            };
-            reader.readAsDataURL(blob);
-            imageFound = true;
-            break;
-          }
-        }
-        if (imageFound) {
-          break;
+        const type = clipboardItem.types.find((itemType) =>
+          itemType.startsWith("image/"),
+        );
+        if (type !== undefined) {
+          setScreenshotImage(await clipboardItem.getType(type), type);
+          return;
         }
       }
-      if (!imageFound) {
-        showInfo("warning", gettext("No image found in clipboard"));
-      }
+      showInfo("warning", gettext("No image found in clipboard"));
     } catch (_err) {
-      showInfo("danger", gettext("Something went wrong!"));
+      showPasteInstructions();
     }
   });
 });

--- a/weblate/templates/screenshots/screenshot_detail.html
+++ b/weblate/templates/screenshots/screenshot_detail.html
@@ -121,7 +121,7 @@
         <div class="card-header">
           <h4 class="card-title">{% translate "Edit screenshot" %}</h4>
         </div>
-        <div class="card-body">{{ edit_form|crispy }}</div>
+        <div class="card-body">{% crispy edit_form %}</div>
         <div class="card-footer">
           <input type="submit" class="btn btn-primary" value="{% translate "Save" %}" />
         </div>

--- a/weblate/templates/screenshots/screenshot_list.html
+++ b/weblate/templates/screenshots/screenshot_list.html
@@ -230,7 +230,7 @@
               <h4 class="card-title">{% translate "Add new screenshot" %}</h4>
             </div>
             <div class="card-body">
-              <div id="screenshot-form-container">{{ add_form|crispy }}</div>
+              <div id="screenshot-form-container">{% crispy add_form %}</div>
             </div>
             <div class="card-footer">
               <input type="submit" class="btn btn-primary" value="{% translate "Save" %}" />

--- a/weblate/templates/screenshots/snippets/image-field.html
+++ b/weblate/templates/screenshots/snippets/image-field.html
@@ -1,0 +1,48 @@
+{% load crispy_forms_field %}
+
+<div id="div_{{ field.auto_id }}"
+     class="mb-3{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+  {% if field.label and form_show_labels %}
+    <label for="{{ field.id_for_label }}"
+           class="{% if 'form-horizontal' in form_class %}col-form-label {% else %}form-label{% endif %}{% if label_class %} {{ label_class }}{% endif %}{% if field.field.required %} requiredField{% endif %}">
+      {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+    </label>
+  {% endif %}
+  {% if field_class %}<div class="{{ field_class }}">{% endif %}
+  {% for widget in field.subwidgets %}
+    {% if widget.data.is_initial %}
+      <div class="input-group mb-2">
+        <span class="input-group-text">{{ widget.data.initial_text }}</span>
+        <div class="form-control d-flex h-auto">
+          <span class="text-break flex-grow-1">
+            <a href="{{ field.value.url }}">{{ field.value.name }}</a>
+          </span>
+          {% if not widget.data.required %}
+            <span class="align-self-center ms-2">
+              <span class="form-check">
+                <input type="checkbox"
+                       name="{{ widget.data.checkbox_name }}"
+                       id="{{ widget.data.checkbox_id }}"
+                       class="form-check-input"
+                       {% if field.field.disabled %}disabled{% endif %} />
+                <label class="form-check-label mb-0" for="{{ widget.data.checkbox_id }}">{{ widget.data.clear_checkbox_label }}</label>
+              </span>
+            </span>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+    <div {% if field.errors %}class="is-invalid"{% endif %}>
+      <div class="input-group">
+        <input type="{{ widget.data.type }}" name="{{ widget.data.name }}" class="form-control{% if widget.data.attrs.class %} {{ widget.data.attrs.class }}{% endif %}{% if field.errors %} is-invalid{% endif %}" {% if field.field.disabled %}disabled{% endif %} {% for name, value in widget.data.attrs.items %} {% if value is not False and name != "class" %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %} {% endif %} {% endfor %} />
+        {% include "screenshots/snippets/paste-button.html" %}
+      </div>
+      <div id="paste-screenshot-info-label"
+           class="form-text"
+           role="status"
+           aria-live="polite"></div>
+      {% include "bootstrap5/layout/help_text_and_errors.html" %}
+    </div>
+  {% endfor %}
+  {% if field_class %}</div>{% endif %}
+</div>

--- a/weblate/templates/screenshots/snippets/paste-button.html
+++ b/weblate/templates/screenshots/snippets/paste-button.html
@@ -1,4 +1,6 @@
 {% load i18n %}
 
-<p id="paste-screenshot-info-label" class="text-center"></p>
-<button id="paste-screenshot-btn" class="btn" type="button">{% translate "Paste from clipboard" %}</button>
+<button id="paste-screenshot-btn"
+        class="btn btn-outline-secondary"
+        type="button"
+        aria-describedby="paste-screenshot-info-label">{% translate "Paste from clipboard" %}</button>

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -1126,7 +1126,7 @@
                       aria-label="{% translate "Close" %}"></button>
             </div>
             <div class="modal-body">
-              <div id="screenshot-form-container">{{ screenshot_form|crispy }}</div>
+              <div id="screenshot-form-container">{% crispy screenshot_form %}</div>
               <input type="hidden" name="source" value="{{ unit.pk }}" />
               <input type="hidden" name="next" value="{{ this_unit_url }}" />
             </div>

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -16,6 +16,7 @@ from django.core.exceptions import ValidationError
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from lxml import html
 
 from weblate.addons.resx import ResxUpdateAddon
 from weblate.auth.data import SELECTION_ALL
@@ -84,6 +85,19 @@ class EditScreenshotContextTest(ViewTestCase):
         response = self.client.get(self.translation.get_translate_url())
         self.assertContains(
             response, get_doc_url("admin/translating", "screenshots", user=self.user)
+        )
+
+    def test_screenshot_upload_has_paste_button(self) -> None:
+        self.make_manager()
+        response = self.client.get(self.translation.get_translate_url())
+        self.assertContains(response, 'id="paste-screenshot-btn"')
+        modal = html.fromstring(response.content).get_element_by_id(
+            "add-screenshot-form"
+        )
+        form = modal.xpath("ancestor::form[1]")[0]
+        self.assertEqual(
+            len(form.xpath('.//input[@name="csrfmiddlewaretoken"]')),
+            1,
         )
 
     def test_screenshot_context_deduplicates_source_and_unit_links(self) -> None:

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import base64
 import logging
 import math
 import os
@@ -27,6 +28,7 @@ from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
+from PIL import Image
 from selenium import webdriver
 from selenium.common.exceptions import (
     ElementClickInterceptedException,
@@ -824,6 +826,24 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
             raise ValueError(msg)
         element.send_keys(name)
 
+    def set_image_clipboard(self, filename: str | Path) -> None:
+        image = base64.b64encode(Path(filename).read_bytes()).decode("ascii")
+        error = self.driver.execute_async_script(
+            """
+            const image = Uint8Array.from(atob(arguments[0]), (byte) =>
+                byte.charCodeAt(0),
+            );
+            const done = arguments[arguments.length - 1];
+            navigator.clipboard.write([
+                new ClipboardItem({
+                    "image/png": new Blob([image], {type: "image/png"}),
+                }),
+            ]).then(() => done(null), (exception) => done(String(exception)));
+            """,
+            image,
+        )
+        self.assertIsNone(error, error)
+
     @overload
     def do_login(self, *, create: Literal[False], superuser: bool = False) -> None: ...
     @overload
@@ -1552,6 +1572,66 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
         self.click("Add screenshot")
         self.assert_text_contains("#screenshots-add", "Repository path to screenshot")
         self.screenshot("screenshot-filemask-repository-filename.png")
+
+    def test_screenshot_clipboard_paste(self) -> None:
+        """Test uploading a screenshot pasted from the clipboard."""
+        project = self.create_component()
+        self.do_login(superuser=True)
+        unit = Unit.objects.filter(
+            translation__component__project=project,
+            translation__component__slug="django",
+            translation__language__code="cs",
+        ).first()
+        assert unit is not None
+
+        with self.wait_for_page_load():
+            self.driver.get(f"{self.live_server_url}{unit.get_absolute_url()}")
+        self.click("Add screenshot")
+        modal = WebDriverWait(self.driver, 5).until(
+            element_to_be_clickable((By.ID, "add-screenshot-form"))
+        )
+        modal.find_element(By.ID, "id_name").send_keys("Clipboard screenshot")
+
+        origin = self.driver.execute_script("return window.location.origin;")
+        self.driver.execute_cdp_cmd(
+            "Browser.grantPermissions",
+            {
+                "origin": origin,
+                "permissions": ["clipboardReadWrite", "clipboardSanitizedWrite"],
+            },
+        )
+        try:
+            expected_image_path = get_test_file("screenshot.png")
+            self.set_image_clipboard(expected_image_path)
+            self.click(htmlid="paste-screenshot-btn")
+            image_input = modal.find_element(By.ID, "id_image")
+            WebDriverWait(self.driver, 5).until(
+                lambda driver: driver.execute_script(
+                    "return arguments[0].files.length === 1;", image_input
+                )
+            )
+            self.assert_text_contains("#paste-screenshot-info-label", "Image Pasted!")
+            with self.wait_for_page_load():
+                self.click(modal.find_element(By.CSS_SELECTOR, 'input[type="submit"]'))
+        finally:
+            self.driver.execute_cdp_cmd("Browser.resetPermissions", {})
+
+        screenshot = Screenshot.objects.get(name="Clipboard screenshot")
+        self.assertTrue(screenshot.units.filter(pk=unit.pk).exists())
+        screenshot.image.open("rb")
+        try:
+            with (
+                Image.open(expected_image_path) as expected_image,
+                Image.open(screenshot.image) as uploaded_image,
+            ):
+                self.assertEqual(uploaded_image.format, "PNG")
+                self.assertEqual(uploaded_image.size, expected_image.size)
+                self.assertEqual(
+                    uploaded_image.convert("RGBA").tobytes(),
+                    expected_image.convert("RGBA").tobytes(),
+                )
+        finally:
+            screenshot.image.close()
 
     def test_screenshots(self) -> None:
         """Screenshot tests."""


### PR DESCRIPTION
Crispy Forms reconstructs file inputs and drops markup appended by the custom widget. Render the paste control through an explicit layout and cover the complete upload flow with Selenium.

Closes #21030

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
