### PR TITLE
fix(backups): allowlist restored VCS metadata

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@ Weblate 2026.9
 
 * Project and workspace translation memory now respects restricted component access, and restricted components no longer contribute to shared translation memory.
 * GitLab merge request forks now disable Git LFS to avoid missing-object push failures. See :ref:`git-lfs`.
+* :ref:`Project backup restores <projectbackup>` now allowlists repository metadata for Git, git-svn, and Mercurial to prevent archives from supplying executable configuration or repository indirection.
 
 .. rubric:: Compatibility
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -634,9 +634,9 @@ Security properties Weblate provides
    * - Repository, branch, path, and VCS inputs processed by Weblate must not
        become shell command execution. *(maintainer)*
      - VCS operations are invoked through Weblate-supported repository
-       workflows and configured credentials. Project backup restores discard
-       archive-supplied repository-local Git and Mercurial configuration, Git
-       hooks, and Mercurial shared-repository indirection.
+       workflows and configured credentials. Project backup restores allow only
+       non-executable Git, git-svn, and Mercurial repository state, and rebuild
+       repository-local configuration from validated component settings.
      - Command injection or arbitrary code execution as the Weblate user.
      - Security-critical.
    * - Private project data, user data, credentials, tokens, SSH keys, and 2FA

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -89,6 +89,7 @@ from weblate.utils.zip import (
 from weblate.utils.zip import (
     validate_zip_members as validate_safe_zip_members,
 )
+from weblate.vcs.models import VCS_REGISTRY
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -97,6 +98,7 @@ if TYPE_CHECKING:
     from django.core.files.storage import Storage
 
     from weblate.billing.models import Billing
+    from weblate.vcs.base import Repository
     from weblate.workspaces.models import Workspace
 
 warnings.filterwarnings("error", module="zipfile")
@@ -198,7 +200,9 @@ class ProjectBackup:
         self.memory_loaded = False
         self.category_paths: set[str] = set()
         self.component_full_slugs: set[str] = set()
+        self.component_slugs_by_length: list[str] = []
         self.component_repo_links: set[str] = set()
+        self.component_vcs: dict[str, type[Repository] | None] = {}
         self.label_names: set[str] = set()
         self.name_siblings: set[tuple[str, str]] = set()
         self.path_siblings: set[tuple[str, str]] = set()
@@ -949,35 +953,53 @@ class ProjectBackup:
             if name.startswith(self.COMPONENTS_PREFIX) and name.endswith(".json")
         ]
 
-    @staticmethod
-    def is_unsafe_vcs_path(path: str) -> bool:
-        normalized = path.replace("\\", "/")
-        casefolded = normalized.casefold()
-        parts = PurePosixPath(casefolded).parts
-        filename = parts[-1] if parts else ""
-        # Mercurial reads hgrc variants and can redirect configuration lookup
-        # through sharedpath.
-        unsafe_mercurial_path = (
-            len(parts) > 1
-            and parts[-2] == ".hg"
-            and (filename.startswith("hgrc") or filename == "sharedpath")
+    @classmethod
+    def is_safe_vcs_path(cls, path: str, vcs: str | type[Repository] | None) -> bool:
+        normalized = path.replace("\\", "/").casefold()
+        parts = PurePosixPath(normalized).parts
+        repository_classes = VCS_REGISTRY.get_unfiltered_data()
+        metadata_dirs = {
+            repository_class.metadata_dir_name.casefold()
+            for repository_class in repository_classes.values()
+            if repository_class.metadata_dir_name is not None
+        }
+        if not isinstance(vcs, str) and vcs is not None and vcs.metadata_dir_name:
+            metadata_dirs.add(vcs.metadata_dir_name.casefold())
+        metadata_positions = [
+            index for index, part in enumerate(parts) if part in metadata_dirs
+        ]
+        if not metadata_positions:
+            return True
+        if len(metadata_positions) != 1 or metadata_positions[0] != 0:
+            return False
+
+        repository_class = repository_classes.get(vcs) if isinstance(vcs, str) else vcs
+        if (
+            repository_class is None
+            or repository_class.metadata_dir_name is None
+            or parts[0] != repository_class.metadata_dir_name.casefold()
+        ):
+            return False
+        return repository_class.is_safe_backup_metadata_path(parts[1:])
+
+    def get_vcs_component(self, path: str) -> str | None:
+        return next(
+            (
+                slug
+                for slug in self.component_slugs_by_length
+                if path == slug or path.startswith(f"{slug}/")
+            ),
+            None,
         )
-        return (
-            unsafe_mercurial_path
-            or casefolded.endswith(
-                (
-                    "/.git",
-                    "/.git/config",
-                    "/.git/config.worktree",
-                    "/.git/hooks",
-                    "/.git/modules",
-                )
-            )
-            # Hooks are executable content; Gerrit's commit-msg hook is recreated
-            # by git-review when needed.
-            or "/.git/hooks/" in casefolded
-            or "/.git/modules/" in casefolded
-        )
+
+    def finalize_restored_repositories(self, project_path: Path) -> None:
+        """Recreate derived repository state excluded from the backup."""
+        for component, repository_class in self.component_vcs.items():
+            if component in self.component_repo_links or repository_class is None:
+                continue
+            repository = repository_class(str(project_path / component), local=True)
+            with repository.lock:
+                repository.finalize_backup_restore()
 
     @classmethod
     def get_limit(cls, setting_name: str, default: int) -> int:
@@ -1144,6 +1166,9 @@ class ProjectBackup:
         if full_slug in self.component_full_slugs:
             raise ValidationError({filename: [gettext("Duplicate component slug.")]})
         self.component_full_slugs.add(full_slug)
+        self.component_vcs[full_slug] = VCS_REGISTRY.get_unfiltered_data().get(
+            component["vcs"]
+        )
         if component["repo"].startswith("weblate:"):
             self.component_repo_links.add(full_slug)
 
@@ -1420,19 +1445,11 @@ class ProjectBackup:
 
     def validate_vcs_component_paths(self, zipfile: ZipFile) -> None:
         """Ensure every restored repository member belongs to a local component."""
-        components = sorted(self.component_full_slugs, key=len, reverse=True)
         for info in zipfile.infolist():
             if info.is_dir() or not info.filename.startswith(self.VCS_PREFIX):
                 continue
             path = info.filename[self.VCS_PREFIX_LEN :]
-            component = next(
-                (
-                    slug
-                    for slug in components
-                    if path == slug or path.startswith(f"{slug}/")
-                ),
-                None,
-            )
+            component = self.get_vcs_component(path)
             if component is None:
                 raise ValidationError(
                     {
@@ -1619,7 +1636,9 @@ class ProjectBackup:
         self.memory_data.clear()
         self.memory_loaded = False
         self.component_full_slugs = set()
+        self.component_slugs_by_length = []
         self.component_repo_links = set()
+        self.component_vcs = {}
         self.category_paths = set()
         self.path_siblings = set()
         self.name_siblings = set()
@@ -1633,6 +1652,9 @@ class ProjectBackup:
         )
         self.load_memory(zipfile)
         self.load_components(zipfile)
+        self.component_slugs_by_length = sorted(
+            self.component_full_slugs, key=len, reverse=True
+        )
         self.validate_vcs_component_paths(zipfile)
         self.validate_team_references(validate_roles=validate_roles)
 
@@ -2391,7 +2413,13 @@ class ProjectBackup:
             if info.is_dir() or not info.filename.startswith(self.VCS_PREFIX):
                 return True
             path = info.filename[self.VCS_PREFIX_LEN :]
-            return path != os.path.normpath(path) or self.is_unsafe_vcs_path(path)
+            component = self.get_vcs_component(path)
+            if component is None:
+                return True
+            repository_path = path.removeprefix(component).lstrip("/")
+            return path != os.path.normpath(path) or not self.is_safe_vcs_path(
+                repository_path, self.component_vcs[component]
+            )
 
         def vcs_member_name(info: ZipInfo) -> str:
             return info.filename[self.VCS_PREFIX_LEN :]
@@ -2406,6 +2434,8 @@ class ProjectBackup:
             if vcs_member_name(info).endswith(".git/packed-refs"):
                 git_refs_dir = targetpath.parent / "refs"
                 git_refs_dir.mkdir(parents=True, exist_ok=True)
+
+        self.finalize_restored_repositories(project_path)
 
         self.load_components(
             zipfile,

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -57,7 +57,8 @@ from weblate.trans.tasks import (
 )
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import get_test_file
-from weblate.vcs.git import GitRepository
+from weblate.vcs.git import GitRepository, SubversionRepository
+from weblate.vcs.mercurial import HgRepository
 from weblate.workspaces.models import Workspace
 
 TEST_SCREENSHOT = get_test_file("screenshot.png")
@@ -1708,50 +1709,55 @@ class BackupsTest(ViewTestCase):
 
         self.assertTrue(os.path.isdir(project_path))
 
-    def test_unsafe_vcs_paths(self) -> None:
-        for path in (
-            "test/.hg/hgrc",
-            "test/.hg/hgrc-not-shared",
-            "test/.hg/hgrc-future",
-            "test/nested/.hg/hgrc",
-            "test/.hg/sharedpath",
-            "test\\.hg\\hgrc-not-shared",
-            "test/.HG/HGRC-NOT-SHARED",
-            "test/.Hg/HgRc-Future",
-            "test/.HG/SHAREDPATH",
-            "test/.GIT/CONFIG",
-            "test/.GiT/HOOKS/pre-commit",
-            "test/.GIT/MODULES/submodule/config",
-        ):
-            with self.subTest(path=path):
-                self.assertTrue(ProjectBackup.is_unsafe_vcs_path(path))
+    def test_safe_vcs_paths(self) -> None:
+        safe_paths = (
+            ("git", "README.md"),
+            ("git", ".GIT\\OBJECTS\\INFO\\PACKS"),
+            ("subversion", ".git/svn/refs/remotes/origin/.rev_map.UUID"),
+            ("mercurial", ".HG\\STORE\\META\\manifest.i"),
+        )
+        for vcs, path in safe_paths:
+            with self.subTest(vcs=vcs, path=path):
+                self.assertTrue(ProjectBackup.is_safe_vcs_path(path, vcs))
 
-        for path in (
-            "test/hgrc-not-shared",
-            "test/.hg/hgrc.d/example.rc",
-            "test/.hg/store/data/hgrc.i",
-            "test/.hg/store/sharedpath",
-            "test/.HG/store/data/HGRC.i",
-            "test/.GITISH/HOOKS/pre-commit",
-            "test/.git/hooks-backup/pre-commit",
-        ):
-            with self.subTest(path=path):
-                self.assertFalse(ProjectBackup.is_unsafe_vcs_path(path))
+        unsafe_paths = (
+            ("git", ".git"),
+            ("git", ".git/config"),
+            ("git", "nested/.git/HEAD"),
+            ("git", ".hg/store/data/file.i"),
+            ("git", ".git/refs/nested/.git/config"),
+            ("subversion", ".git/svn/refs/remotes/origin/unhandled.log"),
+            ("mercurial", "nested/.hg/requires"),
+            ("unknown", ".git/HEAD"),
+        )
+        for vcs, path in unsafe_paths:
+            with self.subTest(vcs=vcs, path=path):
+                self.assertFalse(ProjectBackup.is_safe_vcs_path(path, vcs))
 
     def test_restore_skips_unsafe_vcs_files(self) -> None:
         backup = ProjectBackup()
         backup.backup_project(self.project)
-        unsafe_paths = (
-            ".git/hooks/post-checkout",
-            ".hg/hgrc",
-            ".hg/hgrc-not-shared",
-            ".hg/hgrc-future",
-            ".hg/sharedpath",
-            ".HG/HGRC-NOT-SHARED",
-            ".Hg/SharedPath",
-            ".GIT/HOOKS/pre-commit",
-            ".GiT/CONFIG",
-        )
+        marker = Path(settings.DATA_DIR) / "PWNED_COMMONDIR"
+        marker.unlink(missing_ok=True)
+        self.addCleanup(marker.unlink, missing_ok=True)
+        unsafe_paths = {
+            ".git/commondir": b"evil\n",
+            ".git/evil/config": (
+                b'[filter "pwn"]\n'
+                + f"clean = touch {marker.as_posix()}\n".encode()
+                + b"required = true\n"
+            ),
+            ".git/evil/info/attributes": b"* filter=pwn\n",
+            ".git/hooks/post-checkout": b"unsafe",
+            ".git/info/attributes": b"unsafe",
+            ".git/modules/submodule/config": b"unsafe",
+            ".git/objects/info/alternates": b"evil/objects\n",
+            ".git/worktrees/evil/config": b"unsafe",
+            ".hg/hgrc": b"unsafe",
+            ".hg/sharedpath": b"unsafe",
+            ".GIT/HOOKS/pre-commit": b"unsafe",
+            ".GiT/CONFIG": b"unsafe",
+        }
 
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:
             temp_name = temp_handle.name
@@ -1762,9 +1768,19 @@ class BackupsTest(ViewTestCase):
                 ZipFile(temp_name, "w") as target_zip,
             ):
                 for item in source_zip.infolist():
-                    target_zip.writestr(item, source_zip.read(item.filename))
-                for path in unsafe_paths:
-                    target_zip.writestr(f"vcs/test/{path}", b"unsafe")
+                    data = source_zip.read(item.filename)
+                    target_zip.writestr(item, data)
+                    git_prefix = "vcs/test/.git/"
+                    if (
+                        item.filename.startswith(
+                            (f"{git_prefix}objects/", f"{git_prefix}refs/")
+                        )
+                        or item.filename == f"{git_prefix}packed-refs"
+                    ):
+                        relative_path = item.filename.removeprefix(git_prefix)
+                        target_zip.writestr(f"{git_prefix}evil/{relative_path}", data)
+                for path, data in unsafe_paths.items():
+                    target_zip.writestr(f"vcs/test/{path}", data)
 
             restore = ProjectBackup(temp_name)
             restore.validate()
@@ -1774,13 +1790,25 @@ class BackupsTest(ViewTestCase):
             component = restored.component_set.get(slug="test")
             repository = component.repository
             assert isinstance(repository, GitRepository)
-            for path in unsafe_paths:
+            for path, payload in unsafe_paths.items():
                 with self.subTest(path=path):
                     restored_path = os.path.join(component.full_path, path)
                     if os.path.exists(restored_path):
                         # On case-insensitive filesystems, a mixed-case path can
                         # resolve to the legitimate .git/config from the backup.
-                        self.assertNotEqual(Path(restored_path).read_bytes(), b"unsafe")
+                        self.assertNotEqual(Path(restored_path).read_bytes(), payload)
+            with repository.lock:
+                common_dir = Path(
+                    repository.execute(
+                        ["rev-parse", "--git-common-dir"], remote_op="none"
+                    ).strip()
+                )
+                if not common_dir.is_absolute():
+                    common_dir = Path(component.full_path) / common_dir
+                self.assertEqual(
+                    common_dir.resolve(),
+                    (Path(component.full_path) / ".git").resolve(),
+                )
             self.assertEqual(repository.get_config("remote.origin.url"), component.repo)
             self.assertEqual(
                 repository.get_config(f"branch.{component.branch}.remote"),
@@ -1790,7 +1818,120 @@ class BackupsTest(ViewTestCase):
                 repository.get_config(f"branch.{component.branch}.merge"),
                 f"refs/heads/{component.branch}",
             )
+            security_test = Path(component.full_path) / "security-test.txt"
+            security_test.write_text("security test", encoding="utf-8")
+            with repository.lock:
+                self.assertTrue(
+                    repository.commit("Security test", files=[security_test.name])
+                )
+                self.assertEqual(
+                    repository.execute(
+                        [
+                            "diff-tree",
+                            "--no-commit-id",
+                            "--name-only",
+                            "-r",
+                            "HEAD^",
+                            "HEAD",
+                        ],
+                        remote_op="none",
+                    ).splitlines(),
+                    [security_test.name],
+                )
+            self.assertFalse(marker.exists())
             restored.do_reset()
+
+    def test_restore_git_svn_metadata_allowlist(self) -> None:
+        self.create_po(vcs="subversion", name="Subversion", project=self.project)
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+
+        with ZipFile(backup.filename, "r") as source_zip:
+            git_svn_prefix = "vcs/subversion/.git/svn/"
+            rev_map_names = [
+                name
+                for name in source_zip.namelist()
+                if name.startswith(git_svn_prefix)
+                and "/.rev_map." in name.removeprefix(git_svn_prefix)
+            ]
+        if not rev_map_names:
+            self.skipTest("git-svn fixture has no revision map")
+
+        unsafe_name = f"{git_svn_prefix}injected/unhandled.log"
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:
+            temp_name = temp_handle.name
+
+        with remove_file_after(temp_name):
+            with (
+                ZipFile(backup.filename, "r") as source_zip,
+                ZipFile(temp_name, "w") as target_zip,
+            ):
+                for item in source_zip.infolist():
+                    target_zip.writestr(item, source_zip.read(item.filename))
+                target_zip.writestr(unsafe_name, b"unsafe")
+
+            restore = ProjectBackup(temp_name)
+            restore.validate()
+            restored = restore.restore(
+                project_name="Restored", project_slug="restored", user=self.user
+            )
+            component = restored.component_set.get(slug="subversion")
+            repository = component.repository
+            assert isinstance(repository, SubversionRepository)
+            for name in rev_map_names:
+                relative_name = name.removeprefix("vcs/subversion/")
+                self.assertTrue(Path(component.full_path, relative_name).is_file())
+            self.assertFalse(
+                Path(
+                    component.full_path,
+                    unsafe_name.removeprefix("vcs/subversion/"),
+                ).exists()
+            )
+            self.assertEqual(
+                repository.get_config("svn-remote.svn.url"), component.repo
+            )
+
+    def test_restore_mercurial_metadata_allowlist(self) -> None:
+        self.create_po(vcs="mercurial", name="Mercurial", project=self.project)
+        backup = ProjectBackup()
+        backup.backup_project(self.project)
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_handle:
+            temp_name = temp_handle.name
+
+        malicious_config = b"[hooks]\ncommit.pwn = touch PWNED\n"
+        config_name = "vcs/mercurial/.hg/hgrc"
+        with remove_file_after(temp_name):
+            config_replaced = False
+            with (
+                ZipFile(backup.filename, "r") as source_zip,
+                ZipFile(temp_name, "w") as target_zip,
+            ):
+                for item in source_zip.infolist():
+                    if item.filename == config_name:
+                        data = malicious_config
+                        config_replaced = True
+                    else:
+                        data = source_zip.read(item.filename)
+                    target_zip.writestr(item, data)
+                target_zip.writestr("vcs/mercurial/.hg/sharedpath", b"evil")
+            self.assertTrue(config_replaced)
+
+            restore = ProjectBackup(temp_name)
+            restore.validate()
+            restored = restore.restore(
+                project_name="Restored", project_slug="restored", user=self.user
+            )
+            component = restored.component_set.get(slug="mercurial")
+            repository = component.repository
+            assert isinstance(repository, HgRepository)
+            metadata_dir = Path(component.full_path, ".hg")
+            self.assertTrue(repository.is_valid())
+            self.assertTrue((metadata_dir / "dirstate").is_file())
+            self.assertTrue((metadata_dir / "store" / "00changelog.i").is_file())
+            self.assertNotIn(malicious_config, (metadata_dir / "hgrc").read_bytes())
+            self.assertFalse((metadata_dir / "sharedpath").exists())
+            self.assertEqual(repository.get_config("paths", "default"), component.repo)
 
     def test_restore_rejects_invalid_screenshot(self) -> None:
         screenshot = Screenshot.objects.create(

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -804,6 +804,15 @@ class Repository:
             return None
         return metadata_dir
 
+    @classmethod
+    # ruff: ignore[unused-class-method-argument]
+    def is_safe_backup_metadata_path(cls, parts: tuple[str, ...]) -> bool:
+        """Return whether repository metadata can be restored from a backup."""
+        return False
+
+    def finalize_backup_restore(self) -> None:
+        """Recreate derived repository state after backup extraction."""
+
     def get_repo_temp_dir(self, create: bool = True) -> Path | None:
         metadata_dir = self.get_metadata_dir()
         if metadata_dir is None:

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -364,6 +364,26 @@ class GitRepository(Repository):
     remote_compatibility_deepen: ClassVar[int] = 50
     pinned_remote_schemes: ClassVar[frozenset[str]] = frozenset({"https", "ssh"})
 
+    BACKUP_METADATA_FILES: ClassVar[frozenset[str]] = frozenset(
+        {"head", "packed-refs", "shallow"}
+    )
+    BACKUP_OBJECT_INFO_FILES: ClassVar[frozenset[str]] = frozenset(
+        {"commit-graph", "packs"}
+    )
+    BACKUP_LOOSE_OBJECT_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r"[0-9a-f]{2}/(?:[0-9a-f]{38}|[0-9a-f]{62})\Z"
+    )
+    BACKUP_PACK_OBJECT_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r"pack-(?:[0-9a-f]{40}|[0-9a-f]{64})"
+        r"\.(?:bitmap|idx|keep|mtimes|pack|promisor|rev)\Z"
+    )
+    BACKUP_MULTI_PACK_BITMAP_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r"multi-pack-index-(?:[0-9a-f]{40}|[0-9a-f]{64})\.bitmap\Z"
+    )
+    BACKUP_COMMIT_GRAPH_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r"graph-(?:[0-9a-f]{40}|[0-9a-f]{64})\.graph\Z"
+    )
+
     RESERVED_BRANCH_NAMES: ClassVar[frozenset[str]] = frozenset(
         {
             "HEAD",
@@ -414,6 +434,40 @@ class GitRepository(Repository):
         return os.path.exists(
             os.path.join(self.path, ".git", "config")
         ) or os.path.exists(os.path.join(self.path, "config"))
+
+    @classmethod
+    def is_safe_backup_metadata_path(cls, parts: tuple[str, ...]) -> bool:
+        """Return whether Git metadata can be restored from a backup."""
+        if not parts:
+            return False
+        if len(parts) == 1:
+            return parts[0] in cls.BACKUP_METADATA_FILES
+        if parts[0] == "refs":
+            return True
+        if parts[0] != "objects":
+            return False
+        if len(parts) < 3:
+            return False
+        if parts[1] == "pack" and len(parts) == 3:
+            return parts[2] == "multi-pack-index" or bool(
+                cls.BACKUP_PACK_OBJECT_RE.fullmatch(parts[2])
+                or cls.BACKUP_MULTI_PACK_BITMAP_RE.fullmatch(parts[2])
+            )
+        if parts[1] != "info":
+            return len(parts) == 3 and bool(
+                cls.BACKUP_LOOSE_OBJECT_RE.fullmatch("/".join(parts[1:]))
+            )
+        if len(parts) == 3 and parts[2] in cls.BACKUP_OBJECT_INFO_FILES:
+            return True
+        if parts[2] != "commit-graphs" or len(parts) != 4:
+            return False
+        return parts[3] == "commit-graph-chain" or bool(
+            cls.BACKUP_COMMIT_GRAPH_RE.fullmatch(parts[3])
+        )
+
+    def finalize_backup_restore(self) -> None:
+        """Rebuild the index excluded from restored backups."""
+        self.execute(["read-tree", "--reset", "HEAD"], remote_op="none")
 
     @classmethod
     def create_blank_repository(cls, path: str) -> None:
@@ -1732,6 +1786,13 @@ class SubversionRepository(GitRepository):
     ) -> None:
         super().__init__(path, branch=branch, component=component, local=local)
         self._fetch_revision: str | None = None
+
+    @classmethod
+    def is_safe_backup_metadata_path(cls, parts: tuple[str, ...]) -> bool:
+        """Return whether git-svn metadata can be restored from a backup."""
+        return super().is_safe_backup_metadata_path(parts) or (
+            len(parts) > 2 and parts[0] == "svn" and parts[-1].startswith(".rev_map.")
+        )
 
     @classmethod
     def global_setup(cls) -> None:

--- a/weblate/vcs/mercurial.py
+++ b/weblate/vcs/mercurial.py
@@ -36,6 +36,14 @@ class HgRepository(Repository):
 
     metadata_dir_name: ClassVar[str] = ".hg"
 
+    BACKUP_METADATA_FILES: ClassVar[frozenset[str]] = frozenset(
+        {"bookmarks", "bookmarks.current", "branch", "dirstate", "requires"}
+    )
+    BACKUP_STORE_FILES: ClassVar[frozenset[str]] = frozenset(
+        {"bookmarks", "fncache", "obsstore", "phaseroots", "requires"}
+    )
+    BACKUP_STORE_DIRS: ClassVar[frozenset[str]] = frozenset({"data", "dh", "meta"})
+
     _cmd: ClassVar[str] = "rhg" if which("rhg") is not None else "hg"
     _cmd_last_revision: ClassVar[list[str]] = [
         "log",
@@ -74,6 +82,21 @@ class HgRepository(Repository):
     def is_valid(self):
         """Check whether this is a valid repository."""
         return os.path.exists(os.path.join(self.path, ".hg", "requires"))
+
+    @classmethod
+    def is_safe_backup_metadata_path(cls, parts: tuple[str, ...]) -> bool:
+        """Return whether Mercurial metadata can be restored from a backup."""
+        if not parts:
+            return False
+        if len(parts) == 1:
+            return parts[0] in cls.BACKUP_METADATA_FILES
+        if parts[0] != "store":
+            return False
+        if len(parts) == 2:
+            return parts[1] in cls.BACKUP_STORE_FILES or parts[1].startswith(
+                ("00changelog.", "00manifest.")
+            )
+        return parts[1] in cls.BACKUP_STORE_DIRS
 
     @classmethod
     def create_blank_repository(cls, path: str) -> None:

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -41,6 +41,7 @@ from weblate.utils.tests import http_mock
 from weblate.utils.zip import ZipSafetyLimits
 from weblate.vcs import git as git_module
 from weblate.vcs.base import (
+    Repository,
     RepositoryCommandError,
     RepositoryError,
     RepositoryRedirectError,
@@ -76,8 +77,6 @@ from weblate.vcs.ssh import SSH_WRAPPER, add_host_key
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
-
-    from weblate.vcs.base import Repository
 
 
 class AzureDevOpsFakeRepository(AzureDevOpsRepository):
@@ -166,6 +165,74 @@ class RepositoryTest(SimpleTestCase):
         for git_dir_name in git_dirs:
             (git_dir / git_dir_name).mkdir()
         return GitRepository(tempdir, branch=branch, local=True), git_dir
+
+    def test_backup_metadata_paths(self) -> None:
+        cases = (
+            (Repository, "config", False),
+            (GitRepository, "head", True),
+            (GitRepository, "packed-refs", True),
+            (GitRepository, "shallow", True),
+            (GitRepository, "refs/heads/main", True),
+            (GitRepository, f"objects/01/{'0' * 38}", True),
+            (GitRepository, f"objects/pack/pack-{'0' * 40}.pack", True),
+            (GitRepository, "objects/info/commit-graph", True),
+            (GitRepository, "objects/info/packs", True),
+            (GitRepository, "commondir", False),
+            (GitRepository, "config", False),
+            (GitRepository, "evil/config", False),
+            (GitRepository, "hooks/pre-commit", False),
+            (GitRepository, "info/attributes", False),
+            (GitRepository, "modules/submodule/config", False),
+            (GitRepository, "objects/evil/config", False),
+            (GitRepository, "objects/info/alternates", False),
+            (GitRepository, "worktrees/evil/config", False),
+            (
+                GitRepository,
+                "svn/refs/remotes/origin/.rev_map.uuid",
+                False,
+            ),
+            (
+                SubversionRepository,
+                "svn/refs/remotes/origin/.rev_map.uuid",
+                True,
+            ),
+            (
+                SubversionRepository,
+                "svn/refs/remotes/origin/unhandled.log",
+                False,
+            ),
+            (HgRepository, "requires", True),
+            (HgRepository, "dirstate", True),
+            (HgRepository, "store/00changelog.i", True),
+            (HgRepository, "store/data/hgrc.i", True),
+            (HgRepository, "store/meta/manifest.i", True),
+            (HgRepository, "hgrc", False),
+            (HgRepository, "hgrc-not-shared", False),
+            (HgRepository, "sharedpath", False),
+            (HgRepository, "cache/branch2-served", False),
+            (HgRepository, "store/unknown", False),
+        )
+        for repository_class, path, expected in cases:
+            with self.subTest(repository=repository_class.__name__, path=path):
+                self.assertEqual(
+                    repository_class.is_safe_backup_metadata_path(
+                        tuple(path.split("/"))
+                    ),
+                    expected,
+                )
+
+    def test_git_finalize_backup_restore(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repository, _ = self.create_git_repository(tempdir)
+            with (
+                patch.object(repository, "ensure_lock_session_recovered"),
+                repository.lock,
+                patch.object(repository, "execute") as execute,
+            ):
+                repository.finalize_backup_restore()
+        execute.assert_called_once_with(
+            ["read-tree", "--reset", "HEAD"], remote_op="none"
+        )
 
     def make_stale_lock(self, lockfile: Path) -> None:
         lockfile.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Treat archive-supplied repository metadata as untrusted and restore only the backend-specific state needed by Git, git-svn, and Mercurial. This prevents metadata indirection such as Git commondir from reintroducing executable configuration.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
