### PR TITLE
refactor(templates): isolate translation template tags

### DIFF
--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -31,12 +31,12 @@ from weblate.addons.events import (
 from weblate.trans.actions import ACTIONS_CONTENT
 from weblate.trans.exceptions import FileParseError
 from weblate.trans.models import Component
-from weblate.trans.templatetags.translations import format_json
 from weblate.utils import messages
 from weblate.utils.commands import get_clean_env
 from weblate.utils.docs import DocVersionsMixin
 from weblate.utils.errors import report_error
 from weblate.utils.files import cleanup_error_message, get_repo_temp_dir
+from weblate.utils.formatting import format_json
 from weblate.utils.html import format_html_join_comma, list_to_tuples
 from weblate.utils.render import render_template
 from weblate.utils.validators import validate_filename

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -394,9 +394,7 @@ class TargetCheck(BaseCheck):
 
     def format_value(self, value: str) -> StrOrPromise:
         # ruff: ignore[import-outside-top-level]
-        from weblate.trans.templatetags.translations import (
-            Formatter,
-        )
+        from weblate.trans.formatting import Formatter
 
         fmt = Formatter(0, value, None, None, None, None, None)
         fmt.parse()

--- a/weblate/machinery/views.py
+++ b/weblate/machinery/views.py
@@ -27,8 +27,8 @@ from weblate.machinery.base import (
     MachineTranslationError,
 )
 from weblate.machinery.models import MACHINERY
+from weblate.trans.formatting import format_language_string
 from weblate.trans.models import Project, Unit
-from weblate.trans.templatetags.translations import format_language_string
 from weblate.utils.errors import report_error
 from weblate.utils.views import parse_path
 from weblate.wladmin.views import MENU as MANAGE_MENU

--- a/weblate/trans/change_display.py
+++ b/weblate/trans/change_display.py
@@ -17,13 +17,13 @@ from weblate.addons.models import ADDONS
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.alerts.registry import get_alert_class
-from weblate.trans.models.change import COMPONENT_ORIGINS
-from weblate.trans.models.project import Project
-from weblate.trans.templatetags.translations import (
+from weblate.trans.formatting import (
     format_language_string,
     format_unit_source,
     format_unit_target,
 )
+from weblate.trans.models.change import COMPONENT_ORIGINS
+from weblate.trans.models.project import Project
 from weblate.utils.files import FileUploadMethod, get_upload_message
 from weblate.utils.html import format_html_join_comma
 from weblate.utils.markdown import render_markdown

--- a/weblate/trans/formatting.py
+++ b/weblate/trans/formatting.py
@@ -1,0 +1,761 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from html import escape as html_escape
+from typing import TYPE_CHECKING
+
+from django.urls import reverse
+from django.utils.html import escape, format_html
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext, ngettext, pgettext
+
+from weblate.lang.models import Language
+from weblate.trans.models import Category, Component, Project, Translation, Unit
+from weblate.trans.specialchars import get_display_char
+from weblate.trans.util import split_plural
+from weblate.utils.diff import Differ
+from weblate.utils.html import format_html_join_comma, list_to_tuples
+from weblate.utils.stats import CategoryLanguage, ProjectLanguage
+from weblate.workspaces.models import Workspace
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from django.db.models import Model
+    from django_stubs_ext import StrOrPromise
+
+    from weblate.auth.models import User
+    from weblate.utils.stats import GhostStats
+
+SPACE_START = '<span class="hlspace"><span class="space-space">'
+SPACE_NL_START = '<span class="hlspace"><span class="space-nl">'
+SPACE_MIDDLE_1 = "</span>"
+SPACE_MIDDLE_2 = '<span class="space-space">'
+SPACE_END = "</span></span>"
+SPACE_NL_END = "</span></span><br>"
+
+GLOSSARY_TEMPLATE = """<span class="glossary-term" title="{}">"""
+
+# This should match whitespace_regex in weblate/static/loader-bootstrap.js
+WHITESPACE_REGEX = (
+    r"(\t|\u00A0|\u00AD|\u1680|\u2000|\u2001|\u2002|\u2003|"
+    r"\u2004|\u2005|\u2006|\u2007|\u2008|\u2009|\u200A|"
+    r"\u202F|\u205F|\u3000)"
+)
+WHITESPACE_RE = re.compile(WHITESPACE_REGEX, re.MULTILINE)
+NEWLINE_RE = re.compile(r"(\r\n|\r|\n)", re.MULTILINE)
+MULTISPACE_RE = re.compile(r"(  +| $|^ )", re.MULTILINE)
+ESCAPE_RE = re.compile(r"""['"&<>]""")
+
+SOURCE_LINK = (
+    '<a href="{0}" target="_blank" rel="noopener noreferrer"'
+    ' class="{2}" dir="ltr" tabindex="-1">{1}</a>'
+)
+HLCHECK = '<span class="hlcheck" data-value="{}"><span class="highlight-number"></span>'
+
+
+class Formatter:
+    def __init__(
+        self,
+        idx,
+        value,
+        unit,
+        glossary,
+        diff,
+        search_match,
+        match,
+        whitespace: bool = True,
+    ) -> None:
+        # Inputs
+        self.idx = idx
+        self.cleaned_value = self.value = value
+        self.unit = unit
+        self.glossary = glossary
+        self.diff = diff
+        self.search_match = search_match
+        self.match = match
+        # Tags output
+        self.tags: dict[int, list[str]] = defaultdict(list)
+        self.differ = Differ()
+        self.whitespace = whitespace
+
+    def insert_before_opening_tags(self, position: int, tag: str) -> None:
+        """Insert a tag after closers and before any opening tags at a position."""
+        current = self.tags[position]
+        insert_at = len(current)
+        for index, current_tag in enumerate(current):
+            if not current_tag.startswith("</"):
+                insert_at = index
+                break
+        current.insert(insert_at, tag)
+
+    def parse(self) -> None:
+        if self.unit:
+            self.parse_highlight()
+        if self.glossary:
+            self.parse_glossary()
+        if self.search_match:
+            self.parse_search()
+        if self.whitespace:
+            self.parse_whitespace()
+        if self.diff:
+            self.parse_diff()
+
+    def parse_diff(self) -> None:  # ruff: ignore[complex-structure]
+        """Highlights diff, including extra whitespace."""
+        diff = self.differ.compare(self.value, self.diff[self.idx])
+        offset = 0
+        for op, data in diff:
+            if op == self.differ.DIFF_DELETE:
+                formatter = Formatter(
+                    0,
+                    data,
+                    self.unit,
+                    self.glossary,
+                    None,
+                    self.search_match,
+                    self.match,
+                )
+                formatter.parse()
+                self.tags[offset].append(f"<del>{formatter.format()}</del>")
+            elif op == self.differ.DIFF_INSERT:
+                end = offset + len(data)
+                # Rearrange space highlighting
+                move_space = False
+                start_space = -1
+                start_nl = -1
+                append_end = True
+                if offset in self.tags:
+                    for pos, tag in enumerate(self.tags[offset]):
+                        if tag == SPACE_MIDDLE_2:
+                            self.tags[offset][pos] = SPACE_MIDDLE_1
+                            move_space = True
+                            break
+                        if tag == SPACE_START:
+                            start_space = pos
+                            break
+                        if tag == SPACE_NL_START:
+                            start_nl = pos
+                            break
+
+                if start_space != -1:
+                    self.tags[offset].insert(start_space, "<ins>")
+                    last_middle = None
+                    for i in range(len(data)):
+                        tagoffset = offset + i + 1
+                        if tagoffset not in self.tags:
+                            continue
+                        for pos, tag in enumerate(self.tags[tagoffset]):
+                            if tag == SPACE_END:
+                                # Whitespace ends within <ins>
+                                start_space = -1
+                                break
+                            if tag == SPACE_MIDDLE_2:
+                                last_middle = (tagoffset, pos)
+                        if start_space == -1:
+                            break
+                    if start_space != -1 and last_middle is not None:
+                        self.tags[tagoffset][pos] = SPACE_MIDDLE_1
+
+                elif start_nl != -1:
+                    # The line break is always one char wide, so we do not
+                    # need the complex logic used for generic whitespace
+                    start_tag = self.tags[offset].pop(start_nl)
+                    self.tags[end].insert(0, "<ins>")
+                    self.tags[end].insert(1, start_tag)
+                    self.tags[end].append("</ins>")
+                    append_end = False
+
+                else:
+                    self.tags[offset].append("<ins>")
+                if move_space:
+                    self.tags[offset].append(SPACE_START)
+                if append_end:
+                    self.insert_before_opening_tags(end, "</ins>")
+                if start_space != -1:
+                    self.tags[end].append(SPACE_START)
+
+                # Rearange other tags
+                open_tags = 0
+                process = False
+                for i in range(offset, end + 1):
+                    remove = []
+                    for pos, tag in enumerate(self.tags[i]):
+                        if not process:
+                            if tag.startswith("<ins"):
+                                process = True
+                            continue
+                        if tag.startswith("</ins>"):
+                            break
+                        if tag.startswith("<span"):
+                            open_tags += 1
+                        elif tag.startswith("</span"):
+                            if open_tags == 0:
+                                # Remove tags spanning over <ins>
+                                remove.append(pos)
+                                found = None
+                                for back in range(offset - 1, 0, -1):
+                                    for child_pos, child in reversed(
+                                        list(enumerate(self.tags[back]))
+                                    ):
+                                        if child.startswith("<span"):
+                                            found = child_pos
+                                            break
+                                    if found is not None:
+                                        del self.tags[back][found]
+                                        break
+                            else:
+                                open_tags -= 1
+                    # Remove closing tags (do this outside the loop)
+                    for pos in reversed(remove):
+                        del self.tags[i][pos]
+
+                offset = end
+            elif op == self.differ.DIFF_EQUAL:
+                offset += len(data)
+
+    def parse_highlight(self) -> None:
+        """Highlights unit placeables."""
+        # Importing the check registry here would create a cycle for checks which use
+        # Formatter and would make every formatting helper user load all checks.
+        from weblate.checks.utils import (  # ruff: ignore[import-outside-top-level]
+            highlight_string,
+        )
+
+        highlights = highlight_string(self.value, self.unit)
+        cleaned_value = list(self.value)
+        for highlight in highlights:
+            self.tags[highlight.start].append(format_html(HLCHECK, highlight.text))
+            self.tags[highlight.end].insert(0, "</span>")
+            cleaned_value[highlight.start : highlight.end] = [" "] * (
+                highlight.end - highlight.start
+            )
+
+        # Prepare cleaned up value for glossary terms (we do not want to extract those
+        # from format strings)
+        self.cleaned_value = "".join(cleaned_value)
+
+    @staticmethod
+    def format_terms(terms):
+        forbidden = []
+        nontranslatable = []
+        translations = []
+        for term in terms:
+            flags = term.all_flags
+            target = html_escape(term.target)
+            source = html_escape(term.source)
+            # Translators: Glossary term formatting used in a tooltip
+            formatted = pgettext("glossary term", "{target} [{source}]").format(
+                source=source, target=target
+            )
+            if "read-only" in flags:
+                nontranslatable.append(source)
+            elif not target:
+                continue
+            elif "forbidden" in flags:
+                forbidden.append(formatted)
+            else:
+                translations.append(formatted)
+
+        output = []
+        if forbidden:
+            output.append(
+                "\n".join(
+                    (
+                        ngettext(
+                            "Forbidden translation:",
+                            "Forbidden translations:",
+                            len(forbidden),
+                        ),
+                        *forbidden,
+                    )
+                )
+            )
+        if nontranslatable:
+            output.append(
+                "\n".join(
+                    (
+                        ngettext(
+                            "Untranslatable term:",
+                            "Untranslatable terms:",
+                            len(nontranslatable),
+                        ),
+                        *nontranslatable,
+                    )
+                )
+            )
+        if translations:
+            output.append(
+                "\n".join(
+                    (
+                        ngettext(
+                            "Glossary term:",
+                            "Glossary terms:",
+                            len(translations),
+                        ),
+                        *translations,
+                    )
+                )
+            )
+        return "\n\n".join(output)
+
+    def parse_glossary(self) -> None:
+        """Highlights glossary entries."""
+        # Annotate string with glossary terms
+        locations = defaultdict(list)
+        for term in self.glossary:
+            for start, end in term.glossary_positions:
+                # Skip terms whose parts belong to placeholders
+                if self.cleaned_value[start:end].lower() != term.source.lower():
+                    continue
+
+                for i in range(start, end):
+                    locations[i].append(term)
+                locations[end].extend([])
+
+        # Render span tags for each glossary term match
+        last_entries: list[str] = []
+        for position, entries in sorted(locations.items()):
+            if last_entries and entries != last_entries:
+                self.tags[position].insert(0, "</span>")
+
+            if entries and entries != last_entries:
+                self.tags[position].append(
+                    GLOSSARY_TEMPLATE.format(self.format_terms(entries))
+                )
+            last_entries = entries
+
+    def parse_search(self) -> None:
+        """Highlights search matches."""
+        tag = self.match
+        if self.match == "search":
+            tag = "hlmatch"
+
+        start_tag = format_html('<span class="{}">', tag)
+        end_tag = "</span>"
+
+        for match in re.finditer(
+            re.escape(self.search_match), self.value, flags=re.IGNORECASE
+        ):
+            self.insert_before_opening_tags(match.start(), start_tag)
+            self.insert_before_opening_tags(match.end(), end_tag)
+
+    def parse_whitespace(self) -> None:
+        """Highlight whitespaces."""
+        value = self.value
+
+        for match in NEWLINE_RE.finditer(value):
+            self.tags[match.start()].append(SPACE_NL_START)
+            self.tags[match.end()].insert(0, SPACE_NL_END)
+
+        for match in MULTISPACE_RE.finditer(value):
+            self.tags[match.start()].append(SPACE_START)
+            for i in range(match.start() + 1, match.end()):
+                self.tags[i].insert(0, SPACE_MIDDLE_1)
+                self.tags[i].append(SPACE_MIDDLE_2)
+            self.tags[match.end()].insert(0, SPACE_END)
+
+        for match in WHITESPACE_RE.finditer(value):
+            whitespace = match.group(0)
+            cls = "space-tab" if whitespace == "\t" else "space-space"
+            title = get_display_char(whitespace)[0]
+            self.tags[match.start()].append(
+                format_html(
+                    '<span class="hlspace"><span class="{}" title="{}">', cls, title
+                )
+            )
+            self.tags[match.end()].insert(0, "</span></span>")
+
+    def format_generator(self) -> Generator[str]:
+        tags = self.tags
+        value = self.value
+        current: list[str]
+        replacements: dict[int, str] = {}
+
+        # Extract tag positions
+        positions: set[int] = set(tags.keys())
+
+        # Avoid processing trailing tags in the loop
+        positions.discard(len(value))
+
+        # Replace special characters "&", "<" and ">" to HTML-safe sequences.
+        # This is like html.escape but inline
+        for match in ESCAPE_RE.finditer(value):
+            position = match.start()
+            positions.add(position)
+            char = match.group()
+            if char == "&":
+                next_output = "&amp;"
+            elif char == "<":
+                next_output = "&lt;"
+            elif char == ">":
+                next_output = "&gt;"
+            elif char == '"':
+                next_output = "&quot;"
+            elif char == "'":
+                next_output = "&#x27;"
+            else:
+                raise ValueError(char)
+            replacements[position] = next_output
+
+        previous_start = 0
+        for pos in sorted(positions):
+            # String up to current position
+            yield value[previous_start:pos]
+
+            if pos in tags:
+                current = tags[pos]
+                # Special case for leading/trailing whitespace char in diff
+                if (
+                    current
+                    and value[pos] == " "
+                    and "<ins>" in current
+                    and SPACE_START not in current
+                ):
+                    current.append(SPACE_START)
+                    tags[pos + 1].insert(0, SPACE_END)
+
+                elif pos + 1 in tags:
+                    next_tags = tags[pos + 1]
+                    if (
+                        next_tags
+                        and value[pos] == " "
+                        and "</ins>" in next_tags
+                        and SPACE_END not in next_tags
+                        and SPACE_MIDDLE_1 not in next_tags
+                    ):
+                        current.append(SPACE_START)
+                        next_tags.insert(0, SPACE_END)
+
+                # Tags
+                yield from current
+
+            if pos in replacements:
+                # HTML escaped string
+                yield replacements[pos]
+                previous_start = pos + 1
+            else:
+                previous_start = pos
+
+        yield value[previous_start:]
+
+        # Trailing tags
+        yield from tags[len(value)]
+
+    def format(self):
+        # Safe to mark because format_generator escapes raw string content inline
+        # and only emits formatter-controlled markup for diffs/highlights/tooltips.
+        return mark_safe("".join(self.format_generator()))  # ruff: ignore[suspicious-mark-safe-usage]
+
+
+def format_unit_target(
+    unit,
+    *,
+    value: str | None = None,
+    diff=None,
+    search_match: str | None = None,
+    match: str = "search",
+    simple: bool = False,
+    wrap: bool = False,
+    show_copy: bool = False,
+):
+    return format_translation(
+        plurals=unit.get_target_plurals() if value is None else split_plural(value),
+        language=unit.translation.language,
+        plural=unit.translation.plural,
+        unit=unit,
+        diff=diff,
+        search_match=search_match,
+        match=match,
+        simple=simple,
+        wrap=wrap,
+        show_copy=show_copy,
+    )
+
+
+def format_unit_source(
+    unit,
+    *,
+    value: str | None = None,
+    diff=None,
+    search_match: str | None = None,
+    match: str = "search",
+    simple: bool = False,
+    glossary=None,
+    wrap: bool = False,
+    show_copy: bool = False,
+):
+    source_translation = unit.translation.component.source_translation
+    return format_translation(
+        plurals=unit.get_source_plurals() if value is None else split_plural(value),
+        language=source_translation.language,
+        plural=source_translation.plural,
+        unit=unit,
+        diff=diff,
+        search_match=search_match,
+        match=match,
+        simple=simple,
+        glossary=glossary,
+        wrap=wrap,
+        show_copy=show_copy,
+    )
+
+
+def format_source_string(
+    value: str,
+    unit,
+    *,
+    search_match: str | None = None,
+    match: str = "search",
+    simple: bool = False,
+    glossary=None,
+    wrap: bool = False,
+    whitespace: bool = True,
+):
+    """Format simple string as in the unit source language."""
+    return format_translation(
+        plurals=[value],
+        language=unit.translation.component.source_language,
+        plural=unit.translation.plural,
+        search_match=search_match,
+        match=match,
+        simple=simple,
+        wrap=wrap,
+        whitespace=whitespace,
+    )
+
+
+def format_language_string(
+    value: str,
+    translation,
+    *,
+    diff=None,
+):
+    """Format simple string as in the language."""
+    return format_translation(
+        plurals=split_plural(value),
+        language=translation.language,
+        plural=translation.plural,
+        diff=diff,
+    )
+
+
+def format_translation(
+    plurals: list[str],
+    language=None,
+    *,
+    plural=None,
+    diff=None,
+    search_match: str | None = None,
+    simple: bool = False,
+    wrap: bool = False,
+    unit=None,
+    match: str = "search",
+    glossary=None,
+    whitespace: bool = True,
+    show_copy: bool = False,
+):
+    """Nicely formats translation text possibly handling plurals or diff."""
+    is_multivalue = unit is not None and unit.translation.component.is_multivalue
+
+    if plural is None:
+        plural = language.plural
+
+    # Split diff plurals
+    if diff is not None:
+        diff = split_plural(diff)
+        # Previous message did not have to be a plural
+        while len(diff) < len(plurals):
+            diff.append(diff[0])
+
+    # We will collect part for each plural
+    parts = []
+    has_content = False
+
+    for idx, text in enumerate(plurals):
+        formatter = Formatter(
+            idx, text, unit, glossary, diff, search_match, match, whitespace=whitespace
+        )
+        formatter.parse()
+
+        # Show label for plural (if there are any)
+        title = ""
+        if len(plurals) > 1 and not is_multivalue:
+            title = plural.get_plural_name(idx)
+
+        # Join paragraphs
+        content = formatter.format()
+
+        parts.append(
+            {
+                "title": title,
+                "content": content,
+                "copy": escape(text) if show_copy else "",
+            }
+        )
+        has_content |= bool(content)
+
+    return {
+        "simple": simple,
+        "wrap": wrap,
+        "items": parts,
+        "language": language,
+        "unit": unit,
+        "has_content": has_content,
+    }
+
+
+def unit_state_class(unit) -> str:
+    """Return state flags."""
+    if unit.has_failing_check:
+        return "unit-state-bad"
+    if not unit.translated:
+        return "unit-state-todo"
+    if unit.approved or (unit.readonly and unit.translation.enable_review):
+        return "unit-state-approved"
+    return "unit-state-translated"
+
+
+def unit_state_title(unit) -> str:
+    state = [unit.get_state_display()]
+    checks = unit.active_checks
+    if checks:
+        state.append(
+            f"{pgettext('String state', 'Failing checks:')} {format_html_join_comma('{}', list_to_tuples(checks))}"
+        )
+    checks = unit.dismissed_checks
+    if checks:
+        state.append(
+            f"{pgettext('String state', 'Dismissed checks:')} {format_html_join_comma('{}', list_to_tuples(checks))}"
+        )
+    if unit.has_comment:
+        state.append(pgettext("String state", "Commented"))
+    if unit.has_suggestion:
+        state.append(pgettext("String state", "Suggested"))
+    if unit.automatically_translated:
+        state.append(pgettext("String state", "Automatically translated"))
+    if "forbidden" in unit.all_flags:
+        state.append(gettext("This translation is forbidden."))
+    return "; ".join(state)
+
+
+def try_linkify_filename(
+    text,
+    filename: str,
+    line: str,
+    unit: Unit,
+    user: User | None,
+    link_class: str = "",
+):
+    """
+    Attempt to convert `text` to a repo link to `filename:line`.
+
+    If the `text` is prefixed with http:// or https://, the
+    link will be an absolute link to the specified resource.
+    """
+    link = None
+    if re.search(r"^https?://", text):
+        link = text
+    elif user:
+        link = unit.translation.component.get_repoweb_link(
+            filename, line, user.profile.editor_link, user=user
+        )
+    if link:
+        return format_html(SOURCE_LINK, link, text, link_class)
+    return text
+
+
+def get_glossary_badge(component: Component | GhostStats) -> StrOrPromise:
+    if isinstance(component, Component) and component.is_glossary:
+        return format_html(
+            '<span class="badge label-{}">{}</span>',
+            component.glossary_color,
+            gettext("Glossary"),
+        )
+    return ""
+
+
+def get_breadcrumbs(  # ruff: ignore[complex-structure]
+    path_object, *, flags: bool = True, only_names: bool = False
+) -> Generator[str | tuple[str, str]]:
+    def with_url(
+        name: Model | int | str, url: str | None = None
+    ) -> str | tuple[str, str]:
+        if not isinstance(name, str):
+            name = str(name)
+        if only_names:
+            return name
+        if url is None:
+            url = path_object.get_absolute_url()
+        return url, name
+
+    if isinstance(path_object, Unit):
+        yield from get_breadcrumbs(
+            path_object.translation, flags=flags, only_names=only_names
+        )
+        yield with_url(path_object.pk)
+    elif isinstance(path_object, Translation):
+        yield from get_breadcrumbs(
+            path_object.component, flags=flags, only_names=only_names
+        )
+        yield with_url(path_object.language)
+    elif isinstance(path_object, Component):
+        if path_object.category:
+            yield from get_breadcrumbs(
+                path_object.category, flags=flags, only_names=only_names
+            )
+        else:
+            yield from get_breadcrumbs(
+                path_object.project, flags=flags, only_names=only_names
+            )
+        name = path_object.name
+        if flags:
+            name = format_html("{}{}", name, get_glossary_badge(path_object))
+        yield with_url(name)
+    elif isinstance(path_object, Category):
+        if path_object.category:
+            yield from get_breadcrumbs(
+                path_object.category, flags=flags, only_names=only_names
+            )
+        else:
+            yield from get_breadcrumbs(
+                path_object.project, flags=flags, only_names=only_names
+            )
+        yield with_url(path_object.name)
+    elif isinstance(path_object, Project):
+        workspace = path_object.workspace
+        if workspace is not None:
+            yield with_url(workspace.name, workspace.get_absolute_url())
+        yield with_url(path_object.name)
+    elif isinstance(path_object, Workspace):
+        yield with_url(path_object.name)
+    elif isinstance(path_object, Language):
+        yield with_url(gettext("Languages"), url=reverse("languages"))
+        yield with_url(path_object)
+    elif isinstance(path_object, ProjectLanguage):
+        yield from get_breadcrumbs(
+            path_object.project, flags=flags, only_names=only_names
+        )
+        yield with_url(path_object.language)
+    elif isinstance(path_object, CategoryLanguage):
+        if path_object.category.category:
+            yield from get_breadcrumbs(
+                path_object.category.category, flags=flags, only_names=only_names
+            )
+        else:
+            yield from get_breadcrumbs(
+                path_object.category.project, flags=flags, only_names=only_names
+            )
+        yield (
+            path_object.category.get_absolute_url(),
+            path_object.category.name,
+        )
+        yield with_url(path_object.language)
+    else:
+        msg = f"No breadcrumbs for {path_object}"
+        raise TypeError(msg)

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -3,11 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-import json
-import re
-from collections import defaultdict
 from datetime import date, datetime
-from html import escape as html_escape
 from typing import TYPE_CHECKING
 
 from django import template
@@ -17,8 +13,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.formats import date_format
-from django.utils.formats import number_format as django_number_format
-from django.utils.html import escape, format_html, format_html_join, linebreaks, urlize
+from django.utils.html import escape, format_html, format_html_join, urlize
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext, gettext_lazy, ngettext, pgettext
 from siphashc import siphash
@@ -27,13 +22,21 @@ from weblate.accounts.avatar import get_user_display
 from weblate.accounts.models import Profile
 from weblate.auth.models import User
 from weblate.checks.models import CHECKS
-from weblate.checks.utils import highlight_string
-from weblate.lang.models import Language
 from weblate.trans.filter import FILTERS, get_filter_choice
+from weblate.trans.formatting import (
+    format_language_string,
+    format_source_string,
+    format_unit_source,
+    format_unit_target,
+    get_breadcrumbs,
+    get_glossary_badge,
+    try_linkify_filename,
+    unit_state_class,
+    unit_state_title,
+)
 from weblate.trans.forms import FieldDocsMixin
 from weblate.trans.models import (
     Announcement,
-    Category,
     Component,
     ContributorAgreement,
     Project,
@@ -41,33 +44,34 @@ from weblate.trans.models import (
     Unit,
 )
 from weblate.trans.models.translation import GhostTranslation
-from weblate.trans.specialchars import get_display_char
-from weblate.trans.util import split_plural, translation_percent
-from weblate.utils.diff import Differ
+from weblate.trans.util import translation_percent
 from weblate.utils.docs import get_doc_url
+from weblate.utils.formatting import (
+    format_json,
+    number_format,
+    render_documentation_icon,
+)
 from weblate.utils.hash import hash_to_checksum
-from weblate.utils.html import format_html_join_comma, list_to_tuples
 from weblate.utils.markdown import render_markdown
 from weblate.utils.messages import get_message_kind as get_message_kind_impl
 from weblate.utils.random import get_random_identifier
 from weblate.utils.stats import (
     BaseStats,
-    CategoryLanguage,
     ProjectLanguage,
 )
 from weblate.utils.templatetags.icons import icon
 from weblate.utils.views import SORT_CHOICES
-from weblate.workspaces.models import Workspace
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import Iterable
 
     from django import forms
-    from django.db.models import Model, QuerySet
+    from django.db.models import QuerySet
     from django.template.context import Context
     from django.utils.safestring import SafeString
     from django_stubs_ext import StrOrPromise
 
+    from weblate.lang.models import Language
     from weblate.metrics.wrapper import MetricsWrapper
     from weblate.trans.models import (
         Alert,
@@ -77,30 +81,11 @@ if TYPE_CHECKING:
     from weblate.utils.stats import (
         GhostCategoryLanguageStats,
         GhostProjectLanguageStats,
-        GhostStats,
     )
+    from weblate.workspaces.models import Workspace
 
 register = template.Library()
 
-SPACE_START = '<span class="hlspace"><span class="space-space">'
-SPACE_NL_START = '<span class="hlspace"><span class="space-nl">'
-SPACE_MIDDLE_1 = "</span>"
-SPACE_MIDDLE_2 = '<span class="space-space">'
-SPACE_END = "</span></span>"
-SPACE_NL_END = "</span></span><br>"
-
-GLOSSARY_TEMPLATE = """<span class="glossary-term" title="{}">"""
-
-# This should match whitespace_regex in weblate/static/loader-bootstrap.js
-WHITESPACE_REGEX = (
-    r"(\t|\u00A0|\u00AD|\u1680|\u2000|\u2001|\u2002|\u2003|"
-    r"\u2004|\u2005|\u2006|\u2007|\u2008|\u2009|\u200A|"
-    r"\u202F|\u205F|\u3000)"
-)
-WHITESPACE_RE = re.compile(WHITESPACE_REGEX, re.MULTILINE)
-NEWLINE_RE = re.compile(r"(\r\n|\r|\n)", re.MULTILINE)
-MULTISPACE_RE = re.compile(r"(  +| $|^ )", re.MULTILINE)
-ESCAPE_RE = re.compile(r"""['"&<>]""")
 TYPE_MAPPING = {True: "yes", False: "no", None: "unknown"}
 # Mapping of status report flags to names
 NAME_MAPPING = {
@@ -118,560 +103,18 @@ PRIORITY_ICONS = {
     140: ("double_arrow_down", "text-secondary", gettext_lazy("Priority: Very low")),
 }
 
-SOURCE_LINK = (
-    '<a href="{0}" target="_blank" rel="noopener noreferrer"'
-    ' class="{2}" dir="ltr" tabindex="-1">{1}</a>'
+format_unit_target = register.inclusion_tag("snippets/format-translation.html")(
+    format_unit_target
 )
-HLCHECK = '<span class="hlcheck" data-value="{}"><span class="highlight-number"></span>'
-
-
-class Formatter:
-    def __init__(
-        self,
-        idx,
-        value,
-        unit,
-        glossary,
-        diff,
-        search_match,
-        match,
-        whitespace: bool = True,
-    ) -> None:
-        # Inputs
-        self.idx = idx
-        self.cleaned_value = self.value = value
-        self.unit = unit
-        self.glossary = glossary
-        self.diff = diff
-        self.search_match = search_match
-        self.match = match
-        # Tags output
-        self.tags: dict[int, list[str]] = defaultdict(list)
-        self.differ = Differ()
-        self.whitespace = whitespace
-
-    def insert_before_opening_tags(self, position: int, tag: str) -> None:
-        """Insert a tag after closers and before any opening tags at a position."""
-        current = self.tags[position]
-        insert_at = len(current)
-        for index, current_tag in enumerate(current):
-            if not current_tag.startswith("</"):
-                insert_at = index
-                break
-        current.insert(insert_at, tag)
-
-    def parse(self) -> None:
-        if self.unit:
-            self.parse_highlight()
-        if self.glossary:
-            self.parse_glossary()
-        if self.search_match:
-            self.parse_search()
-        if self.whitespace:
-            self.parse_whitespace()
-        if self.diff:
-            self.parse_diff()
-
-    def parse_diff(self) -> None:  # ruff: ignore[complex-structure]
-        """Highlights diff, including extra whitespace."""
-        diff = self.differ.compare(self.value, self.diff[self.idx])
-        offset = 0
-        for op, data in diff:
-            if op == self.differ.DIFF_DELETE:
-                formatter = Formatter(
-                    0,
-                    data,
-                    self.unit,
-                    self.glossary,
-                    None,
-                    self.search_match,
-                    self.match,
-                )
-                formatter.parse()
-                self.tags[offset].append(f"<del>{formatter.format()}</del>")
-            elif op == self.differ.DIFF_INSERT:
-                end = offset + len(data)
-                # Rearrange space highlighting
-                move_space = False
-                start_space = -1
-                start_nl = -1
-                append_end = True
-                if offset in self.tags:
-                    for pos, tag in enumerate(self.tags[offset]):
-                        if tag == SPACE_MIDDLE_2:
-                            self.tags[offset][pos] = SPACE_MIDDLE_1
-                            move_space = True
-                            break
-                        if tag == SPACE_START:
-                            start_space = pos
-                            break
-                        if tag == SPACE_NL_START:
-                            start_nl = pos
-                            break
-
-                if start_space != -1:
-                    self.tags[offset].insert(start_space, "<ins>")
-                    last_middle = None
-                    for i in range(len(data)):
-                        tagoffset = offset + i + 1
-                        if tagoffset not in self.tags:
-                            continue
-                        for pos, tag in enumerate(self.tags[tagoffset]):
-                            if tag == SPACE_END:
-                                # Whitespace ends within <ins>
-                                start_space = -1
-                                break
-                            if tag == SPACE_MIDDLE_2:
-                                last_middle = (tagoffset, pos)
-                        if start_space == -1:
-                            break
-                    if start_space != -1 and last_middle is not None:
-                        self.tags[tagoffset][pos] = SPACE_MIDDLE_1
-
-                elif start_nl != -1:
-                    # The line break is always one char wide, so we do not
-                    # need the complex logic used for generic whitespace
-                    start_tag = self.tags[offset].pop(start_nl)
-                    self.tags[end].insert(0, "<ins>")
-                    self.tags[end].insert(1, start_tag)
-                    self.tags[end].append("</ins>")
-                    append_end = False
-
-                else:
-                    self.tags[offset].append("<ins>")
-                if move_space:
-                    self.tags[offset].append(SPACE_START)
-                if append_end:
-                    self.insert_before_opening_tags(end, "</ins>")
-                if start_space != -1:
-                    self.tags[end].append(SPACE_START)
-
-                # Rearange other tags
-                open_tags = 0
-                process = False
-                for i in range(offset, end + 1):
-                    remove = []
-                    for pos, tag in enumerate(self.tags[i]):
-                        if not process:
-                            if tag.startswith("<ins"):
-                                process = True
-                            continue
-                        if tag.startswith("</ins>"):
-                            break
-                        if tag.startswith("<span"):
-                            open_tags += 1
-                        elif tag.startswith("</span"):
-                            if open_tags == 0:
-                                # Remove tags spanning over <ins>
-                                remove.append(pos)
-                                found = None
-                                for back in range(offset - 1, 0, -1):
-                                    for child_pos, child in reversed(
-                                        list(enumerate(self.tags[back]))
-                                    ):
-                                        if child.startswith("<span"):
-                                            found = child_pos
-                                            break
-                                    if found is not None:
-                                        del self.tags[back][found]
-                                        break
-                            else:
-                                open_tags -= 1
-                    # Remove closing tags (do this outside the loop)
-                    for pos in reversed(remove):
-                        del self.tags[i][pos]
-
-                offset = end
-            elif op == self.differ.DIFF_EQUAL:
-                offset += len(data)
-
-    def parse_highlight(self) -> None:
-        """Highlights unit placeables."""
-        highlights = highlight_string(self.value, self.unit)
-        cleaned_value = list(self.value)
-        for highlight in highlights:
-            self.tags[highlight.start].append(format_html(HLCHECK, highlight.text))
-            self.tags[highlight.end].insert(0, "</span>")
-            cleaned_value[highlight.start : highlight.end] = [" "] * (
-                highlight.end - highlight.start
-            )
-
-        # Prepare cleaned up value for glossary terms (we do not want to extract those
-        # from format strings)
-        self.cleaned_value = "".join(cleaned_value)
-
-    @staticmethod
-    def format_terms(terms):
-        forbidden = []
-        nontranslatable = []
-        translations = []
-        for term in terms:
-            flags = term.all_flags
-            target = html_escape(term.target)
-            source = html_escape(term.source)
-            # Translators: Glossary term formatting used in a tooltip
-            formatted = pgettext("glossary term", "{target} [{source}]").format(
-                source=source, target=target
-            )
-            if "read-only" in flags:
-                nontranslatable.append(source)
-            elif not target:
-                continue
-            elif "forbidden" in flags:
-                forbidden.append(formatted)
-            else:
-                translations.append(formatted)
-
-        output = []
-        if forbidden:
-            output.append(
-                "\n".join(
-                    (
-                        ngettext(
-                            "Forbidden translation:",
-                            "Forbidden translations:",
-                            len(forbidden),
-                        ),
-                        *forbidden,
-                    )
-                )
-            )
-        if nontranslatable:
-            output.append(
-                "\n".join(
-                    (
-                        ngettext(
-                            "Untranslatable term:",
-                            "Untranslatable terms:",
-                            len(nontranslatable),
-                        ),
-                        *nontranslatable,
-                    )
-                )
-            )
-        if translations:
-            output.append(
-                "\n".join(
-                    (
-                        ngettext(
-                            "Glossary term:",
-                            "Glossary terms:",
-                            len(translations),
-                        ),
-                        *translations,
-                    )
-                )
-            )
-        return "\n\n".join(output)
-
-    def parse_glossary(self) -> None:
-        """Highlights glossary entries."""
-        # Annotate string with glossary terms
-        locations = defaultdict(list)
-        for term in self.glossary:
-            for start, end in term.glossary_positions:
-                # Skip terms whose parts belong to placeholders
-                if self.cleaned_value[start:end].lower() != term.source.lower():
-                    continue
-
-                for i in range(start, end):
-                    locations[i].append(term)
-                locations[end].extend([])
-
-        # Render span tags for each glossary term match
-        last_entries: list[str] = []
-        for position, entries in sorted(locations.items()):
-            if last_entries and entries != last_entries:
-                self.tags[position].insert(0, "</span>")
-
-            if entries and entries != last_entries:
-                self.tags[position].append(
-                    GLOSSARY_TEMPLATE.format(self.format_terms(entries))
-                )
-            last_entries = entries
-
-    def parse_search(self) -> None:
-        """Highlights search matches."""
-        tag = self.match
-        if self.match == "search":
-            tag = "hlmatch"
-
-        start_tag = format_html('<span class="{}">', tag)
-        end_tag = "</span>"
-
-        for match in re.finditer(
-            re.escape(self.search_match), self.value, flags=re.IGNORECASE
-        ):
-            self.insert_before_opening_tags(match.start(), start_tag)
-            self.insert_before_opening_tags(match.end(), end_tag)
-
-    def parse_whitespace(self) -> None:
-        """Highlight whitespaces."""
-        value = self.value
-
-        for match in NEWLINE_RE.finditer(value):
-            self.tags[match.start()].append(SPACE_NL_START)
-            self.tags[match.end()].insert(0, SPACE_NL_END)
-
-        for match in MULTISPACE_RE.finditer(value):
-            self.tags[match.start()].append(SPACE_START)
-            for i in range(match.start() + 1, match.end()):
-                self.tags[i].insert(0, SPACE_MIDDLE_1)
-                self.tags[i].append(SPACE_MIDDLE_2)
-            self.tags[match.end()].insert(0, SPACE_END)
-
-        for match in WHITESPACE_RE.finditer(value):
-            whitespace = match.group(0)
-            cls = "space-tab" if whitespace == "\t" else "space-space"
-            title = get_display_char(whitespace)[0]
-            self.tags[match.start()].append(
-                format_html(
-                    '<span class="hlspace"><span class="{}" title="{}">', cls, title
-                )
-            )
-            self.tags[match.end()].insert(0, "</span></span>")
-
-    def format_generator(self) -> Generator[str]:
-        tags = self.tags
-        value = self.value
-        current: list[str]
-        replacements: dict[int, str] = {}
-
-        # Extract tag positions
-        positions: set[int] = set(tags.keys())
-
-        # Avoid processing trailing tags in the loop
-        positions.discard(len(value))
-
-        # Replace special characters "&", "<" and ">" to HTML-safe sequences.
-        # This is like html.escape but inline
-        for match in ESCAPE_RE.finditer(value):
-            position = match.start()
-            positions.add(position)
-            char = match.group()
-            if char == "&":
-                next_output = "&amp;"
-            elif char == "<":
-                next_output = "&lt;"
-            elif char == ">":
-                next_output = "&gt;"
-            elif char == '"':
-                next_output = "&quot;"
-            elif char == "'":
-                next_output = "&#x27;"
-            else:
-                raise ValueError(char)
-            replacements[position] = next_output
-
-        previous_start = 0
-        for pos in sorted(positions):
-            # String up to current position
-            yield value[previous_start:pos]
-
-            if pos in tags:
-                current = tags[pos]
-                # Special case for leading/trailing whitespace char in diff
-                if (
-                    current
-                    and value[pos] == " "
-                    and "<ins>" in current
-                    and SPACE_START not in current
-                ):
-                    current.append(SPACE_START)
-                    tags[pos + 1].insert(0, SPACE_END)
-
-                elif pos + 1 in tags:
-                    next_tags = tags[pos + 1]
-                    if (
-                        next_tags
-                        and value[pos] == " "
-                        and "</ins>" in next_tags
-                        and SPACE_END not in next_tags
-                        and SPACE_MIDDLE_1 not in next_tags
-                    ):
-                        current.append(SPACE_START)
-                        next_tags.insert(0, SPACE_END)
-
-                # Tags
-                yield from current
-
-            if pos in replacements:
-                # HTML escaped string
-                yield replacements[pos]
-                previous_start = pos + 1
-            else:
-                previous_start = pos
-
-        yield value[previous_start:]
-
-        # Trailing tags
-        yield from tags[len(value)]
-
-    def format(self):
-        # Safe to mark because format_generator escapes raw string content inline
-        # and only emits formatter-controlled markup for diffs/highlights/tooltips.
-        return mark_safe("".join(self.format_generator()))  # ruff: ignore[suspicious-mark-safe-usage]
-
-
-@register.inclusion_tag("snippets/format-translation.html")
-def format_unit_target(
-    unit,
-    *,
-    value: str | None = None,
-    diff=None,
-    search_match: str | None = None,
-    match: str = "search",
-    simple: bool = False,
-    wrap: bool = False,
-    show_copy: bool = False,
-):
-    return format_translation(
-        plurals=unit.get_target_plurals() if value is None else split_plural(value),
-        language=unit.translation.language,
-        plural=unit.translation.plural,
-        unit=unit,
-        diff=diff,
-        search_match=search_match,
-        match=match,
-        simple=simple,
-        wrap=wrap,
-        show_copy=show_copy,
-    )
-
-
-@register.inclusion_tag("snippets/format-translation.html")
-def format_unit_source(
-    unit,
-    *,
-    value: str | None = None,
-    diff=None,
-    search_match: str | None = None,
-    match: str = "search",
-    simple: bool = False,
-    glossary=None,
-    wrap: bool = False,
-    show_copy: bool = False,
-):
-    source_translation = unit.translation.component.source_translation
-    return format_translation(
-        plurals=unit.get_source_plurals() if value is None else split_plural(value),
-        language=source_translation.language,
-        plural=source_translation.plural,
-        unit=unit,
-        diff=diff,
-        search_match=search_match,
-        match=match,
-        simple=simple,
-        glossary=glossary,
-        wrap=wrap,
-        show_copy=show_copy,
-    )
-
-
-@register.inclusion_tag("snippets/format-translation.html")
-def format_source_string(
-    value: str,
-    unit,
-    *,
-    search_match: str | None = None,
-    match: str = "search",
-    simple: bool = False,
-    glossary=None,
-    wrap: bool = False,
-    whitespace: bool = True,
-):
-    """Format simple string as in the unit source language."""
-    return format_translation(
-        plurals=[value],
-        language=unit.translation.component.source_language,
-        plural=unit.translation.plural,
-        search_match=search_match,
-        match=match,
-        simple=simple,
-        wrap=wrap,
-        whitespace=whitespace,
-    )
-
-
-@register.inclusion_tag("snippets/format-translation.html")
-def format_language_string(
-    value: str,
-    translation,
-    *,
-    diff=None,
-):
-    """Format simple string as in the language."""
-    return format_translation(
-        plurals=split_plural(value),
-        language=translation.language,
-        plural=translation.plural,
-        diff=diff,
-    )
-
-
-def format_translation(
-    plurals: list[str],
-    language=None,
-    *,
-    plural=None,
-    diff=None,
-    search_match: str | None = None,
-    simple: bool = False,
-    wrap: bool = False,
-    unit=None,
-    match: str = "search",
-    glossary=None,
-    whitespace: bool = True,
-    show_copy: bool = False,
-):
-    """Nicely formats translation text possibly handling plurals or diff."""
-    is_multivalue = unit is not None and unit.translation.component.is_multivalue
-
-    if plural is None:
-        plural = language.plural
-
-    # Split diff plurals
-    if diff is not None:
-        diff = split_plural(diff)
-        # Previous message did not have to be a plural
-        while len(diff) < len(plurals):
-            diff.append(diff[0])
-
-    # We will collect part for each plural
-    parts = []
-    has_content = False
-
-    for idx, text in enumerate(plurals):
-        formatter = Formatter(
-            idx, text, unit, glossary, diff, search_match, match, whitespace=whitespace
-        )
-        formatter.parse()
-
-        # Show label for plural (if there are any)
-        title = ""
-        if len(plurals) > 1 and not is_multivalue:
-            title = plural.get_plural_name(idx)
-
-        # Join paragraphs
-        content = formatter.format()
-
-        parts.append(
-            {
-                "title": title,
-                "content": content,
-                "copy": escape(text) if show_copy else "",
-            }
-        )
-        has_content |= bool(content)
-
-    return {
-        "simple": simple,
-        "wrap": wrap,
-        "items": parts,
-        "language": language,
-        "unit": unit,
-        "has_content": has_content,
-    }
+format_unit_source = register.inclusion_tag("snippets/format-translation.html")(
+    format_unit_source
+)
+format_source_string = register.inclusion_tag("snippets/format-translation.html")(
+    format_source_string
+)
+format_language_string = register.inclusion_tag("snippets/format-translation.html")(
+    format_language_string
+)
 
 
 @register.simple_tag
@@ -710,18 +153,6 @@ def documentation(context: Context, page, anchor=""):
     if hasattr(page, "get_doc_url"):
         return page.get_doc_url(user=user)
     return get_doc_url(page, anchor, user=user)
-
-
-def render_documentation_icon(doc_url: str, *, right: bool = False):
-    if not doc_url:
-        return ""
-    return format_html(
-        """<a class="{} doc-link" href="{}" title="{}" target="_blank" rel="noopener">{}</a>""",
-        "float-end" if right else "",
-        doc_url,
-        gettext("Documentation"),
-        icon("info.svg"),
-    )
 
 
 @register.simple_tag(takes_context=True)
@@ -929,66 +360,8 @@ def chars_progress(obj):
     )
 
 
-@register.simple_tag
-def unit_state_class(unit) -> str:
-    """Return state flags."""
-    if unit.has_failing_check:
-        return "unit-state-bad"
-    if not unit.translated:
-        return "unit-state-todo"
-    if unit.approved or (unit.readonly and unit.translation.enable_review):
-        return "unit-state-approved"
-    return "unit-state-translated"
-
-
-@register.simple_tag
-def unit_state_title(unit) -> str:
-    state = [unit.get_state_display()]
-    checks = unit.active_checks
-    if checks:
-        state.append(
-            f"{pgettext('String state', 'Failing checks:')} {format_html_join_comma('{}', list_to_tuples(checks))}"
-        )
-    checks = unit.dismissed_checks
-    if checks:
-        state.append(
-            f"{pgettext('String state', 'Dismissed checks:')} {format_html_join_comma('{}', list_to_tuples(checks))}"
-        )
-    if unit.has_comment:
-        state.append(pgettext("String state", "Commented"))
-    if unit.has_suggestion:
-        state.append(pgettext("String state", "Suggested"))
-    if unit.automatically_translated:
-        state.append(pgettext("String state", "Automatically translated"))
-    if "forbidden" in unit.all_flags:
-        state.append(gettext("This translation is forbidden."))
-    return "; ".join(state)
-
-
-def try_linkify_filename(
-    text,
-    filename: str,
-    line: str,
-    unit: Unit,
-    user: User | None,
-    link_class: str = "",
-):
-    """
-    Attempt to convert `text` to a repo link to `filename:line`.
-
-    If the `text` is prefixed with http:// or https://, the
-    link will be an absolute link to the specified resource.
-    """
-    link = None
-    if re.search(r"^https?://", text):
-        link = text
-    elif user:
-        link = unit.translation.component.get_repoweb_link(
-            filename, line, user.profile.editor_link, user=user
-        )
-    if link:
-        return format_html(SOURCE_LINK, link, text, link_class)
-    return text
+unit_state_class = register.simple_tag(unit_state_class)
+unit_state_title = register.simple_tag(unit_state_title)
 
 
 @register.simple_tag
@@ -1401,18 +774,7 @@ def percent_format(number: float) -> str:
     )
 
 
-@register.filter
-def number_format(number: int) -> str:
-    format_string = "%s"
-    if number > 99999999:
-        number //= 1000000
-        # Translators: Number format, in millions (mega)
-        format_string = gettext("%s M")
-    elif number > 99999:
-        number //= 1000
-        # Translators: Number format, in thousands (kilo)
-        format_string = gettext("%s k")
-    return format_string % django_number_format(number, force_grouping=True)
+number_format = register.filter(number_format)
 
 
 @register.filter
@@ -1467,96 +829,7 @@ def urlize_ugc(value: str, autoescape: bool = True) -> str:
     return mark_safe(html.replace('rel="nofollow"', 'rel="ugc" target="_blank"'))  # ruff: ignore[suspicious-mark-safe-usage]
 
 
-@register.simple_tag
-def get_glossary_badge(component: Component | GhostStats) -> StrOrPromise:
-    if isinstance(component, Component) and component.is_glossary:
-        return format_html(
-            '<span class="badge label-{}">{}</span>',
-            component.glossary_color,
-            gettext("Glossary"),
-        )
-    return ""
-
-
-def get_breadcrumbs(  # ruff: ignore[complex-structure]
-    path_object, *, flags: bool = True, only_names: bool = False
-) -> Generator[str | tuple[str, str]]:
-    def with_url(
-        name: Model | int | str, url: str | None = None
-    ) -> str | tuple[str, str]:
-        if not isinstance(name, str):
-            name = str(name)
-        if only_names:
-            return name
-        if url is None:
-            url = path_object.get_absolute_url()
-        return url, name
-
-    if isinstance(path_object, Unit):
-        yield from get_breadcrumbs(
-            path_object.translation, flags=flags, only_names=only_names
-        )
-        yield with_url(path_object.pk)
-    elif isinstance(path_object, Translation):
-        yield from get_breadcrumbs(
-            path_object.component, flags=flags, only_names=only_names
-        )
-        yield with_url(path_object.language)
-    elif isinstance(path_object, Component):
-        if path_object.category:
-            yield from get_breadcrumbs(
-                path_object.category, flags=flags, only_names=only_names
-            )
-        else:
-            yield from get_breadcrumbs(
-                path_object.project, flags=flags, only_names=only_names
-            )
-        name = path_object.name
-        if flags:
-            name = format_html("{}{}", name, get_glossary_badge(path_object))
-        yield with_url(name)
-    elif isinstance(path_object, Category):
-        if path_object.category:
-            yield from get_breadcrumbs(
-                path_object.category, flags=flags, only_names=only_names
-            )
-        else:
-            yield from get_breadcrumbs(
-                path_object.project, flags=flags, only_names=only_names
-            )
-        yield with_url(path_object.name)
-    elif isinstance(path_object, Project):
-        workspace = path_object.workspace
-        if workspace is not None:
-            yield with_url(workspace.name, workspace.get_absolute_url())
-        yield with_url(path_object.name)
-    elif isinstance(path_object, Workspace):
-        yield with_url(path_object.name)
-    elif isinstance(path_object, Language):
-        yield with_url(gettext("Languages"), url=reverse("languages"))
-        yield with_url(path_object)
-    elif isinstance(path_object, ProjectLanguage):
-        yield from get_breadcrumbs(
-            path_object.project, flags=flags, only_names=only_names
-        )
-        yield with_url(path_object.language)
-    elif isinstance(path_object, CategoryLanguage):
-        if path_object.category.category:
-            yield from get_breadcrumbs(
-                path_object.category.category, flags=flags, only_names=only_names
-            )
-        else:
-            yield from get_breadcrumbs(
-                path_object.category.project, flags=flags, only_names=only_names
-            )
-        yield (
-            path_object.category.get_absolute_url(),
-            path_object.category.name,
-        )
-        yield with_url(path_object.language)
-    else:
-        msg = f"No breadcrumbs for {path_object}"
-        raise TypeError(msg)
+get_glossary_badge = register.simple_tag(get_glossary_badge)
 
 
 @register.simple_tag
@@ -1745,9 +1018,7 @@ def show_info(  # ruff: ignore[too-many-arguments]
     }
 
 
-@register.filter(is_safe=True)
-def format_json(value: dict) -> str:
-    return mark_safe(linebreaks(json.dumps(value, indent=4), autoescape=True))  # ruff: ignore[suspicious-mark-safe-usage]
+format_json = register.filter(is_safe=True)(format_json)
 
 
 @register.filter(is_safe=True)

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -25,6 +25,7 @@ from weblate.checks.models import Check
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.exceptions import FileParseError
+from weblate.trans.formatting import unit_state_title
 from weblate.trans.forms import get_new_unit_form
 from weblate.trans.models import (
     Change,
@@ -35,7 +36,6 @@ from weblate.trans.models import (
     Translation,
     Unit,
 )
-from weblate.trans.templatetags.translations import unit_state_title
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.util import join_plural
 from weblate.trans.views.edit import (

--- a/weblate/trans/tests/test_imports.py
+++ b/weblate/trans/tests/test_imports.py
@@ -1,0 +1,48 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import os
+import subprocess  # ruff: ignore[suspicious-subprocess-import]
+import sys
+
+from django.test import SimpleTestCase
+
+
+class BackendImportTest(SimpleTestCase):
+    def test_backend_does_not_import_translation_template_tags(self) -> None:
+        environment = os.environ.copy()
+        environment["DJANGO_SETTINGS_MODULE"] = "weblate.settings_test"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                """
+import sys
+
+import django
+
+django.setup()
+
+import weblate.addons.base
+import weblate.checks.base
+import weblate.machinery.views
+import weblate.trans.change_display
+import weblate.trans.views.edit
+import weblate.trans.widgets
+import weblate.utils.views
+import weblate.wladmin.templatetags.check_links
+
+if any(name.startswith("weblate.trans.templatetags") for name in sys.modules):
+    raise RuntimeError("backend imported translation template tags")
+""",
+            ],
+            check=False,
+            capture_output=True,
+            env=environment,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)

--- a/weblate/trans/tests/test_templatetags.py
+++ b/weblate/trans/tests/test_templatetags.py
@@ -19,14 +19,14 @@ from django.utils.html import format_html
 from weblate.auth.models import User
 from weblate.checks.flags import Flags
 from weblate.lang.models import Language
+from weblate.trans.formatting import format_translation
 from weblate.trans.models import Component, Project, Translation, Unit
 from weblate.trans.templatetags.translations import (
     PRIORITY_ICONS,
-    format_translation,
     get_location_links,
     indicate_alerts,
     naturaltime,
-    render_documentation_icon,
+    register,
     same_naturaltime,
     translation_progress_render,
 )
@@ -34,6 +34,27 @@ from weblate.trans.templatetags.upload_methods import get_upload_method_help
 from weblate.trans.tests.factories import make_language, make_unit
 from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.utils.files import FileUploadMethod
+from weblate.utils.formatting import render_documentation_icon
+
+
+class ExtractedHelperRegistrationTest(SimpleTestCase):
+    def test_helpers_remain_registered(self) -> None:
+        self.assertLessEqual(
+            {
+                "format_language_string",
+                "format_source_string",
+                "format_unit_source",
+                "format_unit_target",
+                "get_glossary_badge",
+                "unit_state_class",
+                "unit_state_title",
+            },
+            register.tags.keys(),
+        )
+        self.assertLessEqual(
+            {"format_json", "number_format"},
+            register.filters.keys(),
+        )
 
 
 class NaturalTimeTest(SimpleTestCase):

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -39,6 +39,11 @@ from weblate.trans.exceptions import (
     SuggestionSimilarToTranslationError,
     SuggestionTooLongError,
 )
+from weblate.trans.formatting import (
+    try_linkify_filename,
+    unit_state_class,
+    unit_state_title,
+)
 from weblate.trans.forms import (
     AutoForm,
     ChecksumForm,
@@ -63,11 +68,6 @@ from weblate.trans.models import (
 )
 from weblate.trans.models.unit import fill_in_source_translation
 from weblate.trans.tasks import auto_translate
-from weblate.trans.templatetags.translations import (
-    try_linkify_filename,
-    unit_state_class,
-    unit_state_title,
-)
 from weblate.trans.util import redirect_next, render
 from weblate.trans.validators import SUGGESTION_REJECTION_REASON_LENGTH
 from weblate.utils import messages

--- a/weblate/trans/widgets.py
+++ b/weblate/trans/widgets.py
@@ -38,9 +38,9 @@ from weblate.fonts.render import (
 from weblate.fonts.utils import render_size
 from weblate.lang.models import Language
 from weblate.trans.models import Component, Project
-from weblate.trans.templatetags.translations import number_format
 from weblate.trans.util import sort_unicode, translation_percent
 from weblate.utils import messages
+from weblate.utils.formatting import number_format
 from weblate.utils.icons import find_static_file
 from weblate.utils.site import get_site_url
 from weblate.utils.stats import (

--- a/weblate/utils/formatting.py
+++ b/weblate/utils/formatting.py
@@ -1,0 +1,43 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+
+from django.utils.formats import number_format as django_number_format
+from django.utils.html import format_html, linebreaks
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext
+
+from weblate.utils.templatetags.icons import icon
+
+
+def format_json(value: dict) -> str:
+    return mark_safe(linebreaks(json.dumps(value, indent=4), autoescape=True))  # ruff: ignore[suspicious-mark-safe-usage]
+
+
+def number_format(number: int) -> str:
+    format_string = "%s"
+    if number > 99999999:
+        number //= 1000000
+        # Translators: Number format, in millions (mega)
+        format_string = gettext("%s M")
+    elif number > 99999:
+        number //= 1000
+        # Translators: Number format, in thousands (kilo)
+        format_string = gettext("%s k")
+    return format_string % django_number_format(number, force_grouping=True)
+
+
+def render_documentation_icon(doc_url: str, *, right: bool = False):
+    if not doc_url:
+        return ""
+    return format_html(
+        """<a class="{} doc-link" href="{}" title="{}" target="_blank" rel="noopener">{}</a>""",
+        "float-end" if right else "",
+        doc_url,
+        gettext("Documentation"),
+        icon("info.svg"),
+    )

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -64,7 +64,7 @@ class UnsupportedPathObjectError(Http404):
 
 def key_name(instance):
     # ruff: ignore[import-outside-top-level]
-    from weblate.trans.templatetags.translations import get_breadcrumbs
+    from weblate.trans.formatting import get_breadcrumbs
 
     return "/".join(
         str(item) for item in get_breadcrumbs(instance, flags=False, only_names=True)

--- a/weblate/wladmin/templatetags/check_links.py
+++ b/weblate/wladmin/templatetags/check_links.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, cast
 
 from django import template
 
-from weblate.trans.templatetags.translations import render_documentation_icon
 from weblate.utils.checks import check_doc_link
+from weblate.utils.formatting import render_documentation_icon
 
 if TYPE_CHECKING:
     from django.core.checks import CheckMessage

--- a/weblate/workspaces/tests.py
+++ b/weblate/workspaces/tests.py
@@ -20,8 +20,8 @@ from weblate.billing.models import Billing, BillingQuerySet
 from weblate.lang.models import Language
 from weblate.memory.models import Memory, MemoryScope
 from weblate.trans.actions import ActionEvents
+from weblate.trans.formatting import get_breadcrumbs
 from weblate.trans.models import Change, ComponentLink, Project
-from weblate.trans.templatetags.translations import get_breadcrumbs
 from weblate.trans.tests.test_models import BaseTestCase
 from weblate.trans.tests.test_views import FixtureComponentTestCase
 from weblate.trans.tests.utils import (


### PR DESCRIPTION
Backend modules only need selected rendering helpers, but importing the template-tag library loads its full dependency graph. Move shared helpers to dedicated modules while preserving the template interface.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
