### PR TITLE
fix(screenshots): link unused screenshot alerts

### DIFF
--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -42,6 +42,7 @@ from weblate.addons.models import Addon
 from weblate.auth.data import SELECTION_ALL
 from weblate.auth.models import Group, Permission, Role, User
 from weblate.lang.models import Language
+from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Announcement, Change, Comment, Suggestion
 from weblate.trans.tests.test_views import (
@@ -50,6 +51,7 @@ from weblate.trans.tests.test_views import (
     ViewTestCase,
 )
 from weblate.trans.tests.utils import create_test_billing
+from weblate.utils.site import get_site_url
 from weblate.utils.version import USER_AGENT
 from weblate.utils.version_display import VERSION_DISPLAY_HIDE, VERSION_DISPLAY_SOFT
 
@@ -821,6 +823,21 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
         with self.captureOnCommitCallbacks(execute=True):
             self.component.add_alert("MissingScreenshots")
         self.validate_notifications(0)
+
+    def test_notify_unused_screenshot_links_to_screenshot(self) -> None:
+        self.component.project.add_user(self.user, "Administration")
+        with self.captureOnCommitCallbacks(execute=True):
+            screenshot = Screenshot.objects.create(
+                name="Unassigned screenshot",
+                image="screenshots/test.png",
+                translation=self.component.source_translation,
+            )
+
+        self.validate_notifications(1, "[Weblate] New alert on Test/Test")
+        self.assertIn(
+            f'href="{get_site_url(screenshot.get_absolute_url())}"',
+            get_html_content(mail.outbox[0]),
+        )
 
     def test_notify_reopened_alert(self) -> None:
         self.component.project.add_user(self.user, "Administration")

--- a/weblate/templates/trans/alert/unusedscreenshot.html
+++ b/weblate/templates/trans/alert/unusedscreenshot.html
@@ -4,5 +4,10 @@
   {% blocktranslate count count=unassigned %}One screenshot has no string assigned to it.{% plural %}{{ count }} screenshots have no string assigned to them.{% endblocktranslate %}
 </p>
 
+{% if screenshot_id %}
+  {% url "screenshot" pk=screenshot_id as screenshot_url %}
+{% else %}
+  {% url "screenshots" path=component.get_url_path as screenshot_url %}
+{% endif %}
 <a class="btn btn-primary"
-   href="{% url 'screenshots' path=component.get_url_path %}">{% translate "Manage screenshots" %}</a>
+   href="{{ screenshot_url }}{% if not screenshot_id %}?q={{ "NOT has:string"|urlencode }}{% endif %}">{% translate "Manage screenshots" %}</a>

--- a/weblate/trans/alerts/config.py
+++ b/weblate/trans/alerts/config.py
@@ -325,14 +325,20 @@ class UnusedScreenshot(BaseAlert):
 
     def get_context(self, user: User) -> dict[str, Any]:
         result = super().get_context(user)
-        if "unassigned" not in result:
+        if "unassigned" not in result or result["unassigned"] == 1:
             # ruff: ignore[import-outside-top-level]
             from weblate.screenshots.models import Screenshot
 
-            result["unassigned"] = Screenshot.objects.filter(
+            screenshots = Screenshot.objects.filter(
                 translation__component=self.instance.component,
                 units__isnull=True,
-            ).count()
+            )
+            if "unassigned" not in result:
+                result["unassigned"] = screenshots.count()
+            if result["unassigned"] == 1:
+                screenshot_ids = list(screenshots.values_list("pk", flat=True)[:2])
+                if len(screenshot_ids) == 1:
+                    result["screenshot_id"] = screenshot_ids[0]
         return result
 
     @classmethod
@@ -364,9 +370,10 @@ class UnusedScreenshot(BaseAlert):
         # ruff: ignore[import-outside-top-level]
         from weblate.screenshots.models import Screenshot
 
-        unassigned = Screenshot.objects.filter(
+        screenshots = Screenshot.objects.filter(
             translation__component=component, units__isnull=True
-        ).count()
+        )
+        unassigned = screenshots.count()
         if unassigned:
             return {"unassigned": unassigned}
         return False

--- a/weblate/trans/tests/test_guidance.py
+++ b/weblate/trans/tests/test_guidance.py
@@ -632,11 +632,65 @@ class ExtractorGuidanceAlertTest(ViewTestCase):
 
         response = self.client.get(self.component.get_absolute_url())
         self.assertContains(response, "One screenshot has no string assigned to it.")
+        self.assertContains(response, f'href="{screenshot.get_absolute_url()}"')
 
         screenshot.units.add(self.component.source_translation.unit_set.first())
 
         self.assertFalse(
             self.component.alert_set.filter(name=UnusedScreenshot.__name__).exists()
+        )
+
+    def test_unassigned_screenshot_legacy_alert_links_to_screenshot(self) -> None:
+        screenshot = Screenshot.objects.create(
+            name="Unassigned screenshot",
+            image="screenshots/test.png",
+            translation=self.component.source_translation,
+        )
+        alert = self.component.alert_set.get(name=UnusedScreenshot.__name__)
+        alert.details = {"unassigned": 1}
+        alert.save(update_fields=["details"])
+
+        response = self.client.get(self.component.get_absolute_url())
+
+        self.assertContains(response, f'href="{screenshot.get_absolute_url()}"')
+
+    def test_unassigned_screenshot_keeps_legacy_dismissal(self) -> None:
+        Screenshot.objects.create(
+            name="Unassigned screenshot",
+            image="screenshots/test.png",
+            translation=self.component.source_translation,
+        )
+        alert = self.component.alert_set.get(name=UnusedScreenshot.__name__)
+        alert.details = {"unassigned": 1}
+        alert.save(update_fields=["details"])
+        self.assertTrue(alert.dismiss(self.user))
+
+        update_alerts(self.component, {UnusedScreenshot.__name__})
+        alert.refresh_from_db()
+
+        self.assertTrue(alert.is_dismissed)
+
+    def test_multiple_unassigned_screenshots_link_to_filtered_list(self) -> None:
+        Screenshot.objects.create(
+            name="First unassigned screenshot",
+            image="screenshots/test.png",
+            translation=self.component.source_translation,
+        )
+        Screenshot.objects.create(
+            name="Second unassigned screenshot",
+            image="screenshots/test-2.png",
+            translation=self.component.source_translation,
+        )
+        alert = self.component.alert_set.get(name=UnusedScreenshot.__name__)
+
+        response = self.client.get(self.component.get_absolute_url())
+
+        self.assertEqual(alert.details, {"unassigned": 2})
+        self.assertContains(response, "2 screenshots have no string assigned to them.")
+        self.assertContains(
+            response,
+            f"{reverse('screenshots', kwargs={'path': self.component.get_url_path()})}"
+            "?q=NOT%20has%3Astring",
         )
 
     def test_addon_guidance_removed_when_addon_is_added(self) -> None:


### PR DESCRIPTION
Direct singular alerts to the affected screenshot and filter the screenshot list when multiple items need attention. This makes diagnostics and notification emails immediately actionable.

Closes #21128

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
