### PR TITLE
Use ComponentSerializer in import_json to preserve source_language and improve validation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Weblate 2026.8.1
 .. rubric:: Bug fixes
 
 * Large language model machine translation services no longer fail when the optional persona and style settings are absent from the stored configuration, as happens when the service is installed through the REST API.
+* :wladmin:`import_json` now preserves the component source language from JSON exports.
 * Repository actions now require permission on every component sharing the affected repository, including linked components in other projects.
 
 .. rubric:: Compatibility

--- a/weblate/trans/management/commands/import_json.py
+++ b/weblate/trans/management/commands/import_json.py
@@ -5,18 +5,55 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from django.core.exceptions import ValidationError
 from django.core.management.base import CommandError
 from django.utils.text import slugify
+from rest_framework.exceptions import ValidationError
 
-from weblate.trans.inherited_settings import apply_create_inheritance_defaults
+from weblate.api.serializers import ComponentSerializer
 from weblate.trans.models import Component, Project
 from weblate.utils.management.base import BaseCommand
 
 if TYPE_CHECKING:
     from django.core.management.base import CommandParser
+
+
+class ImportUser:
+    """User object granting permissions for serializer validation."""
+
+    needs_component_restrictions_filter = False
+    needs_project_filter = False
+    component_permissions: tuple[int, ...] = ()
+
+    def has_perm(self, perm, obj=None) -> bool:
+        return True
+
+    def get_author_name(self) -> str:
+        return "Weblate import"
+
+
+class ImportRequest:
+    """Request object for serializer context."""
+
+    user = ImportUser()
+
+
+def format_serializer_error(error: ValidationError) -> str:
+    return str(error.detail)
+
+
+def get_component_serializer(
+    project: Project, data: dict[str, Any], component: Component | None = None
+) -> ComponentSerializer:
+    kwargs: dict[str, Any] = {
+        "context": {"request": ImportRequest(), "project": project},
+        "data": data,
+    }
+    if component is not None:
+        kwargs["instance"] = component
+        kwargs["partial"] = True
+    return ComponentSerializer(**kwargs)
 
 
 class Command(BaseCommand):
@@ -84,13 +121,6 @@ class Command(BaseCommand):
                 msg = "Could not parse JSON file!"
                 raise CommandError(msg) from error
 
-        allfields = {
-            field.name
-            # ruff: ignore[private-member-access]
-            for field in Component._meta.get_fields()
-            if field.editable and not field.is_relation
-        }
-
         # Handle dumps from API
         if "results" in data:
             data = data["results"]
@@ -112,17 +142,14 @@ class Command(BaseCommand):
             try:
                 component = Component.objects.get(slug=item["slug"], project=project)
             except Component.DoesNotExist:
-                params = {key: item[key] for key in allfields if key in item}
-                apply_create_inheritance_defaults(params, item)
-                component = Component(project=project, **params)
+                serializer = get_component_serializer(project, item)
                 try:
-                    component.full_clean()
+                    serializer.is_valid(raise_exception=True)
+                    component = serializer.save()
                 except ValidationError as error:
-                    for key, value in error.message_dict.items():
-                        self.stderr.write(f"Error in {key}: {', '.join(value)}")
+                    self.stderr.write(format_serializer_error(error))
                     msg = "Component failed validation!"
                     raise CommandError(msg) from error
-                component.save(force_insert=True)
                 self.stdout.write(
                     f"Imported {component} with {component.translation_set.count()} translations"
                 )
@@ -131,11 +158,14 @@ class Command(BaseCommand):
                 if options["ignore"]:
                     continue
                 if options["update"]:
-                    for key in item:
-                        if key not in allfields or key == "slug":
-                            continue
-                        setattr(component, key, item[key])
-                    component.save()
+                    serializer = get_component_serializer(project, item, component)
+                    try:
+                        serializer.is_valid(raise_exception=True)
+                        serializer.save()
+                    except ValidationError as error:
+                        self.stderr.write(format_serializer_error(error))
+                        msg = "Component failed validation!"
+                        raise CommandError(msg) from error
                     continue
                 msg = "Component already exists, use --ignore or --update!"
                 raise CommandError(msg)

--- a/weblate/trans/tests/test_commands.py
+++ b/weblate/trans/tests/test_commands.py
@@ -4,8 +4,11 @@
 
 """Test for management commands."""
 
+import json
 import sys
 from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import cast
 from unittest import SkipTest
 from unittest.mock import Mock, patch
@@ -661,6 +664,72 @@ class ImportCommandTest(RepoTestCase):
         self.assertEqual(self.component.project.component_set.count(), 3)
         self.assertEqual(Translation.objects.count(), 10)
         self.assertIn("Imported Test/Gettext PO with 4 translations", output.getvalue())
+
+    def test_import_source_language(self) -> None:
+        with TemporaryDirectory() as tempdir:
+            filename = Path(tempdir) / "components.json"
+            filename.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "Android",
+                            "filemask": "android/values-*/strings.xml",
+                            "template": "android/values/strings.xml",
+                            "repo": "weblate://test/test",
+                            "file_format": "aresource",
+                            "source_language": {
+                                "code": "ru",
+                                "name": "Russian",
+                                "direction": "ltr",
+                            },
+                        }
+                    ]
+                )
+            )
+
+            with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
+                call_command(
+                    "import_json",
+                    "--main-component",
+                    "test",
+                    "--project",
+                    "test",
+                    filename,
+                )
+
+        component = Component.objects.get(slug="android")
+        self.assertEqual(component.source_language.code, "ru")
+
+    def test_import_source_language_string(self) -> None:
+        with TemporaryDirectory() as tempdir:
+            filename = Path(tempdir) / "components.json"
+            filename.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "Android",
+                            "filemask": "android/values-*/strings.xml",
+                            "template": "android/values/strings.xml",
+                            "repo": "weblate://test/test",
+                            "file_format": "aresource",
+                            "source_language": "ru",
+                        }
+                    ]
+                )
+            )
+
+            with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
+                call_command(
+                    "import_json",
+                    "--main-component",
+                    "test",
+                    "--project",
+                    "test",
+                    filename,
+                )
+
+        component = Component.objects.get(slug="android")
+        self.assertEqual(component.source_language.code, "ru")
 
     def test_import_invalid(self) -> None:
         with (


### PR DESCRIPTION
### Motivation

* Preserve `source_language` when importing components from JSON exports and unify import/update validation with the API serializer to avoid divergence. 
* Provide a serializer-friendly request context so validation runs with expected permission and request helpers. 

### Description

* Replace manual field extraction and `full_clean`/`setattr` updates in `import_json` with `ComponentSerializer` usage for creation and updates. 
* Add `ImportUser`, `ImportRequest`, `get_component_serializer`, and `format_serializer_error` helpers to provide serializer context and consistent error formatting. 
* Switch to `rest_framework.exceptions.ValidationError` handling and use `serializer.is_valid(raise_exception=True)` / `serializer.save()` for persistence. 
* Update release notes in `docs/changes.rst` to mention that `:wladmin:import_json` preserves component source language from JSON exports. 

### Testing

* Added unit tests `test_import_source_language` and `test_import_source_language_string` in `weblate.trans.tests.test_commands` to verify `source_language` is preserved from both object and string JSON representations. 
* Ran the `ImportCommandTest` cases in `weblate.trans.tests.test_commands`, including the new tests, and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72d5d0ec1483298c504e146c56caff)