### PR TITLE
fix(vcs): redact empty repository credentials

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,7 @@ Weblate 2026.8.1
 * Legal document confirmation now explicitly covers the linked privacy policy. See :ref:`legal`.
 * Add-on change history now retains only explicitly public configuration values and marks changed credential fields as redacted.
 * Translator work reports with metrics can now be displayed and downloaded as HTML.
+* Repository credentials are now consistently hidden from web and API output.
 
 .. rubric:: Compatibility
 

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -6796,6 +6796,26 @@ class ComponentAPITest(APIBaseTest):
             response.data["repoweb"], "https://example.com/src/{{filename}}#L{{line}}"
         )
 
+    def test_anonymous_component_hides_empty_password_credentials(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(
+            repo="https://repo-secret:@git.example/owner/repo",
+            push="https://push-secret:@git.example/owner/repo",
+        )
+
+        detail = self.client.get(
+            reverse("api:component-detail", kwargs=self.component_kwargs)
+        )
+        listing = self.client.get(reverse("api:component-list"))
+        listed = next(
+            item for item in listing.data["results"] if item["slug"] == "test"
+        )
+
+        for data in (detail.data, listed):
+            self.assertEqual(data["repo"], "https://git.example/owner/repo")
+            self.assertEqual(data["push"], "https://git.example/owner/repo")
+            self.assertNotIn("repo-secret", str(data))
+            self.assertNotIn("push-secret", str(data))
+
     def test_get_component_hides_vcs_view_fields_without_permission(self) -> None:
         private_component = self.create_acl()
         Component.objects.filter(pk=self.component.pk).update(

--- a/weblate/trans/migrations/0099_sanitize_repository_redirect_credentials.py
+++ b/weblate/trans/migrations/0099_sanitize_repository_redirect_credentials.py
@@ -1,0 +1,73 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from django.db import migrations
+
+COMPONENT_SETTING_CHANGE = 96
+BATCH_SIZE = 1000
+
+
+def cleanup_repo_url(url: str) -> str:
+    """Remove raw userinfo from a repository URL."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return url
+    userinfo, separator, _hostinfo = parsed.netloc.rpartition("@")
+    if separator:
+        return url.replace(f"//{userinfo}@", "//", 1)
+    return url
+
+
+def sanitize_repository_redirect_credentials(apps, schema_editor) -> None:
+    Change = apps.get_model("trans", "Change")
+    database_alias = schema_editor.connection.alias
+    queryset = (
+        Change.objects.using(database_alias)
+        .filter(
+            action=COMPONENT_SETTING_CHANGE,
+            target__in=("repo", "push"),
+            details__reason="http_redirect",
+            details__field__in=("repo", "push"),
+        )
+        .only("id", "details")
+    )
+    pending = []
+    for change in queryset.iterator(chunk_size=BATCH_SIZE):
+        if not isinstance(change.details, dict):
+            continue
+        details = change.details.copy()
+        for field in ("old", "target"):
+            value = details.get(field)
+            if isinstance(value, str):
+                details[field] = cleanup_repo_url(value)
+        if details == change.details:
+            continue
+        change.details = details
+        pending.append(change)
+        if len(pending) == BATCH_SIZE:
+            Change.objects.using(database_alias).bulk_update(
+                pending, ("details",), batch_size=BATCH_SIZE
+            )
+            pending.clear()
+    if pending:
+        Change.objects.using(database_alias).bulk_update(
+            pending, ("details",), batch_size=BATCH_SIZE
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0098_scrub_addon_change_details"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            sanitize_repository_redirect_credentials, migrations.RunPython.noop
+        ),
+    ]

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -98,8 +98,8 @@ class ComponentTest(RepoTestCase):
 
     def test_persist_repository_redirect_uses_repository_bot(self) -> None:
         component = self.create_component()
-        old_url = "https://user:secret@git.example/owner/repo"
-        canonical_url = "https://user:secret@git.example/owner/repo.git"
+        old_url = "https://redirect-secret:@git.example/owner/repo"
+        canonical_url = "https://redirect-secret:@git.example/owner/repo.git"
         Component.objects.filter(pk=component.pk).update(repo=old_url)
         component.repo = old_url
         repository = component.repository

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -1883,6 +1883,75 @@ class ChangeTest(ModelTestCase):
         self.assertIsNone(standalone.workspace_id)
         self.assertIsNone(standalone_project_change.workspace_id)
 
+    def test_repository_redirect_credentials_migration(self) -> None:
+        migration = importlib.import_module(
+            "weblate.trans.migrations.0099_sanitize_repository_redirect_credentials"
+        )
+        affected = Change.objects.create(
+            component=self.component,
+            action=ActionEvents.COMPONENT_SETTING_CHANGE,
+            target="repo",
+            details={
+                "field": "repo",
+                "old": "https://old-secret:@git.example/owner/repo",
+                "target": "https://new-secret:@git.example/owner/repo.git",
+                "automatic": True,
+                "reason": "http_redirect",
+            },
+        )
+        affected_push = Change.objects.create(
+            component=self.component,
+            action=ActionEvents.COMPONENT_SETTING_CHANGE,
+            target="push",
+            details={
+                "field": "push",
+                "old": "https://old-push-secret:@git.example/owner/repo",
+                "target": "https://new-push-secret:@git.example/owner/repo.git",
+                "automatic": True,
+                "reason": "http_redirect",
+            },
+        )
+        unaffected = Change.objects.create(
+            component=self.component,
+            action=ActionEvents.COMPONENT_SETTING_CHANGE,
+            target="repo",
+            details={
+                "field": "repo",
+                "old": "https://kept-secret:@git.example/owner/repo",
+                "target": "https://kept-secret:@git.example/owner/repo.git",
+                "reason": "manual",
+            },
+        )
+
+        migration.sanitize_repository_redirect_credentials(
+            apps, SimpleNamespace(connection=connection)
+        )
+
+        affected.refresh_from_db()
+        affected_push.refresh_from_db()
+        unaffected.refresh_from_db()
+        self.assertEqual(
+            affected.details,
+            {
+                "field": "repo",
+                "old": "https://git.example/owner/repo",
+                "target": "https://git.example/owner/repo.git",
+                "automatic": True,
+                "reason": "http_redirect",
+            },
+        )
+        self.assertEqual(
+            affected_push.details,
+            {
+                "field": "push",
+                "old": "https://git.example/owner/repo",
+                "target": "https://git.example/owner/repo.git",
+                "automatic": True,
+                "reason": "http_redirect",
+            },
+        )
+        self.assertIn("kept-secret", unaffected.details["old"])
+
     def test_day_filtering(self) -> None:
         Change.objects.all().delete()
         for days_since in range(3):

--- a/weblate/trans/tests/test_util.py
+++ b/weblate/trans/tests/test_util.py
@@ -59,6 +59,24 @@ class HideCredentialsTest(SimpleTestCase):
             cleanup_repo_url("http://foo@example.com"), "http://example.com"
         )
 
+    def test_http_userinfo_variants(self) -> None:
+        variants = (
+            "http://token:@example.com",
+            "http://:password@example.com",
+            "http://@example.com",
+            "http://user%40example:password%3A@example.com",
+        )
+        for url in variants:
+            with self.subTest(url=url):
+                self.assertEqual(cleanup_repo_url(url), "http://example.com")
+
+    def test_embedded_url(self) -> None:
+        url = "http://token:@example.com"
+        self.assertEqual(
+            cleanup_repo_url(url, f"Contact admin@example.com about {url}"),
+            "Contact admin@example.com about http://example.com",
+        )
+
     def test_git(self) -> None:
         self.assertEqual(
             cleanup_repo_url("git://git.weblate.org/weblate.git"),

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -1115,6 +1115,17 @@ class BasicViewTest(ViewTestCase):
         self.assertContains(response, "Test/Test")
         self.assertNotContains(response, "Spanish")
 
+    def test_anonymous_view_component_hides_empty_password_credentials(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(
+            repo="https://page-secret:@git.example/owner/repo"
+        )
+        self.client.logout()
+
+        response = self.client.get(self.component.get_absolute_url())
+
+        self.assertContains(response, "https://git.example/owner/repo")
+        self.assertNotContains(response, "page-secret")
+
     def test_view_component_upload_placeholder(self) -> None:
         response = self.client.get(self.component.get_absolute_url())
 

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -172,10 +172,10 @@ def cleanup_repo_url(url: str, text: str | None = None) -> str:
     except ValueError:
         # The URL can not be parsed, so avoid stripping
         return text
-    if parsed.username and parsed.password:
-        return text.replace(f"{parsed.username}:{parsed.password}@", "")
-    if parsed.username:
-        return text.replace(f"{parsed.username}@", "")
+    userinfo, separator, _hostinfo = parsed.netloc.rpartition("@")
+    if separator:
+        cleaned_url = url.replace(f"//{userinfo}@", "//", 1)
+        return text.replace(url, cleaned_url)
     return text
 
 


### PR DESCRIPTION
Repository URLs with explicit empty passwords bypassed redaction and could expose stored credentials in public views and API responses. Sanitize raw userinfo and existing redirect history.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
