### PR TITLE
fix(trans): allow multiple components for a GitHub App repository

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,7 @@ Weblate 2026.9
 * :ref:`Project backup restores <projectbackup>` now allowlists repository metadata for Git, git-svn, and Mercurial to prevent archives from supplying executable configuration or repository indirection.
 * Notification e-mails now wrap long strings instead of overflowing, keeping the :guilabel:`View` button reachable without horizontal scrolling.
 * The translation flags editor no longer splits a flag on a comma inside a quoted value, so flags such as ``regex:"^.{1,32}$"`` can be typed and pasted again.
+* Creating additional components for a repository imported through the :ref:`GitHub App <code-hosting-github-repositories>` no longer fails without showing any error, and component creation errors which previously could go unreported are now always displayed.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2264,6 +2264,21 @@ class ProjectDocsMixin(FieldDocsMixin):
         return ("admin/projects", f"project-{field.name.replace('_', '-')}")
 
 
+class HiddenFieldErrorsMixin(forms.Form):
+    """Surface validation errors attached to hidden fields."""
+
+    def full_clean(self) -> None:
+        super().full_clean()
+        # Hidden fields are rendered without their errors, show them on the
+        # form level instead of failing with no visible explanation.
+        for name in list(self._errors):
+            if name == NON_FIELD_ERRORS or not self[name].is_hidden:
+                continue
+            label = self[name].label
+            messages = self._errors.pop(name)
+            self.add_error(None, [f"{label}: {message}" for message in messages])
+
+
 class SpamCheckMixin(forms.Form):
     spam_fields: ClassVar[tuple[str, ...]]
     request: AuthenticatedHttpRequest
@@ -2623,6 +2638,7 @@ class ComponentSettingsForm(
 
 
 class ComponentCreateForm(
+    HiddenFieldErrorsMixin,
     InheritedSettingsFormMixin,
     SettingsBaseForm,
     ComponentDocsMixin,
@@ -2869,7 +2885,9 @@ class ComponentCreateForm(
                 setattr(self.instance, get_inherit_field_name(field), False)
 
 
-class ComponentNameForm(ComponentDocsMixin, ComponentAntispamMixin):
+class ComponentNameForm(
+    HiddenFieldErrorsMixin, ComponentDocsMixin, ComponentAntispamMixin
+):
     name = forms.CharField(
         label=Component.name.field.verbose_name,
         max_length=COMPONENT_NAME_LENGTH,

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -2271,11 +2271,12 @@ class HiddenFieldErrorsMixin(forms.Form):
         super().full_clean()
         # Hidden fields are rendered without their errors, show them on the
         # form level instead of failing with no visible explanation.
-        for name in list(self._errors):
+        errors = self.errors
+        for name in list(errors):
             if name == NON_FIELD_ERRORS or not self[name].is_hidden:
                 continue
             label = self[name].label
-            messages = self._errors.pop(name)
+            messages = errors.pop(name)
             self.add_error(None, [f"{label}: {message}" for message in messages])
 
 

--- a/weblate/trans/tests/test_create.py
+++ b/weblate/trans/tests/test_create.py
@@ -15,8 +15,14 @@ from translation_finder import DiscoveryResult
 
 from weblate.lang.models import Language, get_default_lang
 from weblate.trans.actions import ActionEvents
-from weblate.trans.forms import ComponentCreateForm, ComponentInitCreateForm
-from weblate.trans.models import Component, Project
+from weblate.trans.forms import (
+    ComponentCreateForm,
+    ComponentDiscoverForm,
+    ComponentInitCreateForm,
+    ComponentProjectForm,
+    get_repository_redirect_change,
+)
+from weblate.trans.models import Category, Component, Project
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.tests.utils import (
     create_another_user,
@@ -1119,7 +1125,195 @@ class CreateTest(ViewTestCase):
         )
         session_data = self.client.session[SESSION_CREATE_KEY]
         self.assertEqual(session_data["vcs"], "github-app")
+        self.assertEqual(session_data["branch"], self.component.branch)
         self.assertEqual(session_data[INTEGRATION_IMPORT_VCS_KEY], "github-app")
+
+    def make_github_app_component(self) -> str:
+        """Turn the test component into a GitHub App one and return its repo."""
+        self.user.is_superuser = True
+        self.user.save()
+        self.project.workspace = Workspace.objects.create(name="GitHub App workspace")
+        self.project.save(update_fields=["workspace"])
+        self.component.vcs = "github-app"
+        self.component.repo = "https://github.com/test-org/repo.git"
+        self.component.branch = "main"
+        self.component.save(update_fields=["vcs", "repo", "branch"])
+        return self.component.repo
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_create_component_existing_github_app_links_repository(self) -> None:
+        self.make_github_app_component()
+
+        self.client.post(
+            reverse("create-component"),
+            {
+                "origin": "existing",
+                "name": "Second GitHub App Component",
+                "slug": "second-github-app-component",
+                "component": self.component.pk,
+                "is_glossary": False,
+            },
+        )
+
+        url = f"{reverse('create-component-vcs')}?{SESSION_CREATE_KEY}=1"
+        with (
+            patch.object(Component, "clean_repo"),
+            patch("weblate.trans.forms.discover", return_value=[]),
+        ):
+            response = self.client.get(url)
+
+        form = response.context["form"]
+        self.assertEqual(form.errors, {})
+        self.assertEqual(response.context["stage"], "discover")
+        self.assertEqual(form.initial["repo"], self.component.get_repo_link_url())
+        self.assertEqual(form.initial["branch"], "")
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_create_component_github_app_link_survives_discovery(self) -> None:
+        repo = self.make_github_app_component()
+        session = self.client.session
+        session[SESSION_CREATE_KEY] = {
+            "repo": repo,
+            "branch": "main",
+            "vcs": "github-app",
+            "name": "Second GitHub App Component",
+            "slug": "second-github-app-component",
+            "project": self.project.pk,
+            INTEGRATION_IMPORT_VCS_KEY: "github-app",
+        }
+        session.save()
+
+        url = f"{reverse('create-component-vcs')}?{SESSION_CREATE_KEY}=1"
+        with (
+            patch.object(Component, "clean_repo"),
+            patch("weblate.trans.forms.discover", return_value=[]),
+        ):
+            response = self.client.get(url)
+            self.assertEqual(response.context["stage"], "init")
+
+            data = get_form_data(response.context["form"].initial)
+            data["project"] = self.project.pk
+            data["source_language"] = self.component.source_language.pk
+            response = self.client.post(url, data, follow=True)
+            self.assertEqual(response.context["form"].errors, {})
+            self.assertEqual(response.context["stage"], "discover")
+
+            # The disabled field is not posted back, keep it in the session.
+            self.assertEqual(
+                self.client.session[SESSION_CREATE_KEY]["repo"],
+                self.component.get_repo_link_url(),
+            )
+
+            data = get_form_data(response.context["form"].initial)
+            data["project"] = self.project.pk
+            data["source_language"] = self.component.source_language.pk
+            data["discovery"] = "manual"
+            response = self.client.post(url, data, follow=True)
+
+        self.assertEqual(response.context["form"].errors, {})
+        self.assertEqual(response.context["stage"], "create")
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_component_discover_form_shows_hidden_field_errors(self) -> None:
+        repo = self.make_github_app_component()
+        initial = {
+            "project": self.project,
+            "name": "Second GitHub App Component",
+            "slug": "second-github-app-component",
+            "source_language": self.component.source_language,
+            "vcs": "github-app",
+            "repo": repo,
+            "branch": "main",
+        }
+        data = get_form_data(initial)
+        # Missing branch is rejected by the GitHub App integration
+        data["branch"] = ""
+
+        request = self.get_request()
+        request.session = {}
+        with patch("weblate.trans.forms.discover", return_value=[]):
+            form = ComponentDiscoverForm(request, initial=initial, data=data)
+
+        self.assertFalse(form.is_valid())
+        self.assertNotIn("branch", form.errors)
+        self.assertIn(
+            "Repository branch is required for this integration.",
+            " ".join(form.non_field_errors()),
+        )
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_component_project_form_shows_hidden_field_errors(self) -> None:
+        other_project = Project.objects.create(name="Other", slug="other")
+        other_category = Category.objects.create(
+            name="Other category", slug="other-category", project=other_project
+        )
+
+        form = ComponentProjectForm(
+            self.get_request(),
+            data={
+                "name": "Hidden Category Component",
+                "slug": "hidden-category-component",
+                "project": self.project.pk,
+                "category": other_category.pk,
+                "source_language": get_default_lang(),
+            },
+        )
+        form.fields["project"].queryset = Project.objects.all()
+
+        self.assertFalse(form.is_valid())
+        # The category field is hidden, show the error on the form level
+        self.assertNotIn("category", form.errors)
+        self.assertIn(
+            "Category does not belong to this project.",
+            " ".join(form.non_field_errors()),
+        )
+
+    @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})
+    def test_create_component_session_keeps_redirect_proof(self) -> None:
+        self.user.is_superuser = True
+        self.user.save()
+        original_url = self.component.repo
+        canonical_url = f"{original_url}-canonical"
+
+        def canonicalize(component: Component) -> None:
+            component.repo = canonical_url
+
+        session = self.client.session
+        session[SESSION_CREATE_KEY] = {
+            "repo": original_url,
+            "branch": "main",
+            "vcs": "git",
+            "name": "Redirected Component",
+            "slug": "redirected-component",
+            "project": self.project.pk,
+        }
+        session.save()
+
+        url = f"{reverse('create-component-vcs')}?{SESSION_CREATE_KEY}=1"
+        with (
+            patch.object(Component, "clean_repo", autospec=True) as clean_repo,
+            patch("weblate.trans.forms.discover", return_value=[]),
+        ):
+            clean_repo.side_effect = canonicalize
+            response = self.client.get(url)
+            self.assertEqual(response.context["stage"], "init")
+
+            data = get_form_data(response.context["form"].initial)
+            data["project"] = self.project.pk
+            data["source_language"] = self.component.source_language.pk
+            response = self.client.post(url, data, follow=True)
+
+        self.assertEqual(response.context["form"].errors, {})
+        self.assertEqual(response.context["stage"], "discover")
+
+        # The redirect is not detected again, keep the proof for it
+        session_data = self.client.session[SESSION_CREATE_KEY]
+        self.assertEqual(session_data["repo"], canonical_url)
+        self.assertTrue(session_data["repository_redirect_proof"])
+        self.assertEqual(
+            get_repository_redirect_change(self.get_request(), session_data),
+            ("repo", original_url, canonical_url),
+        )
 
     @modify_settings(INSTALLED_APPS={"append": "weblate.billing"})
     def test_create_component_rejects_inaccessible_source_component(self) -> None:
@@ -1157,7 +1351,10 @@ class CreateTest(ViewTestCase):
         response = self.client_create_component(
             False, source_component=private_component.pk
         )
-        self.assertIn("source_component", response.context["form"].errors)
+        form = response.context["form"]
+        # The field is hidden, so the error is shown on the form level
+        self.assertNotIn("source_component", form.errors)
+        self.assertIn("Select a valid choice.", " ".join(form.non_field_errors()))
         self.assertFalse(Component.objects.filter(slug="create-component").exists())
 
     @modify_settings(INSTALLED_APPS={"remove": "weblate.billing"})

--- a/weblate/trans/views/create.py
+++ b/weblate/trans/views/create.py
@@ -298,7 +298,23 @@ class CreateComponent(BaseCreateView):
             for field in ComponentCreateForm.CREATE_INHERITABLE_SETTINGS
         ),
     )
-    initial_fields = (*basic_fields, "branch", *passthrough_fields)
+    initial_fields = (
+        *basic_fields,
+        "branch",
+        "push",
+        "push_branch",
+        *passthrough_fields,
+    )
+    # Fields which are rendered disabled or derived only once, so they have to
+    # survive in the session for the whole wizard.
+    session_sync_fields = (
+        "repo",
+        "branch",
+        "vcs",
+        "push",
+        "push_branch",
+        "repository_redirect_proof",
+    )
     empty_form = False
     form_class: type[ComponentProjectForm] = ComponentInitCreateForm
     origin = "vcs"
@@ -530,6 +546,32 @@ class CreateComponent(BaseCreateView):
 
     def update_initial(self, cleaned_data: dict) -> None:
         self.initial = {**self.initial, **cleaned_data}
+        self.update_session_initial()
+
+    def update_session_initial(self) -> None:
+        """
+        Persist wizard progress into the session-backed import parameters.
+
+        These are not posted back by the browser, so without syncing, changes
+        made in an earlier step (such as turning the repository into a link to
+        an existing component) would be reverted on the next one.
+        """
+        if (
+            SESSION_CREATE_KEY not in self.request.GET
+            or SESSION_CREATE_KEY not in self.request.session
+        ):
+            return
+        session_data = self.request.session[SESSION_CREATE_KEY]
+        changed = False
+        for field in self.session_sync_fields:
+            if field not in self.initial:
+                continue
+            value = self.initial[field]
+            if session_data.get(field) != value:
+                session_data[field] = value
+                changed = True
+        if changed:
+            self.request.session[SESSION_CREATE_KEY] = session_data
 
     def has_all_fields(self):
         session_data = {}
@@ -829,6 +871,7 @@ class CreateComponentSelection(CreateComponent):
         if self.origin == "existing":
             kwargs = {
                 "repo": component.repo or component.get_repo_link_url(),
+                "branch": component.branch,
                 "project": component.project.pk,
                 "category": component.category.pk if component.category else "",
                 "name": form.cleaned_data["name"],


### PR DESCRIPTION
Creating a second component for an App-imported repository failed. The branch was not carried over from the source component, so validation rejected it as empty before the repository could be turned into a link to the existing one.

The failure was silent because hidden fields render without their messages, leaving only the generic invalid configuration banner.

Pass the branch into the creation parameters, persist derived repository settings for the whole wizard, and report hidden field errors on the form level.

Fixes #21114
