### PR TITLE
fix(ci): avoid cloning full SPDX history

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,6 +62,16 @@
       "respectLatest": false
     },
     {
+      "description": "Update SPDX submodule through the release workflow",
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "matchPackageNames": [
+        "https://github.com/spdx/license-list-data.git"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Extract Unicode release versions from the public directory listing",
       "matchDatasources": [
         "custom.unicode-public"
@@ -82,6 +92,20 @@
       "depNameTemplate": "Unicode UCD",
       "packageNameTemplate": "unicode",
       "datasourceTemplate": "custom.unicode-public",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update tagged SPDX license data release",
+      "managerFilePatterns": [
+        "/^\\.gitmodules$/"
+      ],
+      "matchStrings": [
+        "\\[submodule \"scripts/spdx-license-list\"\\]\\s+path = scripts/spdx-license-list\\s+url = https://github\\.com/spdx/license-list-data\\.git\\s+tag = (?<currentValue>v\\d+\\.\\d+\\.\\d+)\\s+shallow = true"
+      ],
+      "depNameTemplate": "spdx/license-list-data",
+      "packageNameTemplate": "spdx/license-list-data",
+      "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver"
     },
     {

--- a/.github/workflows/apply-maintenance-patch.yml
+++ b/.github/workflows/apply-maintenance-patch.yml
@@ -126,7 +126,7 @@ jobs:
           "licenses update")
             message="utils: Update SPDX license data"
             pr_branch="create-pull-request/licenses-update"
-            allowed_pattern='^weblate/utils/licensedata\.py$'
+            allowed_pattern='^(scripts/spdx-license-list|weblate/utils/licensedata\.py)$'
             ;;
           *)
             echo "Unsupported workflow: $RUN_NAME" >&2

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -11,6 +11,7 @@ on:
     - dependabot/**
     - main
     paths:
+    - .gitmodules
     - .github/workflows/licenses-update.yml
     - scripts/generate-license-data.py
     - scripts/spdx-license-list
@@ -27,7 +28,28 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
       with:
         persist-credentials: false
-        submodules: true
+
+    - name: Read SPDX release
+      id: spdx-release
+      shell: bash
+      run: |
+        SPDX_RELEASE="$(git config --file .gitmodules --get submodule.scripts/spdx-license-list.tag)"
+        if [[ ! "${SPDX_RELEASE}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid SPDX release: ${SPDX_RELEASE}" >&2
+          exit 1
+        fi
+        echo "version=${SPDX_RELEASE}" >> "${GITHUB_OUTPUT}"
+
+    - name: Checkout SPDX license data
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
+      with:
+        repository: spdx/license-list-data
+        ref: ${{ steps.spdx-release.outputs.version }}
+        path: scripts/spdx-license-list
+        fetch-depth: 1
+        sparse-checkout: json
+        persist-credentials: false
+
     - uses: ./.github/actions/pre-commit-setup
     - run: ./scripts/generate-license-data.py
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "scripts/spdx-license-list"]
 	path = scripts/spdx-license-list
 	url = https://github.com/spdx/license-list-data.git
+	tag = v3.28.0
+	shallow = true

--- a/docs/contributing/submodules.rst
+++ b/docs/contributing/submodules.rst
@@ -17,7 +17,9 @@ SPDX license data
 
 The SPDX license data is included as a Git submodule in the source code and
 :file:`weblate/utils/licensedata.py` is generated using
-:file:`scripts/generate-license-data.py`.
+:file:`scripts/generate-license-data.py`. The submodule tracks tagged SPDX
+releases. Renovate updates the release recorded in :file:`.gitmodules`, and
+the license update workflow updates the submodule and generated license data.
 
 Test data
 ---------

--- a/weblate/utils/licensedata.py
+++ b/weblate/utils/licensedata.py
@@ -298,12 +298,6 @@ LICENSES = (
         False,
     ),
     (
-        "atc-game",
-        "atc Game License",
-        "https://spdx.org/licenses/atc-game.html",
-        False,
-    ),
-    (
         "AAL",
         "Attribution Assurance License",
         "https://spdx.org/licenses/AAL.html",
@@ -403,12 +397,6 @@ LICENSES = (
         "Brian-Gladman-3-Clause",
         "Brian Gladman 3-Clause License",
         "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
-        False,
-    ),
-    (
-        "Brian-Gladman-3-Clause-no-conversion",
-        "Brian Gladman 3-Clause License (no conversion clause)",
-        "https://spdx.org/licenses/Brian-Gladman-3-Clause-no-conversion.html",
         False,
     ),
     (
@@ -574,12 +562,6 @@ LICENSES = (
         False,
     ),
     (
-        "BSD-Source-Code-no-disclaimer",
-        "BSD Source Code Attribution - no disclaimer",
-        "https://spdx.org/licenses/BSD-Source-Code-no-disclaimer.html",
-        False,
-    ),
-    (
         "BSD-3-Clause-Attribution",
         "BSD with attribution",
         "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
@@ -625,12 +607,6 @@ LICENSES = (
         "BOLA-1.1",
         "Buena Onda License Agreement v1.1",
         "https://spdx.org/licenses/BOLA-1.1.html",
-        False,
-    ),
-    (
-        "Bugroff",
-        "Bugroff License",
-        "https://spdx.org/licenses/Bugroff.html",
         False,
     ),
     (
@@ -817,7 +793,7 @@ LICENSES = (
         "CDDL-1.1",
         "Common Development and Distribution License 1.1",
         "https://spdx.org/licenses/CDDL-1.1.html",
-        True,
+        False,
     ),
     (
         "CDL-1.0",
@@ -1051,12 +1027,6 @@ LICENSES = (
         "CC-BY-NC-3.0-DE",
         "Creative Commons Attribution Non Commercial 3.0 Germany",
         "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
-        False,
-    ),
-    (
-        "CC-BY-NC-3.0-IGO",
-        "Creative Commons Attribution Non Commercial 3.0 IGO",
-        "https://spdx.org/licenses/CC-BY-NC-3.0-IGO.html",
         False,
     ),
     (
@@ -1573,12 +1543,6 @@ LICENSES = (
         "FDK-AAC",
         "Fraunhofer FDK AAC Codec Library",
         "https://spdx.org/licenses/FDK-AAC.html",
-        False,
-    ),
-    (
-        "FDK-MPEG-H",
-        "Fraunhofer FDK MPEG-H Software",
-        "https://spdx.org/licenses/FDK-MPEG-H.html",
         False,
     ),
     (
@@ -2212,12 +2176,6 @@ LICENSES = (
         False,
     ),
     (
-        "Informatica",
-        "Informatica License",
-        "https://spdx.org/licenses/Informatica.html",
-        False,
-    ),
-    (
         "Inner-Net-2.0",
         "Inner Net License v2.0",
         "https://spdx.org/licenses/Inner-Net-2.0.html",
@@ -2761,12 +2719,6 @@ LICENSES = (
         "Mup",
         "Mup License",
         "https://spdx.org/licenses/Mup.html",
-        False,
-    ),
-    (
-        "MVT-1.1",
-        "MVT License 1.1",
-        "https://spdx.org/licenses/MVT-1.1.html",
         False,
     ),
     (


### PR DESCRIPTION
Renovate's submodule update now times out while cloning the large SPDX repository. Track tagged releases separately and let the license workflow fetch only the selected JSON snapshot.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
