### PR TITLE
fix: handle tab navigation for triggers outside of .nav

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -958,6 +958,19 @@ onReady(() => {
     });
   });
 
+  /* Activate a tab from outside the navigation */
+  document.querySelectorAll("[data-tab-target]").forEach((element) => {
+    element.addEventListener("click", (e) => {
+      e.preventDefault();
+      const trigger = document.querySelector(
+        `.nav [data-bs-toggle=tab][data-bs-target="${element.getAttribute("data-tab-target")}"]`,
+      );
+      if (trigger !== null) {
+        bootstrap.Tab.getOrCreateInstance(trigger).show();
+      }
+    });
+  });
+
   /* Navigate to a tab when the history changes */
   window.addEventListener("popstate", (_e) => {
     let tab = null;

--- a/weblate/templates/snippets/upload-placeholder.html
+++ b/weblate/templates/snippets/upload-placeholder.html
@@ -14,9 +14,6 @@
         translation and upload the file there.
       {% endblocktranslate %}
     </p>
-    <a class="btn btn-primary"
-       data-bs-target="{{ upload_translation_tab }}"
-       data-bs-toggle="tab"
-       href="#">{{ upload_translation_label }}</a>
+    <a class="btn btn-primary" data-tab-target="{{ upload_translation_tab }}" href="#">{{ upload_translation_label }}</a>
   </div>
 </div>

--- a/weblate/templates/trans/component_create.html
+++ b/weblate/templates/trans/component_create.html
@@ -172,7 +172,7 @@
             <input type="hidden" name="project" value="{{ selected_project }}" />
             <p class="check">
               {% translate "Create a new empty translation component to start from scratch." %}
-              {% blocktranslate with link_start='<a data-bs-target="#zip" data-bs-toggle="tab" href="#">' link_end='</a>' %}Create a ZIP file containing any existing translation files you have, and {{ link_start }}upload it{{ link_end }}.{% endblocktranslate %}
+              {% blocktranslate with link_start='<a data-tab-target="#zip" href="#">' link_end='</a>' %}Create a ZIP file containing any existing translation files you have, and {{ link_start }}upload it{{ link_end }}.{% endblocktranslate %}
             </p>
             {% crispy scratch_form %}
             <input type="submit"


### PR DESCRIPTION
Adds a new handler for triggers that try to activate a tab from outside of a .nav block and changes templates to use this new handler
fixes #21339 
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
