### PR TITLE
fix(vcs): recover checkout with untracked files

### DIFF
--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -832,7 +832,11 @@ class GitRepository(Repository):
 
     def checkout_with_temp_cleanup(self, branch: str) -> None:
         current_branch = self.get_current_branch()
-        self.execute(["checkout", branch], remote_op="none")
+        command = ["checkout"]
+        if current_branch in TEMPORARY_BRANCHES and current_branch != branch:
+            command.append("--force")
+        command.append(branch)
+        self.execute(command, remote_op="none")
         if current_branch in TEMPORARY_BRANCHES and current_branch != branch:
             with suppress(RepositoryCommandError):
                 self.execute(["branch", "-D", current_branch], remote_op="none")

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -1111,6 +1111,38 @@ class GitCrashRecoveryTest(SimpleTestCase, RepoTestMixin, TempDirMixin):
                 ).strip()
             )
 
+    def test_recovery_overwrites_conflicting_untracked_file(self) -> None:
+        conflict_path = Path(self.tempdir) / "recovery-conflict.txt"
+        with self.repo.lock:
+            original_revision = self.repo.get_last_revision()
+            self.repo.set_committer("Weblate Test", "weblate@example.com")
+            conflict_path.write_text("TRACKED\n", encoding="utf-8")
+            self.assertTrue(
+                self.repo.commit("Add recovery conflict", files=[conflict_path.name])
+            )
+            self.repo.execute(
+                [
+                    "checkout",
+                    "-b",
+                    "weblate-squash-tmp",
+                    original_revision,
+                ],
+                remote_op="none",
+            )
+            conflict_path.write_text("UNTRACKED\n", encoding="utf-8")
+
+        with self.repo.lock:
+            self.assertEqual(self.repo.get_current_branch(), "main")
+            self.assertEqual(conflict_path.read_text(encoding="utf-8"), "TRACKED\n")
+            self.assertNotIn("weblate-squash-tmp", self.repo.list_branches())
+            self.assertFalse(
+                self.repo.execute(
+                    ["status", "--short"],
+                    remote_op="none",
+                    needs_lock=False,
+                ).strip()
+            )
+
 
 class GitBranchValidationTest(SimpleTestCase):
     def test_empty_branch_in_constructor_uses_default(self) -> None:


### PR DESCRIPTION
Hard resets retain untracked files, which can block checkout when recovering an interrupted temporary branch. Force checkout only when leaving Weblate's disposable temporary branches.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
