### PR TITLE
Fix screenshot upload in Selenium tests by cleaning storage and using consistent filenames

### DIFF
--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -13,6 +13,7 @@ import warnings
 from contextlib import contextmanager, suppress
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Literal, cast, overload
 from unittest.mock import patch
@@ -1712,11 +1713,12 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
         self.click("Add screenshot")
         self.driver.find_element(By.ID, "id_name").send_keys("Automatic translation")
         element = self.driver.find_element(By.ID, "id_image")
-        upload_path = Path(self.tempdir) / upload_filename
-        upload_path.write_bytes(Path(get_test_file("screenshot.png")).read_bytes())
-        self.upload_file(element, upload_path)
-        with self.wait_for_page_load():
-            element.submit()
+        with TemporaryDirectory(prefix="weblate-selenium-upload-") as upload_dir:
+            upload_path = Path(upload_dir) / upload_filename
+            upload_path.write_bytes(Path(get_test_file("screenshot.png")).read_bytes())
+            self.upload_file(element, upload_path)
+            with self.wait_for_page_load():
+                element.submit()
         uploaded_screenshot = Screenshot.objects.get(name="Automatic translation")
 
         listing_filename = "main-menu.png"

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -22,6 +22,7 @@ from django.conf import settings
 from django.core import mail
 from django.core.cache import cache
 from django.core.files import File
+from django.core.files.storage import default_storage
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest
 from django.test.utils import modify_settings, override_settings
@@ -1706,19 +1707,25 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
             self.click("Screenshots")
 
         # Upload screenshot
+        upload_filename = "automatic-translation.png"
+        default_storage.delete(f"screenshots/{upload_filename}")
         self.click("Add screenshot")
         self.driver.find_element(By.ID, "id_name").send_keys("Automatic translation")
         element = self.driver.find_element(By.ID, "id_image")
-        self.upload_file(element, get_test_file("screenshot.png"))
+        upload_path = Path(self.tempdir) / upload_filename
+        upload_path.write_bytes(Path(get_test_file("screenshot.png")).read_bytes())
+        self.upload_file(element, upload_path)
         with self.wait_for_page_load():
             element.submit()
         uploaded_screenshot = Screenshot.objects.get(name="Automatic translation")
 
+        listing_filename = "main-menu.png"
+        default_storage.delete(f"screenshots/{listing_filename}")
         with open(get_test_file("screenshot.png"), "rb") as handle:
             listing_screenshot = Screenshot.objects.create(
                 name="Main menu",
                 repository_filename="fastlane/metadata/android/en-US/images/menu.png",
-                image=File(handle, name="main-menu.png"),
+                image=File(handle, name=listing_filename),
                 translation=component.source_translation,
                 user=user,
             )


### PR DESCRIPTION
### Motivation

- Prevent flaky Selenium screenshot tests caused by existing files in storage and inconsistent upload filenames across storage backends.

### Description

- Import `default_storage` and delete any existing `screenshots/<filename>` before creating or uploading screenshots to avoid name collisions.
- Write a copy of the test screenshot into the test `tempdir` with a controlled filename and upload that path via Selenium instead of uploading directly from the packaged test asset.
- Use a `listing_filename` variable for the created `Screenshot` file name to ensure consistency.

### Testing

- Ran the Selenium screenshot tests in `weblate/trans/tests/test_selenium.py::SeleniumTests` with the updated upload flow; the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72b13167148329a24b31b0642a573b)