### PR TITLE
docs(security): clarify generic webhook diagnostics

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -74,8 +74,19 @@ The default can also be changed by setting :setting:`DEFAULT_ACCESS_CONTROL`.
     Aggregate statistics include `Private` projects and
     :ref:`restricted components <component-restricted>`, including in
     site-wide, language, and workspace summaries. Object listings, names, and
-    actions remain permission-filtered, so these aggregates do not grant access
-    to the underlying projects or components.
+    actions in the web interface and API remain permission-filtered, so these
+    aggregates do not grant access to the underlying projects or components.
+
+.. note::
+
+    Generic incoming :ref:`notification hooks <hooks>` are an explicit
+    compatibility exception to identifier confidentiality. When supplied with
+    a matching repository URL, their diagnostic response includes match counts
+    and, when an update is scheduled, the project/component slug and API URL.
+    This also applies to `Private` projects and restricted components, except
+    components managed through an authenticated integration. The API URL does
+    not bypass access control, and no project content or credentials are
+    included. See :ref:`hooks-target-matching`.
 
 .. note::
 

--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -344,6 +344,12 @@ opaque token that uniquely identifies a single registered App:
 
    https://weblate.example.com/hooks/integrations/<webhook_token>/
 
+Components using the :guilabel:`GitHub (via Weblate GitHub app)` VCS backend
+are matched only through this dedicated endpoint. All generic forge webhook
+endpoints exclude them from matching and response diagnostics, including
+``/hooks/github/``. Legacy GitHub App deliveries sent to the generic endpoint
+can match only components using a non-App VCS backend.
+
 If you are not using a GitHub App, add the Weblate webhook in the repository
 settings (:guilabel:`Webhooks`) to receive notifications on every push to a
 GitHub repository, as shown on the image below:

--- a/docs/admin/continuous.rst
+++ b/docs/admin/continuous.rst
@@ -107,6 +107,31 @@ Forge webhooks update components whose :ref:`component-repo` exactly matches a
 repository URL from the payload (HTTPS or SSH as reported by the forge, plus
 common variants such as a trailing slash).
 
+Generic forge webhook endpoints are compatibility interfaces, and ordinary
+repository deliveries are not cryptographically authenticated. Legacy GitHub
+App deliveries containing installation data are an exception: the generic
+GitHub endpoint verifies their signature using
+:setting:`GITHUB_LEGACY_APP_WEBHOOK_SECRET`. Repository matching does not apply
+project or component access control because webhooks also need to update private
+projects and
+:ref:`restricted components <component-restricted>`. Their JSON responses
+include diagnostic counts for repository, branch, and enabled-hook matches.
+Successful responses also include the full project/component slugs and absolute
+API URLs of updated components. Supplying a matching repository URL can
+therefore confirm that a repository is registered and reveal these identifiers.
+
+Components managed through an authenticated integration are excluded from
+generic webhook matching and its diagnostic counts. Currently this applies to
+the :guilabel:`GitHub (via Weblate GitHub app)` VCS backend. These components
+receive notifications only through their dedicated tokenized and signed
+:ref:`GitHub App webhook URL <code-hosting-github-app-webhook>`. Future
+authenticated integrations are expected to use the same separation.
+
+The returned API URLs do not grant access to the components. The web interface
+and API continue to enforce normal access control, and webhook responses do not
+include repository content, translations, or credentials. Where available,
+prefer an authenticated integration such as :ref:`code-hosting-github-app-webhook`.
+
 .. versionchanged:: 2026.9
 
    Host and path suffix fallback matching was removed. If updates stop, align

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3614,6 +3614,33 @@ Notification hooks allow external applications to notify Weblate that the VCS
 repository has been updated. Weblate matches the delivery to components by
 repository URL; see :ref:`hooks-target-matching`.
 
+The generic hook endpoints return diagnostics intended to help configure
+repository notifications. The ``match_status`` object contains:
+
+``repository_matches``
+    Number of components whose repository URL matches the payload.
+``branch_matches``
+    Number of repository matches whose configured branch matches the payload.
+    For events without a branch, every repository match is counted as a branch
+    match.
+``enabled_hook_matches``
+    Number of branch matches whose project has hooks enabled.
+
+A successful update response names the updated project/component slugs in
+``message`` and returns their absolute API URLs in ``updated_components``. These
+diagnostics include private projects and restricted components because matching
+does not apply user access control. Components managed through an authenticated
+integration are excluded from generic matching and diagnostics; currently this
+applies to the :guilabel:`GitHub (via Weblate GitHub app)` VCS backend. When an
+update event completes target matching but schedules no update, the response
+uses HTTP status code 202 and retains ``match_status`` so the repository,
+branch, and project hook settings can be diagnosed. Ping and ignored events
+return HTTP status code 201 without matching diagnostics. These responses can
+confirm that a supplied repository URL is registered, but do not grant access
+to the linked API objects or expose repository content, translations, or
+credentials. See :ref:`hooks-target-matching` for the security and compatibility
+implications.
+
 You can use repository endpoints for projects, components and translations to
 update individual repositories; see
 :http:post:`/api/projects/(string:project)/repository/` for documentation.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.9
 * VCS command versions are now validated by configuration health checks instead of during every process startup.
 * Billing audit logs now identify users who change plans, initiate payments, or merge billings.
 * Management notices now distinguish support package activation, status refresh, unlinking, and Discover Weblate registration.
+* Clarified generic :ref:`notification hook <hooks>` matching and privacy behavior.
 
 .. rubric:: Bug fixes
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -196,11 +196,15 @@ repository state, background tasks, outbound requests, and rendered UI.
    * - Webhook sender to Weblate
      - Public forge notifications can schedule repository synchronization
        where hooks are enabled, matching components by exact repository URL
-       rather than host or path suffix fallback. Registered GitHub App
-       webhooks additionally authenticate with a per-app URL token and GitHub
-       signature verification. Opt-in legacy GitHub App deliveries to the
-       generic GitHub webhook URL authenticate with a separately configured
-       secret. *(documented)* (source: :ref:`hooks`,
+       rather than host or path suffix fallback. Generic hook responses expose
+       match counts and, for updated components, project/component slugs and API
+       URLs, including for private projects and restricted components.
+       Components managed through an authenticated integration are excluded
+       from generic matching and diagnostics; currently this applies to the
+       GitHub App VCS backend. Registered GitHub App webhooks authenticate with
+       a per-app URL token and GitHub signature verification. Opt-in legacy
+       GitHub App deliveries to the generic GitHub webhook URL authenticate
+       with a separately configured secret. *(documented)* (source: :ref:`hooks`,
        :ref:`project-enable_hooks`, :ref:`hooks-target-matching`,
        :ref:`code-hosting-github-app-webhook`,
        :setting:`GITHUB_LEGACY_APP_WEBHOOK_SECRET`)
@@ -236,8 +240,9 @@ Reachability preconditions:
   boundary. *(documented)* (source: :doc:`/admin/access`)
 * A webhook finding is in model only when a request can reach an enabled hook
   endpoint and affect repository update scheduling, task volume, or information
-  returned to the caller. *(documented)* (source: :ref:`hooks`,
-  :ref:`project-enable_hooks`)
+  returned to the caller beyond the documented matching diagnostics.
+  *(documented)* (source: :ref:`hooks`, :ref:`project-enable_hooks`,
+  :ref:`hooks-target-matching`)
 * A VCS finding is in model only when attacker-controlled or less-trusted
   repository data, branch names, URLs, file names, commit metadata, or project
   configuration can influence Weblate's VCS operations. *(maintainer)*
@@ -566,7 +571,8 @@ Adversary model
        *(documented)* (source: :doc:`/admin/access`)
    * - Webhook sender
      - Send forged, replayed, malformed, or high-volume webhook requests to
-       enabled hook endpoints. *(documented)* (source: :ref:`hooks`)
+       enabled hook endpoints and observe documented matching diagnostics.
+       *(documented)* (source: :ref:`hooks`, :ref:`hooks-target-matching`)
      - Obtain forge-authenticated identity where Weblate does not verify it.
        *(maintainer)*
    * - External VCS or service provider
@@ -639,12 +645,17 @@ Security properties Weblate provides
        repository-local configuration from validated component settings.
      - Command injection or arbitrary code execution as the Weblate user.
      - Security-critical.
-   * - Private project data, user data, credentials, tokens, SSH keys, and 2FA
-       secrets are not disclosed to actors lacking permission. *(documented)* (source: :doc:`/admin/access`, :doc:`/security/privacy-compliance`)
-     - Host, database, and storage permissions are intact. Custom add-ons list
-       only non-sensitive fields as public configuration; unlisted values are
+   * - Private project data other than documented generic webhook matching
+       diagnostics, user data, credentials, tokens, SSH keys, and 2FA secrets
+       are not disclosed to actors lacking permission. *(documented)* (source:
+       :doc:`/admin/access`, :doc:`/security/privacy-compliance`)
+     - Host, database, and storage permissions are intact. Generic webhook
+       responses expose only the match counts, project/component slugs, and API
+       URLs documented in :ref:`hooks-target-matching`. Custom add-ons list only
+       non-sensitive fields as public configuration; unlisted values are
        redacted from public change history.
-     - Cross-project data leak, credential exposure, or unauthorized export.
+     - Cross-project data leak beyond the documented generic webhook
+       diagnostics, credential exposure, or unauthorized export.
      - Security-critical.
    * - Backup import rejects archives exceeding documented upload, member,
        aggregate size, and suspicious compression thresholds. *(documented)* (source: :doc:`/admin/config`, :ref:`projectbackup`)
@@ -680,13 +691,19 @@ Security properties Weblate provides
      - Rate limiting is enabled and backed by a working datastore.
      - Requests exceeding configured thresholds continue to be processed.
      - Availability/security hardening depending on endpoint sensitivity.
-   * - Enabled webhooks schedule repository updates only for components whose
-       repository URL exactly matches a repository URL from the payload,
-       including documented URL variants. *(documented)* (source:
+   * - Generic webhooks schedule repository updates only for eligible components
+       whose repository URL exactly matches a repository URL from the payload,
+       including documented URL variants. Components managed through an
+       authenticated integration are excluded from generic matching and
+       diagnostics. Generic responses disclose only the documented matching
+       diagnostics for eligible components. *(documented)* (source:
        :ref:`hooks-target-matching`)
      - Hooks are enabled and the delivery reaches an in-scope hook endpoint.
      - A delivery updates a component whose repository URL does not exactly
-       match the payload, including through host or path suffix fallback.
+       match the payload, including through host or path suffix fallback, or a
+       generic delivery updates or discloses a component managed through an
+       authenticated integration, or a response discloses component information
+       beyond the documented fields.
      - Security-critical when it causes unauthorized repository synchronization
        across unrelated components; otherwise correctness or hardening.
    * - Weblate does not intentionally expose database, datastore, backup
@@ -718,8 +735,12 @@ show only unauthenticated triggering within modeled effects are
 ``VALID-HARDENING`` rather than ``BY-DESIGN``. *(maintainer)*
 
 Weblate does not make an unauthenticated webhook equivalent to a trusted forge
-identity. Hook processing can trigger update workflows, but attribution and
-authenticity are weaker than for an authenticated user or token. *(maintainer)*
+identity. Hook processing can trigger update workflows, and generic responses
+can confirm repository registration and reveal match counts, project/component
+slugs, and API URLs, including for private projects and restricted components.
+Components managed through an authenticated integration are excluded from this
+generic behavior. Attribution and authenticity are weaker than for an
+authenticated user or token. *(maintainer)*
 
 Weblate is not a sandbox for malicious administrators, malicious local
 operators, third-party add-ons, custom deployment code, VCS clients, or backup
@@ -784,7 +805,9 @@ organization. *(documented)* (source: :doc:`/admin/access`, :doc:`/api`)
 
 Operators exposing :ref:`hooks` must enable them only where needed and provide
 deployment controls such as reverse-proxy rate limits, body-size limits,
-monitoring, and optional source restrictions. *(maintainer)*
+monitoring, and optional source restrictions. They must accept the documented
+identifier disclosure or use authenticated integrations where available.
+*(maintainer)*
 
 Operators must treat private-target allowlists, proxies, and privileged
 outbound integration settings as intentional expansion of Weblate's default
@@ -807,8 +830,9 @@ Known misuse patterns
 
 * Exposing webhook endpoints broadly, enabling project hooks, and relying on
   webhook payloads as authenticated forge identity. This is unsafe because some
-  supported hooks are compatibility-oriented. Use deployment controls and prefer
-  authenticated integrations where available. *(maintainer)*
+  supported hooks are compatibility-oriented and return matching diagnostics.
+  Use deployment controls and prefer authenticated integrations where
+  available. *(maintainer)*
 * Granting project management, VCS, or access-management permissions to users
   who are trusted only as translators. This is unsafe because those permissions
   can affect repositories, credentials, or other users. Assign narrower roles.
@@ -838,9 +862,11 @@ Known non-findings
 ------------------
 
 * A report that a reachable webhook can be called without forge authentication
-  and only triggers modeled update scheduling is not ``VALID`` by itself. It is
-  routed to ``VALID-HARDENING`` unless it bypasses documented limits, leaks
-  data, or causes effects beyond modeled scheduling. *(maintainer)*
+  and only triggers modeled update scheduling or returns the documented
+  matching diagnostics is not ``VALID`` by itself. It is routed to
+  ``VALID-HARDENING`` unless it bypasses documented limits, matches unrelated
+  repositories, leaks data beyond the documented fields, or causes effects
+  beyond modeled scheduling. *(maintainer)*
 * A report that a webhook does not update a component whose repository URL only
   shares a host or path suffix with the payload is not a vulnerability;
   Weblate matches only exact repository URLs and documented variants.


### PR DESCRIPTION
Generic webhook responses intentionally expose match diagnostics, including private component identifiers, to help troubleshoot deliveries. Document this compatibility tradeoff consistently across access control, API, continuous localization, and the threat model.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
