### PR TITLE
perf(translations): batch metadata updates

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Weblate 2026.9
 .. rubric:: Improvements
 
 * Deployment checks and the performance report now detect slow filesystem metadata access in data and cache directories.
+* Improved translation file loading performance for metadata-only string changes.
 
 .. rubric:: Bug fixes
 

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -18,6 +18,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import DatabaseError, IntegrityError, models, transaction
 from django.db.models import F, Q
+from django.db.models.signals import post_save
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -48,7 +49,7 @@ from weblate.trans.mixins import CacheKeyMixin, LockMixin, LoggerMixin, URLMixin
 from weblate.trans.models.change import Change
 from weblate.trans.models.pending import PendingUnitChange
 from weblate.trans.models.suggestion import Suggestion, SuggestionAddResult
-from weblate.trans.models.unit import Unit
+from weblate.trans.models.unit import UNIT_METADATA_UPDATE_FIELDS, Unit
 from weblate.trans.signals import (
     component_post_update,
     translation_post_remove,
@@ -588,6 +589,7 @@ class Translation(
         }
         updated: dict[int, Unit] = {}
         duplicates: list[Unit] = []
+        metadata_updates: dict[int, Unit] = {}
 
         # Process based on intermediate store if available
         if self.component.intermediate:
@@ -687,7 +689,31 @@ class Translation(
                 op="unit.update_from_unit",
                 name=f"{self.full_slug}:{newunit.unit_attributes['pos']}",
             ):
-                newunit.update_from_unit(user=user, author=author)
+                newunit.update_from_unit(
+                    user=user,
+                    author=author,
+                    metadata_updates=metadata_updates,
+                )
+
+        if metadata_updates:
+            metadata_timestamp = timezone.now()
+            for unit in metadata_updates.values():
+                unit.last_updated = metadata_timestamp
+            Unit.objects.bulk_update(
+                metadata_updates.values(),
+                UNIT_METADATA_UPDATE_FIELDS,
+                batch_size=500,
+            )
+            update_fields = frozenset(UNIT_METADATA_UPDATE_FIELDS)
+            for unit in metadata_updates.values():
+                post_save.send(
+                    sender=Unit,
+                    instance=unit,
+                    created=False,
+                    raw=False,
+                    using=unit._state.db,  # ruff: ignore[private-member-access]
+                    update_fields=update_fields,
+                )
 
         # Trigger duplicate alerts
         for newunit in duplicates:

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -93,6 +93,14 @@ COMPONENT_ORDER_FIELDS = [
     "translation__component__is_glossary",
     "translation__component__name",
 ]
+UNIT_METADATA_UPDATE_FIELDS = (
+    "location",
+    "note",
+    "position",
+    "automatically_translated",
+    "flags",
+    "last_updated",
+)
 
 
 def orders_units_by_component(obj: object) -> bool:
@@ -1201,7 +1209,17 @@ class Unit(models.Model, LoggerMixin):
                 )
 
     def update_source_unit(
-        self, component, source, context, pos, note, location, flags: Flags, explanation
+        self,
+        component,
+        source,
+        context,
+        pos,
+        note,
+        location,
+        flags: Flags,
+        explanation,
+        *,
+        metadata_updates: dict[int, Unit] | None = None,
     ) -> None:
         source_unit = component.get_source(
             self.id_hash,
@@ -1221,6 +1239,7 @@ class Unit(models.Model, LoggerMixin):
         except ParseException:
             parsed_flags = Flags()
         same_flags = flags == parsed_flags
+        same_explanation = explanation == source_unit.explanation
         if (
             not source_unit.source_updated
             and not source_unit.translation.filename
@@ -1238,12 +1257,21 @@ class Unit(models.Model, LoggerMixin):
             source_unit.explanation = explanation
             source_unit.flags = flags.format()
             source_unit.note = note
-            source_unit.save(
-                update_fields=["position", "location", "explanation", "flags", "note"],
-                same_content=True,
-                run_checks=False,
-                only_save=same_flags,
-            )
+            if same_flags and same_explanation and metadata_updates is not None:
+                metadata_updates[source_unit.pk] = source_unit
+            else:
+                source_unit.save(
+                    update_fields=[
+                        "position",
+                        "location",
+                        "explanation",
+                        "flags",
+                        "note",
+                    ],
+                    same_content=True,
+                    run_checks=False,
+                    only_save=same_flags,
+                )
         self.source_unit = source_unit
 
     def store_unit_attributes(
@@ -1317,11 +1345,12 @@ class Unit(models.Model, LoggerMixin):
             "automatically_translated": unit.is_automatically_translated(),
         }
 
-    def update_from_unit(  # ruff: ignore[complex-structure, too-many-locals]
+    def update_from_unit(  # ruff: ignore[complex-structure, too-many-locals, too-many-statements]
         self,
         *,
         user: User | None = None,
         author: User | None = None,
+        metadata_updates: dict[int, Unit] | None = None,
     ) -> None:
         """Update Unit from ttkit unit."""
         translation = self.translation
@@ -1368,6 +1397,7 @@ class Unit(models.Model, LoggerMixin):
                 location,
                 flags,
                 source_explanation,
+                metadata_updates=metadata_updates,
             )
 
         # Get comparison state (disk_state if exists, otherwise current state)
@@ -1484,19 +1514,22 @@ class Unit(models.Model, LoggerMixin):
         # Metadata update only, these do not trigger any actions in Weblate and
         # are display only
         if same_data and not same_metadata:
-            update_fields = [
-                "location",
-                "note",
-                "position",
-                "automatically_translated",
-            ]
-            if not supports_explanation:
-                update_fields.append("explanation")
-            self.save(
-                same_content=True,
-                only_save=True,
-                update_fields=update_fields,
-            )
+            if metadata_updates is not None:
+                metadata_updates[self.pk] = self
+            else:
+                update_fields = [
+                    "location",
+                    "note",
+                    "position",
+                    "automatically_translated",
+                ]
+                if not supports_explanation:
+                    update_fields.append("explanation")
+                self.save(
+                    same_content=True,
+                    only_save=True,
+                    update_fields=update_fields,
+                )
             return
 
         # Sanitize number of plurals

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -9,7 +9,7 @@ import os
 from contextlib import ExitStack
 from datetime import timedelta
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from asgiref.sync import async_to_sync
 from django.apps import apps
@@ -17,6 +17,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import connection, transaction
+from django.db.models.signals import post_save
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import CaptureQueriesContext, override_settings
@@ -577,6 +578,139 @@ class TranslationTest(RepoTestCase):
         self.assertEqual(translation.stats.all, 4)
         self.assertEqual(translation.stats.fuzzy, 0)
         self.assertEqual(translation.stats.all_words, 19)
+
+    def test_metadata_only_updates_are_batched(self) -> None:
+        component = self.create_component()
+        translation = component.translation_set.get(language_code="cs")
+        source_translation = component.source_translation
+        target_units = list(translation.unit_set.order_by("pk"))
+        source_units = list(source_translation.unit_set.order_by("pk"))
+        original_num_words = {
+            unit.pk: unit.num_words for unit in [*target_units, *source_units]
+        }
+        original_last_updated = max(
+            unit.last_updated for unit in [*target_units, *source_units]
+        )
+        hello = translation.unit_set.get(source="Hello, world!\n")
+        thanks = translation.unit_set.get(source="Thank you for using Weblate.")
+        hello_position = hello.position
+        thanks_position = thanks.position
+
+        filename = get_optional_path(translation.get_filename())
+        store = translation.store
+        hello_store_unit = next(
+            unit for unit in store.content_units if unit.source == hello.source
+        )
+        thanks_store_unit = next(
+            unit for unit in store.content_units if unit.source == thanks.source
+        )
+        hello_index = store.store.units.index(hello_store_unit.unit)
+        thanks_index = store.store.units.index(thanks_store_unit.unit)
+        store.store.units[hello_index], store.store.units[thanks_index] = (
+            store.store.units[thanks_index],
+            store.store.units[hello_index],
+        )
+        store.save()
+        filename.write_text(
+            filename.read_text(encoding="utf-8").replace("#: main.c:", "#: moved.c:"),
+            encoding="utf-8",
+        )
+        translation.drop_store_cache()
+        component.unload_sources()
+
+        unit_post_save = Mock()
+        post_save.connect(unit_post_save, sender=Unit, weak=False)
+        self.addCleanup(post_save.disconnect, unit_post_save, sender=Unit)
+        with CaptureQueriesContext(connection) as queries:
+            self.assertTrue(translation.check_sync(force=True))
+
+        unit_update_queries = [
+            query["sql"]
+            for query in queries.captured_queries
+            if query["sql"].startswith('UPDATE "trans_unit"')
+        ]
+        self.assertEqual(len(unit_update_queries), 1)
+
+        updated_units = list(
+            Unit.objects.filter(pk__in=original_num_words).order_by("pk")
+        )
+        self.assertTrue(updated_units)
+        self.assertTrue(
+            all(unit.location.startswith("moved.c:") for unit in updated_units)
+        )
+        self.assertTrue(
+            all(unit.num_words == original_num_words[unit.pk] for unit in updated_units)
+        )
+        self.assertTrue(
+            all(unit.last_updated > original_last_updated for unit in updated_units)
+        )
+        self.assertEqual(len({unit.last_updated for unit in updated_units}), 1)
+        self.assertEqual(
+            {
+                call.kwargs["instance"].pk
+                for call in unit_post_save.call_args_list
+                if not call.kwargs["created"]
+            },
+            set(original_num_words),
+        )
+        hello.refresh_from_db()
+        thanks.refresh_from_db()
+        self.assertEqual(hello.position, thanks_position)
+        self.assertEqual(thanks.position, hello_position)
+
+    def test_content_and_metadata_updates_use_separate_paths(self) -> None:
+        component = self.create_component()
+        translation = component.translation_set.get(language_code="cs")
+        hello = translation.unit_set.get(source="Hello, world!\n")
+        original_num_words = hello.num_words
+
+        filename = get_optional_path(translation.get_filename())
+        content = filename.read_text(encoding="utf-8")
+        content = content.replace("#: main.c:", "#: moved.c:")
+        content = content.replace(
+            'msgid "Hello, world!\\n"\nmsgstr ""',
+            'msgid "Hello, world!\\n"\nmsgstr "Nazdar světe!\\n"',
+        )
+        filename.write_text(content, encoding="utf-8")
+        translation.drop_store_cache()
+        component.unload_sources()
+
+        with CaptureQueriesContext(connection) as queries:
+            self.assertTrue(translation.check_sync(force=True))
+
+        hello.refresh_from_db()
+        self.assertEqual(hello.target, "Nazdar světe!\n")
+
+        unit_update_queries = [
+            query["sql"]
+            for query in queries.captured_queries
+            if query["sql"].startswith('UPDATE "trans_unit"')
+        ]
+        self.assertEqual(len(unit_update_queries), 2)
+
+        self.assertEqual(hello.num_words, original_num_words)
+        self.assertTrue(hello.location.startswith("moved.c:"))
+        self.assertFalse(PendingUnitChange.objects.filter(unit=hello).exists())
+
+    def test_metadata_update_preserves_pending_explanation(self) -> None:
+        component = self.create_tbx()
+        translation = component.translation_set.get(language_code="cs")
+        unit = translation.unit_set.get(source="address bar")
+        explanation = "Pending explanation"
+        unit.update_explanation(explanation, create_test_user())
+
+        store = translation.store
+        store.store.units.reverse()
+        store.save()
+        translation.drop_store_cache()
+        component.unload_sources()
+
+        self.assertTrue(translation.check_sync(force=True))
+
+        unit.refresh_from_db()
+        pending = PendingUnitChange.objects.get(unit=unit)
+        self.assertEqual(unit.explanation, explanation)
+        self.assertEqual(pending.explanation, explanation)
 
     def test_source_translation_heals_managed_readonly_flag(self) -> None:
         component = self.create_component()


### PR DESCRIPTION
Metadata-heavy catalog refreshes changed thousands of otherwise unchanged units. Batch those database writes to shorten repository lock duration and reduce update contention.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
