### PR TITLE
fix(vcs): disable LFS on GitLab forks

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Weblate 2026.9
 .. rubric:: Bug fixes
 
 * Project and workspace translation memory now respects restricted component access, and restricted components no longer contribute to shared translation memory.
+* GitLab merge request forks now disable Git LFS to avoid missing-object push failures. See :ref:`git-lfs`.
 
 .. rubric:: Compatibility
 

--- a/docs/snippets/git-export-lfs-note.rst
+++ b/docs/snippets/git-export-lfs-note.rst
@@ -1,7 +1,7 @@
 .. note::
 
    Weblate serves the Git repository itself, but it does not serve Git LFS
-   objects. For repositories using Git LFS, clone from the upstream repository
-   and add Weblate as another remote. If you only need Git-tracked files, you
-   can clone from Weblate with ``GIT_LFS_SKIP_SMUDGE=1`` to skip downloading
-   Git LFS objects.
+   objects. See :ref:`git-lfs` for supported behavior. Clone repositories using
+   Git LFS from the upstream repository and add Weblate as another remote. If
+   you only need Git-tracked files, you can clone from Weblate with
+   ``GIT_LFS_SKIP_SMUDGE=1`` to skip downloading Git LFS objects.

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -294,11 +294,26 @@ Git
 
    Weblate needs Git 2.46 or newer.
 
-.. note::
+.. _git-lfs:
 
-   Weblate does not configure or transfer Git LFS objects. Git LFS smudging
-   and pre-push uploads are disabled for Weblate-managed repositories, so LFS
-   tracked files remain pointer files and cannot be used as translation files.
+Git LFS
++++++++
+
+Weblate does not support files tracked by Git LFS as translation files. It does
+not download or upload Git LFS objects. Git LFS smudging and pre-push uploads
+are disabled for Weblate-managed repositories, so LFS-tracked files remain
+pointer files. This behavior applies to every Git hosting provider.
+
+A repository can use Git LFS for files that Weblate does not need to read or
+modify. The upstream repository remains the authoritative source for these LFS
+objects. Clone from upstream when you need the actual files rather than their
+pointers because repositories served by Weblate do not include LFS objects.
+
+For the GitLab merge request workflow, Weblate disables Git LFS in its managed
+fork. This prevents GitLab from rejecting pointer-only translation branches
+when the upstream repository added LFS objects after the fork was created.
+Existing managed forks are reconfigured on their next push. This does not
+change the Git LFS configuration of the upstream project.
 
 .. note::
 

--- a/weblate/templates/trans/alert/common-repo.html
+++ b/weblate/templates/trans/alert/common-repo.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n translations %}
 
 {% if analysis.redirect %}
   <p>
@@ -31,6 +31,12 @@
     {% else %}
       {% translate "The GitHub repository allows only collaborators to create pull requests. Ask a repository maintainer to allow pull requests from all users." %}
     {% endif %}
+  </p>
+{% endif %}
+
+{% if analysis.git_lfs_missing_objects %}
+  <p>
+    {% translate "The repository references Git LFS objects that are missing from the push destination. Weblate does not download or upload Git LFS objects, and files tracked by Git LFS cannot be used as translation files." %} {% documentation_icon "vcs" "git-lfs" %}
   </p>
 {% endif %}
 

--- a/weblate/trans/alerts/vcs.py
+++ b/weblate/trans/alerts/vcs.py
@@ -86,6 +86,7 @@ class RepositoryErrorAlert(ErrorAlert):
     def get_analysis(self) -> dict[str, Any]:
         return {
             "redirect": self.has_diagnosis("repository_redirect"),
+            "git_lfs_missing_objects": self.has_diagnosis("git_lfs_missing_objects"),
         }
 
     @classmethod

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -1905,6 +1905,41 @@ class RepositoryAlertTemplateTest(SimpleTestCase):
 
         self.assertIn("n’a pas été trouvé. Veuillez vérifier", rendered)
 
+    def test_git_lfs_diagnosis_links_documentation(self) -> None:
+        component = SimpleNamespace(
+            get_ssh_host_key_mismatch_error_message=lambda: "host key changed",
+            get_ssh_host_key_error_message=lambda: "host key missing",
+            push="",
+            repo="",
+            vcs="git",
+            merge_style="merge",
+            push_branch="",
+        )
+        instance = cast("Alert", SimpleNamespace(component=component))
+        alerts = (
+            UpdateFailure(
+                instance,
+                "remote rejected the push",
+                diagnoses=[{"code": "git_lfs_missing_objects"}],
+            ),
+            UpdateFailure(
+                instance,
+                "remote: GitLab: LFS objects are missing.",
+            ),
+        )
+
+        for alert in alerts:
+            with self.subTest(diagnoses=alert.diagnoses):
+                rendered = render_to_string(
+                    "trans/alert/common-repo.html",
+                    {"analysis": alert.get_analysis()},
+                )
+
+                self.assertIn(
+                    "Weblate does not download or upload Git LFS objects", rendered
+                )
+                self.assertIn("vcs.html#git-lfs", rendered)
+
     def test_github_pull_request_diagnosis_renders_username(self) -> None:
         rendered = render_to_string(
             "trans/alert/common-repo.html",

--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -131,6 +131,7 @@ type RemoteOperation = Literal["none", "pull", "push"]
 type RepositoryDiagnosisCode = Literal[
     "branch_behind",
     "gerrit_permission",
+    "git_lfs_missing_objects",
     "github_pull_request_creation_restricted",
     "missing_credentials",
     "repository_not_found",
@@ -668,6 +669,8 @@ def get_repository_error_diagnoses(error: str) -> list[RepositoryDiagnosis]:
         diagnoses.append({"code": "repository_permission"})
     if any(message in error for message in REPOSITORY_GERRIT_PERMISSION_MESSAGES):
         diagnoses.append({"code": "gerrit_permission"})
+    if "lfs objects are missing" in normalized:
+        diagnoses.append({"code": "git_lfs_missing_objects"})
     if any(message in error for message in REPOSITORY_TEMPORARY_MESSAGES):
         diagnoses.append({"code": "temporary_failure"})
 

--- a/weblate/vcs/git.py
+++ b/weblate/vcs/git.py
@@ -1924,6 +1924,7 @@ class GitMergeRequestBase(GitForcePushRepository):
     API_TEMPLATE: ClassVar[str]
     REQUIRED_CONFIG: ClassVar[set[str]] = {"username", "token"}
     OPTIONAL_CONFIG: ClassVar[set[str]] = {"scheme"}
+    fork_configuration_version: ClassVar[int | None] = None
 
     def get_fork_branch_name(self) -> str:
         """Get the fork branch name used for pushing."""
@@ -2182,7 +2183,10 @@ class GitMergeRequestBase(GitForcePushRepository):
 
     def get_fork_remote_marker(self, credentials: GitCredentials) -> str:
         """Return marker identifying a Weblate-managed fork remote."""
-        return f"{self.identifier}:{credentials['url']}:{credentials['push_scheme']}"
+        marker = f"{self.identifier}:{credentials['url']}:{credentials['push_scheme']}"
+        if self.fork_configuration_version is not None:
+            return f"{marker}:v{self.fork_configuration_version}"
+        return marker
 
     def has_current_fork_remote(self, credentials: GitCredentials) -> bool:
         """Check whether the configured fork remote matches current settings."""
@@ -3329,6 +3333,7 @@ class GitLabRepository(GitMergeRequestBase):
     name: ClassVar[StrOrPromise] = gettext_lazy("GitLab merge request")
     api_service_name: ClassVar[str] = "GitLab"
     identifier: ClassVar[str] = "gitlab"
+    fork_configuration_version: ClassVar[int | None] = 1
     API_TEMPLATE: ClassVar[str] = (
         "{scheme}://{host}/api/v4/projects/{owner_url}%2F{slug_url}"
     )
@@ -3400,6 +3405,7 @@ class GitLabRepository(GitMergeRequestBase):
             "issues_access_level": "disabled",
             "forking_access_level": "disabled",
             "builds_access_level": "enabled",
+            "lfs_enabled": False,
             "wiki_access_level": "disabled",
             "snippets_access_level": "disabled",
             "pages_access_level": "disabled",

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -272,6 +272,10 @@ class RepositoryTest(SimpleTestCase):
             ("Repository not found.", "repository_not_found"),
             ("push denied to user", "repository_permission"),
             ("push prohibited by Gerrit", "gerrit_permission"),
+            (
+                "remote: GitLab: LFS objects are missing. Ensure LFS is properly set up.",
+                "git_lfs_missing_objects",
+            ),
             ("Connection timed out", "temporary_failure"),
             ("Host key verification failed", "ssh_host_key_unverified"),
             (
@@ -2854,6 +2858,14 @@ class VCSGiteaTest(VCSGitUpstreamTest):
             "git@gitea.io:test/test.git",
         )
 
+    def test_fork_remote_marker_is_unversioned(self) -> None:
+        credentials = self.repo.get_credentials()
+
+        self.assertEqual(
+            self.repo.get_fork_remote_marker(credentials),
+            f"gitea:{credentials['url']}:{credentials['push_scheme']}",
+        )
+
     def test_api_url_try_gitea(self) -> None:
         self.repo.component.repo = "https://try.gitea.io/WeblateOrg/test.git"
         self.assertEqual(
@@ -3923,6 +3935,110 @@ class VCSGitLabTest(VCSGitUpstreamTest):
             "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest",
             json={"id": 20227391},
         )
+
+    def test_fork_remote_marker_is_versioned(self) -> None:
+        credentials = self.repo.get_credentials()
+
+        self.assertEqual(
+            self.repo.get_fork_remote_marker(credentials),
+            f"gitlab:{credentials['url']}:{credentials['push_scheme']}:v1",
+        )
+
+    @http_mock.activate
+    def test_configure_fork_features_disables_lfs(self) -> None:
+        self.mock_configure_fork_features()
+
+        self.repo.configure_fork_features(
+            self.repo.get_credentials(),
+            "https://gitlab.com/api/v4/projects/20227391",
+        )
+
+        request = json.loads(http_mock.calls[0].request.content or b"{}")
+        self.assertEqual(
+            request,
+            {
+                "issues_access_level": "disabled",
+                "forking_access_level": "disabled",
+                "builds_access_level": "enabled",
+                "lfs_enabled": False,
+                "wiki_access_level": "disabled",
+                "snippets_access_level": "disabled",
+                "pages_access_level": "disabled",
+            },
+        )
+
+    @http_mock.activate
+    def test_existing_fork_remote_marker_is_upgraded(self) -> None:
+        credentials = self.repo.get_credentials()
+        fork = {
+            "ssh_url_to_repo": "git@gitlab.com:test/test.git",
+            "http_url_to_repo": "https://gitlab.com/test/test.git",
+            "owner": {"username": "test"},
+            "_links": {"self": "https://gitlab.com/api/v4/projects/20227391"},
+        }
+        self.repo.configure_fork_remote(
+            fork["ssh_url_to_repo"], fork["http_url_to_repo"], credentials
+        )
+        legacy_marker = f"gitlab:{credentials['url']}:{credentials['push_scheme']}"
+        self.repo.config_update(
+            ('remote "test"', "weblate-url", legacy_marker),
+        )
+        self.mock_fork_responses([fork])
+        self.mock_configure_fork_features()
+
+        with self.repo.lock:
+            self.repo.fork(credentials)
+
+        self.assertEqual(
+            self.repo.get_config("remote.test.weblate-url"),
+            f"{legacy_marker}:v1",
+        )
+        http_mock.assert_call_count(
+            "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/forks?owned=True",
+            1,
+        )
+        http_mock.assert_call_count("https://gitlab.com/api/v4/projects/20227391", 1)
+        http_mock.assert_call_count(
+            "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/fork", 0
+        )
+
+        with self.repo.lock:
+            self.repo.fork(credentials)
+
+        http_mock.assert_call_count(
+            "https://gitlab.com/api/v4/projects/WeblateOrg%2Ftest/forks?owned=True",
+            1,
+        )
+        http_mock.assert_call_count("https://gitlab.com/api/v4/projects/20227391", 1)
+
+    @http_mock.activate
+    def test_failed_fork_reconfiguration_keeps_legacy_marker(self) -> None:
+        credentials = self.repo.get_credentials()
+        fork = {
+            "ssh_url_to_repo": "git@gitlab.com:test/test.git",
+            "http_url_to_repo": "https://gitlab.com/test/test.git",
+            "owner": {"username": "test"},
+            "_links": {"self": "https://gitlab.com/api/v4/projects/20227391"},
+        }
+        self.repo.configure_fork_remote(
+            fork["ssh_url_to_repo"], fork["http_url_to_repo"], credentials
+        )
+        legacy_marker = f"gitlab:{credentials['url']}:{credentials['push_scheme']}"
+        self.repo.config_update(
+            ('remote "test"', "weblate-url", legacy_marker),
+        )
+        self.mock_fork_responses([fork])
+        http_mock.register(
+            "PUT",
+            "https://gitlab.com/api/v4/projects/20227391",
+            json={"message": "forbidden"},
+            status_code=403,
+        )
+
+        with self.repo.lock, self.assertRaises(RepositoryError):
+            self.repo.fork(credentials)
+
+        self.assertEqual(self.repo.get_config("remote.test.weblate-url"), legacy_marker)
 
     def mock_responses(
         self, pr_response, pr_status=200, get_forks=None, repo_state: int = 409


### PR DESCRIPTION
GitLab rejects pushes when managed forks cannot access LFS objects added upstream after the fork was created. Disable LFS on these forks and version the fork marker so existing forks are repaired on their next push.

Document the unsupported LFS behavior and surface actionable diagnostics.

Closes #13901

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
