### PR TITLE
docs: document trusted proxy upgrade

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -1306,8 +1306,13 @@ If set to ``True``, Weblate gets IP address from a header defined by
 
 .. warning::
 
-   Ensure you are actually using a reverse proxy and that it sets this header,
-   otherwise users will be able to fake the IP address.
+   The reverse proxy which connects to Weblate must overwrite the configured
+   header or append a verified peer address at the position selected by
+   :setting:`IP_PROXY_OFFSET`. Weblate does not verify which peer supplied the
+   header, so trusting a client-controlled value allows IP address spoofing.
+
+   Ensure that untrusted clients cannot reach Weblate without passing through
+   the trusted proxy.
 
 .. note::
 
@@ -1356,9 +1361,12 @@ which address from the header is used as client IP address here.
 
 .. warning::
 
-   Setting this affects the security of your installation. You should only
-   configure it to use trusted proxies for determining the IP address.
-   Please check <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#security_and_privacy_concerns> for more details.
+   Setting this affects the security of your installation. Select only an
+   address added or verified by a proxy under your control. Addresses supplied
+   by the client are untrusted. Ensure that the selected offset matches how
+   your proxies construct the header.
+
+   See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#security_and_privacy_concerns> for more details.
 
 Defaults to -1.
 

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -573,6 +573,10 @@ Client IP address
    :setting:`IP_PROXY_OFFSET` as well (use :envvar:`WEBLATE_IP_PROXY_HEADER`
    and :envvar:`WEBLATE_IP_PROXY_OFFSET` in the Docker container).
 
+   When using ``X-Forwarded-For`` with the Docker container, configure
+   :envvar:`WEBLATE_TRUSTED_PROXY_ADDRESSES` with the reverse proxies allowed
+   to supply client addresses.
+
    .. hint::
 
       This configuration cannot be turned on by default, because it would allow IP
@@ -637,6 +641,7 @@ Client protocol
    * :setting:`IP_PROXY_OFFSET`
    * :setting:`django:SECURE_PROXY_SSL_HEADER`
    * :envvar:`WEBLATE_IP_PROXY_HEADER`
+   * :envvar:`WEBLATE_TRUSTED_PROXY_ADDRESSES`
    * :envvar:`WEBLATE_IP_PROXY_OFFSET`
 
 .. _http-proxy:

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -573,6 +573,12 @@ Client IP address
    :setting:`IP_PROXY_OFFSET` as well (use :envvar:`WEBLATE_IP_PROXY_HEADER`
    and :envvar:`WEBLATE_IP_PROXY_OFFSET` in the Docker container).
 
+   The reverse proxy which connects to Weblate must overwrite the configured
+   header or append a verified peer address at the position selected by
+   :setting:`IP_PROXY_OFFSET`. Do not select a client-supplied address, and do
+   not expose the application server through a path which bypasses the trusted
+   proxy.
+
    When using ``X-Forwarded-For`` with the Docker container, configure
    :envvar:`WEBLATE_TRUSTED_PROXY_ADDRESSES` with the reverse proxies allowed
    to supply client addresses.

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -144,6 +144,12 @@ aware of its actual environment. In more detail, these headers are described in
 
    WEBLATE_ENABLE_HTTPS=1
    WEBLATE_IP_PROXY_HEADER=HTTP_X_FORWARDED_FOR
+   WEBLATE_TRUSTED_PROXY_ADDRESSES=192.0.2.10
+
+Replace the example trusted proxy address with the address or network of the
+reverse proxy as seen by the Weblate container. Make sure that untrusted
+clients cannot reach a published container port by bypassing the reverse
+proxy.
 
 Using own SSL certificates
 ++++++++++++++++++++++++++
@@ -850,6 +856,15 @@ Generic settings
 
     Enables :setting:`IP_BEHIND_REVERSE_PROXY` and sets :setting:`IP_PROXY_HEADER`.
 
+    When set to ``HTTP_X_FORWARDED_FOR``, the bundled nginx resolves the client
+    address using :envvar:`WEBLATE_TRUSTED_PROXY_ADDRESSES`, uses that address
+    in its logs, and forwards one normalized address to Weblate.
+
+    .. versionchanged:: 2026.9
+
+       The bundled nginx no longer trusts ``X-Forwarded-For`` from all network
+       addresses. Trusted proxy addresses have to be configured explicitly.
+
     .. note::
 
         The format must conform to Django's expectations. Django
@@ -868,12 +883,40 @@ Generic settings
 
         environment:
           WEBLATE_IP_PROXY_HEADER: HTTP_X_FORWARDED_FOR
+          WEBLATE_TRUSTED_PROXY_ADDRESSES: "192.0.2.10 2001:db8::/64 proxy"
+
+.. envvar:: WEBLATE_TRUSTED_PROXY_ADDRESSES
+
+    .. versionadded:: 2026.9
+
+    Configures the IPv4 or IPv6 addresses, networks, or hostnames of reverse
+    proxies trusted by the bundled nginx to supply ``X-Forwarded-For``. Separate
+    multiple values by whitespace.
+
+    This setting is used only when :envvar:`WEBLATE_IP_PROXY_HEADER` is
+    ``HTTP_X_FORWARDED_FOR``. If the list is empty, nginx uses the immediate TCP
+    peer in its logs and forwards that address to Weblate.
+
+    Only list proxies under your control, and do not expose the Weblate
+    container through a path which bypasses them.
+
+    **Example:**
+
+    .. code-block:: yaml
+
+        environment:
+          WEBLATE_IP_PROXY_HEADER: HTTP_X_FORWARDED_FOR
+          WEBLATE_TRUSTED_PROXY_ADDRESSES: "192.0.2.10 2001:db8::/64 proxy"
 
 .. envvar:: WEBLATE_IP_PROXY_OFFSET
 
     .. versionadded:: 5.0.1
 
     Configures :setting:`IP_PROXY_OFFSET`.
+
+    When :envvar:`WEBLATE_IP_PROXY_HEADER` is ``HTTP_X_FORWARDED_FOR``, the
+    bundled nginx forwards one normalized address and the container uses an
+    effective offset of ``0``.
 
 .. envvar:: WEBLATE_USE_X_FORWARDED_PORT
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,12 @@ Weblate 2026.9
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 
+* Docker deployments need to configure trusted proxy addresses.
+  Set :envvar:`WEBLATE_TRUSTED_PROXY_ADDRESSES` to preserve client IP addresses
+  in nginx logs and Weblate when
+  ``WEBLATE_IP_PROXY_HEADER=HTTP_X_FORWARDED_FOR`` is used; otherwise, the
+  immediate TCP peer is used.
+
 .. rubric:: Contributors
 
 .. include:: /changes/contributors/2026.9.rst

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -773,6 +773,11 @@ headers, hostnames, request-size limits, and secure-cookie behavior.
 *(documented)* (source: :doc:`/admin/install`, :setting:`ENABLE_HTTPS`,
 :setting:`ALLOWED_HOSTS`)
 
+Operators enabling forwarded client-IP handling must trust only reverse proxies
+under their control and prevent untrusted clients from bypassing those proxies
+to reach Weblate directly. *(documented)* (source:
+:envvar:`WEBLATE_TRUSTED_PROXY_ADDRESSES`, :ref:`reverse-proxy`)
+
 Operators must assign teams, roles, project-scoped tokens, VCS credentials, and
 project management permissions according to least privilege for their
 organization. *(documented)* (source: :doc:`/admin/access`, :doc:`/api`)


### PR DESCRIPTION
Docker deployments that restore client addresses from X-Forwarded-For now need to identify the proxies nginx may trust. Document the new setting, normalized offset behavior, and migration fallback so operators retain accurate nginx logs and Weblate audit/rate-limit attribution without reopening direct-header spoofing.

Record the no-bypass requirement in the threat model because forwarded client attribution is part of Weblate's deployment security boundary.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
