### PR TITLE
fix(vcs): uninstall GitHub App on account removal

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -327,6 +327,16 @@ the install-time GitHub user can administer the organization installation.
 Projects that are not in a workspace cannot connect a GitHub account through
 the GitHub App.
 
+Removing a connected GitHub account also uninstalls the App from GitHub when
+no other Weblate workspace uses that installation. If another workspace still
+uses the installation, Weblate removes only the selected workspace connection.
+Components imported through that connection lose access to their repositories.
+Removing a workspace uninstalls its connected accounts the same way.
+
+Weblate removes the connection even when GitHub no longer knows about the
+installation, and keeps it only when GitHub could not be reached, so that the
+removal can be retried.
+
 Components imported through the GitHub App flow use the dedicated
 :guilabel:`GitHub (via Weblate GitHub app)` VCS backend. The component
 settings UI keeps the repository URL read-only to prevent the App-issued

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.9
 
 .. rubric:: Improvements
 
+* Removing the final Weblate workspace connection for a GitHub account, or removing the workspace holding it, now also uninstalls the Weblate GitHub App from GitHub.
 * :ref:`addon-weblate.gettext.xgettext` now accepts multiple custom keywords (newline-separated) passed to xgettext via ``--keyword``, enabling extraction from different function names.
 * Screenshot images are now cached in browsers to reduce repeated downloads.
 * Administrators can now find removed accounts by their former e-mail address in the audit log until :setting:`AUDITLOG_EXPIRY`.

--- a/weblate/templates/vcs/snippets/github_account_remove_modal.html
+++ b/weblate/templates/vcs/snippets/github_account_remove_modal.html
@@ -29,10 +29,36 @@
           </p>
           <p class="text-body-secondary">
             {% blocktranslate trimmed %}
-              The Weblate GitHub app stays installed on GitHub. Remove it on
-              GitHub separately if you no longer need it.
+              If no other Weblate workspace uses this connection, the Weblate
+              GitHub App will also be uninstalled from GitHub. Reconnecting it
+              then requires installing the app on GitHub again.
             {% endblocktranslate %}
           </p>
+          {% with components=installation.components %}
+            {% if components %}
+              <div class="alert alert-warning" role="alert">
+                <p>
+                  {% blocktranslate trimmed count counter=components|length %}
+                    The following component will lose access to its repository:
+                  {% plural %}
+                    The following {{ counter }} components will lose access to their repositories:
+                  {% endblocktranslate %}
+                </p>
+                <ul class="mb-0">
+                  {% for component in components|slice:":10" %}<li>{{ component }}</li>{% endfor %}
+                  {% if components|length > 10 %}
+                    <li>
+                      {% blocktranslate trimmed count counter=components|length|add:"-10" %}
+                        and {{ counter }} more component
+                      {% plural %}
+                        and {{ counter }} more components
+                      {% endblocktranslate %}
+                    </li>
+                  {% endif %}
+                </ul>
+              </div>
+            {% endif %}
+          {% endwith %}
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{% translate "Cancel" %}</button>

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -12,6 +12,7 @@ import hmac
 import logging
 import time
 import uuid
+from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote, urlencode, urlparse
 
@@ -20,11 +21,13 @@ import jwt
 from asgiref.sync import async_to_sync
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy
 
+from weblate.utils.errors import report_error
 from weblate.utils.requests import async_fetch_url
 from weblate.vcs.base import RepositoryInternalError
 from weblate.vcs.git import GithubRepository
@@ -42,6 +45,10 @@ logger = logging.getLogger(__name__)
 TOKEN_CACHE_TTL = 50 * 60
 # GitHub enforces a 10-minute maximum on App JWTs
 JWT_MAX_LIFETIME = 9 * 60
+
+# The installation is gone (404/410), suspended (403) or the App credentials are
+# no longer accepted (401); there is nothing left to uninstall
+GITHUB_UNINSTALL_UNREACHABLE_STATUSES = frozenset({401, 403, 404, 410})
 
 # Permissions and manifest-selectable events Weblate needs when registering a
 # GitHub App via the manifest flow. GitHub delivers App lifecycle events such as
@@ -392,6 +399,47 @@ async def get_app_installation(
     return response.json()
 
 
+async def delete_app_installation(
+    app_id: str | int,
+    private_key: str,
+    installation_id: str | int,
+    hostname: str,
+) -> bool:
+    """
+    Uninstall the GitHub App.
+
+    Returns whether GitHub confirmed the removal; an unreachable installation
+    returns ``False``, transient failures raise.
+    """
+    installation_id = normalize_github_installation_id(installation_id)
+    private_key_pem = validate_private_key(private_key)
+    token = generate_jwt(app_id, private_key_pem)
+    api_base = get_github_api_base(hostname)
+    response = await async_fetch_url(
+        "delete",
+        f"{api_base}/app/installations/{installation_id}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+        },
+        timeout=30,
+        raise_for_status=False,
+    )
+    unreachable = response.status_code in GITHUB_UNINSTALL_UNREACHABLE_STATUSES
+    if not unreachable:
+        response.raise_for_status()
+    else:
+        logger.info(
+            "GitHub App installation %s/%s is not reachable (HTTP %d), "
+            "treating it as uninstalled",
+            hostname,
+            installation_id,
+            response.status_code,
+        )
+    await cache.adelete(f"github-app-token:{hostname}:{installation_id}")
+    return not unreachable
+
+
 async def get_app_repositories(
     app_id: str | int,
     private_key: str,
@@ -665,9 +713,14 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
     ) -> models.QuerySet[GitHubInstallation]:
         """Return installations by host and installation ID."""
         hostname = normalize_github_app_hostname(hostname)
+        try:
+            lookup = normalize_github_installation_id(installation_id)
+        except (TypeError, ValueError):
+            # Invalid ID, match verbatim so that it simply finds nothing
+            lookup = str(installation_id)
         return self.filter(
             hostname=hostname,
-            installation_id=str(installation_id),
+            installation_id=lookup,
         )
 
     def get_for_installation(
@@ -890,6 +943,8 @@ class GitHubInstallation(Installation):
     def save(self, *args, **kwargs) -> None:
         self.provider = InstallationProvider.GITHUB
         self.hostname = normalize_github_app_hostname(self.hostname)
+        # Keep the stored ID canonical so that lookups cannot miss it
+        self.installation_id = normalize_github_installation_id(self.installation_id)
         super().save(*args, **kwargs)
 
     @property
@@ -942,11 +997,104 @@ class GitHubInstallation(Installation):
     def has_repository(self, full_name: str) -> bool:
         return any(repo.get("full_name") == full_name for repo in self.repositories)
 
+    @cached_property
+    def components(self) -> list[Component]:
+        """Return components authenticating through this connected account."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models import Component
+
+        result = []
+        for component in Component.objects.filter(
+            vcs=GithubAppRepository.identifier,
+            project__workspace_id=self.workspace_id,
+        ).select_related("project"):
+            parsed = urlparse(component.repo)
+            if (parsed.hostname or "").lower() != self.hostname:
+                continue
+            if self.has_repository(parsed.path.strip("/").removesuffix(".git")):
+                result.append(component)
+        return result
+
     def get_webhook_secret(self) -> str:
         config = get_github_app_settings(self.hostname)
         if config is None:
             return ""
         return config.webhook_secret
+
+
+class InstallationRemoval(StrEnum):
+    """Outcome of removing a connected GitHub account."""
+
+    # Another workspace still uses it, the App stays installed
+    SHARED = "shared"
+    UNINSTALLED = "uninstalled"
+    # Nothing left to uninstall on GitHub
+    UNREACHABLE = "unreachable"
+    # No credentials for the host, so the App cannot be reached
+    UNCONFIGURED = "unconfigured"
+    # GitHub could not be reached, retrying might work
+    FAILED = "failed"
+
+
+def remove_github_installation(
+    installation: GitHubInstallation, *, best_effort: bool = False
+) -> InstallationRemoval:
+    """
+    Remove a connected GitHub account, uninstalling the App when it was the last.
+
+    The connection is kept when GitHub failed in a way worth retrying, unless
+    ``best_effort`` is set because it is going away anyway.
+    """
+    with transaction.atomic():
+        # Lock all connections before deciding whether this is the last one,
+        # otherwise two concurrent removals both see the other one
+        siblings = set(
+            GitHubInstallation.objects.filter_for_installation(
+                installation.hostname, installation.installation_id
+            )
+            .select_for_update()
+            .values_list("pk", flat=True)
+        )
+        siblings.discard(installation.pk)
+        if siblings:
+            installation.delete()
+            return InstallationRemoval.SHARED
+
+        config = get_github_app_settings(installation.hostname)
+        if config is None:
+            # The App cannot be reached, nor its credentials re-registered
+            installation.delete()
+            return InstallationRemoval.UNCONFIGURED
+
+        try:
+            uninstalled = async_to_sync(delete_app_installation)(
+                config.app_id,
+                config.private_key,
+                installation.installation_id,
+                installation.hostname,
+            )
+        except (ValueError, TypeError, ValidationError, jwt.PyJWTError) as error:
+            # The stored credentials cannot produce a valid request at all
+            report_error(
+                "Failed to uninstall connected GitHub account", exception=error
+            )
+            installation.delete()
+            return InstallationRemoval.UNREACHABLE
+        except Exception as error:
+            report_error(
+                "Failed to uninstall connected GitHub account", exception=error
+            )
+            if not best_effort:
+                return InstallationRemoval.FAILED
+            installation.delete()
+            return InstallationRemoval.FAILED
+
+        installation.delete()
+        return (
+            InstallationRemoval.UNINSTALLED
+            if uninstalled
+            else InstallationRemoval.UNREACHABLE
+        )
 
 
 class GithubAppRepository(GithubRepository):

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -12,6 +12,7 @@ import hmac
 import logging
 import time
 import uuid
+from collections import defaultdict
 from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote, urlencode, urlparse
@@ -34,6 +35,9 @@ from weblate.vcs.git import GithubRepository
 from weblate.vcs.models import Installation, InstallationProvider
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from uuid import UUID
+
     from django_stubs_ext import StrOrPromise
 
     from weblate.trans.models import Component
@@ -723,6 +727,27 @@ class GitHubInstallationManager(models.Manager["GitHubInstallation"]):
             installation_id=lookup,
         )
 
+    def prefetch_components(self, installations: Iterable[GitHubInstallation]) -> None:
+        """Populate :attr:`GitHubInstallation.components` with a single query."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models import Component
+
+        pending: defaultdict[UUID, list[GitHubInstallation]] = defaultdict(list)
+        for installation in installations:
+            if "components" in installation.__dict__:
+                continue
+            installation.__dict__["components"] = []
+            pending[installation.workspace_id].append(installation)
+        if not pending:
+            return
+        for component in Component.objects.filter(
+            vcs=GithubAppRepository.identifier,
+            project__workspace_id__in=list(pending),
+        ).select_related("project"):
+            for installation in pending[component.project.workspace_id]:
+                if installation.matches_component(component):
+                    installation.components.append(component)
+
     def get_for_installation(
         self,
         hostname: str,
@@ -997,23 +1022,32 @@ class GitHubInstallation(Installation):
     def has_repository(self, full_name: str) -> bool:
         return any(repo.get("full_name") == full_name for repo in self.repositories)
 
+    def matches_component(self, component: Component) -> bool:
+        """Check whether the component authenticates through this account."""
+        parsed = urlparse(component.repo)
+        if (parsed.hostname or "").lower() != self.hostname:
+            return False
+        return self.has_repository(parsed.path.strip("/").removesuffix(".git"))
+
     @cached_property
     def components(self) -> list[Component]:
-        """Return components authenticating through this connected account."""
+        """
+        Return components authenticating through this connected account.
+
+        Use :meth:`GitHubInstallationManager.prefetch_components` when several
+        installations are rendered at once to avoid a query for each of them.
+        """
         # ruff: ignore[import-outside-top-level]
         from weblate.trans.models import Component
 
-        result = []
-        for component in Component.objects.filter(
-            vcs=GithubAppRepository.identifier,
-            project__workspace_id=self.workspace_id,
-        ).select_related("project"):
-            parsed = urlparse(component.repo)
-            if (parsed.hostname or "").lower() != self.hostname:
-                continue
-            if self.has_repository(parsed.path.strip("/").removesuffix(".git")):
-                result.append(component)
-        return result
+        return [
+            component
+            for component in Component.objects.filter(
+                vcs=GithubAppRepository.identifier,
+                project__workspace_id=self.workspace_id,
+            ).select_related("project")
+            if self.matches_component(component)
+        ]
 
     def get_webhook_secret(self) -> str:
         config = get_github_app_settings(self.hostname)

--- a/weblate/vcs/tests/test_github_models.py
+++ b/weblate/vcs/tests/test_github_models.py
@@ -21,10 +21,12 @@ from weblate.vcs.github import (
     GitHubAppNotConfiguredError,
     GithubAppRepository,
     GitHubInstallation,
+    InstallationRemoval,
     exchange_github_app_manifest_code,
     get_installation_token,
     normalize_github_callback_code,
     normalize_github_installation_id,
+    remove_github_installation,
 )
 from weblate.vcs.tests.utils import generate_private_key
 from weblate.workspaces.models import Workspace
@@ -166,6 +168,47 @@ class TestGitHubInstallationManager(TestCase):
         self.assertEqual(
             GitHubInstallation.objects.get_for_installation("github.com", "67890"),
             self.installation,
+        )
+
+    def test_installation_id_is_normalized_on_save(self):
+        installation = _make_installation(installation_id=" 0067891 ")
+        self.assertEqual(installation.installation_id, "67891")
+
+    @patch("weblate.vcs.github.report_error")
+    def test_remove_installation_with_broken_private_key(self, report_error):
+        """Unusable credentials must not make the connection undeletable."""
+        _make_credentials(private_key="not a pem block")
+        installation = _make_installation(installation_id="13579")
+
+        self.assertEqual(
+            remove_github_installation(installation),
+            InstallationRemoval.UNREACHABLE,
+        )
+        self.assertFalse(GitHubInstallation.objects.filter(pk=installation.pk).exists())
+        report_error.assert_called_once()
+
+    def test_installation_id_is_validated_on_save(self):
+        with self.assertRaises(ValueError):
+            _make_installation(installation_id="67890/access_tokens")
+
+    def test_filter_for_installation_normalizes_id(self):
+        # Any spelling of the ID has to find the same row
+        for installation_id in ("67890", " 0067890 ", 67890):
+            with self.subTest(installation_id=installation_id):
+                self.assertEqual(
+                    list(
+                        GitHubInstallation.objects.filter_for_installation(
+                            "api.github.com", installation_id
+                        )
+                    ),
+                    [self.installation],
+                )
+
+    def test_filter_for_installation_ignores_invalid_id(self):
+        self.assertFalse(
+            GitHubInstallation.objects.filter_for_installation(
+                "github.com", "not-an-id"
+            ).exists()
         )
 
     def test_normalize_installation_id(self):
@@ -379,8 +422,11 @@ class TestGitHubInstallationManager(TestCase):
         self,
     ):
         _make_credentials()
-        self.installation.installation_id = "67890/access_tokens"
-        self.installation.save(update_fields=["installation_id"])
+        # Saving normalizes the ID, plant the malformed value directly
+        GitHubInstallation.objects.filter(pk=self.installation.pk).update(
+            installation_id="67890/access_tokens"
+        )
+        self.installation.refresh_from_db()
         repository = self._make_app_repository()
 
         with self.assertRaisesRegex(

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 from datetime import timedelta
 from typing import cast
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from asgiref.sync import async_to_sync
@@ -231,6 +232,7 @@ class GitHubInstallationViewTest(ViewTestCase):
             f'id="remove-github-account-{installation.pk}"',
         )
         self.assertContains(response, "Remove connected account?")
+        self.assertContains(response, "will also be uninstalled from GitHub")
         self.assertContains(
             response,
             f'action="{reverse("manage-github-account-remove", kwargs={"pk": installation.pk})}"',
@@ -1093,6 +1095,26 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertContains(response, "test-org/repo1")
         self.assertNotContains(response, "stale-org/repo2")
 
+    def test_installation_detail_warns_about_affected_components(self):
+        repo = _repo_entry("test-org/repo1")
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[repo],
+        )
+        self.component.vcs = "github-app"
+        self.component.repo = "https://github.com/test-org/repo1.git"
+        self.component.save(update_fields=["vcs", "repo"])
+
+        response = self.client.get(
+            reverse("manage-github-account-detail", kwargs={"pk": installation.pk})
+        )
+
+        self.assertContains(response, "will lose access to its repository")
+        self.assertContains(response, str(self.component))
+
     def test_installation_detail_hides_import_link_when_disabled(self):
         repo = _repo_entry("test-org/repo1")
         installation = GitHubInstallation.objects.create(
@@ -1319,12 +1341,18 @@ class GitHubInstallationViewTest(ViewTestCase):
 
         self.assertEqual(response.status_code, 405)
 
+    @http_mock.activate
     def test_remove_installation(self):
         installation = GitHubInstallation.objects.create(
             installation_id="12345",
             target_type="Organization",
             target_login="test-org",
             workspace=self.workspace,
+        )
+        http_mock.register(
+            "DELETE",
+            "https://api.github.com/app/installations/12345",
+            status_code=202,
         )
 
         self.async_client.force_login(self.user)
@@ -1338,6 +1366,182 @@ class GitHubInstallationViewTest(ViewTestCase):
             fetch_redirect_response=False,
         )
         self.assertFalse(GitHubInstallation.objects.filter(pk=installation.pk).exists())
+        self.assertEqual(
+            [(call.request.method, call.request.url) for call in http_mock.calls],
+            [("DELETE", "https://api.github.com/app/installations/12345")],
+        )
+        response_messages = [
+            str(message) for message in get_messages(response.asgi_request)
+        ]
+        self.assertEqual(len(response_messages), 1)
+        self.assertIn("uninstalled the Weblate GitHub App", response_messages[0])
+
+    @http_mock.activate
+    def test_remove_installation_accepts_missing_github_installation(self):
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+        )
+        http_mock.register(
+            "DELETE",
+            "https://api.github.com/app/installations/12345",
+            status_code=404,
+        )
+
+        self.async_client.force_login(self.user)
+        response = async_to_sync(self.async_client.post)(
+            reverse("manage-github-account-remove", kwargs={"pk": installation.pk}),
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("manage-github-accounts"),
+            fetch_redirect_response=False,
+        )
+        self.assertFalse(GitHubInstallation.objects.filter(pk=installation.pk).exists())
+
+    @http_mock.activate
+    def test_remove_installation_keeps_row_when_github_uninstall_fails(self):
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+        )
+        http_mock.register(
+            "DELETE",
+            "https://api.github.com/app/installations/12345",
+            status_code=500,
+        )
+
+        self.async_client.force_login(self.user)
+        with patch("weblate.vcs.github.report_error") as report_error:
+            response = async_to_sync(self.async_client.post)(
+                reverse("manage-github-account-remove", kwargs={"pk": installation.pk}),
+            )
+
+        self.assertRedirects(
+            response,
+            reverse("manage-github-accounts"),
+            fetch_redirect_response=False,
+        )
+        self.assertTrue(GitHubInstallation.objects.filter(pk=installation.pk).exists())
+        report_error.assert_called_once()
+        self.assertEqual(
+            report_error.call_args.args,
+            ("Failed to uninstall connected GitHub account",),
+        )
+        self.assertIsInstance(report_error.call_args.kwargs["exception"], BaseException)
+        response_messages = [
+            str(message) for message in get_messages(response.asgi_request)
+        ]
+        self.assertEqual(len(response_messages), 1)
+        self.assertIn("connection was not removed", response_messages[0])
+
+    @http_mock.activate
+    def test_remove_installation_accepts_unauthorized_github_app(self):
+        """A deleted or suspended app must not block removing the connection."""
+        for status_code in (401, 403, 410):
+            with self.subTest(status_code=status_code):
+                installation = GitHubInstallation.objects.create(
+                    installation_id="12345",
+                    target_type="Organization",
+                    target_login="test-org",
+                    workspace=self.workspace,
+                )
+                http_mock.reset()
+                http_mock.register(
+                    "DELETE",
+                    "https://api.github.com/app/installations/12345",
+                    status_code=status_code,
+                )
+
+                self.async_client.force_login(self.user)
+                response = async_to_sync(self.async_client.post)(
+                    reverse(
+                        "manage-github-account-remove", kwargs={"pk": installation.pk}
+                    ),
+                )
+
+                self.assertRedirects(
+                    response,
+                    reverse("manage-github-accounts"),
+                    fetch_redirect_response=False,
+                )
+                self.assertFalse(
+                    GitHubInstallation.objects.filter(pk=installation.pk).exists()
+                )
+                response_messages = [
+                    str(message) for message in get_messages(response.asgi_request)
+                ]
+                self.assertIn("remove it there manually", response_messages[-1])
+
+    @http_mock.activate
+    def test_remove_installation_without_app_credentials(self):
+        """Removal must work even once the app credentials are gone."""
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+        )
+        GitHubAppCredentials.objects.all().delete()
+
+        self.async_client.force_login(self.user)
+        response = async_to_sync(self.async_client.post)(
+            reverse("manage-github-account-remove", kwargs={"pk": installation.pk}),
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("manage-github-accounts"),
+            fetch_redirect_response=False,
+        )
+        self.assertFalse(GitHubInstallation.objects.filter(pk=installation.pk).exists())
+        self.assertEqual(len(http_mock.calls), 0)
+        response_messages = [
+            str(message) for message in get_messages(response.asgi_request)
+        ]
+        self.assertEqual(len(response_messages), 1)
+        self.assertIn("remove it there manually", response_messages[0])
+
+    @http_mock.activate
+    def test_remove_installation_keeps_shared_github_installation(self):
+        installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+        )
+        other_installation = GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=Workspace.objects.create(name="Other GitHub Workspace"),
+        )
+
+        self.async_client.force_login(self.user)
+        response = async_to_sync(self.async_client.post)(
+            reverse("manage-github-account-remove", kwargs={"pk": installation.pk}),
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("manage-github-accounts"),
+            fetch_redirect_response=False,
+        )
+        self.assertFalse(GitHubInstallation.objects.filter(pk=installation.pk).exists())
+        self.assertTrue(
+            GitHubInstallation.objects.filter(pk=other_installation.pk).exists()
+        )
+        self.assertEqual(len(http_mock.calls), 0)
+        response_messages = [
+            str(message) for message in get_messages(response.asgi_request)
+        ]
+        self.assertEqual(len(response_messages), 1)
+        self.assertIn("another workspace still uses it", response_messages[0])
 
     def test_remove_installation_rejects_get(self):
         installation = GitHubInstallation.objects.create(

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -13,8 +13,9 @@ from urllib.parse import parse_qs, urlencode, urlparse
 from asgiref.sync import async_to_sync
 from django.contrib.messages import get_messages
 from django.core.cache import cache
+from django.db import connection
 from django.test import TestCase
-from django.test.utils import override_settings
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -1115,6 +1116,44 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertContains(response, "will lose access to its repository")
         self.assertContains(response, str(self.component))
 
+    def test_account_list_prefetches_affected_components(self):
+        """Rendering many removal modals must not query components per row."""
+        repo = _repo_entry("test-org/repo1")
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[repo],
+        )
+        for index in range(3):
+            GitHubInstallation.objects.create(
+                installation_id=f"5432{index}",
+                target_type="Organization",
+                target_login=f"other-org-{index}",
+                workspace=Workspace.objects.create(name=f"Workspace {index}"),
+                repositories=[repo],
+            )
+        self.component.vcs = "github-app"
+        self.component.repo = "https://github.com/test-org/repo1.git"
+        self.component.save(update_fields=["vcs", "repo"])
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(reverse("account-vcs"))
+
+        self.assertContains(response, "will lose access to its repository")
+        self.assertContains(response, str(self.component))
+        self.assertEqual(
+            len(
+                [
+                    query
+                    for query in queries.captured_queries
+                    if "trans_component" in query["sql"]
+                ]
+            ),
+            1,
+        )
+
     def test_installation_detail_hides_import_link_when_disabled(self):
         repo = _repo_entry("test-org/repo1")
         installation = GitHubInstallation.objects.create(
@@ -1476,7 +1515,10 @@ class GitHubInstallationViewTest(ViewTestCase):
                 response_messages = [
                     str(message) for message in get_messages(response.asgi_request)
                 ]
-                self.assertIn("remove it there manually", response_messages[-1])
+                self.assertIn(
+                    "no longer grants access to this installation",
+                    response_messages[-1],
+                )
 
     @http_mock.activate
     def test_remove_installation_without_app_credentials(self):
@@ -1505,7 +1547,9 @@ class GitHubInstallationViewTest(ViewTestCase):
             str(message) for message in get_messages(response.asgi_request)
         ]
         self.assertEqual(len(response_messages), 1)
-        self.assertIn("remove it there manually", response_messages[0])
+        self.assertIn(
+            "no longer configured on this Weblate instance", response_messages[0]
+        )
 
     @http_mock.activate
     def test_remove_installation_keeps_shared_github_installation(self):

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -454,6 +454,12 @@ class UserVCSIntegrationListView(View):
             for installation in installations
             if _user_can_manage_installation(request.user, installation)
         }
+        # Only manageable installations render the removal confirmation
+        GitHubInstallation.objects.prefetch_components(
+            installation
+            for installation in installations
+            if installation.pk in manageable_installations
+        )
         installations_by_host: defaultdict[str, list[GitHubInstallation]] = defaultdict(
             list
         )
@@ -578,13 +584,23 @@ async def remove_installation(request, pk):
             )
             % {"target": target},
         )
+    elif result == InstallationRemoval.UNREACHABLE:
+        messages.warning(
+            request,
+            gettext(
+                "Removed connected GitHub account %(target)s. GitHub no longer "
+                "grants access to this installation, so it was not uninstalled. "
+                "Check on GitHub whether the Weblate GitHub App is still installed."
+            )
+            % {"target": target},
+        )
     else:
         messages.warning(
             request,
             gettext(
                 "Removed connected GitHub account %(target)s. The Weblate GitHub "
-                "App could not be uninstalled from GitHub, please remove it "
-                "there manually."
+                "App is no longer configured on this Weblate instance, so it "
+                "could not be uninstalled, please remove it on GitHub manually."
             )
             % {"target": target},
         )
@@ -988,6 +1004,12 @@ def github_app_repository_list(request):
         for installation in installations
         if _user_can_manage_installation(request.user, installation)
     }
+    # Only manageable installations render the removal confirmation
+    GitHubInstallation.objects.prefetch_components(
+        installation
+        for installation in installations
+        if installation.pk in manageable_installations
+    )
     all_repos = []
     for installation in installations:
         for repo in installation.repositories:

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -47,6 +47,7 @@ from weblate.vcs.github import (
     GITHUB_APP_NAME_MAX_LENGTH,
     GitHubAppCredentials,
     GitHubInstallation,
+    InstallationRemoval,
     aget_github_app_configurations,
     aget_github_app_settings,
     build_github_app_manifest,
@@ -60,6 +61,7 @@ from weblate.vcs.github import (
     get_user_admin_installation,
     github_app_is_configured,
     normalize_github_app_hostname,
+    remove_github_installation,
 )
 from weblate.vcs.permissions import (
     github_app_installation_workspaces,
@@ -549,11 +551,43 @@ async def remove_installation(request, pk):
         ),
     )
     target = str(installation)
-    await installation.adelete()
-    messages.success(
-        request,
-        gettext("Removed connected GitHub account %(target)s.") % {"target": target},
-    )
+    result = await sync_to_async(remove_github_installation)(installation)
+    if result == InstallationRemoval.FAILED:
+        messages.error(
+            request,
+            gettext(
+                "GitHub could not uninstall the connected account. "
+                "The connection was not removed from Weblate, please try again."
+            ),
+        )
+    elif result == InstallationRemoval.SHARED:
+        messages.success(
+            request,
+            gettext(
+                "Removed connected GitHub account %(target)s. The Weblate GitHub "
+                "App remains installed because another workspace still uses it."
+            )
+            % {"target": target},
+        )
+    elif result == InstallationRemoval.UNINSTALLED:
+        messages.success(
+            request,
+            gettext(
+                "Removed connected GitHub account %(target)s and uninstalled "
+                "the Weblate GitHub App from GitHub."
+            )
+            % {"target": target},
+        )
+    else:
+        messages.warning(
+            request,
+            gettext(
+                "Removed connected GitHub account %(target)s. The Weblate GitHub "
+                "App could not be uninstalled from GitHub, please remove it "
+                "there manually."
+            )
+            % {"target": target},
+        )
     return redirect(next_url)
 
 
@@ -594,9 +628,9 @@ async def refresh_repositories(request, pk):
     )
     try:
         repos = await installation.refresh_repositories()
-    except Exception:
+    except Exception as error:
         await sync_to_async(report_error)(
-            "Failed to refresh connected GitHub account repositories"
+            "Failed to refresh connected GitHub account repositories", exception=error
         )
         messages.error(
             request,
@@ -686,9 +720,9 @@ async def _get_authorized_installation(
     try:
         user_token = await exchange_github_user_code(config, code)
         return await get_user_admin_installation(config, user_token, installation_id)
-    except Exception:
+    except Exception as error:
         await sync_to_async(report_error)(
-            "Failed to verify GitHub installation ownership"
+            "Failed to verify GitHub installation ownership", exception=error
         )
         return None
 
@@ -875,9 +909,9 @@ async def github_app_setup(request):
             config.hostname, installation_id, workspace
         )
         is_new_install = is_new_install or synced_is_new_install
-    except Exception:
+    except Exception as error:
         await sync_to_async(report_error)(
-            "Failed to connect GitHub account to workspace"
+            "Failed to connect GitHub account to workspace", exception=error
         )
         messages.warning(
             request,
@@ -891,9 +925,9 @@ async def github_app_setup(request):
 
     try:
         await installation.refresh_repositories()
-    except Exception:
+    except Exception as error:
         await sync_to_async(report_error)(
-            "Failed to refresh connected GitHub account repositories"
+            "Failed to refresh connected GitHub account repositories", exception=error
         )
         messages.warning(
             request,
@@ -1308,8 +1342,10 @@ async def github_app_register_callback(request):
 
     try:
         data = await exchange_github_app_manifest_code(code, hostname)
-    except Exception:
-        await sync_to_async(report_error)("Failed to exchange GitHub App manifest code")
+    except Exception as error:
+        await sync_to_async(report_error)(
+            "Failed to exchange GitHub App manifest code", exception=error
+        )
         messages.error(
             request,
             gettext(

--- a/weblate/workspaces/tests.py
+++ b/weblate/workspaces/tests.py
@@ -29,7 +29,10 @@ from weblate.trans.tests.utils import (
     create_test_billing,
     create_test_user,
 )
+from weblate.utils.tests import http_mock
 from weblate.utils.views import UnsupportedPathObjectError, parse_path
+from weblate.vcs.github import GitHubAppCredentials, GitHubInstallation
+from weblate.vcs.tests.utils import generate_private_key
 from weblate.workspaces.admin import WorkspaceAdmin
 from weblate.workspaces.models import WORKSPACE_PROJECT_CREATORS_GROUP, Workspace
 
@@ -349,6 +352,79 @@ class WorkspaceViewTest(BaseTestCase):
         self.assertIsNone(moved_project_change.workspace_id)
         self.assertEqual(moved_project_change.project_id, moved_project.pk)
         self.assertFalse(Change.objects.filter(pk=workspace_change.pk).exists())
+
+    @http_mock.activate
+    def test_workspace_removal_uninstalls_github_app(self) -> None:
+        """Cascading the installation away must not orphan the app on GitHub."""
+        user = create_test_user()
+        workspace = Workspace.objects.create(name="GitHub removal workspace")
+        workspace.add_owner(user)
+        GitHubAppCredentials.objects.create(
+            hostname="github.com",
+            app_id="99999",
+            app_slug="weblate-app",
+            private_key=generate_private_key(),
+            webhook_secret="secret",
+            client_id="Iv1.testclientid",
+            client_secret="client-secret",
+        )
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=workspace,
+        )
+        http_mock.register(
+            "DELETE",
+            "https://api.github.com/app/installations/12345",
+            status_code=204,
+        )
+        remove_url = reverse("workspace-remove", kwargs={"pk": workspace.pk})
+
+        self.client.login(username=user.username, password="testpassword")
+        response = self.client.post(remove_url, {"confirm": workspace.name})
+
+        self.assertRedirects(response, reverse("home"), fetch_redirect_response=False)
+        self.assertFalse(Workspace.objects.filter(pk=workspace.pk).exists())
+        self.assertEqual(
+            [(call.request.method, call.request.url) for call in http_mock.calls],
+            [("DELETE", "https://api.github.com/app/installations/12345")],
+        )
+
+    @http_mock.activate
+    def test_workspace_removal_survives_github_failure(self) -> None:
+        """A GitHub outage must not block removing the workspace."""
+        user = create_test_user()
+        workspace = Workspace.objects.create(name="GitHub failure workspace")
+        workspace.add_owner(user)
+        GitHubAppCredentials.objects.create(
+            hostname="github.com",
+            app_id="99999",
+            app_slug="weblate-app",
+            private_key=generate_private_key(),
+            webhook_secret="secret",
+            client_id="Iv1.testclientid",
+            client_secret="client-secret",
+        )
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=workspace,
+        )
+        http_mock.register(
+            "DELETE",
+            "https://api.github.com/app/installations/12345",
+            status_code=500,
+        )
+        remove_url = reverse("workspace-remove", kwargs={"pk": workspace.pk})
+
+        self.client.login(username=user.username, password="testpassword")
+        with patch("weblate.vcs.github.report_error"):
+            response = self.client.post(remove_url, {"confirm": workspace.name})
+
+        self.assertRedirects(response, reverse("home"), fetch_redirect_response=False)
+        self.assertFalse(Workspace.objects.filter(pk=workspace.pk).exists())
 
     def test_workspace_removal_requires_matching_name(self) -> None:
         user = create_test_user()

--- a/weblate/workspaces/views.py
+++ b/weblate/workspaces/views.py
@@ -32,6 +32,7 @@ from weblate.trans.views.reports import get_reports_context
 from weblate.utils import messages
 from weblate.utils.stats import prefetch_stats
 from weblate.utils.views import get_paginator, show_form_errors
+from weblate.vcs.github import GitHubInstallation, remove_github_installation
 from weblate.workspaces.forms import WorkspaceDeleteForm, WorkspaceSearchForm
 from weblate.workspaces.models import Workspace
 
@@ -333,6 +334,10 @@ def remove(request: AuthenticatedHttpRequest, pk) -> HttpResponse:
     if not form.is_valid():
         show_form_errors(request, form)
         return redirect(f"{workspace.get_absolute_url()}#organize")
+
+    # Installations cascade with the workspace, uninstall the App first
+    for installation in GitHubInstallation.objects.filter(workspace=workspace):
+        remove_github_installation(installation, best_effort=True)
 
     try:
         workspace.delete()


### PR DESCRIPTION
Uninstall the GitHub App through its authenticated installation API when the final Weblate workspace connection is removed, including when that connection goes away together with its workspace. Decide whether the connection is the last one under a row lock so that two workspaces removing it at once cannot both leave the App installed.

Keep shared installations active, and remove the connection even when GitHub no longer knows the installation or no longer accepts the App credentials, as there is nothing left to uninstall and keeping it would make the connection impossible to remove. Preserve it only when GitHub could not be reached at all, so that the removal can be retried.

Warn about the components that lose access to their repositories before confirming the removal.