### PR TITLE
fix(vcs): release stale automatic locks

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -4299,32 +4299,73 @@ class Component(  # ruff: ignore[too-many-public-methods]
             self.alerts_trigger[name] = [kwargs]
 
     def delete_alert(self, alert: str) -> None:
-        if alert in self.all_alerts:
-            self.all_alerts[alert].delete()
-            del self.all_alerts[alert]
-            self.update_alert_caches()
-            self.clear_prefetched_alerts()
-            if (
-                self.locked
-                and self.effective_auto_lock_error
-                and alert in LOCKING_ALERTS
-                and not self.alert_set.filter(name__in=LOCKING_ALERTS).exists()
-                and getattr(
-                    # The object might not exist
-                    self.change_set.filter(action=ActionEvents.LOCK)
-                    .order_by("-id")
-                    .first(),
-                    "auto_status",
-                    None,
-                )
-            ):
-                self.do_lock(user=None, lock=False, auto=True)
+        alert_class = get_alert_class(alert)
+        linked_children = list(self.linked_children) if alert_class.link_wide else []
+        alert_exists = alert in self.all_alerts
 
-        if get_alert_class(alert).link_wide:
-            for component in self.linked_children:
+        if alert not in LOCKING_ALERTS:
+            if alert_exists:
+                self._delete_alert(self.all_alerts[alert])
+            for component in linked_children:
                 component.delete_alert(alert)
+            return
+
+        if not alert_exists and not any(
+            alert in component.all_alerts for component in linked_children
+        ):
+            return
+
+        with transaction.atomic():
+            locked_component = Component.objects.get_for_update(pk=self.pk)
+            alert_obj = locked_component.alert_set.filter(name=alert).first()
+            if alert_obj is not None:
+                self._delete_alert(alert_obj, locked_component=locked_component)
+            if alert_class.link_wide:
+                for component in locked_component.linked_children:
+                    component.delete_alert(alert)
+
+    def _delete_alert(
+        self, alert_obj: Alert, *, locked_component: Component | None = None
+    ) -> None:
+        alert = alert_obj.name
+        alert_obj.delete()
+        cached_alerts = self.__dict__.get("all_alerts")
+        if cached_alerts is not None:
+            cached_alerts.pop(alert, None)
+        self.update_alert_caches()
+        self.clear_prefetched_alerts()
+        if (
+            locked_component is not None
+            and locked_component.locked
+            and locked_component.effective_auto_lock_error
+            and not locked_component.alert_set.filter(name__in=LOCKING_ALERTS).exists()
+            and getattr(
+                # The object might not exist
+                locked_component.change_set.filter(action=ActionEvents.LOCK)
+                .order_by("-id")
+                .first(),
+                "auto_status",
+                None,
+            )
+        ):
+            self.do_lock(user=None, lock=False, auto=True)
 
     def add_alert(self, alert: str, noupdate: bool = False, **details) -> None:
+        alert_class = get_alert_class(alert)
+        if alert in LOCKING_ALERTS and alert_class.link_wide:
+            with transaction.atomic():
+                Component.objects.get_for_update(pk=self.pk)
+                self._add_alert(alert, noupdate=noupdate, **details)
+                for component in self.linked_children:
+                    component.add_alert(alert, noupdate=noupdate, **details)
+            return
+
+        self._add_alert(alert, noupdate=noupdate, **details)
+        if alert_class.link_wide:
+            for component in self.linked_children:
+                component.add_alert(alert, noupdate=noupdate, **details)
+
+    def _add_alert(self, alert: str, noupdate: bool = False, **details) -> None:
         alert_class = get_alert_class(alert)
         severity = alert_class.severity
         if alert in self.all_alerts:
@@ -4393,10 +4434,6 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         self.update_alert_caches()
         self.clear_prefetched_alerts()
-
-        if alert_class.link_wide:
-            for component in self.linked_children:
-                component.add_alert(alert, noupdate=noupdate, **details)
 
     def update_import_alerts(self, delete: bool = True) -> None:
         self.log_info("checking triggered alerts")

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import os
 import pathlib
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import Mock, call, patch
@@ -15,8 +17,9 @@ from unittest.mock import Mock, call, patch
 from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.db import close_old_connections, connection
 from django.db.models import F
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils import timezone
 from translate.storage.base import ParseError
@@ -41,6 +44,7 @@ from weblate.trans.tests.test_views import (
     FixtureTestCase,
     ViewTestCase,
 )
+from weblate.trans.tests.utils import RepoTestMixin
 from weblate.utils.files import remove_tree
 from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import (
@@ -1255,6 +1259,52 @@ class ComponentChangeTest(RepoTestCase):
         # Unlocked event
         self.assertEqual(component.change_set.count() - start, 4)
 
+    def test_successful_push_unlocks_with_stale_component(self) -> None:
+        component = self.create_component()
+        stale_component = Component.objects.get(pk=component.pk)
+
+        component.add_alert("PushFailure")
+        self.assertTrue(component.locked)
+        self.assertFalse(stale_component.locked)
+
+        with patch.object(stale_component.repository, "push") as mocked_push:
+            self.assertTrue(
+                stale_component.push_repo(None, stale_component.get_push_user(None))
+            )
+
+        mocked_push.assert_called_once_with(stale_component.push_branch)
+        stale_component.refresh_from_db()
+        self.assertFalse(stale_component.locked)
+        change = stale_component.change_set.latest("id")
+        self.assertEqual(change.action, ActionEvents.UNLOCK)
+        self.assertTrue(change.auto_status)
+
+    def test_autolock_preserves_manual_lock(self) -> None:
+        component = self.create_component()
+        component.add_alert("PushFailure")
+        component.do_lock(user=None, lock=False)
+        component.do_lock(user=None)
+
+        component.delete_alert("PushFailure")
+
+        component.refresh_from_db()
+        self.assertTrue(component.locked)
+        change = component.change_set.latest("id")
+        self.assertEqual(change.action, ActionEvents.LOCK)
+        self.assertFalse(change.auto_status)
+
+    def test_absent_locking_alert_does_not_lock_component(self) -> None:
+        component = self.create_component()
+
+        with patch.object(
+            Component.objects,
+            "get_for_update",
+            wraps=Component.objects.get_for_update,
+        ) as get_for_update:
+            component.delete_alert("PushFailure")
+
+        get_for_update.assert_not_called()
+
     def test_do_lock_rolls_back_when_change_save_fails(self) -> None:
         component = self.create_component()
 
@@ -1330,6 +1380,131 @@ class ComponentChangeTest(RepoTestCase):
         linked_component.refresh_from_db()
         self.assertTrue(component.locked)
         self.assertTrue(linked_component.locked)
+
+
+class ComponentAlertConcurrencyTest(RepoTestMixin, TransactionTestCase):
+    def setUp(self) -> None:
+        self.clone_test_repos()
+        super().setUp()
+
+    def test_alert_addition_is_serialized_with_automatic_unlock(self) -> None:
+        component = self.create_component()
+        component.add_alert("PushFailure")
+        delete_ready = Event()
+        add_started = Event()
+        original_do_lock = Component.do_lock
+
+        def coordinated_do_lock(
+            instance, user, lock: bool = True, auto: bool = False
+        ) -> None:
+            if not lock:
+                delete_ready.set()
+                self.assertTrue(add_started.wait(5))
+            original_do_lock(instance, user, lock=lock, auto=auto)
+
+        def delete_alert() -> None:
+            close_old_connections()
+            try:
+                Component.objects.get(pk=component.pk).delete_alert("PushFailure")
+            finally:
+                connection.close()
+
+        def add_alert() -> None:
+            self.assertTrue(delete_ready.wait(5))
+            add_started.set()
+            close_old_connections()
+            try:
+                Component.objects.get(pk=component.pk).add_alert("MergeFailure")
+            finally:
+                connection.close()
+
+        with (
+            patch.object(
+                Component,
+                "do_lock",
+                autospec=True,
+                side_effect=coordinated_do_lock,
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            delete_future = executor.submit(delete_alert)
+            add_future = executor.submit(add_alert)
+            delete_future.result(timeout=10)
+            add_future.result(timeout=10)
+
+        component.refresh_from_db()
+        self.assertTrue(component.locked)
+        self.assertFalse(component.alert_set.filter(name="PushFailure").exists())
+        self.assertTrue(component.alert_set.filter(name="MergeFailure").exists())
+        changes = list(
+            component.change_set.filter(
+                action__in=(ActionEvents.LOCK, ActionEvents.UNLOCK)
+            ).order_by("-id")[:2]
+        )
+        self.assertEqual(
+            [change.action for change in changes],
+            [ActionEvents.LOCK, ActionEvents.UNLOCK],
+        )
+        self.assertTrue(all(change.auto_status for change in changes))
+
+    def test_linked_alert_propagation_is_serialized_with_deletion(self) -> None:
+        component = self.create_component()
+        self.component = component
+        self.project = component.project
+        linked_component = self.create_link_existing()
+        component._add_alert(  # ruff: ignore[private-member-access]
+            "MergeFailure"
+        )
+        child_add_started = Event()
+        delete_started = Event()
+        original_add_alert = Component._add_alert  # ruff: ignore[private-member-access]
+
+        def coordinated_add_alert(
+            instance, alert: str, noupdate: bool = False, **details
+        ) -> None:
+            if instance.pk == linked_component.pk:
+                child_add_started.set()
+                self.assertTrue(delete_started.wait(5))
+            original_add_alert(instance, alert, noupdate=noupdate, **details)
+
+        def add_alert() -> None:
+            close_old_connections()
+            try:
+                Component.objects.get(pk=component.pk).add_alert("MergeFailure")
+            finally:
+                connection.close()
+
+        def delete_alert() -> None:
+            self.assertTrue(child_add_started.wait(5))
+            delete_started.set()
+            close_old_connections()
+            try:
+                Component.objects.get(pk=component.pk).delete_alert("MergeFailure")
+            finally:
+                connection.close()
+
+        with (
+            patch.object(
+                Component,
+                "_add_alert",
+                autospec=True,
+                side_effect=coordinated_add_alert,
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            add_future = executor.submit(add_alert)
+            delete_future = executor.submit(delete_alert)
+            add_future.result(timeout=10)
+            delete_future.result(timeout=10)
+
+        component.refresh_from_db()
+        linked_component.refresh_from_db()
+        self.assertFalse(component.locked)
+        self.assertFalse(linked_component.locked)
+        self.assertFalse(component.alert_set.filter(name="MergeFailure").exists())
+        self.assertFalse(
+            linked_component.alert_set.filter(name="MergeFailure").exists()
+        )
 
 
 class ComponentValidationTest(RepoTestCase):


### PR DESCRIPTION
A component instance can retain an unlocked state after another worker automatically locks it following a push failure. Rely on the transactional database check so clearing the last repository alert releases the automatic lock while preserving manual locks.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
