### PR TITLE
fix(import): ignore source_language on JSON updates

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,7 +10,7 @@ Weblate 2026.8.1
 .. rubric:: Bug fixes
 
 * Large language model machine translation services no longer fail when the optional persona and style settings are absent from the stored configuration, as happens when the service is installed through the REST API.
-* :wladmin:`import_json` now preserves the component source language from JSON exports.
+* :wladmin:`import_json` now preserves the component source language for newly imported components from JSON exports.
 * Repository actions now require permission on every component sharing the affected repository, including linked components in other projects.
 
 .. rubric:: Compatibility

--- a/weblate/trans/management/commands/import_json.py
+++ b/weblate/trans/management/commands/import_json.py
@@ -46,6 +46,9 @@ def format_serializer_error(error: ValidationError) -> str:
 def get_component_serializer(
     project: Project, data: dict[str, Any], component: Component | None = None
 ) -> ComponentSerializer:
+    if component is not None and "source_language" in data:
+        data = data.copy()
+        del data["source_language"]
     kwargs: dict[str, Any] = {
         "context": {"request": ImportRequest(), "project": project},
         "data": data,

--- a/weblate/trans/tests/test_commands.py
+++ b/weblate/trans/tests/test_commands.py
@@ -809,6 +809,39 @@ class ImportCommandTest(RepoTestCase):
                 TEST_COMPONENTS,
             )
 
+    def test_import_update_ignores_source_language(self) -> None:
+        with TemporaryDirectory() as tempdir:
+            filename = Path(tempdir) / "components.json"
+            with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
+                call_command(
+                    "import_json",
+                    "--main-component",
+                    "test",
+                    "--project",
+                    "test",
+                    TEST_COMPONENTS,
+                )
+
+            components = json.loads(Path(TEST_COMPONENTS).read_text(encoding="utf-8"))
+            components[0]["source_language"] = "ru"
+            components[0]["name"] = "Updated Gettext PO"
+            filename.write_text(json.dumps(components))
+
+            with override_settings(CREATE_GLOSSARIES=self.CREATE_GLOSSARIES):
+                call_command(
+                    "import_json",
+                    "--main-component",
+                    "test",
+                    "--project",
+                    "test",
+                    "--update",
+                    filename,
+                )
+
+        component = Component.objects.get(slug="po")
+        self.assertEqual(component.name, "Updated Gettext PO")
+        self.assertEqual(component.source_language.code, "en")
+
     def test_invalid_file(self) -> None:
         with (
             self.assertRaises(CommandError),


### PR DESCRIPTION
### Motivation

- A regression caused `import_json --update` to route updates through `ComponentSerializer`, which applied incoming `source_language` to a copied instance and triggered model validation that forbids changing `source_language`, aborting updates with `CommandError`.
- The intent is to preserve the new behavior that creation imports can set `source_language` while ensuring the update path does not attempt a model-forbidden change and still updates other fields.

### Description

- Strip `source_language` from the incoming `data` when `get_component_serializer()` is invoked with an existing `component`, so updates do not attempt to change the stored `source_language` (file: `weblate/trans/management/commands/import_json.py`).
- Add a regression test `test_import_update_ignores_source_language` in `weblate/trans/tests/test_commands.py` verifying that `--update` ignores `source_language` but still applies other valid field changes.
- Clarify the changelog line in `docs/changes.rst` to state source language preservation applies to newly imported components only.

### Testing

- Ran the targeted tests with `uv run pytest -q weblate/trans/tests/test_commands.py::ImportCommandTest::test_import_source_language weblate/trans/tests/test_commands.py::ImportCommandTest::test_import_source_language_string weblate/trans/tests/test_commands.py::ImportCommandTest::test_import_update_ignores_source_language` and all targeted tests passed.
- Ran the repository pre-commit/formatting checks with `uv run prek run --files weblate/trans/management/commands/import_json.py weblate/trans/tests/test_commands.py docs/changes.rst` and the hooks (including Ruff) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a731bee4f408329b07af4acd0f9bad0)