### PR TITLE
fix(analytics): avoid global const shadowing window._paq

### DIFF
--- a/weblate/static/js/matomo.js
+++ b/weblate/static/js/matomo.js
@@ -5,7 +5,7 @@
 const matomoTracker = document.getElementById("matomo-tracker");
 
 // biome-ignore lint/suspicious/noAssignInExpressions: keep upstream compatibility
-const _paq = (window._paq = window._paq || []);
+var _paq = (window._paq = window._paq || []);
 const customVariables = {
   Language: matomoTracker.dataset.language,
 };

--- a/weblate/static/js/matomo.js
+++ b/weblate/static/js/matomo.js
@@ -5,6 +5,7 @@
 const matomoTracker = document.getElementById("matomo-tracker");
 
 // biome-ignore lint/suspicious/noAssignInExpressions: keep upstream compatibility
+// biome-ignore lint/suspicious/noVar: keep upstream compatibility
 var _paq = (window._paq = window._paq || []);
 const customVariables = {
   Language: matomoTracker.dataset.language,


### PR DESCRIPTION
Matomo integration is currently broken. This PR fixes this

matomo.js is loaded as a classic script, so the top-level `const _paq` creates a global lexical binding that shadows the window property. Matomo's own matomo.js assigns to the unqualified `_paq` in addTracker, which then throws "invalid assignment to const" and aborts tracker initialisation before any request is sent.

This worked while the snippet was inlined in the template; it broke when it moved to a static file in https://github.com/WeblateOrg/weblate/commit/5a3518c3a38714e801d353110d7f864c002a74f9

```
Uncaught TypeError: invalid assignment to const '_paq'
    ai https://my-matomo/matomo.js:70
    addTracker https://my-matomo/matomo.js:72
    <anonymous> https://my-matomo/matomo.js:76
    <anonymous> https://my-matomo/matomo.js:76
matomo.js:70:794
```