### PR TITLE
fix(migrations): handle unhashable legacy `json_sort_keys` values during migration

### DIFF
--- a/weblate/trans/migrations/0102_migrate_json_sort_keys_to_choice.py
+++ b/weblate/trans/migrations/0102_migrate_json_sort_keys_to_choice.py
@@ -17,7 +17,7 @@ def migrate_json_sort_keys_from_bool_to_choice(apps, schema_editor) -> None:
     def convert(component):
         file_format_params = component.file_format_params or {}
         value = file_format_params.get(JSON_SORT_KEYS)
-        if value in NEW_VALUES:
+        if isinstance(value, str) and value in NEW_VALUES:
             return component
         if value is True:
             file_format_params[JSON_SORT_KEYS] = "case_sensitive"
@@ -41,7 +41,7 @@ def reverse_json_sort_keys_to_choice(apps, schema_editor) -> None:
     def convert(component):
         file_format_params = component.file_format_params or {}
         value = file_format_params.get(JSON_SORT_KEYS)
-        if value not in NEW_VALUES:
+        if not isinstance(value, str) or value not in NEW_VALUES:
             return component
         if value == "case_sensitive":
             file_format_params[JSON_SORT_KEYS] = True

--- a/weblate/trans/tests/test_migrations.py
+++ b/weblate/trans/tests/test_migrations.py
@@ -1,0 +1,37 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for translation migrations."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from django.test import SimpleTestCase
+
+
+class JSONSortKeysMigrationTest(SimpleTestCase):
+    def test_unhashable_legacy_values(self) -> None:
+        migration = import_module(
+            "weblate.trans.migrations.0102_migrate_json_sort_keys_to_choice"
+        )
+        components = [
+            SimpleNamespace(file_format_params={"json_sort_keys": []}),
+            SimpleNamespace(file_format_params={"json_sort_keys": {}}),
+        ]
+        manager = Mock()
+        manager.filter.return_value.iterator.return_value = iter(components)
+        component_model = SimpleNamespace(objects=manager)
+        apps = Mock()
+        apps.get_model.return_value = component_model
+
+        migration.migrate_json_sort_keys_from_bool_to_choice(apps, None)
+
+        self.assertEqual(
+            [component.file_format_params for component in components],
+            [{"json_sort_keys": "none"}, {"json_sort_keys": "none"}],
+        )
+        manager.bulk_update.assert_called_once_with(components, ["file_format_params"])


### PR DESCRIPTION
### Motivation

- The migration `0102_migrate_json_sort_keys_to_choice` performed `value in NEW_VALUES` on database-sourced JSON values, which raises `TypeError` for legacy unhashable values such as lists or dicts and can abort instance-wide upgrades.

### Description

- Add defensive checks to the forward migration so membership is only tested when `value` is a `str` by changing `if value in NEW_VALUES` to `if isinstance(value, str) and value in NEW_VALUES` and mirror this in the reverse migration. 
- Ensure converted components are still updated by preserving the normalized `file_format_params` and calling `bulk_update` as before. 
- Add `weblate/trans/tests/test_migrations.py` with a regression test that mocks components containing `[]` and `{}` for `json_sort_keys` and asserts they are normalized to `"none"` and that `bulk_update` is invoked.

### Testing

- Ran `uv run pytest weblate/trans/tests/test_migrations.py` and the new test passed (`1 passed`).
- Ran repository pre-commit checks via `uv run prek run --files weblate/trans/migrations/0102_migrate_json_sort_keys_to_choice.py weblate/trans/tests/test_migrations.py` and the checks succeeded.
- Verified there are no trailing-diff or lint failures with `git diff --check` (no issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97ed4656c48329bd9854fc5598a409)