### PR TITLE
fix(vcs): run repository reset in transaction

### DIFF
--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -3233,6 +3233,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
 
         return True
 
+    @transaction.atomic
     def reset_repository_to_remote(
         self,
         request: AuthenticatedHttpRequest | None,

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -600,7 +600,7 @@ class UnitQuerySet(models.QuerySet["Unit", "Unit"]):
             strings=Count("pk"), words=Sum("num_words"), chars=Sum(Length("source"))
         )
 
-    def clear_disk_state(self):
+    def clear_disk_state(self) -> None:
         units_to_update = list(
             self.filter(details__has_key="disk_state").select_for_update()
         )

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -1434,6 +1434,25 @@ class ComponentChangeTest(RepoTestCase):
         self.assertTrue(linked_component.locked)
 
 
+class ComponentResetTransactionTest(RepoTestMixin, TransactionTestCase):
+    def setUp(self) -> None:
+        self.clone_test_repos()
+        super().setUp()
+
+    def test_reset_opens_transaction(self) -> None:
+        component = self.create_component()
+        unit = Unit.objects.filter(translation__component=component).first()
+        self.assertIsNotNone(unit)
+        unit.details["disk_state"] = {}
+        unit.save(update_fields=["details"], only_save=True)
+
+        self.assertTrue(connection.get_autocommit())
+        self.assertTrue(component.do_reset())
+
+        unit.refresh_from_db()
+        self.assertNotIn("disk_state", unit.details)
+
+
 class ComponentAlertConcurrencyTest(RepoTestMixin, TransactionTestCase):
     def setUp(self) -> None:
         self.clone_test_repos()


### PR DESCRIPTION
Background repository resets no longer inherit the request transaction. Restore the reset transaction boundary so unit disk state can be locked and cleared safely.

Fixes WEBLATE-3BFR

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
