### PR TITLE
perf(celery): preload URLs before worker fork

### DIFF
--- a/weblate/utils/celery.py
+++ b/weblate/utils/celery.py
@@ -15,7 +15,12 @@ from typing import Any
 
 from celery import Celery
 from celery.contrib.django.task import DjangoTask
-from celery.signals import after_setup_logger, before_task_publish, task_failure
+from celery.signals import (
+    after_setup_logger,
+    before_task_publish,
+    task_failure,
+    worker_before_create_process,
+)
 from django.conf import settings
 from django.core.cache import cache
 from django.core.checks import run_checks
@@ -46,6 +51,15 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
 
 TASK_METADATA_TTL = 6 * 3600
+
+
+@worker_before_create_process.connect
+def preload_urls_before_fork(**kwargs) -> None:
+    """Load URL patterns in the parent process before forking a worker."""
+    # ruff: ignore[import-outside-top-level]
+    from weblate.utils.startup import preload_url_patterns
+
+    preload_url_patterns()
 
 
 def get_task_metadata_key(task_id: str) -> str:

--- a/weblate/utils/tests/test_celery.py
+++ b/weblate/utils/tests/test_celery.py
@@ -140,6 +140,35 @@ print("tesserocr" in sys.modules)
 
         self.assertEqual(output, "False")
 
+    def test_url_loading_before_worker_fork(self) -> None:
+        output = self.run_python(
+            """
+import json
+import sys
+
+from celery.signals import worker_before_create_process
+from weblate.utils.celery import app
+
+app.loader.import_default_modules()
+urls_loaded_before_fork = "weblate.urls" in sys.modules
+worker_before_create_process.send(sender=app)
+print(json.dumps({
+    "urls_loaded_before_fork": urls_loaded_before_fork,
+    "urls_loaded_after_fork": "weblate.urls" in sys.modules,
+    "tesserocr_loaded": "tesserocr" in sys.modules,
+}))
+"""
+        )
+
+        self.assertEqual(
+            json.loads(output),
+            {
+                "urls_loaded_before_fork": False,
+                "urls_loaded_after_fork": True,
+                "tesserocr_loaded": False,
+            },
+        )
+
     def test_explicit_check_configuration_is_preserved(self) -> None:
         output = self.run_python(
             """


### PR DESCRIPTION
Load Django URL patterns in the prefork parent so workers share the resolver and imported view memory instead of allocating it independently at runtime.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
