### PR TITLE
fix(wladmin): clarify support status messages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,7 @@ Weblate 2026.9
 * Improved translation file loading performance for metadata-only string changes.
 * VCS command versions are now validated by configuration health checks instead of during every process startup.
 * Billing audit logs now identify users who change plans, initiate payments, or merge billings.
+* Management notices now distinguish support package activation, status refresh, unlinking, and Discover Weblate registration.
 
 .. rubric:: Bug fixes
 

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -14,6 +14,7 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlparse
 
+import httpx2
 from django.conf import settings
 from django.core import mail
 from django.core.checks import Critical
@@ -1764,7 +1765,11 @@ class AdminTest(ViewTestCase):
         response = self.client.post(
             reverse("manage-activate"), {"secret": "123456"}, follow=True
         )
-        self.assertContains(response, "Please ensure your activation token is correct.")
+        self.assertContains(
+            response,
+            "Could not activate the support package. Please ensure the activation "
+            "token is correct.",
+        )
         self.assertFalse(SupportStatus.objects.exists())
         self.assertFalse(BackupService.objects.exists())
 
@@ -1779,9 +1784,42 @@ class AdminTest(ViewTestCase):
         response = self.client.post(
             reverse("manage-activate"), {"secret": "123456"}, follow=True
         )
-        self.assertContains(response, "Please try again later.")
+        self.assertContains(
+            response,
+            "Could not activate the support package. Please try again later.",
+        )
         self.assertFalse(SupportStatus.objects.exists())
         self.assertFalse(BackupService.objects.exists())
+
+    @override_settings(SITE_TITLE="Test Weblate")
+    def test_activation_timeout(self) -> None:
+        with patch(
+            "weblate.wladmin.views.SupportStatus.refresh",
+            side_effect=httpx2.TimeoutException("timeout"),
+        ):
+            response = self.client.post(
+                reverse("manage-activate"), {"secret": "123456"}, follow=True
+            )
+
+        self.assertContains(
+            response,
+            "Could not activate the support package. Please try again later.",
+        )
+
+    @override_settings(SITE_TITLE="Test Weblate")
+    def test_activation_unexpected_error(self) -> None:
+        with patch(
+            "weblate.wladmin.views.SupportStatus.refresh",
+            side_effect=RuntimeError("internal detail"),
+        ):
+            response = self.client.post(
+                reverse("manage-activate"), {"secret": "123456"}, follow=True
+            )
+
+        self.assertContains(
+            response,
+            "Could not activate the support package: internal detail",
+        )
 
     @http_mock.activate
     @override_settings(SITE_TITLE="Test Weblate")
@@ -1801,7 +1839,10 @@ class AdminTest(ViewTestCase):
                 cls=DjangoJSONEncoder,
             ),
         )
-        self.client.post(reverse("manage-activate"), {"secret": "123456"})
+        response = self.client.post(
+            reverse("manage-activate"), {"secret": "123456"}, follow=True
+        )
+        self.assertContains(response, "Support package activated.")
         status = SupportStatus.objects.get()
         self.assertEqual(status.name, "community")
         self.assertFalse(BackupService.objects.exists())
@@ -1811,6 +1852,111 @@ class AdminTest(ViewTestCase):
         self.client.post(reverse("manage-discovery"))
         status = SupportStatus.objects.get()
         self.assertTrue(status.discoverable)
+
+    @http_mock.activate
+    def test_support_status_refresh(self) -> None:
+        SupportStatus.objects.create(
+            name="hosted",
+            secret="123456",
+            expiry=timezone.now(),
+            enabled=True,
+        )
+        http_mock.register(
+            "POST",
+            get_support_url(),
+            text=json.dumps(
+                {
+                    "name": "hosted",
+                    "backup_repository": "",
+                    "expiry": timezone.now(),
+                    "in_limits": True,
+                    "has_subscription": True,
+                    "limits": {},
+                },
+                cls=DjangoJSONEncoder,
+            ),
+        )
+
+        response = self.client.post(
+            reverse("manage-activate"), {"refresh": "1"}, follow=True
+        )
+
+        self.assertContains(response, "Support status refreshed.")
+
+    @http_mock.activate
+    def test_support_status_refresh_invalid_token(self) -> None:
+        SupportStatus.objects.create(
+            name="hosted",
+            secret="123456",
+            expiry=timezone.now(),
+            enabled=True,
+        )
+        http_mock.register("POST", get_support_url(), status_code=404)
+
+        response = self.client.post(
+            reverse("manage-activate"), {"refresh": "1"}, follow=True
+        )
+
+        self.assertContains(
+            response,
+            "Could not refresh support status. The activation token is invalid.",
+        )
+
+    @http_mock.activate
+    def test_support_status_refresh_error(self) -> None:
+        SupportStatus.objects.create(
+            name="hosted",
+            secret="123456",
+            expiry=timezone.now(),
+            enabled=True,
+        )
+        http_mock.register("POST", get_support_url(), status_code=500)
+
+        response = self.client.post(
+            reverse("manage-activate"), {"refresh": "1"}, follow=True
+        )
+
+        self.assertContains(
+            response, "Could not refresh support status. Please try again later."
+        )
+
+    def test_support_status_refresh_timeout(self) -> None:
+        SupportStatus.objects.create(
+            name="hosted",
+            secret="123456",
+            expiry=timezone.now(),
+            enabled=True,
+        )
+        with patch(
+            "weblate.wladmin.views.SupportStatus.refresh",
+            side_effect=httpx2.TimeoutException("timeout"),
+        ):
+            response = self.client.post(
+                reverse("manage-activate"), {"refresh": "1"}, follow=True
+            )
+
+        self.assertContains(
+            response, "Could not refresh support status. Please try again later."
+        )
+
+    def test_support_status_refresh_unexpected_error(self) -> None:
+        SupportStatus.objects.create(
+            name="hosted",
+            secret="123456",
+            expiry=timezone.now(),
+            enabled=True,
+        )
+        with patch(
+            "weblate.wladmin.views.SupportStatus.refresh",
+            side_effect=RuntimeError("internal detail"),
+        ):
+            response = self.client.post(
+                reverse("manage-activate"), {"refresh": "1"}, follow=True
+            )
+
+        self.assertContains(
+            response, "Could not refresh support status: internal detail"
+        )
 
     def test_discovery_toggle_requires_site_title(self) -> None:
         status = SupportStatus.objects.create(
@@ -1906,7 +2052,9 @@ class AdminTest(ViewTestCase):
             {"code": "code-123", "state": "wrong"},
             follow=True,
         )
-        self.assertContains(response, "Invalid activation state.")
+        self.assertContains(
+            response, "Could not enable Discover Weblate. Invalid activation state."
+        )
         self.assertFalse(SupportStatus.objects.exists())
 
     @http_mock.activate
@@ -1925,7 +2073,9 @@ class AdminTest(ViewTestCase):
             {"code": "old-code", "state": "stale"},
             follow=True,
         )
-        self.assertContains(response, "Invalid activation state.")
+        self.assertContains(
+            response, "Could not enable Discover Weblate. Invalid activation state."
+        )
         self.assertEqual(
             self.client.session[DISCOVERY_REGISTRATION_SESSION]["state"], state
         )
@@ -1957,7 +2107,7 @@ class AdminTest(ViewTestCase):
             {"code": "code-123", "state": state},
             follow=True,
         )
-        self.assertContains(response, "Activation completed.")
+        self.assertContains(response, "Discover Weblate enabled.")
         self.assertEqual(SupportStatus.objects.get().secret, "secret-123")
 
     @override_settings(
@@ -1973,7 +2123,9 @@ class AdminTest(ViewTestCase):
         response = self.client.get(
             reverse("manage-discovery-callback"), {"state": state}, follow=True
         )
-        self.assertContains(response, "Missing activation code.")
+        self.assertContains(
+            response, "Could not enable Discover Weblate. Missing activation code."
+        )
         self.assertFalse(SupportStatus.objects.exists())
 
     @http_mock.activate
@@ -2025,7 +2177,7 @@ class AdminTest(ViewTestCase):
         for callback in callbacks:
             callback()
         update_task.assert_called_once_with()
-        self.assertContains(response, "Activation completed.")
+        self.assertContains(response, "Discover Weblate enabled.")
         status = SupportStatus.objects.get()
         self.assertEqual(status.secret, "secret-123")
         self.assertEqual(status.name, "community")
@@ -2100,7 +2252,9 @@ class AdminTest(ViewTestCase):
             {"code": "x" * 101, "state": state},
             follow=True,
         )
-        self.assertContains(response, "Invalid activation code.")
+        self.assertContains(
+            response, "Could not enable Discover Weblate. Invalid activation code."
+        )
         self.assertFalse(SupportStatus.objects.exists())
 
     @override_settings(
@@ -2122,7 +2276,9 @@ class AdminTest(ViewTestCase):
                 {"code": "code-123", "state": state},
                 follow=True,
             )
-        self.assertContains(response, "Please try again later.")
+        self.assertContains(
+            response, "Could not enable Discover Weblate. Please try again later."
+        )
         self.assertNotContains(response, "internal detail")
         self.assertFalse(SupportStatus.objects.exists())
 
@@ -2156,7 +2312,9 @@ class AdminTest(ViewTestCase):
             {"code": "code-123", "state": "state-123"},
             follow=True,
         )
-        self.assertContains(response, "Please try again later.")
+        self.assertContains(
+            response, "Could not enable Discover Weblate. Please try again later."
+        )
         old_status.refresh_from_db()
         self.assertTrue(old_status.enabled)
         self.assertEqual(SupportStatus.objects.get_current(), old_status)
@@ -2209,7 +2367,11 @@ class AdminTest(ViewTestCase):
             follow=True,
         )
 
-        self.assertContains(response, "a support package is already linked")
+        self.assertContains(
+            response,
+            "Could not enable Discover Weblate because a support package is already "
+            "linked.",
+        )
         refresh_body = parse_qs(get_response_call_body(1))
         self.assertNotIn("discoverable", refresh_body)
         self.assertNotIn("public_projects", refresh_body)
@@ -2245,13 +2407,32 @@ class AdminTest(ViewTestCase):
             ),
         )
 
-        self.client.post(reverse("manage-activate"), {"unlink": "1"})
+        response = self.client.post(
+            reverse("manage-activate"), {"unlink": "1"}, follow=True
+        )
 
+        self.assertContains(response, "Support package unlinked.")
         unlink_body = parse_qs(get_response_call_body(0))
         self.assertEqual(unlink_body["secret"], ["discovery-secret"])
         self.assertNotIn("discoverable", unlink_body)
         self.assertNotIn("public_projects", unlink_body)
         self.assertFalse(SupportStatus.objects.filter(enabled=True).exists())
+
+    def test_activation_unlink_locally(self) -> None:
+        status = SupportStatus.objects.create(
+            name="hosted",
+            secret="support-secret",
+            expiry=timezone.now(),
+            enabled=True,
+        )
+
+        response = self.client.post(
+            reverse("manage-activate"), {"unlink": "1"}, follow=True
+        )
+
+        self.assertContains(response, "Support package unlinked.")
+        status.refresh_from_db()
+        self.assertFalse(status.enabled)
 
     @http_mock.activate
     def test_activation_unlink_disables_locally_on_discovery_error(self) -> None:

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -383,19 +383,19 @@ def discovery_callback(request: AuthenticatedHttpRequest) -> HttpResponse:
     if not validate_discovery_registration_state(request, state):
         messages.error(
             request,
-            gettext("Could not activate your installation. Invalid activation state."),
+            gettext("Could not enable Discover Weblate. Invalid activation state."),
         )
         return redirect("manage")
     if not code:
         messages.error(
             request,
-            gettext("Could not activate your installation. Missing activation code."),
+            gettext("Could not enable Discover Weblate. Missing activation code."),
         )
         return redirect("manage")
     if len(code) > DISCOVERY_ACTIVATION_CODE_MAX_LENGTH:
         messages.error(
             request,
-            gettext("Could not activate your installation. Invalid activation code."),
+            gettext("Could not enable Discover Weblate. Invalid activation code."),
         )
         return redirect("manage")
 
@@ -415,13 +415,13 @@ def discovery_callback(request: AuthenticatedHttpRequest) -> HttpResponse:
         report_error("Activation timeout")
         messages.error(
             request,
-            gettext("Could not activate your installation. Please try again later."),
+            gettext("Could not enable Discover Weblate. Please try again later."),
         )
     except Exception:
         report_error("Activation error")
         messages.error(
             request,
-            gettext("Could not activate your installation. Please try again later."),
+            gettext("Could not enable Discover Weblate. Please try again later."),
         )
     else:
         with transaction.atomic():
@@ -434,7 +434,7 @@ def discovery_callback(request: AuthenticatedHttpRequest) -> HttpResponse:
                 messages.error(
                     request,
                     gettext(
-                        "Could not activate discovery because a support package "
+                        "Could not enable Discover Weblate because a support package "
                         "is already linked."
                     ),
                 )
@@ -445,8 +445,29 @@ def discovery_callback(request: AuthenticatedHttpRequest) -> HttpResponse:
                 )
                 support.save()
                 transaction.on_commit(support_status_update.delay)
-                messages.success(request, gettext("Activation completed."))
+                messages.success(request, gettext("Discover Weblate enabled."))
     return redirect("manage")
+
+
+def _get_support_action_messages(*, refresh: bool) -> tuple[str, str, str, str]:
+    if refresh:
+        return (
+            gettext("Support status refreshed."),
+            gettext("Could not refresh support status. Please try again later."),
+            gettext(
+                "Could not refresh support status. The activation token is invalid."
+            ),
+            gettext("Could not refresh support status: %s"),
+        )
+    return (
+        gettext("Support package activated."),
+        gettext("Could not activate the support package. Please try again later."),
+        gettext(
+            "Could not activate the support package. Please ensure the activation "
+            "token is correct."
+        ),
+        gettext("Could not activate the support package: %s"),
+    )
 
 
 @management_permission_required("management.configure")
@@ -454,18 +475,30 @@ def discovery_callback(request: AuthenticatedHttpRequest) -> HttpResponse:
 @transaction.atomic
 def activate(request: AuthenticatedHttpRequest) -> HttpResponse:
     support: SupportStatus | None = None
+    refresh = "refresh" in request.POST
     unlink = False
-    if "refresh" in request.POST:
+    if refresh:
+        success_message, retry_error, token_error, unexpected_error = (
+            _get_support_action_messages(refresh=True)
+        )
         support = SupportStatus.objects.get_current(for_update=True)
     elif "unlink" in request.POST:
         unlink = True
+        success_message = gettext("Support package unlinked.")
+        _, retry_error, token_error, unexpected_error = _get_support_action_messages(
+            refresh=False
+        )
         support = SupportStatus.objects.get_current(for_update=True)
         if support.secret and support.discoverable:
             support.discoverable = False
         else:
             support = None
             unlink_support_status()
+            messages.success(request, success_message)
     else:
+        success_message, retry_error, token_error, unexpected_error = (
+            _get_support_action_messages(refresh=False)
+        )
         form = ActivateForm(request.POST)
         if form.is_valid():
             support = SupportStatus(**form.cleaned_data)
@@ -478,25 +511,16 @@ def activate(request: AuthenticatedHttpRequest) -> HttpResponse:
             support.refresh()
         except httpx2.TimeoutException:
             report_error("Activation timeout")
-            activation_error = gettext(
-                "Could not activate your installation. Please try again later."
-            )
+            activation_error = retry_error
         except httpx2.HTTPStatusError as error:
             report_error("Activation error")
             if error.response is not None and error.response.status_code == 404:
-                activation_error = gettext(
-                    "Could not activate your installation. "
-                    "Please ensure your activation token is correct."
-                )
+                activation_error = token_error
             else:
-                activation_error = gettext(
-                    "Could not activate your installation. Please try again later."
-                )
+                activation_error = retry_error
         except Exception as error:
             report_error("Activation error")
-            activation_error = (
-                gettext("Could not activate your installation: %s") % error
-            )
+            activation_error = unexpected_error % error
         if activation_error:
             if unlink:
                 unlink_support_status()
@@ -519,7 +543,7 @@ def activate(request: AuthenticatedHttpRequest) -> HttpResponse:
                 support.save()
             else:
                 support.save()
-            messages.success(request, gettext("Activation completed."))
+            messages.success(request, success_message)
     return redirect("manage")
 
 


### PR DESCRIPTION
Refreshing support status reported that activation completed, which obscured the action and made failures misleading. Use action-specific feedback for activation, refresh, unlinking, and Discover Weblate registration.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
