### PR TITLE
fix(vcs): detect commands in Weblate virtualenv

### DIFF
--- a/weblate/vcs/base.py
+++ b/weblate/vcs/base.py
@@ -16,7 +16,6 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from shutil import which
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -37,7 +36,7 @@ from django.utils.translation import gettext_lazy, gettext_noop
 from packaging.version import Version
 
 from weblate.trans.util import path_separator
-from weblate.utils.commands import get_clean_env
+from weblate.utils.commands import find_runtime_command, get_clean_env
 from weblate.utils.data import data_path
 from weblate.utils.errors import add_breadcrumb
 from weblate.utils.files import (
@@ -1386,7 +1385,9 @@ class Repository:
     def get_missing_commands(cls) -> tuple[str, ...]:
         """Return commands required by this backend that are not available."""
         commands = cls.required_commands or (cls._cmd,)
-        return tuple(command for command in commands if which(command) is None)
+        return tuple(
+            command for command in commands if find_runtime_command(command) is None
+        )
 
     @classmethod
     def is_available(cls) -> bool:

--- a/weblate/vcs/tests/test_apps.py
+++ b/weblate/vcs/tests/test_apps.py
@@ -64,7 +64,7 @@ class VCSChecksTest(SimpleTestCase):
         VCS_REGISTRY.clear_cache()
 
     def test_builtin_required_commands(self) -> None:
-        with patch("weblate.vcs.base.which", return_value=None):
+        with patch("weblate.vcs.base.find_runtime_command", return_value=None):
             self.assertEqual(GitRepository.get_missing_commands(), ("git",))
             self.assertEqual(
                 GitWithGerritRepository.get_missing_commands(),
@@ -79,7 +79,7 @@ class VCSChecksTest(SimpleTestCase):
     @override_settings(VCS_BACKENDS=OPTIONAL_BACKENDS)
     def test_registry_checks_availability_without_version_probe(self) -> None:
         with (
-            patch("weblate.vcs.base.which", return_value=None),
+            patch("weblate.vcs.base.find_runtime_command", return_value=None),
             patch.object(OptionalRepository, "_get_version") as get_version,
         ):
             self.assertEqual(list(VCS_REGISTRY), [])
@@ -93,7 +93,10 @@ class VCSChecksTest(SimpleTestCase):
     @override_settings(VCS_BACKENDS=OPTIONAL_BACKENDS)
     def test_standard_check_does_not_probe_version(self) -> None:
         with (
-            patch("weblate.vcs.base.which", return_value="/usr/bin/optional-vcs"),
+            patch(
+                "weblate.vcs.base.find_runtime_command",
+                return_value="/usr/bin/optional-vcs",
+            ),
             patch.object(OptionalRepository, "_get_version") as get_version,
         ):
             self.assertEqual(
@@ -106,7 +109,10 @@ class VCSChecksTest(SimpleTestCase):
     @override_settings(VCS_BACKENDS=OPTIONAL_BACKENDS)
     def test_deployment_check_reports_outdated_version(self) -> None:
         with (
-            patch("weblate.vcs.base.which", return_value="/usr/bin/optional-vcs"),
+            patch(
+                "weblate.vcs.base.find_runtime_command",
+                return_value="/usr/bin/optional-vcs",
+            ),
             patch.object(OptionalRepository, "_get_version", return_value="1"),
         ):
             errors = list(check_vcs_versions(app_configs=None, databases=None))
@@ -118,7 +124,10 @@ class VCSChecksTest(SimpleTestCase):
     @override_settings(VCS_BACKENDS=OPTIONAL_BACKENDS)
     def test_deployment_check_reports_invalid_version(self) -> None:
         with (
-            patch("weblate.vcs.base.which", return_value="/usr/bin/optional-vcs"),
+            patch(
+                "weblate.vcs.base.find_runtime_command",
+                return_value="/usr/bin/optional-vcs",
+            ),
             patch.object(
                 OptionalRepository,
                 "_get_version",
@@ -133,7 +142,10 @@ class VCSChecksTest(SimpleTestCase):
     @override_settings(VCS_BACKENDS=OPTIONAL_BACKENDS)
     def test_deployment_check_reports_version_probe_failure(self) -> None:
         with (
-            patch("weblate.vcs.base.which", return_value="/usr/bin/optional-vcs"),
+            patch(
+                "weblate.vcs.base.find_runtime_command",
+                return_value="/usr/bin/optional-vcs",
+            ),
             patch.object(
                 OptionalRepository,
                 "_get_version",
@@ -148,7 +160,10 @@ class VCSChecksTest(SimpleTestCase):
     @override_settings(VCS_BACKENDS=SHARED_BACKENDS)
     def test_deployment_check_shares_version_probe(self) -> None:
         with (
-            patch("weblate.vcs.base.which", return_value="/usr/bin/shared-vcs"),
+            patch(
+                "weblate.vcs.base.find_runtime_command",
+                return_value="/usr/bin/shared-vcs",
+            ),
             patch.object(
                 SharedVersionRepository,
                 "_popen",


### PR DESCRIPTION
VCS subprocesses include the active interpreter directory in PATH. Use the same lookup for availability checks so optional tools such as git-review are not incorrectly hidden.

Fixes WEBLATE-3B5G
Fixes WEBLATE-3B5H

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
