### PR TITLE
fix(api): return 404 when unit is deleted mid-request

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -11900,6 +11900,28 @@ class UnitAPITest(APIBaseTest):
         # The auto fixer adds the trailing newline
         self.assertEqual(unit.target, "Test translation\n")
 
+    def test_translate_unit_deleted_mid_request(self) -> None:
+        """Unit removed between get_object() and the locking re-fetch."""
+        unit = Unit.objects.get(
+            translation__language_code="cs", source="Hello, world!\n"
+        )
+
+        def delete_unit(self) -> None:
+            Unit.objects.filter(pk=unit.pk).delete()
+
+        # invalidate_checks_cache() runs at the top of Unit.translate(),
+        # before the select_for_update() re-fetch
+        with patch.object(
+            Unit, "invalidate_checks_cache", autospec=True, side_effect=delete_unit
+        ):
+            self.do_request(
+                "api:unit-detail",
+                kwargs={"pk": unit.pk},
+                method="patch",
+                code=404,
+                request={"state": "20", "target": "Test translation"},
+            )
+
     def test_translate_unit_whitespace(self) -> None:
         unit = Unit.objects.get(
             translation__language_code="cs", source="Hello, world!\n"

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -3845,7 +3845,13 @@ class UnitViewSet(viewsets.ReadOnlyModelViewSet, UpdateModelMixin, DestroyModelM
 
         # Handle translate
         if do_translate:
-            unit.translate(user, new_target, new_state)
+            try:
+                unit.translate(user, new_target, new_state)
+            except Unit.DoesNotExist as error:
+                # The unit can be removed by a concurrent component update between
+                # the initial lookup and the locking re-fetch in Unit.translate()
+                msg = "Unit was removed while processing the request"
+                raise Http404(msg) from error
 
     def destroy(self, request: Request, *args, **kwargs):
         """Delete a translation unit."""


### PR DESCRIPTION
`PATCH /api/units/{id}/` returned an unhandled 500 when the unit row was deleted between DRF's `get_object()` and the `select_for_update()` re-fetch in `Unit.translate()`. The raw `Unit.DoesNotExist` is now turned into a 404, consistent with the response when the unit is already gone at the start of the request.

Fixes #20997

## Test

`test_translate_unit_deleted_mid_request` drives the race deterministically by deleting the row from `invalidate_checks_cache()`, which runs at the top of `Unit.translate()` just before the re-fetch — no threads or sleeps.

Without the fix it reproduces the reported traceback exactly:

```
weblate/api/views.py:3848: in perform_update
    unit.translate(user, new_target, new_state)
weblate/trans/models/unit.py:2385: in translate
    old_unit = Unit.objects.select_for_update().get(pk=self.pk)
E   weblate.trans.models.unit.Unit.DoesNotExist: Unit matching query does not exist.
ERROR django.request: Server Error (500): /api/units/5/
```

With the fix, `weblate/api/tests.py::UnitAPITest` passes (24 tests), and `ruff check` / `ruff format --check` are clean on both changed files.

## Open question

`Unit.translate()` re-fetches the row under `select_for_update()` after the caller has already resolved it, so the same TOCTOU window exists for every caller, not just the API:

- `weblate/api/views.py:3849` (this PR)
- `weblate/trans/views/edit.py:862` and `:976`
- `weblate/trans/views/search.py:140`
- `weblate/trans/views/js.py:144`

I fixed it at the API boundary to keep the diff narrow and leave the model's exception semantics unchanged. The alternative is catching `Unit.DoesNotExist` inside `translate()` itself, which would cover the web editor too but means a model method raising `Http404`.

Also happy to move it if you prefer the model layer fix.