### PR TITLE
feat: support multiple gettext keywords in xgettext addon

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.8
 
 .. rubric:: Improvements
 
+* :ref:`addon-weblate.gettext.xgettext` now accepts multiple custom keywords (newline-separated) passed to xgettext via ``--keyword``, enabling extraction from different function names.
 * Added grouped project and workspace :guilabel:`Diagnostics` views with state, severity, category, and actionable-by-user filters.
 * Component diagnostics now record dismissal ownership, reopen after relevant changes, and notify only project maintainers who can act on warnings and errors.
 * :ref:`Add-on activity logs <addon-activity-logging>` now distinguish pending, successful, failed, and skipped executions and explain why an add-on was skipped.

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -2415,6 +2415,65 @@ class GettextAddonTest(ViewTestCase):
         # Bare --keyword must NOT be present when exclusivity is disabled.
         self.assertNotIn("--keyword", command)
 
+    def test_xgettext_keyword_string_backward_compatibility(self) -> None:
+        """Keyword stored as string (old format) should work after migration to list."""
+        source = Path(self.component.full_path) / "src" / "messages.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text('tr("Hello")\n', encoding="utf-8")
+        # Simulate old configuration where keyword was stored as a string
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+                "keyword": "tr",  # String format (old)
+            },
+        )
+
+        with (
+            patch.object(XgettextAddon, "run_process", return_value="") as mocked,
+            patch.object(XgettextAddon, "validate_repository_tree", return_value=True),
+        ):
+            addon.update_translations(self.component, "", [])
+
+        command = mocked.call_args.args[1]
+        self.assertIn("--keyword=tr", command)
+
+    def test_xgettext_multiple_keywords_string_backward_compatibility(self) -> None:
+        """Multiple newline-separated keywords stored as string (old format) should work."""
+        source = Path(self.component.full_path) / "src" / "messages.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text('tr("Hello")\nN_("World")\n', encoding="utf-8")
+        # Simulate old configuration with newline-separated keywords
+        addon = XgettextAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "interval": "weekly",
+                "update_po_files": False,
+                "language": "Python",
+                "source_patterns": ["src/*.py"],
+                "keyword": "tr\nN_",  # Newline-separated string format (old)
+            },
+        )
+
+        with (
+            patch.object(XgettextAddon, "run_process", return_value="") as mocked,
+            patch.object(XgettextAddon, "validate_repository_tree", return_value=True),
+        ):
+            addon.update_translations(self.component, "", [])
+
+        command = mocked.call_args.args[1]
+        self.assertIn("--keyword=tr", command)
+        self.assertIn("--keyword=N_", command)
+        self.assertEqual(
+            [arg for arg in command if arg.startswith("--keyword=")],
+            ["--keyword=tr", "--keyword=N_"],
+        )
+
     def test_xgettext_no_keyword_emits_no_keyword_args(self) -> None:
         """When no keyword is set, no --keyword args at all should appear."""
         source = Path(self.component.full_path) / "src" / "main.py"


### PR DESCRIPTION
## Description

Allow defining multiple extra keywords for the gettext POT extractor. Previously the xgettext addon accepted a single keyword; this change lets users pass several newline-separated keywords, each emitted as `--keyword=<kw>`.

Closes #21152

## Changes

- `weblate/addons/forms.py`: `keyword` field switched to a textarea, one keyword per line; cleaned data stored as a list (backwards compatible with stored string values).
- `weblate/addons/gettext.py`: `get_keyword()` → `get_keywords()` returning a list; each keyword emitted as its own `--keyword=` argument. Bare `--keyword` is still emitted exactly once when exclusive mode is on.
- `weblate/addons/tests.py`: updated existing asserts and added tests for form multi-keyword parsing, list round-tripping, and multi-keyword command generation (normal and exclusive).

## Testing

- `pytest weblate/addons/tests.py -k xgettext` → 48 passed
- `pytest weblate/addons/tests.py -q` → 475 passed, 3 skipped