### PR TITLE
fix(add-ons): validate Fedora Messaging URL at runtime

### DIFF
--- a/weblate/addons/fedora_messaging.py
+++ b/weblate/addons/fedora_messaging.py
@@ -37,6 +37,7 @@ from weblate.utils.data import data_path
 from weblate.utils.errors import add_breadcrumb, report_error
 from weblate.utils.outbound import validate_connected_peer
 from weblate.utils.site import get_site_url
+from weblate.utils.validators import validate_fedora_messaging_url
 
 from .forms import FedoraMessagingAddonForm
 
@@ -568,6 +569,8 @@ class FedoraMessagingAddon(ChangeBaseAddon):
         force_update: bool = False,
     ) -> None:
         """Configure Fedora Messaging."""
+        validate_fedora_messaging_url(amqp_url)
+
         # ruff: ignore[import-outside-top-level]
         import fedora_messaging.config
 

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 import tempfile
+from collections import UserDict
 from copy import deepcopy
 from datetime import timedelta
 from io import StringIO
@@ -7367,7 +7368,7 @@ class AddonChangeDetailsMigrationTest(TestCase):
             action=ActionEvents.ADDON_CHANGE,
             target=FedoraMessagingAddon.name,
             details={
-                "amqp_url": "amqps://user:password@example.com/%2F",
+                "amqp_url": "amqps://user:password@example.com/%2F",  # kingfisher:ignore
                 "ca_cert": "private-ca",
                 "client_cert": "private-certificate",
                 "client_key": "private-key",
@@ -8138,7 +8139,7 @@ class AddonConfigurationUnitTest(SimpleTestCase):
         addon = FedoraMessagingAddon(
             Addon(
                 configuration={
-                    "amqp_url": "amqps://user:password@example.com/%2F",
+                    "amqp_url": "amqps://user:password@example.com/%2F",  # kingfisher:ignore
                     "ca_cert": "private-ca",
                     "client_cert": "private-certificate",
                     "client_key": "private-key",
@@ -10068,6 +10069,43 @@ class FedoraMessagingPEMBlockTest(SimpleTestCase):
             )
 
 
+class FedoraMessagingRuntimeValidationTest(SimpleTestCase):
+    def test_cached_configuration_still_validates_amqp_url(self) -> None:
+        class FakeMessagingConfig(UserDict[str, object]):
+            loaded = True
+
+            def _validate(self) -> None:
+                msg = "configuration fast path should return"
+                raise AssertionError(msg)
+
+        config = FakeMessagingConfig(
+            {
+                "amqp_url": "amqp://broker.example?connection_attempts=1&retry_delay=2",
+                "consumer_config": {"weblate_cert_hash": "cert-hash"},
+            }
+        )
+
+        with (
+            patch("weblate.addons.fedora_messaging.siphash", return_value="cert-hash"),
+            patch("fedora_messaging.config.conf", config),
+            patch(
+                "weblate.addons.fedora_messaging.validate_fedora_messaging_url"
+            ) as validate_fedora_messaging_url,
+            patch.object(
+                FedoraMessagingAddon, "validate_tls_credentials"
+            ) as validate_tls_credentials,
+        ):
+            FedoraMessagingAddon.configure_fedora_messaging(
+                amqp_url="amqp://broker.example",
+                ca_cert=None,
+                client_key=None,
+                client_cert=None,
+            )
+
+        validate_fedora_messaging_url.assert_called_once_with("amqp://broker.example")
+        validate_tls_credentials.assert_not_called()
+
+
 class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
     WEBHOOK_CLS = FedoraMessagingAddon
     # Not really used
@@ -10082,6 +10120,10 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.url_validation_patcher = patch(
+            "weblate.addons.fedora_messaging.validate_fedora_messaging_url"
+        )
+        self.validate_fedora_messaging_url = self.url_validation_patcher.start()
         self.patcher = patch("fedora_messaging.api._twisted_publish_wrapper")
         self.mock_class = self.patcher.start()
         self.prepare_service_patcher = patch.object(
@@ -10096,6 +10138,9 @@ class FedoraMessagingAddonTestCase(BaseWebhookTests, ViewTestCase):
         del self.mock_class
         self.patcher.stop()
         del self.patcher
+        del self.validate_fedora_messaging_url
+        self.url_validation_patcher.stop()
+        del self.url_validation_patcher
         super().tearDown()
 
     def count_requests(self) -> int:


### PR DESCRIPTION
The Fedora Messaging configuration can return early when the cached broker setup still matches. Validate the configured AMQP URL before that fast path so runtime sends keep enforcing outbound URL restrictions.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
