### PR TITLE
fix(metrics): split daily metric collection

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 2026.9
 
 .. rubric:: Bug fixes
 
+* Daily metric collection now uses independent tasks and more efficient database queries to reduce peak memory usage and avoid losing all scopes when one collection fails.
 * Database dump failures are now shown in the backups management interface.
 * Project administrators can no longer remove API tokens belonging to other projects.
 * Project and workspace translation memory now respects restricted component access, and restricted components no longer contribute to shared translation memory.

--- a/weblate/metrics/models.py
+++ b/weblate/metrics/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from itertools import zip_longest
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from django.core.cache import cache
 from django.db import models, transaction
@@ -29,7 +29,7 @@ from weblate.trans.models import (
     Project,
     Translation,
 )
-from weblate.trans.models.change import Change
+from weblate.trans.models.change import Change, dt_as_day_range
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.stats import (
     CategoryLanguage,
@@ -100,6 +100,77 @@ METRIC_ORDER = [
 ]
 
 
+class ChangeMetricData(TypedDict):
+    changes: int
+    contributors: int
+    contributors_total: int
+
+
+def get_change_metric_data(
+    changes: ChangeQuerySet, date: datetime.date
+) -> ChangeMetricData:
+    """Calculate change metrics using two aggregate queries."""
+    active_user = Q(user__is_active=True, user__is_bot=False)
+    recent = changes.since_day(date - datetime.timedelta(days=30)).aggregate(
+        changes=Count(
+            "id",
+            filter=Q(
+                timestamp__range=dt_as_day_range(date - datetime.timedelta(days=1))
+            ),
+        ),
+        contributors=Count("user", filter=active_user, distinct=True),
+    )
+    total = changes.aggregate(
+        contributors_total=Count("user", filter=active_user, distinct=True)
+    )
+    return {
+        "changes": recent["changes"],
+        "contributors": recent["contributors"],
+        "contributors_total": total["contributors_total"],
+    }
+
+
+def get_language_change_metric_data(
+    changes: ChangeQuerySet, date: datetime.date
+) -> dict[int, ChangeMetricData]:
+    """Calculate change metrics grouped by translation language."""
+    active_user = Q(user__is_active=True, user__is_bot=False)
+    language_key = "translation__language_id"
+    result: dict[int, ChangeMetricData] = {}
+    for row in (
+        changes.since_day(date - datetime.timedelta(days=30))
+        .values(language_key)
+        .annotate(
+            changes=Count(
+                "id",
+                filter=Q(
+                    timestamp__range=dt_as_day_range(date - datetime.timedelta(days=1))
+                ),
+            ),
+            contributors=Count("user", filter=active_user, distinct=True),
+        )
+    ):
+        language_id = row[language_key]
+        if language_id is not None:
+            result[language_id] = {
+                "changes": row["changes"],
+                "contributors": row["contributors"],
+                "contributors_total": 0,
+            }
+    for row in (
+        changes.filter(active_user)
+        .values(language_key)
+        .annotate(contributors_total=Count("user", distinct=True))
+    ):
+        language_id = row[language_key]
+        if language_id is not None:
+            result.setdefault(
+                language_id,
+                {"changes": 0, "contributors": 0, "contributors_total": 0},
+            )["contributors_total"] = row["contributors_total"]
+    return result
+
+
 class MetricQuerySet(models.QuerySet["Metric", "Metric"]):
     def filter_metric(
         self, scope: int, relation: int, secondary: int = 0
@@ -143,7 +214,7 @@ class MetricManager(models.Manager["Metric"]):
         scope: int,
         relation: int,
         secondary: int = 0,
-        date=None,
+        date: datetime.date | None = None,
     ):
         if stats is not None:
             for key in keys:
@@ -252,8 +323,10 @@ class MetricManager(models.Manager["Metric"]):
         raise ValueError(msg)
 
     @transaction.atomic
-    def collect_global(self):
+    def collect_global(self, date: datetime.date | None = None):
+        date = date or timezone.now().date()
         stats = GlobalStats()
+        changes = Change.objects.all()
         data = {
             "projects": Project.objects.count(),
             "public_projects": Project.objects.filter(
@@ -263,77 +336,80 @@ class MetricManager(models.Manager["Metric"]):
             "translations": Translation.objects.count(),
             "memory": Memory.objects.count(),
             "screenshots": Screenshot.objects.count(),
-            "changes": Change.objects.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1)
-            ).count(),
-            "contributors": Change.objects.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": Change.objects.count_users(),
             "users": User.objects.count(),
+            **get_change_metric_data(changes, date),
         }
-        return self.create_metrics(data, stats, SOURCE_KEYS, Metric.SCOPE_GLOBAL, 0)
-
-    @transaction.atomic
-    def collect_project_language(self, project_language: ProjectLanguage):
-        project = project_language.project
-        changes = project.change_set.filter(
-            translation__language=project_language.language
+        return self.create_metrics(
+            data, stats, SOURCE_KEYS, Metric.SCOPE_GLOBAL, 0, date=date
         )
 
-        data = {
-            "changes": changes.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1),
-            ).count(),
-            "contributors": changes.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": changes.count_users(),
-        }
+    @transaction.atomic
+    def collect_project_language(
+        self,
+        project_language: ProjectLanguage,
+        date: datetime.date | None = None,
+        change_data: ChangeMetricData | None = None,
+    ):
+        date = date or timezone.now().date()
+        project = project_language.project
+        if change_data is None:
+            changes = project.change_set.filter(
+                translation__language=project_language.language
+            )
+            change_data = get_change_metric_data(changes, date)
 
         return self.create_metrics(
-            data,
+            dict(change_data),
             project_language.stats,
             SOURCE_KEYS,
             Metric.SCOPE_PROJECT_LANGUAGE,
             project.pk,
             project_language.language.pk,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_category_language(self, category_language: CategoryLanguage):
+    def collect_category_language(
+        self,
+        category_language: CategoryLanguage,
+        date: datetime.date | None = None,
+        change_data: ChangeMetricData | None = None,
+    ):
+        date = date or timezone.now().date()
         category = category_language.category
-        changes = Change.objects.for_category(category).filter(
-            translation__language=category_language.language
-        )
-
-        data = {
-            "changes": changes.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1),
-            ).count(),
-            "contributors": changes.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": changes.count_users(),
-        }
+        if change_data is None:
+            changes = Change.objects.for_category(category).filter(
+                translation__language=category_language.language
+            )
+            change_data = get_change_metric_data(changes, date)
 
         return self.create_metrics(
-            data,
+            dict(change_data),
             category_language.stats,
             SOURCE_KEYS,
             Metric.SCOPE_CATEGORY_LANGUAGE,
             category.pk,
             category_language.language.pk,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_category(self, category: Category):
+    def collect_category(self, category: Category, date: datetime.date | None = None):
+        date = date or timezone.now().date()
+        changes = Change.objects.for_category(category)
+        language_change_data = get_language_change_metric_data(changes, date)
         languages = prefetch_stats(
             [CategoryLanguage(category, language) for language in category.languages]
         )
         for category_language in languages:
-            self.collect_category_language(category_language)
-        changes = Change.objects.for_category(category)
+            self.collect_category_language(
+                category_language,
+                date,
+                language_change_data.get(
+                    category_language.language.pk,
+                    {"changes": 0, "contributors": 0, "contributors_total": 0},
+                ),
+            )
         category_filter = (
             Q(category=category)
             | Q(category__category=category)
@@ -352,26 +428,35 @@ class MetricManager(models.Manager["Metric"]):
             "translations": Translation.objects.filter(
                 component__in=components
             ).count(),
-            "changes": changes.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1)
-            ).count(),
-            "contributors": changes.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": changes.count_users(),
+            **get_change_metric_data(changes, date),
         }
 
         return self.create_metrics(
-            data, category.stats, SOURCE_KEYS, Metric.SCOPE_CATEGORY, category.pk
+            data,
+            category.stats,
+            SOURCE_KEYS,
+            Metric.SCOPE_CATEGORY,
+            category.pk,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_project(self, project: Project):
+    def collect_project(self, project: Project, date: datetime.date | None = None):
+        date = date or timezone.now().date()
+        changes = project.change_set.all()
+        language_change_data = get_language_change_metric_data(changes, date)
         languages = prefetch_stats(
             [ProjectLanguage(project, language) for language in project.languages]
         )
         for project_language in languages:
-            self.collect_project_language(project_language)
+            self.collect_project_language(
+                project_language,
+                date,
+                language_change_data.get(
+                    project_language.language.pk,
+                    {"changes": 0, "contributors": 0, "contributors_total": 0},
+                ),
+            )
         project_scope = MemoryScope.objects.filter(
             memory_id=OuterRef("pk"),
             project=project,
@@ -388,13 +473,7 @@ class MetricManager(models.Manager["Metric"]):
             "screenshots": Screenshot.objects.filter(
                 translation__component__project=project
             ).count(),
-            "changes": project.change_set.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1)
-            ).count(),
-            "contributors": project.change_set.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": project.change_set.count_users(),
+            **get_change_metric_data(changes, date),
         }
         keys = [
             f"machinery-accounting:internal:{project.id}",
@@ -408,11 +487,19 @@ class MetricManager(models.Manager["Metric"]):
         cache.delete_many(keys)
 
         return self.create_metrics(
-            data, project.stats, SOURCE_KEYS, Metric.SCOPE_PROJECT, project.pk
+            data,
+            project.stats,
+            SOURCE_KEYS,
+            Metric.SCOPE_PROJECT,
+            project.pk,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_workspace(self, workspace: Workspace):
+    def collect_workspace(
+        self, workspace: Workspace, date: datetime.date | None = None
+    ):
+        date = date or timezone.now().date()
         workspace_scope = MemoryScope.objects.filter(
             memory_id=OuterRef("pk"),
             workspace=workspace,
@@ -433,13 +520,7 @@ class MetricManager(models.Manager["Metric"]):
             "screenshots": Screenshot.objects.filter(
                 translation__component__project__workspace=workspace
             ).count(),
-            "changes": changes.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1)
-            ).count(),
-            "contributors": changes.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": changes.count_users(),
+            **get_change_metric_data(changes, date),
         }
         return self.create_metrics(
             data,
@@ -447,58 +528,56 @@ class MetricManager(models.Manager["Metric"]):
             SOURCE_KEYS,
             Metric.SCOPE_WORKSPACE,
             workspace.metric_id,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_component(self, component: Component):
+    def collect_component(
+        self, component: Component, date: datetime.date | None = None
+    ):
+        date = date or timezone.now().date()
+        changes = component.change_set.all()
         data = {
             "translations": component.translation_set.count(),
             "screenshots": Screenshot.objects.filter(
                 translation__component=component
             ).count(),
-            "changes": component.change_set.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1)
-            ).count(),
-            "contributors": component.change_set.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": component.change_set.count_users(),
+            **get_change_metric_data(changes, date),
         }
         return self.create_metrics(
-            data, component.stats, SOURCE_KEYS, Metric.SCOPE_COMPONENT, component.pk
+            data,
+            component.stats,
+            SOURCE_KEYS,
+            Metric.SCOPE_COMPONENT,
+            component.pk,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_component_list(self, clist: ComponentList):
+    def collect_component_list(
+        self, clist: ComponentList, date: datetime.date | None = None
+    ):
+        date = date or timezone.now().date()
         changes = Change.objects.filter(component__in=clist.components.all())
-        data = {
-            "changes": changes.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1)
-            ).count(),
-            "contributors": changes.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": changes.count_users(),
-        }
+        data = dict(get_change_metric_data(changes, date))
         return self.create_metrics(
             data,
             clist.stats,
             SOURCE_KEYS,
             Metric.SCOPE_COMPONENT_LIST,
             clist.pk,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_translation(self, translation: Translation):
+    def collect_translation(
+        self, translation: Translation, date: datetime.date | None = None
+    ):
+        date = date or timezone.now().date()
+        changes = translation.change_set.all()
         data = {
             "screenshots": translation.screenshot_set.count(),
-            "changes": translation.change_set.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1)
-            ).count(),
-            "contributors": translation.change_set.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": translation.change_set.count_users(),
+            **get_change_metric_data(changes, date),
         }
         return self.create_metrics(
             data,
@@ -506,12 +585,14 @@ class MetricManager(models.Manager["Metric"]):
             BASIC_KEYS,
             Metric.SCOPE_TRANSLATION,
             translation.pk,
+            date=date,
         )
 
     @transaction.atomic
-    def collect_user(self, user: User):
+    def collect_user(self, user: User, date: datetime.date | None = None):
+        date = date or timezone.now().date()
         data = user.change_set.filter_by_day(
-            timezone.now().date() - datetime.timedelta(days=1)
+            date - datetime.timedelta(days=1)
         ).aggregate(
             changes=Count("id"),
             comments=Count("id", filter=Q(action=ActionEvents.COMMENT)),
@@ -527,20 +608,17 @@ class MetricManager(models.Manager["Metric"]):
                 ),
             ),
         )
-        return self.create_metrics(data, None, set(), Metric.SCOPE_USER, user.pk)
+        return self.create_metrics(
+            data, None, set(), Metric.SCOPE_USER, user.pk, date=date
+        )
 
     @transaction.atomic
-    def collect_language(self, language: Language):
+    def collect_language(self, language: Language, date: datetime.date | None = None):
+        date = date or timezone.now().date()
         changes = language.change_set.all()
         data = {
-            "changes": changes.filter_by_day(
-                timezone.now().date() - datetime.timedelta(days=1),
-            ).count(),
-            "contributors": changes.since_day(
-                timezone.now().date() - datetime.timedelta(days=30)
-            ).count_users(),
-            "contributors_total": changes.count_users(),
             "users": language.profile_set.count(),
+            **get_change_metric_data(changes, date),
         }
         return self.create_metrics(
             data,
@@ -548,6 +626,7 @@ class MetricManager(models.Manager["Metric"]):
             SOURCE_KEYS,
             Metric.SCOPE_LANGUAGE,
             language.pk,
+            date=date,
         )
 
 

--- a/weblate/metrics/tasks.py
+++ b/weblate/metrics/tasks.py
@@ -2,7 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from datetime import timedelta
+from __future__ import annotations
+
+import logging
+import time
+from datetime import date, timedelta
 
 from celery.schedules import crontab
 from django.utils import timezone
@@ -21,26 +25,149 @@ from weblate.utils.celery import app
 from weblate.utils.stats import iter_prefetch_stats
 from weblate.workspaces.models import Workspace
 
+LOGGER = logging.getLogger("weblate.metrics")
+
+
+def _parse_date(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def _log_finished(
+    scope: str, collection_date: date, count: int, started: float
+) -> None:
+    LOGGER.info(
+        "Collected %d %s metrics for %s in %.2f seconds",
+        count,
+        scope,
+        collection_date,
+        time.monotonic() - started,
+    )
+
+
+@app.task(trail=False)
+def collect_global_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting global metrics for %s", collection_date)
+    Metric.objects.collect_global(collection_date)
+    _log_finished("global", collection_date, 1, started)
+
+
+@app.task(trail=False)
+def collect_project_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting project metrics for %s", collection_date)
+    count = 0
+    for project in iter_prefetch_stats(Project.objects.all()):
+        Metric.objects.collect_project(project, collection_date)
+        count += 1
+    _log_finished("project", collection_date, count, started)
+
+
+@app.task(trail=False)
+def collect_workspace_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting workspace metrics for %s", collection_date)
+    count = 0
+    for workspace in iter_prefetch_stats(Workspace.objects.all()):
+        Metric.objects.collect_workspace(workspace, collection_date)
+        count += 1
+    _log_finished("workspace", collection_date, count, started)
+
+
+@app.task(trail=False)
+def collect_category_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting category metrics for %s", collection_date)
+    count = 0
+    for category in iter_prefetch_stats(Category.objects.all()):
+        Metric.objects.collect_category(category, collection_date)
+        count += 1
+    _log_finished("category", collection_date, count, started)
+
+
+@app.task(trail=False)
+def collect_component_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting component metrics for %s", collection_date)
+    count = 0
+    for component in iter_prefetch_stats(Component.objects.all()):
+        Metric.objects.collect_component(component, collection_date)
+        count += 1
+    _log_finished("component", collection_date, count, started)
+
+
+@app.task(trail=False)
+def collect_component_list_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting component list metrics for %s", collection_date)
+    count = 0
+    for component_list in iter_prefetch_stats(ComponentList.objects.all()):
+        Metric.objects.collect_component_list(component_list, collection_date)
+        count += 1
+    _log_finished("component list", collection_date, count, started)
+
+
+@app.task(trail=False)
+def collect_translation_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting translation metrics for %s", collection_date)
+    count = 0
+    for translation in iter_prefetch_stats(Translation.objects.all()):
+        Metric.objects.collect_translation(translation, collection_date)
+        count += 1
+    _log_finished("translation", collection_date, count, started)
+
+
+@app.task(trail=False)
+def collect_user_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting user metrics for %s", collection_date)
+    count = 0
+    for user in User.objects.all().iterator(chunk_size=500):
+        Metric.objects.collect_user(user, collection_date)
+        count += 1
+    _log_finished("user", collection_date, count, started)
+
+
+@app.task(trail=False)
+def collect_language_metrics(date_value: str) -> None:
+    collection_date = _parse_date(date_value)
+    started = time.monotonic()
+    LOGGER.info("Collecting language metrics for %s", collection_date)
+    count = 0
+    for language in iter_prefetch_stats(Language.objects.all()):
+        Metric.objects.collect_language(language, collection_date)
+        count += 1
+    _log_finished("language", collection_date, count, started)
+
+
+METRIC_COLLECTION_TASKS = (
+    collect_global_metrics,
+    collect_project_metrics,
+    collect_workspace_metrics,
+    collect_category_metrics,
+    collect_component_metrics,
+    collect_component_list_metrics,
+    collect_translation_metrics,
+    collect_user_metrics,
+    collect_language_metrics,
+)
+
 
 @app.task(trail=False)
 def collect_metrics() -> None:
-    Metric.objects.collect_global()
-    for project in iter_prefetch_stats(Project.objects.all()):
-        Metric.objects.collect_project(project)
-    for workspace in iter_prefetch_stats(Workspace.objects.all()):
-        Metric.objects.collect_workspace(workspace)
-    for category in iter_prefetch_stats(Category.objects.all()):
-        Metric.objects.collect_category(category)
-    for component in iter_prefetch_stats(Component.objects.all()):
-        Metric.objects.collect_component(component)
-    for clist in iter_prefetch_stats(ComponentList.objects.all()):
-        Metric.objects.collect_component_list(clist)
-    for translation in iter_prefetch_stats(Translation.objects.all()):
-        Metric.objects.collect_translation(translation)
-    for user in User.objects.filter():
-        Metric.objects.collect_user(user)
-    for language in iter_prefetch_stats(Language.objects.all()):
-        Metric.objects.collect_language(language)
+    """Schedule independent metric collection tasks for each scope."""
+    date_value = timezone.now().date().isoformat()
+    for task in METRIC_COLLECTION_TASKS:
+        task.delay(date_value)
 
 
 @app.task(trail=False)

--- a/weblate/metrics/tests.py
+++ b/weblate/metrics/tests.py
@@ -4,21 +4,40 @@
 
 import importlib
 from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 from django.apps import apps
 from django.utils import timezone
 
-from weblate.metrics.models import Metric
-from weblate.metrics.tasks import cleanup_metrics, collect_metrics
+from weblate.metrics.models import (
+    Metric,
+    get_change_metric_data,
+    get_language_change_metric_data,
+)
+from weblate.metrics.tasks import (
+    METRIC_COLLECTION_TASKS,
+    cleanup_metrics,
+    collect_metrics,
+)
 from weblate.metrics.wrapper import MetricsWrapper
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Category, ComponentLink, Project
 from weblate.trans.models.change import Change
 from weblate.trans.tests.test_views import FixtureComponentTestCase
+from weblate.trans.tests.utils import create_another_user
 from weblate.workspaces.models import Workspace
 
 
 class MetricTestCase(FixtureComponentTestCase):
+    def test_collect_schedules_scope_tasks(self) -> None:
+        tasks = [MagicMock() for task in METRIC_COLLECTION_TASKS]
+        with patch("weblate.metrics.tasks.METRIC_COLLECTION_TASKS", tasks):
+            collect_metrics()
+
+        date_value = timezone.now().date().isoformat()
+        for task in tasks:
+            task.delay.assert_called_once_with(date_value)
+
     def test_collect(self) -> None:
         category = Category.objects.create(
             project=self.project, name="Metrics", slug="metrics"
@@ -112,6 +131,43 @@ class MetricTestCase(FixtureComponentTestCase):
     def test_collect_global(self) -> None:
         Metric.objects.collect_global()
         self.assertNotEqual(Metric.objects.count(), 0)
+
+    def test_collect_uses_requested_date(self) -> None:
+        collection_date = timezone.now().date() - timedelta(days=5)
+
+        metric = Metric.objects.collect_component(self.component, collection_date)
+
+        self.assertEqual(metric.date, collection_date)
+
+    def test_change_metric_aggregates(self) -> None:
+        Change.objects.all().delete()
+        collection_date = timezone.now().date()
+        old_user = create_another_user("-old-metric")
+        yesterday = self.translation.change_set.create(
+            action=ActionEvents.CHANGE, user=self.user
+        )
+        old = self.translation.change_set.create(
+            action=ActionEvents.CHANGE, user=old_user
+        )
+        Change.objects.filter(pk=yesterday.pk).update(
+            timestamp=timezone.now() - timedelta(days=1)
+        )
+        Change.objects.filter(pk=old.pk).update(
+            timestamp=timezone.now() - timedelta(days=45)
+        )
+
+        with self.assertNumQueries(2):
+            data = get_change_metric_data(
+                self.component.change_set.all(), collection_date
+            )
+        with self.assertNumQueries(2):
+            language_data = get_language_change_metric_data(
+                self.component.change_set.all(), collection_date
+            )[self.translation.language_id]
+
+        expected = {"changes": 1, "contributors": 1, "contributors_total": 2}
+        self.assertEqual(data, expected)
+        self.assertEqual(language_data, expected)
 
     def test_collect_workspace(self) -> None:
         workspace = Workspace.objects.create(name="Metrics workspace")

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -380,19 +380,6 @@ class ChangeQuerySet(models.QuerySet["Change", "Change"]):
         """
         return self.filter(timestamp__gte=dt_as_day_range(dt)[0])
 
-    def count_users(self) -> int:
-        """
-        Count contributing users.
-
-        Used mostly in the metrics.
-        """
-        return (
-            self.filter(user__is_active=True, user__is_bot=False)
-            .values("user")
-            .distinct()
-            .count()
-        )
-
 
 class ChangeManager(models.Manager["Change"]):
     def get_queryset(self) -> ChangeQuerySet:

--- a/weblate/utils/management/commands/ensure_stats.py
+++ b/weblate/utils/management/commands/ensure_stats.py
@@ -6,7 +6,6 @@
 from django.utils import timezone
 
 from weblate.metrics.models import Metric
-from weblate.metrics.tasks import collect_metrics
 from weblate.utils.management.base import BaseCommand
 from weblate.utils.stats import GlobalStats
 
@@ -17,7 +16,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options) -> None:
         all_strings = GlobalStats().all
         self.stdout.write(f"found {all_strings} strings")
-        if not Metric.objects.filter(
-            date=timezone.now().date(), scope=Metric.SCOPE_GLOBAL
-        ).exists():
-            collect_metrics()
+        today = timezone.now().date()
+        if not Metric.objects.filter(date=today, scope=Metric.SCOPE_GLOBAL).exists():
+            Metric.objects.collect_global(today)


### PR DESCRIPTION
Collect each metric scope independently and aggregate change counts in fewer queries to reduce peak worker memory and keep one failed scope from blocking the others.

Fixes #21209

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
