### PR TITLE
ci(pylint): use prebuilt development image

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,13 +20,12 @@ permissions:
 jobs:
   pylint:
     runs-on: ubuntu-24.04
+    container: ghcr.io/weblateorg/dev:2026.34.0@sha256:685c40324663cee40d67d0ad651fc4b29cbf71e989ef4870aa3d51cc0802462e
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - name: Install apt dependencies
-      run: sudo ./ci/apt-install
     - name: Setup Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       id: setup_python


### PR DESCRIPTION
Avoid fetching APT dependencies for every pylint run. The pinned development image already contains the required native build packages, reducing exposure to transient repository failures.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
