### PR TITLE
fix(vcs): require executable runtime commands

### DIFF
--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -1931,16 +1931,7 @@ class GettextAddonTest(ViewTestCase):
             sphinx_build.write_text("", encoding="utf-8")
             sphinx_build.chmod(0o755)
 
-            with (
-                patch(
-                    "weblate.utils.commands.find_command",
-                    side_effect=lambda command, path=None: shutil.which(
-                        command,
-                        path=None if path is None else os.pathsep.join(path),
-                    ),
-                ),
-                patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)),
-            ):
+            with patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)):
                 self.assertTrue(SphinxAddon.can_install(component=self.component))
 
     def test_sphinx_can_install_uses_symlinked_runtime_venv_bin(self) -> None:
@@ -1962,16 +1953,7 @@ class GettextAddonTest(ViewTestCase):
             sphinx_build.write_text("", encoding="utf-8")
             sphinx_build.chmod(0o755)
 
-            with (
-                patch(
-                    "weblate.utils.commands.find_command",
-                    side_effect=lambda command, path=None: shutil.which(
-                        command,
-                        path=None if path is None else os.pathsep.join(path),
-                    ),
-                ),
-                patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)),
-            ):
+            with patch("weblate.utils.commands.sys.executable", os.fspath(fake_python)):
                 self.assertTrue(SphinxAddon.can_install(component=self.component))
 
     def test_sphinx_can_install_ignores_relative_runtime_executable(self) -> None:
@@ -1981,7 +1963,7 @@ class GettextAddonTest(ViewTestCase):
         (docs_dir / "conf.py").write_text("", encoding="utf-8")
 
         with (
-            patch("weblate.utils.commands.find_command", return_value=None),
+            patch("weblate.utils.commands.which", return_value=None),
             patch("weblate.utils.commands.sys.executable", "python"),
         ):
             self.assertFalse(SphinxAddon.can_install(component=self.component))
@@ -4747,16 +4729,14 @@ msgstr ""
         self.component.new_base = "locale/django.pot"
         self.component.save(update_fields=["new_base"])
 
-        def fake_find_command(name, path=None):
+        def fake_which(name, path=None):
             if name == "xgettext":
                 return "/usr/bin/xgettext"
             if name == "msguniq":
                 return None
             return "/usr/bin/other"
 
-        with patch(
-            "weblate.utils.commands.find_command", side_effect=fake_find_command
-        ):
+        with patch("weblate.utils.commands.which", side_effect=fake_which):
             self.assertFalse(DjangoAddon.can_install(component=self.component))
 
     def test_generate(self) -> None:

--- a/weblate/utils/commands.py
+++ b/weblate/utils/commands.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-
-from django.core.management.utils import find_command
+from shutil import which
 
 from weblate.utils.data import data_dir
 
@@ -110,9 +109,9 @@ def get_clean_env(
 
 def find_runtime_command(command: str, *, extra_path: str | None = None) -> str | None:
     """Find executable using the same PATH used for subprocess execution."""
-    return find_command(
+    return which(
         command,
-        path=build_runtime_path_entries(
+        path=build_runtime_path(
             os.environ.get("PATH", DEFAULT_PATH), extra_path=extra_path
         ),
     )

--- a/weblate/utils/tests/test_commands.py
+++ b/weblate/utils/tests/test_commands.py
@@ -5,7 +5,6 @@
 import csv
 import json
 import os
-import shutil
 import tempfile
 from io import StringIO
 from pathlib import Path
@@ -306,13 +305,6 @@ class RuntimeCommandTests(SimpleTestCase):
 
     def test_find_runtime_command_uses_runtime_path(self) -> None:
         with (
-            patch(
-                "weblate.utils.commands.find_command",
-                side_effect=lambda command, path=None: shutil.which(
-                    command,
-                    path=None if path is None else os.pathsep.join(path),
-                ),
-            ),
             patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
             patch.dict(os.environ, {"PATH": "/usr/bin"}),
             tempfile.TemporaryDirectory(prefix="weblate-runtime-command-") as tempdir,
@@ -332,33 +324,45 @@ class RuntimeCommandTests(SimpleTestCase):
                     os.fspath(xgettext),
                 )
 
+    def test_find_runtime_command_requires_executable(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="weblate-runtime-command-") as tempdir:
+            command = Path(tempdir) / "non-executable-command"
+            command.write_text("", encoding="utf-8")
+            command.chmod(0o644)
+            if os.access(command, os.X_OK):
+                self.skipTest("Platform does not support executable permissions")
+
+            with (
+                patch("weblate.utils.commands.sys.executable", ""),
+                patch(
+                    "weblate.utils.commands.sys.exec_prefix",
+                    os.fspath(Path(tempdir) / "prefix"),
+                ),
+                patch.dict(os.environ, {"PATH": tempdir}),
+            ):
+                self.assertIsNone(find_runtime_command(command.name))
+
     def test_find_runtime_command_ignores_relative_runtime_path(self) -> None:
         with (
-            patch("weblate.utils.commands.find_command", return_value=None),
+            patch("weblate.utils.commands.which", return_value=None),
             patch("weblate.utils.commands.sys.executable", "python"),
             patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
             patch.dict(os.environ, {"PATH": "/usr/bin"}),
         ):
             self.assertIsNone(find_runtime_command("xgettext"))
 
-    def test_find_runtime_command_passes_split_path_entries(self) -> None:
+    def test_find_runtime_command_passes_runtime_path(self) -> None:
         with (
             patch("weblate.utils.commands.sys.executable", "/runtime/bin/python"),
             patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
             patch.dict(os.environ, {"PATH": "/usr/bin:/usr/local/bin"}),
-            patch("weblate.utils.commands.find_command", return_value=None) as mocked,
+            patch("weblate.utils.commands.which", return_value=None) as mocked,
         ):
             find_runtime_command("xgettext", extra_path="/extra/bin")
 
         self.assertEqual(
             mocked.call_args.kwargs["path"],
-            [
-                "/extra/bin",
-                "/runtime/bin",
-                "/venv-prefix/bin",
-                "/usr/bin",
-                "/usr/local/bin",
-            ],
+            "/extra/bin:/runtime/bin:/venv-prefix/bin:/usr/bin:/usr/local/bin",
         )
 
     def test_get_clean_env_preserves_existing_path_precedence(self) -> None:
@@ -384,20 +388,13 @@ class RuntimeCommandTests(SimpleTestCase):
             patch("weblate.utils.commands.sys.executable", "/runtime/bin/python"),
             patch("weblate.utils.commands.sys.exec_prefix", "/venv-prefix"),
             patch.dict(os.environ, {}, clear=True),
-            patch("weblate.utils.commands.find_command", return_value=None) as mocked,
+            patch("weblate.utils.commands.which", return_value=None) as mocked,
         ):
             find_runtime_command("xgettext", extra_path="/extra/bin")
 
         self.assertEqual(
             mocked.call_args.kwargs["path"],
-            [
-                "/extra/bin",
-                "/runtime/bin",
-                "/venv-prefix/bin",
-                "/bin",
-                "/usr/bin",
-                "/usr/local/bin",
-            ],
+            "/extra/bin:/runtime/bin:/venv-prefix/bin:/bin:/usr/bin:/usr/local/bin",
         )
 
     def test_get_clean_env_deduplicates_runtime_prefixes(self) -> None:


### PR DESCRIPTION
Django's lookup accepts non-executable regular files, making unavailable VCS backends appear usable. Use shutil.which with the constructed runtime PATH to retain virtualenv discovery while checking executability.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
