### PR TITLE
fix(vcs): clear obsolete alerts after GitHub App migration

### DIFF
--- a/weblate/vcs/tests/test_github_views.py
+++ b/weblate/vcs/tests/test_github_views.py
@@ -1645,7 +1645,8 @@ class GitHubInstallationViewTest(ViewTestCase):
             },
         )
         self.component.refresh_from_db()
-        self.component.add_alert("GitHubAppMigration")
+        for alert_name in ("GitHubAppMigration", "PushFailure", "UpdateFailure"):
+            self.component.add_alert(alert_name)
         url = reverse(
             "github-app-migration", kwargs={"workspace_id": self.workspace.pk}
         )
@@ -1663,7 +1664,9 @@ class GitHubInstallationViewTest(ViewTestCase):
             {"create_merge_request": False},
         )
         self.assertFalse(
-            self.component.alert_set.filter(name="GitHubAppMigration").exists()
+            self.component.alert_set.filter(
+                name__in=("GitHubAppMigration", "PushFailure", "UpdateFailure")
+            ).exists()
         )
 
     @override_settings(

--- a/weblate/vcs/views.py
+++ b/weblate/vcs/views.py
@@ -1118,6 +1118,9 @@ def github_app_migration(request, workspace_id):
                 except ValidationError as error:
                     errors.append((component.full_slug, " ".join(error.messages)))
                     continue
+                component.delete_alert("GitHubAppMigration")
+                component.delete_alert("PushFailure")
+                component.delete_alert("UpdateFailure")
                 component.save(
                     update_fields=(
                         "vcs",
@@ -1127,7 +1130,6 @@ def github_app_migration(request, workspace_id):
                         "vcs_params",
                     )
                 )
-                component.delete_alert("GitHubAppMigration")
                 migrated += 1
 
         if migrated:


### PR DESCRIPTION
Remove prior push and update failure alerts once a component has successfully switched repository backends. Fresh failures during the follow-up repository operation will create new alerts.

Identified in https://github.com/WeblateOrg/weblate/pull/21420

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
