### PR TITLE
fix(l10n): preserve languages.csv in Vietnamese docs

### DIFF
--- a/docs/locales/vi/LC_MESSAGES/docs.po
+++ b/docs/locales/vi/LC_MESSAGES/docs.po
@@ -35555,7 +35555,7 @@ msgid ""
 "to :file:`languages.csv`, other files are generated from that file. The "
 "columns in the CSV file correspond to :ref:`language-definitions`."
 msgstr ""
-"Bạn có thể thêm các định nghĩa ngôn ngữ còn thiếu vào :file:`lingu.csv`, các "
+"Bạn có thể thêm các định nghĩa ngôn ngữ còn thiếu vào :file:`languages.csv`, các "
 "tệp khác được tạo từ tệp đó. Các cột trong tệp CSV tương ứng với "
 ":ref:`language-definitions`."
 


### PR DESCRIPTION
### Motivation
- Correct a translation defect in the Vietnamese documentation that replaced the technical filename `languages.csv` with the nonexistent `lingu.csv`, which could prevent contributors from finding the language-definition source file.

### Description
- Update `docs/locales/vi/LC_MESSAGES/docs.po` to restore the original technical filename by replacing `:file:`lingu.csv`` with `:file:`languages.csv`` in the affected translated string.

### Testing
- Verified the fix with `msgfmt --check --check-format --statistics -o /tmp/weblate-vi-docs.mo docs/locales/vi/LC_MESSAGES/docs.po` (succeeded, 8,806 translated messages), `git diff --check` (no issues), and a repository search `rg -n -F 'lingu.csv' .` (zero matches), and confirmed the working tree is clean with `git status --porcelain=v1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9902bf5e3883298cf3fd63118fd230)