### PR TITLE
docs(auth): clarify site-wide permission impact

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -198,9 +198,16 @@ bulk invites also apply the selected superuser flag.
 
 Site-wide user management is controlled by the global ``user.edit``
 permission. Unlike project access management, this is a trusted administrative
-permission which allows editing user accounts across the whole instance,
-including assigning site-wide teams and granting superuser status to the
-managed account, even the caller's own account.
+permission which allows editing user accounts across the whole instance. It
+includes adding or removing the managed account from any site-wide, workspace,
+or project team, and granting or revoking superuser status, even for the
+caller's own account. These actions do not require the :guilabel:`Manage teams`
+permission or separate authority over the affected team.
+
+Treat ``user.edit`` as effectively equivalent to superuser access, not as a
+limited helpdesk permission. To delegate access management within a narrower
+scope, use a project `Administration` team or a :ref:`team administrator
+<team-admins>` instead.
 
 Site administrators can also disable password authentication for a user. The
 :guilabel:`Regenerate API key` option is enabled by default so that the current
@@ -563,11 +570,19 @@ set of permissions.
 
 .. include:: /snippets/permissions.rst
 
-.. note::
+.. warning::
 
-   Site-wide privileges are not granted to any default role.
-   These are powerful and quite close to the Superuser status.
-   Most of them affect all projects in your Weblate installation.
+   Roles do not have a separate scope; the permissions in a role determine its
+   scope. A role containing a permission listed under
+   :guilabel:`Site wide privileges` grants that permission across the Weblate
+   instance when assigned through a site-wide team. The team's project
+   selection does not narrow these permissions.
+
+   Site-wide privileges are not granted to any default role. Treat custom roles
+   containing them as trusted administrative access because some are
+   effectively equivalent to superuser status. For example, ``user.edit``
+   allows users to change their own team memberships and grant themselves
+   superuser status.
 
 .. include:: /snippets/roles.rst
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -449,6 +449,9 @@ Users
 
     Requires the global ``user.edit`` permission. See
     :ref:`access-control` for the user management permission model.
+    This permission authorizes membership changes for every team, including
+    project and workspace teams; no separate permission over the target team is
+    required.
 
     :param username: User's username
     :type username: string
@@ -462,6 +465,9 @@ Users
 
     Requires the global ``user.edit`` permission. See
     :ref:`access-control` for the user management permission model.
+    This permission authorizes membership changes for every team, including
+    project and workspace teams; no separate permission over the target team is
+    required.
 
     :param username: User's username
     :type username: string

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Weblate 2026.9
 .. rubric:: Improvements
 
 * Deployment checks and the performance report now detect slow filesystem metadata access in data and cache directories.
+* Clarified the instance-wide impact of roles containing site-wide permissions, including :ref:`site-wide user management <site-wide-user-management>`.
 * Improved translation file loading performance for metadata-only string changes.
 * VCS command versions are now validated by configuration health checks instead of during every process startup.
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -808,6 +808,13 @@ Known misuse patterns
   who are trusted only as translators. This is unsafe because those permissions
   can affect repositories, credentials, or other users. Assign narrower roles.
   *(documented)* (source: :doc:`/admin/access`)
+* Assigning site-wide permissions to roles intended for limited project or
+  helpdesk delegation. Site-wide permissions apply across the instance and are
+  not narrowed by the team's project selection. In particular, ``user.edit``
+  permits changing team memberships and superuser status for editable accounts,
+  including the caller's own account. Delegate permissions through project or
+  workspace teams for limited scopes. *(documented)* (source:
+  :doc:`/admin/access`)
 * Sending sensitive source strings or private customer content to machine
   translation providers without treating the provider as a data recipient. This
   is unsafe because Weblate must transmit content to the configured service, and


### PR DESCRIPTION
Site-wide permissions can be mistaken for project-scoped delegation when added to custom roles. Document that user.edit authorizes all team membership changes and is effectively equivalent to superuser access.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
