### PR TITLE
fix(api): normalize response contracts

### DIFF
--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -2715,7 +2715,7 @@ class GroupAPITest(APIBaseTest):
             superuser=True,
             request={"user_id": self.user.id},
         )
-        self.assertIn("Administration rights granted.", response.data)
+        self.assertEqual(response.data["detail"], "Administration rights granted.")
 
         # Invalid user ID
         response = self.do_request(
@@ -2790,7 +2790,7 @@ class GroupAPITest(APIBaseTest):
             superuser=False,
             request={"user_id": user.id},
         )
-        self.assertIn("Administration rights granted.", response.data)
+        self.assertEqual(response.data["detail"], "Administration rights granted.")
 
     def test_revoke_admin(self) -> None:
         group = Group.objects.create(name="Test Group")
@@ -6596,7 +6596,7 @@ class ProjectAPITest(APIBaseTest):
             "api:project-machinery-settings",
             self.project_kwargs,
             method="put",
-            code=201,
+            code=200,
             superuser=True,
             request=new_config,
             format="json",

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1630,7 +1630,9 @@ class GroupViewSet(viewsets.ModelViewSet):
         validate_api_team_assignable_user(user, "user_id")
         group.admins.add(user)
         user.add_team(cast("AuthenticatedHttpRequest", request), group)
-        return Response({"Administration rights granted."}, status=HTTP_200_OK)
+        return Response(
+            {"detail": "Administration rights granted."}, status=HTTP_200_OK
+        )
 
     @extend_schema(description="Delete a user from group admins.", methods=["delete"])
     @action(detail=True, methods=["delete"], url_path="admins/(?P<user_pk>[0-9]+)")
@@ -2488,7 +2490,7 @@ class ProjectViewSet(
                 {
                     "message": f"Services installed: {', '.join(valid_configurations.keys())}"
                 },
-                status=HTTP_201_CREATED,
+                status=HTTP_200_OK,
             )
 
         # GET method
@@ -3148,7 +3150,7 @@ class MemoryViewSet(viewsets.ReadOnlyModelViewSet, DestroyModelMixin):
             for scope in scopes
             if scope.scope in {MemoryScope.SCOPE_PROJECT, MemoryScope.SCOPE_WORKSPACE}
         }
-        accessible_component_scoped_ids = set(
+        accessible_project_or_workspace_scope_ids = set(
             MemoryScope.objects.filter(id__in=component_scoped_ids)
             .filter(MemoryQuerySet.get_component_access_query(user))
             .values_list("id", flat=True)
@@ -3157,7 +3159,7 @@ class MemoryViewSet(viewsets.ReadOnlyModelViewSet, DestroyModelMixin):
         for scope in scopes:
             if (
                 scope.id in component_scoped_ids
-                and scope.id not in accessible_component_scoped_ids
+                and scope.id not in accessible_project_or_workspace_scope_ids
             ):
                 continue
             if scope.user_id == user.id:


### PR DESCRIPTION
Return group administration success messages in the standard detail field and use 200 OK when machinery configuration is replaced.\n\nClarify project and workspace scope access naming, and align API tests with the updated response contracts.


_This PR applies 3/4 suggestions from code quality [AI findings](https://github.com/WeblateOrg/weblate/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._