### PR TITLE
fix(trans): handle settings repository lock timeout

### DIFF
--- a/weblate/trans/tests/test_manage.py
+++ b/weblate/trans/tests/test_manage.py
@@ -25,6 +25,7 @@ from weblate.trans.models.component import ComponentQuerySet
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.data import data_dir
 from weblate.utils.files import remove_tree
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.stats import ProjectLanguage
 from weblate.vcs.base import RepositoryLock
 
@@ -179,6 +180,11 @@ class RemovalTest(ViewTestCase):
 
 
 class RenameTest(ViewTestCase):
+    lock_timeout_message = (
+        "There appears to be an ongoing operation on the repository. "
+        "Please try again later."
+    )
+
     def test_denied(self) -> None:
         self.assertNotContains(
             self.client.get(self.project.get_absolute_url()), "#organize"
@@ -268,6 +274,78 @@ class RenameTest(ViewTestCase):
         # Test rename redirect for the old name in middleware
         response = self.client.get(original_url)
         self.assertRedirects(response, component.get_absolute_url(), status_code=301)
+
+    def test_rename_component_repository_locked(self) -> None:
+        self.make_manager()
+        url = reverse("rename", kwargs=self.kw_component)
+        lock_error = WeblateLockTimeoutError(
+            "repository locked", lock=self.component.repository.lock.lock_object
+        )
+
+        with patch.object(Component, "locked_for_update", side_effect=lock_error):
+            response = self.client.post(
+                url,
+                {
+                    "project": self.project.pk,
+                    "slug": "locked-rename",
+                    "name": "Locked rename",
+                },
+                follow=True,
+            )
+
+        self.assertRedirects(response, f"{self.component.get_absolute_url()}#organize")
+        self.assertContains(response, self.lock_timeout_message)
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.slug, "test")
+        self.assertEqual(self.component.name, "Test")
+
+    def test_rename_project_repository_locked(self) -> None:
+        self.make_manager()
+        url = reverse("rename", kwargs={"path": self.project.get_url_path()})
+        lock_error = WeblateLockTimeoutError(
+            "repository locked", lock=self.component.repository.lock.lock_object
+        )
+
+        with patch.object(RepositoryLock, "__enter__", side_effect=lock_error):
+            response = self.client.post(
+                url,
+                {"slug": "locked-project", "name": "Locked project"},
+                follow=True,
+            )
+
+        self.assertRedirects(response, f"{self.project.get_absolute_url()}#organize")
+        self.assertContains(response, self.lock_timeout_message)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.slug, "test")
+        self.assertEqual(self.project.name, "Test")
+
+    def test_rename_category_repository_locked(self) -> None:
+        self.make_manager()
+        category = Category.objects.create(
+            name="Category", slug="category", project=self.project
+        )
+        Component.objects.filter(pk=self.component.pk).update(category=category)
+        url = reverse("rename", kwargs={"path": category.get_url_path()})
+        lock_error = WeblateLockTimeoutError(
+            "repository locked", lock=self.component.repository.lock.lock_object
+        )
+
+        with patch.object(RepositoryLock, "__enter__", side_effect=lock_error):
+            response = self.client.post(
+                url,
+                {
+                    "project": self.project.pk,
+                    "slug": "locked-category",
+                    "name": "Locked category",
+                },
+                follow=True,
+            )
+
+        self.assertRedirects(response, f"{category.get_absolute_url()}#organize")
+        self.assertContains(response, self.lock_timeout_message)
+        category.refresh_from_db()
+        self.assertEqual(category.slug, "category")
+        self.assertEqual(category.name, "Category")
 
     def test_rename_component_replaces_stale_target_dir(self) -> None:
         self.make_manager()

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -37,6 +37,7 @@ from weblate.trans.models import (
 from weblate.trans.models.component import ComponentQuerySet
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import create_test_billing
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.render import (
     validate_render_addon,
     validate_render_commit,
@@ -1287,6 +1288,28 @@ class SettingsTest(ViewTestCase):
             self.assertFalse(
                 unit.translated, f"{unit} should not be marked as translated"
             )
+
+    def test_component_repository_locked(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        url = reverse("settings", kwargs=self.kw_component)
+        response = self.client.get(url)
+        data = get_form_data(response.context["form"].initial)
+        data["license"] = "MIT"
+        lock_error = WeblateLockTimeoutError(
+            "repository locked", lock=self.component.repository.lock.lock_object
+        )
+
+        with patch.object(Component, "locked_for_update", side_effect=lock_error):
+            response = self.client.post(url, data, follow=True)
+
+        self.assertRedirects(response, url)
+        self.assertContains(
+            response,
+            "There appears to be an ongoing operation on the repository. "
+            "Please try again later.",
+        )
+        self.component.refresh_from_db()
+        self.assertNotEqual(self.component.license, "MIT")
 
     def test_component_inherited_required_license_validates(self) -> None:
         self.project.add_user(self.user, "Administration")

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -62,6 +62,7 @@ from weblate.trans.tasks import (
 )
 from weblate.trans.util import redirect_param, render
 from weblate.utils import messages
+from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.random import get_random_identifier
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.utils.views import aparse_path, parse_path, show_form_errors
@@ -72,6 +73,15 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from weblate.auth.models import AuthenticatedHttpRequest
+
+
+def _show_repository_lock_timeout(request: AuthenticatedHttpRequest) -> None:
+    messages.error(
+        request,
+        gettext(
+            "There appears to be an ongoing operation on the repository. Please try again later."
+        ),
+    )
 
 
 @never_cache
@@ -89,7 +99,13 @@ def change(request: AuthenticatedHttpRequest, path):
         raise Http404
 
     if isinstance(obj, Component):
-        return change_component(request, obj)
+        try:
+            return change_component(request, obj)
+        except WeblateLockTimeoutError:
+            if request.method != "POST":
+                raise
+            _show_repository_lock_timeout(request)
+            return redirect("settings", path=obj.get_url_path())
     if isinstance(obj, Category):
         return change_category(request, obj)
     if isinstance(obj, ProjectLanguage):
@@ -381,11 +397,15 @@ def perform_rename(
 @require_POST
 def rename(request: AuthenticatedHttpRequest, path):
     obj = parse_path(request, path, (Component, Project, Category))
-    if isinstance(obj, Component):
-        return perform_rename(ComponentRenameForm, request, obj, "component.edit")
-    if isinstance(obj, Category):
-        return perform_rename(CategoryRenameForm, request, obj, "project.edit")
-    return perform_rename(ProjectRenameForm, request, obj, "project.edit")
+    try:
+        if isinstance(obj, Component):
+            return perform_rename(ComponentRenameForm, request, obj, "component.edit")
+        if isinstance(obj, Category):
+            return perform_rename(CategoryRenameForm, request, obj, "project.edit")
+        return perform_rename(ProjectRenameForm, request, obj, "project.edit")
+    except WeblateLockTimeoutError:
+        _show_repository_lock_timeout(request)
+        return redirect_param(obj, "#organize")
 
 
 @login_required


### PR DESCRIPTION
Repository operations can legitimately outlive the web lock wait. Show a retry-later message for rename and component settings instead of surfacing expected contention as an unhandled error.

Fixes #21140

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
