### PR TITLE
fix(auth): scope project token removal

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Weblate 2026.9
 
 .. rubric:: Bug fixes
 
+* Project administrators can no longer remove API tokens belonging to other projects.
 * Project and workspace translation memory now respects restricted component access, and restricted components no longer contribute to shared translation memory.
 * GitLab merge request forks now disable Git LFS to avoid missing-object push failures. See :ref:`git-lfs`.
 * :ref:`Project backup restores <projectbackup>` now allowlists repository metadata for Git, git-svn, and Mercurial to prevent archives from supplying executable configuration or repository indirection.

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -1629,6 +1629,21 @@ class UserManageForm(forms.Form):
     )
 
 
+class ProjectMemberManageForm(UserManageForm):
+    def __init__(self, project: Project, *args, **kwargs) -> None:
+        self.project = project
+        super().__init__(*args, **kwargs)
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data["user"]
+        if (
+            user.is_internal
+            or not user.groups.filter(defining_project=self.project).exists()
+        ):
+            raise ValidationError(gettext("Could not find any such user."))
+        return user
+
+
 class TeamAssignableUserMixin:
     allow_bot_user = False
     cleaned_data: dict[str, Any]
@@ -4532,7 +4547,7 @@ class ProjectGroupDeleteForm(forms.Form):
         self.fields["group"].queryset = project.defined_groups.all()
 
 
-class ProjectUserGroupForm(UserManageForm):
+class ProjectUserGroupForm(ProjectMemberManageForm):
     groups = forms.ModelMultipleChoiceField(
         Group.objects.none(),
         widget=forms.CheckboxSelectMultiple,
@@ -4548,8 +4563,7 @@ class ProjectUserGroupForm(UserManageForm):
         limit_language_choices: list[tuple[str, str]] | None = None,
         **kwargs,
     ) -> None:
-        self.project = project
-        super().__init__(*args, **kwargs)
+        super().__init__(project, *args, **kwargs)
         self.fields["user"].widget = forms.HiddenInput()
         groups_queryset = (
             group_queryset
@@ -4584,6 +4598,12 @@ class ProjectUserGroupForm(UserManageForm):
             }
             for index, group in enumerate(groups)
         ]
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data["user"]
+        if not user.groups.filter(defining_project=self.project).exists():
+            validate_team_assignable_user(user, allow_bot=True)
+        return super().clean_user()
 
     def get_selected_group_ids(self) -> set[str]:
         if self.is_bound:

--- a/weblate/trans/tests/test_projecttoken.py
+++ b/weblate/trans/tests/test_projecttoken.py
@@ -9,8 +9,9 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.authtoken.models import Token
 
-from weblate.auth.models import setup_project_groups
+from weblate.auth.models import User, setup_project_groups
 from weblate.lang.models import Language
+from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Project
 from weblate.trans.tasks import actual_project_removal
 from weblate.trans.tests.test_views import FixtureTestCase
@@ -60,7 +61,21 @@ class ProjectTokenTest(FixtureTestCase):
             web="https://nonexisting.weblate.org/",
         )
         self.addCleanup(remove_tree, project.full_path, True)
+        if not project.defined_groups.exists():
+            setup_project_groups(sender=Project, instance=project, created=False)
         return project
+
+    def create_attacker(self):
+        project = self.create_additional_project(name="Attacker", slug="attacker")
+        project.access_control = Project.ACCESS_PRIVATE
+        project.save()
+        attacker = User.objects.create_user(
+            "attacker", "attacker@example.org", "testpassword"
+        )
+        project.add_user(attacker, "Administration")
+        client = self.client_class()
+        self.assertTrue(client.login(username="attacker", password="testpassword"))
+        return project, attacker, client
 
     def test_create_token(self) -> None:
         """Managers should be able to create new tokens."""
@@ -110,7 +125,17 @@ class ProjectTokenTest(FixtureTestCase):
     def test_revoke_token(self) -> None:
         """Create a token revoke it, check that usage is not allowed."""
         token = self.create_token()
+        token_user = self.get_token_user(token)
+        username = token_user.username
         self.delete_token(token)
+        token_user.refresh_from_db()
+
+        self.assertFalse(token_user.is_active)
+        self.assertTrue(token_user.username.startswith("deleted-"))
+        self.assertFalse(token_user.groups.exists())
+        change = self.project.change_set.get(action=ActionEvents.REMOVE_USER)
+        self.assertEqual(change.details["username"], username)
+
         self.client.logout()
 
         response = self.client.get(
@@ -135,6 +160,126 @@ class ProjectTokenTest(FixtureTestCase):
         self.assertEqual(
             audit.get_extra_message(), f"Triggered by {self.user.username}."
         )
+
+    def test_revoke_foreign_token_denied(self) -> None:
+        """Project administrators can not revoke another project's token."""
+        token_key = self.create_token()
+        token_user = self.get_token_user(token_key)
+        username = token_user.username
+        attacker_project, attacker, attacker_client = self.create_attacker()
+
+        self.assertTrue(attacker.has_perm("project.permissions", attacker_project))
+        self.assertFalse(attacker.has_perm("project.permissions", self.project))
+        self.assertFalse(attacker.has_perm("user.edit"))
+
+        response = attacker_client.post(
+            reverse("delete-user", kwargs={"project": attacker_project.slug}),
+            {"user": username},
+            follow=True,
+        )
+
+        self.assertContains(response, "Could not find any such user.")
+        self.assertTrue(Token.objects.filter(key=token_key).exists())
+        token_user.refresh_from_db()
+        self.assertEqual(token_user.username, username)
+        self.assertTrue(token_user.is_active)
+        self.assertTrue(
+            token_user.groups.filter(defining_project=self.project).exists()
+        )
+        self.assertFalse(
+            token_user.groups.filter(defining_project=attacker_project).exists()
+        )
+        self.assertFalse(
+            token_user.auditlog_set.filter(activity="token-removed").exists()
+        )
+        self.assertFalse(
+            attacker_project.change_set.filter(action=ActionEvents.REMOVE_USER).exists()
+        )
+
+    def test_foreign_token_team_assignment_denied(self) -> None:
+        """Project administrators can not attach another project's token."""
+        token_key = self.create_token()
+        token_user = self.get_token_user(token_key)
+        attacker_project, _attacker, attacker_client = self.create_attacker()
+        admin_group = attacker_project.defined_groups.get(name="Administration")
+
+        response = attacker_client.post(
+            reverse("set-groups", kwargs={"project": attacker_project.slug}),
+            {"user": token_user.username, "groups": [admin_group.pk]},
+            follow=True,
+        )
+
+        self.assertContains(response, "Could not find any such user.")
+        self.assertTrue(Token.objects.filter(key=token_key).exists())
+        self.assertFalse(
+            token_user.groups.filter(defining_project=attacker_project).exists()
+        )
+        self.assertTrue(
+            token_user.groups.filter(defining_project=self.project).exists()
+        )
+
+    def test_revoke_shared_token_detaches_project(self) -> None:
+        """Removing a shared token keeps it active for its other projects."""
+        token_key = self.create_token()
+        token_user = self.get_token_user(token_key)
+        username = token_user.username
+        second_project = self.create_additional_project(name="Other", slug="other")
+        second_project.access_control = Project.ACCESS_PRIVATE
+        second_project.save()
+        second_project.add_user(token_user, "Administration", allow_bot=True)
+
+        response = self.client.post(
+            reverse("delete-user", kwargs=self.kw_project),
+            {"user": username},
+            follow=True,
+        )
+
+        self.assertContains(response, "Token has been removed from this project.")
+        token_user.refresh_from_db()
+        self.assertEqual(token_user.username, username)
+        self.assertTrue(token_user.is_active)
+        self.assertTrue(Token.objects.filter(key=token_key).exists())
+        self.assertFalse(
+            token_user.groups.filter(defining_project=self.project).exists()
+        )
+        self.assertTrue(
+            token_user.groups.filter(defining_project=second_project).exists()
+        )
+        self.assertFalse(
+            token_user.auditlog_set.filter(activity="token-removed").exists()
+        )
+        change = self.project.change_set.get(action=ActionEvents.REMOVE_USER)
+        self.assertEqual(change.details["username"], username)
+
+        token_client = self.client_class()
+        token_response = token_client.get(
+            reverse("api:project-detail", kwargs={"slug": second_project.slug}),
+            headers={"authorization": f"Token {token_key}"},
+        )
+        self.assertEqual(token_response.status_code, 200)
+
+    def test_revoke_internal_bot_denied(self) -> None:
+        """Project access management can not remove internal bots."""
+        self.make_manager()
+        internal_bot = User.objects.create_user(
+            "addon:security-test",
+            "addon-security-test@example.org",
+            is_active=False,
+            is_bot=True,
+        )
+        admin_group = self.project.defined_groups.get(name="Administration")
+        internal_bot.groups.add(admin_group)
+
+        response = self.client.post(
+            reverse("delete-user", kwargs=self.kw_project),
+            {"user": internal_bot.username},
+            follow=True,
+        )
+
+        self.assertContains(response, "Could not find any such user.")
+        internal_bot.refresh_from_db()
+        self.assertEqual(internal_bot.username, "addon:security-test")
+        self.assertTrue(internal_bot.groups.filter(pk=admin_group.pk).exists())
 
     def test_remove_all_groups_token(self) -> None:
         """Removing all teams from a token should not be allowed."""

--- a/weblate/trans/views/acl.py
+++ b/weblate/trans/views/acl.py
@@ -10,7 +10,9 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.db.models import Count, Prefetch
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -34,6 +36,7 @@ from weblate.auth.utils import (
 from weblate.lang.forms import get_language_code_choices
 from weblate.trans.actions import ActionEvents
 from weblate.trans.forms import (
+    ProjectMemberManageForm,
     ProjectTokenCreateForm,
     ProjectUserGroupForm,
     UserBlockForm,
@@ -79,6 +82,18 @@ def check_user_form(
         return obj, form
     show_form_errors(request, form)
     return obj, None
+
+
+def lock_project_member(project: Project, user: User) -> User:
+    """Lock and recheck a project member before destructive changes."""
+    users = User.objects.select_for_update()
+    memberships = TeamMembership.objects.select_for_update().filter(
+        user_id=user.pk, group__defining_project=project
+    )
+    user = get_object_or_404(users, pk=user.pk)
+    if user.is_internal or not memberships.exists():
+        raise Http404
+    return user
 
 
 def is_contribution_cleanup_requested(form: UserContributionCleanupForm) -> bool:
@@ -403,36 +418,41 @@ def invite_user(request: AuthenticatedHttpRequest, project):
 
 @require_POST
 @login_required
+@transaction.atomic
 def delete_user(request: AuthenticatedHttpRequest, project):
     """Remove user from a project."""
     obj, form = check_user_form(
         request,
         project,
+        form_class=ProjectMemberManageForm,
+        pass_project=True,
     )
     redirect_url = ""
 
     if form is not None:
-        user = form.cleaned_data["user"]
+        user = lock_project_member(obj, form.cleaned_data["user"])
         if request.user == user:
             messages.error(request, gettext("You can not remove yourself!"))
         else:
+            username = user.username
+            is_bot = user.is_bot
+            obj.remove_user(user)
             if user.is_bot:
                 redirect_url = "#api"
-                remove_user(
-                    user,
-                    request,
-                    activity="token-removed",
-                    project=obj.name,
-                    username=request.user.username,
-                )
-            else:
-                obj.remove_user(user)
+                if not user.groups.filter(defining_project__isnull=False).exists():
+                    remove_user(
+                        user,
+                        request,
+                        activity="token-removed",
+                        project=obj.name,
+                        username=request.user.username,
+                    )
             obj.change_set.create(
                 action=ActionEvents.REMOVE_USER,
                 user=request.user,
-                details={"username": user.username},
+                details={"username": username},
             )
-            if user.is_bot:
+            if is_bot:
                 messages.success(
                     request, gettext("Token has been removed from this project.")
                 )


### PR DESCRIPTION
Project administrators could resolve a global bot account through a project-scoped removal endpoint and revoke tokens belonging to other projects. Restrict ACL targets to project members and preserve shared tokens until their final project membership is removed.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
