### PR TITLE
fix(screenshots): cache viewed images

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Weblate 2026.9
 
 .. rubric:: Improvements
 
+* Screenshot images are now cached in browsers to reduce repeated downloads.
 * Administrators can now find removed accounts by their former e-mail address in the audit log until :setting:`AUDITLOG_EXPIRY`.
 * Deployment checks and the performance report now detect slow filesystem metadata access in data and cache directories.
 * Clarified the instance-wide impact of roles containing site-wide permissions, including :ref:`site-wide user management <site-wide-user-management>`.

--- a/weblate/screenshots/models.py
+++ b/weblate/screenshots/models.py
@@ -29,6 +29,7 @@ from weblate.trans.models import Translation, Unit
 from weblate.trans.signals import component_post_update, vcs_post_update
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.errors import report_error
+from weblate.utils.hash import calculate_checksum
 from weblate.vcs.base import RepositorySymlinkError
 
 if TYPE_CHECKING:
@@ -99,7 +100,14 @@ class Screenshot(models.Model, UserDisplayMixin):
         return reverse("screenshot", kwargs={"pk": self.pk})
 
     def get_view_url(self) -> str:
-        return reverse("screenshot-view", kwargs={"pk": self.pk})
+        kwargs = {"pk": self.pk}
+        if not self.image.name:
+            return reverse("screenshot-view", kwargs=kwargs)
+        return reverse(
+            "screenshot-view",
+            kwargs=kwargs,
+            query={"v": calculate_checksum(self.image.name)},
+        )
 
     @classmethod
     def validate_image_file(cls, image: File) -> None:

--- a/weblate/screenshots/tests.py
+++ b/weblate/screenshots/tests.py
@@ -403,10 +403,23 @@ class ViewTest(FixtureTestCase):
         self.make_manager()
         self.do_upload()
         screenshot = Screenshot.objects.all()[0]
-        response = self.client.get(screenshot.get_view_url())
+        view_url = screenshot.get_view_url()
+        self.assertRegex(view_url, r"/view/\?v=[0-9a-f]{16}$")
+        self.assertEqual(screenshot.get_view_url(), view_url)
+        response = self.client.get(view_url)
         # Admin can access this
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["content-type"], "image/png")
+        self.assertIn("max-age=3600", response["Cache-Control"])
+        self.assertIn("private", response["Cache-Control"])
+
+        # Legacy unversioned URLs remain supported
+        response = self.client.get(
+            reverse("screenshot-view", kwargs={"pk": screenshot.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "image/png")
+        self.assertIn("max-age=3600", response["Cache-Control"])
 
         # Private admin access
         self.project.access_control = Project.ACCESS_PRIVATE
@@ -1137,6 +1150,7 @@ class ViewTest(FixtureTestCase):
         screenshot = Screenshot.objects.all()[0]
         old_name = screenshot.image.name
         old_filename = screenshot.image.file.name
+        old_view_url = screenshot.get_view_url()
 
         data = Path(TEST_SCREENSHOT).read_bytes()
         http_mock.register(
@@ -1157,6 +1171,7 @@ class ViewTest(FixtureTestCase):
         screenshot.refresh_from_db()
         self.assertNotEqual(screenshot.image.name, old_name)
         self.assertNotEqual(screenshot.image.file.name, old_filename)
+        self.assertNotEqual(screenshot.get_view_url(), old_view_url)
 
     @http_mock.activate
     @patch(
@@ -1597,10 +1612,12 @@ class ScreenshotVCSTest(APITestCase, RepoTestCase):
     def test_update_screenshots_from_repo(self) -> None:
         repository = self.component.repository
         last_revision = repository.last_revision
-        existing_ss_size = Screenshot.objects.filter(
+        screenshot = Screenshot.objects.get(
             translation__component=self.component,
             repository_filename="test-update.png",
-        )[0].image.size
+        )
+        existing_ss_size = screenshot.image.size
+        existing_view_url = screenshot.get_view_url()
 
         copyfile(TEST_SCREENSHOT, os.path.join(repository.path, "test-update.png"))
         with repository.lock:
@@ -1623,11 +1640,12 @@ class ScreenshotVCSTest(APITestCase, RepoTestCase):
             ).count(),
             1,
         )
-        updated_ss_size = Screenshot.objects.filter(
+        screenshot = Screenshot.objects.get(
             translation__component=self.component,
             repository_filename="test-update.png",
-        )[0].image.size
-        self.assertNotEqual(existing_ss_size, updated_ss_size)
+        )
+        self.assertNotEqual(existing_ss_size, screenshot.image.size)
+        self.assertNotEqual(existing_view_url, screenshot.get_view_url())
 
     def test_linked_screenshots_reuse_changed_files(self) -> None:
         repository = self.component.repository

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -18,8 +18,10 @@ from django.http import FileResponse, JsonResponse
 from django.shortcuts import aget_object_or_404, get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.http import urlencode
 from django.utils.translation import gettext, ngettext
+from django.views.decorators.cache import cache_control
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, ListView
 from PIL import Image
@@ -541,6 +543,7 @@ class ScreenshotBaseView(DetailView):
         return obj
 
 
+@method_decorator(cache_control(max_age=3600, private=True), name="dispatch")
 class ScreenshotView(ScreenshotBaseView):
     def get(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> FileResponse:  # type: ignore[override]
         obj = self.get_object()


### PR DESCRIPTION
Repeated screenshot requests waste bandwidth while translators move through related strings. Cache responses privately for one hour to preserve access boundaries.

Fixes #21206

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
