### PR TITLE
ci(tests): limit pytest worker concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
     - name: Test with Django
       run: |
         source .venv/bin/activate
-        uv run --all-extras pytest --junitxml=junit.xml --cov=weblate --numprocesses=auto weblate
+        uv run --all-extras pytest --junitxml=junit.xml --cov=weblate --numprocesses=auto --maxprocesses=2 weblate
         cp .coverage .coverage.pytest
     - name: Test wsgi startup
       env:


### PR DESCRIPTION
Leave CPU headroom for CI services and coverage to avoid spurious regex timeouts on heavily loaded runners.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
