### PR TITLE
fix(l10n): preserve Vietnamese payment details

### DIFF
--- a/weblate/locale/vi/LC_MESSAGES/django.po
+++ b/weblate/locale/vi/LC_MESSAGES/django.po
@@ -3790,7 +3790,7 @@ msgid "Automatic payment \"{}\" received for \"{}\" ({})."
 msgstr "Đã nhận được khoản thanh toán tự động \"{}\" cho \"{}\" ({})."
 
 msgid "Payment \"{}\" received for \"{}\" ({})."
-msgstr "Đã nhận thanh toán cho \"{}\" ({})."
+msgstr "Đã nhận thanh toán \"{}\" cho \"{}\" ({})."
 
 msgid "Merged billing \"{}\" into \"{}\"."
 msgstr "Đã hợp nhất hóa đơn \"{}\" thành \"{}\"."


### PR DESCRIPTION
### Motivation
- Fix a localization regression where the Vietnamese translation for the payment-received audit message omitted one positional placeholder, causing the billing period to be dropped from superuser audit logs.

### Description
- Update `weblate/locale/vi/LC_MESSAGES/django.po` to include the missing third placeholder so the message preserves the payment identifier, plan, and billing period in the correct order.

### Testing
- Ran `msgfmt --check --check-format -o /tmp/weblate-vi.mo weblate/locale/vi/LC_MESSAGES/django.po`, a compiled-catalog reproduction via Python that formatted the three arguments, and `uv run prek run --files weblate/locale/vi/LC_MESSAGES/django.po`, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a980cf1b05083298ca8d64c8df2e795)