### PR TITLE
docs(security): define queued work authorization boundary

### DIFF
--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -752,6 +752,12 @@ Components managed through an authenticated integration are excluded from this
 generic behavior. Attribution and authenticity are weaker than for an
 authenticated user or token. *(maintainer)*
 
+User-requested background work is authorized when Weblate accepts and queues
+the request. Background tasks do not always verify the initiating user's
+permissions again when they execute. Later changes to the user's account,
+permissions, or team memberships therefore do not reliably prevent
+already-authorized work from completing. *(maintainer)*
+
 Weblate is not a sandbox for malicious administrators, malicious local
 operators, third-party add-ons, custom deployment code, VCS clients, or backup
 tools. *(maintainer)*


### PR DESCRIPTION
Permission changes cannot reliably cancel work Weblate has already authorized and queued. Document this boundary so revocation-only reports are triaged consistently.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
