### PR TITLE
docs(agents): document PostgreSQL test recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,13 @@ For application-developer workflows and broader product integration guidance, us
   (`DJANGO_SETTINGS_MODULE=weblate.settings_test`, `collectstatic`, and test
   database prerequisites). `scripts/test-database.sh` can be sourced to set up
   the database connection variables such as `CI_DB_USER`, `CI_DB_PASSWORD`,
-  `CI_DB_HOST`, and `CI_DB_PORT`.
+  `CI_DB_HOST`, and `CI_DB_PORT`. If tests cannot reach the configured
+  PostgreSQL server, do not assume it is stopped: local sandboxing can block
+  access to an already-running service. Retry with permission to access the
+  local service when sandboxing is the cause. Only when PostgreSQL is confirmed
+  not to be running, and it is installed as a local Linux service, try
+  `sudo service postgresql start` and rerun the failed command. Treat service
+  startup as a recovery step, not a prerequisite for every test invocation.
 - Use `pylint` to lint the Python code: `uv run pylint weblate/ scripts/`
 - Use `mypy` to type check with the same command as CI:
   `uv run mypy --show-column-numbers weblate scripts/*.py ./*.py | ./scripts/filter-mypy.sh`.


### PR DESCRIPTION
Cloud test environments can lack a running PostgreSQL service after setup. Document an on-demand recovery step without making service startup mandatory for every test run.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
