### PR TITLE
fix(l10n): correct Portuguese API key guidance

### DIFF
--- a/weblate/locale/pt/LC_MESSAGES/django.po
+++ b/weblate/locale/pt/LC_MESSAGES/django.po
@@ -10035,7 +10035,7 @@ msgstr "Desativa a autenticação por palavra-passe para o utilizador."
 
 #: weblate/templates/accounts/user.html:458
 msgid "Leave enabled to revoke the current API key and generate a new one."
-msgstr "Deixe em branco para revogar a chave API atual e gerar uma nova."
+msgstr "Deixe ativado para revogar a chave API atual e gerar uma nova."
 
 #: weblate/templates/accounts/user.html:464
 msgid "Disable password"


### PR DESCRIPTION
### Motivation

- Fix an incorrect Portuguese help text that told administrators to "leave blank" the API-key regeneration option, which could cause existing API keys to remain active when password authentication is disabled.

### Description

- Update the Portuguese translation in `weblate/locale/pt/LC_MESSAGES/django.po` for the message id `"Leave enabled to revoke the current API key and generate a new one."` to `"Deixe ativado para revogar a chave API atual e gerar uma nova."`.
- Ensure the localized help text matches the template behavior where the `regenerate_api_key` checkbox must remain checked to revoke and regenerate the API key.

### Testing

- Ran `uv sync --all-extras --dev` to prepare the development environment and dependency graph, which completed successfully.
- Ran `uv run prek run --files weblate/locale/pt/LC_MESSAGES/django.po` which passed the configured pre-commit checks for the changed file.
- Ran `msgfmt --check --check-format --output-file=/dev/null weblate/locale/pt/LC_MESSAGES/django.po` which exited with status 0 indicating a valid .po format.
- Ran `git diff --check` to verify no whitespace or diff-check issues were introduced and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a704544f54c83298e6a41bc8e3cbf96)