### PR TITLE
feat(vcs): run repository maintenance in background

### DIFF
--- a/docs/admin/continuous.rst
+++ b/docs/admin/continuous.rst
@@ -227,10 +227,17 @@ Availability of individual actions depends on permissions, the configured
 version control system, whether pushing is configured, and whether the selected
 object can be locked.
 
-The :guilabel:`File management` actions are available only from
-:guilabel:`Repository maintenance` for an individual translation. These actions
-rewrite that translation file and commit the result; they are not project-wide
-or component-wide operations.
+Repository actions started from this view are queued for background processing.
+For a project, Weblate processes the affected repositories sequentially in one
+task and shows its progress. Repeating the same action opens the existing task;
+a different action cannot be started for the same repository until that task
+finishes.
+
+The :guilabel:`Synchronize` and :guilabel:`Rescan` repository operations are
+queued for background processing as described above. The separate
+:guilabel:`File management` actions are available only for an individual
+translation. They rewrite that translation file and commit the result during
+the web request; they are not project-wide or component-wide operations.
 
 Operations that read repository content, such as updating, resetting, or
 rescanning, also reconcile translation files in Weblate. Added or removed

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1204,10 +1204,19 @@ Projects
     :param project: Project URL slug
     :type project: string
     :<json string operation: Operation to perform: one of ``push``, ``pull``, ``commit``, ``reset``, ``cleanup``, ``file-sync``, ``file-scan``
-    :>json boolean result: result of the operation
+    :<json boolean background: Schedule the operation as a background task instead of waiting for it to finish. Defaults to ``false``.
+    :>json boolean result: result of a synchronous operation
     :>json array included_components: full paths of project components included in the operation
     :>json array skipped_components: full paths of project components omitted from the operation
     :>json array permission_blockers: full paths of components preventing access to omitted repositories
+    :>json string detail: Status of a background operation
+    :>json string task_url: URL for tracking a background operation; see :http:get:`/api/tasks/(str:uuid)/`
+
+    With ``background`` set to ``true``, the endpoint returns ``202 Accepted``.
+    Repeating an identical queued operation returns the existing task URL. A
+    conflicting operation returns ``423 Locked`` and the active task URL when
+    available. Eligible project repositories are processed sequentially in one
+    task.
 
     **CURL example:**
 
@@ -1249,6 +1258,33 @@ Projects
             "permission_blockers": ["shared/glossary"],
             "result": true,
             "skipped_components": ["hello/glossary"]
+        }
+
+    **Background JSON request example:**
+
+    .. sourcecode:: http
+
+        POST /api/projects/hello/repository/ HTTP/1.1
+        Host: example.com
+        Accept: application/json
+        Content-Type: application/json
+        Authorization: Token TOKEN
+
+        {"operation":"pull","background":true}
+
+    **Background JSON response example:**
+
+    .. sourcecode:: http
+
+        HTTP/1.0 202 Accepted
+        Content-Type: application/json
+
+        {
+            "detail": "Repository operation has been queued.",
+            "included_components": ["hello/app"],
+            "permission_blockers": ["shared/glossary"],
+            "skipped_components": ["hello/glossary"],
+            "task_url": "https://example.com/api/tasks/01234567-89ab-cdef-0123-456789abcdef/"
         }
 
 
@@ -3384,6 +3420,13 @@ Tasks
     :>json int progress: Task progress in percent
     :>json object result: Task result or progress details
     :>json string log: Task log
+    :>json boolean cancellable: Whether the task can be cancelled
+
+.. http:delete:: /api/tasks/(str:uuid)/
+
+    Cancels a running task when its ``cancellable`` property is ``true``.
+    Repository operation tasks cannot be cancelled because interruption can
+    leave a repository operation incomplete.
 
 .. _api-statistics:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.9
 .. rubric:: Improvements
 
 * Removing the final Weblate workspace connection for a GitHub account, or removing the workspace holding it, now also uninstalls the Weblate GitHub App from GitHub.
+* Core repository maintenance actions now run as background tasks, avoiding request and proxy timeouts. The repository API supports the same behavior using ``background: true``. See :ref:`repository-maintenance`.
 * :ref:`addon-weblate.gettext.xgettext` now accepts multiple custom keywords (newline-separated) passed to xgettext via ``--keyword``, enabling extraction from different function names.
 * Screenshot images are now cached in browsers to reduce repeated downloads.
 * Administrators can now find removed accounts by their former e-mail address in the audit log until :setting:`AUDITLOG_EXPIRY`.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -25,7 +25,7 @@ documentation; ``*(maintainer)*`` means it was stated by a maintainer during
 this threat-model process; ``*(inferred)*`` means it was reasoned from the
 current project shape and needs maintainer confirmation.
 
-Provenance summary: 103 documented / 64 maintainer / 0 inferred claims.
+Provenance summary: 103 documented / 65 maintainer / 0 inferred claims.
 
 Weblate is a Django-based web localization platform. It accepts work from
 browser users, API clients, project-scoped tokens, repository webhooks, VCS
@@ -193,6 +193,13 @@ repository state, background tasks, outbound requests, and rendered UI.
    * - Client browser/API client to Weblate
      - Untrusted or authenticated requests become permission-checked
        application actions. *(documented)* (source: :doc:`/api`, :doc:`/admin/access`)
+   * - Weblate request process to repository Celery worker
+     - Permission-checked browser and API repository actions become queued work
+       carrying the initiating user and affected repository scope. The worker
+       reacquires the datastore reservation and rechecks the user's current VCS
+       permission across the current linked-component scope before mutation.
+       The broker, datastore, and workers are trusted parts of the same Weblate
+       instance. *(maintainer)*
    * - Webhook sender to Weblate
      - Public forge notifications can schedule repository synchronization
        where hooks are enabled, matching components by exact repository URL
@@ -621,9 +628,13 @@ Security properties Weblate provides
        explicit VCS actions cover every component sharing an affected
        repository, including linked components in other projects. Project-wide
        VCS actions omit repositories where this permission check fails; they do
-       not partially operate on an individual shared checkout. Weblate's normal
-       background commit and push of authorized translation changes does not
-       require the editor to have these VCS permissions. Translation memory
+       not partially operate on an individual shared checkout. Explicit VCS
+       actions queued from the browser or API retain the initiating user,
+       serialize access to the affected repositories, and recheck that user's
+       permission against the current linked-component scope in the worker
+       before mutation. Weblate's normal background commit and push of
+       authorized translation changes does not require the editor to have
+       these VCS permissions. Translation memory
        attributed to an existing restricted component follows that component's
        access rules.
        Unattributed automatic memory, including unmatched legacy entries and

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -8049,12 +8049,6 @@ paths:
                       detail: Unsupported media type "application/json" in request.
                       attr: null
           description: The request media type is not supported.
-        '423':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse423'
-          description: The resource is locked.
         '429':
           content:
             application/json:
@@ -8096,6 +8090,18 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
               $ref: '#/components/headers/X-RateLimit-Reset'
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryOperation'
+          description: The request was accepted for asynchronous processing.
+        '423':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryOperationConflict'
+          description: The resource is locked.
   /api/components/{project__slug}/{slug}/screenshots/:
     get:
       operationId: api_components_screenshots_list
@@ -19258,12 +19264,6 @@ paths:
                       detail: Unsupported media type "application/json" in request.
                       attr: null
           description: The request media type is not supported.
-        '423':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse423'
-          description: The resource is locked.
         '429':
           content:
             application/json:
@@ -19305,6 +19305,18 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
               $ref: '#/components/headers/X-RateLimit-Reset'
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryOperation'
+          description: The request was accepted for asynchronous processing.
+        '423':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryOperationConflict'
+          description: The resource is locked.
   /api/projects/{slug}/statistics/:
     get:
       operationId: api_projects_statistics_retrieve
@@ -24558,6 +24570,8 @@ paths:
                       detail: You do not have permission to perform this action.
                       attr: null
           description: The authenticated user does not have permission for this operation.
+        '409':
+          description: This task cannot be cancelled.
   /api/translations/:
     get:
       operationId: api_translations_list
@@ -26683,12 +26697,6 @@ paths:
                       detail: Unsupported media type "application/json" in request.
                       attr: null
           description: The request media type is not supported.
-        '423':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse423'
-          description: The resource is locked.
         '429':
           content:
             application/json:
@@ -26730,6 +26738,18 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
               $ref: '#/components/headers/X-RateLimit-Reset'
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryOperation'
+          description: The request was accepted for asynchronous processing.
+        '423':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryOperationConflict'
+          description: The resource is locked.
   /api/translations/{component__project__slug}/{component__slug}/{language__code}/statistics/:
     get:
       operationId: api_translations_statistics_retrieve
@@ -37682,6 +37702,9 @@ components:
       properties:
         operation:
           $ref: '#/components/schemas/OperationEnum'
+        background:
+          type: boolean
+          default: false
       required:
       - operation
     Report:
@@ -38027,8 +38050,13 @@ components:
           items:
             type: string
           description: Full paths of components preventing access to skipped repositories.
-      required:
-      - result
+        task_url:
+          type: string
+          format: uri
+    RepositoryOperationConflict:
+      oneOf:
+      - $ref: '#/components/schemas/RepositoryOperation'
+      - $ref: '#/components/schemas/ErrorResponse423'
     ResultEnum:
       enum:
       - voted
@@ -38512,7 +38540,10 @@ components:
           - type: 'null'
         log:
           type: string
+        cancellable:
+          type: boolean
       required:
+      - cancellable
       - completed
       - log
       - progress

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -2831,7 +2831,8 @@ class BooleanResultSerializer(ReadOnlySerializer):
     result = serializers.BooleanField()
 
 
-class RepositoryOperationSerializer(BooleanResultSerializer):
+class RepositoryOperationSerializer(ReadOnlySerializer):
+    result = serializers.BooleanField(required=False)
     detail = serializers.CharField(required=False)
     included_components = serializers.ListField(
         child=serializers.CharField(),
@@ -2848,6 +2849,7 @@ class RepositoryOperationSerializer(BooleanResultSerializer):
         required=False,
         help_text="Full paths of components preventing access to skipped repositories.",
     )
+    task_url = serializers.URLField(required=False)
 
 
 class UploadResultSerializer(BooleanResultSerializer):
@@ -3058,6 +3060,7 @@ class RepoRequestSerializer(ReadOnlySerializer):
     operation = serializers.ChoiceField(
         choices=RepoOperations.choices,
     )
+    background = serializers.BooleanField(required=False, default=False)
 
 
 class CommitInfoSerializer(ReadOnlySerializer):
@@ -4347,6 +4350,7 @@ class TaskSerializer(ReadOnlySerializer):
     progress = serializers.IntegerField(min_value=0, max_value=100)
     result = TaskResultField()
     log = serializers.CharField(allow_blank=True)
+    cancellable = serializers.BooleanField()
 
 
 @extend_schema_serializer(

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -7,7 +7,7 @@ import operator
 import os
 import tempfile
 import zipfile
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from copy import copy
 from datetime import UTC, date, datetime, timedelta
 from io import BytesIO, StringIO
@@ -22,7 +22,7 @@ from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.core.files import File
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.db import DatabaseError
+from django.db import DatabaseError, transaction
 from django.db.models import Q
 from django.templatetags.static import static
 from django.test.utils import modify_settings, override_settings
@@ -68,6 +68,7 @@ from weblate.auth.models import (
     User,
     UserBlock,
 )
+from weblate.auth.permissions import get_project_repository_selection
 from weblate.lang.models import Language
 from weblate.memory.models import Memory, MemoryScope
 from weblate.screenshots.models import Screenshot
@@ -98,6 +99,10 @@ from weblate.trans.models import (
     WorkflowSetting,
 )
 from weblate.trans.models.component import ComponentQuerySet
+from weblate.trans.repository import (
+    QueuedRepositoryOperation,
+    RepositoryOperationConflictError,
+)
 from weblate.trans.tests.utils import (
     RepoTestMixin,
     clear_users_cache,
@@ -3584,6 +3589,198 @@ class ProjectAPITest(APIBaseTest):
                 superuser=True,
                 request={"operation": operation},
             )
+
+    def test_repo_operation_can_be_queued(self) -> None:
+        task_id = "01234567-89ab-cdef-0123-456789abcdef"
+        with patch(
+            "weblate.api.views.queue_repository_operation",
+            return_value=QueuedRepositoryOperation(task_id),
+        ) as queue_operation:
+            response = self.do_request(
+                "api:project-repository",
+                self.project_kwargs,
+                method="post",
+                superuser=True,
+                code=202,
+                request={"operation": "pull", "background": True},
+            )
+
+        self.assertEqual(
+            response.data,
+            {
+                "detail": "Repository operation has been queued.",
+                "task_url": f"http://example.com/api/tasks/{task_id}/",
+                "included_components": sorted(
+                    component.full_slug
+                    for component in self.project.component_set.all()
+                ),
+                "skipped_components": [],
+                "permission_blockers": [],
+            },
+        )
+        selection = get_project_repository_selection(
+            self.user, self.project, ("vcs.update",)
+        )
+        queue_operation.assert_called_once_with(
+            self.project,
+            "pull",
+            self.user,
+            repository_components=selection.repositories,
+        )
+
+    def test_eager_repo_operation_returns_result(self) -> None:
+        with patch(
+            "weblate.api.views.queue_repository_operation",
+            return_value=QueuedRepositoryOperation("task-id", successful=False),
+        ):
+            response = self.do_request(
+                "api:project-repository",
+                self.project_kwargs,
+                method="post",
+                superuser=True,
+                request={"operation": "pull", "background": True},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "result": False,
+                "included_components": sorted(
+                    component.full_slug
+                    for component in self.project.component_set.all()
+                ),
+                "skipped_components": [],
+                "permission_blockers": [],
+            },
+        )
+
+    def test_synchronous_repo_operation_releases_before_followups(self) -> None:
+        events = []
+
+        @contextmanager
+        def reserve(*args, **kwargs):
+            events.append("reserved")
+
+            def release() -> None:
+                events.append("released")
+
+            try:
+                yield release
+            finally:
+                events.append("reservation context exited")
+
+        def update(*args, **kwargs):
+            transaction.on_commit(lambda: events.append("follow-up"))
+            return True
+
+        with (
+            self.captureOnCommitCallbacks(execute=True),
+            patch("weblate.api.views.reserve_repository_operation", reserve),
+            patch.object(Project, "do_update", update),
+        ):
+            self.do_request(
+                "api:project-repository",
+                self.project_kwargs,
+                method="post",
+                superuser=True,
+                request={"operation": "pull"},
+            )
+
+        self.assertEqual(
+            events,
+            [
+                "reserved",
+                "reservation context exited",
+                "released",
+                "follow-up",
+            ],
+        )
+
+    def test_repo_operation_queue_conflict(self) -> None:
+        task_id = "01234567-89ab-cdef-0123-456789abcdef"
+        with (
+            patch(
+                "weblate.api.views.queue_repository_operation",
+                side_effect=RepositoryOperationConflictError(task_id),
+            ),
+            patch(
+                "weblate.api.views.can_access_repository_operation_task",
+                return_value=True,
+            ),
+        ):
+            response = self.do_request(
+                "api:project-repository",
+                self.project_kwargs,
+                method="post",
+                superuser=True,
+                code=423,
+                request={"operation": "push", "background": True},
+            )
+
+        self.assertEqual(
+            response.data,
+            {
+                "detail": "Another repository operation is already in progress.",
+                "task_url": f"http://example.com/api/tasks/{task_id}/",
+                "included_components": sorted(
+                    component.full_slug
+                    for component in self.project.component_set.all()
+                ),
+                "skipped_components": [],
+                "permission_blockers": [],
+            },
+        )
+
+    def test_repo_operation_conflict_hides_inaccessible_task(self) -> None:
+        task_id = "01234567-89ab-cdef-0123-456789abcdef"
+        with (
+            patch(
+                "weblate.api.views.queue_repository_operation",
+                side_effect=RepositoryOperationConflictError(task_id),
+            ),
+            patch(
+                "weblate.api.views.can_access_repository_operation_task",
+                return_value=False,
+            ),
+        ):
+            response = self.do_request(
+                "api:project-repository",
+                self.project_kwargs,
+                method="post",
+                superuser=True,
+                code=423,
+                request={"operation": "push", "background": True},
+            )
+
+        self.assertNotIn("task_url", response.data)
+
+    def test_synchronous_repo_operation_honors_reservation(self) -> None:
+        task_id = "01234567-89ab-cdef-0123-456789abcdef"
+        with (
+            patch(
+                "weblate.api.views.reserve_repository_operation",
+                side_effect=RepositoryOperationConflictError(task_id),
+            ),
+            patch(
+                "weblate.api.views.can_access_repository_operation_task",
+                return_value=False,
+            ),
+        ):
+            response = self.do_request(
+                "api:project-repository",
+                self.project_kwargs,
+                method="post",
+                superuser=True,
+                code=423,
+                request={"operation": "pull"},
+            )
+
+        self.assertEqual(
+            response.data["detail"],
+            "Another repository operation is already in progress.",
+        )
+        self.assertNotIn("task_url", response.data)
 
     def test_repo_file_sync_returns_true(self) -> None:
         with patch.object(Component, "queue_background_task", return_value=None):
@@ -9936,7 +10133,13 @@ class TasksAPITest(APIBaseTest):
 
         self.assertEqual(
             response.data,
-            {"completed": False, "progress": 0, "result": None, "log": ""},
+            {
+                "completed": False,
+                "progress": 0,
+                "result": None,
+                "log": "",
+                "cancellable": True,
+            },
         )
 
     def test_retrieve_requires_authentication(self) -> None:
@@ -9976,8 +10179,84 @@ class TasksAPITest(APIBaseTest):
 
         self.assertEqual(
             response.data,
-            {"completed": False, "progress": 0, "result": None, "log": ""},
+            {
+                "completed": False,
+                "progress": 0,
+                "result": None,
+                "log": "",
+                "cancellable": False,
+            },
         )
+
+    def test_retrieve_repository_task_after_tracked_component_deleted(self) -> None:
+        cache.set(
+            get_task_metadata_key(self.task_id),
+            {
+                "component_ids": [self.component.id, self.component.id + 1_000_000],
+                "user_id": self.user.id,
+                "cancellable": False,
+            },
+            3600,
+        )
+
+        class DummyAsyncResult:
+            def __init__(self, task_id):
+                self.id = task_id
+                self.result = None
+                self.state = "PENDING"
+
+            def ready(self):
+                return False
+
+        with patch("weblate.api.views.AsyncResult", DummyAsyncResult):
+            response = self.do_request(
+                "api:task-detail",
+                kwargs={"pk": self.task_id},
+                method="get",
+                code=200,
+            )
+
+        self.assertFalse(response.data["completed"])
+        self.assertFalse(response.data["cancellable"])
+
+    def test_destroy_rejects_non_cancellable_task(self) -> None:
+        cache.set(
+            get_task_metadata_key(self.task_id),
+            {
+                "component_ids": [self.component.id],
+                "cancellable": False,
+            },
+            3600,
+        )
+
+        class DummyAsyncResult:
+            latest = None
+
+            def __init__(self, task_id):
+                self.id = task_id
+                self.result = None
+                self.state = "PENDING"
+                self.revoked = False
+                DummyAsyncResult.latest = self
+
+            def ready(self):
+                return False
+
+            def revoke(self, *args, **kwargs) -> None:
+                self.revoked = True
+
+        with patch("weblate.api.views.AsyncResult", DummyAsyncResult):
+            response = self.do_request(
+                "api:task-detail",
+                kwargs={"pk": self.task_id},
+                method="delete",
+                superuser=True,
+                code=409,
+            )
+
+        self.assertEqual(response.data, {"detail": "This task cannot be cancelled."})
+        assert DummyAsyncResult.latest is not None
+        self.assertFalse(DummyAsyncResult.latest.revoked)
 
     def test_retrieve_rejects_other_user_metadata(self) -> None:
         cache.set(
@@ -11800,6 +12079,33 @@ class TranslationAPITest(APIBaseTest):
                 code=403,
                 request={"operation": operation},
             )
+
+    def test_background_commit_preserves_translation_noop(self) -> None:
+        translation = self.component.translation_set.get(language_code="cs")
+        PendingUnitChange.objects.filter(unit__translation=translation).delete()
+        other_translation = (
+            self.component.translation_set.exclude(pk=translation.pk)
+            .exclude(filename="")
+            .first()
+        )
+        assert other_translation is not None
+        unit = other_translation.unit_set.first()
+        assert unit is not None
+        PendingUnitChange.objects.create(unit=unit, author=self.user)
+        self.assertFalse(translation.needs_commit())
+        self.assertTrue(self.component.needs_commit())
+
+        with patch("weblate.api.views.queue_repository_operation") as queue:
+            response = self.do_request(
+                "api:translation-repository",
+                self.translation_kwargs,
+                method="post",
+                superuser=True,
+                request={"operation": "commit", "background": True},
+            )
+
+        self.assertEqual(response.data, {"result": False})
+        queue.assert_not_called()
 
     def test_repo_status(self) -> None:
         response = self.do_request(
@@ -17579,7 +17885,8 @@ class OpenAPITest(APIBaseTest):
         )
         task_schema = schema["components"]["schemas"]["Task"]
         self.assertEqual(
-            task_schema["required"], ["completed", "log", "progress", "result"]
+            task_schema["required"],
+            ["cancellable", "completed", "log", "progress", "result"],
         )
         self.assertEqual(
             task_schema["properties"]["completed"],
@@ -17590,9 +17897,11 @@ class OpenAPITest(APIBaseTest):
             {"type": "integer", "maximum": 100, "minimum": 0},
         )
         self.assertEqual(task_schema["properties"]["log"], {"type": "string"})
+        self.assertEqual(task_schema["properties"]["cancellable"], {"type": "boolean"})
         self.assertEqual(
             task_schema["properties"]["result"]["oneOf"].count({"type": "null"}), 1
         )
+        self.assertIn("409", schema["paths"]["/api/tasks/{id}/"]["delete"]["responses"])
 
     def test_action_nested_list_schema_matches_runtime_behavior(self) -> None:
         schema = self.get_schema()
@@ -17634,11 +17943,22 @@ class OpenAPITest(APIBaseTest):
             ],
             {"$ref": "#/components/schemas/RepoRequest"},
         )
+        for status_code in ("200", "202"):
+            self.assertEqual(
+                project_repository["post"]["responses"][status_code]["content"][
+                    "application/json"
+                ]["schema"],
+                {"$ref": "#/components/schemas/RepositoryOperation"},
+            )
         self.assertEqual(
-            project_repository["post"]["responses"]["200"]["content"][
+            project_repository["post"]["responses"]["423"]["content"][
                 "application/json"
             ]["schema"],
-            {"$ref": "#/components/schemas/RepositoryOperation"},
+            {"$ref": "#/components/schemas/RepositoryOperationConflict"},
+        )
+        self.assertEqual(
+            schema["components"]["schemas"]["RepoRequest"]["properties"]["background"],
+            {"type": "boolean", "default": False},
         )
         component_lock = schema["paths"]["/api/components/{project__slug}/{slug}/lock/"]
         self.assertEqual(

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -14,7 +14,6 @@ from urllib.parse import unquote
 
 from celery.result import AsyncResult
 from django.conf import settings
-from django.contrib import messages
 from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.core.exceptions import (
@@ -58,6 +57,7 @@ from rest_framework.status import (
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
+    HTTP_409_CONFLICT,
     HTTP_423_LOCKED,
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
@@ -85,6 +85,7 @@ from weblate.api.serializers import (
     ComponentListSerializer,
     ComponentSerializer,
     ComponentTranslationSerializer,
+    ErrorResponse423Serializer,
     FullUserSerializer,
     GroupSerializer,
     LabelSerializer,
@@ -177,6 +178,14 @@ from weblate.trans.models import (
 )
 from weblate.trans.models.project import ProjectQuerySet, prefetch_project_flags
 from weblate.trans.models.translation import Translation, TranslationQuerySet
+from weblate.trans.repository import (
+    RepositoryOperation,
+    RepositoryOperationConflictError,
+    can_access_repository_operation_task,
+    get_repository_components,
+    queue_repository_operation,
+    reserve_repository_operation,
+)
 from weblate.trans.tasks import (
     category_removal,
     component_removal,
@@ -195,6 +204,7 @@ from weblate.utils.celery import (
 from weblate.utils.docs import get_doc_url
 from weblate.utils.errors import report_error
 from weblate.utils.lock import WeblateLockTimeoutError
+from weblate.utils.messages import store_task_completion_message
 from weblate.utils.search import SearchQueryError, parse_query
 from weblate.utils.similarity import Comparer
 from weblate.utils.state import (
@@ -516,6 +526,16 @@ REPO_OPERATIONS: dict[str, tuple[str, str, tuple, dict, bool]] = {
     "file-scan": ("vcs.reset", "do_file_scan", (), {}, True),
 }
 
+REPOSITORY_OPERATION_RESPONSES = {
+    HTTP_200_OK: RepositoryOperationSerializer,
+    HTTP_202_ACCEPTED: RepositoryOperationSerializer,
+    HTTP_423_LOCKED: PolymorphicProxySerializer(
+        component_name="RepositoryOperationConflict",
+        serializers=[RepositoryOperationSerializer, ErrorResponse423Serializer],
+        resource_type_field_name=None,
+    ),
+}
+
 DOC_TEXT = """
 <p>See <a href="{0}">the Weblate's Web API documentation</a> for detailed
 description of the API.</p>
@@ -695,7 +715,6 @@ class WeblateViewSet(DownloadViewSet):
             ],
         }
 
-    @transaction.atomic
     def repository_operation(self, request: Request, obj, operation: str):
         permission, method, args, kwargs, takes_request = REPO_OPERATIONS[operation]
         user = get_request_user(request)
@@ -704,22 +723,120 @@ class WeblateViewSet(DownloadViewSet):
             raise PermissionDenied
 
         selection = None
+        repository_components = None
         if isinstance(obj, Project):
             selection = get_project_repository_selection(user, obj, (permission,))
             if not selection.repositories:
                 raise PermissionDenied
-            kwargs = {**kwargs, "repo_components": selection.repositories}
+            repository_components = selection.repositories
+            kwargs = {**kwargs, "repo_components": repository_components}
+
+        repositories, _display_components = get_repository_components(
+            obj, repository_components
+        )
 
         obj.acting_user = user
-
-        if takes_request:
-            result = getattr(obj, method)(*args, request, **kwargs)
-        else:
-            result = getattr(obj, method)(*args, user, **kwargs)
+        with (
+            reserve_repository_operation(
+                [component.pk for component in repositories],
+                cast("RepositoryOperation", operation),
+            ) as release_reservation,
+            transaction.atomic(),
+        ):
+            # Register this before repository operations add their follow-ups.
+            # Django runs on-commit callbacks in registration order, so the
+            # reservation covers the commit but not the follow-up tasks.
+            transaction.on_commit(release_reservation)
+            if takes_request:
+                result = getattr(obj, method)(*args, request, **kwargs)
+            else:
+                result = getattr(obj, method)(*args, user, **kwargs)
         data = {"result": result}
         if selection is not None:
             data.update(self.get_repository_scope_data(user, selection))
         return data
+
+    @staticmethod
+    def repository_operation_conflict_response(
+        request: Request,
+        user: User,
+        error: RepositoryOperationConflictError,
+        scope_data: dict,
+    ) -> Response:
+        data = {
+            "detail": "Another repository operation is already in progress.",
+            **scope_data,
+        }
+        if error.task_id and can_access_repository_operation_task(user, error.task_id):
+            data["task_url"] = reverse(
+                "api:task-detail",
+                kwargs={"pk": error.task_id},
+                request=request,
+            )
+        return Response(data, status=HTTP_423_LOCKED)
+
+    def queue_repository_operation(
+        self,
+        request: Request,
+        obj: Project | Component | Translation,
+        operation: RepositoryOperation,
+    ) -> Response:
+        permission = REPO_OPERATIONS[operation][0]
+        user = get_request_user(request)
+        if not user.has_perm(permission, obj):
+            raise PermissionDenied
+        if (
+            operation == "commit"
+            and isinstance(obj, Translation)
+            and not obj.needs_commit()
+        ):
+            return Response({"result": False})
+
+        selection = None
+        repository_components = None
+        if isinstance(obj, Project):
+            selection = get_project_repository_selection(user, obj, (permission,))
+            if not selection.repositories:
+                raise PermissionDenied
+            repository_components = selection.repositories
+
+        scope_data = (
+            self.get_repository_scope_data(user, selection)
+            if selection is not None
+            else {}
+        )
+        try:
+            queued = queue_repository_operation(
+                obj,
+                operation,
+                user,
+                repository_components=repository_components,
+            )
+        except RepositoryOperationConflictError as error:
+            return self.repository_operation_conflict_response(
+                request, user, error, scope_data
+            )
+
+        if queued.successful is not None:
+            return Response({"result": queued.successful, **scope_data})
+
+        detail = (
+            "This repository operation is already queued."
+            if queued.reused
+            else "Repository operation has been queued."
+        )
+        return Response(
+            {
+                "detail": detail,
+                "task_url": reverse(
+                    "api:task-detail",
+                    kwargs={"pk": queued.task_id},
+                    request=request,
+                ),
+                **scope_data,
+            },
+            status=HTTP_202_ACCEPTED,
+        )
 
     @extend_schema(
         description="Return information about VCS repository status.",
@@ -729,7 +846,7 @@ class WeblateViewSet(DownloadViewSet):
     @extend_schema(
         description="Perform given operation on the VCS repository.",
         methods=["post"],
-        responses=RepositoryOperationSerializer,
+        responses=REPOSITORY_OPERATION_RESPONSES,
     )
     @action(
         detail=True, methods=["get", "post"], serializer_class=RepoRequestSerializer
@@ -740,10 +857,25 @@ class WeblateViewSet(DownloadViewSet):
         if request.method == "POST":
             request_serializer = RepoRequestSerializer(data=request.data)
             request_serializer.is_valid(raise_exception=True)
+            operation = request_serializer.validated_data["operation"]
 
-            data = self.repository_operation(
-                request, obj, request_serializer.validated_data["operation"]
-            )
+            if request_serializer.validated_data["background"]:
+                return self.queue_repository_operation(request, obj, operation)
+
+            try:
+                data = self.repository_operation(request, obj, operation)
+            except RepositoryOperationConflictError as error:
+                user = get_request_user(request)
+                scope_data = {}
+                if isinstance(obj, Project):
+                    permission = REPO_OPERATIONS[operation][0]
+                    selection = get_project_repository_selection(
+                        user, obj, (permission,)
+                    )
+                    scope_data = self.get_repository_scope_data(user, selection)
+                return self.repository_operation_conflict_response(
+                    request, user, error, scope_data
+                )
 
             storage = get_messages(request)
             if storage:
@@ -2046,7 +2178,7 @@ class ProjectViewSet(
     @extend_schema(
         description="Perform given operation on the VCS repository.",
         methods=["post"],
-        responses=RepositoryOperationSerializer,
+        responses=REPOSITORY_OPERATION_RESPONSES,
     )
     @action(
         detail=True, methods=["get", "post"], serializer_class=RepoRequestSerializer
@@ -2799,7 +2931,7 @@ class ComponentViewSet(
     @extend_schema(
         description="Perform given operation on the VCS repository.",
         methods=["post"],
-        responses=RepositoryOperationSerializer,
+        responses=REPOSITORY_OPERATION_RESPONSES,
     )
     @action(
         detail=True, methods=["get", "post"], serializer_class=RepoRequestSerializer
@@ -3462,7 +3594,7 @@ class TranslationViewSet(MultipleFieldViewSet, DestroyModelMixin, AnnouncementsM
     @extend_schema(
         description="Perform given operation on the VCS repository.",
         methods=["post"],
-        responses=RepositoryOperationSerializer,
+        responses=REPOSITORY_OPERATION_RESPONSES,
     )
     @action(
         detail=True, methods=["get", "post"], serializer_class=RepoRequestSerializer
@@ -4962,7 +5094,7 @@ class TasksViewSet(ViewSet):
 
     def get_task(
         self, request, pk, permission: str | None = None
-    ) -> tuple[AsyncResult, Component | None]:
+    ) -> tuple[AsyncResult, Component | None, dict]:
         obj: Model
         component: Component | None
         user = cast("User", request.user)
@@ -4974,6 +5106,30 @@ class TasksViewSet(ViewSet):
             )
             obj = translation
             component = translation.component
+        elif component_ids := metadata.get("component_ids"):
+            unique_component_ids = set(component_ids)
+            existing_component_ids = set(
+                Component.objects.filter(pk__in=unique_component_ids).values_list(
+                    "pk", flat=True
+                )
+            )
+            components = list(
+                Component.objects.filter_access(user)
+                .filter(pk__in=existing_component_ids)
+                .order_by("pk")
+            )
+            if len(components) != len(existing_component_ids) or (
+                existing_component_ids != unique_component_ids
+                and metadata.get("user_id") != user.pk
+            ):
+                msg = "Invalid task"
+                raise Http404(msg)
+            if components:
+                component = components[0]
+                obj = component
+            else:
+                component = None
+                obj = user
         elif component_id := metadata.get("component_id"):
             component = get_object_or_404(
                 Component.objects.filter_access(user), pk=component_id
@@ -4998,34 +5154,7 @@ class TasksViewSet(ViewSet):
         elif component is not None and not user.can_access_component(component):
             raise PermissionDenied
 
-        return task, component
-
-    @staticmethod
-    def store_completion_message(request: Request, task: AsyncResult) -> None:
-        """Store an explicitly opted-in task completion message in the session."""
-        result = task.result
-        if not isinstance(result, dict):
-            return
-
-        completion_message = result.get("completion_message")
-        if not isinstance(completion_message, dict):
-            return
-
-        text = completion_message.get("text")
-        if not text:
-            return
-
-        session_key = f"task-completion-message-{task.id}"
-        if request.session.get(session_key):
-            return
-
-        level = {
-            "error": messages.ERROR,
-            "info": messages.INFO,
-            "warning": messages.WARNING,
-        }.get(completion_message.get("level"), messages.SUCCESS)
-        messages.add_message(request, level, str(text))
-        request.session[session_key] = True
+        return task, component, metadata
 
     @extend_schema(
         description="Return information about a task",
@@ -5033,16 +5162,17 @@ class TasksViewSet(ViewSet):
         responses=TaskSerializer,
     )
     def retrieve(self, request: Request, pk=None):
-        task, _component = self.get_task(request, pk)
+        task, component, metadata = self.get_task(request, pk)
         result = task.result
         if task.ready():
-            self.store_completion_message(request, task)
+            store_task_completion_message(request, task)
         serializer = self.serializer_class(
             {
                 "completed": task.ready(),
                 "progress": get_task_progress(task),
                 "result": str(result) if isinstance(result, Exception) else result,
                 "log": "\n".join(cache.get(f"task-log-{task.id}", [])),
+                "cancellable": metadata.get("cancellable", component is not None),
             }
         )
         return Response(serializer.data)
@@ -5056,10 +5186,18 @@ class TasksViewSet(ViewSet):
                 response=ErrorResponse403Serializer,
                 description="The authenticated user does not have permission for this operation.",
             ),
+            HTTP_409_CONFLICT: OpenApiResponse(
+                description="This task cannot be cancelled.",
+            ),
         },
     )
     def destroy(self, request: Request, pk=None):
-        task, component = self.get_task(request, pk, "component.edit")
+        task, component, metadata = self.get_task(request, pk, "component.edit")
+        if not metadata.get("cancellable", True):
+            return Response(
+                {"detail": "This task cannot be cancelled."},
+                status=HTTP_409_CONFLICT,
+            )
         if not task.ready() and component is not None:
             task.revoke(terminate=True)
             # Unlink task from component

--- a/weblate/templates/component-progress.html
+++ b/weblate/templates/component-progress.html
@@ -36,7 +36,7 @@
       <form class="form-inline">
         <div class="form-group">
           <a href="{{ return_url }}" class="btn btn-primary" id="progress-return">{% blocktranslate %}Continue to {{ return_target }}{% endblocktranslate %}</a>
-          {% if user_can_edit_component %}
+          {% if user_can_edit_component and task_cancellable %}
             <a href="#" class="btn btn-danger" id="terminate-task-button">{% translate "Abort the update" %}</a>
           {% endif %}
         </div>

--- a/weblate/templates/multi-progress.html
+++ b/weblate/templates/multi-progress.html
@@ -17,7 +17,7 @@
     <div class="card-body">
 
       {% for component in components %}
-        {% include "snippets/component-progress.html" with task_id=component.background_task tags="success" %}
+        {% include "snippets/component-progress.html" with task_id=component.background_task progress=0 tags="success" %}
       {% endfor %}
 
     </div>

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -300,20 +300,19 @@ class CommitTaskPayload(TypedDict):
 
 def prefetch_tasks(components):
     """Prefetch update tasks."""
-    lookup = {component.update_key: component for component in components}
-    if lookup:
-        results_dict = cache.get_many(lookup.keys())
-        results: dict[str, AsyncResult] = {
-            value: AsyncResult(value) for value in results_dict.values() if value
-        }
-
-        for item, value in results_dict.items():
-            if not value:
-                continue
-            lookup[item].__dict__["background_task"] = results[value]
-            lookup.pop(item)
-        for component in lookup.values():
-            component.__dict__["background_task"] = None
+    component_list = list(components)
+    keys = {
+        key
+        for component in component_list
+        for key in (component.update_key, component.repository_operation_update_key)
+    }
+    task_ids = cache.get_many(keys)
+    results: dict[str, AsyncResult] = {
+        task_id: AsyncResult(task_id) for task_id in task_ids.values() if task_id
+    }
+    for component in component_list:
+        task_id = component.select_background_task_id(task_ids)
+        component.__dict__["background_task"] = results.get(task_id)
     return components
 
 
@@ -1885,6 +1884,13 @@ class Component(  # ruff: ignore[too-many-public-methods]
         return f"component-update-{self.pk}"
 
     @cached_property
+    def repository_operation_update_key(self) -> str:
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.repository import get_repository_operation_update_key
+
+        return get_repository_operation_update_key(self.pk)
+
+    @cached_property
     def commit_task_key(self) -> str:
         return f"component-commit-{self.effective_repo_component.pk}"
 
@@ -1893,7 +1899,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         return f"component-commit-reschedule-{self.effective_repo_component.pk}"
 
     def delete_background_task(self) -> None:
-        delete_task_metadata(self.background_task_id)
+        delete_task_metadata(cache.get(self.update_key))
         cache.delete(self.update_key)
 
     def store_background_task(self, task=None) -> None:
@@ -1905,9 +1911,19 @@ class Component(  # ruff: ignore[too-many-public-methods]
         store_task_metadata(task.id, component_id=self.pk)
 
     def queue_background_task(self, task, /, *args, **kwargs) -> None:
-        transaction.on_commit(
-            lambda: self.store_background_task(task.delay(*args, **kwargs))
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.repository_context import (
+            repository_task_deferred_background_tasks,
         )
+
+        def publish() -> None:
+            self.store_background_task(task.delay(*args, **kwargs))
+
+        deferred = repository_task_deferred_background_tasks.get()
+        if deferred is None:
+            transaction.on_commit(publish)
+        else:
+            transaction.on_commit(lambda: deferred.append(publish))
 
     @staticmethod
     def get_current_task_id() -> str | None:
@@ -2002,7 +2018,18 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
     @cached_property
     def background_task_id(self):
-        return cache.get(self.update_key)
+        return self.select_background_task_id(
+            cache.get_many((self.update_key, self.repository_operation_update_key))
+        )
+
+    def select_background_task_id(self, task_ids: dict[str, str]) -> str | None:
+        repository_task_id = task_ids.get(self.repository_operation_update_key)
+        background_task_id = task_ids.get(self.update_key)
+        if repository_task_id and background_task_id:
+            if not AsyncResult(repository_task_id).ready():
+                return repository_task_id
+            return background_task_id
+        return repository_task_id or background_task_id
 
     @cached_property
     def background_task(self):
@@ -2024,6 +2051,12 @@ class Component(  # ruff: ignore[too-many-public-methods]
         if progress is None:
             self.translations_progress += 1
             progress = 100 * self.translations_progress // self.translations_count
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.repository_context import repository_task_progress_scope
+
+        if (scope := repository_task_progress_scope.get()) is not None:
+            completed, total = scope
+            progress = (100 * completed + progress) // total
         # Store task state
         current_task.update_state(
             state="PROGRESS", meta={"progress": progress, "component": self.pk}
@@ -2033,9 +2066,20 @@ class Component(  # ruff: ignore[too-many-public-methods]
         if self.translations_count == -1 and self.linked_component:
             self.linked_component.store_log(slug, msg, *args)
             return
-        self.logs.append(f"{slug}: {msg % args}")
+        entry = f"{slug}: {msg % args}"
         if current_task and current_task.request.id:
-            cache.set(f"task-log-{current_task.request.id}", self.logs, 2 * 3600)
+            # ruff: ignore[import-outside-top-level]
+            from weblate.trans.repository_context import (
+                repository_task_inline_followups,
+            )
+
+            task_log_key = f"task-log-{current_task.request.id}"
+            if repository_task_inline_followups.get():
+                self.logs = cache.get(task_log_key, [])
+            self.logs.append(entry)
+            cache.set(task_log_key, self.logs, 2 * 3600)
+        else:
+            self.logs.append(entry)
 
     def log_hook(self, level, msg, *args) -> None:
         if level != "DEBUG":
@@ -2878,6 +2922,12 @@ class Component(  # ruff: ignore[too-many-public-methods]
     @perform_on_link
     def do_update(self, request: AuthenticatedHttpRequest | None = None, method=None):
         """Perform repository update."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.repository_context import (
+            RepositoryFollowupLockError,
+            repository_task_inline_followups,
+        )
+
         user = self.get_update_user(request)
         self.translations_progress = 0
         self.translations_count = 0
@@ -2923,17 +2973,12 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 result = False
 
         if result:
-            # create translation objects for all files
-            parse_error = None
             try:
-                self.create_translations(request=request, user=user)
-            except FileParseError as error:
-                parse_error = error
-
-            # Push after possible merge
-            self.push_if_needed(do_update=False)
-            if parse_error is not None:
-                raise parse_error
+                self.finish_update(request, user)
+            except WeblateLockTimeoutError as error:
+                if repository_task_inline_followups.get():
+                    raise RepositoryFollowupLockError(error, "pull") from error
+                raise
 
         if not self.repo_needs_push():
             self.delete_alert("RepositoryChanges")
@@ -2942,6 +2987,20 @@ class Component(  # ruff: ignore[too-many-public-methods]
         self.translations_count = None
 
         return result
+
+    def finish_update(
+        self, request: AuthenticatedHttpRequest | None, user: User
+    ) -> None:
+        """Parse and push a repository after a successful pull."""
+        parse_error = None
+        try:
+            self.create_translations(request=request, user=user)
+        except FileParseError as error:
+            parse_error = error
+
+        self.push_if_needed(do_update=False)
+        if parse_error is not None:
+            raise parse_error
 
     def get_update_user(self, request: AuthenticatedHttpRequest | None) -> User:
         """Return user to credit for background update events."""
@@ -2967,6 +3026,20 @@ class Component(  # ruff: ignore[too-many-public-methods]
         * Configured push
         * Whether there is something to push
         """
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.repository_context import (
+            repository_task_deferred_auto_push,
+            repository_task_inline_followups,
+            repository_task_suppress_auto_push,
+        )
+
+        if repository_task_suppress_auto_push.get():
+            self.log_info("skipped push: handled by repository operation")
+            return
+        if (deferred := repository_task_deferred_auto_push.get()) is not None:
+            deferred[self.pk] = lambda: self.push_if_needed(do_update=do_update)
+            self.log_info("deferred push: repository operation in progress")
+            return
         if not self.effective_push_on_commit:
             self.log_info("skipped push: push on commit disabled")
             return
@@ -2980,7 +3053,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 self.count_push_branch_outgoing,
             )
             return
-        if settings.CELERY_TASK_ALWAYS_EAGER:
+        if settings.CELERY_TASK_ALWAYS_EAGER or repository_task_inline_followups.get():
             self.do_push(None, force_commit=False, do_update=do_update)
         else:
             # ruff: ignore[import-outside-top-level]
@@ -3115,7 +3188,15 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         if do_update:
             # Update the repo
-            self.do_update(request)
+            # ruff: ignore[import-outside-top-level]
+            from weblate.trans.repository_context import suppress_repository_auto_push
+
+            try:
+                with suppress_repository_auto_push():
+                    self.do_update(request)
+            except FileParseError:
+                self.push_if_needed(do_update=False)
+                raise
 
             # Were all changes merged?
             if not self.pushes_to_different_location and self.repo_needs_merge():
@@ -3224,7 +3305,13 @@ class Component(  # ruff: ignore[too-many-public-methods]
     ) -> bool:
         """Reset repo to match remote."""
         # ruff: ignore[import-outside-top-level]
-        from weblate.trans.tasks import perform_commit
+        from weblate.trans.repository_context import (
+            RepositoryFollowupLockError,
+            repository_task_inline_followups,
+        )
+
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.tasks import perform_commit, perform_component_commit
 
         user = request.user if request else self.acting_user
         try:
@@ -3248,15 +3335,31 @@ class Component(  # ruff: ignore[too-many-public-methods]
             return False
 
         if keep_changes:
-            # Trigger commit and scan in the background
-            self.queue_background_task(
-                perform_commit,
-                self.pk,
-                "reset-sync",
-                user_id=request.user.id if request else None,
-                force_scan=True,
-                previous_head=previous_head,
-            )
+            if repository_task_inline_followups.get():
+                try:
+                    perform_component_commit(
+                        self,
+                        "reset-sync",
+                        user,
+                        force_scan=True,
+                        previous_head=previous_head,
+                    )
+                except WeblateLockTimeoutError as error:
+                    raise RepositoryFollowupLockError(
+                        error,
+                        "reset-keep",
+                        previous_head=previous_head,
+                    ) from error
+            else:
+                # Trigger commit and scan in the background
+                self.queue_background_task(
+                    perform_commit,
+                    self.pk,
+                    "reset-sync",
+                    user_id=request.user.id if request else None,
+                    force_scan=True,
+                    previous_head=previous_head,
+                )
         return True
 
     def get_pending_translation_restore_rollback_revision(
@@ -3601,7 +3704,13 @@ class Component(  # ruff: ignore[too-many-public-methods]
         from weblate.auth.models import get_anonymous
 
         # ruff: ignore[import-outside-top-level]
-        from weblate.trans.tasks import perform_commit
+        from weblate.trans.repository_context import (
+            RepositoryFollowupLockError,
+            repository_task_inline_followups,
+        )
+
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.tasks import perform_commit, perform_component_commit
 
         pending: list[PendingUnitChange] = []
         units_to_update: list[Unit] = []
@@ -3690,12 +3799,23 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 reset_repository_on_failure=False,
             ):
                 return False
-            self.queue_background_task(
-                perform_commit,
-                self.pk,
-                "file-sync",
-                user_id=request.user.id if request else None,
-            )
+            if repository_task_inline_followups.get():
+                user = request.user if request else self.acting_user
+
+                def commit_file_sync() -> None:
+                    try:
+                        perform_component_commit(self, "file-sync", user)
+                    except WeblateLockTimeoutError as error:
+                        raise RepositoryFollowupLockError(error, "file-sync") from error
+
+                transaction.on_commit(commit_file_sync)
+            else:
+                self.queue_background_task(
+                    perform_commit,
+                    self.pk,
+                    "file-sync",
+                    user_id=request.user.id if request else None,
+                )
 
         return True
 
@@ -4500,8 +4620,28 @@ class Component(  # ruff: ignore[too-many-public-methods]
                 preserve_pending_units=preserve_pending_units,
             )
 
-        # When already in a Celery repository task, scan inline so the same
-        # task tracks progress instead of finishing before a nested load task.
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.repository_context import (
+            repository_task_inline_followups,
+        )
+
+        # Keep scans in the serialized repository task. Lock contention must
+        # propagate to that task so it retains its reservation while retrying.
+        if repository_task_inline_followups.get():
+            return self.create_translations_immediate(
+                force=force,
+                force_scan=force_scan,
+                langs=langs,
+                request=request,
+                user=user,
+                changed_template=changed_template,
+                from_link=from_link,
+                change=change,
+                preserve_pending_units=preserve_pending_units,
+            )
+
+        # Existing Celery VCS tasks scan inline, but retain their established
+        # fallback to a separate load task when the scan lock is contended.
         if current_task and current_task.request.id:
             try:
                 return self.create_translations_immediate(

--- a/weblate/trans/repository.py
+++ b/weblate/trans/repository.py
@@ -1,0 +1,470 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from threading import Event, Thread
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+
+from celery import uuid
+from django.conf import settings
+from django.core.cache import cache
+
+from weblate.utils.celery import (
+    TASK_METADATA_TTL,
+    delete_task_metadata,
+    get_task_metadata,
+    get_task_metadata_key,
+    store_task_metadata,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable
+
+    from weblate.auth.models import User
+    from weblate.trans.models import Component, Project, Translation
+
+
+RepositoryOperation = Literal[
+    "commit",
+    "pull",
+    "pull-rebase",
+    "pull-merge",
+    "pull-merge-noff",
+    "push",
+    "reset",
+    "reset-keep",
+    "cleanup",
+    "file-sync",
+    "file-scan",
+    "remove-duplicates",
+    "cleanup-unused",
+    "remove-obsolete",
+]
+
+
+class RepositoryOperationReservation(TypedDict):
+    operation: RepositoryOperation
+    task_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class QueuedRepositoryOperation:
+    task_id: str
+    reused: bool = False
+    successful: bool | None = None
+
+
+class RepositoryOperationConflictError(Exception):
+    def __init__(self, task_id: str | None = None) -> None:
+        super().__init__("A repository operation is already in progress")
+        self.task_id = task_id
+
+
+REPOSITORY_OPERATION_TTL = TASK_METADATA_TTL
+REPOSITORY_OPERATION_HEARTBEAT = REPOSITORY_OPERATION_TTL // 3
+
+
+def get_repository_operation_key(component_id: int) -> str:
+    return f"repository-operation-{component_id}"
+
+
+def get_repository_operation_scope_key(task_id: str) -> str:
+    return f"repository-operation-scope-{task_id}"
+
+
+def get_repository_operation_published_key(task_id: str) -> str:
+    return f"repository-operation-published-{task_id}"
+
+
+def get_repository_operation_update_key(component_id: int) -> str:
+    return f"component-repository-operation-{component_id}"
+
+
+def get_repository_components(
+    obj: Project | Component | Translation,
+    repository_components: Iterable[Component] | None = None,
+) -> tuple[list[Component], list[Component]]:
+    # Importing models here avoids a models -> tasks -> repository import cycle.
+    from weblate.trans.models import (  # ruff: ignore[import-outside-top-level]
+        Component,
+        Translation,
+    )
+
+    if repository_components is None:
+        display_components = list(obj.all_repo_components)
+        if isinstance(obj, Component):
+            display_components.append(obj)
+        elif isinstance(obj, Translation):
+            display_components.append(obj.component)
+    else:
+        display_components = list(repository_components)
+
+    display_by_id = {component.pk: component for component in display_components}
+    repository_by_id = {
+        component.effective_repo_component.pk: component.effective_repo_component
+        for component in display_components
+    }
+    return (
+        [repository_by_id[pk] for pk in sorted(repository_by_id)],
+        [display_by_id[pk] for pk in sorted(display_by_id)],
+    )
+
+
+def get_affected_component_ids(repository_ids: list[int]) -> list[int]:
+    from django.db.models import Q  # ruff: ignore[import-outside-top-level]
+
+    from weblate.trans.models import Component  # ruff: ignore[import-outside-top-level]
+
+    return list(
+        Component.objects.filter(
+            Q(pk__in=repository_ids) | Q(linked_component_id__in=repository_ids)
+        )
+        .order_by("pk")
+        .values_list("pk", flat=True)
+    )
+
+
+def _get_active_reservation(component_id: int) -> RepositoryOperationReservation | None:
+    key = get_repository_operation_key(component_id)
+    reservation = cache.get(key)
+    if not isinstance(reservation, dict):
+        return None
+    task_id = reservation.get("task_id")
+    operation = reservation.get("operation")
+    if not isinstance(task_id, str) or not isinstance(operation, str):
+        cache.delete(key)
+        return None
+    return cast("RepositoryOperationReservation", reservation)
+
+
+def get_repository_operation_scope(task_id: str) -> list[int] | None:
+    component_ids = cache.get(get_repository_operation_scope_key(task_id))
+    if not isinstance(component_ids, list) or not all(
+        isinstance(component_id, int) for component_id in component_ids
+    ):
+        return None
+    return component_ids
+
+
+def acquire_repository_operation(
+    component_ids: list[int], operation: RepositoryOperation, task_id: str
+) -> None:
+    """Acquire all repository reservations, rolling back partial acquisition."""
+    reservation: RepositoryOperationReservation = {
+        "operation": operation,
+        "task_id": task_id,
+    }
+    for component_id in component_ids:
+        active = _get_active_reservation(component_id)
+        if active is None and cache.add(
+            get_repository_operation_key(component_id),
+            reservation,
+            REPOSITORY_OPERATION_TTL,
+        ):
+            continue
+        if active is None:
+            active = _get_active_reservation(component_id)
+        if active == reservation:
+            cache.touch(
+                get_repository_operation_key(component_id),
+                REPOSITORY_OPERATION_TTL,
+            )
+            continue
+
+        # Retries can already own later reservations in the scope. Release
+        # every reservation still owned by this task, not just those visited.
+        release_repository_operation(component_ids, task_id)
+        raise RepositoryOperationConflictError(
+            active["task_id"] if active is not None else None
+        )
+
+    cache.set(
+        get_repository_operation_scope_key(task_id),
+        component_ids,
+        REPOSITORY_OPERATION_TTL,
+    )
+
+
+def release_repository_operation(component_ids: list[int], task_id: str) -> None:
+    for component_id in component_ids:
+        key = get_repository_operation_key(component_id)
+        reservation = cache.get(key)
+        if isinstance(reservation, dict) and reservation.get("task_id") == task_id:
+            cache.delete(key)
+    cache.delete(get_repository_operation_scope_key(task_id))
+    cache.delete(get_repository_operation_published_key(task_id))
+
+
+def refresh_repository_operation(
+    component_ids: list[int],
+    task_id: str,
+    tracking_component_ids: list[int] | None = None,
+) -> None:
+    for component_id in component_ids:
+        key = get_repository_operation_key(component_id)
+        reservation = cache.get(key)
+        if isinstance(reservation, dict) and reservation.get("task_id") == task_id:
+            cache.touch(key, REPOSITORY_OPERATION_TTL)
+    cache.touch(get_repository_operation_scope_key(task_id), REPOSITORY_OPERATION_TTL)
+    cache.touch(
+        get_repository_operation_published_key(task_id), REPOSITORY_OPERATION_TTL
+    )
+    cache.touch(get_task_metadata_key(task_id), TASK_METADATA_TTL)
+    for component_id in tracking_component_ids or ():
+        key = get_repository_operation_update_key(component_id)
+        if cache.get(key) == task_id:
+            cache.touch(key, REPOSITORY_OPERATION_TTL)
+
+
+def mark_repository_operation_published(component_ids: list[int], task_id: str) -> None:
+    """Mark a task reusable once all its repositories have been published."""
+    if all(
+        (active := _get_active_reservation(component_id)) is not None
+        and active["task_id"] == task_id
+        for component_id in component_ids
+    ):
+        cache.set(
+            get_repository_operation_published_key(task_id),
+            True,
+            REPOSITORY_OPERATION_TTL,
+        )
+
+
+def store_repository_operation_tracking(
+    task_id: str,
+    tracking_component_ids: list[int],
+    user_id: int,
+    *,
+    authorization_component_ids: list[int] | None = None,
+) -> None:
+    cache.set_many(
+        {
+            get_repository_operation_update_key(component_id): task_id
+            for component_id in tracking_component_ids
+        },
+        REPOSITORY_OPERATION_TTL,
+    )
+    store_task_metadata(
+        task_id,
+        component_ids=authorization_component_ids,
+        user_id=user_id,
+        task_kind="repository-operation",
+        cancellable=False,
+    )
+
+
+@contextmanager
+def keep_repository_operation_reservation(
+    component_ids: list[int],
+    task_id: str,
+    tracking_component_ids: list[int] | None = None,
+) -> Generator[None]:
+    """Refresh a reservation while a potentially long operation is running."""
+    stopped = Event()
+
+    def heartbeat() -> None:
+        while not stopped.wait(REPOSITORY_OPERATION_HEARTBEAT):
+            refresh_repository_operation(component_ids, task_id, tracking_component_ids)
+
+    refresh_repository_operation(component_ids, task_id, tracking_component_ids)
+    thread = Thread(
+        target=heartbeat,
+        name=f"repository-operation-{task_id}",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        yield
+    finally:
+        stopped.set()
+        thread.join(timeout=5)
+
+
+@contextmanager
+def reserve_repository_operation(
+    component_ids: list[int], operation: RepositoryOperation
+) -> Generator[Callable[[], None]]:
+    """Reserve repositories and yield an idempotent early-release callback."""
+    task_id = uuid()
+    acquire_repository_operation(component_ids, operation, task_id)
+
+    def release() -> None:
+        release_repository_operation(component_ids, task_id)
+
+    try:
+        with keep_repository_operation_reservation(component_ids, task_id):
+            yield release
+    finally:
+        release()
+
+
+def can_access_repository_operation_task(user: User, task_id: str) -> bool:
+    """Return whether a repository task URL is usable by a user."""
+    metadata = get_task_metadata(task_id)
+    if metadata is None:
+        return False
+    component_ids = metadata.get("component_ids")
+    if not isinstance(component_ids, list) or not all(
+        isinstance(component_id, int) for component_id in component_ids
+    ):
+        return False
+
+    from weblate.trans.models import Component  # ruff: ignore[import-outside-top-level]
+
+    unique_component_ids = set(component_ids)
+    existing_component_ids = set(
+        Component.objects.filter(pk__in=unique_component_ids).values_list(
+            "pk", flat=True
+        )
+    )
+    accessible_component_ids = set(
+        Component.objects.filter_access(user)
+        .filter(pk__in=existing_component_ids)
+        .values_list("pk", flat=True)
+    )
+    if accessible_component_ids != existing_component_ids:
+        return False
+    return (
+        bool(existing_component_ids) and existing_component_ids == unique_component_ids
+    ) or metadata.get("user_id") == user.pk
+
+
+def get_repository_operation_tracking_ids(
+    repositories: list[Component], display_components: list[Component], user: User
+) -> list[int]:
+    """Return components where the user can access operation progress."""
+    from weblate.trans.models import Component  # ruff: ignore[import-outside-top-level]
+
+    repository_ids = [component.pk for component in repositories]
+    affected_ids = get_affected_component_ids(repository_ids)
+    candidate_ids = (
+        {component.pk for component in display_components}
+        | set(repository_ids)
+        | set(affected_ids)
+    )
+    return list(
+        Component.objects.filter_access(user)
+        .filter(pk__in=candidate_ids)
+        .order_by("pk")
+        .values_list("pk", flat=True)
+    )
+
+
+def queue_repository_operation(
+    obj: Project | Component | Translation,
+    operation: RepositoryOperation,
+    user: User,
+    *,
+    repository_components: Iterable[Component] | None = None,
+) -> QueuedRepositoryOperation:
+    # ruff: ignore[import-outside-top-level]
+    from weblate.trans.tasks import (
+        perform_repository_operation,
+    )
+
+    repositories, display_components = get_repository_components(
+        obj, repository_components
+    )
+    repository_ids = [component.pk for component in repositories]
+    existing = [
+        active_reservation
+        for component_id in repository_ids
+        if (active_reservation := _get_active_reservation(component_id)) is not None
+    ]
+    if existing:
+        task_ids = {reservation["task_id"] for reservation in existing}
+        operations = {reservation["operation"] for reservation in existing}
+        existing_task_id = next(iter(task_ids), None)
+        if (
+            len(existing) == len(repository_ids)
+            and len(task_ids) == 1
+            and operations == {operation}
+            and existing_task_id is not None
+            and get_repository_operation_scope(existing_task_id) == repository_ids
+            and cache.get(get_repository_operation_published_key(existing_task_id))
+            is True
+        ):
+            return QueuedRepositoryOperation(existing_task_id, reused=True)
+        raise RepositoryOperationConflictError(existing_task_id)
+
+    task_id = uuid()
+    acquire_repository_operation(repository_ids, operation, task_id)
+    display_ids: list[int] = []
+    try:
+        display_ids = get_repository_operation_tracking_ids(
+            repositories, display_components, user
+        )
+        store_repository_operation_tracking(
+            task_id,
+            display_ids,
+            user.pk,
+            authorization_component_ids=display_ids,
+        )
+        task = perform_repository_operation.apply_async(
+            kwargs={
+                "operation": operation,
+                "component_ids": repository_ids,
+                "tracking_component_ids": display_ids,
+                "user_id": user.pk,
+            },
+            task_id=task_id,
+        )
+        mark_repository_operation_published(repository_ids, task_id)
+    except Exception:
+        release_repository_operation(repository_ids, task_id)
+        cache.delete_many(
+            [
+                get_repository_operation_update_key(component_id)
+                for component_id in display_ids
+            ]
+        )
+        delete_task_metadata(task_id)
+        raise
+    successful = None
+    if settings.CELERY_TASK_ALWAYS_EAGER and isinstance(task.result, dict):
+        result = task.result.get("result")
+        if isinstance(result, bool):
+            successful = result
+    return QueuedRepositoryOperation(task_id, successful=successful)
+
+
+def get_operation_call(
+    operation: RepositoryOperation,
+) -> tuple[str, tuple[Any, ...], dict[str, Any]]:
+    if operation == "commit":
+        return "commit_pending", ("commit",), {}
+    if operation == "pull":
+        return "do_update", (), {}
+    if operation == "pull-rebase":
+        return "do_update", (), {"method": "rebase"}
+    if operation == "pull-merge":
+        return "do_update", (), {"method": "merge"}
+    if operation == "pull-merge-noff":
+        return "do_update", (), {"method": "merge_noff"}
+    if operation == "push":
+        return "do_push", (), {}
+    if operation == "reset":
+        return "do_reset", (), {}
+    if operation == "reset-keep":
+        return "do_reset", (), {"keep_changes": True}
+    if operation == "cleanup":
+        return "do_cleanup", (), {}
+    if operation == "file-sync":
+        return "do_file_sync", (), {}
+    if operation == "file-scan":
+        return "do_file_scan", (), {}
+    raise ValueError(operation)
+
+
+def get_repository_operation_permission(operation: RepositoryOperation) -> str:
+    if operation == "commit":
+        return "vcs.commit"
+    if operation == "push":
+        return "vcs.push"
+    if operation.startswith("pull"):
+        return "vcs.update"
+    return "vcs.reset"

--- a/weblate/trans/repository_context.py
+++ b/weblate/trans/repository_context.py
@@ -1,0 +1,97 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+    from weblate.utils.lock import WeblateLockTimeoutError
+
+
+RepositoryOperationFollowup = Literal["file-sync", "pull", "reset-keep"]
+
+
+class RepositoryFollowupLockError(Exception):
+    """Mark lock contention after the main repository operation committed."""
+
+    def __init__(
+        self,
+        error: WeblateLockTimeoutError,
+        followup: RepositoryOperationFollowup,
+        *,
+        previous_head: str | None = None,
+    ) -> None:
+        super().__init__(str(error))
+        self.error = error
+        self.followup = followup
+        self.previous_head = previous_head
+
+
+repository_task_inline_followups: ContextVar[bool] = ContextVar(
+    "repository_task_inline_followups", default=False
+)
+repository_task_suppress_auto_push: ContextVar[bool] = ContextVar(
+    "repository_task_suppress_auto_push", default=False
+)
+repository_task_deferred_auto_push: ContextVar[dict[int, Callable[[], None]] | None] = (
+    ContextVar("repository_task_deferred_auto_push", default=None)
+)
+repository_task_deferred_background_tasks: ContextVar[
+    list[Callable[[], None]] | None
+] = ContextVar("repository_task_deferred_background_tasks", default=None)
+repository_task_progress_scope: ContextVar[tuple[int, int] | None] = ContextVar(
+    "repository_task_progress_scope", default=None
+)
+
+
+@contextmanager
+def inline_repository_followups() -> Generator[None]:
+    token = repository_task_inline_followups.set(True)
+    try:
+        yield
+    finally:
+        repository_task_inline_followups.reset(token)
+
+
+@contextmanager
+def suppress_repository_auto_push() -> Generator[None]:
+    token = repository_task_suppress_auto_push.set(True)
+    try:
+        yield
+    finally:
+        repository_task_suppress_auto_push.reset(token)
+
+
+@contextmanager
+def defer_repository_auto_push() -> Generator[dict[int, Callable[[], None]]]:
+    deferred: dict[int, Callable[[], None]] = {}
+    token = repository_task_deferred_auto_push.set(deferred)
+    try:
+        yield deferred
+    finally:
+        repository_task_deferred_auto_push.reset(token)
+
+
+@contextmanager
+def defer_repository_background_tasks() -> Generator[list[Callable[[], None]]]:
+    deferred: list[Callable[[], None]] = []
+    token = repository_task_deferred_background_tasks.set(deferred)
+    try:
+        yield deferred
+    finally:
+        repository_task_deferred_background_tasks.reset(token)
+
+
+@contextmanager
+def repository_component_progress(completed: int, total: int) -> Generator[None]:
+    token = repository_task_progress_scope.set((completed, total))
+    try:
+        yield
+    finally:
+        repository_task_progress_scope.reset(token)

--- a/weblate/trans/tasks.py
+++ b/weblate/trans/tasks.py
@@ -13,12 +13,15 @@ from glob import glob
 from itertools import batched
 from operator import itemgetter
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from celery import current_task
+from celery.exceptions import Retry
 from celery.schedules import crontab
 from celery.utils.time import get_exponential_backoff_interval
 from django.conf import settings
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.cookie import CookieStorage
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import IntegrityError, transaction
@@ -26,6 +29,7 @@ from django.db.models import Exists, F, OuterRef, Q
 from django.utils import timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext, ngettext, override
+from translate.storage.base import ParseError as TranslateParseError
 
 from weblate.accounts.utils import remove_user
 from weblate.addons.events import AddonActivityLogReason, AddonActivityLogStatus
@@ -51,6 +55,28 @@ from weblate.trans.models import (
     Unit,
 )
 from weblate.trans.removal import RemovalBatch, removal_batch_context
+from weblate.trans.repository import (
+    RepositoryOperation,
+    RepositoryOperationConflictError,
+    acquire_repository_operation,
+    get_operation_call,
+    get_repository_components,
+    get_repository_operation_permission,
+    keep_repository_operation_reservation,
+    refresh_repository_operation,
+    release_repository_operation,
+    reserve_repository_operation,
+    store_repository_operation_tracking,
+)
+from weblate.trans.repository_context import (
+    RepositoryFollowupLockError,
+    RepositoryOperationFollowup,
+    defer_repository_auto_push,
+    defer_repository_background_tasks,
+    inline_repository_followups,
+    repository_component_progress,
+    suppress_repository_auto_push,
+)
 from weblate.utils.celery import app
 from weblate.utils.data import data_dir
 from weblate.utils.errors import report_error
@@ -61,6 +87,7 @@ from weblate.utils.stats import ProjectLanguage, prefetch_stats
 from weblate.vcs.base import RepositoryError
 
 COMPONENT_MEMORY_CLEANUP_BATCH_SIZE = 1000
+LEGACY_REPOSITORY_LOCK_MAX_RETRIES = 3
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -71,8 +98,8 @@ if TYPE_CHECKING:
     from weblate.workspaces.models import Workspace
 
 
-def commit_lock_retries_exhausted() -> bool:
-    """Check whether a commit lock timeout will no longer be retried."""
+def commit_retries_exhausted() -> bool:
+    """Check whether a commit failure will no longer be retried."""
     if not current_task:
         return True
 
@@ -90,6 +117,57 @@ def schedule_deferred_commit(component: Component) -> None:
             force_scan=followup["force_scan"],
             previous_head=followup["previous_head"],
         )
+
+
+def retry_legacy_repository_operation(
+    task: Task,
+    error: RepositoryOperationConflictError | WeblateLockTimeoutError,
+    repository_lock_retries: int,
+) -> None:
+    """Retry reservation conflicts without extending repository lock retries."""
+    retry_kwargs = dict(task.request.kwargs or {})
+    if isinstance(error, WeblateLockTimeoutError):
+        if repository_lock_retries >= LEGACY_REPOSITORY_LOCK_MAX_RETRIES:
+            raise error
+        retry_kwargs["_repository_lock_retries"] = repository_lock_retries + 1
+        retries = repository_lock_retries
+    else:
+        retries = task.request.retries
+    countdown = get_exponential_backoff_interval(
+        factor=600,
+        retries=retries,
+        maximum=3600,
+        full_jitter=True,
+    )
+    raise task.retry(exc=error, countdown=countdown, kwargs=retry_kwargs)
+
+
+def execute_legacy_update(
+    obj: Project | Component,
+    repositories: list[Component],
+    request: AuthenticatedHttpRequest | None,
+    auto: bool,
+) -> tuple[list[Callable[[], None]], dict[int, Callable[[], None]]]:
+    """Run a legacy update and return follow-ups after releasing its reservation."""
+    with (
+        reserve_repository_operation(
+            [component.pk for component in repositories], "pull"
+        ),
+        defer_repository_auto_push() as deferred_pushes,
+        defer_repository_background_tasks() as deferred_tasks,
+        # This is stored as alert, so we can silently ignore some exceptions here.
+        suppress(FileParseError, RepositoryError, FileNotFoundError),
+    ):
+        obj.log_info("Updating remote repository")
+        if (
+            isinstance(obj, Project)
+            or settings.AUTO_UPDATE in {"full", True}
+            or not auto
+        ):
+            obj.do_update(request)
+        else:
+            obj.update_remote_branch(user=obj.get_update_user(request))
+    return deferred_tasks, deferred_pushes
 
 
 def perform_component_commit(
@@ -112,44 +190,43 @@ def perform_component_commit(
             component.create_translations(force=True)
 
 
-@app.task(
-    trail=False,
-    autoretry_for=(WeblateLockTimeoutError,),
-    retry_backoff=600,
-    retry_backoff_max=3600,
-)
+@app.task(bind=True, trail=False, max_retries=None)
 def perform_update(
+    task: Task,
     cls: Literal["Project", "Component"],
     pk: int,
     auto: bool = False,
     obj=None,
     user_id: int = 0,
+    *,
+    _repository_lock_retries: int = 0,
 ) -> None:
     request: AuthenticatedHttpRequest | None = None
     if user_id:
         request = AuthenticatedHttpRequest()
         request.user = User.objects.get(pk=user_id)
-    # This is stored as alert, so we can silently ignore some exceptions here
-    with suppress(FileParseError, RepositoryError, FileNotFoundError):
-        if obj is None:
-            if cls == "Project":
-                obj = Project.objects.get(pk=pk)
-            else:
-                obj = Component.objects.get(pk=pk)
-        obj.log_info("Updating remote repository")
-        if settings.AUTO_UPDATE in {"full", True} or not auto:
-            obj.do_update(request)
+    if obj is None:
+        if cls == "Project":
+            obj = Project.objects.get(pk=pk)
         else:
-            obj.update_remote_branch(user=obj.get_update_user(request))
+            obj = Component.objects.get(pk=pk)
+    repositories, _display_components = get_repository_components(obj)
+    try:
+        deferred_tasks, deferred_pushes = execute_legacy_update(
+            obj, repositories, request, auto
+        )
+    except (RepositoryOperationConflictError, WeblateLockTimeoutError) as error:
+        retry_legacy_repository_operation(task, error, _repository_lock_retries)
+        return
+    for publish in deferred_tasks:
+        publish()
+    for push in deferred_pushes.values():
+        push()
 
 
-@app.task(
-    trail=False,
-    autoretry_for=(WeblateLockTimeoutError,),
-    retry_backoff=600,
-    retry_backoff_max=3600,
-)
+@app.task(bind=True, trail=False, max_retries=None)
 def perform_load(
+    task: Task,
     pk: int,
     *,
     force: bool = False,
@@ -160,6 +237,7 @@ def perform_load(
     change: int | None = None,
     preserve_pending_units: bool = False,
     user_id: int | None = None,
+    _repository_lock_retries: int = 0,
 ) -> None:
     request: AuthenticatedHttpRequest | None = None
     user: User | None = None
@@ -172,22 +250,28 @@ def perform_load(
     except Component.DoesNotExist:
         # Component was removed
         return
-    component.create_translations_immediate(
-        force=force,
-        force_scan=force_scan,
-        langs=langs,
-        changed_template=changed_template,
-        from_link=from_link,
-        change=change,
-        preserve_pending_units=preserve_pending_units,
-        request=request,
-        user=user,
-    )
+    try:
+        with reserve_repository_operation(
+            [component.effective_repo_component.pk], "file-scan"
+        ):
+            component.create_translations_immediate(
+                force=force,
+                force_scan=force_scan,
+                langs=langs,
+                changed_template=changed_template,
+                from_link=from_link,
+                change=change,
+                preserve_pending_units=preserve_pending_units,
+                request=request,
+                user=user,
+            )
+    except (RepositoryOperationConflictError, WeblateLockTimeoutError) as error:
+        retry_legacy_repository_operation(task, error, _repository_lock_retries)
 
 
 @app.task(
     trail=False,
-    autoretry_for=(WeblateLockTimeoutError,),
+    autoretry_for=(WeblateLockTimeoutError, RepositoryOperationConflictError),
     retry_backoff=600,
     retry_backoff_max=3600,
 )
@@ -202,15 +286,22 @@ def perform_commit(
     component = Component.objects.get(pk=pk)
     try:
         user = User.objects.get(pk=user_id) if user_id else None
-        perform_component_commit(
-            component,
-            reason,
-            user,
-            force_scan=force_scan,
-            previous_head=previous_head,
-        )
-    except WeblateLockTimeoutError:
-        if commit_lock_retries_exhausted():
+        with (
+            reserve_repository_operation(
+                [component.effective_repo_component.pk], "commit"
+            ),
+            suppress_repository_auto_push(),
+        ):
+            perform_component_commit(
+                component,
+                reason,
+                user,
+                force_scan=force_scan,
+                previous_head=previous_head,
+            )
+        component.push_if_needed()
+    except (RepositoryOperationConflictError, WeblateLockTimeoutError):
+        if commit_retries_exhausted():
             schedule_deferred_commit(component)
         raise
     except Exception:
@@ -219,15 +310,310 @@ def perform_commit(
     schedule_deferred_commit(component)
 
 
-@app.task(
-    trail=False,
-    autoretry_for=(WeblateLockTimeoutError,),
-    retry_backoff=600,
-    retry_backoff_max=3600,
-)
-def perform_push(pk, *args, **kwargs) -> None:
+@app.task(bind=True, trail=False, max_retries=None)
+def perform_push(
+    task: Task,
+    pk,
+    *args,
+    _repository_lock_retries: int = 0,
+    **kwargs,
+) -> None:
     component = Component.objects.get(pk=pk)
-    component.do_push(*args, **kwargs)
+    try:
+        with reserve_repository_operation(
+            [component.effective_repo_component.pk], "push"
+        ):
+            component.do_push(*args, **kwargs)
+    except (RepositoryOperationConflictError, WeblateLockTimeoutError) as error:
+        retry_legacy_repository_operation(task, error, _repository_lock_retries)
+
+
+@app.task(bind=True, trail=False, max_retries=3)
+def perform_repository_operation(
+    task: Task,
+    *,
+    operation: RepositoryOperation,
+    component_ids: list[int],
+    user_id: int,
+    tracking_component_ids: list[int] | None = None,
+    start_index: int = 0,
+    successful: bool = True,
+    failure_messages: list[str] | None = None,
+    resume_followup: RepositoryOperationFollowup | None = None,
+    followup_previous_head: str | None = None,
+) -> dict[str, dict[str, str] | bool]:
+    """Celery wrapper for a user-requested repository operation."""
+    task_id = str(task.request.id)
+    tracking_component_ids = tracking_component_ids or component_ids
+    reservation_acquired = False
+    release_reservation = True
+    try:
+        acquire_repository_operation(component_ids, operation, task_id)
+        reservation_acquired = True
+        store_repository_operation_tracking(
+            task_id,
+            tracking_component_ids,
+            user_id,
+            authorization_component_ids=tracking_component_ids,
+        )
+        with keep_repository_operation_reservation(
+            component_ids, task_id, tracking_component_ids
+        ):
+            result = execute_repository_operation(
+                task,
+                operation,
+                component_ids,
+                user_id,
+                task_id,
+                start_index=start_index,
+                successful=successful,
+                failure_messages=failure_messages,
+                resume_followup=resume_followup,
+                followup_previous_head=followup_previous_head,
+            )
+    except RepositoryOperationRetryError as retry:
+        if task.max_retries is None or task.request.retries < task.max_retries:
+            refresh_repository_operation(component_ids, task_id, tracking_component_ids)
+            countdown = get_exponential_backoff_interval(
+                factor=600,
+                retries=task.request.retries,
+                maximum=3600,
+                full_jitter=False,
+            )
+            try:
+                task.retry(
+                    exc=retry.error,
+                    countdown=countdown,
+                    kwargs={
+                        "operation": operation,
+                        "component_ids": component_ids,
+                        "tracking_component_ids": tracking_component_ids,
+                        "user_id": user_id,
+                        "start_index": retry.start_index,
+                        "successful": retry.successful,
+                        "failure_messages": retry.failure_messages,
+                        "resume_followup": retry.resume_followup,
+                        "followup_previous_head": retry.followup_previous_head,
+                    },
+                )
+            except Retry:
+                release_reservation = False
+                raise
+        with override(User.objects.get(pk=user_id).profile.language):
+            message = gettext(
+                "Repository operation could not be completed because it remained locked."
+            )
+        return {
+            "result": False,
+            "completion_message": {"level": "error", "text": message},
+        }
+    except (
+        FileParseError,
+        RepositoryError,
+        FileNotFoundError,
+        TranslateParseError,
+        ValueError,
+    ):
+        with override(User.objects.get(pk=user_id).profile.language):
+            message = gettext("Repository operation could not be completed.")
+        return {
+            "result": False,
+            "completion_message": {"level": "error", "text": message},
+        }
+    except PermissionDenied:
+        with override(User.objects.get(pk=user_id).profile.language):
+            message = gettext(
+                "Repository operation could not be completed because access is no longer permitted."
+            )
+        return {
+            "result": False,
+            "completion_message": {"level": "error", "text": message},
+        }
+    else:
+        return result
+    finally:
+        if reservation_acquired and release_reservation:
+            release_repository_operation(component_ids, task_id)
+
+
+class RepositoryOperationRequest(AuthenticatedHttpRequest):
+    """Request carrying the context expected by repository operations."""
+
+    def __init__(self, user: User) -> None:
+        super().__init__()
+        self.user = user
+        self._messages = CookieStorage(self)
+
+
+def execute_repository_operation(
+    task: Task,
+    operation: RepositoryOperation,
+    component_ids: list[int],
+    user_id: int,
+    task_id: str,
+    *,
+    start_index: int = 0,
+    successful: bool = True,
+    failure_messages: list[str] | None = None,
+    resume_followup: RepositoryOperationFollowup | None = None,
+    followup_previous_head: str | None = None,
+) -> dict[str, dict[str, str] | bool]:
+    """Execute the components covered by one repository operation task."""
+    user = User.objects.get(pk=user_id)
+    total = len(component_ids)
+    permission = get_repository_operation_permission(operation)
+    failure_messages = list(failure_messages or ())
+
+    with override(user.profile.language), inline_repository_followups():
+        for index in range(start_index, total):
+            component_id = component_ids[index]
+            completed = index + 1
+            try:
+                component = Component.objects.get(pk=component_id)
+            except Component.DoesNotExist:
+                successful = False
+                resume_followup = None
+                followup_previous_head = None
+            else:
+                if component.effective_repo_component.pk != component_id:
+                    component.log_info(
+                        "skipping repository operation: repository link changed"
+                    )
+                    successful = False
+                    resume_followup = None
+                    followup_previous_head = None
+                else:
+                    if not user.has_perm(permission, component):
+                        raise PermissionDenied
+                    component.acting_user = user
+                    component.log_info("running repository operation: %s", operation)
+                    # Repository methods use request messages for actionable VCS
+                    # failures. Give each operation fresh in-memory storage.
+                    request = RepositoryOperationRequest(user)
+                    method_name, args, kwargs = get_operation_call(operation)
+                    method = getattr(component, method_name)
+                    try:
+                        with repository_component_progress(completed - 1, total):
+                            result = execute_repository_operation_method(
+                                operation,
+                                component,
+                                method,
+                                request,
+                                user,
+                                args,
+                                kwargs,
+                                resume_followup=resume_followup,
+                                followup_previous_head=followup_previous_head,
+                            )
+                            resume_followup = None
+                            followup_previous_head = None
+                    except RepositoryFollowupLockError as error:
+                        raise RepositoryOperationRetryError(
+                            error.error,
+                            start_index=index,
+                            successful=successful,
+                            failure_messages=failure_messages,
+                            resume_followup=error.followup,
+                            followup_previous_head=error.previous_head,
+                        ) from error
+                    except WeblateLockTimeoutError as error:
+                        raise RepositoryOperationRetryError(
+                            error,
+                            start_index=index,
+                            successful=successful,
+                            failure_messages=failure_messages,
+                            resume_followup=resume_followup,
+                            followup_previous_head=followup_previous_head,
+                        ) from error
+                    method_messages = [
+                        str(message) for message in get_messages(request)
+                    ]
+                    for method_message in method_messages:
+                        component.log_info("repository operation: %s", method_message)
+                    if result is False:
+                        successful = False
+                        failure_messages.extend(method_messages)
+            task.update_state(
+                state="PROGRESS",
+                meta={"progress": 100 * completed // total if total else 100},
+            )
+
+        if successful:
+            message = gettext("Repository operation completed.")
+            level = "success"
+        else:
+            message = "\n".join(dict.fromkeys(failure_messages)) or gettext(
+                "Repository operation completed with errors."
+            )
+            level = "error"
+    return {
+        "result": successful,
+        "completion_message": {"level": level, "text": message},
+    }
+
+
+def execute_repository_operation_method(
+    operation: RepositoryOperation,
+    component: Component,
+    method,
+    request: AuthenticatedHttpRequest,
+    user: User,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    resume_followup: RepositoryOperationFollowup | None,
+    followup_previous_head: str | None,
+) -> bool | None:
+    """Execute one repository method or its already-committed follow-up."""
+    if resume_followup == "file-sync":
+        if operation != resume_followup:
+            raise ValueError(operation)
+        perform_component_commit(component, "file-sync", user)
+        return True
+    if resume_followup == "pull":
+        component.finish_update(request, user)
+        if operation == "push":
+            return component.do_push(request, force_commit=False, do_update=False)
+        return True
+    if resume_followup == "reset-keep":
+        if operation != resume_followup or followup_previous_head is None:
+            raise ValueError(operation)
+        perform_component_commit(
+            component,
+            "reset-sync",
+            user,
+            force_scan=True,
+            previous_head=followup_previous_head,
+        )
+        return True
+    if resume_followup is not None:
+        raise ValueError(resume_followup)
+    if operation == "commit":
+        perform_component_commit(component, "commit", user)
+        return True
+    return cast("bool | None", method(request, *args, **kwargs))
+
+
+class RepositoryOperationRetryError(Exception):
+    """Carry the resume position across a repository task retry."""
+
+    def __init__(
+        self,
+        error: WeblateLockTimeoutError,
+        *,
+        start_index: int,
+        successful: bool,
+        failure_messages: list[str] | None = None,
+        resume_followup: RepositoryOperationFollowup | None = None,
+        followup_previous_head: str | None = None,
+    ) -> None:
+        super().__init__(str(error))
+        self.error = error
+        self.start_index = start_index
+        self.successful = successful
+        self.failure_messages = list(failure_messages or ())
+        self.resume_followup = resume_followup
+        self.followup_previous_head = followup_previous_head
 
 
 @app.task(trail=False)
@@ -514,7 +900,7 @@ def cleanup_suggestions() -> None:
 
 @app.task(trail=False)
 def update_remotes() -> None:
-    """Update all remote branches (without attempt to merge)."""
+    """Queue updates of all remote branches (without attempt to merge)."""
     if settings.AUTO_UPDATE not in {"full", "remote", True, False}:
         return
 
@@ -524,8 +910,9 @@ def update_remotes() -> None:
         .annotate(hourmod=F("id") % 24)
         .filter(hourmod=now.hour)
     )
-    for component in components.prefetch().iterator(chunk_size=100):
-        perform_update("Component", -1, auto=True, obj=component)
+    component_ids = components.values_list("pk", flat=True)
+    for component_id in component_ids.iterator(chunk_size=100):
+        perform_update.delay("Component", component_id, auto=True)
 
 
 @app.task(trail=False)

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock, call, patch
 from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.core.paginator import Paginator
 from django.db import close_old_connections, connection
 from django.db.models import F
 from django.test import SimpleTestCase, TransactionTestCase
@@ -37,6 +38,11 @@ from weblate.trans.models import (
     Project,
     Translation,
     Unit,
+)
+from weblate.trans.models.component import prefetch_tasks
+from weblate.trans.repository_context import (
+    RepositoryFollowupLockError,
+    inline_repository_followups,
 )
 from weblate.trans.tests.test_models import RepoTestCase
 from weblate.trans.tests.test_views import (
@@ -75,6 +81,15 @@ remote: Host key verification failed.
 
 class ComponentTest(RepoTestCase):
     """Component object testing."""
+
+    def test_prefetch_tasks_preserves_page(self) -> None:
+        component = self.create_po()
+        page = Paginator(
+            Component.objects.filter(pk=component.pk).order_by("pk"), 1
+        ).page(1)
+
+        self.assertIs(prefetch_tasks(page), page)
+        self.assertEqual(list(page), [component])
 
     def test_select_for_update_uses_component_only_no_key_lock(self) -> None:
         queryset = Component.objects.select_for_update()
@@ -236,6 +251,46 @@ class ComponentTest(RepoTestCase):
             self.assertTrue(component.do_reset(None))
 
         recover_lock_session.assert_not_called()
+
+    def test_inline_reset_marks_followup_lock_contention(self) -> None:
+        component = self.create_component()
+        lock_timeout = WeblateLockTimeoutError("locked", lock=component.lock)
+
+        with (
+            self.assertRaises(RepositoryFollowupLockError) as raised,
+            patch.object(
+                component, "reset_repository_to_remote", return_value="previous-head"
+            ),
+            patch(
+                "weblate.trans.tasks.perform_component_commit",
+                side_effect=lock_timeout,
+            ),
+            inline_repository_followups(),
+        ):
+            component.do_reset(None, keep_changes=True)
+
+        self.assertEqual(raised.exception.followup, "reset-keep")
+        self.assertEqual(raised.exception.previous_head, "previous-head")
+
+    def test_inline_update_marks_followup_lock_contention(self) -> None:
+        component = self.create_component()
+        lock_timeout = WeblateLockTimeoutError("locked", lock=component.lock)
+
+        with (
+            self.assertRaises(RepositoryFollowupLockError) as raised,
+            patch.object(component, "store_background_task"),
+            patch.object(component, "configure_repo"),
+            patch.object(component, "update_remote_branch", return_value=True),
+            patch.object(component, "configure_branch"),
+            patch.object(component, "repo_needs_merge", return_value=True),
+            patch.object(component, "needs_commit_upstream", return_value=False),
+            patch.object(component, "update_branch", return_value=True),
+            patch.object(component, "finish_update", side_effect=lock_timeout),
+            inline_repository_followups(),
+        ):
+            component.do_update(None)
+
+        self.assertEqual(raised.exception.followup, "pull")
 
     def verify_component(
         self,
@@ -2038,6 +2093,21 @@ class ComponentErrorTest(RepoTestCase):
         self.assertIs(context.exception, error)
         push_if_needed.assert_called_once_with(do_update=False)
 
+    def test_push_pushes_before_reraising_update_parse_error(self) -> None:
+        error = FileParseError("parse failed")
+
+        with (
+            patch.object(self.component, "can_push", return_value=True),
+            patch.object(self.component, "repo_needs_push", return_value=True),
+            patch.object(self.component, "do_update", side_effect=error),
+            patch.object(self.component, "push_if_needed") as push_if_needed,
+            self.assertRaises(FileParseError) as context,
+        ):
+            self.component.do_push(None, force_commit=False)
+
+        self.assertIs(context.exception, error)
+        push_if_needed.assert_called_once_with(do_update=False)
+
     def test_failed_update_remote(self) -> None:
         self.assertFalse(self.component.update_remote_branch())
 
@@ -2154,17 +2224,16 @@ class ComponentErrorTest(RepoTestCase):
         immediate.assert_not_called()
         queue_task.assert_called_once()
 
-    def test_create_translations_runs_immediately_inside_celery_task(self) -> None:
-        task = SimpleNamespace(request=SimpleNamespace(id="task-id"))
+    def test_create_translations_runs_immediately_inside_repository_task(self) -> None:
         request = SimpleNamespace(user=None)
 
         with (
             override_settings(CELERY_TASK_ALWAYS_EAGER=False),
-            patch("weblate.trans.models.component.current_task", task),
             patch.object(
                 self.component, "create_translations_immediate", return_value=True
             ) as immediate,
             patch.object(self.component, "queue_background_task") as queue_task,
+            inline_repository_followups(),
         ):
             self.assertTrue(
                 self.component.create_translations(force=True, request=request)
@@ -2183,16 +2252,49 @@ class ComponentErrorTest(RepoTestCase):
         )
         queue_task.assert_not_called()
 
+    def test_create_translations_propagates_repository_lock_timeout(self) -> None:
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch.object(
+                self.component,
+                "create_translations_immediate",
+                side_effect=lock_timeout,
+            ) as immediate,
+            patch.object(self.component, "queue_background_task") as queue_task,
+            inline_repository_followups(),
+            self.assertRaises(WeblateLockTimeoutError),
+        ):
+            self.component.create_translations(force=True)
+
+        immediate.assert_called_once()
+        queue_task.assert_not_called()
+
+    def test_create_translations_runs_immediately_inside_celery_task(self) -> None:
+        task = SimpleNamespace(request=SimpleNamespace(id="task-id"))
+        with (
+            override_settings(CELERY_TASK_ALWAYS_EAGER=False),
+            patch("weblate.trans.models.component.current_task", task),
+            patch.object(
+                self.component, "create_translations_immediate", return_value=True
+            ) as immediate,
+            patch.object(self.component, "queue_background_task") as queue_task,
+        ):
+            self.assertTrue(self.component.create_translations(force=True))
+
+        immediate.assert_called_once()
+        queue_task.assert_not_called()
+
     def test_create_translations_queues_after_celery_lock_timeout(self) -> None:
         task = SimpleNamespace(request=SimpleNamespace(id="task-id"))
-
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
         with (
             override_settings(CELERY_TASK_ALWAYS_EAGER=False),
             patch("weblate.trans.models.component.current_task", task),
             patch.object(
                 self.component,
                 "create_translations_immediate",
-                side_effect=WeblateLockTimeoutError("locked", lock=self.component.lock),
+                side_effect=lock_timeout,
             ) as immediate,
             patch.object(self.component, "queue_background_task") as queue_task,
         ):
@@ -2285,6 +2387,22 @@ class PendingChangeCleanupTest(SimpleTestCase):
 
 
 class FileSyncPendingUnitOptimizationTest(ComponentTestCase):
+    def test_inline_file_sync_marks_post_commit_lock_contention(self) -> None:
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+
+        with (
+            self.assertRaises(RepositoryFollowupLockError),
+            patch(
+                "weblate.trans.tasks.perform_component_commit",
+                side_effect=lock_timeout,
+            ),
+            inline_repository_followups(),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self.component.do_file_sync(self.get_request())
+
+        self.assertTrue(PendingUnitChange.objects.filter(unit=self.get_unit()).exists())
+
     def test_file_sync_creates_pending_changes_from_unit_values(self) -> None:
         unit = self.get_unit()
         Unit.objects.filter(pk=unit.source_unit_id).update(

--- a/weblate/trans/tests/test_git_views.py
+++ b/weblate/trans/tests/test_git_views.py
@@ -4,18 +4,37 @@
 
 """Test for Git manipulation views."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.messages import get_messages
+from django.core.cache import cache
 from django.test.utils import override_settings
 from django.urls import reverse
 
 from weblate.auth.data import SELECTION_ALL
 from weblate.auth.models import Group, Permission, Role, TeamMembership
 from weblate.lang.models import Language
-from weblate.trans.models import Component, PendingUnitChange, Project
+from weblate.trans.models import Component, PendingUnitChange, Project, Translation
+from weblate.trans.repository import (
+    RepositoryOperationConflictError,
+    acquire_repository_operation,
+    get_repository_operation_key,
+    get_repository_operation_published_key,
+    get_repository_operation_scope_key,
+    get_repository_operation_update_key,
+    keep_repository_operation_reservation,
+    queue_repository_operation,
+    refresh_repository_operation,
+    release_repository_operation,
+    store_repository_operation_tracking,
+)
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import get_optional_path
+from weblate.utils.celery import (
+    delete_task_metadata,
+    get_task_metadata,
+    get_task_metadata_key,
+)
 
 
 class GitNoChangeProjectTest(ViewTestCase):
@@ -42,26 +61,39 @@ class GitNoChangeProjectTest(ViewTestCase):
         obj = getattr(self, self.TEST_TYPE)
         return f"{reverse('show_progress', kwargs={'path': obj.get_url_path()})}?info=1"
 
+    def assert_progress_redirect(self, response) -> None:
+        self.assertRedirects(
+            response,
+            self.get_expected_redirect_progress(),
+            # Eager execution can finish before the progress page is retrieved.
+            fetch_redirect_response=False,
+        )
+
     def test_commit(self) -> None:
+        has_changes = self.TEST_TYPE != "translation" or self.translation.needs_commit()
         response = self.client.post(self.get_test_url("commit"))
-        self.assertRedirects(response, self.get_expected_redirect())
+        if has_changes:
+            self.assert_progress_redirect(response)
+        else:
+            self.assertRedirects(response, self.get_expected_redirect())
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     def test_commit_queues_background_task(self) -> None:
-        with patch.object(
-            Component, "queue_commit_pending", autospec=True
-        ) as queue_commit:
+        with patch(
+            "weblate.trans.tasks.perform_repository_operation.apply_async"
+        ) as queue_operation:
             response = self.client.post(self.get_test_url("commit"))
 
-        self.assertRedirects(response, self.get_expected_redirect())
         if self.TEST_TYPE == "translation" and not self.translation.needs_commit():
-            queue_commit.assert_not_called()
+            self.assertRedirects(response, self.get_expected_redirect())
+            queue_operation.assert_not_called()
             self.assertEqual(list(get_messages(response.wsgi_request)), [])
         else:
-            self.assertGreaterEqual(queue_commit.call_count, 1)
-            for call in queue_commit.call_args_list:
-                self.assertEqual(call.args[1], "commit")
-                self.assertEqual(call.kwargs, {"user_id": self.user.id})
+            self.assert_progress_redirect(response)
+            queue_operation.assert_called_once()
+            self.assertEqual(
+                queue_operation.call_args.kwargs["kwargs"]["operation"], "commit"
+            )
 
     def test_update(self) -> None:
         response = self.client.post(self.get_test_url("update"))
@@ -75,9 +107,24 @@ class GitNoChangeProjectTest(ViewTestCase):
             fetch_redirect_response=False,
         )
 
+    def test_conflict_does_not_redirect_to_inaccessible_task(self) -> None:
+        with (
+            patch(
+                "weblate.trans.views.git.queue_repository_operation",
+                side_effect=RepositoryOperationConflictError("task-id"),
+            ),
+            patch(
+                "weblate.trans.views.git.can_access_repository_operation_task",
+                return_value=False,
+            ),
+        ):
+            response = self.client.post(self.get_test_url("update"))
+
+        self.assertRedirects(response, self.get_expected_redirect())
+
     def test_push(self) -> None:
         response = self.client.post(self.get_test_url("push"))
-        self.assertRedirects(response, self.get_expected_redirect())
+        self.assert_progress_redirect(response)
 
     def test_get_push_redirects_to_repository_status(self) -> None:
         response = self.client.get(self.get_test_url("push"))
@@ -130,11 +177,11 @@ class GitNoChangeProjectTest(ViewTestCase):
 
     def test_cleanup(self) -> None:
         response = self.client.post(self.get_test_url("cleanup"))
-        self.assertRedirects(response, self.get_expected_redirect())
+        self.assert_progress_redirect(response)
 
     def test_file_sync(self) -> None:
         response = self.client.post(self.get_test_url("file_sync"))
-        self.assertRedirects(response, self.get_expected_redirect())
+        self.assert_progress_redirect(response)
 
     def test_file_scan(self) -> None:
         response = self.client.post(self.get_test_url("file_scan"))
@@ -383,6 +430,417 @@ class RepositoryPermissionScopeTest(ViewTestCase):
         self.assertContains(response, "Some repositories are not accessible")
         self.assertContains(response, self.component.full_slug)
         self.assertNotContains(response, linked.full_slug)
+
+
+class RepositoryOperationQueueTest(ViewTestCase):
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_task_tracking_excludes_inaccessible_linked_components(self) -> None:
+        self.user.groups.clear()
+        other_project = self.create_project(name="Other", slug="other")
+        linked = self.create_link_existing(
+            name="Hidden linked component",
+            slug="hidden-linked-component",
+            project=other_project,
+        )
+        linked.restricted = True
+        linked.save(update_fields=["restricted"])
+        group = Group.objects.create(
+            name="Visible repository scope", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.can_access_component(self.component))
+        self.assertFalse(self.user.can_access_component(linked))
+
+        with patch("weblate.trans.tasks.perform_repository_operation.apply_async"):
+            queued = queue_repository_operation(self.component, "pull", self.user)
+
+        self.addCleanup(
+            release_repository_operation, [self.component.pk], queued.task_id
+        )
+        self.addCleanup(delete_task_metadata, queued.task_id)
+        self.addCleanup(
+            cache.delete_many,
+            [
+                get_repository_operation_update_key(self.component.pk),
+                get_repository_operation_update_key(linked.pk),
+            ],
+        )
+        metadata = get_task_metadata(queued.task_id)
+
+        self.assertIsNotNone(metadata)
+        self.assertEqual(metadata["component_ids"], [self.component.pk])
+        self.assertEqual(
+            cache.get(get_repository_operation_update_key(self.component.pk)),
+            queued.task_id,
+        )
+        self.assertIsNone(cache.get(get_repository_operation_update_key(linked.pk)))
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_progress_hides_aggregated_task_from_partial_viewer(self) -> None:
+        hidden = self.create_po(project=self.project, name="Hidden")
+        hidden.restricted = True
+        hidden.save(update_fields=["restricted"])
+        owner_group = Group.objects.create(
+            name="Hidden component access", language_selection=SELECTION_ALL
+        )
+        owner_group.components.add(hidden)
+        self.user.groups.add(owner_group)
+        self.user.clear_permissions_cache()
+        self.anotheruser.groups.add(Group.objects.get(name="Users"))
+        self.anotheruser.clear_permissions_cache()
+        self.assertTrue(self.user.can_access_component(hidden))
+        self.assertTrue(self.anotheruser.can_access_component(self.component))
+        self.assertFalse(self.anotheruser.can_access_component(hidden))
+
+        task_id = "aggregated-task-id"
+        component_ids = [self.component.pk, hidden.pk]
+        store_repository_operation_tracking(
+            task_id,
+            component_ids,
+            self.user.pk,
+            authorization_component_ids=component_ids,
+        )
+        self.addCleanup(delete_task_metadata, task_id)
+        self.addCleanup(
+            cache.delete_many,
+            [
+                get_repository_operation_update_key(component_id)
+                for component_id in component_ids
+            ],
+        )
+        progress_url = reverse(
+            "show_progress", kwargs={"path": self.component.get_url_path()}
+        )
+        pending_task = Mock(id=task_id)
+        pending_task.ready.return_value = False
+
+        with (
+            patch(
+                "weblate.trans.models.component.AsyncResult",
+                return_value=pending_task,
+            ),
+            patch.object(Component, "get_progress", return_value=(10, ["Owner log"])),
+        ):
+            owner_response = self.client.get(progress_url)
+
+        self.assertContains(owner_response, "Owner log")
+        self.client.force_login(self.anotheruser)
+
+        with (
+            patch.object(
+                Component,
+                "get_progress",
+                side_effect=AssertionError("Unauthorized task log was read"),
+            ),
+        ):
+            response = self.client.get(progress_url)
+            project_response = self.client.get(
+                reverse("show_progress", kwargs={"path": self.project.get_url_path()})
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertRedirects(
+            project_response,
+            self.project.get_absolute_url(),
+            fetch_redirect_response=False,
+        )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_progress_stores_completed_repository_message(self) -> None:
+        task_id = "completed-task-id"
+        component_ids = [self.component.pk]
+        store_repository_operation_tracking(
+            task_id,
+            component_ids,
+            self.user.pk,
+            authorization_component_ids=component_ids,
+        )
+        self.addCleanup(delete_task_metadata, task_id)
+        self.addCleanup(
+            cache.delete, get_repository_operation_update_key(self.component.pk)
+        )
+
+        class CompletedTask:
+            def __init__(self, result_task_id: str) -> None:
+                self.id = result_task_id
+                self.result = {
+                    "result": False,
+                    "completion_message": {
+                        "level": "error",
+                        "text": "Repository operation failed.",
+                    },
+                }
+
+            def ready(self) -> bool:
+                return True
+
+        with patch("weblate.trans.models.component.AsyncResult", CompletedTask):
+            response = self.client.get(
+                reverse("show_progress", kwargs={"path": self.component.get_url_path()})
+            )
+
+        self.assertRedirects(
+            response,
+            f"{self.component.get_absolute_url()}#alerts",
+            fetch_redirect_response=False,
+        )
+        stored_messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(stored_messages), 1)
+        self.assertEqual(stored_messages[0].message, "Repository operation failed.")
+        self.assertTrue(
+            response.wsgi_request.session[f"task-completion-message-{task_id}"]
+        )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_tracking_failure_releases_repository_reservation(self) -> None:
+        with (
+            patch("weblate.trans.repository.uuid", return_value="task-id"),
+            patch(
+                "weblate.trans.repository.store_repository_operation_tracking",
+                side_effect=RuntimeError("cache failure"),
+            ),
+            patch(
+                "weblate.trans.tasks.perform_repository_operation.apply_async"
+            ) as apply_async,
+            self.assertRaisesRegex(RuntimeError, "cache failure"),
+        ):
+            queue_repository_operation(self.component, "pull", self.user)
+
+        self.assertIsNone(cache.get(get_repository_operation_key(self.component.pk)))
+        self.assertIsNone(cache.get(get_repository_operation_scope_key("task-id")))
+        apply_async.assert_not_called()
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_operation_is_not_reused_before_publication(self) -> None:
+        def fail_publication(**kwargs):
+            with self.assertRaises(RepositoryOperationConflictError):
+                queue_repository_operation(self.component, "pull", self.user)
+            msg = "broker failure"
+            raise RuntimeError(msg)
+
+        with (
+            patch("weblate.trans.repository.uuid", return_value="task-id"),
+            patch(
+                "weblate.trans.tasks.perform_repository_operation.apply_async",
+                side_effect=fail_publication,
+            ),
+            self.assertRaisesRegex(RuntimeError, "broker failure"),
+        ):
+            queue_repository_operation(self.component, "pull", self.user)
+
+        self.assertIsNone(cache.get(get_repository_operation_key(self.component.pk)))
+        self.assertIsNone(cache.get(get_repository_operation_published_key("task-id")))
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_eager_repository_failure_is_reported(self) -> None:
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+
+        with patch.object(Component, "do_update", return_value=False):
+            response = self.client.post(
+                reverse("update", kwargs={"path": self.project.get_url_path()})
+            )
+
+        self.assertRedirects(response, f"{self.project_url}#repository")
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(
+            messages[0].message,
+            "Repository operation completed with errors.",
+        )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_project_progress_deduplicates_repository_task(self) -> None:
+        second = self.create_po(project=self.project, name="Second")
+        task_id = "task-id"
+        component_ids = [self.component.pk, second.pk]
+        store_repository_operation_tracking(
+            task_id,
+            component_ids,
+            self.user.pk,
+            authorization_component_ids=component_ids,
+        )
+        self.addCleanup(delete_task_metadata, task_id)
+        self.addCleanup(
+            cache.delete_many,
+            [
+                get_repository_operation_update_key(component_id)
+                for component_id in component_ids
+            ],
+        )
+
+        pending_task = Mock(id=task_id)
+        pending_task.ready.return_value = False
+        with patch(
+            "weblate.trans.models.component.AsyncResult", return_value=pending_task
+        ):
+            response = self.client.get(
+                reverse("show_progress", kwargs={"path": self.project.get_url_path()})
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["components"]), 1)
+
+    def test_repository_progress_takes_precedence_over_normal_task(self) -> None:
+        repository_task_id = "repository-task-id"
+        normal_task_id = "normal-task-id"
+        repository_key = get_repository_operation_update_key(self.component.pk)
+        cache.set(repository_key, repository_task_id, 3600)
+        cache.set(self.component.update_key, normal_task_id, 3600)
+        self.addCleanup(cache.delete_many, [repository_key, self.component.update_key])
+
+        with patch("weblate.trans.models.component.AsyncResult") as async_result:
+            async_result.return_value.ready.return_value = False
+            self.assertEqual(self.component.background_task_id, repository_task_id)
+
+    def test_file_cleanup_respects_repository_reservation(self) -> None:
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+        acquire_repository_operation([self.component.pk], "pull", "task-id")
+        self.addCleanup(release_repository_operation, [self.component.pk], "task-id")
+
+        with patch.object(
+            Translation, "do_remove_duplicate_units", autospec=True
+        ) as remove_duplicates:
+            response = self.client.post(
+                reverse(
+                    "remove_duplicate_units",
+                    kwargs={"path": self.translation.get_url_path()},
+                )
+            )
+
+        self.assertRedirects(response, f"{self.translation_url}#repository")
+        remove_duplicates.assert_not_called()
+        self.assertEqual(
+            next(iter(get_messages(response.wsgi_request))).message,
+            "Another repository operation is already in progress.",
+        )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_reuses_identical_operation_and_rejects_conflict(self) -> None:
+        with patch(
+            "weblate.trans.tasks.perform_repository_operation.apply_async"
+        ) as apply_async:
+            first = queue_repository_operation(self.component, "pull", self.user)
+            self.addCleanup(
+                release_repository_operation, [self.component.pk], first.task_id
+            )
+            repeated = queue_repository_operation(self.component, "pull", self.user)
+
+            self.assertEqual(repeated.task_id, first.task_id)
+            self.assertTrue(repeated.reused)
+            apply_async.assert_called_once()
+            self.assertEqual(
+                cache.get(get_repository_operation_key(self.component.pk)),
+                {"operation": "pull", "task_id": first.task_id},
+            )
+            self.assertEqual(
+                cache.get(get_repository_operation_scope_key(first.task_id)),
+                [self.component.pk],
+            )
+            self.assertIs(
+                cache.get(get_repository_operation_published_key(first.task_id)), True
+            )
+
+            with self.assertRaises(RepositoryOperationConflictError) as raised:
+                queue_repository_operation(self.component, "push", self.user)
+
+        self.assertEqual(raised.exception.task_id, first.task_id)
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_worker_reacquires_expired_reservation(self) -> None:
+        with patch("weblate.trans.tasks.perform_repository_operation.apply_async"):
+            queued = queue_repository_operation(self.component, "pull", self.user)
+
+        cache.delete(get_repository_operation_key(self.component.pk))
+        cache.delete(get_repository_operation_scope_key(queued.task_id))
+        acquire_repository_operation([self.component.pk], "pull", queued.task_id)
+        self.addCleanup(
+            release_repository_operation, [self.component.pk], queued.task_id
+        )
+
+        self.assertEqual(
+            cache.get(get_repository_operation_key(self.component.pk)),
+            {"operation": "pull", "task_id": queued.task_id},
+        )
+        self.assertEqual(
+            cache.get(get_repository_operation_scope_key(queued.task_id)),
+            [self.component.pk],
+        )
+
+    def test_reacquisition_conflict_releases_entire_owned_scope(self) -> None:
+        second = self.create_po(project=self.project, name="Second")
+        third = self.create_po(project=self.project, name="Third")
+        component_ids = [self.component.pk, second.pk, third.pk]
+        keys = [get_repository_operation_key(pk) for pk in component_ids]
+        self.addCleanup(cache.delete_many, keys)
+        reservation = {"operation": "pull", "task_id": "task-id"}
+        cache.set(keys[0], reservation)
+        cache.set(keys[1], {"operation": "push", "task_id": "other-task"})
+        cache.set(keys[2], reservation)
+
+        with self.assertRaises(RepositoryOperationConflictError):
+            acquire_repository_operation(component_ids, "pull", "task-id")
+
+        self.assertIsNone(cache.get(keys[0]))
+        self.assertEqual(
+            cache.get(keys[1]), {"operation": "push", "task_id": "other-task"}
+        )
+        self.assertIsNone(cache.get(keys[2]))
+
+    def test_heartbeat_refreshes_task_tracking(self) -> None:
+        task_id = "task-id"
+        component_ids = [self.component.pk]
+        acquire_repository_operation(component_ids, "pull", task_id)
+        store_repository_operation_tracking(task_id, component_ids, self.user.pk)
+        self.addCleanup(release_repository_operation, component_ids, task_id)
+
+        with patch.object(cache, "touch", wraps=cache.touch) as touch:
+            refresh_repository_operation(component_ids, task_id, component_ids)
+
+        touched_keys = {call.args[0] for call in touch.call_args_list}
+        self.assertIn(get_repository_operation_key(self.component.pk), touched_keys)
+        self.assertIn(get_repository_operation_scope_key(task_id), touched_keys)
+        self.assertIn(get_task_metadata_key(task_id), touched_keys)
+        self.assertIn(
+            get_repository_operation_update_key(self.component.pk), touched_keys
+        )
+
+    def test_reservation_heartbeat_refreshes_long_operations(self) -> None:
+        class ImmediateThread:
+            def __init__(self, *, target, **kwargs) -> None:
+                self.target = target
+
+            def start(self) -> None:
+                self.target()
+
+            def join(self, *, timeout) -> None:
+                return None
+
+        class ImmediateEvent:
+            def __init__(self) -> None:
+                self.wait_count = 0
+
+            def wait(self, timeout) -> bool:
+                self.wait_count += 1
+                return self.wait_count > 1
+
+            def set(self) -> None:
+                return None
+
+        with (
+            patch("weblate.trans.repository.Thread", ImmediateThread),
+            patch("weblate.trans.repository.Event", ImmediateEvent),
+            patch("weblate.trans.repository.refresh_repository_operation") as refresh,
+            keep_repository_operation_reservation(
+                [self.component.pk], "task-id", [self.component.pk]
+            ),
+        ):
+            pass
+
+        self.assertEqual(refresh.call_count, 2)
 
 
 class GitNoChangeComponentTest(GitNoChangeProjectTest):

--- a/weblate/trans/tests/test_remote.py
+++ b/weblate/trans/tests/test_remote.py
@@ -253,7 +253,7 @@ class MultiRepoTest(ViewTestCase):
         )
 
         with self.captureOnCommitCallbacks(execute=True):
-            perform_update("Component", self.component2.pk, user_id=hook_user.id)
+            perform_update.run("Component", self.component2.pk, user_id=hook_user.id)
 
         change = self.component2.change_set.filter(action=ActionEvents.REBASE).latest(
             "timestamp"
@@ -434,7 +434,7 @@ class MultiRepoTest(ViewTestCase):
         with patch.object(
             self.component2, "update_remote_branch", return_value=True
         ) as update_remote_branch:
-            perform_update("Component", -1, auto=True, obj=self.component2)
+            perform_update.run("Component", -1, auto=True, obj=self.component2)
 
         user = update_remote_branch.call_args.kwargs["user"]
         self.assertIsNotNone(user)

--- a/weblate/trans/tests/test_tasks.py
+++ b/weblate/trans/tests/test_tasks.py
@@ -4,18 +4,22 @@
 
 import os
 import time
+from contextlib import contextmanager, nullcontext
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import ANY, Mock, patch
 
+from celery.exceptions import Retry
 from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, connection
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils import timezone
 
 from weblate.auth.models import User
 from weblate.checks.tasks import finalize_component_checks
+from weblate.trans.exceptions import FileParseError
 from weblate.trans.models import (
     Category,
     Component,
@@ -24,19 +28,39 @@ from weblate.trans.models import (
     Suggestion,
 )
 from weblate.trans.models.project import CommitPolicyChoices
+from weblate.trans.repository import (
+    RepositoryOperationConflictError,
+    acquire_repository_operation,
+    release_repository_operation,
+)
+from weblate.trans.repository_context import (
+    RepositoryFollowupLockError,
+    repository_task_deferred_auto_push,
+    repository_task_deferred_background_tasks,
+    repository_task_suppress_auto_push,
+)
 from weblate.trans.tasks import (
+    RepositoryOperationRetryError,
     cleanup_repos,
     cleanup_stale_repos,
     cleanup_suggestions,
     commit_pending,
     component_alerts,
     daily_update_checks,
+    execute_repository_operation,
+    execute_repository_operation_method,
     perform_commit,
+    perform_load,
+    perform_push,
+    perform_repository_operation,
+    perform_update,
     project_removal,
     update_checks,
     update_remotes,
 )
 from weblate.trans.tests.test_views import ComponentTestCase
+from weblate.utils import messages
+from weblate.utils.celery import delete_task_metadata
 from weblate.utils.files import remove_tree
 from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import STATE_FUZZY, STATE_TRANSLATED
@@ -93,6 +117,748 @@ class CleanupTest(ComponentTestCase):
 
 
 class TasksTest(ComponentTestCase):
+    def test_repository_commit_uses_locked_wrapper(self) -> None:
+        method = Mock()
+
+        with patch("weblate.trans.tasks.perform_component_commit") as commit:
+            result = execute_repository_operation_method(
+                "commit",
+                self.component,
+                method,
+                self.get_request(),
+                self.user,
+                ("commit",),
+                {},
+                resume_followup=None,
+                followup_previous_head=None,
+            )
+
+        self.assertTrue(result)
+        commit.assert_called_once_with(self.component, "commit", self.user)
+        method.assert_not_called()
+
+    def test_repository_operation_retry_preserves_resume_state(self) -> None:
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        retry_error = RepositoryOperationRetryError(
+            lock_timeout,
+            start_index=2,
+            successful=False,
+            failure_messages=["Earlier repository failure."],
+        )
+
+        with (
+            patch(
+                "weblate.trans.tasks.keep_repository_operation_reservation",
+                return_value=nullcontext(),
+            ),
+            patch("weblate.trans.tasks.acquire_repository_operation"),
+            patch(
+                "weblate.trans.tasks.store_repository_operation_tracking"
+            ) as store_tracking,
+            patch(
+                "weblate.trans.tasks.execute_repository_operation",
+                side_effect=retry_error,
+            ),
+            patch(
+                "weblate.trans.tasks.get_exponential_backoff_interval",
+                return_value=600,
+            ),
+            patch("weblate.trans.tasks.refresh_repository_operation"),
+            patch("weblate.trans.tasks.release_repository_operation") as release,
+            patch.object(
+                perform_repository_operation,
+                "retry",
+                side_effect=Retry(),
+            ) as retry,
+            self.assertRaises(Retry),
+        ):
+            perform_repository_operation.run(
+                operation="cleanup",
+                component_ids=[1, 2, 3],
+                user_id=self.user.pk,
+            )
+
+        retry.assert_called_once_with(
+            exc=lock_timeout,
+            countdown=600,
+            kwargs={
+                "operation": "cleanup",
+                "component_ids": [1, 2, 3],
+                "tracking_component_ids": [1, 2, 3],
+                "user_id": self.user.pk,
+                "start_index": 2,
+                "successful": False,
+                "failure_messages": ["Earlier repository failure."],
+                "resume_followup": None,
+                "followup_previous_head": None,
+            },
+        )
+        store_tracking.assert_called_once_with(
+            ANY,
+            [1, 2, 3],
+            self.user.pk,
+            authorization_component_ids=[1, 2, 3],
+        )
+        release.assert_not_called()
+
+    def test_repository_operation_releases_reservation_on_retry_broker_failure(
+        self,
+    ) -> None:
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        retry_error = RepositoryOperationRetryError(
+            lock_timeout, start_index=0, successful=True
+        )
+
+        with (
+            patch(
+                "weblate.trans.tasks.keep_repository_operation_reservation",
+                return_value=nullcontext(),
+            ),
+            patch("weblate.trans.tasks.acquire_repository_operation"),
+            patch("weblate.trans.tasks.store_repository_operation_tracking"),
+            patch(
+                "weblate.trans.tasks.execute_repository_operation",
+                side_effect=retry_error,
+            ),
+            patch("weblate.trans.tasks.refresh_repository_operation"),
+            patch("weblate.trans.tasks.release_repository_operation") as release,
+            patch.object(
+                perform_repository_operation,
+                "retry",
+                side_effect=RuntimeError("broker failure"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "broker failure"),
+        ):
+            perform_repository_operation.run(
+                operation="cleanup",
+                component_ids=[self.component.pk],
+                user_id=self.user.pk,
+            )
+
+        release.assert_called_once()
+
+    def test_repository_operation_reports_exhausted_lock_retries(self) -> None:
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        retry_error = RepositoryOperationRetryError(
+            lock_timeout, start_index=0, successful=True
+        )
+
+        with (
+            patch(
+                "weblate.trans.tasks.keep_repository_operation_reservation",
+                return_value=nullcontext(),
+            ),
+            patch("weblate.trans.tasks.acquire_repository_operation"),
+            patch("weblate.trans.tasks.store_repository_operation_tracking"),
+            patch(
+                "weblate.trans.tasks.execute_repository_operation",
+                side_effect=retry_error,
+            ),
+            patch.object(perform_repository_operation, "max_retries", 0),
+            patch("weblate.trans.tasks.release_repository_operation") as release,
+        ):
+            result = perform_repository_operation.run(
+                operation="cleanup",
+                component_ids=[self.component.pk],
+                user_id=self.user.pk,
+            )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(result["completion_message"]["level"], "error")
+        self.assertIn("remained locked", result["completion_message"]["text"])
+        release.assert_called_once()
+
+    def test_repository_operation_reports_expected_failure(self) -> None:
+        with (
+            patch(
+                "weblate.trans.tasks.keep_repository_operation_reservation",
+                return_value=nullcontext(),
+            ),
+            patch("weblate.trans.tasks.acquire_repository_operation"),
+            patch("weblate.trans.tasks.store_repository_operation_tracking"),
+            patch(
+                "weblate.trans.tasks.execute_repository_operation",
+                side_effect=FileParseError(),
+            ),
+            patch("weblate.trans.tasks.release_repository_operation") as release,
+        ):
+            result = perform_repository_operation.run(
+                operation="file-scan",
+                component_ids=[self.component.pk],
+                user_id=self.user.pk,
+            )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(result["completion_message"]["level"], "error")
+        self.assertIn("could not be completed", result["completion_message"]["text"])
+        release.assert_called_once()
+
+    def test_repository_operation_reports_permission_failure(self) -> None:
+        with (
+            patch(
+                "weblate.trans.tasks.keep_repository_operation_reservation",
+                return_value=nullcontext(),
+            ),
+            patch("weblate.trans.tasks.acquire_repository_operation"),
+            patch("weblate.trans.tasks.store_repository_operation_tracking"),
+            patch(
+                "weblate.trans.tasks.execute_repository_operation",
+                side_effect=PermissionDenied,
+            ),
+            patch("weblate.trans.tasks.release_repository_operation") as release,
+        ):
+            result = perform_repository_operation.run(
+                operation="cleanup",
+                component_ids=[self.component.pk],
+                user_id=self.user.pk,
+            )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(result["completion_message"]["level"], "error")
+        self.assertIn(
+            "access is no longer permitted", result["completion_message"]["text"]
+        )
+        release.assert_called_once()
+
+    def test_repository_operation_reports_raw_template_failure(self) -> None:
+        with (
+            patch(
+                "weblate.trans.tasks.keep_repository_operation_reservation",
+                return_value=nullcontext(),
+            ),
+            patch("weblate.trans.tasks.acquire_repository_operation"),
+            patch("weblate.trans.tasks.store_repository_operation_tracking"),
+            patch(
+                "weblate.trans.tasks.execute_repository_operation",
+                side_effect=ValueError("invalid template"),
+            ),
+            patch("weblate.trans.tasks.release_repository_operation"),
+        ):
+            result = perform_repository_operation.run(
+                operation="file-scan",
+                component_ids=[self.component.pk],
+                user_id=self.user.pk,
+            )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(result["completion_message"]["level"], "error")
+
+    def test_legacy_repository_task_respects_reservation(self) -> None:
+        acquire_repository_operation([self.component.pk], "pull", "task-id")
+        self.addCleanup(release_repository_operation, [self.component.pk], "task-id")
+
+        with (
+            patch.object(Component, "do_update", autospec=True) as update,
+            self.assertRaises(RepositoryOperationConflictError),
+        ):
+            perform_update.run("Component", self.component.pk)
+
+        update.assert_not_called()
+
+    def test_perform_update_publishes_push_after_releasing_reservation(self) -> None:
+        events: list[str] = []
+        original_push_if_needed = Component.push_if_needed
+
+        @contextmanager
+        def reservation(*args, **kwargs):
+            events.append("reserve")
+            try:
+                yield
+            finally:
+                events.append("release")
+
+        def update(component, request) -> None:
+            self.assertIsNotNone(repository_task_deferred_auto_push.get())
+            events.append("update")
+            original_push_if_needed(component, do_update=False)
+
+        def push(component, *, do_update=True) -> None:
+            events.append("push")
+
+        with (
+            patch(
+                "weblate.trans.tasks.reserve_repository_operation",
+                side_effect=reservation,
+            ),
+            patch.object(Component, "do_update", autospec=True, side_effect=update),
+            patch.object(Component, "push_if_needed", autospec=True, side_effect=push),
+        ):
+            perform_update.run("Component", self.component.pk)
+
+        self.assertEqual(events, ["reserve", "update", "release", "push"])
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_perform_update_publishes_load_after_releasing_reservation(self) -> None:
+        events: list[str] = []
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+
+        @contextmanager
+        def reservation(*args, **kwargs):
+            events.append("reserve")
+            try:
+                yield
+            finally:
+                events.append("release")
+
+        def update(component, request) -> None:
+            self.assertIsNotNone(repository_task_deferred_background_tasks.get())
+            events.append("update")
+            component.create_translations()
+
+        def load(*args, **kwargs):
+            events.append("load")
+            return SimpleNamespace(id="load-task-id")
+
+        with (
+            patch(
+                "weblate.trans.tasks.reserve_repository_operation",
+                side_effect=reservation,
+            ),
+            patch.object(Component, "do_update", autospec=True, side_effect=update),
+            patch.object(
+                Component,
+                "create_translations_immediate",
+                side_effect=lock_timeout,
+            ),
+            patch(
+                "weblate.trans.models.component.current_task",
+                SimpleNamespace(request=SimpleNamespace(id="update-task-id")),
+            ),
+            patch.object(perform_load, "delay", side_effect=load),
+            patch(
+                "weblate.trans.models.component.transaction.on_commit",
+                side_effect=lambda callback: callback(),
+            ),
+        ):
+            perform_update.run("Component", self.component.pk)
+
+        self.assertEqual(events, ["reserve", "update", "release", "load"])
+
+    def test_perform_update_persistently_retries_reservation_conflict(self) -> None:
+        conflict = RepositoryOperationConflictError("repository-task-id")
+        perform_update.push_request(retries=10, kwargs={})
+        try:
+            with (
+                patch(
+                    "weblate.trans.tasks.reserve_repository_operation",
+                    side_effect=conflict,
+                ),
+                patch(
+                    "weblate.trans.tasks.get_exponential_backoff_interval",
+                    return_value=3600,
+                ),
+                patch.object(perform_update, "retry", side_effect=Retry()) as retry,
+                self.assertRaises(Retry),
+            ):
+                perform_update.run("Component", self.component.pk)
+        finally:
+            perform_update.pop_request()
+
+        retry.assert_called_once_with(exc=conflict, countdown=3600, kwargs={})
+
+    def test_perform_update_preserves_lock_retry_budget_after_conflicts(self) -> None:
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        perform_update.push_request(retries=10, kwargs={})
+        try:
+            with (
+                patch.object(Component, "do_update", side_effect=lock_timeout),
+                patch(
+                    "weblate.trans.tasks.get_exponential_backoff_interval",
+                    return_value=600,
+                ),
+                patch.object(perform_update, "retry", side_effect=Retry()) as retry,
+                self.assertRaises(Retry),
+            ):
+                perform_update.run(
+                    "Component",
+                    self.component.pk,
+                    _repository_lock_retries=1,
+                )
+        finally:
+            perform_update.pop_request()
+
+        retry.assert_called_once_with(
+            exc=lock_timeout,
+            countdown=600,
+            kwargs={"_repository_lock_retries": 2},
+        )
+
+    def test_perform_update_exhausts_only_lock_retry_budget(self) -> None:
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        perform_update.push_request(retries=10, kwargs={})
+        try:
+            with (
+                patch.object(Component, "do_update", side_effect=lock_timeout),
+                patch.object(perform_update, "retry") as retry,
+                self.assertRaises(WeblateLockTimeoutError),
+            ):
+                perform_update.run(
+                    "Component",
+                    self.component.pk,
+                    _repository_lock_retries=3,
+                )
+        finally:
+            perform_update.pop_request()
+
+        retry.assert_not_called()
+
+    def test_perform_load_persistently_retries_reservation_conflict(self) -> None:
+        conflict = RepositoryOperationConflictError("repository-task-id")
+        perform_load.push_request(retries=10, kwargs={})
+        try:
+            with (
+                patch(
+                    "weblate.trans.tasks.reserve_repository_operation",
+                    side_effect=conflict,
+                ),
+                patch(
+                    "weblate.trans.tasks.get_exponential_backoff_interval",
+                    return_value=3600,
+                ),
+                patch.object(perform_load, "retry", side_effect=Retry()) as retry,
+                self.assertRaises(Retry),
+            ):
+                perform_load.run(self.component.pk)
+        finally:
+            perform_load.pop_request()
+
+        retry.assert_called_once_with(exc=conflict, countdown=3600, kwargs={})
+
+    def test_perform_push_persistently_retries_reservation_conflict(self) -> None:
+        conflict = RepositoryOperationConflictError("repository-task-id")
+        perform_push.push_request(retries=10, kwargs={})
+        try:
+            with (
+                patch(
+                    "weblate.trans.tasks.reserve_repository_operation",
+                    side_effect=conflict,
+                ),
+                patch(
+                    "weblate.trans.tasks.get_exponential_backoff_interval",
+                    return_value=3600,
+                ),
+                patch.object(perform_push, "retry", side_effect=Retry()) as retry,
+                self.assertRaises(Retry),
+            ):
+                perform_push.run(self.component.pk)
+        finally:
+            perform_push.pop_request()
+
+        retry.assert_called_once_with(exc=conflict, countdown=3600, kwargs={})
+
+    def test_repository_operation_revalidates_permission(self) -> None:
+        task = SimpleNamespace(update_state=Mock())
+        with (
+            patch.object(User, "has_perm", return_value=False),
+            patch.object(Component, "do_cleanup", autospec=True) as cleanup,
+            self.assertRaises(PermissionDenied),
+        ):
+            execute_repository_operation(
+                task,
+                "cleanup",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+            )
+
+        cleanup.assert_not_called()
+
+    def test_repository_operation_rejects_changed_repository_link(self) -> None:
+        repository = self.create_po(project=self.project, name="Other repository")
+        Component.objects.filter(pk=self.component.pk).update(
+            repo=repository.get_repo_link_url(), linked_component=repository
+        )
+        task = SimpleNamespace(update_state=Mock())
+
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "do_cleanup", autospec=True) as cleanup,
+        ):
+            result = execute_repository_operation(
+                task,
+                "cleanup",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+            )
+
+        self.assertFalse(result["result"])
+        cleanup.assert_not_called()
+
+    def test_repository_operation_preserves_failure_message(self) -> None:
+        task = SimpleNamespace(update_state=Mock())
+
+        def cleanup(component, request):
+            messages.error(request, "Specific repository failure.")
+            return False
+
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "do_cleanup", autospec=True, side_effect=cleanup),
+        ):
+            result = execute_repository_operation(
+                task,
+                "cleanup",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+            )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(
+            result["completion_message"],
+            {"level": "error", "text": "Specific repository failure."},
+        )
+
+    def test_repository_operation_retries_only_file_sync_commit(self) -> None:
+        task = SimpleNamespace(update_state=Mock())
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        followup_error = RepositoryFollowupLockError(lock_timeout, "file-sync")
+
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(
+                Component,
+                "do_file_sync",
+                autospec=True,
+                side_effect=followup_error,
+            ),
+            self.assertRaises(RepositoryOperationRetryError) as raised,
+        ):
+            execute_repository_operation(
+                task,
+                "file-sync",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+            )
+
+        self.assertEqual(raised.exception.resume_followup, "file-sync")
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "do_file_sync", autospec=True) as file_sync,
+            patch("weblate.trans.tasks.perform_component_commit") as commit,
+        ):
+            result = execute_repository_operation(
+                task,
+                "file-sync",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+                start_index=raised.exception.start_index,
+                successful=raised.exception.successful,
+                resume_followup=raised.exception.resume_followup,
+                followup_previous_head=raised.exception.followup_previous_head,
+            )
+
+        self.assertTrue(result["result"])
+        file_sync.assert_not_called()
+        commit.assert_called_once_with(self.component, "file-sync", self.user)
+
+    def test_repository_operation_retries_only_pull_followup(self) -> None:
+        task = perform_repository_operation
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        followup_error = RepositoryFollowupLockError(lock_timeout, "pull")
+
+        with (
+            patch.object(task, "update_state"),
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(
+                Component,
+                "do_update",
+                autospec=True,
+                side_effect=followup_error,
+            ),
+            self.assertRaises(RepositoryOperationRetryError) as raised,
+        ):
+            execute_repository_operation(
+                task,
+                "pull",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+            )
+
+        self.assertEqual(raised.exception.resume_followup, "pull")
+        with (
+            patch.object(task, "update_state"),
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "do_update", autospec=True) as update,
+            patch.object(Component, "finish_update", autospec=True) as finish_update,
+        ):
+            result = execute_repository_operation(
+                task,
+                "pull",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+                start_index=raised.exception.start_index,
+                successful=raised.exception.successful,
+                resume_followup=raised.exception.resume_followup,
+                followup_previous_head=raised.exception.followup_previous_head,
+            )
+
+        self.assertTrue(result["result"])
+        update.assert_not_called()
+        finish_update.assert_called_once_with(self.component, ANY, self.user)
+
+    def test_repository_operation_resumes_push_after_pull_followup(self) -> None:
+        task = perform_repository_operation
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        followup_error = RepositoryFollowupLockError(lock_timeout, "pull")
+
+        with (
+            patch.object(task, "update_state"),
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(
+                Component,
+                "do_push",
+                autospec=True,
+                side_effect=followup_error,
+            ),
+            self.assertRaises(RepositoryOperationRetryError) as raised,
+        ):
+            execute_repository_operation(
+                task,
+                "push",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+            )
+
+        with (
+            patch.object(task, "update_state"),
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "finish_update", autospec=True) as finish_update,
+            patch.object(
+                Component, "do_push", autospec=True, return_value=True
+            ) as push,
+        ):
+            result = execute_repository_operation(
+                task,
+                "push",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+                start_index=raised.exception.start_index,
+                successful=raised.exception.successful,
+                resume_followup=raised.exception.resume_followup,
+                followup_previous_head=raised.exception.followup_previous_head,
+            )
+
+        self.assertTrue(result["result"])
+        finish_update.assert_called_once_with(self.component, ANY, self.user)
+        push.assert_called_once_with(
+            self.component, ANY, force_commit=False, do_update=False
+        )
+
+    def test_repository_operation_retries_only_reset_followup(self) -> None:
+        task = SimpleNamespace(update_state=Mock())
+        lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
+        followup_error = RepositoryFollowupLockError(
+            lock_timeout, "reset-keep", previous_head="previous-head"
+        )
+
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(
+                Component,
+                "do_reset",
+                autospec=True,
+                side_effect=followup_error,
+            ),
+            self.assertRaises(RepositoryOperationRetryError) as raised,
+        ):
+            execute_repository_operation(
+                task,
+                "reset-keep",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+            )
+
+        self.assertEqual(raised.exception.resume_followup, "reset-keep")
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "do_reset", autospec=True) as reset,
+            patch("weblate.trans.tasks.perform_component_commit") as commit,
+        ):
+            result = execute_repository_operation(
+                task,
+                "reset-keep",
+                [self.component.pk],
+                self.user.pk,
+                "task-id",
+                start_index=raised.exception.start_index,
+                successful=raised.exception.successful,
+                resume_followup=raised.exception.resume_followup,
+                followup_previous_head=raised.exception.followup_previous_head,
+            )
+
+        self.assertTrue(result["result"])
+        reset.assert_not_called()
+        commit.assert_called_once_with(
+            self.component,
+            "reset-sync",
+            self.user,
+            force_scan=True,
+            previous_head="previous-head",
+        )
+
+    def test_repository_operation_retry_resumes_timed_out_repository(self) -> None:
+        second = self.create_po(project=self.project, name="Second")
+        self.addCleanup(delete_task_metadata, "task-id")
+        task = SimpleNamespace(update_state=Mock())
+        calls: list[int] = []
+        lock_timeout = WeblateLockTimeoutError("locked", lock=second.lock)
+
+        def cleanup(component, request):
+            calls.append(component.pk)
+            if component == self.component:
+                messages.error(request, "Earlier repository failure.")
+                return False
+            if component == second and calls.count(second.pk) == 1:
+                raise lock_timeout
+            return True
+
+        component_ids = [self.component.pk, second.pk]
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "do_cleanup", autospec=True, side_effect=cleanup),
+            patch("weblate.trans.tasks.refresh_repository_operation"),
+            self.assertRaises(RepositoryOperationRetryError) as raised,
+        ):
+            execute_repository_operation(
+                task, "cleanup", component_ids, self.user.pk, "task-id"
+            )
+
+        self.assertEqual(raised.exception.start_index, 1)
+        self.assertEqual(
+            raised.exception.failure_messages, ["Earlier repository failure."]
+        )
+
+        with (
+            patch.object(User, "has_perm", return_value=True),
+            patch.object(Component, "do_cleanup", autospec=True, side_effect=cleanup),
+            patch("weblate.trans.tasks.refresh_repository_operation"),
+        ):
+            result = execute_repository_operation(
+                task,
+                "cleanup",
+                component_ids,
+                self.user.pk,
+                "task-id",
+                start_index=raised.exception.start_index,
+                successful=raised.exception.successful,
+                failure_messages=raised.exception.failure_messages,
+            )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(
+            result["completion_message"]["text"], "Earlier repository failure."
+        )
+        self.assertEqual(calls, [self.component.pk, second.pk, second.pk])
+
     def test_project_removal_retries_without_backup(self) -> None:
         task_id = "project-removal-task-id"
         original_get = Project.objects.get
@@ -210,7 +976,14 @@ class TasksTest(ComponentTestCase):
         self.assertTrue(component_path.is_dir())
 
     def test_update_remotes(self) -> None:
-        update_remotes()
+        current_time = timezone.now().replace(hour=self.component.pk % 24)
+        with (
+            patch("weblate.trans.tasks.timezone.now", return_value=current_time),
+            patch.object(perform_update, "delay") as update,
+        ):
+            update_remotes()
+
+        update.assert_any_call("Component", self.component.pk, auto=True)
 
     def test_commit_pending(self) -> None:
         self.component.commit_pending_age = 1
@@ -258,6 +1031,38 @@ class TasksTest(ComponentTestCase):
         self.assertEqual(cache.get(self.component.commit_task_key), "commit-task-id")
         cache.delete(self.component.commit_task_key)
 
+    def test_perform_commit_publishes_push_after_releasing_reservation(self) -> None:
+        events: list[str] = []
+
+        @contextmanager
+        def reservation(*args, **kwargs):
+            events.append("reserve")
+            try:
+                yield
+            finally:
+                events.append("release")
+
+        def commit(*args, **kwargs) -> None:
+            self.assertTrue(repository_task_suppress_auto_push.get())
+            events.append("commit")
+
+        def push(*args, **kwargs) -> None:
+            events.append("push")
+
+        with (
+            patch(
+                "weblate.trans.tasks.reserve_repository_operation",
+                side_effect=reservation,
+            ),
+            patch("weblate.trans.tasks.perform_component_commit", side_effect=commit),
+            patch.object(Component, "push_if_needed", autospec=True, side_effect=push),
+            patch("weblate.trans.tasks.schedule_deferred_commit") as schedule,
+        ):
+            perform_commit.run(self.component.pk, "commit")
+
+        self.assertEqual(events, ["reserve", "commit", "release", "push"])
+        schedule.assert_called_once()
+
     def test_perform_commit_clears_commit_task_on_exhausted_lock_retry(self) -> None:
         cache.set(self.component.commit_task_key, "commit-task-id")
         lock_timeout = WeblateLockTimeoutError("locked", lock=self.component.lock)
@@ -270,6 +1075,27 @@ class TasksTest(ComponentTestCase):
             patch("weblate.trans.tasks.current_task", task),
             patch.object(Component, "commit_pending", side_effect=lock_timeout),
             self.assertRaises(WeblateLockTimeoutError),
+        ):
+            perform_commit.run(self.component.pk, "commit")
+
+        self.assertIsNone(cache.get(self.component.commit_task_key))
+
+    def test_perform_commit_clears_commit_task_on_exhausted_reservation_retry(
+        self,
+    ) -> None:
+        cache.set(self.component.commit_task_key, "commit-task-id")
+        task = SimpleNamespace(
+            request=SimpleNamespace(id="commit-task-id", retries=3), max_retries=3
+        )
+
+        with (
+            patch("weblate.trans.models.component.current_task", task),
+            patch("weblate.trans.tasks.current_task", task),
+            patch(
+                "weblate.trans.tasks.reserve_repository_operation",
+                side_effect=RepositoryOperationConflictError("repository-task-id"),
+            ),
+            self.assertRaises(RepositoryOperationConflictError),
         ):
             perform_commit.run(self.component.pk, "commit")
 

--- a/weblate/trans/views/git.py
+++ b/weblate/trans/views/git.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING
 
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
@@ -17,6 +16,14 @@ from django.utils.translation import gettext
 
 from weblate.auth.permissions import get_project_repository_selection
 from weblate.trans.models import Component, Project, Translation
+from weblate.trans.repository import (
+    RepositoryOperation,
+    RepositoryOperationConflictError,
+    can_access_repository_operation_task,
+    get_repository_components,
+    queue_repository_operation,
+    reserve_repository_operation,
+)
 from weblate.trans.util import redirect_param
 from weblate.utils import messages
 from weblate.utils.errors import report_error
@@ -51,16 +58,34 @@ def require_repository_action_post(
     return wrapper
 
 
-@transaction.atomic
 def execute_locked(
-    request: AuthenticatedHttpRequest, obj, message, call, *args, **kwargs
+    request: AuthenticatedHttpRequest,
+    obj,
+    operation: RepositoryOperation,
+    message,
+    call,
+    *args,
+    **kwargs,
 ):
     """Wrap function call and gracefully handle possible lock exception."""
+    repositories, _display_components = get_repository_components(obj)
     try:
-        result = call(*args, **kwargs)
-        # With False the call is supposed to show errors on its own
-        if result is None or result:
-            messages.success(request, message)
+        with (
+            reserve_repository_operation(
+                [component.pk for component in repositories], operation
+            ) as release_reservation,
+            transaction.atomic(),
+        ):
+            transaction.on_commit(release_reservation)
+            result = call(*args, **kwargs)
+            # With False the call is supposed to show errors on its own
+            if result is None or result:
+                messages.success(request, message)
+    except RepositoryOperationConflictError:
+        messages.error(
+            request,
+            gettext("Another repository operation is already in progress."),
+        )
     except WeblateLockTimeoutError:
         messages.error(
             request,
@@ -78,22 +103,45 @@ def execute_locked(
     return redirect_param(obj, "#repository")
 
 
-def queue_commit(request: AuthenticatedHttpRequest, obj) -> bool:
-    """Queue commit operation for browser requests."""
-    user_id = request.user.id
-    if isinstance(obj, Project):
-        selection = get_project_repository_selection(request.user, obj, ("vcs.commit",))
-        if not selection.repositories:
-            raise PermissionDenied
-        for component in selection.repositories:
-            component.queue_commit_pending("commit", user_id=user_id)
-    elif isinstance(obj, Translation):
-        if not obj.needs_commit():
-            return False
-        obj.component.queue_commit_pending("commit", user_id=user_id)
+def queue_operation(
+    request: AuthenticatedHttpRequest,
+    obj: Project | Component | Translation,
+    operation: RepositoryOperation,
+    *,
+    repo_components: tuple[Component, ...] | None = None,
+) -> HttpResponseBase:
+    """Queue a repository operation and redirect to its progress page."""
+    try:
+        queued = queue_repository_operation(
+            obj,
+            operation,
+            request.user,
+            repository_components=repo_components,
+        )
+    except RepositoryOperationConflictError as error:
+        messages.error(
+            request,
+            gettext("Another repository operation is already in progress."),
+        )
+        if error.task_id and can_access_repository_operation_task(
+            request.user, error.task_id
+        ):
+            return redirect(
+                f"{reverse('show_progress', kwargs={'path': obj.get_url_path()})}?info=1"
+            )
+        return redirect_param(obj, "#repository")
+
+    if queued.successful is False:
+        messages.error(request, gettext("Repository operation completed with errors."))
+        return redirect_param(obj, "#repository")
+
+    if queued.reused:
+        messages.info(request, gettext("This repository operation is already queued."))
     else:
-        obj.queue_commit_pending("commit", user_id=user_id)
-    return True
+        messages.success(request, gettext("Repository operation has been queued."))
+    return redirect(
+        f"{reverse('show_progress', kwargs={'path': obj.get_url_path()})}?info=1"
+    )
 
 
 def get_project_repository_kwargs(
@@ -112,40 +160,21 @@ def get_project_repository_kwargs(
     return {"repo_components": repositories}
 
 
-def get_repository_success_message(obj, message: str, project_message: str) -> str:
-    if isinstance(obj, Project):
-        return project_message
-    return message
-
-
 @login_required
 @require_repository_action_post
 def update(request: AuthenticatedHttpRequest, path: list[str]) -> HttpResponseBase:
     obj = parse_path(request, path, (Project, Component, Translation))
     repository_kwargs = get_project_repository_kwargs(request, obj, "vcs.update")
 
-    result = execute_locked(
-        request,
-        obj,
-        get_repository_success_message(
-            obj,
-            gettext(
-                "All repositories have been updated, updates of translations are in progress."
-            ),
-            gettext(
-                "Accessible repositories have been updated, updates of translations are in progress."
-            ),
-        ),
-        obj.do_update,
-        request,
-        method=request.GET.get("method"),
-        **repository_kwargs,
-    )
-    if result:
-        return redirect(
-            f"{reverse('show_progress', kwargs={'path': obj.get_url_path()})}?info=1"
-        )
-    return result
+    method = request.GET.get("method")
+    operation: RepositoryOperation = "pull"
+    if method == "rebase":
+        operation = "pull-rebase"
+    elif method == "merge":
+        operation = "pull-merge"
+    elif method == "merge_noff":
+        operation = "pull-merge-noff"
+    return queue_operation(request, obj, operation, **repository_kwargs)
 
 
 @login_required
@@ -154,18 +183,7 @@ def push(request: AuthenticatedHttpRequest, path: list[str]) -> HttpResponseBase
     obj = parse_path(request, path, (Project, Component, Translation))
     repository_kwargs = get_project_repository_kwargs(request, obj, "vcs.push")
 
-    return execute_locked(
-        request,
-        obj,
-        get_repository_success_message(
-            obj,
-            gettext("All repositories were pushed."),
-            gettext("Accessible repositories were pushed."),
-        ),
-        obj.do_push,
-        request,
-        **repository_kwargs,
-    )
+    return queue_operation(request, obj, "push", **repository_kwargs)
 
 
 @login_required
@@ -174,28 +192,10 @@ def reset(request: AuthenticatedHttpRequest, path: list[str]) -> HttpResponseBas
     obj = parse_path(request, path, (Project, Component, Translation))
     repository_kwargs = get_project_repository_kwargs(request, obj, "vcs.reset")
 
-    result = execute_locked(
-        request,
-        obj,
-        get_repository_success_message(
-            obj,
-            gettext(
-                "All repositories have been reset, updates of translations are in progress."
-            ),
-            gettext(
-                "Accessible repositories have been reset, updates of translations are in progress."
-            ),
-        ),
-        obj.do_reset,
-        request,
-        keep_changes="keep_changes" in request.POST,
-        **repository_kwargs,
+    operation: RepositoryOperation = (
+        "reset-keep" if "keep_changes" in request.POST else "reset"
     )
-    if result:
-        return redirect(
-            f"{reverse('show_progress', kwargs={'path': obj.get_url_path()})}?info=1"
-        )
-    return result
+    return queue_operation(request, obj, operation, **repository_kwargs)
 
 
 @login_required
@@ -204,18 +204,7 @@ def cleanup(request: AuthenticatedHttpRequest, path: list[str]) -> HttpResponseB
     obj = parse_path(request, path, (Project, Component, Translation))
     repository_kwargs = get_project_repository_kwargs(request, obj, "vcs.reset")
 
-    return execute_locked(
-        request,
-        obj,
-        get_repository_success_message(
-            obj,
-            gettext("All repositories have been cleaned up."),
-            gettext("Accessible repositories have been cleaned up."),
-        ),
-        obj.do_cleanup,
-        request,
-        **repository_kwargs,
-    )
+    return queue_operation(request, obj, "cleanup", **repository_kwargs)
 
 
 @login_required
@@ -224,20 +213,7 @@ def file_sync(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
     obj = parse_path(request, path, (Project, Component, Translation))
     repository_kwargs = get_project_repository_kwargs(request, obj, "vcs.reset")
 
-    return execute_locked(
-        request,
-        obj,
-        get_repository_success_message(
-            obj,
-            gettext("Translation files have been synchronized."),
-            gettext(
-                "Translation files in accessible repositories have been synchronized."
-            ),
-        ),
-        obj.do_file_sync,
-        request,
-        **repository_kwargs,
-    )
+    return queue_operation(request, obj, "file-sync", **repository_kwargs)
 
 
 @login_required
@@ -246,25 +222,7 @@ def file_scan(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
     obj = parse_path(request, path, (Project, Component, Translation))
     repository_kwargs = get_project_repository_kwargs(request, obj, "vcs.reset")
 
-    result = execute_locked(
-        request,
-        obj,
-        get_repository_success_message(
-            obj,
-            gettext("Updates of translations are in progress."),
-            gettext(
-                "Updates of translations in accessible repositories are in progress."
-            ),
-        ),
-        obj.do_file_scan,
-        request,
-        **repository_kwargs,
-    )
-    if result:
-        return redirect(
-            f"{reverse('show_progress', kwargs={'path': obj.get_url_path()})}?info=1"
-        )
-    return result
+    return queue_operation(request, obj, "file-scan", **repository_kwargs)
 
 
 @login_required
@@ -279,6 +237,7 @@ def remove_duplicate_units(
     return execute_locked(
         request,
         obj,
+        "remove-duplicates",
         gettext("Duplicate strings have been removed from the translation file."),
         obj.do_remove_duplicate_units,
         request,
@@ -297,6 +256,7 @@ def cleanup_unused(
     return execute_locked(
         request,
         obj,
+        "cleanup-unused",
         gettext("Unused strings have been removed from the translation file."),
         obj.do_cleanup_unused,
         request,
@@ -315,6 +275,7 @@ def remove_obsolete_units(
     return execute_locked(
         request,
         obj,
+        "remove-obsolete",
         gettext("Obsolete strings have been removed from the translation file."),
         obj.do_remove_obsolete_units,
         request,
@@ -327,24 +288,6 @@ def commit(request: AuthenticatedHttpRequest, path: list[str]) -> HttpResponseBa
     obj = parse_path(request, path, (Project, Component, Translation))
     repository_kwargs = get_project_repository_kwargs(request, obj, "vcs.commit")
 
-    if not settings.CELERY_TASK_ALWAYS_EAGER:
-        result = queue_commit(request, obj)
-        if result:
-            messages.success(
-                request, gettext("Pending translations are being committed.")
-            )
+    if isinstance(obj, Translation) and not obj.needs_commit():
         return redirect_param(obj, "#repository")
-
-    return execute_locked(
-        request,
-        obj,
-        get_repository_success_message(
-            obj,
-            gettext("All pending translations were committed."),
-            gettext("Pending translations in accessible repositories were committed."),
-        ),
-        obj.commit_pending,
-        "commit",
-        request.user,
-        **repository_kwargs,
-    )
+    return queue_operation(request, obj, "commit", **repository_kwargs)

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.db import transaction
 from django.http import Http404, JsonResponse
@@ -53,6 +54,7 @@ from weblate.trans.models import (
     Translation,
     WorkflowSetting,
 )
+from weblate.trans.repository import can_access_repository_operation_task
 from weblate.trans.tasks import (
     category_removal,
     component_removal,
@@ -62,7 +64,9 @@ from weblate.trans.tasks import (
 )
 from weblate.trans.util import redirect_param, render
 from weblate.utils import messages
+from weblate.utils.celery import get_task_metadata
 from weblate.utils.lock import WeblateLockTimeoutError
+from weblate.utils.messages import store_task_completion_message
 from weblate.utils.random import get_random_identifier
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.utils.views import aparse_path, parse_path, show_form_errors
@@ -72,7 +76,7 @@ from weblate.workspaces.models import Workspace
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from weblate.auth.models import AuthenticatedHttpRequest
+    from weblate.auth.models import AuthenticatedHttpRequest, User
 
 
 def _show_repository_lock_timeout(request: AuthenticatedHttpRequest) -> None:
@@ -606,11 +610,33 @@ def show_progress(request: AuthenticatedHttpRequest, path):
     return component_progress(request, obj)
 
 
+def can_view_component_progress(user: User, component: Component, task_id: str) -> bool:
+    """Authorize shared repository tasks against their complete component scope."""
+    repository_task_id = cache.get(component.repository_operation_update_key)
+    return repository_task_id != task_id or can_access_repository_operation_task(
+        user, task_id
+    )
+
+
 def multi_progress(request: AuthenticatedHttpRequest, obj: Category | Project):
-    components = list(obj.all_repo_components)
+    components_by_task: dict[str, Component] = {}
+    for component in obj.all_repo_components:
+        if (task_id := component.background_task_id) and can_view_component_progress(
+            request.user, component, task_id
+        ):
+            components_by_task.setdefault(task_id, component)
+    components = []
+    for component in components_by_task.values():
+        task = component.background_task
+        if task is None:
+            continue
+        if task.ready():
+            store_task_completion_message(request, task)
+        else:
+            components.append(component)
     return_target = obj
     return_url = obj.get_absolute_url()
-    if not any(component.in_progress() for component in components):
+    if not components:
         return redirect(return_url)
     return render(
         request,
@@ -633,9 +659,21 @@ def component_progress(request: AuthenticatedHttpRequest, obj: Component | Trans
         return_target = component
         return_url = f"{component.get_absolute_url()}#alerts"
 
-    if not component.in_progress():
+    task_id = component.background_task_id
+    if task_id is None:
+        return redirect(return_url)
+    if not can_view_component_progress(request.user, component, task_id):
+        msg = "Invalid task"
+        raise Http404(msg)
+
+    task = component.background_task
+    if task is None:
+        return redirect(return_url)
+    if task.ready():
+        store_task_completion_message(request, task)
         return redirect(return_url)
 
+    metadata = get_task_metadata(task_id)
     progress, log = component.get_progress()
 
     return render(
@@ -647,6 +685,7 @@ def component_progress(request: AuthenticatedHttpRequest, obj: Component | Trans
             "progress": progress,
             "log": "\n".join(log),
             "return_url": return_url,
+            "task_cancellable": (metadata or {}).get("cancellable", True),
         },
     )
 

--- a/weblate/utils/celery.py
+++ b/weblate/utils/celery.py
@@ -56,17 +56,34 @@ def store_task_metadata(
     task_id: str | None,
     *,
     component_id: int | None = None,
+    component_ids: list[int] | None = None,
     translation_id: int | None = None,
     user_id: int | None = None,
+    task_kind: str | None = None,
+    cancellable: bool = True,
 ) -> None:
     if not task_id:
         return
-    data = {
-        "component_id": component_id,
-        "translation_id": translation_id,
-    }
+    existing = get_task_metadata(task_id)
+    if existing is None:
+        data: dict[str, Any] = {
+            "component_id": component_id,
+            "translation_id": translation_id,
+        }
+    else:
+        data = existing.copy()
+        if component_id is not None:
+            data["component_id"] = component_id
+        if translation_id is not None:
+            data["translation_id"] = translation_id
+    if component_ids is not None:
+        data["component_ids"] = component_ids
     if user_id is not None:
         data["user_id"] = user_id
+    if task_kind is not None:
+        data["task_kind"] = task_kind
+    if not cancellable:
+        data["cancellable"] = False
     cache.set(
         get_task_metadata_key(task_id),
         data,
@@ -74,7 +91,7 @@ def store_task_metadata(
     )
 
 
-def get_task_metadata(task_id: str) -> dict[str, int | None] | None:
+def get_task_metadata(task_id: str) -> dict[str, Any] | None:
     return cache.get(get_task_metadata_key(task_id))
 
 

--- a/weblate/utils/messages.py
+++ b/weblate/utils/messages.py
@@ -10,18 +10,19 @@ It also ignories messages without request object (for example from CLI).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from django.contrib.messages import add_message as django_add_message
 from django.contrib.messages import constants
 
 if TYPE_CHECKING:
+    from celery.result import AsyncResult
     from django.http import HttpRequest
 
 
-def get_request(request: HttpRequest):
+def get_request(request: object) -> HttpRequest:
     """Return Django request object even for DRF requests."""
-    return getattr(request, "_request", request)
+    return cast("HttpRequest", getattr(request, "_request", request))
 
 
 def add_message(
@@ -38,6 +39,40 @@ def add_message(
             extra_tags=extra_tags,
             fail_silently=True,
         )
+
+
+def store_task_completion_message(request: object, task: AsyncResult) -> None:
+    """Store an explicitly opted-in task completion message in the session."""
+    result = task.result
+    if not isinstance(result, dict):
+        return
+
+    completion_message = result.get("completion_message")
+    if not isinstance(completion_message, dict):
+        return
+
+    text = completion_message.get("text")
+    if not text:
+        return
+
+    request = get_request(request)
+    session_key = f"task-completion-message-{task.id}"
+    if request.session.get(session_key):
+        return
+
+    message_levels = {
+        "error": constants.ERROR,
+        "info": constants.INFO,
+        "warning": constants.WARNING,
+    }
+    message_level = completion_message.get("level")
+    level = (
+        message_levels.get(message_level, constants.SUCCESS)
+        if isinstance(message_level, str)
+        else constants.SUCCESS
+    )
+    add_message(request, level, str(text))
+    request.session[session_key] = True
 
 
 def debug(

--- a/weblate/utils/tests/test_celery.py
+++ b/weblate/utils/tests/test_celery.py
@@ -11,6 +11,51 @@ import sys
 
 from django.test import SimpleTestCase
 
+from weblate.utils.celery import (
+    delete_task_metadata,
+    get_task_metadata,
+    store_task_metadata,
+)
+
+
+class TaskMetadataTest(SimpleTestCase):
+    task_id = "01234567-89ab-cdef-0123-456789abcdef"
+
+    def tearDown(self) -> None:
+        delete_task_metadata(self.task_id)
+        super().tearDown()
+
+    def test_extended_metadata_is_only_stored_when_requested(self) -> None:
+        store_task_metadata(self.task_id, component_id=1, user_id=2)
+
+        self.assertEqual(
+            get_task_metadata(self.task_id),
+            {"component_id": 1, "translation_id": None, "user_id": 2},
+        )
+
+    def test_updates_preserve_repository_operation_metadata(self) -> None:
+        store_task_metadata(
+            self.task_id,
+            component_ids=[1, 2],
+            user_id=3,
+            task_kind="repository-operation",
+            cancellable=False,
+        )
+
+        store_task_metadata(self.task_id, component_id=1)
+
+        self.assertEqual(
+            get_task_metadata(self.task_id),
+            {
+                "component_id": 1,
+                "component_ids": [1, 2],
+                "translation_id": None,
+                "user_id": 3,
+                "task_kind": "repository-operation",
+                "cancellable": False,
+            },
+        )
+
 
 class CeleryStartupTest(SimpleTestCase):
     @staticmethod


### PR DESCRIPTION
Repository operations can exceed proxy timeouts and provide little feedback while requests remain open. Queue browser actions and opt-in API requests as serialized, trackable Celery tasks.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
