### PR TITLE
feat(xgettext): allow multiple keywords in pot file update

### DIFF
--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -302,10 +302,11 @@ class BaseXgettextExtractPotForm(BaseExtractPotForm):
         ),
     )
     keyword = forms.CharField(
-        label=gettext_lazy("Additional keyword"),
+        label=gettext_lazy("Additional keywords"),
         required=False,
+        widget=forms.Textarea(),
         help_text=gettext_lazy(
-            "Optional extra keyword passed to xgettext using --keyword."
+            "Optional newline-separated extra keywords passed to xgettext using --keyword."
         ),
     )
     keyword_exclusive = forms.BooleanField(
@@ -313,8 +314,8 @@ class BaseXgettextExtractPotForm(BaseExtractPotForm):
         required=False,
         help_text=gettext_lazy(
             "When enabled, passes --keyword without a value to xgettext before "
-            "the additional keyword, disabling all default keywords so that only "
-            "the keyword specified above is recognized."
+            "the additional keywords, disabling all default keywords so that only "
+            "the keywords specified above is recognized."
         ),
     )
 
@@ -323,8 +324,16 @@ class BaseXgettextExtractPotForm(BaseExtractPotForm):
             kwargs.get("data"), "comment_mode", "off"
         )
         if data is not None:
+            keywords = data.get("keyword")
+            if isinstance(keywords, list):
+                data = data.copy()
+                data["keyword"] = "\n".join(keywords)
             kwargs["data"] = data
         super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def parse_keywords(value: str) -> list[str]:
+        return [line.strip() for line in value.splitlines() if line.strip()]
 
     def clean_xgettext_options(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
         comment_mode = cleaned_data.get("comment_mode", "off")
@@ -335,7 +344,7 @@ class BaseXgettextExtractPotForm(BaseExtractPotForm):
         else:
             comment_tag = ""
         cleaned_data["comment_tag"] = comment_tag
-        cleaned_data["keyword"] = cleaned_data.get("keyword", "").strip()
+        cleaned_data["keyword"] = self.parse_keywords(cleaned_data.get("keyword", ""))
         keyword_exclusive = bool(cleaned_data.get("keyword_exclusive"))
         if keyword_exclusive and not cleaned_data["keyword"]:
             self.add_error(

--- a/weblate/addons/gettext.py
+++ b/weblate/addons/gettext.py
@@ -1103,8 +1103,8 @@ class XgettextAddon(ExtractPotBaseAddon):
             return [str(check) for check in checks]
         return []
 
-    def get_keyword(self) -> str:
-        return str(self.instance.configuration.get("keyword", ""))
+    def get_keywords(self) -> list[str]:
+        return self.instance.configuration.get("keyword", [])
 
     def get_keyword_exclusive(self) -> bool:
         return bool(self.instance.configuration.get("keyword_exclusive", False))
@@ -1117,10 +1117,11 @@ class XgettextAddon(ExtractPotBaseAddon):
         elif comment_mode == "tagged" and (comment_tag := self.get_comment_tag()):
             result.append(f"--add-comments={comment_tag}")
         result.extend(f"--check={name}" for name in self.get_checks())
-        if keyword := self.get_keyword():
+        if keywords := self.get_keywords():
             if self.get_keyword_exclusive():
                 result.append("--keyword")
-            result.append(f"--keyword={keyword}")
+            for keyword in keywords:
+                result.append(f"--keyword={keyword}")
         return result
 
     def get_extra_xgettext_args(self, component: Component) -> list[str]:

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -1375,7 +1375,7 @@ class GettextAddonTest(ViewTestCase):
         self.assertEqual(form.cleaned_data["comment_mode"], "off")
         self.assertEqual(form.cleaned_data["comment_tag"], "")
         self.assertEqual(form.cleaned_data["checks"], [])
-        self.assertEqual(form.cleaned_data["keyword"], "")
+        self.assertEqual(form.cleaned_data["keyword"], [])
         self.assertEqual(form.cleaned_data["location_mode"], "file")
 
     def test_xgettext_form_accepts_blank_language(self) -> None:
@@ -1439,7 +1439,7 @@ class GettextAddonTest(ViewTestCase):
                 "comment_mode": "tagged",
                 "comment_tag": "TRANSLATORS",
                 "checks": ["ellipsis-unicode", "bullet-unicode"],
-                "keyword": "tr",
+                "keyword": ["tr", "another_tr"],
                 "location_mode": "keep",
             },
         )
@@ -1450,7 +1450,7 @@ class GettextAddonTest(ViewTestCase):
         self.assertEqual(
             form.cleaned_data["checks"], ["ellipsis-unicode", "bullet-unicode"]
         )
-        self.assertEqual(form.cleaned_data["keyword"], "tr")
+        self.assertEqual(form.cleaned_data["keyword"], ["tr", "another_tr"])
         self.assertEqual(form.cleaned_data["location_mode"], "keep")
 
     def test_xgettext_form_keyword_exclusive(self) -> None:
@@ -1466,13 +1466,13 @@ class GettextAddonTest(ViewTestCase):
                 "language": "Java",
                 "source_patterns": "src/*.java\n",
                 "potfiles_path": "",
-                "keyword": "tr",
+                "keyword": ["tr", "another_tr"],
                 "keyword_exclusive": True,
             },
         )
         assert form is not None
         self.assertTrue(form.is_valid(), form.errors)
-        self.assertEqual(form.cleaned_data["keyword"], "tr")
+        self.assertEqual(form.cleaned_data["keyword"], ["tr", "another_tr"])
         self.assertTrue(form.cleaned_data["keyword_exclusive"])
 
         # keyword_exclusive=True without a keyword is invalid.
@@ -1487,7 +1487,7 @@ class GettextAddonTest(ViewTestCase):
                 "language": "Java",
                 "source_patterns": "src/*.java\n",
                 "potfiles_path": "",
-                "keyword": "",
+                "keyword": [],
                 "keyword_exclusive": True,
             },
         )
@@ -1667,7 +1667,7 @@ class GettextAddonTest(ViewTestCase):
                 "comment_mode": "tagged",
                 "comment_tag": "TRANSLATORS",
                 "checks": ["ellipsis-unicode", "quote-unicode"],
-                "keyword": "tr",
+                "keyword": ["tr", "another_tr"],
                 "location_mode": "omit",
             },
         )
@@ -1681,7 +1681,7 @@ class GettextAddonTest(ViewTestCase):
         self.assertEqual(
             form.serialize_form()["checks"], ["ellipsis-unicode", "quote-unicode"]
         )
-        self.assertEqual(form.serialize_form()["keyword"], "tr")
+        self.assertEqual(form.serialize_form()["keyword"], ["tr", "another_tr"])
         self.assertEqual(form.serialize_form()["location_mode"], "omit")
 
     def test_django_form(self) -> None:
@@ -2380,7 +2380,7 @@ class GettextAddonTest(ViewTestCase):
                 "comment_mode": "tagged",
                 "comment_tag": "TRANSLATORS",
                 "checks": ["ellipsis-unicode", "bullet-unicode"],
-                "keyword": "tr",
+                "keyword": ["tr", "another_tr"],
             },
         )
 
@@ -2396,11 +2396,12 @@ class GettextAddonTest(ViewTestCase):
         self.assertIn("--check=ellipsis-unicode", command)
         self.assertIn("--check=bullet-unicode", command)
         self.assertIn("--keyword=tr", command)
+        self.assertIn("--keyword=another_tr", command)
 
     def test_xgettext_uses_exclusive_keywords(self) -> None:
         source = Path(self.component.full_path) / "src" / "Main.java"
         source.parent.mkdir(parents=True, exist_ok=True)
-        source.write_text('tr("Hello");\n', encoding="utf-8")
+        source.write_text('tr("Hello");', encoding="utf-8")
         addon = XgettextAddon.create(
             component=self.component,
             run=False,
@@ -2409,7 +2410,7 @@ class GettextAddonTest(ViewTestCase):
                 "update_po_files": False,
                 "language": "Java",
                 "source_patterns": ["src/*.java"],
-                "keyword": "tr",
+                "keyword": ["tr", "another_tr"],
                 "keyword_exclusive": True,
             },
         )
@@ -2425,7 +2426,9 @@ class GettextAddonTest(ViewTestCase):
         self.assertIn("--keyword", command)
         bare_idx = command.index("--keyword")
         named_idx = command.index("--keyword=tr")
+        another_idx = command.index("--keyword=another_tr")
         self.assertLess(bare_idx, named_idx)
+        self.assertLess(named_idx, another_idx)
         # Only the custom keyword should be present; no default keywords.
         self.assertNotIn("--keyword=gettext", command)
 
@@ -2442,7 +2445,7 @@ class GettextAddonTest(ViewTestCase):
                 "update_po_files": False,
                 "language": "Java",
                 "source_patterns": ["src/*.java"],
-                "keyword": "tr",
+                "keyword": ["tr", "another_tr"],
                 "keyword_exclusive": False,
             },
         )
@@ -2456,6 +2459,7 @@ class GettextAddonTest(ViewTestCase):
         command = mocked.call_args.args[1]
         # Named keyword must be present.
         self.assertIn("--keyword=tr", command)
+        self.assertIn("--keyword=another_tr", command)
         # Bare --keyword must NOT be present when exclusivity is disabled.
         self.assertNotIn("--keyword", command)
 
@@ -2549,7 +2553,7 @@ class GettextAddonTest(ViewTestCase):
                 "comment_mode": "tagged",
                 "comment_tag": "TRANSLATORS",
                 "checks": ["ellipsis-unicode"],
-                "keyword": "custom_tr",
+                "keyword": ["custom_tr", "another_keyword"],
             },
         )
 
@@ -2562,6 +2566,7 @@ class GettextAddonTest(ViewTestCase):
         self.assertIn("--add-comments=TRANSLATORS", command)
         self.assertIn("--check=ellipsis-unicode", command)
         self.assertIn("--keyword=custom_tr", command)
+        self.assertIn("--keyword=another_keyword", command)
         # Preset keywords must also still be present (non-exclusive mode).
         self.assertIn("--keyword=_", command)
         self.assertIn("--keyword=N_", command)


### PR DESCRIPTION
Refs: #21152

See issue. Kept the config option name for backwards compatibility.

First contribution here. Let me know if I missed something.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
