### PR TITLE
feat(vcs): migrate components to GitHub App

### DIFF
--- a/docs/admin/code-hosting.rst
+++ b/docs/admin/code-hosting.rst
@@ -342,6 +342,23 @@ Components imported through the GitHub App flow use the dedicated
 settings UI keeps the repository URL read-only to prevent the App-issued
 credentials from being redirected to an unrelated repository.
 
+.. _code-hosting-github-app-migrate:
+
+Migrating existing components
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Weblate reports an informational diagnostic for Git and GitHub pull request
+components that can be migrated to a registered Weblate GitHub App. Follow
+the :guilabel:`Migrate to GitHub App` link from the diagnostic to review all
+eligible components in the workspace.
+
+Connect or update the GitHub account for the workspace, grant the App access
+to the listed repositories, and select the components to migrate. Weblate
+changes the selected components to the
+:guilabel:`GitHub (via Weblate GitHub app)` VCS backend, replaces their
+repository addresses with canonical HTTPS clone URLs, and removes separate
+push URLs because the App authenticates pushes to the source repository.
+
 .. _code-hosting-github-app-webhook:
 
 App webhook URL

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Weblate 2026.9
 
 * :ref:`addon-weblate.discovery.discovery` can optionally create components from a monolingual base or new base file when no translation files exist yet.
 * Added :ref:`vcs_params` to configure repository behavior per component, including force pushing, opting out of pull requests, and GitHub pull request automerge.
+* Added :ref:`code-hosting-github-app-migrate` for migrating existing Git and GitHub components to the Weblate GitHub App integration.
 
 .. rubric:: Improvements
 

--- a/weblate/templates/trans/alert/githubappmigration.html
+++ b/weblate/templates/trans/alert/githubappmigration.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+<p>{% translate "This component can use the Weblate GitHub App for repository access and pull requests." %}</p>
+
+{% if migration_url %}
+  <p>
+    <a class="btn btn-primary" href="{{ migration_url }}">{% translate "Migrate to GitHub App" %}</a>
+  </p>
+{% endif %}

--- a/weblate/templates/vcs/github_app_migration.html
+++ b/weblate/templates/vcs/github_app_migration.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+
+{% block breadcrumbs %}
+  <li class="breadcrumb-item">
+    <a href="{% url 'account-vcs' %}?workspace={{ workspace.pk }}">{% translate "Code-hosting integrations" %}</a>
+  </li>
+  <li class="breadcrumb-item">{% translate "Migrate to GitHub App" %}</li>
+{% endblock breadcrumbs %}
+
+{% block content %}
+
+  <div class="card">
+    <div class="card-header">
+      <h4 class="card-title">
+        {% blocktranslate with workspace_name=workspace.name %}Migrate {{ workspace_name }} to the Weblate GitHub App{% endblocktranslate %}
+        {% if github_app_install_url %}
+          <a href="{{ github_app_install_url }}" class="btn btn-primary btn-sm float-end">{% translate "Connect or update GitHub account" %}</a>
+        {% endif %}
+      </h4>
+    </div>
+    <div class="card-body">
+      <p>
+        {% blocktranslate trimmed %}
+          Select existing Git or GitHub components to use the Weblate GitHub App. Their repository URLs will be replaced by canonical HTTPS URLs, and separate push URLs will be removed.
+        {% endblocktranslate %}
+      </p>
+
+      {% if required_accounts %}
+        <p class="text-body-secondary">
+          {% blocktranslate trimmed with accounts=required_accounts|join:", " %}
+            The GitHub App needs repository access for these accounts: {{ accounts }}.
+          {% endblocktranslate %}
+        </p>
+      {% endif %}
+
+      {% if installations %}
+        <p>{% translate "Connected GitHub accounts:" %}</p>
+        <ul class="list-inline">
+          {% for installation in installations %}
+            <li class="list-inline-item mb-2">
+              <span class="badge text-bg-secondary">{{ installation.target_login }} ({{ installation.hostname }})</span>
+              {% if installation.pk in manageable_installations %}
+                <form method="post"
+                      action="{% url 'manage-github-account-refresh' installation.pk %}"
+                      class="d-inline">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ next_url }}" />
+                  <button type="submit" class="btn btn-outline-primary btn-sm">{% translate "Refresh repositories" %}</button>
+                </form>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+
+      {% if available_entries %}
+        <form method="post">
+          {% csrf_token %}
+          {{ form.non_field_errors }}
+          {{ form.components.errors }}
+          <fieldset>
+            <legend class="h5">{{ form.components.label }}</legend>
+            {% for checkbox in form.components %}
+              <div class="form-check mb-2">
+                {{ checkbox.tag }}
+                <label class="form-check-label" for="{{ checkbox.id_for_label }}">{{ checkbox.choice_label }}</label>
+              </div>
+            {% endfor %}
+          </fieldset>
+          <button type="submit" class="btn btn-primary">{% translate "Migrate selected components" %}</button>
+        </form>
+      {% endif %}
+
+      {% if unavailable_entries %}
+        <div class="alert alert-info" role="status">
+          {% if github_app_install_url %}
+            {% if available_entries %}
+              {% translate "Connect or update the GitHub App to grant access to the remaining repositories." %}
+            {% else %}
+              {% translate "Connect the GitHub App to the listed accounts and grant access to their repositories before migrating." %}
+            {% endif %}
+          {% else %}
+            {% translate "A workspace owner needs to connect the GitHub App and grant access to these repositories before they can be migrated." %}
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {% if entries %}
+        <h5>{% translate "Migration status" %}</h5>
+        <div class="table-responsive">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>{% translate "Component" %}</th>
+                <th>{% translate "Repository" %}</th>
+                <th>{% translate "Status" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in entries %}
+                <tr>
+                  <td>{{ entry.component.project.name }} / {{ entry.component.name }}</td>
+                  <td>{{ entry.full_name }}</td>
+                  <td>
+                    {% if entry.canonical_url %}
+                      <span class="badge text-bg-success">{% translate "Ready" %}</span>
+                    {% else %}
+                      <span class="badge text-bg-warning">{% translate "Repository access needed" %}</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="text-body-secondary">{% translate "There are no GitHub components in this workspace that can be migrated." %}</p>
+      {% endif %}
+    </div>
+  </div>
+
+{% endblock content %}

--- a/weblate/trans/alerts/vcs.py
+++ b/weblate/trans/alerts/vcs.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from django.urls import reverse
 from django.utils.translation import gettext, gettext_lazy
 
 from weblate.trans.alerts.base import (
     AlertCategory,
+    AlertSeverity,
     BaseAlert,
     ErrorAlert,
 )
@@ -71,6 +73,72 @@ class RepositoryAlert(BaseAlert):
             user.has_perm(permission, component)
             for permission in cls.repository_permissions
         )
+
+
+@register
+class GitHubAppMigration(RepositoryAlert):
+    verbose = gettext_lazy(
+        "This component can be migrated to the Weblate GitHub App integration."
+    )
+    severity = AlertSeverity.INFO
+    dismissible = True
+    doc_page = "admin/code-hosting"
+    doc_anchor = "code-hosting-github-app-migrate"
+
+    @classmethod
+    def get_url(cls, component: Component) -> str:
+        if component.project.workspace_id is None:
+            return ""
+        return reverse(
+            "github-app-migration",
+            kwargs={"workspace_id": component.project.workspace_id},
+        )
+
+    @classmethod
+    def get_dismissal_context(cls, component: Component, details: dict) -> dict:
+        return {
+            "details": details,
+            "repo": component.repo,
+            "vcs": component.vcs,
+            "workspace": str(component.project.workspace_id or ""),
+        }
+
+    @classmethod
+    def check_component(cls, component: Component) -> bool:
+        # Imports stay local because alerts are loaded while Django initializes
+        # the VCS registry and model modules.
+        from weblate.vcs.github import (  # ruff: ignore[import-outside-top-level]
+            GITHUB_APP_MIGRATABLE_VCS,
+            get_github_repository_identity,
+            github_app_is_configured,
+        )
+
+        if (
+            component.vcs not in GITHUB_APP_MIGRATABLE_VCS
+            or component.project.workspace_id is None
+        ):
+            return False
+        identity = get_github_repository_identity(component.repo)
+        return identity is not None and github_app_is_configured(identity[0])
+
+    def get_context(self, user: User) -> dict[str, Any]:
+        # Imports stay local because alerts are loaded while Django initializes
+        # the VCS registry and model modules.
+        from weblate.vcs.permissions import (  # ruff: ignore[import-outside-top-level]
+            user_can_migrate_to_github_app,
+        )
+
+        result = super().get_context(user)
+        component = self.instance.component
+        # The migration view is workspace-scoped, so offering the link on the
+        # weaker component.edit permission behind can_user_act() would send some
+        # users to a page they cannot open.
+        result["migration_url"] = (
+            self.get_url(component)
+            if user_can_migrate_to_github_app(user, component.project.workspace_id)
+            else ""
+        )
+        return result
 
 
 class RepositoryErrorAlert(ErrorAlert):

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -47,6 +47,7 @@ from weblate.vcs.base import (
     RepositoryInternalError,
     RepositoryStructuredError,
 )
+from weblate.vcs.github import GitHubAppCredentials
 from weblate.vcs.models import VCS_REGISTRY
 from weblate.workspaces.models import Workspace
 
@@ -1225,6 +1226,90 @@ class AlertQueryPrefetchTest(ViewTestCase):
             alert_maps = [child.all_alerts for child in children]
 
         self.assertEqual(len(alert_maps), 2)
+
+
+class GitHubAppMigrationAlertTest(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.workspace = Workspace.objects.create(name="Migration alert")
+        self.project.workspace = self.workspace
+        self.project.save(update_fields=["workspace"])
+        GitHubAppCredentials.objects.create(
+            hostname="github.com",
+            app_id="123",
+            app_slug="weblate",
+            private_key="test",
+            client_id="client",
+            client_secret="secret",
+            webhook_secret="webhook",
+        )
+
+    def test_migration_alert_lifecycle(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="git",
+            repo="git@github.com:WeblateOrg/weblate.git",
+        )
+        self.component.refresh_from_db()
+
+        update_alerts(self.component, {"GitHubAppMigration"})
+
+        alert = self.component.alert_set.get(name="GitHubAppMigration")
+        self.assertEqual(alert.severity, AlertSeverity.INFO)
+        self.assertTrue(alert.obj.dismissible)
+        self.assertEqual(
+            alert.obj.get_url(self.component),
+            reverse(
+                "github-app-migration",
+                kwargs={"workspace_id": self.workspace.pk},
+            ),
+        )
+
+        self.component.vcs = "github-app"
+        update_alerts(self.component, {"GitHubAppMigration"})
+        self.assertFalse(
+            self.component.alert_set.filter(name="GitHubAppMigration").exists()
+        )
+
+    def test_migration_alert_requires_workspace_and_configured_host(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="github",
+            repo="https://github.example.com/WeblateOrg/weblate.git",
+        )
+        self.component.refresh_from_db()
+
+        update_alerts(self.component, {"GitHubAppMigration"})
+
+        self.assertFalse(
+            self.component.alert_set.filter(name="GitHubAppMigration").exists()
+        )
+
+    def test_migration_alert_link_needs_workspace_access(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="git",
+            repo="git@github.com:WeblateOrg/weblate.git",
+        )
+        self.component.refresh_from_db()
+        update_alerts(self.component, {"GitHubAppMigration"})
+        alert = self.component.alert_set.get(name="GitHubAppMigration")
+
+        # Editing the component is not enough; the migration view is scoped to
+        # the workspace.
+        role = Role.objects.create(name="Component editor")
+        role.permissions.add(Permission.objects.get(codename="component.edit"))
+        group = Group.objects.create(name="Component editors")
+        group.roles.add(role)
+        group.projects.add(self.project)
+        self.anotheruser.groups.add(group)
+        self.assertTrue(
+            self.anotheruser.has_perm("component.edit", self.component),
+        )
+        self.assertEqual(alert.obj.get_context(self.anotheruser)["migration_url"], "")
+
+        self.make_manager()
+        self.assertEqual(
+            alert.obj.get_context(self.user)["migration_url"],
+            alert.obj.get_url(self.component),
+        )
 
 
 @override_settings(

--- a/weblate/vcs/forms.py
+++ b/weblate/vcs/forms.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
 from crispy_forms.helper import FormHelper
@@ -17,6 +18,9 @@ from weblate.vcs.github import (
     GITHUB_APP_NAME_MAX_LENGTH,
     normalize_github_app_hostname,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def clean_github_app_hostname(value: str) -> str:
@@ -50,6 +54,26 @@ class GitHubAppSetupCallbackForm(forms.Form):
 
     def clean_installation_id(self) -> str:
         return str(self.cleaned_data["installation_id"])
+
+
+class GitHubAppMigrationForm(forms.Form):
+    components = forms.MultipleChoiceField(
+        label=gettext_lazy("Components to migrate"),
+        widget=forms.CheckboxSelectMultiple(attrs={"class": "form-check-input"}),
+        error_messages={
+            "required": gettext_lazy("Select at least one component to migrate."),
+        },
+    )
+
+    def __init__(
+        self,
+        *args,
+        component_choices: Iterable[tuple[str, str]],
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        field = cast("forms.MultipleChoiceField", self.fields["components"])
+        field.choices = component_choices
 
 
 class GitHubAppRegisterCallbackForm(forms.Form):

--- a/weblate/vcs/github.py
+++ b/weblate/vcs/github.py
@@ -28,6 +28,13 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy
 
+from weblate.trans.hooks.repository import (
+    normalize_full_name,
+    parse_repo_url,
+    repo_connection,
+    repo_is_scp_like,
+    repo_path,
+)
 from weblate.utils.errors import report_error
 from weblate.utils.requests import async_fetch_url
 from weblate.vcs.base import RepositoryInternalError
@@ -74,6 +81,7 @@ GITHUB_APP_MANIFEST_EVENTS: tuple[str, ...] = (
 # GitHub rejects App names longer than this; mirror the limit on our side so
 # users see the constraint up front and the manifest is always accepted.
 GITHUB_APP_NAME_MAX_LENGTH = 34
+GITHUB_APP_MIGRATABLE_VCS: frozenset[str] = frozenset({"git", "github"})
 
 
 def normalize_github_app_hostname(hostname: str) -> str:
@@ -82,6 +90,74 @@ def normalize_github_app_hostname(hostname: str) -> str:
     if normalized == "api.github.com":
         return "github.com"
     return normalized
+
+
+def get_github_repository_full_name(full_name: str | None) -> str | None:
+    """
+    Normalize an ``owner/repository`` pair usable in a GitHub repository URL.
+
+    GitHub full names are always exactly two path segments and the segments are
+    interpolated into clone URLs, so relative path segments are rejected here
+    rather than at each call site.
+    """
+    normalized = normalize_full_name(full_name)
+    if normalized is None or normalized.count("/") != 1:
+        return None
+    if any(part in {".", ".."} for part in normalized.split("/")):
+        return None
+    return normalized
+
+
+def get_github_repository_identity(repository: str) -> tuple[str, str] | None:
+    """Return the normalized host and full name for a GitHub repository URL."""
+    parsed = parse_repo_url(repository)
+    if parsed is None or (
+        parsed.hostname is not None
+        and parsed.scheme not in {"git", "http", "https", "ssh"}
+    ):
+        return None
+    if parsed.hostname is None and not repo_is_scp_like(repository):
+        return None
+    hostname, _username, _port, _is_ssh_url = repo_connection(repository)
+    full_name = get_github_repository_full_name(repo_path(repository))
+    if hostname is None or full_name is None:
+        return None
+    return normalize_github_app_hostname(hostname), full_name
+
+
+def get_github_repository_clone_url(hostname: str, repository: dict) -> str | None:
+    """Return a validated canonical HTTPS clone URL from cached GitHub data."""
+    hostname = normalize_github_app_hostname(hostname)
+    full_name = get_github_repository_full_name(repository.get("full_name"))
+    if full_name is None:
+        return None
+
+    clone_url = repository.get("clone_url")
+    if isinstance(clone_url, str):
+        parsed = urlparse(clone_url)
+        identity = get_github_repository_identity(clone_url)
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        valid_clone_url = (
+            parsed.scheme == "https"
+            and parsed.username is None
+            and parsed.password is None
+            and port is None
+            and not parsed.params
+            and not parsed.query
+            and not parsed.fragment
+        )
+        matching_identity = (
+            identity is not None
+            and identity[0] == hostname
+            and identity[1] == full_name
+        )
+        if valid_clone_url and matching_identity:
+            return clone_url
+
+    return f"https://{hostname}/{full_name}.git"
 
 
 def normalize_github_callback_code(code: str) -> str:
@@ -130,24 +206,12 @@ def get_github_app_configurations() -> dict[str, GitHubAppCredentials]:
     database (:class:`GitHubAppCredentials`); there is no settings-based
     configuration.
     """
-    try:
-        rows = list(GitHubAppCredentials.objects.all())
-    except Exception:
-        # Database may not be migrated yet (e.g. during initial setup or
-        # when this is called outside a request).
-        return {}
-    return {row.hostname: row for row in rows}
+    return {row.hostname: row for row in GitHubAppCredentials.objects.all()}
 
 
 async def aget_github_app_configurations() -> dict[str, GitHubAppCredentials]:
     """Asynchronously return configured GitHub apps keyed by hostname."""
-    try:
-        rows = [row async for row in GitHubAppCredentials.objects.all()]
-    except Exception:
-        # Database may not be migrated yet (e.g. during initial setup or
-        # when this is called outside a request).
-        return {}
-    return {row.hostname: row for row in rows}
+    return {row.hostname: row async for row in GitHubAppCredentials.objects.all()}
 
 
 def get_github_app_settings(hostname: str | None = None) -> GitHubAppCredentials | None:
@@ -173,10 +237,16 @@ async def aget_github_app_settings(
 
 
 def github_app_is_configured(hostname: str | None = None) -> bool:
-    """Return whether the Weblate GitHub app is configured for installs on the host."""
+    """
+    Return whether the Weblate GitHub app is configured for installs on the host.
+
+    Alert checks ask this once per component, so this deliberately avoids
+    loading the credentials (private keys included) just to test for presence.
+    """
+    queryset = GitHubAppCredentials.objects.all()
     if hostname is not None:
-        return get_github_app_settings(hostname) is not None
-    return bool(get_github_app_configurations())
+        queryset = queryset.filter(hostname=normalize_github_app_hostname(hostname))
+    return queryset.exists()
 
 
 def get_github_app_install_url(state: str, hostname: str | None = None) -> str:

--- a/weblate/vcs/permissions.py
+++ b/weblate/vcs/permissions.py
@@ -13,6 +13,26 @@ if TYPE_CHECKING:
     from weblate.auth.results import PermissionResult
 
 
+def managed_workspaces(user: User):
+    """Return workspaces the user can manage."""
+    return (
+        Workspace.objects.filter(projects__in=user.managed_projects)
+        | user.workspaces_with_perm("workspace.edit")
+    ).distinct()
+
+
+def user_can_migrate_to_github_app(user: User, workspace_id) -> bool:
+    """
+    Return whether the user may open the GitHub App migration for a workspace.
+
+    Kept next to the queryset backing the view so that the alert offering the
+    migration link never points at a workspace the user cannot manage.
+    """
+    if workspace_id is None:
+        return False
+    return managed_workspaces(user).filter(pk=workspace_id).exists()
+
+
 def github_app_installation_workspaces(user: User):
     """Return workspaces where the user can connect GitHub accounts."""
     if user.has_perm("management.use"):

--- a/weblate/vcs/tests/test_github_models.py
+++ b/weblate/vcs/tests/test_github_models.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from asgiref.sync import async_to_sync
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from weblate.trans.models import Component, Project
 from weblate.utils.tests import http_mock
@@ -23,6 +23,8 @@ from weblate.vcs.github import (
     GitHubInstallation,
     InstallationRemoval,
     exchange_github_app_manifest_code,
+    get_github_repository_clone_url,
+    get_github_repository_identity,
     get_installation_token,
     normalize_github_callback_code,
     normalize_github_installation_id,
@@ -32,6 +34,49 @@ from weblate.vcs.tests.utils import generate_private_key
 from weblate.workspaces.models import Workspace
 
 SETTINGS_PRIVATE_KEY = generate_private_key()
+
+
+class TestGitHubRepositoryURLs(SimpleTestCase):
+    def test_repository_identity(self) -> None:
+        for repository in (
+            "https://github.com/WeblateOrg/weblate.git",
+            "https://user:token@github.com/WeblateOrg/weblate.git",
+            "git@github.com:WeblateOrg/weblate.git",
+            "ssh://git@github.com/WeblateOrg/weblate.git",
+            "git://github.com/WeblateOrg/weblate",
+        ):
+            with self.subTest(repository=repository):
+                self.assertEqual(
+                    get_github_repository_identity(repository),
+                    ("github.com", "WeblateOrg/weblate"),
+                )
+
+        for repository in (
+            "file://github.com/WeblateOrg/weblate.git",
+            "ftp://github.com/WeblateOrg/weblate.git",
+            "local:",
+            "weblate://project/component",
+            "https://github.com/owner/repository/extra.git",
+            "https://github.com/../repository.git",
+        ):
+            with self.subTest(repository=repository):
+                self.assertIsNone(get_github_repository_identity(repository))
+
+    def test_clone_url_validation(self) -> None:
+        repository = {
+            "full_name": "WeblateOrg/weblate",
+            "clone_url": "https://github.com/WeblateOrg/weblate.git",
+        }
+        self.assertEqual(
+            get_github_repository_clone_url("github.com", repository),
+            repository["clone_url"],
+        )
+
+        repository["clone_url"] = "https://attacker.example/WeblateOrg/weblate.git"
+        self.assertEqual(
+            get_github_repository_clone_url("github.com", repository),
+            "https://github.com/WeblateOrg/weblate.git",
+        )
 
 
 def _make_credentials(

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from datetime import timedelta
 from typing import cast
 from unittest.mock import patch
@@ -14,13 +15,14 @@ from asgiref.sync import async_to_sync
 from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.db import connection
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from weblate.auth.models import Group, Permission, Role, User
-from weblate.trans.models import Project
+from weblate.trans.models import Component, Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.site import get_site_url
 from weblate.utils.tests import http_mock
@@ -28,6 +30,7 @@ from weblate.vcs.github import (
     GITHUB_APP_MANIFEST_EVENTS,
     GITHUB_APP_MANIFEST_PERMISSIONS,
     GitHubAppCredentials,
+    GithubAppRepository,
     GitHubInstallation,
 )
 from weblate.vcs.models import InstallationProvider, PendingInstallation
@@ -1602,6 +1605,197 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertEqual(response.status_code, 405)
         self.assertTrue(GitHubInstallation.objects.filter(pk=installation.pk).exists())
 
+    def test_migration_lists_components_and_install_url(self):
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="git",
+            repo="git@github.com:test-org/repo1.git",
+        )
+        self.component.refresh_from_db()
+        url = reverse(
+            "github-app-migration", kwargs={"workspace_id": self.workspace.pk}
+        )
+
+        response = self.client.get(url)
+
+        self.assertContains(response, "test-org/repo1")
+        self.assertContains(response, "Repository access needed")
+        install_url = response.context["github_app_install_url"]
+        self.assertTrue(install_url.startswith(reverse("github-app-install")))
+        install_query = parse_qs(urlparse(install_url).query)
+        self.assertEqual(install_query["workspace"], [str(self.workspace.pk)])
+        self.assertEqual(install_query["next"], [url])
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_migration_updates_selected_component(self):
+        repository = _repo_entry("test-org/repo1")
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[repository],
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="git",
+            repo="git@github.com:test-org/repo1.git",
+            push="git@github.com:weblate/repo1.git",
+            push_branch="translations",
+            vcs_params={
+                "git_force_push": True,
+                "create_merge_request": False,
+            },
+        )
+        self.component.refresh_from_db()
+        self.component.add_alert("GitHubAppMigration")
+        url = reverse(
+            "github-app-migration", kwargs={"workspace_id": self.workspace.pk}
+        )
+
+        response = self.client.post(url, {"components": [str(self.component.pk)]})
+
+        self.assertRedirects(response, url, fetch_redirect_response=False)
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.vcs, "github-app")
+        self.assertEqual(self.component.repo, repository["clone_url"])
+        self.assertEqual(self.component.push, "")
+        self.assertEqual(self.component.push_branch, "")
+        self.assertEqual(
+            self.component.vcs_params,
+            {"create_merge_request": False},
+        )
+        self.assertFalse(
+            self.component.alert_set.filter(name="GitHubAppMigration").exists()
+        )
+
+    def test_migration_rejects_unavailable_component(self):
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="github",
+            repo="https://github.com/test-org/repo1.git",
+        )
+        url = reverse(
+            "github-app-migration", kwargs={"workspace_id": self.workspace.pk}
+        )
+
+        response = self.client.post(url, {"components": [str(self.component.pk)]})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "Select a valid choice",
+            response.context["form"].errors["components"][0],
+        )
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.vcs, "github")
+
+    def test_migration_ignores_archived_repositories(self):
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[_repo_entry("test-org/repo1", archived=True)],
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="git",
+            repo="git@github.com:test-org/repo1.git",
+        )
+        url = reverse(
+            "github-app-migration", kwargs={"workspace_id": self.workspace.pk}
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.context["available_entries"], [])
+        self.assertEqual(len(response.context["unavailable_entries"]), 1)
+        self.assertContains(response, "Repository access needed")
+
+    def _migrate_with_concurrent_change(self, url, change):
+        """POST the migration form, applying ``change`` just before each lock."""
+        original_locked_for_update = Component.locked_for_update
+
+        @contextmanager
+        def locked_for_update(component, **kwargs):
+            change()
+            with original_locked_for_update(component, **kwargs) as locked:
+                yield locked
+
+        with patch.object(Component, "locked_for_update", locked_for_update):
+            return self.client.post(url, {"components": [str(self.component.pk)]})
+
+    def _setup_migratable_component(self):
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[_repo_entry("test-org/repo1")],
+        )
+        Component.objects.filter(pk=self.component.pk).update(
+            vcs="git",
+            repo="git@github.com:test-org/repo1.git",
+        )
+        return reverse(
+            "github-app-migration", kwargs={"workspace_id": self.workspace.pk}
+        )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_migration_skips_component_moved_out_of_workspace(self):
+        url = self._setup_migratable_component()
+
+        response = self._migrate_with_concurrent_change(
+            url,
+            lambda: Project.objects.filter(pk=self.project.pk).update(workspace=None),
+        )
+
+        self.assertRedirects(response, url, fetch_redirect_response=False)
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.vcs, "git")
+        response_messages = [
+            str(message) for message in get_messages(response.wsgi_request)
+        ]
+        self.assertEqual(len(response_messages), 1)
+        self.assertIn("no longer available", response_messages[0])
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_migration_skips_component_pointed_elsewhere(self):
+        url = self._setup_migratable_component()
+
+        response = self._migrate_with_concurrent_change(
+            url,
+            lambda: Component.objects.filter(pk=self.component.pk).update(
+                repo="git@github.com:test-org/other.git"
+            ),
+        )
+
+        self.assertRedirects(response, url, fetch_redirect_response=False)
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.vcs, "git")
+        response_messages = [
+            str(message) for message in get_messages(response.wsgi_request)
+        ]
+        self.assertEqual(len(response_messages), 1)
+        self.assertIn("no longer available", response_messages[0])
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_migration_reports_validation_error(self):
+        url = self._setup_migratable_component()
+
+        with patch.object(
+            GithubAppRepository,
+            "validate_component",
+            side_effect=ValidationError("Repository is not available."),
+        ):
+            response = self.client.post(url, {"components": [str(self.component.pk)]})
+
+        self.assertRedirects(response, url, fetch_redirect_response=False)
+        self.component.refresh_from_db()
+        self.assertEqual(self.component.vcs, "git")
+        response_messages = [
+            str(message) for message in get_messages(response.wsgi_request)
+        ]
+        self.assertEqual(len(response_messages), 1)
+        self.assertIn("Repository is not available.", response_messages[0])
+        self.assertIn(self.component.full_slug, response_messages[0])
+
 
 class GitHubAppAccessControlTest(ViewTestCase):
     """Permission checks for the GitHub App connect/import views."""
@@ -1707,6 +1901,18 @@ class GitHubAppAccessControlTest(ViewTestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertIn(reverse("login"), response["Location"])
+
+    def test_migration_requires_workspace_access(self):
+        self.client.login(username=self.other_user.username, password="testpassword")
+
+        response = self.client.get(
+            reverse(
+                "github-app-migration",
+                kwargs={"workspace_id": self.workspace.pk},
+            )
+        )
+
+        self.assertEqual(response.status_code, 403)
 
     def test_setup_requires_login(self):
         self.client.logout()

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -1666,7 +1666,10 @@ class GitHubInstallationViewTest(ViewTestCase):
             self.component.alert_set.filter(name="GitHubAppMigration").exists()
         )
 
-    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    @override_settings(
+        CELERY_TASK_ALWAYS_EAGER=False,
+        GITHUB_CREDENTIALS={"api.github.com": {"username": "test", "token": "token"}},
+    )
     def test_migration_preserves_github_create_merge_request(self):
         repository = _repo_entry("test-org/repo1")
         GitHubInstallation.objects.create(

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -33,7 +33,7 @@ from weblate.vcs.github import (
     GithubAppRepository,
     GitHubInstallation,
 )
-from weblate.vcs.models import InstallationProvider, PendingInstallation
+from weblate.vcs.models import VCS_REGISTRY, InstallationProvider, PendingInstallation
 from weblate.vcs.pending import PENDING_GITHUB_INSTALLATION_RETENTION
 from weblate.vcs.tests.utils import generate_private_key
 from weblate.workspaces.models import Workspace
@@ -1671,6 +1671,8 @@ class GitHubInstallationViewTest(ViewTestCase):
         GITHUB_CREDENTIALS={"api.github.com": {"username": "test", "token": "token"}},
     )
     def test_migration_preserves_github_create_merge_request(self):
+        VCS_REGISTRY.clear_cache()
+        self.addCleanup(VCS_REGISTRY.clear_cache)
         repository = _repo_entry("test-org/repo1")
         GitHubInstallation.objects.create(
             installation_id="12345",

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -14,8 +14,8 @@ from urllib.parse import parse_qs, urlencode, urlparse
 from asgiref.sync import async_to_sync
 from django.contrib.messages import get_messages
 from django.core.cache import cache
-from django.db import connection
 from django.core.exceptions import ValidationError
+from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
@@ -1642,7 +1642,6 @@ class GitHubInstallationViewTest(ViewTestCase):
             push_branch="translations",
             vcs_params={
                 "git_force_push": True,
-                "create_merge_request": False,
             },
         )
         self.component.refresh_from_db()
@@ -1666,6 +1665,40 @@ class GitHubInstallationViewTest(ViewTestCase):
         self.assertFalse(
             self.component.alert_set.filter(name="GitHubAppMigration").exists()
         )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_migration_preserves_github_create_merge_request(self):
+        repository = _repo_entry("test-org/repo1")
+        GitHubInstallation.objects.create(
+            installation_id="12345",
+            target_type="Organization",
+            target_login="test-org",
+            workspace=self.workspace,
+            repositories=[repository],
+        )
+        url = reverse(
+            "github-app-migration", kwargs={"workspace_id": self.workspace.pk}
+        )
+
+        for create_merge_request in (False, True):
+            with self.subTest(create_merge_request=create_merge_request):
+                Component.objects.filter(pk=self.component.pk).update(
+                    vcs="github",
+                    repo="https://github.com/test-org/repo1.git",
+                    vcs_params={"create_merge_request": create_merge_request},
+                )
+
+                response = self.client.post(
+                    url, {"components": [str(self.component.pk)]}
+                )
+
+                self.assertRedirects(response, url, fetch_redirect_response=False)
+                self.component.refresh_from_db()
+                self.assertEqual(self.component.vcs, "github-app")
+                self.assertEqual(
+                    self.component.vcs_params,
+                    {"create_merge_request": create_merge_request},
+                )
 
     def test_migration_rejects_unavailable_component(self):
         Component.objects.filter(pk=self.component.pk).update(

--- a/weblate/vcs/urls.py
+++ b/weblate/vcs/urls.py
@@ -10,6 +10,7 @@ from weblate.vcs.views import (
     UserVCSIntegrationListView,
     github_app_import_repository,
     github_app_install,
+    github_app_migration,
     github_app_register,
     github_app_register_callback,
     github_app_register_submit,
@@ -70,6 +71,11 @@ urlpatterns = [
         "create/component/github-app/",
         github_app_repository_list,
         name="github-app-repositories",
+    ),
+    path(
+        "accounts/integrations/github-app/migrate/<uuid:workspace_id>/",
+        github_app_migration,
+        name="github-app-migration",
     ),
     path(
         "create/component/github-app/<int:pk>/<path:repo_full_name>/",

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -9,7 +9,7 @@ import logging
 import secrets
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urlencode
 
 from asgiref.sync import sync_to_async
@@ -24,11 +24,11 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.text import slugify
-from django.utils.translation import gettext
+from django.utils.translation import gettext, ngettext
 from django.views import View
 
 from weblate.auth.decorators import management_access, management_permission_required
-from weblate.trans.models import Category, Project
+from weblate.trans.models import Category, Component, Project
 from weblate.trans.views.create import INTEGRATION_IMPORT_VCS_KEY, SESSION_CREATE_KEY
 from weblate.trans.views.hooks import apply_pending_github_installation_event
 from weblate.utils import messages
@@ -36,6 +36,7 @@ from weblate.utils.errors import report_error
 from weblate.utils.ratelimit import check_rate_limit
 from weblate.utils.site import get_site_url
 from weblate.vcs.forms import (
+    GitHubAppMigrationForm,
     GitHubAppRegisterCallbackForm,
     GitHubAppRegisterForm,
     GitHubAppSetupCallbackForm,
@@ -44,8 +45,10 @@ from weblate.vcs.forms import (
 from weblate.vcs.github import (
     GITHUB_APP_MANIFEST_EVENTS,
     GITHUB_APP_MANIFEST_PERMISSIONS,
+    GITHUB_APP_MIGRATABLE_VCS,
     GITHUB_APP_NAME_MAX_LENGTH,
     GitHubAppCredentials,
+    GithubAppRepository,
     GitHubInstallation,
     InstallationRemoval,
     aget_github_app_configurations,
@@ -57,14 +60,18 @@ from weblate.vcs.github import (
     get_github_app_install_url,
     get_github_app_manifest_new_url,
     get_github_app_settings,
+    get_github_repository_clone_url,
+    get_github_repository_identity,
     get_github_repository_import_url,
     get_user_admin_installation,
     github_app_is_configured,
     normalize_github_app_hostname,
     remove_github_installation,
 )
+from weblate.vcs.params import strip_unused_vcs_params
 from weblate.vcs.permissions import (
     github_app_installation_workspaces,
+    managed_workspaces,
     user_can_install_github_app_in_workspace,
 )
 from weblate.wladmin.views import MENU
@@ -82,12 +89,11 @@ _GITHUB_APP_REGISTER_SALT = "weblate.vcs.github.register"
 _GITHUB_APP_REGISTER_MAX_AGE = 60 * 60
 
 
-def _managed_workspaces(user):
-    """Return workspaces the user can manage."""
-    return (
-        Workspace.objects.filter(projects__in=user.managed_projects)
-        | user.workspaces_with_perm("workspace.edit")
-    ).distinct()
+class GitHubAppMigrationEntry(TypedDict):
+    component: Component
+    hostname: str
+    full_name: str
+    canonical_url: str
 
 
 def _installation_workspaces(user):
@@ -144,7 +150,7 @@ def _default_next_url(request, workspace: Workspace | None = None) -> str:
             f"{reverse('github-app-repositories')}?"
             f"{urlencode({'workspace': workspace.pk})}"
         )
-    if _managed_workspaces(request.user).exists():
+    if managed_workspaces(request.user).exists():
         return reverse("github-app-repositories")
     return reverse("manage-github-accounts")
 
@@ -156,7 +162,7 @@ async def _adefault_next_url(request, workspace: Workspace | None = None) -> str
             f"{urlencode({'workspace': workspace.pk})}"
         )
     await request.user.aprepare_permissions()
-    if await _managed_workspaces(request.user).aexists():
+    if await managed_workspaces(request.user).aexists():
         return reverse("github-app-repositories")
     return reverse("manage-github-accounts")
 
@@ -181,7 +187,7 @@ def _get_workspace(workspaces, workspace_id) -> Workspace:
 
 
 def _get_managed_workspace(user, workspace_id) -> Workspace:
-    return _get_workspace(_managed_workspaces(user), workspace_id)
+    return _get_workspace(managed_workspaces(user), workspace_id)
 
 
 async def _aget_installation_workspace(user, workspace_id) -> Workspace:
@@ -203,7 +209,7 @@ def _get_requested_workspace(request, workspaces) -> Workspace | None:
 
 
 def _get_managed_request_workspace(request) -> Workspace | None:
-    return _get_requested_workspace(request, _managed_workspaces(request.user))
+    return _get_requested_workspace(request, managed_workspaces(request.user))
 
 
 def _get_install_workspace(request) -> Workspace | None:
@@ -249,6 +255,88 @@ def _get_install_choices(next_url: str, workspace: Workspace) -> list[dict[str, 
             }
         )
     return result
+
+
+def _get_github_app_migration_repositories(
+    workspace: Workspace,
+) -> tuple[dict[tuple[str, str], str], list[GitHubInstallation], set[str]]:
+    """Return canonical repository URLs available to a workspace."""
+    configured_hosts = set(get_github_app_configurations())
+    installations = list(
+        GitHubInstallation.objects.filter(
+            enabled=True,
+            hostname__in=configured_hosts,
+            workspace=workspace,
+        ).order_by("hostname", "target_login", "pk")
+    )
+    repositories: dict[tuple[str, str], str] = {}
+    for installation in installations:
+        for repository in installation.repositories:
+            if repository.get("archived", False):
+                continue
+            clone_url = get_github_repository_clone_url(
+                installation.hostname, repository
+            )
+            full_name = repository.get("full_name")
+            if clone_url is None or not isinstance(full_name, str):
+                continue
+            repositories.setdefault(
+                (installation.hostname, full_name.casefold()), clone_url
+            )
+    return repositories, installations, configured_hosts
+
+
+def _get_github_app_migration_target(
+    component: Component, repositories: dict[tuple[str, str], str]
+) -> tuple[str, str, str] | None:
+    """Return host, full name, and canonical URL for an eligible component."""
+    if component.vcs not in GITHUB_APP_MIGRATABLE_VCS:
+        return None
+    identity = get_github_repository_identity(component.repo)
+    if identity is None:
+        return None
+    hostname, full_name = identity
+    canonical_url = repositories.get((hostname, full_name.casefold()))
+    if canonical_url is None:
+        return None
+    return hostname, full_name, canonical_url
+
+
+def _get_github_app_migration_entries(
+    user, workspace: Workspace
+) -> tuple[
+    list[GitHubAppMigrationEntry],
+    dict[tuple[str, str], str],
+    list[GitHubInstallation],
+]:
+    repositories, installations, configured_hosts = (
+        _get_github_app_migration_repositories(workspace)
+    )
+    entries: list[GitHubAppMigrationEntry] = []
+    components = (
+        Component.objects.filter(
+            project__workspace=workspace,
+            vcs__in=GITHUB_APP_MIGRATABLE_VCS,
+        )
+        .select_related("project")
+        .order_by("project__name", "name", "pk")
+    )
+    for component in components:
+        if not user.has_perm("component.edit", component):
+            continue
+        identity = get_github_repository_identity(component.repo)
+        if identity is None or identity[0] not in configured_hosts:
+            continue
+        hostname, full_name = identity
+        entries.append(
+            {
+                "component": component,
+                "hostname": hostname,
+                "full_name": full_name,
+                "canonical_url": repositories.get((hostname, full_name.casefold()), ""),
+            }
+        )
+    return entries, repositories, installations
 
 
 def _build_install_state(
@@ -344,9 +432,7 @@ async def _auser_can_use_installation(user, installation: GitHubInstallation) ->
     await user.aprepare_permissions()
     if user.has_perm("management.use"):
         return True
-    return (
-        await _managed_workspaces(user).filter(pk=installation.workspace_id).aexists()
-    )
+    return await managed_workspaces(user).filter(pk=installation.workspace_id).aexists()
 
 
 async def _auser_can_manage_installation(
@@ -435,7 +521,7 @@ class GitHubInstallationListView(View):
 @method_decorator(login_required, name="dispatch")
 class UserVCSIntegrationListView(View):
     def get(self, request):
-        workspace_queryset = _managed_workspaces(request.user).order_by("name")
+        workspace_queryset = managed_workspaces(request.user).order_by("name")
         selected_workspace = None
         workspace_id = request.GET.get("workspace", "").strip()
         if workspace_id:
@@ -777,7 +863,7 @@ async def _aget_update_callback_installation(
     )
     if not request.user.has_perm("management.use"):
         installations = installations.filter(
-            workspace__in=_managed_workspaces(request.user)
+            workspace__in=managed_workspaces(request.user)
         )
 
     return await (
@@ -967,9 +1053,140 @@ async def github_app_setup(request):
 
 
 @login_required
+def github_app_migration(request, workspace_id):
+    """Migrate existing GitHub components to a workspace GitHub App."""
+    if request.method not in {"GET", "POST"}:
+        return HttpResponseNotAllowed(["GET", "POST"])
+    workspace = _get_managed_workspace(request.user, workspace_id)
+    entries, repositories, installations = _get_github_app_migration_entries(
+        request.user, workspace
+    )
+    available_entries = [entry for entry in entries if entry["canonical_url"]]
+    unavailable_entries = [entry for entry in entries if not entry["canonical_url"]]
+    entries_by_id = {str(entry["component"].pk): entry for entry in available_entries}
+    component_choices = [
+        (
+            component_id,
+            (
+                f"{entry['component'].project.name} / "
+                f"{entry['component'].name} ({entry['full_name']})"
+            ),
+        )
+        for component_id, entry in entries_by_id.items()
+    ]
+    form = GitHubAppMigrationForm(
+        request.POST if request.method == "POST" else None,
+        component_choices=component_choices,
+    )
+
+    if request.method == "POST" and form.is_valid():
+        migrated = 0
+        unavailable = 0
+        errors: list[tuple[str, str]] = []
+        for component_id in form.cleaned_data["components"]:
+            entry = entries_by_id[component_id]
+            source_component = entry["component"]
+            with source_component.locked_for_update() as component:
+                # Both checks guard against the component changing between
+                # building the choices and acquiring the lock. Skipping keeps
+                # the rest of the batch going instead of aborting midway with
+                # part of the selection already migrated.
+                if (
+                    not request.user.has_perm("component.edit", component)
+                    or component.project.workspace_id != workspace.pk
+                ):
+                    unavailable += 1
+                    continue
+                target = _get_github_app_migration_target(component, repositories)
+                if target is None:
+                    unavailable += 1
+                    continue
+                _hostname, _full_name, canonical_url = target
+                component.acting_user = request.user
+                component.vcs = "github-app"
+                component.repo = canonical_url
+                component.push = ""
+                component.push_branch = ""
+                component.vcs_params = strip_unused_vcs_params(
+                    component.vcs, component.vcs_params.copy()
+                )
+                try:
+                    GithubAppRepository.validate_component(component)
+                except ValidationError as error:
+                    errors.append((component.full_slug, " ".join(error.messages)))
+                    continue
+                component.save(
+                    update_fields=(
+                        "vcs",
+                        "repo",
+                        "push",
+                        "push_branch",
+                        "vcs_params",
+                    )
+                )
+                component.delete_alert("GitHubAppMigration")
+                migrated += 1
+
+        if migrated:
+            messages.success(
+                request,
+                ngettext(
+                    "Migrated one component to the Weblate GitHub App.",
+                    "Migrated %(count)d components to the Weblate GitHub App.",
+                    migrated,
+                )
+                % {"count": migrated},
+            )
+        if unavailable:
+            messages.warning(
+                request,
+                ngettext(
+                    "One component was not migrated because its repository is no longer available.",
+                    "%(count)d components were not migrated because their repositories are no longer available.",
+                    unavailable,
+                )
+                % {"count": unavailable},
+            )
+        for component_slug, error_message in errors:
+            messages.error(
+                request,
+                gettext("Could not migrate %(component)s: %(error)s")
+                % {"component": component_slug, "error": error_message},
+            )
+        return redirect("github-app-migration", workspace_id=workspace.pk)
+
+    required_accounts = sorted(
+        {entry["full_name"].split("/", 1)[0] for entry in entries},
+        key=str.casefold,
+    )
+    return render(
+        request,
+        "vcs/github_app_migration.html",
+        {
+            "workspace": workspace,
+            "entries": entries,
+            "available_entries": available_entries,
+            "unavailable_entries": unavailable_entries,
+            "installations": installations,
+            "manageable_installations": {
+                installation.pk
+                for installation in installations
+                if _user_can_manage_installation(request.user, installation)
+            },
+            "required_accounts": required_accounts,
+            "form": form,
+            "next_url": request.get_full_path(),
+            "github_app_install_url": _get_install_link(
+                request, request.get_full_path(), workspace
+            ),
+        },
+    )
+
+
+@login_required
 def github_app_repository_list(request):
     """List repositories from connected GitHub accounts for component creation."""
-    workspaces = _managed_workspaces(request.user)
+    workspaces = managed_workspaces(request.user)
     if not workspaces.exists():
         raise PermissionDenied
 

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -1102,13 +1102,16 @@ def github_app_migration(request, workspace_id):
                     unavailable += 1
                     continue
                 _hostname, _full_name, canonical_url = target
+                vcs_params = component.vcs_params.copy()
+                if component.vcs == "git":
+                    vcs_params["create_merge_request"] = False
                 component.acting_user = request.user
                 component.vcs = "github-app"
                 component.repo = canonical_url
                 component.push = ""
                 component.push_branch = ""
                 component.vcs_params = strip_unused_vcs_params(
-                    component.vcs, component.vcs_params.copy()
+                    component.vcs, vcs_params
                 )
                 try:
                     GithubAppRepository.validate_component(component)


### PR DESCRIPTION
Add a workspace migration flow for eligible Git and GitHub components.

Report migratable components, require repository access through a connected installation, replace repository URLs with canonical HTTPS clone URLs, remove separate push configuration, and validate the GitHub App backend before saving.

Fixes #20281