### PR TITLE
fix(csp): allow Sentry feedback redirect

### DIFF
--- a/weblate/middleware.py
+++ b/weblate/middleware.py
@@ -381,7 +381,8 @@ class CSPBuilder:
             if domain.endswith(".de.sentry.io"):
                 self.directives["connect-src"].add("de.sentry.io")
                 self.directives["script-src"].add("de.sentry.io")
-            elif domain.endswith(".sentry.io"):
+            # Regional ingestion endpoints redirect the feedback script here.
+            if domain.endswith(".sentry.io"):
                 self.directives["script-src"].add("sentry.io")
                 self.directives["connect-src"].add("sentry.io")
             self.directives["img-src"].add("data:")

--- a/weblate/utils/tests/test_middleware.py
+++ b/weblate/utils/tests/test_middleware.py
@@ -107,6 +107,21 @@ class CSPBuilderTest(TestCase):
         self.assertIn("sentry.io", builder.directives["connect-src"])
         self.assertNotIn("'unsafe-inline'", builder.directives["script-src"])
 
+    @override_settings(
+        SENTRY_DSN="https://public@o123.ingest.de.sentry.io/456",
+    )
+    def test_sentry_de_error_allows_redirected_script(self) -> None:
+        request = self.factory.get("/")
+        request.resolver_match = None
+
+        builder = CSPBuilder(request, HttpResponse(status=500))
+
+        for directive in ("script-src", "connect-src"):
+            self.assertIn("o123.ingest.de.sentry.io", builder.directives[directive])
+            self.assertIn("de.sentry.io", builder.directives[directive])
+            self.assertIn("sentry.io", builder.directives[directive])
+        self.assertNotIn("'unsafe-inline'", builder.directives["script-src"])
+
     @override_settings(STATIC_URL="https://cdn.example.test/static/")
     def test_external_static_url_added_to_worker_src(self) -> None:
         request = self.factory.get("/")


### PR DESCRIPTION
Sentry's German-region ingestion endpoint redirects the feedback script to sentry.io. Allow the final host while retaining the existing restrictive script policy.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
