### PR TITLE
perf(celery): reduce worker startup memory

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -1581,6 +1581,13 @@ command-line:
 
    celery --app=weblate.utils worker --beat --queues=celery,notify,memory,translate,backup
 
+To reduce startup memory usage, Celery workers do not repeat the Django system
+checks. The Weblate container runs the more comprehensive
+:command:`weblate check --deploy` automatically during container startup. For
+other installation methods, run the command after installation, upgrades, or
+configuration changes. The checks are also available in the
+:ref:`management interface <manage-performance>`.
+
 .. note::
 
    The Celery process has to be executed under the same user as the WSGI

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.9
 * Deployment checks and the performance report now detect slow filesystem metadata access in data and cache directories.
 * Clarified the instance-wide impact of roles containing site-wide permissions, including :ref:`site-wide user management <site-wide-user-management>`.
 * Improved translation file loading performance for metadata-only string changes.
+* Reduced :ref:`Celery <celery>` worker startup memory usage by avoiding duplicate Django system checks and loading font rendering only when needed.
 * VCS command versions are now validated by configuration health checks instead of during every process startup.
 * Billing audit logs now identify users who change plans, initiate payments, or merge billings.
 * Management notices now distinguish support package activation, status refresh, unlinking, and Discover Weblate registration.

--- a/weblate/fonts/utils.py
+++ b/weblate/fonts/utils.py
@@ -14,18 +14,6 @@ from typing import TYPE_CHECKING, NamedTuple
 from django.core.cache import cache as django_cache
 from PIL import ImageFont
 
-from weblate.fonts.render import (
-    create_clip_box,
-    create_figure,
-    draw_outline_rectangle,
-    draw_text,
-    figure_to_png,
-    get_font_properties,
-    measure_multiline,
-    rendering_lock,
-    split_explicit_lines,
-    wrap_text,
-)
 from weblate.utils.files import read_file_bytes
 from weblate.utils.hash import calculate_hash
 
@@ -69,24 +57,30 @@ def _render_size(
     surface_width: int | None = None,
 ) -> tuple[Dimensions, int, bytes]:
     """Check whether rendered text fits."""
+    # Importing Matplotlib and NumPy has a significant memory cost. Most Weblate
+    # processes only need font metadata, so defer the rendering stack until it is
+    # actually used.
+    # ruff: ignore[import-outside-top-level]
+    from weblate.fonts import render
+
     if surface_height is None:
         surface_height = int(lines * size * 1.5)
     if surface_width is None:
         surface_width = width
 
-    font_properties = get_font_properties(
+    font_properties = render.get_font_properties(
         font,
         size=size,
         weight=weight,
         font_siblings=font_siblings,
     )
-    with rendering_lock():
+    with render.rendering_lock():
         rendered_lines = (
-            split_explicit_lines(text)
+            render.split_explicit_lines(text)
             if lines == 1
-            else wrap_text(text, width, font_properties, spacing=spacing)
+            else render.wrap_text(text, width, font_properties, spacing=spacing)
         )
-        measured_width, measured_height = measure_multiline(
+        measured_width, measured_height = render.measure_multiline(
             rendered_lines, font_properties, spacing=spacing
         )
         pixel_size = Dimensions(measured_width, measured_height)
@@ -103,11 +97,13 @@ def _render_size(
         )
         expected_height = ceil(lines * pixel_size.height / line_count)
         overflow = pixel_size.width > width or line_count > lines
-        figure = create_figure(surface_width, surface_height, facecolor=(0.8, 0.8, 0.8))
+        figure = render.create_figure(
+            surface_width, surface_height, facecolor=(0.8, 0.8, 0.8)
+        )
         rendered_text = "\n".join(rendered_lines)
 
         if overflow:
-            draw_text(
+            render.draw_text(
                 figure,
                 0,
                 0,
@@ -117,10 +113,10 @@ def _render_size(
                 spacing=spacing,
             )
 
-        clip_box = create_clip_box(
+        clip_box = render.create_clip_box(
             0, surface_height - expected_height, width, expected_height
         )
-        draw_text(
+        render.draw_text(
             figure,
             0,
             0,
@@ -130,7 +126,7 @@ def _render_size(
             spacing=spacing,
             clip_box=clip_box,
         )
-        draw_outline_rectangle(
+        render.draw_outline_rectangle(
             figure,
             1,
             1,
@@ -139,7 +135,7 @@ def _render_size(
             color=(0.1, 0.1, 0.1),
         )
         if overflow:
-            draw_outline_rectangle(
+            render.draw_outline_rectangle(
                 figure,
                 1,
                 1,
@@ -147,7 +143,7 @@ def _render_size(
                 pixel_size.height - 2,
                 color=(246 / 255, 102 / 255, 76 / 255),
             )
-        buffer = figure_to_png(figure)
+        buffer = render.figure_to_png(figure)
 
     return pixel_size, line_count, buffer
 

--- a/weblate/utils/celery.py
+++ b/weblate/utils/celery.py
@@ -29,6 +29,11 @@ DjangoTask.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "weblate.settings")
 
+# Avoid loading the complete URL configuration and optional integrations in every
+# Celery worker. Deployment checks are run separately during container startup and
+# remain available through ``weblate check --deploy`` for other installations.
+os.environ.setdefault("CELERY_SKIP_CHECKS", "1")
+
 app = Celery[DjangoTask[..., Any]]("weblate")
 
 # Using a string here means the worker doesn't have to serialize

--- a/weblate/utils/tests/test_celery.py
+++ b/weblate/utils/tests/test_celery.py
@@ -1,0 +1,73 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # ruff: ignore[suspicious-subprocess-import]
+import sys
+
+from django.test import SimpleTestCase
+
+
+class CeleryStartupTest(SimpleTestCase):
+    @staticmethod
+    def run_python(code: str, *, skip_checks: str | None = None) -> str:
+        environment = os.environ.copy()
+        environment["DJANGO_SETTINGS_MODULE"] = "weblate.settings_test"
+        if skip_checks is None:
+            environment.pop("CELERY_SKIP_CHECKS", None)
+        else:
+            environment["CELERY_SKIP_CHECKS"] = skip_checks
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            capture_output=True,
+            env=environment,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout.strip()
+
+    def test_task_discovery_avoids_heavy_startup_imports(self) -> None:
+        output = self.run_python(
+            """
+import json
+import os
+import sys
+
+from weblate.utils.celery import app
+
+app.loader.import_default_modules()
+print(json.dumps({
+    "skip_checks": os.environ.get("CELERY_SKIP_CHECKS"),
+    "urls_loaded": "weblate.urls" in sys.modules,
+    "matplotlib_loaded": "matplotlib" in sys.modules,
+}))
+"""
+        )
+
+        self.assertEqual(
+            json.loads(output),
+            {
+                "skip_checks": "1",
+                "urls_loaded": False,
+                "matplotlib_loaded": False,
+            },
+        )
+
+    def test_explicit_check_configuration_is_preserved(self) -> None:
+        output = self.run_python(
+            """
+import os
+
+import weblate.utils.celery
+
+print(repr(os.environ["CELERY_SKIP_CHECKS"]))
+""",
+            skip_checks="",
+        )
+
+        self.assertEqual(output, "''")


### PR DESCRIPTION
Workers eagerly loaded Django's URL stack and Matplotlib during startup, accounting for substantial idle RSS. Skip duplicate system checks and defer font rendering imports until needed.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
