### PR TITLE
fix(accounts): bound listing columns preference

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -36468,6 +36468,8 @@ components:
           title: Visible columns in lists
           description: Choose which statistics columns are shown in project, component,
             and language lists.
+          uniqueItems: true
+          maxItems: 8
         editor_link:
           type: string
           description: Enter a custom URL to be used as link to the source code. You
@@ -36685,6 +36687,8 @@ components:
           title: Visible columns in lists
           description: Choose which statistics columns are shown in project, component,
             and language lists.
+          uniqueItems: true
+          maxItems: 8
         editor_link:
           type: string
           description: Enter a custom URL to be used as link to the source code. You

--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -39,7 +39,12 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from weblate.accounts.auth import try_get_user
 from weblate.accounts.captcha import MathCaptcha
-from weblate.accounts.models import LISTING_COLUMN_CHOICES, AuditLog, Profile
+from weblate.accounts.models import (
+    LISTING_COLUMN_CHOICES,
+    AuditLog,
+    Profile,
+    validate_listing_columns,
+)
 from weblate.accounts.notifications import NOTIFICATIONS, NotificationScope
 from weblate.accounts.utils import (
     adjust_session_expiry,
@@ -316,6 +321,7 @@ class UserSettingsForm(ProfileBaseForm):
         choices=LISTING_COLUMN_CHOICES,
         widget=forms.CheckboxSelectMultiple,
         required=False,
+        validators=[validate_listing_columns],
     )
 
     class Meta:

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -753,6 +753,7 @@ LISTING_COLUMN_CHOICES = (
     ("suggestions", gettext_lazy("Suggestions")),
     ("comments", gettext_lazy("Comments")),
 )
+MAX_LISTING_COLUMNS = len(LISTING_COLUMN_CHOICES)
 
 DEFAULT_LISTING_COLUMNS = (
     "untranslated",
@@ -771,8 +772,14 @@ def get_default_listing_columns() -> list[str]:
 
 def validate_listing_columns(value) -> None:
     valid_columns = {column for column, _name in LISTING_COLUMN_CHOICES}
-    if not isinstance(value, list) or any(
-        column not in valid_columns for column in value
+    if (
+        not isinstance(value, list)
+        or len(value) > MAX_LISTING_COLUMNS
+        or any(
+            not isinstance(column, str) or column not in valid_columns
+            for column in value
+        )
+        or len(value) != len(set(value))
     ):
         raise ValidationError(gettext("Invalid listing column selection."))
 

--- a/weblate/accounts/tests/test_models.py
+++ b/weblate/accounts/tests/test_models.py
@@ -9,11 +9,20 @@ from __future__ import annotations
 from unittest import mock
 
 from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
 from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
 from weblate.accounts.admin import AuditLogAdmin
-from weblate.accounts.models import AUDIT_WARNING, NOTIFY_ACTIVITY, AuditLog, Profile
+from weblate.accounts.models import (
+    AUDIT_WARNING,
+    LISTING_COLUMN_CHOICES,
+    MAX_LISTING_COLUMNS,
+    NOTIFY_ACTIVITY,
+    AuditLog,
+    Profile,
+    validate_listing_columns,
+)
 from weblate.accounts.utils import remove_user
 from weblate.auth.models import User
 
@@ -62,6 +71,23 @@ class AuditLogTestCase(SimpleTestCase):
             audit = AuditLog(user_agent="PC / Linux / Chrome 120.0.0")
             result = audit.get_user_agent_display()
             self.assertEqual(result, "Translated PC / Linux / Chrome 120.0.0")
+
+
+class ListingColumnsValidationTestCase(SimpleTestCase):
+    def test_valid(self) -> None:
+        validate_listing_columns([])
+        validate_listing_columns([column for column, _name in LISTING_COLUMN_CHOICES])
+
+    def test_invalid(self) -> None:
+        for value in (
+            "comments",
+            ["invalid"],
+            ["comments", "comments"],
+            ["comments"] * (MAX_LISTING_COLUMNS + 1),
+            [["comments"]],
+        ):
+            with self.subTest(value=value), self.assertRaises(ValidationError):
+                validate_listing_columns(value)
 
 
 class AuditLogLoggingTestCase(TestCase):

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -29,7 +29,7 @@ from social_core.exceptions import (
 )
 from weblate_schemas import load_schema
 
-from weblate.accounts.forms import ProfileForm
+from weblate.accounts.forms import ProfileForm, UserSettingsForm
 from weblate.accounts.models import Profile, Subscription
 from weblate.accounts.notifications import (
     NOTIFICATIONS,
@@ -790,6 +790,45 @@ class ProfileTest(FixtureTestCase):
         self.assertEqual(
             self.user.profile.listing_columns, ["total", "untranslated", "checks"]
         )
+
+    def test_profile_listing_columns_rejects_duplicates(self) -> None:
+        original_listing_columns = self.user.profile.listing_columns
+        response = self.client.post(
+            reverse("profile"),
+            {
+                "language": "en",
+                "languages": Language.objects.get(code="cs").id,
+                "secondary_languages": Language.objects.get(code="cs").id,
+                "full_name": "First Last",
+                "email": "weblate@example.org",
+                "username": "testuser",
+                "dashboard_view": Profile.DASHBOARD_WATCHED,
+                "translate_mode": Profile.TRANSLATE_FULL,
+                "zen_mode": Profile.ZEN_VERTICAL,
+                "nearby_strings": 10,
+                "theme": "auto",
+                "listing_columns": ["comments", "comments"],
+                "notifications__0-scope": 0,
+                "notifications__0-project": "",
+                "notifications__0-component": "",
+                "notifications__1-scope": 10,
+                "notifications__1-project": "",
+                "notifications__1-component": "",
+                "notifications__2-scope": 20,
+                "notifications__2-project": "",
+                "notifications__2-component": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        form = next(
+            form
+            for form in response.context["all_forms"]
+            if isinstance(form, UserSettingsForm)
+        )
+        self.assertIn("listing_columns", form.errors)
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.listing_columns, original_listing_columns)
 
     def test_profile_group_display_uses_scoped_team_queryset(self) -> None:
         workspace = Workspace.objects.create(name="Profile workspace")

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -16,7 +16,10 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models, transaction
 from django.db.models import Model, TextChoices
 from django.utils.translation import gettext_lazy
-from drf_spectacular.extensions import OpenApiSerializerExtension
+from drf_spectacular.extensions import (
+    OpenApiSerializerExtension,
+    OpenApiSerializerFieldExtension,
+)
 from drf_spectacular.plumbing import build_basic_type, build_object_type
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -32,7 +35,13 @@ from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.reverse import reverse
 
-from weblate.accounts.models import LISTING_COLUMN_CHOICES, Profile, Subscription
+from weblate.accounts.models import (
+    LISTING_COLUMN_CHOICES,
+    MAX_LISTING_COLUMNS,
+    Profile,
+    Subscription,
+    validate_listing_columns,
+)
 from weblate.accounts.utils import get_all_user_mails
 from weblate.addons.base import is_public_addon_change_details
 from weblate.addons.models import ADDONS, Addon
@@ -818,6 +827,27 @@ class AllowedComponentListField(serializers.Field):
         )
 
 
+class ListingColumnsField(serializers.ListField):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            child=serializers.ChoiceField(choices=LISTING_COLUMN_CHOICES),
+            max_length=MAX_LISTING_COLUMNS,
+            validators=[validate_listing_columns],
+            **kwargs,
+        )
+
+
+class ListingColumnsFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = ListingColumnsField
+
+    def map_serializer_field(self, auto_schema: AutoSchema, direction):
+        schema = auto_schema._map_serializer_field(  # ruff: ignore[private-member-access]
+            self.target, direction, bypass_extensions=True
+        )
+        schema["uniqueItems"] = True
+        return schema
+
+
 class ProfileSerializer(serializers.ModelSerializer[Profile]):
     languages = serializers.HyperlinkedIdentityField(
         view_name="api:language-detail",
@@ -838,8 +868,7 @@ class ProfileSerializer(serializers.ModelSerializer[Profile]):
     commit_email = ProfileEmailChoiceField()
     public_email = ProfileEmailChoiceField()
     commit_name = ProfileCommitNameChoiceField()
-    listing_columns = serializers.ListField(
-        child=serializers.ChoiceField(choices=LISTING_COLUMN_CHOICES),
+    listing_columns = ListingColumnsField(
         required=False,
         label=Profile._meta.get_field("listing_columns").verbose_name,  # ruff: ignore[private-member-access]
         help_text=Profile._meta.get_field("listing_columns").help_text,  # ruff: ignore[private-member-access]

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -31,7 +31,12 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from rest_framework.test import APITestCase
 from weblate_language_data.languages import LANGUAGES
 
-from weblate.accounts.models import Profile, Subscription, VerifiedEmail
+from weblate.accounts.models import (
+    MAX_LISTING_COLUMNS,
+    Profile,
+    Subscription,
+    VerifiedEmail,
+)
 from weblate.accounts.notifications import (
     NotificationFrequency,
     NotificationScope,
@@ -1737,6 +1742,27 @@ class UserAPITest(APIBaseTest):
         )
         other_user.profile.refresh_from_db()
         self.assertEqual(other_user.profile.theme, "dark")
+
+    def test_patch_profile_rejects_invalid_listing_columns(self) -> None:
+        original_listing_columns = self.user.profile.listing_columns
+        invalid_values = (
+            ["comments", "comments"],
+            ["comments"] * (MAX_LISTING_COLUMNS + 1),
+        )
+
+        for value in invalid_values:
+            with self.subTest(value=value):
+                self.do_request(
+                    "api:user-detail",
+                    kwargs={"username": self.user.username},
+                    method="patch",
+                    code=400,
+                    format="json",
+                    request={"profile": {"listing_columns": value}},
+                )
+
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.listing_columns, original_listing_columns)
 
     def test_patch_profile_emails(self) -> None:
         self.do_request(


### PR DESCRIPTION
Reject duplicate and oversized selections so authenticated users cannot persist profile data that causes avoidable storage, parsing, and rendering costs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
