### PR TITLE
fix(tasks): track project removal completion

### DIFF
--- a/weblate/billing/tasks.py
+++ b/weblate/billing/tasks.py
@@ -17,7 +17,7 @@ from django.utils.translation import gettext
 from weblate.accounts.notifications import send_notification_email
 from weblate.billing.models import Billing, BillingEvent
 from weblate.trans.models import Project
-from weblate.trans.tasks import project_removal
+from weblate.trans.tasks import create_project_backup, project_removal
 from weblate.utils.celery import app
 
 if TYPE_CHECKING:
@@ -227,7 +227,8 @@ def remove_single_billing(billing_id: int) -> None:
             event=BillingEvent.REMOVED, summary=f"Removed project {prj}"
         )
         prj.log_warning("removing due to unpaid billing")
-        project_removal(prj.id, None)
+        create_project_backup(prj.id)
+        project_removal.delay(prj.id, None, backup=False)
     bill.removal = None
     bill.state = Billing.STATE_TERMINATED
     bill.save()

--- a/weblate/billing/tests.py
+++ b/weblate/billing/tests.py
@@ -42,6 +42,7 @@ from weblate.billing.tasks import (
     inactive_recurring_check,
     notify_expired,
     perform_removal,
+    remove_single_billing,
     schedule_removal,
 )
 from weblate.lang.models import Language
@@ -1364,6 +1365,34 @@ class BillingTest(BaseTestCase):
         self.assertEqual(
             mail.outbox.pop().subject, "Your translation project was removed"
         )
+
+    def test_removal_backup_failure_preserves_schedule(self) -> None:
+        project = self.add_project()
+        removal = timezone.now() - timedelta(days=1)
+        self.billing.removal = removal
+        self.billing.save(update_fields=["removal"])
+        billing_log_count = self.billing.billinglog_set.count()
+
+        with (
+            patch(
+                "weblate.billing.tasks.create_project_backup",
+                side_effect=RuntimeError("backup failed"),
+            ),
+            patch(
+                "weblate.billing.tasks.project_removal.delay"
+            ) as project_removal_delay,
+            patch("weblate.billing.tasks.send_notification_email"),
+            self.assertRaisesRegex(RuntimeError, "backup failed"),
+        ):
+            remove_single_billing(self.billing.pk)
+
+        project_removal_delay.assert_not_called()
+        self.refresh_from_db()
+        self.assertEqual(self.billing.state, Billing.STATE_ACTIVE)
+        self.assertEqual(self.billing.removal, removal)
+        self.assertEqual(self.billing.billinglog_set.count(), billing_log_count)
+        self.assertEqual(self.billing.count_projects, 1)
+        self.assertTrue(Project.objects.filter(pk=project.pk).exists())
 
     @override_settings(EMAIL_SUBJECT_PREFIX="")
     def test_trial(self) -> None:

--- a/weblate/trans/management/commands/import_demo.py
+++ b/weblate/trans/management/commands/import_demo.py
@@ -10,7 +10,7 @@ from django.test.utils import override_settings
 
 from weblate.addons.discovery import DiscoveryAddon
 from weblate.trans.models import Component, Project
-from weblate.trans.tasks import actual_project_removal
+from weblate.trans.tasks import project_removal
 from weblate.utils.management.base import BaseCommand
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ class Command(BaseCommand):
                     pass
                 else:
                     # Remove without creating a backup
-                    actual_project_removal(project.pk, None)
+                    project_removal.run(project.pk, None, backup=False)
             # Create project
             project = Project.objects.create(
                 name="Demo", slug="demo", web="https://demo.weblate.org/"

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from celery import current_task
 from celery.schedules import crontab
+from celery.utils.time import get_exponential_backoff_interval
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
@@ -63,6 +64,8 @@ COMPONENT_MEMORY_CLEANUP_BATCH_SIZE = 1000
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
+
+    from celery import Task
 
     from weblate.trans.models.change import RevertUserEditsResult
     from weblate.workspaces.models import Workspace
@@ -940,18 +943,7 @@ def cleanup_project_tokens(project: Project, user: User | None) -> None:
         )
 
 
-@app.task(
-    trail=False,
-    autoretry_for=(IntegrityError,),
-    retry_backoff=600,
-    retry_backoff_max=3600,
-)
-def actual_project_removal(pk: int, uid: int | None) -> None:
-    """
-    Remove project.
-
-    This is separated from project_removal to allow retry on integrity errors.
-    """
+def _remove_project(pk: int, uid: int | None) -> None:
     with transaction.atomic():
         user = get_anonymous() if uid is None else User.objects.get(pk=uid)
         try:
@@ -971,11 +963,31 @@ def actual_project_removal(pk: int, uid: int | None) -> None:
         transaction.on_commit(batch.flush)
 
 
-@app.task(trail=False)
-def project_removal(pk: int, uid: int | None) -> None:
-    """Backup project and schedule actual removal."""
-    create_project_backup(pk)
-    actual_project_removal.delay(pk, uid)
+@app.task(bind=True, trail=False)
+def project_removal(
+    task: Task, pk: int, uid: int | None, *, backup: bool = True
+) -> None:
+    """Backup and remove project."""
+    if backup:
+        create_project_backup(pk)
+
+    try:
+        _remove_project(pk, uid)
+    except IntegrityError as error:
+        countdown = get_exponential_backoff_interval(
+            factor=600,
+            retries=task.request.retries,
+            maximum=3600,
+            full_jitter=True,
+        )
+        retry_args = tuple(task.request.args) if task.request.args is not None else None
+        retry_kwargs = {**(task.request.kwargs or {}), "backup": False}
+        raise task.retry(
+            args=retry_args,
+            kwargs=retry_kwargs,
+            exc=error,
+            countdown=countdown,
+        ) from error
 
 
 def store_auto_translate_activity_log(

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -61,7 +61,7 @@ from weblate.trans.models.change import ChangeQuerySet
 from weblate.trans.models.component import ComponentLink
 from weblate.trans.models.project import CommitPolicyChoices
 from weblate.trans.removal import RemovalBatch
-from weblate.trans.tasks import actual_project_removal
+from weblate.trans.tasks import project_removal
 from weblate.trans.tests.utils import (
     RepoTestMixin,
     create_another_user,
@@ -222,7 +222,7 @@ class ProjectTest(RepoTestCase):
         self.assertIsNot(first, second)
         self.assertEqual(prefetch.call_count, 2)
 
-    def test_actual_project_removal_batches_linked_alert_updates(self) -> None:
+    def test_project_removal_batches_linked_alert_updates(self) -> None:
         self.component = self.create_po()
         project = self.create_project(name="Other", slug="other")
         self.project = project
@@ -239,14 +239,14 @@ class ProjectTest(RepoTestCase):
             patch.object(Component, "update_alerts", autospec=True) as update_alerts,
             self.captureOnCommitCallbacks(execute=True),
         ):
-            actual_project_removal(project.pk, None)
+            project_removal.run(project.pk, None, backup=False)
 
         self.assertFalse(
             Component.objects.filter(pk__in=[linked.pk, second.pk]).exists()
         )
         update_alerts.assert_called_once_with(self.component)
 
-    def test_actual_project_removal_batches_parent_stats_updates(self) -> None:
+    def test_project_removal_batches_parent_stats_updates(self) -> None:
         project = self.create_project(name="Other", slug="other")
         self.create_po(project=project, name="Category A", slug="category-a")
         self.create_po(project=project, name="Category B", slug="category-b")
@@ -276,7 +276,7 @@ class ProjectTest(RepoTestCase):
             ),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            actual_project_removal(project.pk, None)
+            project_removal.run(project.pk, None, backup=False)
 
         self.assertEqual(1, len(collected))
         self.assertTrue(
@@ -285,7 +285,7 @@ class ProjectTest(RepoTestCase):
         self.assertEqual(collected[0], set(executed))
         self.assertEqual(len(executed), len(set(executed)))
 
-    def test_actual_project_removal_updates_surviving_project_before_global(
+    def test_project_removal_updates_surviving_project_before_global(
         self,
     ) -> None:
         surviving_component = self.create_po()
@@ -328,7 +328,7 @@ class ProjectTest(RepoTestCase):
             ),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            actual_project_removal(project.pk, None)
+            project_removal.run(project.pk, None, backup=False)
 
         self.assertFalse(
             Component.objects.filter(pk__in=[main.pk, linked.pk, second.pk]).exists()

--- a/weblate/trans/tests/test_projecttoken.py
+++ b/weblate/trans/tests/test_projecttoken.py
@@ -13,7 +13,7 @@ from weblate.auth.models import User, setup_project_groups
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Project
-from weblate.trans.tasks import actual_project_removal
+from weblate.trans.tasks import project_removal
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.utils.files import remove_tree
 
@@ -329,7 +329,7 @@ class ProjectTokenTest(FixtureTestCase):
         token_user = self.get_token_user(token_key)
         project_name = self.project.name
 
-        actual_project_removal(self.project.pk, self.user.pk)
+        project_removal.run(self.project.pk, self.user.pk, backup=False)
 
         self.assertFalse(Project.objects.filter(pk=self.project.pk).exists())
         token_user.refresh_from_db()
@@ -356,7 +356,7 @@ class ProjectTokenTest(FixtureTestCase):
             setup_project_groups(sender=Project, instance=second_project, created=False)
         second_project.add_user(token_user, "Administration", allow_bot=True)
 
-        actual_project_removal(self.project.pk, self.user.pk)
+        project_removal.run(self.project.pk, self.user.pk, backup=False)
 
         token_user.refresh_from_db()
         self.assertTrue(token_user.is_active)

--- a/weblate/trans/tests/test_tasks.py
+++ b/weblate/trans/tests/test_tasks.py
@@ -10,13 +10,19 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.core.cache import cache
-from django.db import connection
+from django.db import IntegrityError, connection
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils import timezone
 
 from weblate.auth.models import User
 from weblate.checks.tasks import finalize_component_checks
-from weblate.trans.models import Category, Component, PendingUnitChange, Suggestion
+from weblate.trans.models import (
+    Category,
+    Component,
+    PendingUnitChange,
+    Project,
+    Suggestion,
+)
 from weblate.trans.models.project import CommitPolicyChoices
 from weblate.trans.tasks import (
     cleanup_repos,
@@ -26,6 +32,7 @@ from weblate.trans.tasks import (
     component_alerts,
     daily_update_checks,
     perform_commit,
+    project_removal,
     update_checks,
     update_remotes,
 )
@@ -86,6 +93,38 @@ class CleanupTest(ComponentTestCase):
 
 
 class TasksTest(ComponentTestCase):
+    def test_project_removal_retries_without_backup(self) -> None:
+        task_id = "project-removal-task-id"
+        original_get = Project.objects.get
+        attempts = 0
+
+        def get_project(*args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise IntegrityError
+            return original_get(*args, **kwargs)
+
+        with (
+            patch("weblate.trans.tasks.create_project_backup") as create_project_backup,
+            patch(
+                "weblate.trans.tasks.get_exponential_backoff_interval", return_value=0
+            ) as get_backoff,
+            patch.object(Project.objects, "get", side_effect=get_project),
+        ):
+            result = project_removal.apply(
+                args=(self.project.pk, self.user.pk), task_id=task_id, throw=False
+            )
+
+        self.assertTrue(result.successful())
+        self.assertEqual(result.id, task_id)
+        self.assertEqual(attempts, 2)
+        create_project_backup.assert_called_once_with(self.project.pk)
+        get_backoff.assert_called_once_with(
+            factor=600, retries=0, maximum=3600, full_jitter=True
+        )
+        self.assertFalse(Project.objects.filter(pk=self.project.pk).exists())
+
     def test_component_alerts_processes_canonical_component_first(self) -> None:
         second = self.create_po(project=self.project, name="Second")
         processed: list[int] = []


### PR DESCRIPTION
Keep backup and deletion under one Celery task ID so callers can reliably observe when removal, including retries, has completed.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
