### PR TITLE
fix(alerts): improve VCS URL failure help

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Weblate 2026.9
 * Clarified generic :ref:`notification hook <hooks>` matching and privacy behavior.
 * Clarified that Weblate does not populate Git submodules. See :ref:`git-submodules`.
 * The initial :ref:`search-replace` action is now labeled :guilabel:`Review changes` to distinguish it from confirmation.
+* Repository failure alerts now provide guidance matching repository URL validation errors. See :ref:`vcs-repository-url-troubleshooting`.
 
 .. rubric:: Bug fixes
 

--- a/docs/vcs.rst
+++ b/docs/vcs.rst
@@ -26,6 +26,32 @@ example ``https://github.com/WeblateOrg/weblate.git``), but for private
 repositories or for push URLs the setup is more complex and requires
 authentication.
 
+.. _vcs-repository-url-troubleshooting:
+
+Troubleshooting repository URLs
++++++++++++++++++++++++++++++++
+
+Weblate validates repository and push URLs before connecting. HTTPS and SSH
+are permitted by default; instance administrators can adjust this using
+:setting:`VCS_ALLOW_SCHEMES`.
+
+Repository hostnames have to resolve from the Weblate server. When
+:setting:`VCS_RESTRICT_PRIVATE` is enabled, Weblate also rejects destinations
+which resolve to internal or otherwise non-public addresses. Use a publicly
+reachable repository URL where possible. For an intentionally private
+repository on a trusted network, ask the instance administrator to add its
+hostname to :setting:`VCS_ALLOW_HOSTS`.
+
+Git over HTTPS and SSH can bind connections to addresses approved during
+validation. Backends which cannot do this safely, including Mercurial and
+Subversion, require the trusted repository hostname in
+:setting:`VCS_ALLOW_HOSTS` while private-address restrictions are enabled.
+
+Configure the final repository URL directly when possible. Weblate can
+automatically accept a permanent HTTP redirect only when it stays on the same
+host and the target is successfully validated. Redirects to another host or
+protocol have to be configured manually.
+
 .. _hosted-push:
 
 Accessing repositories from Hosted Weblate

--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -769,7 +769,15 @@ class NotificationTest(ViewTestCase, RegistrationTestMixin):
 
     def test_notify_alert_includes_documentation(self) -> None:
         self.component.project.add_user(self.user, "Administration")
-        self.add_component_alert("UpdateFailure")
+        with self.captureOnCommitCallbacks(execute=True):
+            self.component.add_alert(
+                "UpdateFailure",
+                error={
+                    "code": "repository_url_backend_unsupported",
+                    "retcode": 0,
+                },
+                diagnoses=[],
+            )
         alert = self.component.alert_set.get(name="UpdateFailure")
         alert_message = next(
             message

--- a/weblate/templates/trans/alert/common-repo.html
+++ b/weblate/templates/trans/alert/common-repo.html
@@ -6,6 +6,40 @@
   </p>
 {% endif %}
 
+{% if analysis.repository_url_backend_unsupported %}
+  <p>
+    {% translate "This version control backend cannot enforce private-address restrictions for the configured URL. Ask the instance administrator to add the trusted repository hostname to VCS_ALLOW_HOSTS." %}
+  </p>
+{% elif analysis.repository_url_private %}
+  <p>
+    {% translate "Weblate blocked the repository URL because its destination is not permitted by this instance. Use a publicly reachable repository URL, or ask the instance administrator to allow the trusted repository host." %}
+  </p>
+{% endif %}
+
+{% if analysis.repository_url_invalid %}
+  <p>
+    {% translate "The configured repository URL is not valid. Check the URL in the component settings and use a complete repository URL supported by the selected version control system." %}
+  </p>
+{% endif %}
+
+{% if analysis.repository_url_scheme %}
+  <p>
+    {% translate "The repository URL uses a protocol which is not permitted by this instance. Use HTTPS or SSH, or ask the instance administrator whether another protocol can be safely enabled." %}
+  </p>
+{% endif %}
+
+{% if analysis.repository_url_resolution %}
+  <p>
+    {% translate "Weblate could not resolve the repository destination. Check the hostname and the instance DNS configuration. Internal or otherwise non-public hosts must also be explicitly allowed by the instance administrator." %}
+  </p>
+{% endif %}
+
+{% if analysis.repository_url_redirect and not analysis.redirect %}
+  <p>
+    {% translate "The repository URL redirect could not be safely followed. Configure the final repository URL directly; Weblate automatically accepts only verified permanent redirects on the same host." %}
+  </p>
+{% endif %}
+
 {% if analysis.not_found %}
   <p>
     {% translate "The upstream repository was not found. Please check whether it exists and is accessible to Weblate." %}
@@ -68,7 +102,7 @@
   </p>
 {% endif %}
 
-{% if not analysis.redirect %}
+{% if not analysis.redirect and not analysis.repository_url_failure %}
   <p>
     {% translate "Weblate will retry the operation once it is needed again, so the alert might disappear for the temporary issues." %}
   </p>

--- a/weblate/templates/trans/alert/mergefailure.html
+++ b/weblate/templates/trans/alert/mergefailure.html
@@ -2,7 +2,9 @@
 
 <p>{% translate "Weblate could not merge upstream changes while updating the repository." %}</p>
 
-{% if analysis.redirect %}
+{% if analysis.repository_url_failure or analysis.redirect %}
+  {% if not analysis.redirect %}<pre>{{ error }}</pre>{% endif %}
+
   {% include "trans/alert/common-repo.html" %}
 {% else %}
   <pre>{{ error }}</pre>

--- a/weblate/trans/alerts/base.py
+++ b/weblate/trans/alerts/base.py
@@ -70,6 +70,10 @@ class BaseAlert:
             return cls.get_doc_url(component, user)
         return get_doc_url(cls.doc_page, cls.doc_anchor, user=user)
 
+    def get_instance_documentation_url(self, user: User | None = None) -> str:
+        """Return documentation matching this alert instance."""
+        return self.get_documentation_url(self.instance.component, user)
+
     @classmethod
     def is_relevant(cls, component) -> bool:  # ruff: ignore[unused-class-method-argument]
         return True

--- a/weblate/trans/alerts/vcs.py
+++ b/weblate/trans/alerts/vcs.py
@@ -14,9 +14,11 @@ from weblate.trans.alerts.base import (
     ErrorAlert,
 )
 from weblate.trans.alerts.registry import register
+from weblate.utils.docs import get_doc_url
 from weblate.vcs.base import (
     RepositoryDiagnosis,
     RepositoryDiagnosisCode,
+    RepositoryErrorCode,
     RepositoryStructuredError,
     format_stored_repository_error,
     get_repository_error_diagnoses,
@@ -25,6 +27,30 @@ from weblate.vcs.base import (
 if TYPE_CHECKING:
     from weblate.auth.models import User
     from weblate.trans.models.component import Component
+
+
+REPOSITORY_URL_INVALID_ERRORS: frozenset[RepositoryErrorCode] = frozenset(
+    {
+        "repository_url_invalid",
+        "repository_url_parse_invalid",
+        "repository_url_parse_failed",
+    }
+)
+REPOSITORY_URL_PRIVATE_ERRORS: frozenset[RepositoryErrorCode] = frozenset(
+    {
+        "repository_url_backend_unsupported",
+        "repository_url_host_not_allowed",
+        "repository_url_private_target",
+    }
+)
+REPOSITORY_URL_RESOLUTION_ERRORS: frozenset[RepositoryErrorCode] = frozenset(
+    {
+        "repository_ssh_destination_unresolved",
+        "repository_ssh_destination_unresolved_with_error",
+        "repository_url_unresolved",
+        "repository_url_unresolved_with_error",
+    }
+)
 
 
 def normalize_repository_error_fingerprint(error: str) -> str:
@@ -83,10 +109,43 @@ class RepositoryErrorAlert(ErrorAlert):
                 return diagnosis.get("params", {})
         return None
 
+    @property
+    def error_code(self) -> RepositoryErrorCode | None:
+        if isinstance(self.stored_error, dict):
+            return self.stored_error["code"]
+        return None
+
+    @property
+    def is_repository_url_error(self) -> bool:
+        return self.error_code is not None and self.error_code.startswith(
+            ("repository_redirect", "repository_ssh_destination_", "repository_url_")
+        )
+
+    def get_instance_documentation_url(self, user: User | None = None) -> str:
+        if self.is_repository_url_error:
+            return get_doc_url("vcs", "vcs-repository-url-troubleshooting", user=user)
+        return super().get_instance_documentation_url(user)
+
     def get_analysis(self) -> dict[str, Any]:
+        error_code = self.error_code
         return {
             "redirect": self.has_diagnosis("repository_redirect"),
             "git_lfs_missing_objects": self.has_diagnosis("git_lfs_missing_objects"),
+            "repository_url_failure": self.is_repository_url_error,
+            "repository_url_backend_unsupported": (
+                error_code == "repository_url_backend_unsupported"
+            ),
+            "repository_url_invalid": error_code in REPOSITORY_URL_INVALID_ERRORS,
+            "repository_url_private": error_code in REPOSITORY_URL_PRIVATE_ERRORS,
+            "repository_url_redirect": (
+                error_code is not None and error_code.startswith("repository_redirect")
+            ),
+            "repository_url_resolution": (
+                error_code in REPOSITORY_URL_RESOLUTION_ERRORS
+            ),
+            "repository_url_scheme": (
+                error_code == "repository_url_scheme_not_allowed"
+            ),
         }
 
     @classmethod

--- a/weblate/trans/models/alert.py
+++ b/weblate/trans/models/alert.py
@@ -124,7 +124,7 @@ class Alert(models.Model):
         return self.obj.render(user)
 
     def get_documentation_url(self, user: User | None = None) -> str:
-        return self.alert_class.get_documentation_url(self.component, user)
+        return self.obj.get_instance_documentation_url(user)
 
     @transaction.atomic
     def dismiss(self, user: User, reason: str = "") -> bool:

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -41,7 +41,12 @@ from weblate.trans.models import (
 )
 from weblate.trans.models.alert import Alert
 from weblate.trans.tests.test_views import ViewTestCase
-from weblate.vcs.base import RepositoryError, RepositoryInternalError
+from weblate.utils.docs import get_doc_url
+from weblate.vcs.base import (
+    RepositoryError,
+    RepositoryInternalError,
+    RepositoryStructuredError,
+)
 from weblate.vcs.models import VCS_REGISTRY
 from weblate.workspaces.models import Workspace
 
@@ -864,6 +869,49 @@ class AlertTest(ViewTestCase):
                 action=ActionEvents.ALERT_REOPENED, alert=alert
             ).exists()
         )
+
+    def test_repository_url_failures_use_troubleshooting_documentation(self) -> None:
+        expected = get_doc_url(
+            "vcs", "vcs-repository-url-troubleshooting", user=self.user
+        )
+
+        for alert_name in ("MergeFailure", "UpdateFailure", "PushFailure"):
+            with self.subTest(alert_name=alert_name):
+                self.component.add_alert(
+                    alert_name,
+                    error={
+                        "code": "repository_url_backend_unsupported",
+                        "retcode": 0,
+                    },
+                    diagnoses=[],
+                )
+                alert = self.component.alert_set.get(name=alert_name)
+
+                self.assertEqual(alert.get_documentation_url(self.user), expected)
+
+                alert.delete()
+
+    def test_repository_failures_keep_operation_documentation(self) -> None:
+        expected = {
+            "MergeFailure": get_doc_url("faq", "merge", user=self.user),
+            "UpdateFailure": get_doc_url(
+                "admin/projects", "component-repo", user=self.user
+            ),
+            "PushFailure": "",
+        }
+
+        for alert_name, documentation_url in expected.items():
+            with self.subTest(alert_name=alert_name):
+                self.component.add_alert(
+                    alert_name, error="Repository operation failed", diagnoses=[]
+                )
+                alert = self.component.alert_set.get(name=alert_name)
+
+                self.assertEqual(
+                    alert.get_documentation_url(self.user), documentation_url
+                )
+
+                alert.delete()
 
     def test_repository_error_is_stored_structured_and_rendered_for_user(
         self,
@@ -1702,6 +1750,98 @@ class RepositoryAlertTemplateTest(SimpleTestCase):
 
         self.assertIn("permanent HTTP redirect", rendered)
         self.assertNotIn(raw_error, rendered)
+
+    def test_merge_url_failure_shows_url_guidance(self) -> None:
+        error = (
+            "This VCS backend cannot safely connect to this URL while private "
+            "address restrictions are enabled."
+        )
+        rendered = self.render_failure_alert(
+            "trans/alert/mergefailure.html",
+            set(),
+            analysis={
+                "repository_url_backend_unsupported": True,
+                "repository_url_failure": True,
+            },
+            error=error,
+        )
+
+        self.assertIn(error, rendered)
+        self.assertIn("cannot enforce private-address restrictions", rendered)
+        self.assertIn("VCS_ALLOW_HOSTS", rendered)
+        self.assertNotIn("Git HTTPS or SSH", rendered)
+        self.assertNotIn("Check the FAQ for info on how to resolve this", rendered)
+        self.assertNotIn("alert might disappear for the temporary issues", rendered)
+
+    def test_repository_url_failure_guidance(self) -> None:
+        cases = (
+            ("repository_url_private", "destination is not permitted"),
+            ("repository_url_invalid", "repository URL is not valid"),
+            ("repository_url_scheme", "protocol which is not permitted"),
+            ("repository_url_resolution", "could not resolve"),
+            ("repository_url_redirect", "redirect could not be safely followed"),
+        )
+
+        for analysis_key, expected in cases:
+            with self.subTest(analysis_key=analysis_key):
+                rendered = render_to_string(
+                    "trans/alert/common-repo.html",
+                    {"analysis": {analysis_key: True}},
+                )
+
+                self.assertIn(expected, rendered)
+
+    def test_repository_url_error_codes_are_classified(self) -> None:
+        cases: tuple[tuple[RepositoryStructuredError, str], ...] = (
+            (
+                {"code": "repository_url_backend_unsupported", "retcode": 0},
+                "repository_url_private",
+            ),
+            (
+                {"code": "repository_url_private_target", "retcode": 0},
+                "repository_url_private",
+            ),
+            (
+                {"code": "repository_url_parse_invalid", "retcode": 0},
+                "repository_url_invalid",
+            ),
+            (
+                {
+                    "code": "repository_url_scheme_not_allowed",
+                    "retcode": 0,
+                    "params": {"scheme": "file"},
+                },
+                "repository_url_scheme",
+            ),
+            (
+                {"code": "repository_url_unresolved", "retcode": 0},
+                "repository_url_resolution",
+            ),
+            (
+                {"code": "repository_ssh_destination_unresolved", "retcode": 0},
+                "repository_url_resolution",
+            ),
+            (
+                {"code": "repository_redirect_insecure", "retcode": 0},
+                "repository_url_redirect",
+            ),
+        )
+        expected_doc_url = get_doc_url("vcs", "vcs-repository-url-troubleshooting")
+
+        for error, analysis_key in cases:
+            with self.subTest(error_code=error["code"]):
+                alert = RepositoryErrorAlert(
+                    cast("Alert", SimpleNamespace(component=SimpleNamespace())),
+                    error,
+                    diagnoses=[],
+                )
+                analysis = alert.get_analysis()
+
+                self.assertTrue(analysis["repository_url_failure"])
+                self.assertTrue(analysis[analysis_key])
+                self.assertEqual(
+                    alert.get_instance_documentation_url(), expected_doc_url
+                )
 
     def test_repository_redirect_errors_are_classified(self) -> None:
         errors = (


### PR DESCRIPTION
Repository operation alerts used static documentation links, so URL policy failures could point users to unrelated merge guidance. Select help from the structured VCS error and explain the required administrator action.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
