### PR TITLE
fix(memory): enforce component access in translation memory

### DIFF
--- a/docs/admin/memory.rst
+++ b/docs/admin/memory.rst
@@ -59,6 +59,14 @@ Per-project translation memory
 All translations within a project are automatically stored in a project
 translation memory only available for this project.
 
+Entries attributed to an existing restricted component are only available to
+users who can access that component. This also applies when project memory is
+downloaded or accessed using the REST API.
+
+Legacy entries which can not be attributed to a current component use the
+project access rules. This can happen when the component path has changed or
+the component has been removed.
+
 Workspace translation memory
 ++++++++++++++++++++++++++++
 
@@ -66,6 +74,10 @@ Projects in the same workspace can share translation memory without enabling
 the global shared translation memory. Workspace translation memory has to be
 enabled both in the workspace settings and in the individual project workflow
 settings.
+
+Entries attributed to an existing restricted component are only available to
+users who can access that component, even when they can access another project
+in the workspace. Unattributed legacy entries use the workspace access rules.
 
 .. seealso::
 
@@ -83,6 +95,14 @@ All translations within projects with shared translation memory turned on
 are stored in a shared translation memory available to all projects.
 Turning off contribution to shared translation memory stops previously
 contributed automatic entries from being used as shared suggestions.
+
+Restricted components do not contribute new entries to shared translation
+memory. On Hosted Weblate, a project with restricted components can not enable
+shared translation memory, and a component can not be restricted while its
+project uses shared translation memory.
+
+Unattributed legacy entries which are already in shared translation memory use
+the shared translation memory access rules.
 
 Please consider carefully whether to turn this feature on for shared Weblate
 installations, as it can have severe implications:
@@ -173,6 +193,20 @@ listed entries can be downloaded as JSON or TMX. Users with the required
 permissions can delete entries, and the project view can rebuild translation
 memory for the whole project or for individual components from the current
 translations.
+
+Removing a component preserves its automatically created translation memory by
+default. Because the component access rule no longer exists after removal, the
+retained entries use the access rules of their remaining translation-memory
+scope. To remove those entries together with a component, select
+:guilabel:`Delete translation memory created from this component` in the
+removal form. Category removal offers the equivalent option for every component
+in the category and its nested categories. This removes attributed entries and
+legacy entries matching the current component path. It does not infer paths
+used before a component or category rename or move. Such unmatched entries can
+be deleted by origin in the project or workspace translation memory management,
+or using the REST API. The REST API accepts the ``delete_memory`` boolean in the
+request body or query string for component and category removal. Personal and
+uploaded entries are preserved.
 
 The project view also shows whether shared translation memory and autoclean
 translation memory are enabled for the project, with a link to the project

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -1289,6 +1289,13 @@ The default value can be changed in :setting:`DEFAULT_RESTRICTED_COMPONENT`.
    This applies to project admins as well — please ensure you will not
    lose access to the component after toggling the status.
 
+Restricted components do not contribute new entries to :ref:`shared-tm`.
+Project and workspace translation memory entries attributed to an existing
+restricted component follow the component restriction. Unattributed legacy
+entries follow the access rules of their translation memory scope. On Hosted
+Weblate, shared translation memory and restricted components can not be enabled
+in the same project.
+
 .. _component-links:
 
 Share in projects

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,9 +12,12 @@ Weblate 2026.9
 
 .. rubric:: Bug fixes
 
+* Project and workspace translation memory now respects restricted component access, and restricted components no longer contribute to shared translation memory.
+
 .. rubric:: Compatibility
 
 * Webhook target matching no longer falls back to host/path suffix matching. Component repository URLs must match a repository URL from the webhook payload. See :ref:`hooks-target-matching`.
+* Component and category removal now preserves automatically generated translation memory by default. See :ref:`translation-memory` for the optional cleanup behavior.
 
 .. rubric:: Upgrading
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -603,12 +603,16 @@ Security properties Weblate provides
    * - Web authorization separates site, project, component, language,
        glossary, VCS, translation memory, screenshot, review, and access
        management permissions. *(documented)* (source: :doc:`/admin/access`,
-       :doc:`/admin/auth`)
+       :doc:`/admin/auth`, :doc:`/admin/memory`)
      - Permission assignments match the intended trust relationship.
        Team-level enforced 2FA is satisfied by human users before
        team-derived permissions apply. Permissions for VCS actions cover every
        component sharing an affected repository, including linked components
-       in other projects.
+       in other projects. Translation memory attributed to an existing
+       restricted component follows that component's access rules.
+       Unattributed automatic memory, including unmatched legacy entries and
+       memory retained after component removal, follows its remaining
+       translation-memory scope.
      - User or token can read or mutate data outside assigned scope.
      - Security-critical when private data or privileged mutation is exposed.
    * - Project-scoped API tokens are limited by assigned project/team

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -1718,8 +1718,14 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Reset'
     delete:
       operationId: api_categories_destroy
-      description: Delete category.
+      description: Delete a category.
       parameters:
+      - in: query
+        name: delete_memory
+        schema:
+          type: boolean
+        description: Also delete project, workspace, and shared translation memory
+          created from components in the category.
       - in: path
         name: id
         schema:
@@ -1816,6 +1822,20 @@ paths:
                       detail: Could not satisfy the request Accept header.
                       attr: null
           description: The requested response media type is not available.
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: The request media type is not supported.
         '423':
           content:
             application/json:
@@ -1852,6 +1872,11 @@ paths:
           description: An unexpected server error occurred.
         '204':
           description: No response body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryDeleteRequest'
   /api/categories/{id}/announcements/:
     get:
       operationId: api_categories_announcements_list
@@ -5141,6 +5166,12 @@ paths:
       operationId: api_components_destroy
       description: Delete a component.
       parameters:
+      - in: query
+        name: delete_memory
+        schema:
+          type: boolean
+        description: Also delete project, workspace, and shared translation memory
+          created from the component.
       - in: path
         name: project__slug
         schema:
@@ -5245,6 +5276,20 @@ paths:
                       detail: Could not satisfy the request Accept header.
                       attr: null
           description: The requested response media type is not available.
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: The request media type is not supported.
         '423':
           content:
             application/json:
@@ -5281,6 +5326,11 @@ paths:
           description: An unexpected server error occurred.
         '204':
           description: No response body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComponentDeleteRequest'
   /api/components/{project__slug}/{slug}/addons/:
     post:
       operationId: api_components_addons_create
@@ -38943,6 +38993,16 @@ components:
           type: integer
       required:
       - group_id
+    ComponentDeleteRequest:
+      type: object
+      properties:
+        delete_memory:
+          type: boolean
+    CategoryDeleteRequest:
+      type: object
+      properties:
+        delete_memory:
+          type: boolean
   securitySchemes:
     bearerAuth:
       type: apiKey

--- a/weblate/api/docs.py
+++ b/weblate/api/docs.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from django.utils.translation import gettext, gettext_noop
 from drf_spectacular.plumbing import (
     ResolvedComponent,
@@ -48,6 +50,8 @@ METRICS_PATH = "/api/metrics/"
 PROJECT_METRICS_PATH = "/api/projects/{slug}/metrics/"
 METRICS_PATHS = {METRICS_PATH, PROJECT_METRICS_PATH}
 USER_GROUPS_PATH = "/api/users/{username}/groups/"
+COMPONENT_PATH = "/api/components/{project__slug}/{slug}/"
+CATEGORY_PATH = "/api/categories/{id}/"
 CHANGES_PATH = "/api/changes/"
 UNSUPPORTED_MEDIA_TYPE_RESPONSE_CODE = "415"
 RESPONSE_DESCRIPTIONS = {
@@ -344,31 +348,36 @@ def document_response_descriptions(result, generator, request, public):
     return result
 
 
-def document_user_group_delete_body(result, generator, request, public):
-    """Document legacy DELETE body support for user group removal."""
-    operation = result.get("paths", {}).get(USER_GROUPS_PATH, {}).get("delete")
-    if not isinstance(operation, dict):
-        return result
-
+def document_delete_bodies(result, generator, request, public):
+    """Document request bodies accepted by DELETE operations."""
     # drf-spectacular does not emit request bodies for DELETE methods.
     schemas = result.setdefault("components", {}).setdefault("schemas", {})
-    schemas["UserGroupDeleteRequest"] = {
-        "type": "object",
-        "properties": {
-            "group_id": {
-                "type": "integer",
+    delete_bodies = (
+        (USER_GROUPS_PATH, "UserGroupDeleteRequest", "group_id", "integer", True),
+        (COMPONENT_PATH, "ComponentDeleteRequest", "delete_memory", "boolean", False),
+        (CATEGORY_PATH, "CategoryDeleteRequest", "delete_memory", "boolean", False),
+    )
+    for path, schema_name, field_name, field_type, required in delete_bodies:
+        operation = result.get("paths", {}).get(path, {}).get("delete")
+        if not isinstance(operation, dict):
+            continue
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {field_name: {"type": field_type}},
+        }
+        if required:
+            schema["required"] = [field_name]
+        schemas[schema_name] = schema
+        request_body: dict[str, Any] = {
+            "content": {
+                JSON_MEDIA_TYPE: {
+                    "schema": {"$ref": f"#/components/schemas/{schema_name}"}
+                }
             }
-        },
-        "required": ["group_id"],
-    }
-    operation["requestBody"] = {
-        "content": {
-            JSON_MEDIA_TYPE: {
-                "schema": {"$ref": "#/components/schemas/UserGroupDeleteRequest"}
-            }
-        },
-        "required": True,
-    }
+        }
+        if required:
+            request_body["required"] = True
+        operation["requestBody"] = request_body
 
     return result
 

--- a/weblate/api/spectacular.py
+++ b/weblate/api/spectacular.py
@@ -134,7 +134,7 @@ The OpenAPI specification is available as feature preview, feedback welcome!
             "weblate.api.docs.document_all_static_vcs_choices",
             "weblate.api.docs.add_middleware_headers",
             "weblate.api.docs.simplify_license_schema",
-            "weblate.api.docs.document_user_group_delete_body",
+            "weblate.api.docs.document_delete_bodies",
             "weblate.api.docs.simplify_media_types",
             "weblate.api.docs.document_response_descriptions",
         ],

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -7457,6 +7457,9 @@ class ComponentAPITest(APIBaseTest):
 
         billing = create_test_billing(self.user)
         billing.add_project(self.project)
+        self.project.use_shared_tm = False
+        self.project.contribute_shared_tm = False
+        self.project.save(update_fields=["use_shared_tm", "contribute_shared_tm"])
         self.do_request(
             "api:component-detail",
             self.component_kwargs,
@@ -8012,6 +8015,52 @@ class ComponentAPITest(APIBaseTest):
             code=204,
         )
         self.assertEqual(Component.objects.count(), 1)
+
+    def test_delete_component_memory_option_in_body(self) -> None:
+        with patch("weblate.api.views.component_removal.delay") as mocked_removal:
+            self.do_request(
+                "api:component-detail",
+                self.component_kwargs,
+                method="delete",
+                superuser=True,
+                code=204,
+                format="json",
+                request={"delete_memory": True},
+            )
+
+        mocked_removal.assert_called_once_with(self.component.pk, self.user.pk, True)
+
+    def test_delete_component_memory_option_in_query(self) -> None:
+        url = (
+            reverse("api:component-detail", kwargs=self.component_kwargs)
+            + "?delete_memory=true"
+        )
+        with patch("weblate.api.views.component_removal.delay") as mocked_removal:
+            self.do_request(
+                url,
+                method="delete",
+                superuser=True,
+                code=204,
+            )
+
+        mocked_removal.assert_called_once_with(self.component.pk, self.user.pk, True)
+
+    def test_delete_component_memory_option_conflict(self) -> None:
+        url = (
+            reverse("api:component-detail", kwargs=self.component_kwargs)
+            + "?delete_memory=true"
+        )
+        with patch("weblate.api.views.component_removal.delay") as mocked_removal:
+            self.do_request(
+                url,
+                method="delete",
+                superuser=True,
+                code=400,
+                format="json",
+                request={"delete_memory": False},
+            )
+
+        mocked_removal.assert_not_called()
 
     def test_create_component_from_component_id(self) -> None:
         translation = self.component.translation_set.get(language_code="cs")
@@ -9988,6 +10037,21 @@ class MemoryAPITest(APIBaseTest):
         if source_project is not None:
             memory.scope_source_project_id = source_project.id
         memory.save()
+        try:
+            component = Component.objects.get_by_path(origin)
+        except Component.DoesNotExist:
+            component = None
+        if component is not None:
+            memory.scopes.filter(
+                scope__in=(
+                    MemoryScope.SCOPE_PROJECT,
+                    MemoryScope.SCOPE_SHARED,
+                    MemoryScope.SCOPE_USER,
+                    MemoryScope.SCOPE_WORKSPACE,
+                )
+            ).update(
+                source_component=component,
+            )
         return memory
 
     def test_memory_lookup_request_serializer_preserves_whitespace(self) -> None:
@@ -10269,6 +10333,64 @@ class MemoryAPITest(APIBaseTest):
             compacted.scopes.filter(scope=MemoryScope.SCOPE_PROJECT).exists()
         )
         self.assertTrue(MemoryScope.objects.filter(pk=shared_scope.pk).exists())
+
+    def test_delete_unattributed_project_memory(self) -> None:
+        self.component.project.add_user(self.user, "Administration")
+        self.authenticate()
+        memory = self.create_memory(
+            source="Delete unattributed project memory",
+            target="Smazat neprirazeny zaznam projektu",
+            project=self.component.project,
+            origin="old-project/removed-component",
+        )
+        self.assertIsNone(memory.scopes.get().source_component_id)
+
+        self.do_request(
+            "api:memory-detail",
+            kwargs={"pk": memory.pk},
+            method="delete",
+            code=204,
+        )
+
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+
+    def test_delete_preserves_hidden_restricted_scope_from_compacted_entry(
+        self,
+    ) -> None:
+        self.component.project.add_user(self.user, "Administration")
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        self.user.clear_permissions_cache()
+        self.authenticate()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="API compacted hidden automatic scope",
+            target="API skryty automaticky rozsah",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        hidden_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.component.project,
+            source_component=self.component,
+        )
+        visible_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT_FILE,
+            project=self.component.project,
+        )
+
+        self.do_request(
+            "api:memory-detail",
+            kwargs={"pk": memory.pk},
+            method="delete",
+            code=204,
+        )
+
+        self.assertTrue(MemoryScope.objects.filter(pk=hidden_scope.pk).exists())
+        self.assertFalse(MemoryScope.objects.filter(pk=visible_scope.pk).exists())
 
     def test_delete_workspace_scope_requires_source_project_permission(self) -> None:
         workspace = Workspace.objects.create(
@@ -15262,6 +15384,43 @@ class CategoryAPITest(APIBaseTest):
         response = self.list_categories()
         self.assertEqual(response.data["count"], 0)
 
+    def test_delete_memory_option_in_body(self) -> None:
+        response = self.api_create_category()
+        with patch("weblate.api.views.category_removal.delay") as mocked_removal:
+            self.do_request(
+                response.data["url"],
+                method="delete",
+                superuser=True,
+                code=204,
+                format="json",
+                request={"delete_memory": True},
+            )
+
+        mocked_removal.assert_called_once_with(response.data["id"], self.user.pk, True)
+
+    def test_delete_memory_option_in_query(self) -> None:
+        response = self.api_create_category()
+        url = f"{response.data['url']}?delete_memory=true"
+        with patch("weblate.api.views.category_removal.delay") as mocked_removal:
+            self.do_request(url, method="delete", superuser=True, code=204)
+
+        mocked_removal.assert_called_once_with(response.data["id"], self.user.pk, True)
+
+    def test_delete_memory_option_conflict(self) -> None:
+        response = self.api_create_category()
+        url = f"{response.data['url']}?delete_memory=true"
+        with patch("weblate.api.views.category_removal.delay") as mocked_removal:
+            self.do_request(
+                url,
+                method="delete",
+                superuser=True,
+                code=400,
+                format="json",
+                request={"delete_memory": False},
+            )
+
+        mocked_removal.assert_not_called()
+
     def test_rename(self) -> None:
         response = self.api_create_category()
         category_url = response.data["url"]
@@ -16851,6 +17010,36 @@ class OpenAPITest(APIBaseTest):
             delete_request_schema,
             {"$ref": "#/components/schemas/UserGroupDeleteRequest"},
         )
+
+    def test_component_and_category_delete_memory_schema(self) -> None:
+        schema = self.get_schema()
+
+        for path, schema_name in (
+            (
+                "/api/components/{project__slug}/{slug}/",
+                "ComponentDeleteRequest",
+            ),
+            ("/api/categories/{id}/", "CategoryDeleteRequest"),
+        ):
+            with self.subTest(path=path):
+                operation = schema["paths"][path]["delete"]
+                query_parameter = next(
+                    parameter
+                    for parameter in operation["parameters"]
+                    if parameter["name"] == "delete_memory"
+                )
+                self.assertEqual(query_parameter["schema"]["type"], "boolean")
+                self.assertEqual(
+                    operation["requestBody"]["content"]["application/json"]["schema"],
+                    {"$ref": f"#/components/schemas/{schema_name}"},
+                )
+                self.assertNotIn("required", operation["requestBody"])
+                request_schema = schema["components"]["schemas"][schema_name]
+                self.assertEqual(
+                    request_schema["properties"]["delete_memory"],
+                    {"type": "boolean"},
+                )
+                self.assertNotIn("required", request_schema)
 
     def test_addon_trigger_schema_matches_runtime_behavior(self) -> None:
         schema = self.get_schema()

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -142,7 +142,7 @@ from weblate.lang.forms import validate_language_code
 from weblate.lang.models import Language
 from weblate.machinery.base import MACHINERY_DEFAULT_THRESHOLD
 from weblate.machinery.models import validate_service_configuration
-from weblate.memory.models import Memory, MemoryScope
+from weblate.memory.models import Memory, MemoryQuerySet, MemoryScope
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.autotranslate import AutoTranslate, check_auto_translate_permission
@@ -893,6 +893,30 @@ class MemoryLookupMatchData(TypedDict):
 class MemoryLookupResultData(TypedDict):
     query: str
     match: MemoryLookupMatchData | None
+
+
+def get_delete_memory_option(request: Request) -> bool:
+    """Parse the optional translation-memory cleanup flag for delete requests."""
+    boolean_field = serializers.BooleanField()
+    body_value = query_value = None
+    request_data = request.data
+    if not isinstance(request_data, Mapping):
+        raise ValidationError({"delete_memory": "Expected an object."})
+    if "delete_memory" in request_data:
+        body_value = boolean_field.run_validation(request_data["delete_memory"])
+    if "delete_memory" in request.query_params:
+        query_value = boolean_field.run_validation(
+            request.query_params["delete_memory"]
+        )
+    if body_value is not None and query_value is not None and body_value != query_value:
+        raise ValidationError(
+            {
+                "delete_memory": (
+                    "Conflicting values were supplied in the request body and query."
+                )
+            }
+        )
+    return body_value if body_value is not None else query_value or False
 
 
 @extend_schema_view(
@@ -2612,6 +2636,24 @@ class ProjectViewSet(
         description="Return information about translation component."
     ),
     partial_update=extend_schema(description="Edit a component by a PATCH request."),
+    destroy=extend_schema(
+        description="Delete a component.",
+        parameters=[
+            OpenApiParameter(
+                "delete_memory",
+                type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "Also delete project, workspace, and shared translation memory "
+                    "created from the component."
+                ),
+            )
+        ],
+        request=inline_serializer(
+            name="ComponentDeleteRequest",
+            fields={"delete_memory": serializers.BooleanField(required=False)},
+        ),
+    ),
 )
 class ComponentViewSet(
     MultipleFieldViewSet,
@@ -2935,7 +2977,9 @@ class ComponentViewSet(
         if not request.user.has_perm("component.edit", instance):
             self.permission_denied(request, "Can not delete component")
         instance.acting_user = request.user
-        component_removal.delay(instance.pk, request.user.pk)
+        component_removal.delay(
+            instance.pk, request.user.pk, get_delete_memory_option(request)
+        )
         return Response(status=HTTP_204_NO_CONTENT)
 
     def add_link(self, request: Request, instance: Component):
@@ -3080,8 +3124,23 @@ class MemoryViewSet(viewsets.ReadOnlyModelViewSet, DestroyModelMixin):
         if user.is_superuser or user.has_perm("memory.manage"):
             return [scope.id for scope in scopes]
 
+        component_scoped_ids = {
+            scope.id
+            for scope in scopes
+            if scope.scope in {MemoryScope.SCOPE_PROJECT, MemoryScope.SCOPE_WORKSPACE}
+        }
+        accessible_component_scoped_ids = set(
+            MemoryScope.objects.filter(id__in=component_scoped_ids)
+            .filter(MemoryQuerySet.get_component_access_query(user))
+            .values_list("id", flat=True)
+        )
         result = []
         for scope in scopes:
+            if (
+                scope.id in component_scoped_ids
+                and scope.id not in accessible_component_scoped_ids
+            ):
+                continue
             if scope.user_id == user.id:
                 result.append(scope.id)
             elif scope.project_id:
@@ -3143,6 +3202,7 @@ class MemoryViewSet(viewsets.ReadOnlyModelViewSet, DestroyModelMixin):
             project = get_object_or_404(project_queryset, slug=project_slug)
             return Memory.objects.filter_type(
                 user=user,
+                access_user=user,
                 project=project,
                 use_shared=project.use_shared_tm,
                 from_file=True,
@@ -4394,7 +4454,27 @@ class ComponentListViewSet(viewsets.ModelViewSet):
         return Response(status=HTTP_204_NO_CONTENT)
 
 
-@extend_schema_view(list=extend_schema(description="List available categories."))
+@extend_schema_view(
+    list=extend_schema(description="List available categories."),
+    destroy=extend_schema(
+        description="Delete a category.",
+        parameters=[
+            OpenApiParameter(
+                "delete_memory",
+                type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "Also delete project, workspace, and shared translation memory "
+                    "created from components in the category."
+                ),
+            )
+        ],
+        request=inline_serializer(
+            name="CategoryDeleteRequest",
+            fields={"delete_memory": serializers.BooleanField(required=False)},
+        ),
+    ),
+)
 class CategoryViewSet(viewsets.ModelViewSet, ReportsMixin, AnnouncementsMixin):
     """Category API."""
 
@@ -4423,7 +4503,9 @@ class CategoryViewSet(viewsets.ModelViewSet, ReportsMixin, AnnouncementsMixin):
         """Delete category."""
         instance = self.get_object()
         self.perm_check(request, instance)
-        category_removal.delay(instance.pk, request.user.pk)
+        category_removal.delay(
+            instance.pk, request.user.pk, get_delete_memory_option(request)
+        )
         return Response(status=HTTP_204_NO_CONTENT)
 
     def perform_create(self, serializer) -> None:

--- a/weblate/memory/migrations/0007_memoryscope_source_component.py
+++ b/weblate/memory/migrations/0007_memoryscope_source_component.py
@@ -1,0 +1,36 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("memory", "0006_memory_source_gist_prefix"),
+        ("trans", "0097_workflowsetting_restrict_direct_editing"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="memoryscope",
+            name="source_component",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="trans.component",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="memoryscope",
+            index=models.Index(
+                fields=["scope", "source_component", "memory"],
+                name="memory_scope_source_component",
+            ),
+        ),
+    ]

--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
 
     from weblate.auth.models import AuthenticatedHttpRequest, User
-    from weblate.trans.models import Project
+    from weblate.trans.models import Component, Project
     from weblate.workspaces.models import Workspace
 
 NON_WORD_RE = re.compile(r"\W")
@@ -126,29 +126,37 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
             memory_scope_visible=self.get_scope_exists(scope_query),
         ).filter(memory_scope_visible=True)
 
-    def get_type_scope_query(
+    def _get_type_scope_query(
         self,
         *,
         user: User | None = None,
+        access_user: User | None = None,
         project: Project | None = None,
         workspace: Workspace | None = None,
         use_shared: bool = False,
         from_file: bool = False,
         use_workspace: bool = False,
+        check_component_access: bool,
     ) -> Q:
         query = Q(pk__isnull=True)
         if from_file:
             query |= Q(scope=MemoryScope.SCOPE_GLOBAL_FILE)
         if use_shared:
-            query |= Q(
+            shared_query = Q(
                 scope=MemoryScope.SCOPE_SHARED,
                 source_project__contribute_shared_tm=True,
             )
+            if check_component_access:
+                shared_query &= self.get_shared_component_access_query()
+            query |= shared_query
         if project:
-            query |= Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
+            project_query = Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
+            if check_component_access:
+                project_query &= self.get_component_access_query(access_user)
+            query |= project_query
             query |= Q(scope=MemoryScope.SCOPE_PROJECT_FILE, project=project)
             if use_workspace and project.effective_use_workspace_tm:
-                query |= Q(
+                workspace_query = Q(
                     scope=MemoryScope.SCOPE_WORKSPACE,
                     workspace_id=project.workspace_id,
                 ) & Q(
@@ -156,20 +164,67 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
                     source_project__contribute_workspace_tm=True,
                     source_project__workspace__contribute_workspace_tm=True,
                 )
+                if check_component_access:
+                    workspace_query &= self.get_component_access_query(access_user)
+                query |= workspace_query
         if workspace:
-            query |= Q(
+            workspace_query = Q(
                 scope=MemoryScope.SCOPE_WORKSPACE,
                 workspace=workspace,
             )
+            if check_component_access:
+                workspace_query &= self.get_component_access_query(access_user)
+            query |= workspace_query
         if user:
             query |= Q(scope=MemoryScope.SCOPE_USER, user=user)
             query |= Q(scope=MemoryScope.SCOPE_USER_FILE, user=user)
         return query
 
+    def get_type_scope_query(
+        self,
+        *,
+        user: User | None = None,
+        access_user: User | None = None,
+        project: Project | None = None,
+        workspace: Workspace | None = None,
+        use_shared: bool = False,
+        from_file: bool = False,
+        use_workspace: bool = False,
+    ) -> Q:
+        """Build a scope query with component access enforced."""
+        return self._get_type_scope_query(
+            user=user,
+            access_user=access_user,
+            project=project,
+            workspace=workspace,
+            use_shared=use_shared,
+            from_file=from_file,
+            use_workspace=use_workspace,
+            check_component_access=True,
+        )
+
+    @staticmethod
+    def get_component_access_query(user: User | None) -> Q:
+        """Return component access filtering for project and workspace scopes."""
+        if user is not None and (user.is_superuser or user.has_perm("memory.manage")):
+            return Q()
+        query = Q(source_component__isnull=True) | Q(source_component__restricted=False)
+        if user is not None and user.component_permissions:
+            query |= Q(
+                source_component_id__in=user.component_permissions,
+            ) & user.get_project_access_query("source_component__project")
+        return query
+
+    @staticmethod
+    def get_shared_component_access_query() -> Q:
+        """Exclude shared memory attributed to restricted components."""
+        return Q(source_component__isnull=True) | Q(source_component__restricted=False)
+
     def filter_type(
         self,
         *,
         user: User | None = None,
+        access_user: User | None = None,
         project: Project | None = None,
         workspace: Workspace | None = None,
         use_shared: bool = False,
@@ -182,11 +237,38 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         return base.filter_scope(
             base.get_type_scope_query(
                 user=user,
+                access_user=access_user,
                 project=project,
                 workspace=workspace,
                 use_shared=use_shared,
                 from_file=from_file,
                 use_workspace=use_workspace,
+            )
+        )
+
+    def filter_type_unchecked(
+        self,
+        *,
+        user: User | None = None,
+        project: Project | None = None,
+        workspace: Workspace | None = None,
+        use_shared: bool = False,
+        from_file: bool = False,
+        use_workspace: bool = False,
+    ) -> Self:
+        """Filter memory scopes without applying component access checks."""
+        base = self
+        if "memory_db" in settings.DATABASES:
+            base = base.using("memory_db")
+        return base.filter_scope(
+            self._get_type_scope_query(
+                user=user,
+                project=project,
+                workspace=workspace,
+                use_shared=use_shared,
+                from_file=from_file,
+                use_workspace=use_workspace,
+                check_component_access=False,
             )
         )
 
@@ -200,6 +282,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
             use_workspace_tm=True,
             workspace__use_workspace_tm=True,
         ).values("workspace_id")
+        component_access = self.get_component_access_query(user)
         scope_query = (
             Q(scope=MemoryScope.SCOPE_USER, user=user)
             | Q(scope=MemoryScope.SCOPE_USER_FILE, user=user)
@@ -207,15 +290,22 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
                 scope=MemoryScope.SCOPE_SHARED,
                 source_project__contribute_shared_tm=True,
             )
+            & self.get_shared_component_access_query()
             | Q(scope=MemoryScope.SCOPE_GLOBAL_FILE)
-            | Q(scope=MemoryScope.SCOPE_PROJECT, project__in=allowed_projects)
+            | (
+                Q(scope=MemoryScope.SCOPE_PROJECT, project__in=allowed_projects)
+                & component_access
+            )
             | Q(scope=MemoryScope.SCOPE_PROJECT_FILE, project__in=allowed_projects)
-            | Q(
-                scope=MemoryScope.SCOPE_WORKSPACE,
-                workspace__in=allowed_workspaces,
-                workspace_id=F("source_project__workspace_id"),
-                source_project__contribute_workspace_tm=True,
-                source_project__workspace__contribute_workspace_tm=True,
+            | (
+                Q(
+                    scope=MemoryScope.SCOPE_WORKSPACE,
+                    workspace__in=allowed_workspaces,
+                    workspace_id=F("source_project__workspace_id"),
+                    source_project__contribute_workspace_tm=True,
+                    source_project__workspace__contribute_workspace_tm=True,
+                )
+                & component_access
             )
         )
         return self.filter_scope(scope_query)
@@ -458,6 +548,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         return (
             self.filter_type(
                 user=user,
+                access_user=user,
                 project=project,
                 use_shared=use_shared,
                 from_file=True,
@@ -517,6 +608,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
                     "project",
                     "workspace",
                     "source_project",
+                    "source_component",
                 ),
             )
         )
@@ -1146,6 +1238,7 @@ class MemoryScopeManager(models.Manager["MemoryScope"]):
         project: Project | None,
         from_file: bool,
         shared: bool,
+        component: Component | None = None,
     ) -> MemoryScope | None:
         if from_file:
             if project is not None:
@@ -1156,11 +1249,21 @@ class MemoryScopeManager(models.Manager["MemoryScope"]):
                 return MemoryScope(scope=MemoryScope.SCOPE_USER_FILE, user=user)
             return MemoryScope(scope=MemoryScope.SCOPE_GLOBAL_FILE)
         if project is not None:
-            return MemoryScope(scope=MemoryScope.SCOPE_PROJECT, project=project)
+            return MemoryScope(
+                scope=MemoryScope.SCOPE_PROJECT,
+                project=project,
+                source_component=component,
+            )
         if shared:
-            return MemoryScope(scope=MemoryScope.SCOPE_SHARED)
+            return MemoryScope(
+                scope=MemoryScope.SCOPE_SHARED, source_component=component
+            )
         if user is not None:
-            return MemoryScope(scope=MemoryScope.SCOPE_USER, user=user)
+            return MemoryScope(
+                scope=MemoryScope.SCOPE_USER,
+                user=user,
+                source_component=component,
+            )
         return None
 
     def get_scope_query(self, scope: MemoryScope) -> Q:
@@ -1187,6 +1290,7 @@ class MemoryScopeManager(models.Manager["MemoryScope"]):
                     project_id=scope.project_id,
                     workspace_id=scope.workspace_id,
                     source_project_id=scope.source_project_id,
+                    source_component_id=scope.source_component_id,
                     user_id=scope.user_id,
                 )
                 for scope in memory.pending_scopes
@@ -1310,6 +1414,13 @@ class MemoryScope(models.Model):
         blank=True,
         related_name="+",
     )
+    source_component = models.ForeignKey(
+        "trans.Component",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="+",
+    )
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.deletion.CASCADE,
@@ -1336,6 +1447,10 @@ class MemoryScope(models.Model):
             models.Index(
                 fields=["scope", "source_project", "memory"],
                 name="memory_scope_source_project",
+            ),
+            models.Index(
+                fields=["scope", "source_component", "memory"],
+                name="memory_scope_source_component",
             ),
             models.Index(
                 fields=["scope", "workspace", "source_project", "memory"],

--- a/weblate/memory/tasks.py
+++ b/weblate/memory/tasks.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import timedelta
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 from uuid import UUID
 
 from django.db import transaction
@@ -21,6 +21,8 @@ from weblate.utils.celery import app
 from weblate.utils.state import STATE_APPROVED, STATE_TRANSLATED
 
 if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
     from weblate.auth.models import User
     from weblate.lang.models import Language
     from weblate.trans.models import Component, Project, Unit
@@ -32,6 +34,7 @@ MEMORY_SCOPE_COMPACTION_STALE_SECONDS = 4 * MEMORY_SCOPE_BACKFILL_STALE_SECONDS
 MEMORY_SCOPE_COMPACTION_BATCH_SIZE = 50000
 MEMORY_SCOPE_BACKFILL_STATE = "memory-scope-backfill"
 MEMORY_SCOPE_COMPACTION_STATE = "memory-scope-compaction"
+MEMORY_COMPONENT_BACKFILL_STATE = "memory-component-backfill"
 
 
 class MemoryUpdatePayload(TypedDict):
@@ -48,6 +51,7 @@ class MemoryUpdatePayload(TypedDict):
     user_id: int | None
     workspace_id: UUID | None
     project_id: int
+    component_id: NotRequired[int]
     unit_state: int
 
 
@@ -146,11 +150,12 @@ def get_unit_memory_update(
         "source": source,
         "target": target,
         "origin": origin,
-        "add_shared": project.contribute_shared_tm,
+        "add_shared": project.contribute_shared_tm and not component.restricted,
         "add_workspace": project.effective_contribute_workspace_tm,
         "user_id": user_id,
         "workspace_id": project.workspace_id,
         "project_id": project.id,
+        "component_id": component.id,
         "add_project": component.contribute_project_tm,
         "add_user": add_user,
         "unit_state": unit.state,
@@ -217,6 +222,95 @@ def set_scope_source_project_ids(memories: list[Memory]) -> None:
         memory.scope_source_project_id = source_project_ids.get(memory.id)
 
 
+def _get_component_path_lookup(
+    components: list[Component],
+) -> dict[tuple[int, str], Component]:
+    """Build a current project-relative component path lookup."""
+    return {
+        (
+            component.project_id,
+            component.full_slug.split("/", 1)[1].casefold(),
+        ): component
+        for component in components
+    }
+
+
+def _attribute_memory_scope_components(scopes: list[MemoryScope]) -> None:
+    """Associate a batch of memory scopes with their source components."""
+    # ruff: ignore[import-outside-top-level]
+    from weblate.trans.models import Component
+
+    memories = list({scope.memory_id: scope.memory for scope in scopes}.values())
+    inferred_project_ids = infer_scope_source_project_ids(memories)
+    scope_project_ids = {
+        scope.id: (
+            scope.project_id
+            or scope.source_project_id
+            or inferred_project_ids.get(scope.memory_id)
+        )
+        for scope in scopes
+    }
+    project_ids = {
+        project_id
+        for project_id in scope_project_ids.values()
+        if project_id is not None
+    }
+    components = list(Component.objects.filter(project_id__in=project_ids).prefetch())
+    components_by_project_path = _get_component_path_lookup(components)
+    restricted_shared_scope_ids = []
+    to_update = []
+    for scope in scopes:
+        _project_slug, separator, component_path = scope.memory.origin.partition("/")
+        scope_project_id = scope_project_ids[scope.id]
+        component = (
+            components_by_project_path.get(
+                (scope_project_id, component_path.casefold())
+            )
+            if scope.scope in AUTOMATIC_SCOPE_TYPES
+            and separator
+            and scope_project_id is not None
+            else None
+        )
+        scope.source_component = component
+        if (
+            component is not None
+            and component.restricted
+            and scope.scope == MemoryScope.SCOPE_SHARED
+        ):
+            restricted_shared_scope_ids.append(scope.id)
+        else:
+            to_update.append(scope)
+
+    if to_update:
+        MemoryScope.objects.using("default").bulk_update(
+            to_update,
+            fields=["source_component"],
+        )
+    if restricted_shared_scope_ids:
+        Memory.objects.using("default").filter(
+            scopes__id__in=restricted_shared_scope_ids
+        ).delete_scope(Q(id__in=restricted_shared_scope_ids), delete_legacy=False)
+
+
+def attribute_memory_scope_queryset(
+    queryset: QuerySet[MemoryScope], batch_size: int = 5000
+) -> None:
+    """Attribute scopes from a restricted queryset in batches."""
+    last_scope_id = 0
+    while True:
+        with transaction.atomic(using="default"):
+            scopes = list(
+                queryset.filter(id__gt=last_scope_id)
+                .select_for_update()
+                .select_related("memory")
+                .order_by("id")[:batch_size]
+            )
+            if not scopes:
+                return
+            last_scope_id = scopes[-1].id
+            _attribute_memory_scope_components(scopes)
+
+
 @app.task(trail=False)
 def backfill_memory_scopes(batch_size: int = 5000) -> None:
     # TODO(2028.1): Remove this background TM scope backfill once Weblate no
@@ -269,6 +363,53 @@ def backfill_memory_scopes(batch_size: int = 5000) -> None:
         backfill_memory_scopes.delay(batch_size=batch_size)
     elif run_compact:
         schedule_memory_scope_compaction()
+
+
+@app.task(trail=False)
+def backfill_memory_scope_components(batch_size: int = 5000) -> None:
+    # TODO(2028.1): Remove this component-attribution backfill once Weblate no
+    # longer supports direct upgrades from 2026 releases.
+    """Associate existing automatic memory scopes with source components."""
+    scope_objects = MemoryScope.objects.using("default")
+    state_objects = MemoryScopeMigrationState.objects.using("default")
+
+    with transaction.atomic(using="default"):
+        state, _created = state_objects.select_for_update().get_or_create(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        )
+        if state.completed:
+            return
+
+        scopes = list(
+            scope_objects.filter(
+                id__gt=state.last_memory_id,
+                scope__in=AUTOMATIC_SCOPE_TYPES,
+                source_component__isnull=True,
+            )
+            .select_for_update()
+            .select_related("memory")
+            .order_by("id")[:batch_size]
+        )
+        if not scopes:
+            state.completed = True
+            state.updated = timezone.now()
+            state.save(using="default", update_fields=["completed", "updated"])
+            run_next = False
+        else:
+            _attribute_memory_scope_components(scopes)
+
+            state.last_memory_id = scopes[-1].id
+            state.updated = timezone.now()
+            run_next = len(scopes) == batch_size
+            if not run_next:
+                state.completed = True
+            state.save(
+                using="default",
+                update_fields=["last_memory_id", "completed", "updated"],
+            )
+
+    if run_next:
+        backfill_memory_scope_components.delay(batch_size=batch_size)
 
 
 def set_memory_scope_compaction_completed(
@@ -447,6 +588,52 @@ def resume_memory_scope_backfill() -> None:
         backfill_memory_scopes.delay()
 
 
+@app.task(trail=False)
+def resume_memory_component_backfill() -> None:
+    # TODO(2028.1): Remove this component-attribution backfill once Weblate no
+    # longer supports direct upgrades from 2026 releases.
+    """Resume the component attribution backfill after interrupted workers."""
+    state_objects = MemoryScopeMigrationState.objects.using("default")
+    state = state_objects.filter(name=MEMORY_COMPONENT_BACKFILL_STATE).first()
+    last_scope_id = 0 if state is None else state.last_memory_id
+    needs_backfill = MemoryScope.objects.using("default").filter(
+        id__gt=last_scope_id,
+        scope__in=AUTOMATIC_SCOPE_TYPES,
+        source_component__isnull=True,
+    )
+    if not needs_backfill.exists():
+        if state is None:
+            state_objects.create(
+                name=MEMORY_COMPONENT_BACKFILL_STATE,
+                completed=True,
+                updated=timezone.now(),
+            )
+        elif not state.completed:
+            state.completed = True
+            state.updated = timezone.now()
+            state.save(using="default", update_fields=["completed", "updated"])
+        return
+
+    if state is None:
+        backfill_memory_scope_components.delay()
+        return
+    if state.completed:
+        state.completed = False
+        state.updated = timezone.now()
+        state.save(
+            using="default",
+            update_fields=["completed", "updated"],
+        )
+        backfill_memory_scope_components.delay()
+        return
+
+    stale_before = timezone.now() - timedelta(
+        seconds=MEMORY_SCOPE_BACKFILL_STALE_SECONDS
+    )
+    if state.updated <= stale_before:
+        backfill_memory_scope_components.delay()
+
+
 @app.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs) -> None:
     sender.add_periodic_task(
@@ -454,10 +641,15 @@ def setup_periodic_tasks(sender, **kwargs) -> None:
         resume_memory_scope_backfill.s(),
         name="resume-memory-scope-backfill",
     )
+    sender.add_periodic_task(
+        MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
+        resume_memory_component_backfill.s(),
+        name="resume-memory-component-backfill",
+    )
 
 
 @app.task(trail=False)
-def update_memory(  # ruff: ignore[too-many-arguments]
+def update_memory(  # ruff: ignore[too-many-arguments, complex-structure]
     *,
     source_language_id: int,
     target_language_id: int,
@@ -472,12 +664,30 @@ def update_memory(  # ruff: ignore[too-many-arguments]
     user_id: int | None,
     workspace_id: UUID | None,
     project_id: int,
+    component_id: int | None = None,
     unit_state: int,
 ) -> None:
     # ruff: ignore[import-outside-top-level]
-    from weblate.trans.models import Project
+    from weblate.trans.models import Component
 
-    project = Project.objects.select_related("workspace").get(pk=project_id)
+    components = Component.objects.select_related("project", "project__workspace")
+    if component_id is None:
+        component = (
+            components.filter_by_path(origin).filter(project_id=project_id).first()
+        )
+    else:
+        component = components.filter(pk=component_id, project_id=project_id).first()
+    if component is None:
+        return
+    component_id = component.id
+    project = component.project
+    origin = component.full_slug
+    workspace_id = project.workspace_id
+    add_project = add_project and component.contribute_project_tm
+    add_workspace = add_workspace and project.effective_contribute_workspace_tm
+    add_shared = (
+        add_shared and project.contribute_shared_tm and not component.restricted
+    )
     memory_objects = Memory.objects.using("default")
     memory_scope_objects = MemoryScope.objects.db_manager("default")
     check_matching = True
@@ -517,6 +727,7 @@ def update_memory(  # ruff: ignore[too-many-arguments]
             .filter_scope(Q(scope__in=AUTOMATIC_SCOPE_TYPES))
             .prefetch_related("scopes")
         ):
+            associate_memory_scopes(matching, component_id)
             matching = collect_status_update(matching, memory_status, to_update)
 
             categories = get_memory_categories(matching)
@@ -540,7 +751,11 @@ def update_memory(  # ruff: ignore[too-many-arguments]
             status=memory_status,
         )
         memory.pending_scopes = [
-            MemoryScope(scope=MemoryScope.SCOPE_PROJECT, project_id=project_id)
+            MemoryScope(
+                scope=MemoryScope.SCOPE_PROJECT,
+                project_id=project_id,
+                source_component_id=component_id,
+            )
         ]
         to_create.append(memory)
     if add_shared:
@@ -554,7 +769,11 @@ def update_memory(  # ruff: ignore[too-many-arguments]
             status=memory_status,
         )
         memory.pending_scopes = [
-            MemoryScope(scope=MemoryScope.SCOPE_SHARED, source_project_id=project_id)
+            MemoryScope(
+                scope=MemoryScope.SCOPE_SHARED,
+                source_project_id=project_id,
+                source_component_id=component_id,
+            )
         ]
         to_create.append(memory)
     if add_user:
@@ -568,7 +787,11 @@ def update_memory(  # ruff: ignore[too-many-arguments]
             status=memory_status,
         )
         memory.pending_scopes = [
-            MemoryScope(scope=MemoryScope.SCOPE_USER, user_id=user_id)
+            MemoryScope(
+                scope=MemoryScope.SCOPE_USER,
+                user_id=user_id,
+                source_component_id=component_id,
+            )
         ]
         to_create.append(memory)
     if add_workspace and workspace_id is not None:
@@ -586,6 +809,7 @@ def update_memory(  # ruff: ignore[too-many-arguments]
                 scope=MemoryScope.SCOPE_WORKSPACE,
                 workspace_id=workspace_id,
                 source_project_id=project_id,
+                source_component_id=component_id,
             )
         ]
         to_create.append(memory)
@@ -704,23 +928,46 @@ def compact_exact_memory_group(
         for memory in memories
         for scope in scopes_by_memory[memory.id]
     }
-    scopes = []
-    for memory in memories[1:]:
-        scopes.extend(
-            [
+    preferred_scopes: dict[MemoryScopeKey, MemoryScope] = {}
+    for memory in memories:
+        for scope in scopes_by_memory[memory.id]:
+            key = get_memory_scope_key(scope)
+            current = preferred_scopes.get(key)
+            if current is None or (
+                scope.source_component_id is not None
+                and current.source_component_id is None
+            ):
+                preferred_scopes[key] = scope
+
+    survivor_scopes = {
+        get_memory_scope_key(scope): scope for scope in scopes_by_memory[survivor.id]
+    }
+    scopes_to_create = []
+    scopes_to_update = []
+    for key, preferred in preferred_scopes.items():
+        scope = survivor_scopes.get(key)
+        if scope is None:
+            scopes_to_create.append(
                 MemoryScope(
                     memory=survivor,
-                    scope=scope.scope,
-                    project_id=scope.project_id,
-                    workspace_id=scope.workspace_id,
-                    source_project_id=scope.source_project_id,
-                    user_id=scope.user_id,
+                    scope=preferred.scope,
+                    project_id=preferred.project_id,
+                    workspace_id=preferred.workspace_id,
+                    source_project_id=preferred.source_project_id,
+                    source_component_id=preferred.source_component_id,
+                    user_id=preferred.user_id,
                 )
-                for scope in scopes_by_memory[memory.id]
-            ]
+            )
+        elif scope.source_component_id != preferred.source_component_id:
+            scope.source_component_id = preferred.source_component_id
+            scopes_to_update.append(scope)
+    if scopes_to_create:
+        memory_scope_objects.bulk_create(scopes_to_create, ignore_conflicts=True)
+    if scopes_to_update:
+        memory_scope_objects.bulk_update(
+            scopes_to_update,
+            fields=["source_component"],
         )
-    if scopes:
-        memory_scope_objects.bulk_create(scopes, ignore_conflicts=True)
     if len(scope_keys) >= 2:
         normalize_compacted_memory_owner(survivor)
     memory_objects.filter(id__in=duplicate_ids).delete()
@@ -810,6 +1057,7 @@ def split_automatic_scopes_from_file_memory(memory: Memory, status: int) -> Memo
                 project_id=scope.project_id,
                 workspace_id=scope.workspace_id,
                 source_project_id=scope.source_project_id,
+                source_component_id=scope.source_component_id,
                 user_id=scope.user_id,
             )
             for scope in scopes
@@ -843,6 +1091,21 @@ def normalize_compacted_memory_owner(memory: Memory) -> None:
     memory.normalize_legacy_owner()
 
 
+def associate_memory_scopes(memory: Memory, component_id: int) -> None:
+    """Attach matching automatic scopes to their current source component."""
+    to_update = []
+    for scope in memory.scopes.all():
+        if scope.scope not in AUTOMATIC_SCOPE_TYPES:
+            continue
+        if scope.source_component_id != component_id:
+            scope.source_component_id = component_id
+            to_update.append(scope)
+    if to_update:
+        MemoryScope.objects.using("default").bulk_update(
+            to_update, fields=["source_component"]
+        )
+
+
 def get_memory_categories(memory: Memory) -> set[MemoryCategory]:
     categories: set[MemoryCategory] = set()
     for scope in memory.scopes.all():
@@ -865,6 +1128,9 @@ def get_group_matching_memory(
     origin, source_language_id, target_language_id = group_key
     expected_keys = sorted({key for _, key, _, _ in group_entries})
     expected_key_set = set(expected_keys)
+    components_by_key = {
+        key: entry.get("component_id") for _, key, entry, _ in group_entries
+    }
     existing = defaultdict(set)
     to_update: list[Memory] = []
     memory_objects = Memory.objects.using("default")
@@ -899,6 +1165,9 @@ def get_group_matching_memory(
             )
             if key not in expected_key_set:
                 continue
+            component_id = components_by_key[key]
+            if component_id is not None:
+                associate_memory_scopes(matching, component_id)
             matching = collect_status_update(matching, statuses[key], to_update)
             existing[key].update(get_memory_categories(matching))
 
@@ -919,7 +1188,11 @@ def create_memory_entry(
             status=status,
         )
         memory.pending_scopes = [
-            MemoryScope(scope=MemoryScope.SCOPE_PROJECT, project_id=entry["project_id"])
+            MemoryScope(
+                scope=MemoryScope.SCOPE_PROJECT,
+                project_id=entry["project_id"],
+                source_component_id=entry["component_id"],
+            )
         ]
         return memory
     if category == "shared":
@@ -936,6 +1209,7 @@ def create_memory_entry(
             MemoryScope(
                 scope=MemoryScope.SCOPE_SHARED,
                 source_project_id=entry["project_id"],
+                source_component_id=entry["component_id"],
             )
         ]
         return memory
@@ -956,6 +1230,7 @@ def create_memory_entry(
                     scope=MemoryScope.SCOPE_WORKSPACE,
                     workspace_id=workspace_id,
                     source_project_id=entry["project_id"],
+                    source_component_id=entry["component_id"],
                 )
             ]
         return memory
@@ -969,7 +1244,11 @@ def create_memory_entry(
         status=status,
     )
     memory.pending_scopes = [
-        MemoryScope(scope=MemoryScope.SCOPE_USER, user_id=entry["user_id"])
+        MemoryScope(
+            scope=MemoryScope.SCOPE_USER,
+            user_id=entry["user_id"],
+            source_component_id=entry["component_id"],
+        )
     ]
     return memory
 
@@ -1009,13 +1288,35 @@ def create_missing_memory_entries(
 @app.task(trail=False)
 def update_memory_bulk(entries: list[MemoryUpdatePayload]) -> None:
     # ruff: ignore[import-outside-top-level]
-    from weblate.trans.models import Project
+    from weblate.trans.models import Component
 
     if not entries:
         return
 
-    projects = Project.objects.select_related("workspace").in_bulk(
-        {entry["project_id"] for entry in entries}
+    components_queryset = Component.objects.select_related(
+        "project", "project__workspace"
+    )
+    components = components_queryset.in_bulk(
+        {
+            component_id
+            for entry in entries
+            if (component_id := entry.get("component_id")) is not None
+        }
+    )
+    # TODO(2028.1): Remove support for queued payloads without component_id once
+    # Weblate no longer supports direct upgrades from 2026 releases.
+    legacy_project_ids = {
+        entry["project_id"] for entry in entries if entry.get("component_id") is None
+    }
+    legacy_components = (
+        {
+            component.full_slug.casefold(): component
+            for component in components_queryset.filter(
+                project_id__in=legacy_project_ids
+            ).prefetch()
+        }
+        if legacy_project_ids
+        else {}
     )
     fallback = []
     grouped_entries = defaultdict(list)
@@ -1024,7 +1325,22 @@ def update_memory_bulk(entries: list[MemoryUpdatePayload]) -> None:
     memory_scope_objects = MemoryScope.objects.db_manager("default")
 
     for position, entry in enumerate(entries):
-        project = projects[entry["project_id"]]
+        component_id = entry.get("component_id")
+        component = (
+            components.get(component_id)
+            if component_id is not None
+            else legacy_components.get(entry["origin"].casefold())
+        )
+        if component is None or component.project_id != entry["project_id"]:
+            continue
+        project = component.project
+        entry = entry.copy()
+        entry["component_id"] = component.id
+        entry["origin"] = component.full_slug
+        entry["workspace_id"] = project.workspace_id
+        entry["add_project"] &= component.contribute_project_tm
+        entry["add_workspace"] &= project.effective_contribute_workspace_tm
+        entry["add_shared"] &= project.contribute_shared_tm and not component.restricted
         if project.autoclean_tm:
             fallback.append(entry)
             continue

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -26,6 +26,8 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
 from weblate_schemas import load_schema
 
+from weblate.auth.data import SELECTION_ALL, SELECTION_MANUAL
+from weblate.auth.models import Group, Permission, Role
 from weblate.lang.data import FORMULA_WITH_ZERO
 from weblate.lang.models import Language, Plural
 from weblate.memory.machine import WeblateMemory
@@ -41,12 +43,14 @@ from weblate.memory.models import (
     load_memory_tmx_store,
 )
 from weblate.memory.tasks import (
+    MEMORY_COMPONENT_BACKFILL_STATE,
     MEMORY_SCOPE_BACKFILL_STALE_SECONDS,
     MEMORY_SCOPE_BACKFILL_STATE,
     MEMORY_SCOPE_COMPACTION_STALE_SECONDS,
     MEMORY_SCOPE_COMPACTION_STATE,
     MEMORY_UPDATE_LOOKUP_CHUNK_SIZE,
     MemoryGroupEntry,
+    backfill_memory_scope_components,
     backfill_memory_scopes,
     cleanup_orphaned_memory,
     compact_memory_scopes,
@@ -54,6 +58,7 @@ from weblate.memory.tasks import (
     get_group_matching_memory,
     handle_unit_translation_change,
     import_memory,
+    resume_memory_component_backfill,
     resume_memory_scope_backfill,
     set_scope_source_project_ids,
     update_memory,
@@ -66,7 +71,13 @@ from weblate.memory.utils import (
 )
 from weblate.memory.views import MemoryView
 from weblate.trans.actions import ActionEvents
-from weblate.trans.models import Change, Project
+from weblate.trans.models import Category, Change, Component, Project
+from weblate.trans.tasks import (
+    category_removal,
+    component_removal,
+    delete_collected_component_memory,
+    delete_component_memory,
+)
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.tests.utils import create_another_user, get_test_file
 from weblate.utils.hash import hash_to_checksum
@@ -326,6 +337,817 @@ class MemoryModelTest(FixtureTestCase):
     ) -> None:
         with self.captureOnCommitCallbacks(execute=True):
             import_memory(project_id, component_id)
+
+    def create_automatic_memory(
+        self, source: str, scope: int, **scope_kwargs
+    ) -> Memory:
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source=source,
+            target=f"{source} target",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=scope,
+            source_component=self.component,
+            **scope_kwargs,
+        )
+        return memory
+
+    def test_component_access_filters_automatic_memory_scopes(self) -> None:
+        workspace = Workspace.objects.create(
+            name="Restricted component memory workspace",
+            use_workspace_tm=True,
+            contribute_workspace_tm=True,
+        )
+        Project.objects.filter(pk=self.project.pk).update(
+            workspace=workspace,
+            use_workspace_tm=True,
+            contribute_workspace_tm=True,
+            contribute_shared_tm=True,
+        )
+        self.project.refresh_from_db()
+        project_memory = self.create_automatic_memory(
+            "Restricted project memory",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        workspace_memory = self.create_automatic_memory(
+            "Restricted workspace memory",
+            MemoryScope.SCOPE_WORKSPACE,
+            workspace=workspace,
+            source_project=self.project,
+        )
+        shared_memory = self.create_automatic_memory(
+            "Restricted shared memory",
+            MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        self.user.clear_permissions_cache()
+
+        queryset = Memory.objects.filter_type(
+            project=self.project,
+            use_shared=True,
+            use_workspace=True,
+            access_user=self.user,
+        )
+        self.assertNotIn(project_memory, queryset)
+        self.assertNotIn(workspace_memory, queryset)
+        self.assertNotIn(shared_memory, queryset)
+        self.assertNotIn(
+            project_memory,
+            Memory.objects.filter_type(project=self.project),
+        )
+        unchecked = Memory.objects.filter_type_unchecked(
+            project=self.project,
+            use_shared=True,
+            use_workspace=True,
+        )
+        self.assertIn(project_memory, unchecked)
+        self.assertIn(workspace_memory, unchecked)
+        self.assertIn(shared_memory, unchecked)
+
+        group = Group.objects.create(
+            name="Restricted memory component access",
+            project_selection=SELECTION_MANUAL,
+            language_selection=SELECTION_ALL,
+        )
+        group.roles.add(Role.objects.get(name="Power user"))
+        group.components.add(self.component)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+
+        queryset = Memory.objects.filter_type(
+            project=self.project,
+            use_shared=True,
+            use_workspace=True,
+            access_user=self.user,
+        )
+        self.assertIn(project_memory, queryset)
+        self.assertIn(workspace_memory, queryset)
+        self.assertNotIn(shared_memory, queryset)
+
+        destination = Project.objects.create(
+            name="Workspace memory destination",
+            slug="workspace-memory-destination",
+            workspace=workspace,
+            use_workspace_tm=True,
+        )
+        group.projects.add(destination)
+        self.user.userblock_set.create(project=self.project)
+        self.user.clear_permissions_cache()
+
+        self.assertIn(self.component.id, self.user.component_permissions)
+        self.assertFalse(self.user.can_access_component(self.component))
+        self.assertTrue(self.user.can_access_project(destination))
+        queryset = Memory.objects.filter_type(
+            project=destination,
+            use_workspace=True,
+            access_user=self.user,
+        )
+        self.assertNotIn(workspace_memory, queryset)
+        self.assertNotIn(
+            workspace_memory,
+            Memory.objects.visible_to_user(self.user, alias="default"),
+        )
+
+    def test_automatic_memory_scopes_track_component(self) -> None:
+        workspace = Workspace.objects.create(
+            name="Tracked component memory workspace",
+            contribute_workspace_tm=True,
+        )
+        Project.objects.filter(pk=self.project.pk).update(
+            workspace=workspace,
+            contribute_workspace_tm=True,
+            contribute_shared_tm=True,
+        )
+        self.project.refresh_from_db()
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+
+        update_memory(
+            source_language_id=source_language.id,
+            target_language_id=target_language.id,
+            source="Tracked component source",
+            context="",
+            target="Tracked component target",
+            origin=self.component.full_slug,
+            add_shared=True,
+            add_workspace=True,
+            add_project=True,
+            add_user=True,
+            user_id=self.user.id,
+            workspace_id=workspace.id,
+            project_id=self.project.id,
+            component_id=self.component.id,
+            unit_state=STATE_TRANSLATED,
+        )
+
+        self.assertEqual(
+            set(
+                MemoryScope.objects.filter(
+                    memory__source="Tracked component source",
+                    source_component=self.component,
+                ).values_list("scope", flat=True)
+            ),
+            {
+                MemoryScope.SCOPE_PROJECT,
+                MemoryScope.SCOPE_SHARED,
+                MemoryScope.SCOPE_USER,
+                MemoryScope.SCOPE_WORKSPACE,
+            },
+        )
+
+    def test_component_restriction_removes_and_rebuilds_shared_memory(self) -> None:
+        self.project.contribute_shared_tm = True
+        self.project.save(update_fields=["contribute_shared_tm"])
+        shared_memory = self.create_automatic_memory(
+            "Restriction transition shared memory",
+            MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+
+        self.assertFalse(Memory.objects.filter(pk=shared_memory.pk).exists())
+
+        self.component.restricted = False
+        with patch(
+            "weblate.trans.models.component.import_memory.delay_on_commit"
+        ) as mocked_import:
+            self.component.save(update_fields=["restricted"])
+
+        mocked_import.assert_called_once_with(self.project.id, self.component.id)
+
+    def test_component_restriction_waits_for_legacy_scope_backfill(self) -> None:
+        workspace = Workspace.objects.create(name="Legacy restriction workspace")
+        project_memory = self.create_automatic_memory(
+            "Legacy restricted project memory",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        workspace_memory = self.create_automatic_memory(
+            "Legacy restricted workspace memory",
+            MemoryScope.SCOPE_WORKSPACE,
+            workspace=workspace,
+            source_project=self.project,
+        )
+        shared_memory = self.create_automatic_memory(
+            "Legacy restricted shared memory",
+            MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        legacy_memories = (project_memory, workspace_memory, shared_memory)
+        MemoryScope.objects.filter(memory__in=legacy_memories).update(
+            source_component=None
+        )
+
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+
+        self.assertTrue(Memory.objects.filter(pk=project_memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=workspace_memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=shared_memory.pk).exists())
+
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+        backfill_memory_scope_components()
+
+        self.assertEqual(
+            project_memory.scopes.get().source_component_id, self.component.id
+        )
+        self.assertEqual(
+            workspace_memory.scopes.get().source_component_id, self.component.id
+        )
+        self.assertFalse(Memory.objects.filter(pk=shared_memory.pk).exists())
+
+    def test_partial_save_does_not_apply_unsaved_restriction(self) -> None:
+        shared_memory = self.create_automatic_memory(
+            "Partial save shared memory",
+            MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        self.component.restricted = True
+        self.component.priority += 1
+
+        self.component.save(update_fields=["priority"])
+
+        self.component.refresh_from_db()
+        self.assertFalse(self.component.restricted)
+        self.assertTrue(Memory.objects.filter(pk=shared_memory.pk).exists())
+
+    def test_component_attribution_backfill(self) -> None:
+        self.project.contribute_shared_tm = True
+        self.project.save(update_fields=["contribute_shared_tm"])
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        restricted_memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Backfilled restricted source",
+            target="Backfilled restricted target",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        project_scope = MemoryScope.objects.create(
+            memory=restricted_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        MemoryScope.objects.create(
+            memory=restricted_memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        unresolved_memory = Memory.objects.create(
+            source_language=restricted_memory.source_language,
+            target_language=restricted_memory.target_language,
+            source="Unresolved shared source",
+            target="Unresolved shared target",
+            origin="removed-project/removed-component",
+            status=Memory.STATUS_ACTIVE,
+        )
+        unresolved_scope = MemoryScope.objects.create(
+            memory=unresolved_memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        file_scope = MemoryScope.objects.create(
+            memory=restricted_memory,
+            scope=MemoryScope.SCOPE_GLOBAL_FILE,
+        )
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+
+        backfill_memory_scope_components()
+
+        project_scope.refresh_from_db()
+        unresolved_scope.refresh_from_db()
+        file_scope.refresh_from_db()
+        self.assertEqual(project_scope.source_component_id, self.component.id)
+        self.assertFalse(
+            restricted_memory.scopes.filter(scope=MemoryScope.SCOPE_SHARED).exists()
+        )
+        self.assertIsNone(unresolved_scope.source_component_id)
+        self.assertIsNone(file_scope.source_component_id)
+        self.assertIn(
+            unresolved_memory,
+            Memory.objects.filter_type(use_shared=True, access_user=self.user),
+        )
+
+    def test_component_attribution_backfill_resolves_renamed_project(self) -> None:
+        old_slug = "renamed-memory-project"
+        relative_component_path = self.component.full_slug.split("/", 1)[1]
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Renamed component attribution source",
+            target="Prejmenovany cil komponenty",
+            origin=f"{old_slug}/{relative_component_path}",
+            status=Memory.STATUS_ACTIVE,
+        )
+        project_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+
+        backfill_memory_scope_components()
+
+        project_scope.refresh_from_db()
+        self.assertEqual(project_scope.source_component_id, self.component.id)
+        self.assertFalse(memory.scopes.filter(scope=MemoryScope.SCOPE_SHARED).exists())
+
+    def test_component_attribution_backfill_ignores_moved_project(self) -> None:
+        old_project = Project.objects.create(
+            name="Old component project",
+            slug="old-component-project",
+        )
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Moved project attribution source",
+            target="Presunuty cil projektu",
+            origin=f"{old_project.slug}/{self.component.slug}",
+            status=Memory.STATUS_ACTIVE,
+        )
+        project_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=old_project,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=old_project,
+        )
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+
+        backfill_memory_scope_components()
+
+        project_scope.refresh_from_db()
+        self.assertIsNone(project_scope.source_component_id)
+        self.assertTrue(memory.scopes.filter(scope=MemoryScope.SCOPE_SHARED).exists())
+
+    def test_component_attribution_ignores_historical_paths(self) -> None:
+        old_project = Project.objects.create(
+            name="Old path history project",
+            slug="old-path-history-project",
+        )
+        old_component_slug = "old-path-history-component"
+        historical_memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Historical project and path pair",
+            target="Historicky par projektu a cesty",
+            origin=f"{old_project.slug}/{old_component_slug}",
+            status=Memory.STATUS_ACTIVE,
+        )
+        historical_scope = MemoryScope.objects.create(
+            memory=historical_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=old_project,
+        )
+        unrelated_memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Unrelated project and historical path",
+            target="Nesouvisejici projekt a historicka cesta",
+            origin=f"{self.project.slug}/{old_component_slug}",
+            status=Memory.STATUS_ACTIVE,
+        )
+        unrelated_scope = MemoryScope.objects.create(
+            memory=unrelated_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+
+        backfill_memory_scope_components()
+
+        historical_scope.refresh_from_db()
+        self.assertIsNone(historical_scope.source_component_id)
+        unrelated_scope.refresh_from_db()
+        self.assertIsNone(unrelated_scope.source_component_id)
+
+    def test_component_attribution_backfill_ignores_renamed_path(self) -> None:
+        category = Category.objects.create(
+            project=self.project,
+            name="Current memory category",
+            slug="current-memory-category",
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            category=category,
+            restricted=True,
+        )
+        self.component.refresh_from_db()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Renamed path attribution source",
+            target="Prejmenovana cesta komponenty",
+            origin=(f"{self.project.slug}/old-memory-category/old-memory-component"),
+            status=Memory.STATUS_ACTIVE,
+        )
+        project_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+
+        backfill_memory_scope_components()
+
+        project_scope.refresh_from_db()
+        self.assertIsNone(project_scope.source_component_id)
+        self.assertTrue(memory.scopes.filter(scope=MemoryScope.SCOPE_SHARED).exists())
+
+    def test_component_attribution_prefers_current_reused_path(self) -> None:
+        old_category = Category.objects.create(
+            project=self.project,
+            name="Reused memory category",
+            slug="reused-memory-category",
+        )
+        current_category = Category.objects.create(
+            project=self.project,
+            name="Current memory category",
+            slug="current-memory-category",
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            category=current_category,
+            restricted=True,
+        )
+        self.component.refresh_from_db()
+        replacement = self.create_link_existing(
+            name="Replacement memory component",
+            slug=self.component.slug,
+            category=old_category,
+        )
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Reused current path source",
+            target="Nahrazeny cil aktualni cesty",
+            origin=replacement.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        project_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+
+        backfill_memory_scope_components()
+
+        project_scope.refresh_from_db()
+        self.assertEqual(project_scope.source_component_id, replacement.id)
+        self.assertTrue(memory.scopes.filter(scope=MemoryScope.SCOPE_SHARED).exists())
+
+    def test_resume_component_attribution_backfill_restarts_for_new_scopes(
+        self,
+    ) -> None:
+        last_memory_id = (
+            MemoryScope.objects.order_by("-id").values_list("id", flat=True).first()
+            or 0
+        )
+        state = MemoryScopeMigrationState.objects.create(
+            name=MEMORY_COMPONENT_BACKFILL_STATE,
+            last_memory_id=last_memory_id,
+            completed=True,
+        )
+        memory = self.create_automatic_memory(
+            "Late component backfill scope",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        memory.scopes.update(source_component=None)
+
+        with patch(
+            "weblate.memory.tasks.backfill_memory_scope_components.delay"
+        ) as mocked_delay:
+            resume_memory_component_backfill()
+
+        state.refresh_from_db()
+        self.assertEqual(state.last_memory_id, last_memory_id)
+        self.assertFalse(state.completed)
+        mocked_delay.assert_called_once_with()
+
+    def test_resume_component_attribution_backfill_ignores_terminal_scope(
+        self,
+    ) -> None:
+        memory = self.create_automatic_memory(
+            "Terminal component backfill scope",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        memory.origin = "removed-project/removed-component"
+        memory.save(update_fields=["origin"])
+        memory.scopes.update(source_component=None)
+        MemoryScopeMigrationState.objects.filter(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        ).delete()
+        backfill_memory_scope_components()
+        state = MemoryScopeMigrationState.objects.get(
+            name=MEMORY_COMPONENT_BACKFILL_STATE
+        )
+
+        with patch(
+            "weblate.memory.tasks.backfill_memory_scope_components.delay"
+        ) as mocked_delay:
+            resume_memory_component_backfill()
+
+        state.refresh_from_db()
+        self.assertTrue(state.completed)
+        self.assertGreaterEqual(state.last_memory_id, memory.scopes.get().id)
+        self.assertIsNone(memory.scopes.get().source_component_id)
+        mocked_delay.assert_not_called()
+
+    def test_component_deletion_retains_memory_by_default(self) -> None:
+        memories = [
+            self.create_automatic_memory(
+                "Retained project memory",
+                MemoryScope.SCOPE_PROJECT,
+                project=self.project,
+            ),
+            self.create_automatic_memory(
+                "Retained shared memory",
+                MemoryScope.SCOPE_SHARED,
+                source_project=self.project,
+            ),
+            self.create_automatic_memory(
+                "Retained personal memory",
+                MemoryScope.SCOPE_USER,
+                user=self.user,
+            ),
+        ]
+
+        self.component.delete()
+
+        self.assertEqual(
+            Memory.objects.filter(pk__in=[memory.pk for memory in memories]).count(),
+            len(memories),
+        )
+        self.assertFalse(
+            MemoryScope.objects.filter(
+                memory__in=memories, source_component__isnull=False
+            ).exists()
+        )
+
+    def test_component_deletion_retains_unattributed_memory(self) -> None:
+        memory = self.create_automatic_memory(
+            "Untracked retained component memory",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        memory.scopes.update(source_component=None)
+        scope = memory.scopes.get()
+
+        self.component.delete()
+
+        scope.refresh_from_db()
+        self.assertIsNone(scope.source_component_id)
+
+    def test_optional_component_memory_deletion_preserves_personal_scope(self) -> None:
+        project_memory = self.create_automatic_memory(
+            "Deleted component project memory",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        shared_memory = self.create_automatic_memory(
+            "Deleted component shared memory",
+            MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+        )
+        personal_memory = self.create_automatic_memory(
+            "Preserved component personal memory",
+            MemoryScope.SCOPE_USER,
+            user=self.user,
+        )
+
+        delete_component_memory(self.component)
+
+        self.assertFalse(Memory.objects.filter(pk=project_memory.pk).exists())
+        self.assertFalse(Memory.objects.filter(pk=shared_memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=personal_memory.pk).exists())
+
+    def test_optional_component_memory_deletion_removes_current_legacy_origin(
+        self,
+    ) -> None:
+        memory = self.create_automatic_memory(
+            "Current legacy component cleanup",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        memory.scopes.update(source_component=None)
+
+        delete_component_memory(self.component)
+
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+
+    def test_component_removal_deletes_memory_written_after_initial_cleanup(
+        self,
+    ) -> None:
+        late_memories: list[Memory] = []
+
+        def delete_with_late_write(cleanup):
+            delete_collected_component_memory(cleanup)
+            if not late_memories:
+                late_memories.append(
+                    self.create_automatic_memory(
+                        "Late component removal memory",
+                        MemoryScope.SCOPE_PROJECT,
+                        project=self.project,
+                    )
+                )
+
+        with patch(
+            "weblate.trans.tasks.delete_collected_component_memory",
+            side_effect=delete_with_late_write,
+        ):
+            component_removal(self.component.pk, self.user.pk, delete_memory=True)
+
+        self.assertFalse(Memory.objects.filter(pk=late_memories[0].pk).exists())
+
+    def test_optional_component_memory_deletion_preserves_historical_origin(
+        self,
+    ) -> None:
+        category = Category.objects.create(
+            project=self.project,
+            name="Current cleanup category",
+            slug="current-cleanup-category",
+        )
+        Component.objects.filter(pk=self.component.pk).update(category=category)
+        self.component.refresh_from_db()
+        Change.objects.create(
+            project=self.project,
+            action=ActionEvents.RENAME_PROJECT,
+            old="old-cleanup-project",
+            target=self.project.slug,
+        )
+        Change.objects.create(
+            project=self.project,
+            action=ActionEvents.RENAME_CATEGORY,
+            old="old-cleanup-category",
+            target=category.slug,
+        )
+        Change.objects.create(
+            component=self.component,
+            action=ActionEvents.RENAME_COMPONENT,
+            old="old-cleanup-component",
+            target=self.component.slug,
+        )
+        memory = self.create_automatic_memory(
+            "Historical component cleanup",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        memory.origin = "old-cleanup-project/old-cleanup-category/old-cleanup-component"
+        memory.save(update_fields=["origin"])
+        memory.scopes.update(source_component=None)
+
+        delete_component_memory(self.component)
+
+        self.assertTrue(Memory.objects.filter(pk=memory.pk).exists())
+
+    def test_optional_component_memory_deletion_preserves_moved_project(self) -> None:
+        old_project = Project.objects.create(
+            name="Old cleanup project",
+            slug="old-cleanup-project",
+        )
+        Change.objects.create(
+            component=self.component,
+            action=ActionEvents.MOVE_COMPONENT,
+            old=old_project.slug,
+            target=self.project.slug,
+        )
+        memory = self.create_automatic_memory(
+            "Moved component cleanup",
+            MemoryScope.SCOPE_PROJECT,
+            project=old_project,
+        )
+        memory.origin = f"{old_project.slug}/{self.component.slug}"
+        memory.save(update_fields=["origin"])
+        memory.scopes.update(source_component=None)
+
+        delete_component_memory(self.component)
+
+        self.assertTrue(Memory.objects.filter(pk=memory.pk).exists())
+
+    def test_optional_category_memory_deletion_preserves_personal_scope(self) -> None:
+        category = Category.objects.create(
+            name="Deleted memory category",
+            slug="deleted-memory-category",
+            project=self.project,
+        )
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        project_memory = self.create_automatic_memory(
+            "Deleted category project memory",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        personal_memory = self.create_automatic_memory(
+            "Preserved category personal memory",
+            MemoryScope.SCOPE_USER,
+            user=self.user,
+        )
+
+        category_removal(category.pk, self.user.pk, delete_memory=True)
+
+        self.assertFalse(Memory.objects.filter(pk=project_memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=personal_memory.pk).exists())
+
+    def test_category_removal_deletes_memory_written_after_initial_cleanup(
+        self,
+    ) -> None:
+        category = Category.objects.create(
+            name="Late memory category",
+            slug="late-memory-category",
+            project=self.project,
+        )
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        late_memories: list[Memory] = []
+
+        def delete_with_late_write(cleanup):
+            delete_collected_component_memory(cleanup)
+            if not late_memories:
+                late_memories.append(
+                    self.create_automatic_memory(
+                        "Late category removal memory",
+                        MemoryScope.SCOPE_PROJECT,
+                        project=self.project,
+                    )
+                )
+
+        with patch(
+            "weblate.trans.tasks.delete_collected_component_memory",
+            side_effect=delete_with_late_write,
+        ):
+            category_removal(category.pk, self.user.pk, delete_memory=True)
+
+        self.assertFalse(Memory.objects.filter(pk=late_memories[0].pk).exists())
+
+    def test_category_deletion_retains_unattributed_memory(self) -> None:
+        category = Category.objects.create(
+            name="Retained memory category",
+            slug="retained-memory-category",
+            project=self.project,
+        )
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        memory = self.create_automatic_memory(
+            "Untracked retained category memory",
+            MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        memory.scopes.update(source_component=None)
+        scope = memory.scopes.get()
+
+        category_removal(category.pk, self.user.pk)
+
+        scope.refresh_from_db()
+        self.assertIsNone(scope.source_component_id)
 
     def handle_unit_translation_change_with_callbacks(self, unit, user) -> None:
         with self.captureOnCommitCallbacks(execute=True):
@@ -2062,6 +2884,36 @@ msgstr "Nazdar svete!\n"
             1,
         )
 
+    def test_bulk_current_payload_skips_legacy_component_prefetch(self) -> None:
+        source_language = Language.objects.get(code="en")
+        target_language = Language.objects.get(code="cs")
+        source = "Bulk current component payload source"
+        payload = {
+            "source_language_id": source_language.id,
+            "target_language_id": target_language.id,
+            "source": source,
+            "context": "",
+            "target": "Davkovy aktualni cil",
+            "origin": self.component.full_slug,
+            "add_shared": False,
+            "add_workspace": False,
+            "add_project": True,
+            "add_user": False,
+            "user_id": None,
+            "workspace_id": None,
+            "project_id": self.project.id,
+            "component_id": self.component.id,
+            "unit_state": STATE_TRANSLATED,
+        }
+
+        with patch(
+            "weblate.trans.models.component.ComponentQuerySet.prefetch"
+        ) as mocked_prefetch:
+            update_memory_bulk([payload])
+
+        mocked_prefetch.assert_not_called()
+        self.assertTrue(Memory.objects.filter(source=source).exists())
+
     def test_compact_backfills_scopes_before_merging_duplicates(self) -> None:
         source_language = Language.objects.get(code="en")
         target_language = Language.objects.get(code="cs")
@@ -2997,6 +3849,14 @@ msgstr "Nazdar svete!\n"
 
 
 class MemoryViewTest(FixtureTestCase):
+    def grant_memory_manage(self) -> None:
+        role = Role.objects.create(name="Global memory manager")
+        role.permissions.add(Permission.objects.get(codename="memory.manage"))
+        group = Group.objects.create(name="Global memory managers")
+        group.roles.add(role)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+
     def create_workspace_memory(self):
         workspace = Workspace.objects.create(
             name="Managed memory workspace",
@@ -3021,6 +3881,7 @@ class MemoryViewTest(FixtureTestCase):
             scope=MemoryScope.SCOPE_WORKSPACE,
             workspace=workspace,
             source_project=self.project,
+            source_component=self.component,
         )
         return workspace, memory
 
@@ -3107,8 +3968,52 @@ class MemoryViewTest(FixtureTestCase):
             ).exists()
         )
 
-    def test_workspace_memory_rebuild_component(self) -> None:
+    def test_workspace_memory_delete_removes_unattributed_origin(self) -> None:
         workspace, memory = self.create_workspace_memory()
+        memory.origin = "old-project/removed-component"
+        memory.save(update_fields=["origin"])
+        memory.scopes.update(source_component=None)
+
+        response = self.client.post(
+            reverse("memory-delete", kwargs={"workspace": workspace.pk}),
+            {"confirm": "1", "origin": memory.origin},
+            follow=True,
+        )
+
+        self.assertContains(response, "Entries were deleted.")
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+
+    def test_workspace_memory_rebuild_preserves_unattributed_component(self) -> None:
+        workspace, memory = self.create_workspace_memory()
+        relative_path = self.component.full_slug.partition("/")[2]
+        memory.origin = f"old-project/{relative_path}"
+        memory.save(update_fields=["origin"])
+        memory.scopes.update(source_component=None)
+        other_project = Project.objects.create(
+            name="Unselected workspace memory project",
+            slug="unselected-workspace-memory-project",
+            workspace=workspace,
+            contribute_workspace_tm=True,
+        )
+        other_component = self.create_link_existing(
+            name="Unselected workspace memory component",
+            slug=self.component.slug,
+            project=other_project,
+        )
+        other_memory = Memory.objects.create(
+            source_language=memory.source_language,
+            target_language=memory.target_language,
+            source="Unselected workspace memory source",
+            target="Unselected workspace memory target",
+            origin=other_component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        other_scope = MemoryScope.objects.create(
+            memory=other_memory,
+            scope=MemoryScope.SCOPE_WORKSPACE,
+            workspace=workspace,
+            source_project=other_project,
+        )
 
         with patch("weblate.memory.views.import_memory.delay") as mocked_import:
             response = self.client.post(
@@ -3121,15 +4026,20 @@ class MemoryViewTest(FixtureTestCase):
             response,
             "Translation memory entries created from current translations",
         )
-        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=other_memory.pk).exists())
+        other_scope.refresh_from_db()
+        self.assertIsNone(other_scope.source_component_id)
         mocked_import.assert_called_once_with(
             project_id=self.project.id,
             component_id=self.component.id,
         )
 
-    def test_workspace_memory_rebuilds_contributing_projects(self) -> None:
+    def test_workspace_memory_rebuilds_accessible_contributing_components(
+        self,
+    ) -> None:
         workspace, memory = self.create_workspace_memory()
-        contributing = Project.objects.create(
+        Project.objects.create(
             name="Contributing workspace project",
             slug="contributing-workspace-project",
             workspace=workspace,
@@ -3154,13 +4064,148 @@ class MemoryViewTest(FixtureTestCase):
             "Translation memory entries created from current translations",
         )
         self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
-        self.assertEqual(mocked_import.call_count, 2)
-        mocked_import.assert_has_calls(
-            [
-                call(project_id=self.project.id, component_id=None),
-                call(project_id=contributing.id, component_id=None),
-            ],
-            any_order=True,
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
+        )
+
+    def test_workspace_memory_rebuild_skips_restricted_components(self) -> None:
+        workspace, memory = self.create_workspace_memory()
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        self.user.clear_permissions_cache()
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs={"workspace": workspace.pk}),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertTrue(Memory.objects.filter(pk=memory.pk).exists())
+        mocked_import.assert_not_called()
+
+    def test_workspace_memory_rebuild_preserves_inaccessible_component(self) -> None:
+        workspace, memory = self.create_workspace_memory()
+        private_project = Project.objects.create(
+            name="Private workspace project",
+            slug="private-workspace-project",
+            workspace=workspace,
+            contribute_workspace_tm=True,
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_component = self.create_link_existing(
+            name="Private workspace component",
+            slug="private-workspace-component",
+            project=private_project,
+        )
+        private_memory = Memory.objects.create(
+            source_language=memory.source_language,
+            target_language=memory.target_language,
+            source="Private workspace source",
+            target="Soukromy cil pracovniho prostoru",
+            origin=private_component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=private_memory,
+            scope=MemoryScope.SCOPE_WORKSPACE,
+            workspace=workspace,
+            source_project=private_project,
+            source_component=private_component,
+        )
+        self.user.clear_permissions_cache()
+        self.assertFalse(self.user.can_access_component(private_component))
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs={"workspace": workspace.pk}),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=private_memory.pk).exists())
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
+        )
+
+    def test_workspace_memory_rebuild_preserves_accessible_unattributed_scope(
+        self,
+    ) -> None:
+        workspace, memory = self.create_workspace_memory()
+        memory.scopes.update(source_component=None)
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs={"workspace": workspace.pk}),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertTrue(Memory.objects.filter(pk=memory.pk).exists())
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
+        )
+
+    def test_workspace_memory_rebuild_superuser_removes_tracked_scope(self) -> None:
+        workspace, memory = self.create_workspace_memory()
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+        self.user.clear_permissions_cache()
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs={"workspace": workspace.pk}),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
+        )
+
+    def test_workspace_memory_rebuild_global_manager_includes_restricted(self) -> None:
+        workspace, memory = self.create_workspace_memory()
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        self.grant_memory_manage()
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs={"workspace": workspace.pk}),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
         )
 
     def test_origin_counts_use_single_query(self) -> None:
@@ -3477,7 +4522,7 @@ class MemoryViewTest(FixtureTestCase):
         self.user.save()
         self.test_memory("Number of entries for Test", False, kwargs=self.kw_project)
 
-    def test_rebuild_removes_compacted_automatic_scopes(self) -> None:
+    def test_rebuild_preserves_unattributed_compacted_automatic_scopes(self) -> None:
         self.project.add_user(self.user, "Administration")
         workspace = Workspace.objects.create(name="Memory rebuild workspace")
         self.project.workspace = workspace
@@ -3487,7 +4532,7 @@ class MemoryViewTest(FixtureTestCase):
             target_language=Language.objects.get(code="cs"),
             source="Rebuild stale scope",
             target="Prestaveny stary rozsah",
-            origin=self.component.full_slug,
+            origin=("old-project/" + self.component.full_slug.partition("/")[2]),
             legacy_project=self.project,
             status=Memory.STATUS_ACTIVE,
         )
@@ -3502,6 +4547,23 @@ class MemoryViewTest(FixtureTestCase):
             workspace=workspace,
             source_project=self.project,
         )
+        other_component = self.create_link_existing(
+            name="Unselected project memory component",
+            slug="unselected-project-memory-component",
+        )
+        other_memory = Memory.objects.create(
+            source_language=memory.source_language,
+            target_language=memory.target_language,
+            source="Unselected project memory source",
+            target="Unselected project memory target",
+            origin=other_component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        other_scope = MemoryScope.objects.create(
+            memory=other_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
 
         with patch("weblate.memory.views.import_memory.delay") as mocked_import:
             response = self.client.post(
@@ -3513,9 +4575,198 @@ class MemoryViewTest(FixtureTestCase):
         self.assertContains(
             response, "Translation memory entries created from current translations"
         )
-        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=memory.pk).exists())
+        self.assertTrue(Memory.objects.filter(pk=other_memory.pk).exists())
+        other_scope.refresh_from_db()
+        self.assertIsNone(other_scope.source_component_id)
         mocked_import.assert_called_once_with(
             project_id=self.project.id, component_id=self.component.id
+        )
+
+    def test_delete_preserves_inaccessible_scope_on_compacted_entry(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        self.user.clear_permissions_cache()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Compacted hidden automatic scope",
+            target="Skryty automaticky rozsah",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        automatic_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+            source_component=self.component,
+        )
+        file_scope = MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT_FILE,
+            project=self.project,
+        )
+
+        response = self.client.post(
+            reverse("memory-delete", kwargs=self.kw_project),
+            {"confirm": "1"},
+            follow=True,
+        )
+
+        self.assertContains(response, "Entries were deleted")
+        self.assertTrue(MemoryScope.objects.filter(pk=automatic_scope.pk).exists())
+        self.assertFalse(MemoryScope.objects.filter(pk=file_scope.pk).exists())
+
+    def test_project_rebuild_skips_restricted_components(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        self.user.clear_permissions_cache()
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs=self.kw_project),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        mocked_import.assert_not_called()
+
+    def test_project_memory_delete_removes_unattributed_origin(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        self.user.clear_permissions_cache()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Unattributed project deletion source",
+            target="Neprirazeny cil odstraneni projektu",
+            origin="old-project/removed-component",
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+
+        response = self.client.post(
+            reverse("memory-delete", kwargs=self.kw_project),
+            {"confirm": "1", "origin": memory.origin},
+            follow=True,
+        )
+
+        self.assertContains(response, "Entries were deleted.")
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+
+    def test_project_rebuild_preserves_accessible_unattributed_scope(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Untracked project rebuild source",
+            target="Nesledovany cil prestavby projektu",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs=self.kw_project),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertTrue(Memory.objects.filter(pk=memory.pk).exists())
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
+        )
+
+    def test_project_rebuild_superuser_removes_tracked_scope(self) -> None:
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+        self.user.clear_permissions_cache()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Superuser rebuild source",
+            target="Spravcovsky prestaveny cil",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+            source_component=self.component,
+        )
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs=self.kw_project),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
+        )
+
+    def test_project_rebuild_global_manager_includes_restricted(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        self.grant_memory_manage()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Global manager restricted rebuild source",
+            target="Globalni spravce omezeny cil",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+            source_component=self.component,
+        )
+
+        with patch("weblate.memory.views.import_memory.delay") as mocked_import:
+            response = self.client.post(
+                reverse("memory-rebuild", kwargs=self.kw_project),
+                {"confirm": "1"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response,
+            "Translation memory entries created from current translations",
+        )
+        self.assertFalse(Memory.objects.filter(pk=memory.pk).exists())
+        mocked_import.assert_called_once_with(
+            project_id=self.project.id,
+            component_id=self.component.id,
         )
 
     def test_rebuild_preserves_uploaded_entries(self) -> None:
@@ -3573,7 +4824,7 @@ class MemoryViewTest(FixtureTestCase):
         self.assertContains(response, "Uploaded entries were preserved.")
         self.assertTrue(Memory.objects.filter(pk=file_memory.pk).exists())
         self.assertTrue(Memory.objects.filter(pk=compacted_memory.pk).exists())
-        self.assertFalse(
+        self.assertTrue(
             MemoryScope.objects.filter(
                 memory=compacted_memory,
                 scope=MemoryScope.SCOPE_PROJECT,
@@ -3588,7 +4839,7 @@ class MemoryViewTest(FixtureTestCase):
             ).exists()
         )
         mocked_import.assert_called_once_with(
-            project_id=self.project.id, component_id=None
+            project_id=self.project.id, component_id=self.component.id
         )
 
     def test_global_memory_superuser(self) -> None:
@@ -3634,6 +4885,35 @@ class MemoryViewTest(FixtureTestCase):
         )
 
         self.assertEqual(response.json()[0]["category"], CATEGORY_SHARED)
+
+    def test_shared_memory_download_excludes_restricted_components(self) -> None:
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+        self.project.contribute_shared_tm = True
+        self.project.save(update_fields=["contribute_shared_tm"])
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        memory = Memory.objects.create(
+            source_language=Language.objects.get(code="en"),
+            target_language=Language.objects.get(code="cs"),
+            source="Restricted shared download source",
+            target="Omezeny sdileny cil",
+            origin=self.component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=self.project,
+            source_component=self.component,
+        )
+
+        response = self.client.get(
+            reverse("manage-memory-download"),
+            {"format": "json", "kind": "shared"},
+        )
+
+        self.assertNotIn(memory.source, {entry["source"] for entry in response.json()})
 
     def test_global_memory_download_all_expands_compacted_scopes(self) -> None:
         self.user.is_superuser = True
@@ -3837,14 +5117,18 @@ class LookupPolicyTest(SimpleTestCase):
 
         self.assertIs(result, filtered)
         (scope_query,) = filter_scope.call_args.args
+        component_access = MemoryQuerySet.get_component_access_query(None)
         expected_scope = (
             Q(pk__isnull=True)
             | Q(scope=MemoryScope.SCOPE_GLOBAL_FILE)
-            | Q(
-                scope=MemoryScope.SCOPE_SHARED,
-                source_project__contribute_shared_tm=True,
+            | (
+                Q(
+                    scope=MemoryScope.SCOPE_SHARED,
+                    source_project__contribute_shared_tm=True,
+                )
+                & MemoryQuerySet.get_shared_component_access_query()
             )
-            | Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
+            | (Q(scope=MemoryScope.SCOPE_PROJECT, project=project) & component_access)
             | Q(scope=MemoryScope.SCOPE_PROJECT_FILE, project=project)
             | Q(scope=MemoryScope.SCOPE_USER, user=user)
             | Q(scope=MemoryScope.SCOPE_USER_FILE, user=user)
@@ -4029,6 +5313,7 @@ class LookupPolicyTest(SimpleTestCase):
         self.assertEqual(list(results), [])
         filter_type.assert_called_once_with(
             user=None,
+            access_user=None,
             project=None,
             use_shared=False,
             from_file=True,
@@ -4065,6 +5350,7 @@ class LookupPolicyTest(SimpleTestCase):
         self.assertEqual(list(results), [])
         filter_type.assert_called_once_with(
             user=None,
+            access_user=None,
             project=None,
             use_shared=False,
             from_file=True,
@@ -4174,6 +5460,7 @@ class LookupPolicyTest(SimpleTestCase):
         self.assertEqual(list(results), [])
         filter_type.assert_called_once_with(
             user=None,
+            access_user=None,
             project=None,
             use_shared=False,
             from_file=True,

--- a/weblate/memory/views.py
+++ b/weblate/memory/views.py
@@ -18,7 +18,7 @@ from django.views.generic.base import TemplateView
 
 from weblate.lang.models import Language
 from weblate.memory.forms import DeleteForm, UploadForm
-from weblate.memory.models import Memory, MemoryImportError, MemoryScope
+from weblate.memory.models import Memory, MemoryImportError, MemoryQuerySet, MemoryScope
 from weblate.memory.tasks import import_memory
 from weblate.memory.utils import (
     CATEGORY_FILE,
@@ -79,16 +79,27 @@ def check_perm(user: User, permission: str, objects: ObjectsDict):
     return False
 
 
-def get_scope_delete_query(objects: ObjectsDict) -> Q:
+def get_scope_delete_query(
+    objects: ObjectsDict, *, access_user: User | None = None
+) -> Q:
     if "workspace" in objects:
-        return Q(
+        query = Q(
             scope=MemoryScope.SCOPE_WORKSPACE,
             workspace=objects["workspace"],
         )
+        if access_user is not None:
+            query &= MemoryQuerySet.get_component_access_query(access_user)
+        return query
     if "project" in objects:
         project = objects["project"]
-        return Q(
-            scope__in=(MemoryScope.SCOPE_PROJECT, MemoryScope.SCOPE_PROJECT_FILE),
+        automatic_query = Q(
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=project,
+        )
+        if access_user is not None:
+            automatic_query &= MemoryQuerySet.get_component_access_query(access_user)
+        return automatic_query | Q(
+            scope=MemoryScope.SCOPE_PROJECT_FILE,
             project=project,
         )
     if "user" in objects:
@@ -143,10 +154,14 @@ class DeleteView(MemoryFormView):
     def form_valid(self, form):
         if not check_perm(self.request.user, "memory.delete", self.objects):
             raise PermissionDenied
-        entries = Memory.objects.filter_type(**self.objects)
+        entries = Memory.objects.filter_type(
+            access_user=self.request.user, **self.objects
+        )
         if "origin" in self.request.POST:
             entries = entries.filter(origin=self.request.POST["origin"])
-        entries.using("default").delete_scope(get_scope_delete_query(self.objects))
+        entries.using("default").delete_scope(
+            get_scope_delete_query(self.objects, access_user=self.request.user)
+        )
         messages.success(self.request, gettext("Entries were deleted."))
         return super().form_valid(form)
 
@@ -165,37 +180,45 @@ class RebuildView(MemoryFormView):
             return self.rebuild_workspace(origin, form)
 
         project = self.objects["project"]
-        component_id = None
+        component_queryset = project.component_set.all()
+        if not (
+            self.request.user.is_superuser
+            or self.request.user.has_perm("memory.manage")
+        ):
+            component_queryset = component_queryset.filter_access(self.request.user)
         if origin:
             try:
-                component_id = project.component_set.get_by_path(origin).id
+                component = component_queryset.get_by_path(origin)
             except ObjectDoesNotExist as error:
                 raise PermissionDenied from error
+            components = [component]
+        else:
+            components = list(component_queryset.prefetch())
+        component_ids = [component.id for component in components]
+        # TODO(2028.1): Remove this migration caveat once Weblate no longer
+        # supports direct upgrades from 2026 releases. Legacy unattributed
+        # scopes are intentionally left for the background backfill.
+        component_selection = Q(source_component_id__in=component_ids)
         # Delete private entries
-        entries = Memory.objects.filter_type(**self.objects).exclude(
-            legacy_from_file=True
-        )
-        if origin:
-            entries = entries.filter(origin=origin)
+        entries = Memory.objects.filter_scope(Q())
+        entries = entries.exclude(legacy_from_file=True)
         entries.using("default").delete_scope(
-            Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
+            Q(scope=MemoryScope.SCOPE_PROJECT, project=project) & component_selection
         )
         # Delete possible shared entries
-        if origin:
-            slugs = [origin]
-        else:
-            slugs = [
-                component.full_slug for component in project.component_set.prefetch()
-            ]
-        Memory.objects.filter(origin__in=slugs).using("default").delete_scope(
+        Memory.objects.using("default").delete_scope(
             Q(
                 scope__in=(MemoryScope.SCOPE_SHARED, MemoryScope.SCOPE_WORKSPACE),
                 source_project=project,
-            ),
+            )
+            & component_selection,
             delete_legacy=False,
         )
         # Rebuild memory in background
-        import_memory.delay(project_id=project.id, component_id=component_id)
+        for component in components:
+            import_memory.delay(
+                project_id=component.project_id, component_id=component.id
+            )
         messages.success(
             self.request,
             gettext(
@@ -208,33 +231,41 @@ class RebuildView(MemoryFormView):
 
     def rebuild_workspace(self, origin: str | None, form):
         workspace = self.objects["workspace"]
-        component = None
         projects = workspace.projects.filter(contribute_workspace_tm=True)
         if not workspace.contribute_workspace_tm:
             projects = projects.none()
+        components = Component.objects.filter(project__in=projects)
+        if not (
+            self.request.user.is_superuser
+            or self.request.user.has_perm("memory.manage")
+        ):
+            components = components.filter_access(self.request.user)
         if origin:
             try:
-                component = Component.objects.filter(project__in=projects).get_by_path(
-                    origin
-                )
+                component = components.get_by_path(origin)
             except ObjectDoesNotExist as error:
                 raise PermissionDenied from error
+            rebuild_components = [component]
+        else:
+            rebuild_components = list(components.prefetch(alerts=False))
 
-        entries = Memory.objects.filter_type(workspace=workspace)
-        if origin:
-            entries = entries.filter(origin=origin)
+        component_ids = [component.id for component in rebuild_components]
+        # TODO(2028.1): Remove this migration caveat once Weblate no longer
+        # supports direct upgrades from 2026 releases. Legacy unattributed
+        # scopes are intentionally left for the background backfill.
+        component_selection = Q(source_component_id__in=component_ids)
+
+        entries = Memory.objects.filter_scope(Q())
         entries.using("default").delete_scope(
-            Q(scope=MemoryScope.SCOPE_WORKSPACE, workspace=workspace),
+            Q(scope=MemoryScope.SCOPE_WORKSPACE, workspace=workspace)
+            & component_selection,
             delete_legacy=False,
         )
 
-        if component is not None:
+        for component in rebuild_components:
             import_memory.delay(
                 project_id=component.project_id, component_id=component.id
             )
-        else:
-            for project_id in projects.values_list("id", flat=True):
-                import_memory.delay(project_id=project_id, component_id=None)
         messages.success(
             self.request,
             gettext(
@@ -294,27 +325,57 @@ class MemoryView(TemplateView):
 
     @cached_property
     def entries(self):
-        return Memory.objects.filter_type(**self.objects)
+        request = getattr(self, "request", None)
+        access_user = request.user if request is not None else self.objects.get("user")
+        return Memory.objects.filter_type(access_user=access_user, **self.objects)
 
     @cached_property
-    def component_slugs(self) -> set[str]:
+    def components(self):
         if "workspace" in self.objects:
             workspace = self.objects["workspace"]
             if not workspace.contribute_workspace_tm:
-                return set()
+                return Component.objects.none()
             components = Component.objects.filter(
                 project__workspace=workspace,
                 project__contribute_workspace_tm=True,
-            ).prefetch()
+            )
+        elif "project" in self.objects:
+            components = self.objects["project"].component_set.all()
         else:
-            components = self.objects["project"].component_set.prefetch()
-        return {component.full_slug for component in components}
+            components = Component.objects.all()
+        request = getattr(self, "request", None)
+        access_user = request.user if request is not None else self.objects.get("user")
+        if access_user is None:
+            return components.none()
+        return components.filter_access(access_user).prefetch()
+
+    @cached_property
+    def components_by_origin(self) -> dict[str, Component]:
+        component_ids = list(
+            MemoryScope.objects.using(self.entries.db)
+            .filter(
+                memory_id__in=self.entries.values("id"),
+                source_component_id__isnull=False,
+            )
+            .values_list("source_component_id", flat=True)
+            .distinct()
+        )
+        return {
+            component.full_slug: component
+            for component in self.components.filter(id__in=component_ids)
+        }
+
+    @cached_property
+    def component_slugs(self) -> set[str]:
+        return {component.full_slug for component in self.components}
 
     def get_rebuild_entries(self):
         if "workspace" in self.objects:
             workspace = self.objects["workspace"]
-            return Memory.objects.using(self.entries.db).filter_scope(
-                Q(scope=MemoryScope.SCOPE_WORKSPACE, workspace=workspace)
+            return (
+                Memory.objects.using(self.entries.db)
+                .filter_scope(Q(scope=MemoryScope.SCOPE_WORKSPACE, workspace=workspace))
+                .filter(origin__in=self.component_slugs)
             )
         project = self.objects["project"]
         scope_query = Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
@@ -324,7 +385,11 @@ class MemoryView(TemplateView):
                 source_project=project,
                 memory__origin__in=self.component_slugs,
             )
-        return Memory.objects.using(self.entries.db).filter_scope(scope_query)
+        return (
+            Memory.objects.using(self.entries.db)
+            .filter_scope(scope_query)
+            .filter(origin__in=self.component_slugs)
+        )
 
     @cached_property
     def rebuild_counts(self) -> dict[str, int]:
@@ -337,10 +402,18 @@ class MemoryView(TemplateView):
         }
 
     def get_origins(self):
-        def get_url(slug: str) -> str:
-            if "/" not in slug:
-                return ""
-            return reverse("show", kwargs={"path": slug.split("/")})
+        def get_url(slug: str, *, allow_unassociated: bool = False) -> str:
+            component = self.components_by_origin.get(slug)
+            if component is None and allow_unassociated:
+                component = next(
+                    (
+                        candidate
+                        for candidate in self.components
+                        if candidate.full_slug == slug
+                    ),
+                    None,
+                )
+            return component.get_absolute_url() if component is not None else ""
 
         file_scopes = (
             MemoryScope.SCOPE_GLOBAL_FILE,
@@ -379,7 +452,7 @@ class MemoryView(TemplateView):
                     "id__count": 0,
                     "can_rebuild": True,
                     "rebuild_count": self.rebuild_counts.get(missing, 0),
-                    "url": get_url(missing),
+                    "url": get_url(missing, allow_unassociated=True),
                 }
                 for missing in self.component_slugs - existing
             )
@@ -457,7 +530,9 @@ class DownloadView(MemoryView):
     def get(self, request: AuthenticatedHttpRequest, *args, **kwargs):  # type: ignore[override]
         fmt = request.GET.get("format", "json")
         data = (
-            Memory.objects.filter_type(**self.objects).prefetch_scopes().prefetch_lang()
+            Memory.objects.filter_type(access_user=request.user, **self.objects)
+            .prefetch_scopes()
+            .prefetch_lang()
         )
         category = get_export_category(self.objects)
         if "origin" in request.GET:
@@ -471,7 +546,9 @@ class DownloadView(MemoryView):
         if "from_file" in self.objects and "kind" in request.GET:
             if request.GET["kind"] == "shared":
                 data = (
-                    Memory.objects.filter_type(use_shared=True)
+                    Memory.objects.filter_type(
+                        use_shared=True, access_user=request.user
+                    )
                     .prefetch_scopes()
                     .prefetch_lang()
                 )

--- a/weblate/templates/trans/delete-category.html
+++ b/weblate/templates/trans/delete-category.html
@@ -1,8 +1,11 @@
 {% load i18n icons %}
 
 <p>
-  {% blocktranslate %}This action cannot be undone. This will permanently delete the {{ object }} project and all related content.{% endblocktranslate %}
-  {% translate "This includes, but is not limited to, translation memory, glossaries, or user permissions." %}
+  {% blocktranslate %}This action cannot be undone. This will permanently delete the {{ object }} category and all related content.{% endblocktranslate %}
+</p>
+
+<p class="alert alert-warning">
+  {% translate "If this action removes restricted components, retained translation memory from them will become available according to the project and workspace translation memory access rules unless you also delete it." %}
 </p>
 
 {% with components=object.component_set.order %}

--- a/weblate/templates/trans/delete-component.html
+++ b/weblate/templates/trans/delete-component.html
@@ -4,6 +4,10 @@
   {% blocktranslate %}This action cannot be undone. This will permanently delete the {{ object }} component and all related content.{% endblocktranslate %}
 </p>
 
+<p class="alert alert-warning">
+  {% translate "If this action removes restricted components, retained translation memory from them will become available according to the project and workspace translation memory access rules unless you also delete it." %}
+</p>
+
 {% with components=object.component_set.prefetch.order %}
   {% if components %}
     <p>{% translate "The following translation components will be removed:" %}</p>

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -53,7 +53,7 @@ from weblate.auth.models import (
 from weblate.checks.models import Check
 from weblate.lang.models import Language, Plural
 from weblate.memory.models import Memory, MemoryDict, MemoryScope
-from weblate.memory.utils import CATEGORY_PRIVATE_OFFSET
+from weblate.memory.utils import CATEGORY_FILE, CATEGORY_PRIVATE_OFFSET
 from weblate.screenshots.models import Screenshot
 from weblate.trans import defaults
 from weblate.trans.actions import ActionEvents
@@ -600,11 +600,19 @@ class ProjectBackup:
             .prefetch_scopes()
             .order_by("id")
         )
-        category = CATEGORY_PRIVATE_OFFSET + project.pk
-        return [
-            item.as_dict(category=category)
-            for item in memory.iterator(self.IMPORT_BATCH_SIZE)
-        ]
+        automatic_category = CATEGORY_PRIVATE_OFFSET + project.pk
+        result: list[MemoryDict] = []
+        for item in memory.iterator(self.IMPORT_BATCH_SIZE):
+            project_scope_types = {
+                scope.scope
+                for scope in item.get_scope_list()
+                if scope.project_id == project.pk
+            }
+            if MemoryScope.SCOPE_PROJECT in project_scope_types:
+                result.append(item.as_dict(category=automatic_category))
+            if MemoryScope.SCOPE_PROJECT_FILE in project_scope_types:
+                result.append(item.as_dict(category=CATEGORY_FILE))
+        return result
 
     def backup_categories(
         self, obj: Project | Category
@@ -1987,34 +1995,68 @@ class ProjectBackup:
 
     def restore_memory(self, zipfile: ZipFile, project: Project) -> None:
         memory = self.load_memory(zipfile)
-        memory_batch = []
-        for entry in memory:
-            restored = Memory(
-                origin=entry["origin"],
-                source=entry["source"],
-                context=entry.get("context", ""),
-                target=entry["target"],
-                source_language=self.import_language(entry["source_language"]),
-                target_language=self.import_language(entry["target_language"]),
-                status=entry.get("status", Memory.STATUS_ACTIVE),
-            )
-            restored.pending_scopes = [
-                MemoryScope(scope=MemoryScope.SCOPE_PROJECT, project=project)
-            ]
-            memory_batch.append(restored)
-            if len(memory_batch) >= self.IMPORT_BATCH_SIZE:
-                with transaction.atomic():
-                    Memory.objects.bulk_create(
-                        memory_batch, batch_size=self.IMPORT_BATCH_SIZE
-                    )
-                    MemoryScope.objects.bulk_create_for_memories(memory_batch)
-                memory_batch.clear()
-        if memory_batch:
+        memory_batch: list[Memory] = []
+        previous_identity: tuple[Any, ...] | None = None
+        restored: Memory | None = None
+
+        def flush_memory_batch() -> None:
             with transaction.atomic():
                 Memory.objects.bulk_create(
                     memory_batch, batch_size=self.IMPORT_BATCH_SIZE
                 )
                 MemoryScope.objects.bulk_create_for_memories(memory_batch)
+            memory_batch.clear()
+
+        # A memory row's project and project-file records are emitted next to
+        # each other by backup_memory(), while older backups contain at most one
+        # project scope per row. Keep the current row outside the write batch so
+        # both records merge even when they cross a batch boundary.
+        for entry in memory:
+            source_language = self.import_language(entry["source_language"])
+            target_language = self.import_language(entry["target_language"])
+            identity = (
+                source_language.pk,
+                target_language.pk,
+                entry["origin"],
+                entry["source"],
+                entry.get("context", ""),
+                entry["target"],
+                entry.get("status", Memory.STATUS_ACTIVE),
+            )
+            if restored is None or identity != previous_identity:
+                if restored is not None:
+                    memory_batch.append(restored)
+                    if len(memory_batch) >= self.IMPORT_BATCH_SIZE:
+                        flush_memory_batch()
+                restored = Memory(
+                    origin=entry["origin"],
+                    source=entry["source"],
+                    context=entry.get("context", ""),
+                    target=entry["target"],
+                    source_language=source_language,
+                    target_language=target_language,
+                    status=entry.get("status", Memory.STATUS_ACTIVE),
+                )
+                restored.pending_scopes = []
+                previous_identity = identity
+            pending_scopes = cast("list[MemoryScope]", restored.pending_scopes)
+            scope_type = (
+                MemoryScope.SCOPE_PROJECT_FILE
+                if entry.get("category") == CATEGORY_FILE
+                else MemoryScope.SCOPE_PROJECT
+            )
+            if not any(scope.scope == scope_type for scope in pending_scopes):
+                pending_scopes.append(
+                    MemoryScope(
+                        scope=scope_type,
+                        project=project,
+                    )
+                )
+
+        if restored is not None:
+            memory_batch.append(restored)
+        if memory_batch:
+            flush_memory_batch()
 
         memory.clear()
 
@@ -2371,6 +2413,18 @@ class ProjectBackup:
             actor=user,
             changes=restore_changes,
             progress_callback=progress_callback,
+        )
+
+        # Components have to exist before restored memory can be attributed.
+        # ruff: ignore[import-outside-top-level]
+        from weblate.memory.tasks import attribute_memory_scope_queryset
+
+        attribute_memory_scope_queryset(
+            MemoryScope.objects.using("default").filter(
+                scope=MemoryScope.SCOPE_PROJECT,
+                project=project,
+                source_component__isnull=True,
+            )
         )
 
         if "teams" in self.data:

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -4300,6 +4300,13 @@ class TranslationDeleteForm(BaseDeleteForm):
 
 
 class ComponentDeleteForm(BaseDeleteForm):
+    delete_memory = forms.BooleanField(
+        label=gettext_lazy("Delete translation memory created from this component"),
+        help_text=gettext_lazy(
+            "Project, workspace, and shared translation memory entries will be deleted. Personal and uploaded entries will be preserved."
+        ),
+        required=False,
+    )
     confirm = forms.CharField(
         label=gettext_lazy("Removal confirmation"),
         help_text=gettext_lazy(
@@ -4308,6 +4315,10 @@ class ComponentDeleteForm(BaseDeleteForm):
         required=True,
     )
     warning_template = "trans/delete-component.html"
+
+    def __init__(self, obj, *args, **kwargs) -> None:
+        super().__init__(obj, *args, **kwargs)
+        self.helper.layout.insert(1, Field("delete_memory"))
 
 
 class ProjectDeleteForm(BaseDeleteForm):
@@ -4327,12 +4338,25 @@ class ProjectDeleteForm(BaseDeleteForm):
 
 
 class CategoryDeleteForm(BaseDeleteForm):
+    delete_memory = forms.BooleanField(
+        label=gettext_lazy(
+            "Delete translation memory created from components in this category"
+        ),
+        help_text=gettext_lazy(
+            "Project, workspace, and shared translation memory entries will be deleted. Personal and uploaded entries will be preserved."
+        ),
+        required=False,
+    )
     confirm = forms.CharField(
         label=gettext_lazy("Removal confirmation"),
         help_text=gettext_lazy("Please type in the slug of the category to confirm."),
         required=True,
     )
     warning_template = "trans/delete-category.html"
+
+    def __init__(self, obj, *args, **kwargs) -> None:
+        super().__init__(obj, *args, **kwargs)
+        self.helper.layout.insert(1, Field("delete_memory"))
 
 
 class ProjectLanguageDeleteForm(BaseDeleteForm):

--- a/weblate/trans/models/__init__.py
+++ b/weblate/trans/models/__init__.py
@@ -130,8 +130,6 @@ def project_post_delete(sender, instance: Project, **kwargs) -> None:
 
 @receiver(pre_delete, sender=Component)
 def component_pre_delete(sender, instance: Component, **kwargs) -> None:
-    instance.memory_full_slug = instance.full_slug
-    instance.memory_workspace_id = instance.project.workspace_id
     batch = instance.removal_batch or get_current_removal_batch()
     if batch is not None:
         batch.collect_stats(instance.stats.get_update_objects())
@@ -159,14 +157,6 @@ def component_post_delete(sender, instance: Component, **kwargs) -> None:
     # Do not delete linked components
     if not instance.is_repo_link:
         delete_object_dir(instance)
-
-    memory_full_slug = getattr(instance, "memory_full_slug", None)
-    if memory_full_slug is not None:
-        instance.delete_automatic_memory_scopes(
-            memory_full_slug,
-            instance.project_id,
-            getattr(instance, "memory_workspace_id", None),
-        )
 
     if batch is None:
         instance.cleanup_conflicting_repository_setup_alerts()

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -530,10 +530,6 @@ OldComponentSetting = TypeVar("OldComponentSetting")
 class Component(  # ruff: ignore[too-many-public-methods]
     models.Model, PathMixin, CacheKeyMixin, ComponentCategoryMixin, LockMixin
 ):
-    # Transient values captured before deletion so post_delete can clean up
-    # automatic translation-memory scopes after related project data is gone.
-    memory_full_slug: str | None = None
-    memory_workspace_id: UUID | None = None
     repository_redirect_changes: list[tuple[str, str, str]] | None = None
 
     AUDIT_SETTINGS: ClassVar[tuple[str, ...]] = (
@@ -1184,7 +1180,9 @@ class Component(  # ruff: ignore[too-many-public-methods]
         self._glossary_sync_scheduled = False
         self.new_lang_error_message: str | None = None
 
-    def save(self, *args, **kwargs) -> None:  # ruff: ignore[complex-structure]
+    def save(  # ruff: ignore[complex-structure, too-many-locals]
+        self, *args, **kwargs
+    ) -> None:
         """
         Save wrapper.
 
@@ -1229,6 +1227,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         # loop. A full component TM import is only needed when contribution is
         # enabled later for units that already exist.
         update_tm = False
+        restricted_changed = False
         old_full_slug = None
         old_source_project_id = None
         old_workspace_id = None
@@ -1247,6 +1246,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
             old_full_slug = old.full_slug
             old_source_project_id = old.project_id
             old_workspace_id = old.project.workspace_id
+            restricted_changed = old.restricted != self.restricted
             changed_git = (
                 (old.vcs != self.vcs)
                 or (old.repo != self.repo)
@@ -1276,6 +1276,9 @@ class Component(  # ruff: ignore[too-many-public-methods]
             if update_fields_set is not None:
                 kwargs["update_fields"] = update_fields_set
                 update_fields = update_fields_set
+            restricted_changed = restricted_changed and (
+                update_fields is None or "restricted" in update_fields
+            )
 
             changed_variant = old.variant_regex != self.variant_regex
             # Generate change entries for changes
@@ -1300,6 +1303,8 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
             # Detect if the component had TM contribution disabled but changed to enabled.
             update_tm = self.contribute_project_tm and not old.contribute_project_tm
+            if restricted_changed and not self.restricted:
+                update_tm = update_tm or self.project.contribute_shared_tm
         elif self.is_glossary:
             # Creating new glossary
 
@@ -1327,6 +1332,12 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         # Save/Create object
         super().save(*args, **kwargs)
+        if restricted_changed and self.restricted:
+            # TODO(2028.1): Legacy unattributed shared scopes keep their
+            # pre-upgrade behavior until the component backfill processes them.
+            # Remove this migration caveat once Weblate no longer supports
+            # direct upgrades from 2026 releases.
+            self.delete_shared_memory_scope()
         if repository_redirect_changes:
             self.repository_redirect_changes = None
             for field, old_url, canonical_url in repository_redirect_changes:
@@ -1520,6 +1531,16 @@ class Component(  # ruff: ignore[too-many-public-methods]
             )
         Memory.objects.filter(origin=origin).delete_scope(
             scope_query, delete_legacy=False
+        )
+
+    def delete_shared_memory_scope(self) -> None:
+        """Remove shared TM scopes contributed by this component."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.memory.models import Memory, MemoryScope
+
+        Memory.objects.delete_scope(
+            Q(scope=MemoryScope.SCOPE_SHARED, source_component=self),
+            delete_legacy=False,
         )
 
     def disable_inheritance_for_changed_settings(
@@ -5412,6 +5433,14 @@ class Component(  # ruff: ignore[too-many-public-methods]
         self.drop_file_format_cache()
         if self.project_id is None:
             return
+        if settings.OFFER_HOSTING and self.project.use_shared_tm and self.restricted:
+            raise ValidationError(
+                {
+                    "restricted": gettext(
+                        "A component can not be restricted while its project uses shared translation memory."
+                    )
+                }
+            )
         if self.effective_new_lang == "url" and not self.project.instructions:
             msg = gettext(
                 "Please either fill in an instruction URL "

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -777,6 +777,19 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
 
     def clean(self) -> None:
         super().clean()
+        if (
+            settings.OFFER_HOSTING
+            and self.use_shared_tm
+            and self.pk
+            and self.component_set.filter(restricted=True).exists()
+        ):
+            raise ValidationError(
+                {
+                    "use_shared_tm": gettext(
+                        "Shared translation memory can not be enabled while the project has restricted components."
+                    )
+                }
+            )
         if self.web:
             try:
                 validate_project_web(self.web, project_slug=self.slug or None)

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 import os
 import time
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from glob import glob
+from itertools import batched
 from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -19,7 +21,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import IntegrityError, transaction
-from django.db.models import Exists, F, OuterRef
+from django.db.models import Exists, F, OuterRef, Q
 from django.utils import timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext, ngettext, override
@@ -56,6 +58,8 @@ from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import STATE_APPROVED, STATE_TRANSLATED
 from weblate.utils.stats import ProjectLanguage, prefetch_stats
 from weblate.vcs.base import RepositoryError
+
+COMPONENT_MEMORY_CLEANUP_BATCH_SIZE = 1000
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -726,19 +730,30 @@ def update_enforced_checks(component: int | Component) -> None:
 
 @app.task(trail=False)
 @transaction.atomic
-def component_removal(pk: int, uid: int) -> None:
+def component_removal(pk: int, uid: int, delete_memory: bool = False) -> None:
     user = User.objects.get(pk=uid)
     try:
         component = Component.objects.get(pk=pk)
     except Component.DoesNotExist:
         return
 
-    _component_removal(component, user)
+    _component_removal(component, user, delete_memory=delete_memory)
 
 
 def _component_removal(
-    component: Component, user: User, batch: RemovalBatch | None = None
+    component: Component,
+    user: User,
+    batch: RemovalBatch | None = None,
+    *,
+    delete_memory: bool = False,
 ) -> None:
+    memory_cleanup = None
+    if delete_memory:
+        cleanup_batch = RemovalBatch()
+        _collect_linked_removal_targets([component.pk], cleanup_batch)
+        memory_cleanup = collect_component_memory_cleanup(cleanup_batch)
+        # Remove attributed scopes while their component foreign keys exist.
+        delete_collected_component_memory(memory_cleanup)
     if batch is not None:
         component.removal_batch = batch
     with component.repository.lock:
@@ -758,6 +773,70 @@ def _component_removal(
                 components = components.exclude(pk__in=batch.removed_component_ids)
             for current in components.iterator():
                 current.schedule_update_checks()
+    if memory_cleanup is not None:
+        # Catch memory writes which raced with the initial cleanup. Current
+        # writers normalize origins to the component's current full slug.
+        delete_collected_component_memory(memory_cleanup)
+
+
+@dataclass(frozen=True)
+class ComponentMemoryCleanup:
+    """Component identifiers retained across component deletion."""
+
+    component_ids: frozenset[int]
+    origins: frozenset[str]
+
+
+def delete_component_memory(component: Component) -> None:
+    """Delete non-personal automatic memory for a component and linked children."""
+    batch = RemovalBatch()
+    _collect_linked_removal_targets([component.pk], batch)
+    delete_collected_component_memory(collect_component_memory_cleanup(batch))
+
+
+def collect_component_memory_cleanup(batch: RemovalBatch) -> ComponentMemoryCleanup:
+    """Collect component identifiers needed after removing components."""
+    components = list(
+        Component.objects.filter(pk__in=batch.removed_component_ids).prefetch()
+    )
+    return ComponentMemoryCleanup(
+        component_ids=frozenset(component.id for component in components),
+        origins=frozenset(component.full_slug for component in components),
+    )
+
+
+def delete_collected_component_memory(cleanup: ComponentMemoryCleanup) -> None:
+    """Delete automatic memory collected for removed components."""
+    # ruff: ignore[import-outside-top-level]
+    from weblate.memory.models import Memory, MemoryScope
+
+    automatic_scopes = Q(
+        scope__in=(
+            MemoryScope.SCOPE_PROJECT,
+            MemoryScope.SCOPE_SHARED,
+            MemoryScope.SCOPE_WORKSPACE,
+        ),
+    )
+    for component_ids in batched(
+        cleanup.component_ids, COMPONENT_MEMORY_CLEANUP_BATCH_SIZE
+    ):
+        Memory.objects.delete_scope(
+            automatic_scopes & Q(source_component_id__in=component_ids),
+            delete_legacy=False,
+        )
+    for origins in batched(cleanup.origins, COMPONENT_MEMORY_CLEANUP_BATCH_SIZE):
+        Memory.objects.delete_scope(
+            automatic_scopes & Q(memory__origin__in=origins),
+            delete_legacy=False,
+        )
+        # TODO(2028.1): Remove legacy unscoped cleanup once Weblate no longer
+        # supports direct upgrades from 2026 releases.
+        Memory.objects.filter(
+            scopes__isnull=True,
+            origin__in=origins,
+            legacy_user__isnull=True,
+            legacy_from_file=False,
+        ).delete()
 
 
 def _collect_removal_targets(category: Category, batch: RemovalBatch) -> None:
@@ -809,7 +888,7 @@ def _category_removal(
 
 @app.task(trail=False)
 @transaction.atomic
-def category_removal(pk: int, uid: int) -> None:
+def category_removal(pk: int, uid: int, delete_memory: bool = False) -> None:
     user = User.objects.get(pk=uid)
     try:
         category = Category.objects.get(pk=pk)
@@ -817,8 +896,16 @@ def category_removal(pk: int, uid: int) -> None:
         return
     batch = RemovalBatch()
     _collect_removal_targets(category, batch)
+    memory_cleanup = collect_component_memory_cleanup(batch) if delete_memory else None
+    if memory_cleanup is not None:
+        # Remove attributed scopes while their component foreign keys exist.
+        delete_collected_component_memory(memory_cleanup)
     with removal_batch_context(batch):
         _category_removal(category, user, batch)
+    if memory_cleanup is not None:
+        # Catch memory writes which raced with the initial cleanup. Current
+        # writers normalize origins to the component's current full slug.
+        delete_collected_component_memory(memory_cleanup)
     transaction.on_commit(batch.flush)
 
 

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -29,7 +29,7 @@ from weblate.auth.models import AutoGroup, Group, Role, TeamMembership
 from weblate.checks.models import Check
 from weblate.lang.models import Language
 from weblate.memory.models import Memory, MemoryScope
-from weblate.memory.utils import CATEGORY_PRIVATE_OFFSET
+from weblate.memory.utils import CATEGORY_FILE, CATEGORY_PRIVATE_OFFSET
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.backups import (
@@ -285,6 +285,114 @@ class BackupsTest(ViewTestCase):
 
         self.assertTrue(restored.use_workspace_tm)
         self.assertTrue(restored.contribute_workspace_tm)
+
+    def test_restore_attributes_memory_scopes(self) -> None:
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        attributed_memory = Memory.objects.create(
+            source="Restored attributed memory",
+            context="",
+            target="Obnovena prirazena pamet",
+            origin=self.component.full_slug,
+            source_language=self.component.source_language,
+            target_language=self.translation.language,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=attributed_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+            source_component=self.component,
+        )
+        unresolved_memory = Memory.objects.create(
+            source="Restored unresolved memory",
+            context="",
+            target="Obnovena nerozpoznana pamet",
+            origin=f"{self.project.slug}/missing-component",
+            source_language=self.component.source_language,
+            target_language=self.translation.language,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=unresolved_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        uploaded_memory = Memory.objects.create(
+            source="Restored uploaded memory",
+            context="",
+            target="Obnovena nahrana pamet",
+            origin="uploaded-memory.tmx",
+            source_language=self.component.source_language,
+            target_language=self.translation.language,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=uploaded_memory,
+            scope=MemoryScope.SCOPE_PROJECT_FILE,
+            project=self.project,
+        )
+        MemoryScope.objects.create(
+            memory=uploaded_memory,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=self.project,
+        )
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+
+        with ZipFile(backup.filename, "r") as zipfile:
+            memory_data = json.loads(zipfile.read("weblate-memory.json"))
+        uploaded_entries = [
+            entry for entry in memory_data if entry["source"] == uploaded_memory.source
+        ]
+        self.assertEqual(
+            {entry["category"] for entry in uploaded_entries},
+            {CATEGORY_PRIVATE_OFFSET + self.project.pk, CATEGORY_FILE},
+        )
+
+        restore = ProjectBackup(backup.filename)
+        restore.validate()
+        restore.IMPORT_BATCH_SIZE = 1
+        restored = restore.restore(
+            project_name="Restored memory attribution",
+            project_slug="restored-memory-attribution",
+            user=self.user,
+        )
+
+        restored_component = restored.component_set.get(slug=self.component.slug)
+        attributed_scope = MemoryScope.objects.get(
+            memory__source=attributed_memory.source,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=restored,
+        )
+        self.assertTrue(restored_component.restricted)
+        self.assertEqual(attributed_scope.source_component_id, restored_component.id)
+        unresolved_scope = MemoryScope.objects.get(
+            memory__source=unresolved_memory.source,
+            scope=MemoryScope.SCOPE_PROJECT,
+            project=restored,
+        )
+        self.assertIsNone(unresolved_scope.source_component_id)
+        restored_uploaded_memory = (
+            Memory.objects.filter(
+                source=uploaded_memory.source, scopes__project=restored
+            )
+            .distinct()
+            .get()
+        )
+        self.assertEqual(
+            set(
+                restored_uploaded_memory.scopes.filter(project=restored).values_list(
+                    "scope", flat=True
+                )
+            ),
+            {MemoryScope.SCOPE_PROJECT, MemoryScope.SCOPE_PROJECT_FILE},
+        )
+        self.assertFalse(
+            restored_uploaded_memory.scopes.exclude(
+                source_component__isnull=True
+            ).exists()
+        )
 
     def test_restore_creates_history_entries(self) -> None:
         backup = ProjectBackup()

--- a/weblate/trans/tests/test_manage.py
+++ b/weblate/trans/tests/test_manage.py
@@ -94,6 +94,67 @@ class RemovalTest(ViewTestCase):
             response, "The translation component was scheduled for removal."
         )
 
+    def test_component_with_memory(self) -> None:
+        self.make_manager()
+        url = reverse("remove", kwargs=self.kw_component)
+
+        with patch(
+            "weblate.trans.views.settings.component_removal.delay"
+        ) as mocked_removal:
+            response = self.client.post(
+                url,
+                {"confirm": "test/test", "delete_memory": "on"},
+                follow=True,
+            )
+
+        self.assertContains(
+            response, "The translation component was scheduled for removal."
+        )
+        mocked_removal.assert_called_once_with(self.component.pk, self.user.pk, True)
+
+    def test_component_memory_warning(self) -> None:
+        self.make_manager()
+
+        response = self.client.get(self.component.get_absolute_url())
+
+        self.assertContains(
+            response,
+            "If this action removes restricted components, retained translation memory",
+        )
+
+    def test_category_with_memory(self) -> None:
+        self.make_manager()
+        category = Category.objects.create(
+            name="Removal category",
+            slug="removal-category",
+            project=self.project,
+        )
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        url = reverse("remove", kwargs={"path": category.get_url_path()})
+
+        response = self.client.get(category.get_absolute_url())
+        self.assertContains(
+            response,
+            "If this action removes restricted components, retained translation memory",
+        )
+        self.assertContains(
+            response,
+            "Delete translation memory created from components in this category",
+        )
+
+        with patch(
+            "weblate.trans.views.settings.category_removal.delay"
+        ) as mocked_removal:
+            response = self.client.post(
+                url,
+                {"confirm": category.full_slug, "delete_memory": "on"},
+                follow=True,
+            )
+
+        self.assertContains(response, "The category was scheduled for removal.")
+        mocked_removal.assert_called_once_with(category.pk, self.user.pk, True)
+
     def test_project(self) -> None:
         self.make_manager()
         url = reverse("remove", kwargs={"path": self.project.get_url_path()})

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -9,6 +9,7 @@ from typing import cast
 from unittest.mock import patch
 
 from django.apps import apps
+from django.core.exceptions import ValidationError
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
 from filelock import FileLock
@@ -49,6 +50,36 @@ from weblate.workspaces.models import Workspace
 
 
 class SettingsTest(ViewTestCase):
+    @override_settings(OFFER_HOSTING=True)
+    def test_hosted_restricted_component_rejects_shared_memory(self) -> None:
+        self.component.restricted = True
+        self.project.use_shared_tm = True
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "A component can not be restricted while its project uses shared translation memory.",
+        ):
+            self.component.clean_model_settings()
+
+    @override_settings(OFFER_HOSTING=True)
+    def test_hosted_shared_memory_rejects_restricted_component(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.project.use_shared_tm = True
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "Shared translation memory can not be enabled while the project has restricted components.",
+        ):
+            self.project.clean()
+
+    @override_settings(OFFER_HOSTING=True)
+    def test_hosted_shared_memory_allows_unrestricted_component_edit(self) -> None:
+        self.create_link_existing(restricted=True)
+        Project.objects.filter(pk=self.project.pk).update(use_shared_tm=True)
+        component = Component.objects.get(pk=self.component.pk)
+
+        component.clean_model_settings()
+
     @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
     def test_restricted_component_permission_denial(self) -> None:
         self.project.add_user(self.user, "Administration")

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -31,8 +31,10 @@ from weblate.trans.forms import (
     AddCategoryForm,
     AnnouncementForm,
     BaseDeleteForm,
+    CategoryDeleteForm,
     CategoryRenameForm,
     CategorySettingsForm,
+    ComponentDeleteForm,
     ComponentLinkAddForm,
     ComponentLinkCategoryForm,
     ComponentRenameForm,
@@ -257,7 +259,13 @@ def remove(request: AuthenticatedHttpRequest, path):
     if not request.user.has_perm(obj.remove_permission, obj):
         raise PermissionDenied
 
-    form = BaseDeleteForm(obj, request.POST)
+    if isinstance(obj, Component):
+        form_class = ComponentDeleteForm
+    elif isinstance(obj, Category):
+        form_class = CategoryDeleteForm
+    else:
+        form_class = BaseDeleteForm
+    form = form_class(obj, request.POST)
     if not form.is_valid():
         show_form_errors(request, form)
         return redirect_param(obj, "#organize")
@@ -269,13 +277,17 @@ def remove(request: AuthenticatedHttpRequest, path):
         messages.success(request, gettext("The translation has been removed."))
     elif isinstance(obj, Component):
         parent = obj.category or obj.project
-        component_removal.delay(obj.pk, request.user.pk)
+        component_removal.delay(
+            obj.pk, request.user.pk, form.cleaned_data["delete_memory"]
+        )
         messages.success(
             request, gettext("The translation component was scheduled for removal.")
         )
     elif isinstance(obj, Category):
         parent = obj.category or obj.project
-        category_removal.delay(obj.pk, request.user.pk)
+        category_removal.delay(
+            obj.pk, request.user.pk, form.cleaned_data["delete_memory"]
+        )
         messages.success(request, gettext("The category was scheduled for removal."))
     elif isinstance(obj, Project):
         parent = reverse("home")


### PR DESCRIPTION
Translation memory was scoped only to projects and workspaces, which could expose strings from restricted components. Track each entry's source component so reads and contributions honor component access while keeping retention explicit.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
