### PR TITLE
fix(l10n): preserve Docker Compose build key in Vietnamese docs

### DIFF
--- a/docs/locales/vi/LC_MESSAGES/docs.po
+++ b/docs/locales/vi/LC_MESSAGES/docs.po
@@ -12639,7 +12639,7 @@ msgstr ""
 "chính thức <https://github.com/WeblateOrg/docker-compose>`__, chưa sửa đổi "
 "và mở rộng nó thông qua ``docker-compose.override.yml``, bạn có thể muốn tạo "
 "một bản sao của tệp ``docker-compose.yml`` chính thức và chỉnh sửa bản sao "
-"của mình để thay thế ``image: weblate/weblate`` bằng ``xây dựng: .``."
+"của mình để thay thế ``image: weblate/weblate`` bằng ``build: .``."
 
 msgid ""
 "See the `Compose file build reference`_ for details on building images from "


### PR DESCRIPTION
### Motivation
- The Vietnamese translation incorrectly localized the Docker Compose property `build: .` to `xây dựng: .`, which would produce an invalid compose file if copied verbatim, so the literal key must be preserved in the translation.

### Description
- Update `docs/locales/vi/LC_MESSAGES/docs.po` to replace the erroneous translated literal with the exact `build: .` token while leaving the surrounding translation intact.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors and it reported no issues.
- Validated the PO file with `msgfmt --check --check-format --output-file=/tmp/weblate-docs-vi.mo docs/locales/vi/LC_MESSAGES/docs.po`, which succeeded.
- Executed a targeted Python assertion to verify the string `bằng ``build: .``` is present and the incorrect `bằng ``xây dựng: .``` is absent, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a980cfeb5bc8329802e9b9f58dda19b)