### PR TITLE
fix(vcs): invalidate registry on credential changes

### DIFF
--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -48,7 +48,6 @@ from weblate.vcs.base import (
     RepositoryStructuredError,
 )
 from weblate.vcs.github import GitHubAppCredentials
-from weblate.vcs.models import VCS_REGISTRY
 from weblate.workspaces.models import Workspace
 
 
@@ -1321,23 +1320,8 @@ class GitHubAppMigrationAlertTest(ViewTestCase):
     }
 )
 class ConflictingRepositorySetupAlertTest(ViewTestCase):
-    @staticmethod
-    def clear_vcs_registry_cache() -> None:
-        VCS_REGISTRY.clear_cache()
-
     def create_component(self):
         return self.create_po()
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        super().setUpTestData()
-
-        cls.clear_vcs_registry_cache()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.clear_vcs_registry_cache()
-        super().tearDownClass()
 
     def create_conflicting_component(self, **kwargs) -> Component:
         name = kwargs.pop("name", "Test2")

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -945,9 +945,6 @@ class ComponentTest(RepoTestCase):
     def test_vcs_validation(self) -> None:
         component = self.create_po_push()
 
-        # force reload VCS list to include github
-        VCS_REGISTRY.clear_cache()
-
         component.vcs = "github"
 
         # check push branch cannot be empty when push URL is set

--- a/weblate/trans/tests/test_vcs_params.py
+++ b/weblate/trans/tests/test_vcs_params.py
@@ -16,7 +16,6 @@ from weblate.lang.models import get_default_lang
 from weblate.trans.models import Component
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.views import get_form_data
-from weblate.vcs.models import VCS_REGISTRY
 from weblate.vcs.params import (
     VCS_PARAMS,
     CreateMergeRequest,
@@ -167,8 +166,6 @@ class ComponentVCSParamsTest(ViewTestCase):
         GITHUB_CREDENTIALS={"api.github.com": {"username": "test", "token": "token"}}
     )
     def test_direct_push_accepts_translated_branch(self) -> None:
-        VCS_REGISTRY.clear_cache()
-        self.addCleanup(VCS_REGISTRY.clear_cache)
         self.component.vcs = "github"
         self.component.repo = "https://github.com/WeblateOrg/test.git"
         self.component.push = "https://user:token@github.com/WeblateOrg/test.git"

--- a/weblate/utils/classloader.py
+++ b/weblate/utils/classloader.py
@@ -61,8 +61,10 @@ class ClassLoader[T]:
         base_class: type[T],
         construct: bool = True,
         collect_errors: bool = False,
+        dependent_settings: tuple[str, ...] = (),
     ) -> None:
         self.name = name
+        self.setting_names = frozenset((name, *dependent_settings))
         self.construct = construct
         self.collect_errors = collect_errors
         self.errors: dict[str, str | Exception] = {}
@@ -178,12 +180,14 @@ class ClassRegistry[T: ClassLoaderProtocol](ClassLoader[type[T]]):
         *,
         base_class: type[T],
         collect_errors: bool = False,
+        dependent_settings: tuple[str, ...] = (),
     ) -> None:
         super().__init__(
             name,
             base_class=base_class,  # type: ignore[arg-type]
             construct=False,
             collect_errors=collect_errors,
+            dependent_settings=dependent_settings,
         )
 
 
@@ -192,5 +196,5 @@ def reset_class_loader_cache(sender, setting: str, **_kwargs) -> None:
     """Invalidate class loader data after setting overrides."""
     del sender
     for instance in list(ClassLoader.instances):
-        if instance.name == setting:
+        if setting in instance.setting_names:
             instance.clear_cache()

--- a/weblate/utils/tests/test_classloader.py
+++ b/weblate/utils/tests/test_classloader.py
@@ -100,3 +100,25 @@ class ClassLoaderTestCase(TestCase):
                 self.assertEqual(list(second_loader.keys()), [])
             self.assertEqual(list(loader.keys()), ["weblate.cleanup.generic"])
             self.assertEqual(list(second_loader.keys()), ["weblate.cleanup.generic"])
+
+    def test_dependent_setting_change_invalidates_cache(self) -> None:
+        loader = ClassLoader(
+            "TEST_DYNAMIC_SERVICES",
+            construct=False,
+            base_class=BaseAddon,
+            dependent_settings=("TEST_DYNAMIC_SERVICE_ENABLED",),
+        )
+        unaffected_loader = ClassLoader(
+            "TEST_DYNAMIC_SERVICES", construct=False, base_class=BaseAddon
+        )
+        with override_settings(
+            TEST_DYNAMIC_SERVICES=("weblate.addons.cleanup.CleanupAddon",)
+        ):
+            cached_data = loader.data
+            unaffected_cached_data = unaffected_loader.data
+            with override_settings(TEST_DYNAMIC_SERVICE_ENABLED=True):
+                dependent_cached_data = loader.data
+                self.assertIsNot(dependent_cached_data, cached_data)
+                self.assertIs(unaffected_loader.data, unaffected_cached_data)
+            self.assertIsNot(loader.data, dependent_cached_data)
+            self.assertIs(unaffected_loader.data, unaffected_cached_data)

--- a/weblate/vcs/models.py
+++ b/weblate/vcs/models.py
@@ -193,7 +193,20 @@ class VCSConf(AppConf):
 
 class VcsClassLoader(ClassLoader):
     def __init__(self) -> None:
-        super().__init__("VCS_BACKENDS", construct=False, base_class=Repository)
+        super().__init__(
+            "VCS_BACKENDS",
+            construct=False,
+            base_class=Repository,
+            dependent_settings=(
+                "AZURE_DEVOPS_CREDENTIALS",
+                "BITBUCKETCLOUD_CREDENTIALS",
+                "BITBUCKETSERVER_CREDENTIALS",
+                "GITEA_CREDENTIALS",
+                "GITHUB_CREDENTIALS",
+                "GITLAB_CREDENTIALS",
+                "PAGURE_CREDENTIALS",
+            ),
+        )
 
     def get_unfiltered_choices(self):
         result = self.get_unfiltered_data()

--- a/weblate/vcs/tests/test_apps.py
+++ b/weblate/vcs/tests/test_apps.py
@@ -76,6 +76,23 @@ class VCSChecksTest(SimpleTestCase):
             )
             self.assertIn(HgRepository.get_missing_commands(), (("hg",), ("rhg",)))
 
+    def test_registry_invalidated_on_credentials_change(self) -> None:
+        backends = {
+            "AZURE_DEVOPS_CREDENTIALS": "azure_devops",
+            "BITBUCKETCLOUD_CREDENTIALS": "bitbucketcloud",
+            "BITBUCKETSERVER_CREDENTIALS": "bitbucketserver",
+            "GITEA_CREDENTIALS": "gitea",
+            "GITHUB_CREDENTIALS": "github",
+            "GITLAB_CREDENTIALS": "gitlab",
+            "PAGURE_CREDENTIALS": "pagure",
+        }
+        for setting_name, backend in backends.items():
+            with self.subTest(setting=setting_name):
+                self.assertNotIn(backend, VCS_REGISTRY)
+                with override_settings(**{setting_name: {"example.com": {}}}):
+                    self.assertIn(backend, VCS_REGISTRY)
+                self.assertNotIn(backend, VCS_REGISTRY)
+
     @override_settings(VCS_BACKENDS=OPTIONAL_BACKENDS)
     def test_registry_checks_availability_without_version_probe(self) -> None:
         with (

--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -33,7 +33,7 @@ from weblate.vcs.github import (
     GithubAppRepository,
     GitHubInstallation,
 )
-from weblate.vcs.models import VCS_REGISTRY, InstallationProvider, PendingInstallation
+from weblate.vcs.models import InstallationProvider, PendingInstallation
 from weblate.vcs.pending import PENDING_GITHUB_INSTALLATION_RETENTION
 from weblate.vcs.tests.utils import generate_private_key
 from weblate.workspaces.models import Workspace
@@ -1671,8 +1671,6 @@ class GitHubInstallationViewTest(ViewTestCase):
         GITHUB_CREDENTIALS={"api.github.com": {"username": "test", "token": "token"}},
     )
     def test_migration_preserves_github_create_merge_request(self):
-        VCS_REGISTRY.clear_cache()
-        self.addCleanup(VCS_REGISTRY.clear_cache)
         repository = _repo_entry("test-org/repo1")
         GitHubInstallation.objects.create(
             installation_id="12345",


### PR DESCRIPTION
Track dependent settings in class loaders and register every credential setting used to filter VCS backends. This removes the need for manual cache resets in settings override tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
