### PR TITLE
fix(users): restrict bot accounts in user listings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -293,6 +293,9 @@ Users
     :query int id: User ID to search for
     :query string email: Email to search for (case-insensitive, exact match). Requires ``user.view`` or ``user.edit`` permission; the parameter is ignored for unprivileged users.
 
+    Username searches by users without the global ``user.view`` or ``user.edit``
+    permission exclude bot accounts other than the caller's own account.
+
     .. seealso::
 
         Users object attributes are documented at :http:get:`/api/users/(str:username)/`.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,7 @@ Weblate 2026.9
 * Daily metric collection now uses independent tasks and more efficient database queries to reduce peak memory usage and avoid losing all scopes when one collection fails.
 * Database dump failures are now shown in the :ref:`backups management interface <automated-backup>`.
 * Project administrators can no longer remove :ref:`API tokens <api-tokens>` belonging to other projects.
+* User listings and site-wide searches no longer expose project-scoped :ref:`API tokens <api-tokens>` to users without global user viewing or editing permission.
 * Project and workspace :ref:`translation memory <translation-memory>` now respects restricted component access, and restricted components no longer contribute to shared translation memory.
 * GitLab merge request forks now disable Git LFS to avoid missing-object push failures. See :ref:`git-lfs`.
 * Notification e-mails now wrap long strings instead of overflowing, keeping the :guilabel:`View` button reachable without horizontal scrolling.

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -37,7 +37,7 @@ from weblate.accounts.notifications import (
     NotificationScope,
 )
 from weblate.accounts.views import log_handled_auth_failure
-from weblate.auth.models import Group, User
+from weblate.auth.models import Group, Permission, Role, User
 from weblate.billing.models import Billing, Plan
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
@@ -289,6 +289,34 @@ class ViewTest(RepoTestCase):
         self.assertContains(response, user_url)
         response = self.client.get(reverse("user_list"), {"sort_by": "invalid"})
         self.assertContains(response, user_url)
+
+    def test_user_list_bot_visibility(self) -> None:
+        """User listing hides bots unless the caller can view users globally."""
+        user = self.get_user()
+        bot = User.objects.create(
+            username="bot-confidential-project-ui-token",
+            full_name="Confidential UI token",
+            is_bot=True,
+        )
+        self.client.login(username=user.username, password="testpassword")
+
+        response = self.client.get(reverse("user_list"))
+        self.assertNotContains(response, bot.get_absolute_url())
+        response = self.client.get(reverse("user_list"), {"q": bot.username})
+        self.assertNotContains(response, bot.get_absolute_url())
+
+        permission = Permission.objects.get(codename="user.view")
+        role = Role.objects.create(name="View bot users")
+        role.permissions.add(permission)
+        group = Group.objects.create(name="View bot users")
+        group.roles.add(role)
+        user.groups.add(group)
+        user.clear_permissions_cache()
+
+        response = self.client.get(reverse("user_list"))
+        self.assertContains(response, bot.get_absolute_url())
+        response = self.client.get(reverse("user_list"), {"q": bot.username})
+        self.assertContains(response, bot.get_absolute_url())
 
     def test_user(self) -> None:
         """Test user pages."""

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -2122,10 +2122,10 @@ class UserList(ListView):
     initial_query = ""
 
     def get_base_queryset(self):
-        return User.objects.filter(is_active=True, is_bot=False)
+        return User.objects.filter(is_active=True)
 
     def get_queryset(self):
-        users = self.get_base_queryset()
+        users = self.get_base_queryset().filter_search_access(self.request.user)
         form = self.form
         if form.is_valid():
             search = form.cleaned_data.get("q", "")

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -560,6 +560,60 @@ class UserAPITest(APIBaseTest):
         response = self.client.get(reverse("api:user-list"), {"username": "a"})
         self.assertEqual(response.data["count"], 0)
 
+    def test_filter_bot_user(self) -> None:
+        """Unprivileged searches do not list bot users."""
+        active_bot = User.objects.create(
+            username="bot-private-project-active",
+            full_name="Active project token",
+            is_active=True,
+            is_bot=True,
+        )
+        User.objects.create(
+            username="bot-private-project-expired",
+            full_name="Expired project token",
+            is_active=False,
+            is_bot=True,
+        )
+
+        self.authenticate(False)
+        response = self.client.get(
+            reverse("api:user-list"), {"username": "bot-private-project"}
+        )
+        self.assertEqual(response.data["count"], 0)
+
+        # Exact user lookup remains available with the limited serializer.
+        response = self.client.get(
+            reverse("api:user-detail", kwargs={"username": active_bot.username})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["username"], active_bot.username)
+
+        for permission in ("user.view", "user.edit"):
+            with self.subTest(permission=permission):
+                self.user.groups.set([self.group])
+                self.user.clear_permissions_cache()
+                self.grant_perm_to_user(
+                    permission, group_name=f"Bot search {permission}"
+                )
+                response = self.client.get(
+                    reverse("api:user-list"),
+                    {"username": "bot-private-project"},
+                )
+                self.assertEqual(response.data["count"], 2)
+
+    def test_filter_own_bot_user(self) -> None:
+        """An unprivileged bot can find its own account."""
+        self.user.is_bot = True
+        self.user.save(update_fields=["is_bot"])
+        self.authenticate(False)
+
+        response = self.client.get(
+            reverse("api:user-list"), {"username": self.user.username}
+        )
+
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["username"], self.user.username)
+
     def test_create(self) -> None:
         self.do_request("api:user-list", method="post", code=403)
         response = self.do_request(
@@ -14908,6 +14962,22 @@ class SearchAPITest(APIBaseTest):
                 },
             ],
         )
+
+    def test_bot_visibility(self) -> None:
+        bot = User.objects.create(
+            username="bot-confidential-project-audit-token",
+            full_name="Confidential audit token",
+            is_bot=True,
+        )
+
+        response = self.do_request("api:search", request={"q": "confidential-project"})
+        self.assertFalse(
+            any(result["name"] == bot.username for result in response.data)
+        )
+
+        self.grant_perm_to_user("user.view")
+        response = self.do_request("api:search", request={"q": "confidential-project"})
+        self.assertTrue(any(result["name"] == bot.username for result in response.data))
 
     def test_language(self) -> None:
         response = self.client.get(reverse("api:search"), {"q": "czech"})

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1196,6 +1196,7 @@ class UserViewSet(viewsets.ModelViewSet):
         else:
             queryset = self.get_queryset()
 
+        queryset = queryset.filter_search_access(user)
         queryset = self.filter_queryset(queryset)
 
         page = self.paginate_queryset(queryset)
@@ -4971,13 +4972,16 @@ class Search(APIView):
                 for component in components.search(query).order()[:5]
             )
             if user.is_authenticated:
+                user_queryset = User.objects.filter_search_access(user)
                 results.extend(
                     {
-                        "url": user.get_absolute_url(),
-                        "name": user.username,
+                        "url": search_user.get_absolute_url(),
+                        "name": search_user.username,
                         "category": gettext("User"),
                     }
-                    for user in User.objects.search(query, parser="plain").order()[:5]
+                    for search_user in user_queryset.search(
+                        query, parser="plain"
+                    ).order()[:5]
                 )
             results.extend(
                 {

--- a/weblate/auth/models.py
+++ b/weblate/auth/models.py
@@ -647,6 +647,12 @@ class UserQuerySet(models.QuerySet["User", "User"]):
     def order(self):
         return self.order_by("username")
 
+    def filter_search_access(self, user: User) -> Self:
+        """Hide bot accounts from unprivileged user listings and searches."""
+        if user.has_perm("user.view") or user.has_perm("user.edit"):
+            return self
+        return self.filter(Q(is_bot=False) | Q(pk=user.pk))
+
     def search(
         self,
         query: str,

--- a/weblate/trans/tests/test_projecttoken.py
+++ b/weblate/trans/tests/test_projecttoken.py
@@ -122,6 +122,44 @@ class ProjectTokenTest(FixtureTestCase):
 
         self.assertEqual(response.data["slug"], self.project.slug)
 
+    def test_token_not_enumerated_in_user_search(self) -> None:
+        """Unrelated users can not find project tokens through user searches."""
+        token_key = self.create_token()
+        token_user = self.get_token_user(token_key)
+        _attacker_project, _attacker, attacker_client = self.create_attacker()
+
+        response = attacker_client.get(reverse("api:user-list"), {"username": "bot-"})
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(
+            token_user.username,
+            {result["username"] for result in response.json()["results"]},
+        )
+
+        response = attacker_client.get(
+            reverse("api:search"), {"q": token_user.username}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(
+            token_user.username,
+            {result["name"] for result in response.json()},
+        )
+
+        # Exact API lookup remains available by design.
+        response = attacker_client.get(
+            reverse("api:user-detail", kwargs={"username": token_user.username})
+        )
+        self.assertEqual(response.status_code, 200)
+
+        token_client = self.client_class()
+        response = token_client.get(
+            reverse("api:user-list"),
+            {"username": token_user.username},
+            headers={"authorization": f"Token {token_key}"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["username"], token_user.username)
+
     def test_revoke_token(self) -> None:
         """Create a token revoke it, check that usage is not allowed."""
         token = self.create_token()


### PR DESCRIPTION
Prevent users without global user viewing or editing permission from enumerating project-token bot accounts through the API user list, site-wide search, or UI user directory. Centralize the policy on UserQuerySet while preserving privileged visibility and allowing bot callers to find their own account.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
