### PR TITLE
fix(api): avoid instantiating alerts for metadata

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -3665,6 +3665,27 @@ class ProjectAPITest(APIBaseTest):
         request = self.do_request("api:project-changes", self.project_kwargs)
         self.assertEqual(request.data["count"], 35)
 
+    def test_changes_with_multi_alert(self) -> None:
+        translation = self.component.translation_set.get(language__code="cs")
+        occurrences = [
+            {
+                "language_code": translation.language_code,
+                "translation_pk": translation.pk,
+            }
+        ]
+        self.component.add_alert("UnusedGlossaryLanguage", occurrences=occurrences)
+
+        response = self.do_request("api:project-changes", self.project_kwargs)
+        data = response.json()
+        alert_change = next(
+            change
+            for change in data["results"]
+            if change["alert"] is not None
+            and change["alert"]["name"] == "UnusedGlossaryLanguage"
+        )
+
+        self.assertEqual(alert_change["alert"]["details"]["occurrences"], occurrences)
+
     def test_changes_skip_restricted_component_changes(self) -> None:
         secret = "SECRET-RESTRICTED-STRING-XYZZY"
         self.component.restricted = True

--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -95,33 +95,36 @@ class Alert(models.Model):
         verbose_name_plural = "component alerts"
 
     def __str__(self) -> str:
-        return str(self.obj.verbose)
+        return str(self.alert_class.verbose)
 
     def save(self, *args, **kwargs) -> None:
         is_new = not self.id
         super().save(*args, **kwargs)
         if is_new and self.is_actionable:
-            alert_class = get_alert_class(self.name)
             self.component.change_set.create(
                 action=ActionEvents.ALERT,
                 alert=self,
                 details={
                     "alert": self.name,
-                    "fingerprint": alert_class.get_dismissal_fingerprint(
+                    "fingerprint": self.alert_class.get_dismissal_fingerprint(
                         self.component, self.details
                     ),
                 },
             )
 
     @cached_property
+    def alert_class(self) -> type[BaseAlert]:
+        return get_alert_class(self.name)
+
+    @cached_property
     def obj(self) -> BaseAlert:
-        return get_alert_class(self.name)(self, **self.details)
+        return self.alert_class(self, **self.details)
 
     def render(self, user: User) -> str:
         return self.obj.render(user)
 
     def get_documentation_url(self, user: User | None = None) -> str:
-        return self.obj.get_documentation_url(self.component, user)
+        return self.alert_class.get_documentation_url(self.component, user)
 
     @transaction.atomic
     def dismiss(self, user: User, reason: str = "") -> bool:
@@ -174,7 +177,7 @@ class Alert(models.Model):
 
     @property
     def category(self) -> str:
-        return self.obj.category
+        return self.alert_class.category
 
     @property
     def is_problem(self) -> bool:

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -173,6 +173,20 @@ class AlertTest(ViewTestCase):
             reverse("js-diagnostics", kwargs={"path": obj.get_url_path()}), data
         )
 
+    def test_alert_class_metadata_does_not_initialize_alert_object(self) -> None:
+        details = {"occurrences": [{"language_code": "cs"}]}
+        self.component.add_alert("UnusedGlossaryLanguage", **details)
+        alert = self.component.alert_set.get(name="UnusedGlossaryLanguage")
+
+        self.assertNotIn("alert_class", alert.__dict__)
+        alert_class = alert.alert_class
+
+        self.assertIn("alert_class", alert.__dict__)
+        self.assertIs(alert.alert_class, alert_class)
+        self.assertEqual(alert.category, "configuration")
+        self.assertNotIn("obj", alert.__dict__)
+        self.assertEqual(alert.details, details)
+
     def test_project_diagnostics_loads_lazily_for_authenticated_users(self) -> None:
         with patch("weblate.trans.views.js.get_diagnostics_context") as get_diagnostics:
             response = self.client.get(


### PR DESCRIPTION
Resolve static alert metadata from the registered class so changes API serialization does not enrich JSON details with model objects.

Fixes WEBLATE-3B63

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
