### PR TITLE
fix(auth): enforce second-factor account lockout

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -237,6 +237,10 @@ This is currently applied in the following locations:
 
 * Sign in. Deletes the account password, preventing the user from signing in
   without requesting a new password.
+* Second-factor sign in. Deletes the account password after this many rejected
+  second-factor submissions since the last successful second-factor sign in.
+  This also invalidates pending password sign-ins. Other authentication methods
+  and API tokens remain usable.
 * Password reset. Prevents new e-mails from being sent, avoiding spamming
   users with too many password-reset attempts.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,7 @@ Weblate 2026.9
 
 .. rubric:: Bug fixes
 
+* Rejected :ref:`two-factor authentication <2fa>` attempts now apply :setting:`AUTH_LOCK_ATTEMPTS`, invalidate pending password sign-ins on lock or password change, and accept six-digit TOTP codes with leading zeroes.
 * :ref:`Project backup restores <projectbackup>` now preserve all project, category, and component settings. They also allowlist repository metadata for Git, git-svn, and Mercurial to prevent archives from supplying executable configuration or repository indirection.
 * Daily metric collection now uses independent tasks and more efficient database queries to reduce peak memory usage and avoid losing all scopes when one collection fails.
 * Database dump failures are now shown in the :ref:`backups management interface <automated-backup>`.

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -670,10 +670,15 @@ Security properties Weblate provides
      - Token can act outside project or team scope.
      - Security-critical.
    * - Authentication and session controls protect browser sessions when HTTPS
-       and proxy settings are correct. *(documented)* (source: :doc:`/admin/auth`,
-       :setting:`ENABLE_HTTPS`)
+       and proxy settings are correct. Pending second-factor sessions are bound
+       to the current password authentication state, and repeated rejected
+       second-factor submissions lock password sign-in according to
+       :setting:`AUTH_LOCK_ATTEMPTS`. *(documented)* (source:
+       :doc:`/admin/auth`, :setting:`ENABLE_HTTPS`)
      - Production HTTPS and secure-cookie settings are enabled.
-     - Session fixation, credential bypass, or cross-user session confusion.
+     - Session fixation, credential bypass, cross-user session confusion, or a
+       pending password sign-in remaining usable after a password change or
+       account lock.
      - Security-critical.
    * - User-supplied content rendered by Weblate is expected not to execute
        script in other users' browsers. *(maintainer)*

--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -1339,10 +1339,11 @@ class OTPTokenForm(DjangoOTPTokenForm):
 
 
 class TOTPTokenForm(OTPTokenForm):
-    otp_token = forms.IntegerField(
+    otp_token = forms.RegexField(
+        regex=r"\A[0-9]{6}\Z",
         label=gettext_lazy("Enter the code from the app"),
-        min_value=0,
-        max_value=999999,
+        min_length=6,
+        max_length=6,
     )
     device_class: type[Device] = TOTPDevice
 

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -1466,8 +1466,8 @@ class Profile(models.Model):
 
     def log_2fa_failed(
         self, request: AuthenticatedHttpRequest, device_type: DeviceType
-    ) -> None:
-        AuditLog.objects.create(
+    ) -> AuditLog:
+        return AuditLog.objects.create(
             self.user, request, "twofactor-failed", device_type=device_type
         )
 

--- a/weblate/accounts/pipeline.py
+++ b/weblate/accounts/pipeline.py
@@ -26,11 +26,10 @@ from weblate.accounts.models import AuditLog, VerifiedEmail
 from weblate.accounts.notifications import send_notification_email
 from weblate.accounts.templatetags.authnames import get_auth_name
 from weblate.accounts.utils import (
-    SESSION_SECOND_FACTOR_SOCIAL,
-    SESSION_SECOND_FACTOR_USER,
     adjust_session_expiry,
     cycle_session_keys,
     invalidate_reset_codes,
+    set_second_factor_session,
 )
 from weblate.auth.models import (
     Invitation,
@@ -680,8 +679,7 @@ def second_factor(strategy, backend, user: User, current_partial, **kwargs):
     """Force authentication when adding new association."""
     if user.profile.has_2fa and DEVICE_ID_SESSION_KEY not in strategy.request.session:
         # Store session indication for second factor
-        strategy.request.session[SESSION_SECOND_FACTOR_USER] = (user.id, "")
-        strategy.request.session[SESSION_SECOND_FACTOR_SOCIAL] = True
+        set_second_factor_session(strategy.request, user, "", social=True)
         # Redirect to second factor login
         continue_url = f"{reverse('social:complete', args=(backend.name,))}?partial_token={current_partial.token}"
         login_params = {"next": continue_url}

--- a/weblate/accounts/tests/test_twofactor.py
+++ b/weblate/accounts/tests/test_twofactor.py
@@ -7,22 +7,30 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest import mock
 
 from django.conf import settings
 from django.core import mail
+from django.test import Client, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from django_otp.oath import totp
 from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from django_otp_webauthn.exceptions import OTPWebAuthnApiError
 from django_otp_webauthn.models import WebAuthnCredential
+from rest_framework.authtoken.models import Token
 
 from weblate.accounts.models import AuditLog
+from weblate.accounts.pipeline import second_factor
 from weblate.accounts.tasks import cleanup_auditlog
 from weblate.accounts.utils import (
     SECOND_FACTOR_VERIFY_SECONDS,
+    SESSION_SECOND_FACTOR_HASH,
+    SESSION_SECOND_FACTOR_SOCIAL,
     SESSION_SECOND_FACTOR_TIMESTAMP,
+    SESSION_SECOND_FACTOR_USER,
     SESSION_WEBAUTHN_AUDIT,
 )
 from weblate.trans.tests.test_views import FixtureTestCase
@@ -127,7 +135,7 @@ class TwoFactorTestCase(FixtureTestCase):
 
         # Generate TOTP response
         totp_key = response.context["form"].bin_key
-        totp_response = totp(totp_key, 30, 0, 6, 0)
+        totp_response = f"{totp(totp_key, 30, 0, 6, 0):06d}"
 
         # Register TOTP device
         response = self.post_with_callbacks(
@@ -145,6 +153,26 @@ class TwoFactorTestCase(FixtureTestCase):
         device = devices[0]
         self.assert_audit_mail(expected=expected_mail)
         return device
+
+    def create_totp_device(self) -> TOTPDevice:
+        return TOTPDevice.objects.create(
+            user=self.user, name="test totp name", confirmed=True
+        )
+
+    def start_second_factor_login(
+        self, client: Client | None = None, *, address: str = "127.0.0.1"
+    ) -> tuple[Client, str]:
+        if client is None:
+            client = self.client
+        client.logout()
+        response = client.post(
+            reverse("login"),
+            {"username": "testuser", "password": "testpassword"},
+            REMOTE_ADDR=address,
+        )
+        second_factor_url = reverse("2fa-login", kwargs={"backend": "totp"})
+        self.assertRedirects(response, second_factor_url)
+        return client, second_factor_url
 
     def test_manage_totp(self) -> None:
         self.add_totp("TOTP 1")
@@ -197,12 +225,7 @@ class TwoFactorTestCase(FixtureTestCase):
         # We should be on 2fa page without a user set now
         self.assertNotEqual(response.context["user"], self.user)
 
-        totp_response = totp(
-            device.bin_key, device.step, device.t0, device.digits, device.drift
-        )
-
-        response = self.client.post(expected_url, {"otp_token": "000000"})
-        self.assertNotEqual(response.context["user"], self.user)
+        totp_response = f"{totp(device.bin_key, device.step, device.t0, device.digits, device.drift):06d}"
 
         response = self.client.post(
             expected_url, {"otp_token": totp_response}, follow=True
@@ -212,6 +235,250 @@ class TwoFactorTestCase(FixtureTestCase):
             self.client.session.get_expiry_age(),
             settings.SESSION_COOKIE_AGE_AUTHENTICATED,
         )
+
+    def test_login_totp_leading_zeroes(self) -> None:
+        timestamp = int(now().timestamp())
+        device = TOTPDevice.objects.create(
+            user=self.user,
+            name="zero code",
+            confirmed=True,
+            key="00000000000000000000000000000000003c6643",
+            step=300,
+            t0=timestamp,
+            tolerance=0,
+        )
+        self.assertEqual(
+            totp(device.bin_key, device.step, device.t0, device.digits, device.drift),
+            0,
+        )
+        client, second_factor_url = self.start_second_factor_login()
+
+        response = client.post(second_factor_url, {"otp_token": "000000"}, follow=True)
+
+        self.assertEqual(response.context["user"], self.user)
+        self.assertNotIn(SESSION_SECOND_FACTOR_USER, client.session)
+        self.assertNotIn(SESSION_SECOND_FACTOR_HASH, client.session)
+
+    @override_settings(AUTH_LOCK_ATTEMPTS=10, RATELIMIT_ATTEMPTS=20)
+    def test_login_totp_requires_six_ascii_digits(self) -> None:
+        self.create_totp_device()
+        client, second_factor_url = self.start_second_factor_login()
+
+        for data in (
+            {},
+            {"otp_token": "00000"},
+            {"otp_token": "0000000"},
+            {"otp_token": "abcdef"},
+            {"otp_token": "٠٠٠٠٠٠"},
+        ):
+            response = client.post(second_factor_url, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context["form"].errors["otp_token"])
+
+        self.assertEqual(
+            AuditLog.objects.filter(
+                user=self.user, activity="twofactor-failed"
+            ).count(),
+            5,
+        )
+
+    @override_settings(
+        AUTH_LOCK_ATTEMPTS=3,
+        OTP_TOTP_THROTTLE_FACTOR=0,
+        RATELIMIT_ATTEMPTS=20,
+    )
+    def test_second_factor_failures_lock_account(self) -> None:
+        device = self.create_totp_device()
+        old_token = Token.objects.get(user=self.user).key
+        clients = []
+        for index in range(4):
+            client = Client()
+            clients.append(
+                self.start_second_factor_login(client, address=f"192.0.2.{index + 1}")[
+                    0
+                ]
+            )
+        second_factor_url = reverse("2fa-login", kwargs={"backend": "totp"})
+        valid_token = f"{totp(device.bin_key, device.step, device.t0, device.digits, device.drift):06d}"
+        invalid_token = "000000" if valid_token != "000000" else "000001"
+
+        response = clients[0].post(
+            second_factor_url,
+            {"otp_token": invalid_token},
+            REMOTE_ADDR="192.0.2.1",
+        )
+        self.assertEqual(response.status_code, 200)
+        response = clients[1].post(second_factor_url, {}, REMOTE_ADDR="192.0.2.2")
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.has_usable_password())
+        self.assertFalse(
+            AuditLog.objects.filter(user=self.user, activity="locked").exists()
+        )
+
+        response = clients[2].post(
+            second_factor_url,
+            {"otp_token": "٠٠٠٠٠٠"},
+            REMOTE_ADDR="192.0.2.3",
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse("login"))
+        self.assertContains(
+            response,
+            "Too many failed authentication attempts. Please reset your password "
+            "to regain access to your account.",
+        )
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.has_usable_password())
+        self.assertEqual(Token.objects.get(user=self.user).key, old_token)
+        self.assertEqual(
+            AuditLog.objects.filter(
+                user=self.user, activity="twofactor-failed"
+            ).count(),
+            3,
+        )
+        self.assertEqual(
+            AuditLog.objects.filter(user=self.user, activity="locked").count(), 1
+        )
+        self.assertNotIn(SESSION_SECOND_FACTOR_USER, clients[2].session)
+        self.assertNotIn(SESSION_SECOND_FACTOR_HASH, clients[2].session)
+
+        response = clients[3].post(
+            second_factor_url,
+            {"otp_token": valid_token},
+            REMOTE_ADDR="192.0.2.4",
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn(SESSION_SECOND_FACTOR_USER, clients[3].session)
+
+        fresh_client = Client()
+        response = fresh_client.post(
+            reverse("login"),
+            {"username": "testuser", "password": "testpassword"},
+            REMOTE_ADDR="192.0.2.5",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(SESSION_SECOND_FACTOR_USER, fresh_client.session)
+
+    @override_settings(
+        AUTH_LOCK_ATTEMPTS=3,
+        OTP_TOTP_THROTTLE_FACTOR=0,
+        RATELIMIT_ATTEMPTS=20,
+    )
+    def test_successful_second_factor_resets_lockout_sequence(self) -> None:
+        device = self.create_totp_device()
+        client, second_factor_url = self.start_second_factor_login()
+        for _unused in range(2):
+            response = client.post(second_factor_url, {})
+            self.assertEqual(response.status_code, 200)
+        valid_token = f"{totp(device.bin_key, device.step, device.t0, device.digits, device.drift):06d}"
+
+        response = client.post(
+            second_factor_url, {"otp_token": valid_token}, follow=True
+        )
+
+        self.assertEqual(response.context["user"], self.user)
+        client, second_factor_url = self.start_second_factor_login(client)
+        for _unused in range(2):
+            response = client.post(second_factor_url, {})
+            self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.has_usable_password())
+        self.assertFalse(
+            AuditLog.objects.filter(user=self.user, activity="locked").exists()
+        )
+
+    @override_settings(AUTH_LOCK_ATTEMPTS=1, RATELIMIT_ATTEMPTS=20)
+    def test_recovery_failure_locks_account(self) -> None:
+        self.create_totp_device()
+        recovery = StaticDevice.objects.create(
+            user=self.user, name="recovery", confirmed=True
+        )
+        StaticToken.objects.create(device=recovery, token="recovery-code")
+        client, _second_factor_url = self.start_second_factor_login()
+
+        response = client.post(
+            reverse("2fa-login", kwargs={"backend": "recovery"}),
+            {"otp_token": "invalid-code"},
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse("login"))
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.has_usable_password())
+
+    @override_settings(AUTH_LOCK_ATTEMPTS=1, RATELIMIT_ATTEMPTS=20)
+    def test_webauthn_failure_returns_account_locked_error(self) -> None:
+        self.create_totp_device()
+        client, _second_factor_url = self.start_second_factor_login()
+
+        with mock.patch(
+            "django_otp_webauthn.views.CompleteCredentialAuthenticationView.post",
+            side_effect=OTPWebAuthnApiError("Invalid credential", "invalid_credential"),
+        ):
+            response = client.post(
+                reverse("otp_webauthn:credential-authentication-complete"),
+                data={},
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": (
+                    "Too many failed authentication attempts. Please reset your "
+                    "password to regain access to your account."
+                ),
+                "code": "account_locked",
+            },
+        )
+        self.assertNotIn(SESSION_SECOND_FACTOR_USER, client.session)
+
+    def test_pending_second_factor_requires_auth_hash(self) -> None:
+        self.create_totp_device()
+        client, second_factor_url = self.start_second_factor_login()
+        session = client.session
+        session.pop(SESSION_SECOND_FACTOR_HASH)
+        session.save()
+
+        response = client.get(second_factor_url)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn(SESSION_SECOND_FACTOR_USER, client.session)
+
+    def test_password_change_invalidates_pending_second_factor(self) -> None:
+        self.create_totp_device()
+        client, second_factor_url = self.start_second_factor_login()
+        self.user.set_password("changed-password")
+        self.user.save(update_fields=["password"])
+
+        response = client.get(second_factor_url)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn(SESSION_SECOND_FACTOR_USER, client.session)
+
+    def test_social_second_factor_stores_auth_hash(self) -> None:
+        self.create_totp_device()
+        strategy = SimpleNamespace(request=SimpleNamespace(session={}))
+
+        response = second_factor.__wrapped__(
+            strategy=strategy,
+            backend=SimpleNamespace(name="github"),
+            user=self.user,
+            current_partial=SimpleNamespace(token="partial-token"),
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            strategy.request.session[SESSION_SECOND_FACTOR_HASH],
+            self.user.get_session_auth_hash(),
+        )
+        self.assertEqual(
+            strategy.request.session[SESSION_SECOND_FACTOR_USER], (self.user.id, "")
+        )
+        self.assertTrue(strategy.request.session[SESSION_SECOND_FACTOR_SOCIAL])
 
     def test_login_totp_saml_expiry(self) -> None:
         device = self.add_totp()
@@ -226,9 +493,7 @@ class TwoFactorTestCase(FixtureTestCase):
         )
 
         second_factor_url = response["Location"]
-        totp_response = totp(
-            device.bin_key, device.step, device.t0, device.digits, device.drift
-        )
+        totp_response = f"{totp(device.bin_key, device.step, device.t0, device.digits, device.drift):06d}"
         response = self.client.post(second_factor_url, {"otp_token": totp_response})
 
         self.assertRedirects(
@@ -257,9 +522,7 @@ class TwoFactorTestCase(FixtureTestCase):
         )
         self.assertIn("next=https%3A%2F%2Fevil.example%2F", second_factor_url)
 
-        totp_response = totp(
-            device.bin_key, device.step, device.t0, device.digits, device.drift
-        )
+        totp_response = f"{totp(device.bin_key, device.step, device.t0, device.digits, device.drift):06d}"
         response = self.client.post(
             second_factor_url, {"otp_token": totp_response}, follow=True
         )
@@ -299,6 +562,10 @@ class TwoFactorTestCase(FixtureTestCase):
         self.assertRedirects(
             response,
             f"{reverse('2fa-login', kwargs={'backend': 'totp'})}?next={reverse('password')}",
+        )
+        self.assertEqual(
+            self.client.session[SESSION_SECOND_FACTOR_HASH],
+            self.user.get_session_auth_hash(),
         )
 
     def test_password_allows_recent_second_factor(self) -> None:

--- a/weblate/accounts/utils.py
+++ b/weblate/accounts/utils.py
@@ -28,6 +28,7 @@ from weblate.trans.signals import user_pre_delete
 from weblate.utils.token import get_token
 
 if TYPE_CHECKING:
+    from django.http import HttpRequest
     from django_otp.models import Device
 
     from weblate.accounts.types import DeviceType
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 
 SESSION_WEBAUTHN_AUDIT = "weblate:second_factor:webauthn_audit_log"
 SESSION_SECOND_FACTOR_USER = "weblate:second_factor:user"
+SESSION_SECOND_FACTOR_HASH = "weblate:second_factor:auth_hash"
 SESSION_SECOND_FACTOR_TIMESTAMP = "weblate:second_factor:timestamp"
 SESSION_SECOND_FACTOR_SOCIAL = "weblate:second_factor:social"
 SESSION_SECOND_FACTOR_TOTP = "weblate:second_factor:totp_key"
@@ -321,6 +323,30 @@ def adjust_session_expiry(
     request.session[SESSION_EXPIRY_SCOPE] = scope
     request.session[SESSION_EXPIRY_AGE] = expiry_age
     request.session[SESSION_EXPIRY_REFRESHED] = now
+
+
+def set_second_factor_session(
+    request: HttpRequest,
+    user: User,
+    backend: str,
+    *,
+    social: bool = False,
+) -> None:
+    request.session[SESSION_SECOND_FACTOR_USER] = (user.id, backend)
+    request.session[SESSION_SECOND_FACTOR_HASH] = user.get_session_auth_hash()
+    if social:
+        request.session[SESSION_SECOND_FACTOR_SOCIAL] = True
+    else:
+        request.session.pop(SESSION_SECOND_FACTOR_SOCIAL, None)
+
+
+def clear_second_factor_session(
+    request: HttpRequest, *, preserve_social: bool = False
+) -> None:
+    request.session.pop(SESSION_SECOND_FACTOR_USER, None)
+    request.session.pop(SESSION_SECOND_FACTOR_HASH, None)
+    if not preserve_social:
+        request.session.pop(SESSION_SECOND_FACTOR_SOCIAL, None)
 
 
 def get_key_name(device: Device) -> str:

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -39,7 +39,9 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.cache import patch_response_headers
+from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.http import content_disposition_header, urlencode
 from django.utils.safestring import mark_safe
@@ -133,16 +135,19 @@ from weblate.accounts.notifications import (
 from weblate.accounts.pipeline import EmailAlreadyAssociated, UsernameAlreadyAssociated
 from weblate.accounts.utils import (
     SECOND_FACTOR_VERIFY_SECONDS,
+    SESSION_SECOND_FACTOR_HASH,
     SESSION_SECOND_FACTOR_SOCIAL,
     SESSION_SECOND_FACTOR_TIMESTAMP,
     SESSION_SECOND_FACTOR_TOTP,
     SESSION_SECOND_FACTOR_USER,
     SESSION_WEBAUTHN_AUDIT,
     adjust_session_expiry,
+    clear_second_factor_session,
     get_key_name,
     lock_user,
     remove_user,
     reset_api_token,
+    set_second_factor_session,
 )
 from weblate.auth.decorators import check_management_access
 from weblate.auth.forms import UserEditForm
@@ -1103,7 +1108,7 @@ class BaseLoginView(LoginView):
         user = form.get_user()
         if user.profile.has_2fa:
             # Store session indication for second factor
-            self.request.session[SESSION_SECOND_FACTOR_USER] = (user.id, user.backend)
+            set_second_factor_session(self.request, user, user.backend)
             # Redirect to second factor login
             redirect_to = self.request.POST.get(
                 self.redirect_field_name, self.request.GET.get(self.redirect_field_name)
@@ -1331,8 +1336,9 @@ def password(request: AuthenticatedHttpRequest):
                 "Please confirm your identity using a second factor before proceeding."
             ),
         )
-        request.session[SESSION_SECOND_FACTOR_USER] = (
-            user.id,
+        set_second_factor_session(
+            request,
+            user,
             "weblate.accounts.auth.WeblateUserBackend",
         )
         login_params: dict[str, str] = {"next": reverse("password")}
@@ -2327,6 +2333,18 @@ class TOTPView(FormView):
         return redirect_profile("#account")
 
 
+SECOND_FACTOR_LOCKED_MESSAGE = gettext_lazy(
+    "Too many failed authentication attempts. Please reset your password to "
+    "regain access to your account."
+)
+
+
+class SecondFactorLockedError(OTPWebAuthnApiError):
+    status_code = 403
+    default_detail = SECOND_FACTOR_LOCKED_MESSAGE
+    default_code = "account_locked"
+
+
 class SecondFactorMixin(View):
     request: AuthenticatedHttpRequest
 
@@ -2334,7 +2352,7 @@ class SecondFactorMixin(View):
         # Store audit log entry about used device and update last used device type
         user = self.get_user()
         user.profile.log_2fa(self.request, device)
-        del self.request.session[SESSION_SECOND_FACTOR_USER]
+        clear_second_factor_session(self.request, preserve_social=True)
         self.request.session[SESSION_SECOND_FACTOR_TIMESTAMP] = int(time.time())
 
         if not self.request.session.get(SESSION_SECOND_FACTOR_SOCIAL):
@@ -2353,19 +2371,31 @@ class SecondFactorMixin(View):
             # This is completed in social_complete after completing social login
         return user
 
-    def second_factor_failed(self) -> None:
+    def second_factor_failed(self) -> bool:
         user = self.get_user()
-        user.profile.log_2fa_failed(self.request, self.get_backend())
+        audit = user.profile.log_2fa_failed(self.request, self.get_backend())
+        if not audit.check_rate_limit(self.request):
+            return False
+        clear_second_factor_session(self.request)
+        return True
 
     def get_user(self) -> User:
         try:
             user_id, backend = self.request.session[SESSION_SECOND_FACTOR_USER]
-        except KeyError as error:
+            session_auth_hash = self.request.session[SESSION_SECOND_FACTOR_HASH]
+        except (KeyError, TypeError, ValueError) as error:
+            clear_second_factor_session(self.request)
             raise Http404 from error
         try:
             user = User.objects.get(pk=user_id)
-        except User.DoesNotExist as error:
+        except (TypeError, ValueError, User.DoesNotExist) as error:
+            clear_second_factor_session(self.request)
             raise Http404 from error
+        if not isinstance(session_auth_hash, str) or not constant_time_compare(
+            session_auth_hash, user.get_session_auth_hash()
+        ):
+            clear_second_factor_session(self.request)
+            raise Http404
         user.backend = backend
         return user
 
@@ -2421,7 +2451,9 @@ class SecondFactorLoginView(SecondFactorMixin, RedirectURLMixin, FormView):
         return HttpResponseRedirect(self.get_success_url())
 
     def form_invalid(self, form):
-        self.second_factor_failed()
+        if self.second_factor_failed():
+            messages.error(self.request, force_str(SECOND_FACTOR_LOCKED_MESSAGE))
+            return redirect("login")
         return super().form_invalid(form)
 
 
@@ -2448,6 +2480,7 @@ class WeblateCompleteCredentialAuthenticationView(
     def post(self, *args, **kwargs):
         try:
             return super().post(*args, **kwargs)
-        except OTPWebAuthnApiError:
-            self.second_factor_failed()
+        except OTPWebAuthnApiError as error:
+            if self.second_factor_failed():
+                raise SecondFactorLockedError from error
             raise


### PR DESCRIPTION
Failed second-factor submissions were logged without invoking the existing per-account lockout, so repeated rejected attempts never disabled password sign-in. Wire all rejection paths into the lockout, bind pending sessions to password state, and preserve leading-zero TOTP codes as six-digit strings.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
