### PR TITLE
fix(l10n): mark incorrect Vietnamese "Translation domain" translation as fuzzy

### DIFF
--- a/weblate/locale/vi/LC_MESSAGES/django.po
+++ b/weblate/locale/vi/LC_MESSAGES/django.po
@@ -7407,6 +7407,7 @@ msgid "Enable machine translation"
 msgstr "Bật tính năng dịch máy"
 
 #: weblate/machinery/forms.py:201
+#, fuzzy
 msgctxt "Automatic suggestion service configuration"
 msgid "Translation domain"
 msgstr "Thông báo bản dịch"


### PR DESCRIPTION
### Motivation
- The Vietnamese catalog contains an incorrect active translation for the SAP machine-translation label `Translation domain`, which should fall back to the English source until a correct Vietnamese translation is provided.

### Description
- Added `#, fuzzy` to the `msgid "Translation domain"` entry in `weblate/locale/vi/LC_MESSAGES/django.po` so gettext will ignore the incorrect `msgstr` and fall back to the English label.

### Testing
- Ran `msgfmt --check --check-format --output-file=/tmp/weblate-vi.mo weblate/locale/vi/LC_MESSAGES/django.po`, compiled and loaded the Vietnamese catalog via Python `gettext.translation(...).pgettext(...)`, and ran `git diff --check`, all of which succeeded and confirmed the contextual gettext now returns the fallback `Translation domain`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74702fa34883298ba32fcc7975adf9)