### PR TITLE
fix(l10n): correct Polish message for completed repository commits

### DIFF
--- a/weblate/locale/pl/LC_MESSAGES/django.po
+++ b/weblate/locale/pl/LC_MESSAGES/django.po
@@ -17940,7 +17940,7 @@ msgid "All pending translations were committed."
 msgstr "Wszystkie oczekujące tłumaczenia zostały scommitowane."
 
 msgid "Pending translations in accessible repositories were committed."
-msgstr "Trwa zatwierdzanie oczekujących tłumaczeń w dostępnych repozytoriach."
+msgstr "Oczekujące tłumaczenia w dostępnych repozytoriach zostały zatwierdzone."
 
 msgid "Component is now locked for translation updates!"
 msgstr "Komponent jest obecnie zablokowany do aktualizacji tłumaczenia!"


### PR DESCRIPTION
### Motivation

- The Polish translation for the message `"Pending translations in accessible repositories were committed."` used progressive wording that implies the commit is still running, producing inaccurate completion feedback when the operation runs synchronously.

### Description

- Update `weblate/locale/pl/LC_MESSAGES/django.po` to change the `msgstr` for that msgid to completed-action wording: `"Oczekujące tłumaczenia w dostępnych repozytoriach zostały zatwierdzone."`.

### Testing

- Ran `msgfmt --check --check-accelerators='&' -o /tmp/weblate-pl-django.mo weblate/locale/pl/LC_MESSAGES/django.po`, `uv run prek run --all-files`, and `uv sync --all-extras --dev`, and each command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98201b5bd883299accfdee72005b28)