### PR TITLE
feat(metrics): add metrics management command

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -1685,7 +1685,9 @@ Monitoring Weblate
 Weblate provides the ``/healthz/`` URL to be used in simple health checks, for example
 using Kubernetes. The Docker container has built-in health check using this URL.
 
-For monitoring metrics of Weblate you can use :http:get:`/api/metrics/` API endpoint.
+For monitoring metrics of Weblate you can use the :http:get:`/api/metrics/` API
+endpoint. Monitoring tools running locally can retrieve the same metrics using
+the :wladmin:`metrics` command.
 
 .. seealso::
 

--- a/docs/admin/management.rst
+++ b/docs/admin/management.rst
@@ -988,6 +988,18 @@ You can either define which project or component to update (for example
 
    :wladmin:`unlock_translation`
 
+metrics
+-------
+
+.. weblate-admin:: metrics
+
+Outputs the server metrics exposed by :http:get:`/api/metrics/`.
+
+.. weblate-admin-option:: --format FORMAT
+
+    Selects the output format. Supported formats are ``json``, ``csv``, and
+    ``openmetrics``. The default is ``json``.
+
 migrate
 -------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Weblate 2026.8.1
 .. rubric:: New features
 
 * Project and component APIs now expose all user-configurable settings, including access control and translation-memory settings. See :doc:`api`.
+* Added the :wladmin:`metrics` command for retrieving server metrics locally in JSON, CSV, or OpenMetrics format.
 
 .. rubric:: Improvements
 

--- a/weblate/api/metrics.py
+++ b/weblate/api/metrics.py
@@ -1,0 +1,97 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
+
+from django.conf import settings
+from rest_framework.renderers import JSONRenderer
+
+from weblate.api.renderers import (
+    AutoCSVRenderer,
+    OpenMetricsMetric,
+    OpenMetricsRenderer,
+    OpenMetricsSample,
+)
+from weblate.api.serializers import MetricsSerializer
+from weblate.utils.stats import GlobalStats
+from weblate.utils.version import GIT_VERSION
+from weblate.utils.version_display import show_metrics_version
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+MetricsFormat = Literal["json", "csv", "openmetrics"]
+METRICS_FORMATS: tuple[MetricsFormat, ...] = ("json", "csv", "openmetrics")
+
+OPENMETRICS_METRIC_HELP = (
+    ("units", "Number of translation units."),
+    ("units_translated", "Number of translated translation units."),
+    ("users", "Number of users."),
+    ("changes", "Number of recorded changes."),
+    ("projects", "Number of projects."),
+    ("components", "Number of components."),
+    ("translations", "Number of translations."),
+    ("languages", "Number of configured languages."),
+    ("checks", "Number of triggered quality checks."),
+    ("configuration_errors", "Number of active configuration errors."),
+    ("suggestions", "Number of pending suggestions."),
+)
+
+
+def get_server_metrics_data() -> dict[str, object]:
+    return dict(MetricsSerializer(GlobalStats()).data)
+
+
+def get_server_openmetrics_data(
+    data: Mapping[str, object],
+) -> list[OpenMetricsMetric]:
+    result = [
+        OpenMetricsMetric(
+            name=name,
+            help_text=help_text,
+            metric_type="gauge",
+            samples=(OpenMetricsSample(value=cast("int", data[name]), labels={}),),
+        )
+        for name, help_text in OPENMETRICS_METRIC_HELP
+    ]
+    queues = cast("Mapping[str, int]", data["celery_queues"])
+    result.append(
+        OpenMetricsMetric(
+            name="celery_queues",
+            help_text="Number of tasks in each Celery queue.",
+            metric_type="gauge",
+            samples=tuple(
+                OpenMetricsSample(value=value, labels={"queue": queue})
+                for queue, value in queues.items()
+            ),
+        )
+    )
+    if show_metrics_version(settings.VERSION_DISPLAY):
+        result.append(
+            OpenMetricsMetric(
+                name="weblate_info",
+                help_text="Weblate build information.",
+                metric_type="gauge",
+                samples=(
+                    OpenMetricsSample(
+                        value=1,
+                        labels={"version": GIT_VERSION},
+                    ),
+                ),
+            )
+        )
+    return result
+
+
+def render_server_metrics(output_format: MetricsFormat) -> str:
+    data = get_server_metrics_data()
+    if output_format == "openmetrics":
+        rendered = OpenMetricsRenderer().render(get_server_openmetrics_data(data))
+    elif output_format == "csv":
+        rendered = AutoCSVRenderer().render(data)
+    else:
+        rendered = JSONRenderer().render(data)
+    return rendered if isinstance(rendered, str) else rendered.decode()

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -67,6 +67,7 @@ from rest_framework.viewsets import ViewSet
 from weblate.accounts.models import Subscription
 from weblate.accounts.utils import remove_user
 from weblate.addons.models import Addon
+from weblate.api.metrics import get_server_metrics_data, get_server_openmetrics_data
 from weblate.api.pagination import LargePagination
 from weblate.api.serializers import (
     AddonSerializer,
@@ -198,13 +199,10 @@ from weblate.utils.state import (
     STATE_TRANSLATED,
 )
 from weblate.utils.stats import (
-    GlobalStats,
     ProjectLanguage,
     iter_prefetch_stats,
     prefetch_stats,
 )
-from weblate.utils.version import GIT_VERSION
-from weblate.utils.version_display import show_metrics_version
 from weblate.utils.views import download_translation_file, zip_download
 from weblate.workspaces.models import Workspace
 
@@ -4468,21 +4466,6 @@ class CategoryViewSet(viewsets.ModelViewSet, ReportsMixin, AnnouncementsMixin):
         return Response(serializer.data)
 
 
-OPENMETRICS_METRIC_HELP = (
-    ("units", "Number of translation units."),
-    ("units_translated", "Number of translated translation units."),
-    ("users", "Number of users."),
-    ("changes", "Number of recorded changes."),
-    ("projects", "Number of projects."),
-    ("components", "Number of components."),
-    ("translations", "Number of translations."),
-    ("languages", "Number of configured languages."),
-    ("checks", "Number of triggered quality checks."),
-    ("configuration_errors", "Number of active configuration errors."),
-    ("suggestions", "Number of pending suggestions."),
-)
-
-
 def get_project_metrics_data(
     project: Project, user: User
 ) -> tuple[
@@ -4616,31 +4599,6 @@ def get_project_openmetrics_data(
     return result
 
 
-def get_openmetrics_data(data: Mapping[str, object]) -> list[OpenMetricsMetric]:
-    result = [
-        OpenMetricsMetric(
-            name=name,
-            help_text=help_text,
-            metric_type="gauge",
-            samples=(OpenMetricsSample(value=cast("int", data[name]), labels={}),),
-        )
-        for name, help_text in OPENMETRICS_METRIC_HELP
-    ]
-    queues = cast("Mapping[str, int]", data["celery_queues"])
-    result.append(
-        OpenMetricsMetric(
-            name="celery_queues",
-            help_text="Number of tasks in each Celery queue.",
-            metric_type="gauge",
-            samples=tuple(
-                OpenMetricsSample(value=value, labels={"queue": queue})
-                for queue, value in queues.items()
-            ),
-        )
-    )
-    return result
-
-
 class Metrics(APIView):
     """Metrics view for monitoring."""
 
@@ -4651,27 +4609,10 @@ class Metrics(APIView):
     # pylint: disable-next=redefined-builtin
     def get(self, request: Request, format=None):  # ruff: ignore[builtin-argument-shadowing]
         """Return server metrics."""
-        stats = GlobalStats()
-        serializer = self.serializer_class(stats)
-        data = dict(serializer.data)
+        data = get_server_metrics_data()
         if request.accepted_renderer.format == "openmetrics":
-            metrics = get_openmetrics_data(data)
-            if show_metrics_version(settings.VERSION_DISPLAY):
-                metrics.append(
-                    OpenMetricsMetric(
-                        name="weblate_info",
-                        help_text="Weblate build information.",
-                        metric_type="gauge",
-                        samples=(
-                            OpenMetricsSample(
-                                value=1,
-                                labels={"version": GIT_VERSION},
-                            ),
-                        ),
-                    )
-                )
             return Response(
-                metrics,
+                get_server_openmetrics_data(data),
                 content_type=OpenMetricsRenderer.response_content_type,
             )
         return Response(data)

--- a/weblate/utils/management/commands/metrics.py
+++ b/weblate/utils/management/commands/metrics.py
@@ -1,0 +1,28 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from weblate.api.metrics import METRICS_FORMATS, render_server_metrics
+from weblate.utils.management.base import BaseCommand
+
+if TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
+
+class Command(BaseCommand):
+    help = "display server metrics"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--format",
+            choices=METRICS_FORMATS,
+            default="json",
+            help="output format (default: json)",
+        )
+
+    def handle(self, *args, **options) -> None:
+        self.stdout.write(render_server_metrics(options["format"]))

--- a/weblate/utils/tests/test_commands.py
+++ b/weblate/utils/tests/test_commands.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import csv
+import json
 import os
 import shutil
 import tempfile
@@ -12,10 +14,13 @@ from unittest.mock import patch
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import override_settings
 
 from weblate.trans.tests.utils import TempDirMixin
 from weblate.utils.commands import find_runtime_command, get_clean_env
 from weblate.utils.management.base import DocGeneratorCommand
+from weblate.utils.version import GIT_VERSION
+from weblate.utils.version_display import VERSION_DISPLAY_HIDE
 
 
 class DummyDocGeneratorCommand(DocGeneratorCommand):
@@ -192,6 +197,47 @@ class DBCommandTests(TestCase):
         output = StringIO()
         call_command("ensure_stats", stdout=output)
         self.assertEqual("found 0 strings\n", output.getvalue())
+
+
+class MetricsCommandTests(TestCase):
+    def get_output(self, output_format: str | None = None) -> str:
+        output = StringIO()
+        args = ("--format", output_format) if output_format else ()
+        with patch("weblate.utils.celery.get_queue_stats", return_value={"celery": 3}):
+            call_command("metrics", *args, stdout=output)
+        return output.getvalue()
+
+    def test_json(self) -> None:
+        data = json.loads(self.get_output())
+        self.assertEqual(data["celery_queues"], {"celery": 3})
+        self.assertEqual(data["version"], GIT_VERSION)
+        self.assertIn("units_translated", data)
+
+    def test_csv(self) -> None:
+        rows = list(csv.DictReader(StringIO(self.get_output("csv"))))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["celery_queues.celery"], "3")
+        self.assertEqual(rows[0]["version"], GIT_VERSION)
+        self.assertIn("units_translated", rows[0])
+
+    def test_openmetrics(self) -> None:
+        output = self.get_output("openmetrics")
+        self.assertIn("# HELP units Number of translation units.", output)
+        self.assertIn("# TYPE units gauge", output)
+        self.assertIn('celery_queues{queue="celery"} 3', output)
+        self.assertIn(f'weblate_info{{version="{GIT_VERSION}"}} 1', output)
+        self.assertTrue(output.endswith("# EOF\n"))
+
+    @override_settings(VERSION_DISPLAY=VERSION_DISPLAY_HIDE, HIDE_VERSION=True)
+    def test_hide_version(self) -> None:
+        self.assertNotIn("version", json.loads(self.get_output("json")))
+        csv_row = next(csv.DictReader(StringIO(self.get_output("csv"))))
+        self.assertNotIn("version", csv_row)
+        self.assertNotIn("weblate_info", self.get_output("openmetrics"))
+
+    def test_invalid_format(self) -> None:
+        with self.assertRaises(CommandError):
+            call_command("metrics", "--format", "yaml")
 
 
 class RuntimeCommandTests(SimpleTestCase):


### PR DESCRIPTION
Local monitoring agents need access to server metrics without making an authenticated HTTP request. Share collection and rendering with the API to keep both interfaces consistent.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
