### PR TITLE
fix(api): include component creation task URL

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.8.1
 
 .. rubric:: Bug fixes
 
+* Component creation through the REST API now returns the background task URL in the response when creation work is queued.
 * Large language model machine translation services no longer fail when the optional persona and style settings are absent from the stored configuration, as happens when the service is installed through the REST API.
 * Repository actions now require permission on every component sharing the affected repository, including linked components in other projects.
 

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1987,13 +1987,13 @@ class ProjectViewSet(
                     msg = "Component serializer did not produce an instance"
                     raise RuntimeError(msg)
                 component.post_create(self.request.user, origin="api")
-                return Response(
-                    serializer.data,
-                    status=HTTP_201_CREATED,
-                    headers={
-                        "Location": str(serializer.data[api_settings.URL_FIELD_NAME])
-                    },
-                )
+
+            data = serializer.data
+            return Response(
+                data,
+                status=HTTP_201_CREATED,
+                headers={"Location": str(data[api_settings.URL_FIELD_NAME])},
+            )
 
         queryset = (
             obj.component_set.filter_access(self.request.user)


### PR DESCRIPTION
### Motivation

- Component creation via the REST API could return a response before background-task metadata (used by `RelatedTaskField` / `task_url`) was visible, so callers did not receive the queued task URL for creations that run in the background.
- The goal is to ensure `task_url` is present in the API response when creation work is queued by deferring response serialization until after the DB transaction commits and background-task metadata is stored.

### Description

- Changed `weblate/api/views.py` to serialize the created component after exiting the `with transaction.atomic():` block by moving the `serializer.data` extraction and `Response` construction outside the transaction so background task metadata stored on commit is included.
- Kept existing `component.post_create(...)` behaviour while ensuring the response uses `data = serializer.data` after commit visibility.
- Added a changelog entry in `docs/changes.rst` noting that component creation now returns the background task URL when work is queued.

### Testing

- Ran `uv run pytest weblate/api/tests.py::ProjectAPITest::test_create_component`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72d6e27138832998feb26ed71b5397)