### PR TITLE
fix(docker): avoid duplicate Celery logs by disabling logger propagation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.8.1
 
 .. rubric:: Bug fixes
 
+* Docker Celery worker logging no longer emits duplicate records through both Celery and Weblate log handlers.
 * Large language model machine translation services no longer fail when the optional persona and style settings are absent from the stored configuration, as happens when the service is installed through the REST API.
 * Repository actions now require permission on every component sharing the affected repository, including linked components in other projects.
 

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -1042,7 +1042,7 @@ LOGGING: dict = {
         "django.request": {
             "handlers": [*DEFAULT_LOG],
             "level": "ERROR",
-            "propagate": True,
+            "propagate": False,
         },
         "django.server": {
             "handlers": ["django.server"],
@@ -1054,35 +1054,42 @@ LOGGING: dict = {
             "handlers": [*DEFAULT_LOG],
             # Toggle to DEBUG to log all database queries
             "level": get_env_str("WEBLATE_LOGLEVEL_DATABASE", "CRITICAL"),
+            "propagate": False,
         },
         "weblate": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Logging VCS operations
         "weblate.vcs": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Python Social Auth
         "social": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Django Authentication Using LDAP
         "django_auth_ldap": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # SAML IdP
         "djangosaml2idp": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Fedora messaging
         "fedora_messaging": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
     },
 }

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -569,7 +569,7 @@ LOGGING: dict = {
         "django.request": {
             "handlers": ["mail_admins", *DEFAULT_LOG],
             "level": "ERROR",
-            "propagate": True,
+            "propagate": False,
         },
         "django.server": {
             "handlers": ["django.server"],
@@ -581,35 +581,42 @@ LOGGING: dict = {
             "handlers": [*DEFAULT_LOG],
             # Toggle to DEBUG to log all database queries
             "level": "CRITICAL",
+            "propagate": False,
         },
         "weblate": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Logging VCS operations
         "weblate.vcs": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Python Social Auth
         "social": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Django Authentication Using LDAP
         "django_auth_ldap": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # SAML IdP
         "djangosaml2idp": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
         # Fedora messaging
         "fedora_messaging": {
             "handlers": [*DEFAULT_LOG],
             "level": DEFAULT_LOGLEVEL,
+            "propagate": False,
         },
     },
 }


### PR DESCRIPTION
### Motivation

- Docker Celery workers were producing duplicate log records because Weblate-managed loggers propagated records to parent/root handlers in addition to Celery's handlers.

### Description

- Set `"propagate": False` for relevant loggers in `weblate/settings_docker.py` to stop forwarding records to parent/root handlers. 
- Mirror the same `"propagate": False` changes in the sample configuration file `weblate/settings_example.py` to keep examples consistent. 
- Affected loggers include `django.request`, `django.db.backends`, `weblate`, `weblate.vcs`, `social`, `django_auth_ldap`, `djangosaml2idp`, and `fedora_messaging`.
- Added a brief changelog entry in `docs/changes.rst` describing the bug fix.

### Testing

- Verified the modified settings parse as valid Python using `python -m py_compile weblate/settings_docker.py weblate/settings_example.py`, which succeeded. 
- Performed an AST parse check with `ast.parse(...)` on both files to ensure syntactic correctness, which succeeded. 
- Ran `git diff --check` / basic repository checks to ensure no whitespace or diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72dd1cc7c48329a3f8ee1a964ee70c)