### PR TITLE
fix(api): authenticate task progress

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3352,6 +3352,8 @@ Tasks
 
     Returns information about a task.
 
+    Authentication is required.
+
     :param uuid: Task UUID
     :type uuid: string
     :>json boolean completed: Whether the task has completed

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.8.1
 
 .. rubric:: Bug fixes
 
+* Task progress now requires authentication and works for aggregate automatic translation operations.
 * Docker Celery worker logging no longer emits duplicate records through both Celery and Weblate log handlers.
 * Component creation through the REST API now returns the background task URL in the response when creation work is queued.
 * Large language model machine translation services no longer fail when the optional persona and style settings are absent from the stored configuration, as happens when the service is installed through the REST API.

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -24251,7 +24251,6 @@ paths:
       - tokenAuth: []
       - bearerAuth: []
       - cookieAuth: []
-      - {}
       responses:
         '400':
           content:
@@ -24280,20 +24279,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: Authentication credentials were missing or invalid.
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse403'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: The authenticated user does not have permission for this operation.
         '404':
           content:
             application/json:
@@ -24427,20 +24412,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: Authentication credentials were missing or invalid.
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse403'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: The authenticated user does not have permission for this operation.
         '404':
           content:
             application/json:
@@ -24519,6 +24490,20 @@ paths:
           description: An unexpected server error occurred.
         '204':
           description: No response body
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse403'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
+          description: The authenticated user does not have permission for this operation.
   /api/translations/:
     get:
       operationId: api_translations_list

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -9650,6 +9650,21 @@ class TasksAPITest(APIBaseTest):
             {"completed": False, "progress": 0, "result": None, "log": ""},
         )
 
+    def test_retrieve_requires_authentication(self) -> None:
+        cache.set(
+            get_task_metadata_key(self.task_id),
+            {"component_id": self.component.id, "translation_id": None},
+            3600,
+        )
+
+        self.do_request(
+            "api:task-detail",
+            kwargs={"pk": self.task_id},
+            method="get",
+            authenticated=False,
+            code=401,
+        )
+
     def test_retrieve_uses_cached_user_metadata(self) -> None:
         cache.set(get_task_metadata_key(self.task_id), {"user_id": self.user.id}, 3600)
 
@@ -9673,6 +9688,20 @@ class TasksAPITest(APIBaseTest):
         self.assertEqual(
             response.data,
             {"completed": False, "progress": 0, "result": None, "log": ""},
+        )
+
+    def test_retrieve_rejects_other_user_metadata(self) -> None:
+        cache.set(
+            get_task_metadata_key(self.task_id),
+            {"user_id": self.user.id + 1},
+            3600,
+        )
+
+        self.do_request(
+            "api:task-detail",
+            kwargs={"pk": self.task_id},
+            method="get",
+            code=404,
         )
 
     def test_retrieve_stores_opt_in_completion_message(self) -> None:
@@ -16692,6 +16721,14 @@ class OpenAPITest(APIBaseTest):
         )
         self.assertEqual(task_parameter["schema"]["type"], "string")
         self.assertEqual(task["delete"]["description"], "Cancel a running task.")
+        self.assertEqual(
+            task["delete"]["responses"]["403"]["content"]["application/json"]["schema"],
+            {"$ref": "#/components/schemas/ErrorResponse403"},
+        )
+        self.assertEqual(
+            task["delete"]["responses"]["403"]["description"],
+            "The authenticated user does not have permission for this operation.",
+        )
         self.assertEqual(
             schema["paths"]["/api/changes/"]["get"]["responses"]["400"]["description"],
             "The request was invalid or could not be parsed.",

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -41,6 +41,7 @@ from drf_spectacular.utils import (
     inline_serializer,
 )
 from drf_standardized_errors.handler import ExceptionHandler
+from drf_standardized_errors.openapi_serializers import ErrorResponse403Serializer
 from rest_framework import parsers, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import APIException, ValidationError
@@ -55,6 +56,7 @@ from rest_framework.status import (
     HTTP_202_ACCEPTED,
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
     HTTP_423_LOCKED,
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
@@ -4846,6 +4848,7 @@ class ReportViewSet(viewsets.ModelViewSet):
 class TasksViewSet(ViewSet):
     # Task-related data is handled and queried to Celery.
     # There is no Django model associated with tasks.
+    permission_classes = (IsAuthenticated,)
     serializer_class = TaskSerializer
 
     def get_task(
@@ -4935,7 +4938,17 @@ class TasksViewSet(ViewSet):
         )
         return Response(serializer.data)
 
-    @extend_schema(description="Cancel a running task.", methods=["delete"])
+    @extend_schema(
+        description="Cancel a running task.",
+        methods=["delete"],
+        responses={
+            HTTP_204_NO_CONTENT: None,
+            HTTP_403_FORBIDDEN: OpenApiResponse(
+                response=ErrorResponse403Serializer,
+                description="The authenticated user does not have permission for this operation.",
+            ),
+        },
+    )
     def destroy(self, request: Request, pk=None):
         task, component = self.get_task(request, pk, "component.edit")
         if not task.ready() and component is not None:

--- a/weblate/trans/tests/test_autotranslate.py
+++ b/weblate/trans/tests/test_autotranslate.py
@@ -7,6 +7,7 @@
 from unittest.mock import patch
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test.utils import override_settings
@@ -34,6 +35,7 @@ from weblate.trans.models import (
 )
 from weblate.trans.tasks import auto_translate, auto_translate_component
 from weblate.trans.tests.test_views import ViewTestCase
+from weblate.utils.celery import get_task_metadata, get_task_metadata_key
 from weblate.utils.state import STATE_APPROVED, STATE_READONLY, STATE_TRANSLATED
 from weblate.utils.stats import ProjectLanguage
 from weblate.workspaces.models import Workspace
@@ -97,6 +99,56 @@ class AutoTranslationTest(ViewTestCase):
             reverse("auto_translation", kwargs=self.kw_translation)
         )
         self.assertRedirects(response, self.translation_url)
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_task_metadata(self) -> None:
+        category = self.create_category(project=self.component2.project)
+        self.component2.category = category
+        self.component2.save(update_fields=["category"])
+        workspace = Workspace.objects.create(name="Automatic translation workspace")
+        self.component2.project.workspace = workspace
+        self.component2.project.save(update_fields=["workspace"])
+        translation = self.component2.translation_set.get(language_code="cs")
+        project_language = ProjectLanguage(
+            self.component2.project, language=translation.language
+        )
+        task_id = "01234567-89ab-cdef-0123-456789abcdef"
+        task_metadata_key = get_task_metadata_key(task_id)
+        self.addCleanup(cache.delete, task_metadata_key)
+
+        targets = (
+            (translation, None, translation.id),
+            (self.component2, self.component2.id, None),
+            (category, None, None),
+            (project_language, None, None),
+            (workspace, None, None),
+        )
+        for obj, component_id, translation_id in targets:
+            with (
+                self.subTest(obj=obj),
+                patch("weblate.trans.views.edit.auto_translate.delay") as delay,
+            ):
+                cache.delete(task_metadata_key)
+                delay.return_value.id = task_id
+                response = self.client.post(
+                    reverse("auto_translation", kwargs={"path": obj.get_url_path()}),
+                    {
+                        "auto_source": "others",
+                        "threshold": "100",
+                        "q": "state:<translated",
+                        "mode": "translate",
+                    },
+                )
+
+                self.assertEqual(response.status_code, 302)
+                self.assertEqual(
+                    get_task_metadata(task_id),
+                    {
+                        "component_id": component_id,
+                        "translation_id": translation_id,
+                        "user_id": self.user.id,
+                    },
+                )
 
     def make_different(self, language: str = "cs") -> None:
         with self.captureOnCommitCallbacks(execute=True):

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -72,6 +72,7 @@ from weblate.trans.util import redirect_next, render
 from weblate.trans.validators import SUGGESTION_REJECTION_REASON_LENGTH
 from weblate.utils import messages
 from weblate.utils.antispam import is_spam
+from weblate.utils.celery import store_task_metadata
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.html import format_html_join_comma, list_to_tuples
 from weblate.utils.lock import WeblateLockTimeoutError
@@ -1527,6 +1528,12 @@ def auto_translation(request: AuthenticatedHttpRequest, path):
             source_component_id=autoform.cleaned_data["component"],
             engines=autoform.cleaned_data["engines"],
             threshold=autoform.cleaned_data["threshold"],
+        )
+        store_task_metadata(
+            task.id,
+            component_id=component_id,
+            translation_id=translation_id,
+            user_id=request.user.id,
         )
         messages.success(
             request, gettext("Automatic translation in progress"), f"task:{task.id}"


### PR DESCRIPTION
Aggregate automatic translation jobs lacked ownership metadata, causing status polling to return 404, while task results for public scopes could be read anonymously. Store requester metadata and require authentication for task access.

Closes #21054

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
