### PR TITLE
fix(backups): serialize backup file generation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 2026.9.1
 * Links outside tab navigation now correctly activate their target tabs, fixing upload links for missing translations and new components.
 * Error reporting integrations now distinguish informational messages from exceptions and reliably report the explicitly handled exception.
 * The default Celery per-child memory limit now accommodates the application's baseline memory usage, avoiding unnecessary worker recycling.
+* Backup services now start only after settings and database backup files are fully updated, while backups to different Borg repositories can run in parallel.
 
 .. rubric:: Compatibility
 

--- a/weblate/utils/backup.py
+++ b/weblate/utils/backup.py
@@ -9,21 +9,30 @@ from __future__ import annotations
 import os
 import string
 import subprocess  # ruff: ignore[suspicious-subprocess-import]
+import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from random import SystemRandom
 from shlex import quote
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.db import connection, transaction
 from django.utils.translation import gettext
 
 from weblate.utils.commands import get_clean_env
-from weblate.utils.data import data_dir
+from weblate.utils.data import data_dir, data_path
 from weblate.utils.errors import add_breadcrumb, report_error, report_message
 from weblate.utils.files import cleanup_error_message
-from weblate.utils.lock import WeblateLock
+from weblate.utils.lock import WeblateLockTimeoutError
+from weblate.utils.tracing import start_span
 from weblate.vcs.ssh import SSH_WRAPPER, add_host_key
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import TracebackType
 
 BORG_SSH_OPTIONS = (
     "-o",
@@ -38,23 +47,96 @@ CACHEDIR = """Signature: 8a477f597d28d172789f06886806bc55
 #	https://bford.info/cachedir/spec.html
 """
 
+# Stable application-specific PostgreSQL advisory lock key ("WEBLATE").
+BACKUP_LOCK_KEY = 0x5745424C415445
+BACKUP_LOCK_TIMEOUT = 120
+BACKUP_LOCK_POLL_INTERVAL = 0.1
 
-def ensure_backup_dir():
-    backup_dir = data_dir("backups")
-    if not os.path.exists(backup_dir):
-        os.makedirs(backup_dir)
+
+def ensure_backup_dir() -> Path:
+    backup_dir = data_path("backups")
+    backup_dir.mkdir(parents=True, exist_ok=True)
     return backup_dir
 
 
-def backup_lock():
+class BackupLock:
+    """Transaction-scoped reader/writer lock for backup file access."""
+
+    def __init__(self, *, shared: bool, timeout: int = BACKUP_LOCK_TIMEOUT) -> None:
+        # PostgreSQL is deliberately the only lock authority here. A filesystem
+        # fallback would not coordinate workers running on different hosts.
+        self._shared = shared
+        self._timeout = timeout
+        self._scope = "backup:run"
+        self._origin = None
+        self._name = "postgresql:backup:run"
+        self._locked = False
+
+    @property
+    def _try_lock_query(self) -> str:
+        if self._shared:
+            return "SELECT pg_try_advisory_xact_lock_shared(%s)"
+        return "SELECT pg_try_advisory_xact_lock(%s)"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def scope(self) -> str:
+        return self._scope
+
+    @property
+    def origin(self) -> None:
+        return self._origin
+
+    def get_error_message(self) -> str:
+        return f"Lock on {self._name} could not be acquired in {self._timeout}s"
+
+    def add_breadcrumb(self, operation: str) -> None:
+        mode = "shared" if self._shared else "exclusive"
+        add_breadcrumb(category="lock", message=f"{operation} {self._name} ({mode})")
+
+    @property
+    def is_locked(self) -> bool:
+        return self._locked
+
+    def __enter__(self) -> None:
+        deadline = time.monotonic() + self._timeout
+        self.add_breadcrumb("enter")
+        with start_span(op="lock.wait", name=self._name):
+            while True:
+                with connection.cursor() as cursor:
+                    cursor.execute(self._try_lock_query, [BACKUP_LOCK_KEY])
+                    result = cursor.fetchone()
+                if result is not None and result[0]:
+                    self._locked = True
+                    self.add_breadcrumb("acquire")
+                    return
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self.add_breadcrumb("timeout")
+                    raise WeblateLockTimeoutError(self.get_error_message(), lock=self)
+                time.sleep(min(BACKUP_LOCK_POLL_INTERVAL, remaining))
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self._locked = False
+        self.add_breadcrumb("release")
+
+
+@contextmanager
+def backup_lock(
+    *, shared: bool = False, timeout: int = BACKUP_LOCK_TIMEOUT
+) -> Iterator[None]:
     ensure_backup_dir()
-    return WeblateLock(
-        scope="backup:run",
-        key=0,
-        slug="",
-        timeout=120,
-        expiry_timeout=4 * 3600,
-    )
+    lock = BackupLock(shared=shared, timeout=timeout)
+    with transaction.atomic(), lock:
+        yield
 
 
 class BackupError(Exception):
@@ -114,35 +196,34 @@ def get_borg_rsh() -> str:
 
 def run_borg(cmd: list[str], env: dict[str, str] | None = None) -> BorgResult:
     """Execute borgbackup."""
-    with backup_lock():
-        SSH_WRAPPER.create()
-        try:
-            result = subprocess.run(
-                # ruff: ignore[start-process-with-partial-path]
-                ["borg", "--rsh", get_borg_rsh(), *cmd],
-                check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                env=get_clean_env(env),
-                text=True,
-            )
-        except OSError as error:
-            report_error("Borg could not be executed")
-            msg = f"Could not execute borg program: {error}"
-            raise BackupError(msg) from error
-        stdout = result.stdout or ""
-        if result.returncode == 0:
-            return BorgResult(output=stdout)
-        if result.returncode == 1:
-            if not stdout.strip():
-                stdout = gettext("Borg completed with warnings without any output.")
-            return BorgResult(output=stdout, returncode=1)
-        add_breadcrumb(category="backup", message="borg output", stdout=stdout)
-        report_message("Borg failed")
-        msg = cleanup_error_message(stdout)
-        if not msg.strip():
-            msg = f"Borg exited with status {result.returncode} without any output"
-        raise BackupError(msg)
+    SSH_WRAPPER.create()
+    try:
+        result = subprocess.run(
+            # ruff: ignore[start-process-with-partial-path]
+            ["borg", "--rsh", get_borg_rsh(), *cmd],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=get_clean_env(env),
+            text=True,
+        )
+    except OSError as error:
+        report_error("Borg could not be executed")
+        msg = f"Could not execute borg program: {error}"
+        raise BackupError(msg) from error
+    stdout = result.stdout or ""
+    if result.returncode == 0:
+        return BorgResult(output=stdout)
+    if result.returncode == 1:
+        if not stdout.strip():
+            stdout = gettext("Borg completed with warnings without any output.")
+        return BorgResult(output=stdout, returncode=1)
+    add_breadcrumb(category="backup", message="borg output", stdout=stdout)
+    report_message("Borg failed")
+    msg = cleanup_error_message(stdout)
+    if not msg.strip():
+        msg = f"Borg exited with status {result.returncode} without any output"
+    raise BackupError(msg)
 
 
 def initialize(location: str, passphrase: str) -> BorgResult:
@@ -190,10 +271,11 @@ def backup(location: str, passphrase: str) -> BorgResult:
             settings.DATA_DIR,
         ],
     )
-    return run_borg(
-        command,
-        {"BORG_PASSPHRASE": passphrase},
-    )
+    with backup_lock(shared=True):
+        return run_borg(
+            command,
+            {"BORG_PASSPHRASE": passphrase},
+        )
 
 
 def prune(location: str, passphrase: str) -> BorgResult:

--- a/weblate/utils/lock.py
+++ b/weblate/utils/lock.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import os
 import threading
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Protocol, cast
 from urllib.parse import quote
 
 from django.core.cache import cache
@@ -24,8 +24,21 @@ if TYPE_CHECKING:
     from redis.lock import Lock as RedisLock
 
 
+class LockInfo(Protocol):
+    """Lock metadata exposed on lock errors."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def scope(self) -> str: ...
+
+    @property
+    def origin(self) -> str | None: ...
+
+
 class WeblateLockError(Exception):
-    def __init__(self, message: str, *, lock: WeblateLock) -> None:
+    def __init__(self, message: str, *, lock: LockInfo) -> None:
         super().__init__(message)
         self.lock = lock
 

--- a/weblate/utils/tasks.py
+++ b/weblate/utils/tasks.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from shutil import copyfile
 from typing import cast
 
-from celery.schedules import crontab
 from django.conf import settings
 from django.core.cache import cache
 from django.core.management.commands import diffsettings
@@ -60,27 +59,29 @@ def heartbeat() -> None:
     cache.set("celery_encoding", get_encoding_list())
 
 
+def _run_settings_backup() -> None:
+    # Expand settings in case it contains non-trivial code
+    command = diffsettings.Command()
+    kwargs = {"default": None, "all": False, "output": "hash"}
+    Path(data_dir("backups", "settings-expanded.py")).write_text(
+        command.handle(**kwargs), encoding="utf-8"
+    )
+
+    # Backup original settings
+    if settings.SETTINGS_MODULE:
+        settings_mod = import_module(settings.SETTINGS_MODULE)
+        if settings_mod.__file__ is not None:
+            copyfile(settings_mod.__file__, data_dir("backups", "settings.py"))
+
+    # Backup environment (to make restoring Docker easier)
+    with open(data_dir("backups", "environment.yml"), "w", encoding="utf-8") as handle:
+        yaml = YAML()
+        yaml.dump(dict(os.environ), handle)
+
+
 def run_settings_backup() -> None:
     with backup_lock():
-        # Expand settings in case it contains non-trivial code
-        command = diffsettings.Command()
-        kwargs = {"default": None, "all": False, "output": "hash"}
-        Path(data_dir("backups", "settings-expanded.py")).write_text(
-            command.handle(**kwargs), encoding="utf-8"
-        )
-
-        # Backup original settings
-        if settings.SETTINGS_MODULE:
-            settings_mod = import_module(settings.SETTINGS_MODULE)
-            if settings_mod.__file__ is not None:
-                copyfile(settings_mod.__file__, data_dir("backups", "settings.py"))
-
-        # Backup environment (to make restoring Docker easier)
-        with open(
-            data_dir("backups", "environment.yml"), "w", encoding="utf-8"
-        ) as handle:
-            yaml = YAML()
-            yaml.dump(dict(os.environ), handle)
+        _run_settings_backup()
 
 
 @app.task(trail=False, autoretry_for=(WeblateLockTimeoutError,))
@@ -224,84 +225,126 @@ def _create_database_backup_logs(
     )
 
 
+class _DatabaseBackupError(Exception):
+    def __init__(self, error: OSError | subprocess.CalledProcessError) -> None:
+        super().__init__(str(error))
+        self.error = error
+
+
+def _record_database_backup_error(
+    error: OSError | subprocess.CalledProcessError,
+    additional_service_ids: list[int] | None,
+) -> None:
+    if isinstance(error, subprocess.CalledProcessError):
+        add_breadcrumb(
+            category="backup",
+            message="database dump output",
+            stdout=error.stdout,
+            stderr=error.stderr,
+        )
+        error_output = error.stderr or (
+            f"pg_dump exited with status {error.returncode} without any output"
+        )
+    else:
+        error_output = str(error)
+    error_output = cleanup_error_message(error_output)
+    LOGGER.error("failed database backup: %s", error_output)
+    report_error("Database backup failed")
+    _create_database_backup_logs("database-error", error_output, additional_service_ids)
+
+
+def _record_database_backup_success(
+    additional_service_ids: list[int] | None,
+) -> None:
+    _create_database_backup_logs(
+        "database",
+        "Database dump completed successfully.",
+        additional_service_ids,
+    )
+
+
+def _run_database_backup() -> bool:
+    if settings.DATABASE_BACKUP == "none":
+        return False
+    database = settings.DATABASES["default"]
+    env = get_clean_env()
+    compress = settings.DATABASE_BACKUP == "compressed"
+
+    out_compressed = data_dir("backups", "database.sql.gz")
+    out_text = data_dir("backups", "database.sql")
+
+    cmd = [
+        "pg_dump",
+        # Superuser only, crashes on Alibaba Cloud Database PolarDB
+        "--no-subscriptions",
+        "--clean",
+        "--if-exists",
+        "--dbname",
+        database["NAME"],
+    ]
+
+    if database["HOST"]:
+        cmd.extend(["--host", database["HOST"]])
+    if database["PORT"]:
+        cmd.extend(["--port", database["PORT"]])
+    if database["USER"]:
+        cmd.extend(["--username", database["USER"]])
+    if settings.DATABASE_BACKUP == "compressed":
+        cmd.extend(["--file", out_compressed])
+        cmd.extend(["--compress", "6"])
+        compress = False
+    else:
+        cmd.extend(["--file", out_text])
+
+    env["PGPASSWORD"] = cast("str", database["PASSWORD"])
+
+    try:
+        subprocess.run(
+            cmd,  # type: ignore[arg-type]
+            env=env,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            check=True,
+            text=True,
+        )
+        if compress:
+            with (
+                open(out_text, "rb") as f_in,
+                gzip.open(out_compressed, "wb") as f_out,
+            ):
+                shutil.copyfileobj(f_in, f_out)
+            os.unlink(out_text)
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise _DatabaseBackupError(error) from error
+
+    return True
+
+
 def run_database_backup(additional_service_ids: list[int] | None = None) -> None:
     if settings.DATABASE_BACKUP == "none":
         return
-    with backup_lock():
-        database = settings.DATABASES["default"]
-        env = get_clean_env()
-        compress = settings.DATABASE_BACKUP == "compressed"
+    try:
+        with backup_lock():
+            _run_database_backup()
+    except _DatabaseBackupError as error:
+        _record_database_backup_error(error.error, additional_service_ids)
+        raise error.error from error
+    _record_database_backup_success(additional_service_ids)
 
-        out_compressed = data_dir("backups", "database.sql.gz")
-        out_text = data_dir("backups", "database.sql")
 
-        cmd = [
-            "pg_dump",
-            # Superuser only, crashes on Alibaba Cloud Database PolarDB
-            "--no-subscriptions",
-            "--clean",
-            "--if-exists",
-            "--dbname",
-            database["NAME"],
-        ]
-
-        if database["HOST"]:
-            cmd.extend(["--host", database["HOST"]])
-        if database["PORT"]:
-            cmd.extend(["--port", database["PORT"]])
-        if database["USER"]:
-            cmd.extend(["--username", database["USER"]])
-        if settings.DATABASE_BACKUP == "compressed":
-            cmd.extend(["--file", out_compressed])
-            cmd.extend(["--compress", "6"])
-            compress = False
-        else:
-            cmd.extend(["--file", out_text])
-
-        env["PGPASSWORD"] = cast("str", database["PASSWORD"])
-
-        try:
-            subprocess.run(
-                cmd,  # type: ignore[arg-type]
-                env=env,
-                capture_output=True,
-                stdin=subprocess.DEVNULL,
-                check=True,
-                text=True,
-            )
-            if compress:
-                with (
-                    open(out_text, "rb") as f_in,
-                    gzip.open(out_compressed, "wb") as f_out,
-                ):
-                    shutil.copyfileobj(f_in, f_out)
-                os.unlink(out_text)
-        except (OSError, subprocess.CalledProcessError) as error:
-            if isinstance(error, subprocess.CalledProcessError):
-                add_breadcrumb(
-                    category="backup",
-                    message="database dump output",
-                    stdout=error.stdout,
-                    stderr=error.stderr,
-                )
-                error_output = error.stderr or (
-                    f"pg_dump exited with status {error.returncode} without any output"
-                )
-            else:
-                error_output = str(error)
-            error_output = cleanup_error_message(error_output)
-            LOGGER.error("failed database backup: %s", error_output)
-            report_error("Database backup failed")
-            _create_database_backup_logs(
-                "database-error", error_output, additional_service_ids
-            )
-            raise
-
-        _create_database_backup_logs(
-            "database",
-            "Database dump completed successfully.",
-            additional_service_ids,
-        )
+def run_backup_preparation(
+    additional_service_ids: list[int] | None = None,
+) -> None:
+    """Update all files consumed by Borg while holding the writer lock."""
+    try:
+        with backup_lock():
+            _run_settings_backup()
+            database_backup_created = _run_database_backup()
+    except _DatabaseBackupError as error:
+        _record_database_backup_error(error.error, additional_service_ids)
+        raise error.error from error
+    if database_backup_created:
+        _record_database_backup_success(additional_service_ids)
 
 
 @app.task(trail=False, autoretry_for=(WeblateLockTimeoutError,))
@@ -312,10 +355,4 @@ def database_backup(additional_service_ids: list[int] | None = None) -> None:
 @app.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs) -> None:
     cache.set("celery_loaded", time.time())
-    sender.add_periodic_task(
-        crontab(hour=1, minute=0), settings_backup.s(), name="settings-backup"
-    )
-    sender.add_periodic_task(
-        crontab(hour=1, minute=30), database_backup.s(), name="database-backup"
-    )
     sender.add_periodic_task(HEARTBEAT_FREQUENCY, heartbeat.s(), name="heartbeat")

--- a/weblate/utils/tests/test_backup.py
+++ b/weblate/utils/tests/test_backup.py
@@ -5,18 +5,21 @@
 import os
 import shlex
 import subprocess  # ruff: ignore[suspicious-subprocess-import]
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings
+from django.db import connection
 from django.test import SimpleTestCase, TransactionTestCase
 from django.test.utils import override_settings
 
 from weblate.utils.backup import (
+    BACKUP_LOCK_KEY,
     BackupError,
     BorgResult,
     backup,
+    backup_lock,
     cleanup,
     get_paper_key,
     initialize,
@@ -25,7 +28,12 @@ from weblate.utils.backup import (
     tag_cache_dirs,
 )
 from weblate.utils.data import data_path
-from weblate.utils.tasks import database_backup, settings_backup
+from weblate.utils.lock import WeblateLockTimeoutError
+from weblate.utils.tasks import (
+    database_backup,
+    run_backup_preparation,
+    settings_backup,
+)
 from weblate.utils.unittest import tempdir_setting
 from weblate.wladmin.models import BackupService
 
@@ -149,7 +157,6 @@ class RunBorgTest(SimpleTestCase):
     def test_run_borg_returns_warning_result(self) -> None:
         result = subprocess.CompletedProcess(["borg", "create"], 1, "warning output")
         with (
-            patch("weblate.utils.backup.backup_lock", return_value=nullcontext()),
             patch("weblate.utils.backup.SSH_WRAPPER.create"),
             patch("weblate.utils.backup.report_error"),
             patch("weblate.utils.backup.subprocess.run", return_value=result),
@@ -161,7 +168,6 @@ class RunBorgTest(SimpleTestCase):
     def test_run_borg_disables_weak_crypto_warning(self) -> None:
         result = subprocess.CompletedProcess(["borg", "create"], 0, "")
         with (
-            patch("weblate.utils.backup.backup_lock", return_value=nullcontext()),
             patch("weblate.utils.backup.SSH_WRAPPER.create"),
             patch("weblate.utils.backup.subprocess.run", return_value=result) as run,
         ):
@@ -183,7 +189,6 @@ class RunBorgTest(SimpleTestCase):
     def test_run_borg_reports_silent_failure(self) -> None:
         result = subprocess.CompletedProcess(["borg", "create"], 2, "")
         with (
-            patch("weblate.utils.backup.backup_lock", return_value=nullcontext()),
             patch("weblate.utils.backup.SSH_WRAPPER.create"),
             patch("weblate.utils.backup.add_breadcrumb"),
             patch("weblate.utils.backup.report_message") as report_message,
@@ -197,6 +202,200 @@ class RunBorgTest(SimpleTestCase):
             "Borg exited with status 2 without any output",
         )
         report_message.assert_called_once_with("Borg failed")
+
+
+class BackupLockTest(SimpleTestCase):
+    def test_shared_lock_uses_postgresql_advisory_lock(self) -> None:
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (True,)
+        cursor_context = MagicMock()
+        cursor_context.__enter__.return_value = cursor
+        database_connection = MagicMock()
+        database_connection.cursor.return_value = cursor_context
+        atomic = MagicMock()
+
+        with (
+            patch("weblate.utils.backup.connection", database_connection),
+            patch("weblate.utils.backup.transaction.atomic", return_value=atomic),
+            backup_lock(shared=True),
+        ):
+            pass
+
+        cursor.execute.assert_called_once_with(
+            "SELECT pg_try_advisory_xact_lock_shared(%s)", [BACKUP_LOCK_KEY]
+        )
+        atomic.__enter__.assert_called_once_with()
+        atomic.__exit__.assert_called_once_with(None, None, None)
+
+    def test_transaction_rolls_back_after_exception(self) -> None:
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (True,)
+        cursor_context = MagicMock()
+        cursor_context.__enter__.return_value = cursor
+        database_connection = MagicMock()
+        database_connection.cursor.return_value = cursor_context
+        atomic = MagicMock()
+
+        with (
+            patch("weblate.utils.backup.connection", database_connection),
+            patch("weblate.utils.backup.transaction.atomic", return_value=atomic),
+            self.assertRaisesRegex(RuntimeError, "backup failed"),
+            backup_lock(),
+        ):
+            msg = "backup failed"
+            raise RuntimeError(msg)
+
+        cursor.execute.assert_called_once_with(
+            "SELECT pg_try_advisory_xact_lock(%s)", [BACKUP_LOCK_KEY]
+        )
+        exit_args = atomic.__exit__.call_args.args
+        self.assertIs(exit_args[0], RuntimeError)
+        self.assertEqual(str(exit_args[1]), "backup failed")
+
+    def test_exclusive_lock_times_out(self) -> None:
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (False,)
+        cursor_context = MagicMock()
+        cursor_context.__enter__.return_value = cursor
+        database_connection = MagicMock()
+        database_connection.cursor.return_value = cursor_context
+        atomic = MagicMock()
+
+        with (
+            patch("weblate.utils.backup.connection", database_connection),
+            patch("weblate.utils.backup.transaction.atomic", return_value=atomic),
+            self.assertRaisesRegex(WeblateLockTimeoutError, "could not be acquired"),
+            backup_lock(timeout=0),
+        ):
+            pass
+
+        cursor.execute.assert_called_once_with(
+            "SELECT pg_try_advisory_xact_lock(%s)", [BACKUP_LOCK_KEY]
+        )
+
+
+class BackupLockDatabaseTest(TransactionTestCase):
+    def test_shared_locks_coexist_and_block_exclusive_lock(self) -> None:
+        other_connection = connection.copy(alias="default")
+        try:
+            other_connection.set_autocommit(False)
+            with backup_lock(shared=True), other_connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT pg_try_advisory_xact_lock_shared(%s)", [BACKUP_LOCK_KEY]
+                )
+                self.assertTrue(cursor.fetchone()[0])
+                cursor.execute(
+                    "SELECT pg_try_advisory_xact_lock(%s)", [BACKUP_LOCK_KEY]
+                )
+                self.assertFalse(cursor.fetchone()[0])
+            other_connection.rollback()
+
+            with other_connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT pg_try_advisory_xact_lock(%s)", [BACKUP_LOCK_KEY]
+                )
+                self.assertTrue(cursor.fetchone()[0])
+            other_connection.rollback()
+        finally:
+            other_connection.close()
+
+    def test_exception_releases_exclusive_lock(self) -> None:
+        other_connection = connection.copy(alias="default")
+        try:
+            other_connection.set_autocommit(False)
+            with self.assertRaisesRegex(RuntimeError, "backup failed"), backup_lock():
+                msg = "backup failed"
+                raise RuntimeError(msg)
+
+            with other_connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT pg_try_advisory_xact_lock(%s)", [BACKUP_LOCK_KEY]
+                )
+                self.assertTrue(cursor.fetchone()[0])
+            other_connection.rollback()
+        finally:
+            other_connection.close()
+
+
+class BackupPreparationTest(SimpleTestCase):
+    def test_updates_all_files_under_one_exclusive_lock(self) -> None:
+        operations: list[str | tuple[str, list[int] | None]] = []
+
+        @contextmanager
+        def tracked_lock():
+            operations.append("lock-enter")
+            try:
+                yield
+            finally:
+                operations.append("lock-exit")
+
+        def track_database_backup() -> bool:
+            operations.append("database")
+            return True
+
+        with (
+            patch("weblate.utils.tasks.backup_lock", side_effect=tracked_lock),
+            patch(
+                "weblate.utils.tasks._run_settings_backup",
+                side_effect=lambda: operations.append("settings"),
+            ),
+            patch(
+                "weblate.utils.tasks._run_database_backup",
+                side_effect=track_database_backup,
+            ),
+            patch(
+                "weblate.utils.tasks._record_database_backup_success",
+                side_effect=lambda service_ids: operations.append(
+                    ("database-log", service_ids)
+                ),
+            ),
+        ):
+            run_backup_preparation([7])
+
+        self.assertEqual(
+            operations,
+            [
+                "lock-enter",
+                "settings",
+                "database",
+                "lock-exit",
+                ("database-log", [7]),
+            ],
+        )
+
+    def test_database_failure_is_recorded_after_lock_release(self) -> None:
+        operations = []
+        error = subprocess.CalledProcessError(
+            1,
+            ["pg_dump"],
+            stderr="pg_dump failed",
+        )
+
+        @contextmanager
+        def tracked_lock():
+            operations.append("lock-enter")
+            try:
+                yield
+            finally:
+                operations.append("lock-exit")
+
+        def record_error(*_args: object) -> None:
+            operations.append("database-log")
+
+        with (
+            patch("weblate.utils.tasks.backup_lock", side_effect=tracked_lock),
+            patch("weblate.utils.tasks._run_settings_backup"),
+            patch("weblate.utils.tasks.subprocess.run", side_effect=error),
+            patch(
+                "weblate.utils.tasks._record_database_backup_error",
+                side_effect=record_error,
+            ) as record,
+            self.assertRaises(subprocess.CalledProcessError),
+        ):
+            run_backup_preparation([7])
+
+        self.assertEqual(operations, ["lock-enter", "lock-exit", "database-log"])
+        record.assert_called_once_with(error, [7])
 
 
 class InitializeBackupTest(SimpleTestCase):
@@ -230,9 +429,15 @@ class InitializeBackupTest(SimpleTestCase):
 class BackupCommandTest(SimpleTestCase):
     @override_settings(BORG_EXTRA_ARGS=())
     def test_backup_includes_changed_files_in_filter(self) -> None:
-        with patch(
-            "weblate.utils.backup.run_borg", return_value=BorgResult(output="")
-        ) as mocked:
+        with (
+            patch(
+                "weblate.utils.backup.backup_lock", return_value=nullcontext()
+            ) as lock,
+            patch(
+                "weblate.utils.backup.run_borg", return_value=BorgResult(output="")
+            ) as mocked,
+        ):
             backup("/backup/repository", "key")
 
+        lock.assert_called_once_with(shared=True)
         self.assertIn("ACME", mocked.call_args.args[0])

--- a/weblate/wladmin/management/commands/backup.py
+++ b/weblate/wladmin/management/commands/backup.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from django.core.management.base import CommandError
 
 from weblate.utils.management.base import BaseCommand
-from weblate.utils.tasks import run_database_backup, run_settings_backup
+from weblate.utils.tasks import run_backup_preparation
 from weblate.wladmin.models import BackupService
 from weblate.wladmin.tasks import run_backup_service
 
@@ -86,8 +86,7 @@ class Command(BaseCommand):
         else:
             services = list(BackupService.objects.filter(enabled=True).order_by("pk"))
 
-        run_settings_backup()
-        run_database_backup([service.pk for service in services])
+        run_backup_preparation([service.pk for service in services])
         verbose = int(options["verbosity"]) > 1
         failed_services = [
             service.pk

--- a/weblate/wladmin/migrations/0007_remove_separate_backup_schedules.py
+++ b/weblate/wladmin/migrations/0007_remove_separate_backup_schedules.py
@@ -1,0 +1,40 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from django.db import migrations
+from django.utils.timezone import now
+
+OBSOLETE_BACKUP_SCHEDULES = (
+    "settings-backup",
+    "database-backup",
+)
+
+
+def remove_obsolete_backup_tasks(apps, _schema_editor) -> None:
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTasks = apps.get_model("django_celery_beat", "PeriodicTasks")
+
+    deleted = PeriodicTask.objects.filter(name__in=OBSOLETE_BACKUP_SCHEDULES).delete()[
+        0
+    ]
+
+    if deleted:
+        PeriodicTasks.objects.update_or_create(ident=1, defaults={"last_update": now()})
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_celery_beat", "0019_alter_periodictasks_options"),
+        ("wladmin", "0006_alter_backuplog_event"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_obsolete_backup_tasks,
+            migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/weblate/wladmin/tasks.py
+++ b/weblate/wladmin/tasks.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from weblate.utils.celery import app
 from weblate.utils.lock import WeblateLockTimeoutError
+from weblate.utils.tasks import run_backup_preparation
 from weblate.wladmin.models import BackupService, SupportStatus
 
 
@@ -33,10 +34,18 @@ def support_status_update() -> None:
         support.save()
 
 
-@app.task(trail=False)
-def backup() -> None:
-    for service in BackupService.objects.filter(enabled=True):
-        backup_service.delay(service.pk)
+@app.task(trail=False, autoretry_for=(WeblateLockTimeoutError,))
+def backup(service_ids: list[int] | None = None) -> None:
+    if service_ids is None:
+        service_ids = list(
+            BackupService.objects.filter(enabled=True)
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+
+    run_backup_preparation(service_ids)
+    for service_id in service_ids:
+        backup_service.delay(service_id)
 
 
 @app.task(trail=False, autoretry_for=(WeblateLockTimeoutError,))

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import importlib
 import json
 import os
 from contextlib import contextmanager
@@ -15,6 +16,7 @@ from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlparse
 
 import httpx2
+from django.apps import apps
 from django.conf import settings
 from django.core import mail
 from django.core.checks import Critical
@@ -26,6 +28,7 @@ from django.test import TestCase as DjangoTestCase
 from django.test.utils import CaptureQueriesContext, modify_settings, override_settings
 from django.urls import reverse
 from django.utils import timezone
+from django_celery_beat.models import IntervalSchedule, PeriodicTask, PeriodicTasks
 
 from weblate.accounts.models import AuditLog
 from weblate.auth.models import Group, Invitation, Permission, Role
@@ -60,6 +63,7 @@ from weblate.wladmin.models import (
     SupportStatus,
     get_support_url,
 )
+from weblate.wladmin.tasks import backup as backup_task
 from weblate.wladmin.tasks import backup_service
 from weblate.wladmin.views import (
     DISCOVERY_REGISTRATION_SESSION,
@@ -100,6 +104,43 @@ class BackupFailureService:
 
 
 class BackupTaskTest(TestCase):
+    def test_backup_prepares_before_dispatching_services(self) -> None:
+        operations = []
+
+        with (
+            patch(
+                "weblate.wladmin.tasks.run_backup_preparation",
+                side_effect=lambda service_ids: operations.append(
+                    ("prepare", service_ids)
+                ),
+            ),
+            patch(
+                "weblate.wladmin.tasks.backup_service.delay",
+                side_effect=lambda service_id: operations.append(
+                    ("dispatch", service_id)
+                ),
+            ),
+        ):
+            backup_task([2, 3])
+
+        self.assertEqual(
+            operations,
+            [("prepare", [2, 3]), ("dispatch", 2), ("dispatch", 3)],
+        )
+
+    def test_backup_does_not_dispatch_after_preparation_failure(self) -> None:
+        with (
+            patch(
+                "weblate.wladmin.tasks.run_backup_preparation",
+                side_effect=OSError("pg_dump failed"),
+            ),
+            patch("weblate.wladmin.tasks.backup_service.delay") as delay,
+            self.assertRaisesRegex(OSError, "pg_dump failed"),
+        ):
+            backup_task([2, 3])
+
+        delay.assert_not_called()
+
     def test_backup_service_stops_after_init_failure(self) -> None:
         service = Mock()
         service.ensure_init.return_value = False
@@ -189,19 +230,15 @@ class BackupCommandTest(DjangoTestCase):
 
         with (
             patch(
-                "weblate.wladmin.management.commands.backup.run_settings_backup"
-            ) as settings_backup,
-            patch(
-                "weblate.wladmin.management.commands.backup.run_database_backup"
-            ) as database_backup,
+                "weblate.wladmin.management.commands.backup.run_backup_preparation"
+            ) as prepare_backup,
             patch(
                 "weblate.wladmin.management.commands.backup.run_backup_service"
             ) as backup_service_runner,
         ):
             call_command("backup", "--service", str(service.pk))
 
-        settings_backup.assert_called_once_with()
-        database_backup.assert_called_once_with([service.pk])
+        prepare_backup.assert_called_once_with([service.pk])
         backup_service_runner.assert_called_once_with(service)
 
     def test_all_runs_enabled_services_synchronously(self) -> None:
@@ -214,19 +251,15 @@ class BackupCommandTest(DjangoTestCase):
 
         with (
             patch(
-                "weblate.wladmin.management.commands.backup.run_settings_backup"
-            ) as settings_backup,
-            patch(
-                "weblate.wladmin.management.commands.backup.run_database_backup"
-            ) as database_backup,
+                "weblate.wladmin.management.commands.backup.run_backup_preparation"
+            ) as prepare_backup,
             patch(
                 "weblate.wladmin.management.commands.backup.run_backup_service"
             ) as backup_service_runner,
         ):
             call_command("backup", "--all")
 
-        settings_backup.assert_called_once_with()
-        database_backup.assert_called_once_with([enabled.pk])
+        prepare_backup.assert_called_once_with([enabled.pk])
         self.assertEqual(
             [call.args[0].pk for call in backup_service_runner.call_args_list],
             [enabled.pk],
@@ -239,8 +272,7 @@ class BackupCommandTest(DjangoTestCase):
         )
 
         with (
-            patch("weblate.wladmin.management.commands.backup.run_settings_backup"),
-            patch("weblate.wladmin.management.commands.backup.run_database_backup"),
+            patch("weblate.wladmin.management.commands.backup.run_backup_preparation"),
             patch(
                 "weblate.wladmin.management.commands.backup.run_backup_service",
                 side_effect=[False, True],
@@ -263,8 +295,7 @@ class BackupCommandTest(DjangoTestCase):
 
         output = StringIO()
         with (
-            patch("weblate.wladmin.management.commands.backup.run_settings_backup"),
-            patch("weblate.wladmin.management.commands.backup.run_database_backup"),
+            patch("weblate.wladmin.management.commands.backup.run_backup_preparation"),
             patch(
                 "weblate.wladmin.management.commands.backup.run_backup_service",
                 side_effect=run_backup,
@@ -286,8 +317,7 @@ class BackupCommandTest(DjangoTestCase):
 
         output = StringIO()
         with (
-            patch("weblate.wladmin.management.commands.backup.run_settings_backup"),
-            patch("weblate.wladmin.management.commands.backup.run_database_backup"),
+            patch("weblate.wladmin.management.commands.backup.run_backup_preparation"),
             patch(
                 "weblate.wladmin.management.commands.backup.run_backup_service",
                 side_effect=run_backup,
@@ -308,6 +338,38 @@ class BackupCommandTest(DjangoTestCase):
     def test_rejects_unknown_service(self) -> None:
         with self.assertRaisesRegex(CommandError, "Backup service 1 does not exist"):
             call_command("backup", "--service", "1")
+
+
+class BackupScheduleMigrationTest(DjangoTestCase):
+    def test_only_default_separate_backup_schedules_are_removed(self) -> None:
+        interval = IntervalSchedule.objects.create(
+            every=1, period=IntervalSchedule.HOURS
+        )
+        PeriodicTask.objects.create(
+            name="settings-backup",
+            task="weblate.utils.tasks.settings_backup",
+            interval=interval,
+        )
+        PeriodicTask.objects.create(
+            name="custom-settings-backup",
+            task="weblate.utils.tasks.settings_backup",
+            interval=interval,
+        )
+        PeriodicTask.objects.create(
+            name="backup", task="weblate.wladmin.tasks.backup", interval=interval
+        )
+        PeriodicTasks.objects.all().delete()
+        migration = importlib.import_module(
+            "weblate.wladmin.migrations.0007_remove_separate_backup_schedules"
+        )
+
+        migration.remove_obsolete_backup_tasks(apps, None)
+
+        self.assertEqual(
+            list(PeriodicTask.objects.order_by("name").values_list("name", flat=True)),
+            ["backup", "custom-settings-backup"],
+        )
+        self.assertTrue(PeriodicTasks.objects.exists())
 
 
 class BackupServiceStatusTest(DjangoTestCase):
@@ -1379,10 +1441,10 @@ class AdminTest(ViewTestCase):
         self.assertContains(response, "pg_dump version mismatch")
         response = do_post(service=service.pk, toggle="1")
         self.assertContains(response, "Turned off")
-        with patch("weblate.wladmin.views.database_backup.delay") as database_delay:
+        with patch("weblate.wladmin.views.backup.delay") as backup_delay:
             response = do_post(service=service.pk, trigger="1")
         self.assertContains(response, "triggered")
-        database_delay.assert_called_once_with([service.pk])
+        backup_delay.assert_called_once_with([service.pk])
         response = do_post(service=service.pk, remove="1")
         self.assertNotContains(response, settings.BACKUP_DIR)
 

--- a/weblate/wladmin/views.py
+++ b/weblate/wladmin/views.py
@@ -77,7 +77,6 @@ from weblate.utils.filesystem import filesystem_latency_snapshot
 from weblate.utils.requests import fetch_url
 from weblate.utils.site import get_site_url
 from weblate.utils.stats import prefetch_stats
-from weblate.utils.tasks import database_backup, settings_backup
 from weblate.utils.token import get_token
 from weblate.utils.version import GIT_LINK, GIT_REVISION
 from weblate.utils.views import show_form_errors
@@ -111,7 +110,7 @@ from weblate.wladmin.models import (
     SupportStatus,
     get_support_url,
 )
-from weblate.wladmin.tasks import backup_service, support_status_update
+from weblate.wladmin.tasks import backup, support_status_update
 from weblate.workspaces.models import Workspace
 from weblate.workspaces.views import WorkspaceListBase
 
@@ -583,9 +582,7 @@ def backups(request: AuthenticatedHttpRequest) -> HttpResponse:
                     service.save()
                     return redirect("manage-backups")
                 if "trigger" in request.POST:
-                    settings_backup.delay()
-                    database_backup.delay([service.pk])
-                    backup_service.delay(pk=service.pk)
+                    backup.delay([service.pk])
                     messages.success(request, gettext("Backup process triggered"))
                     return redirect("manage-backups")
             else:


### PR DESCRIPTION
Use transaction-scoped PostgreSQL advisory reader/writer locks so dump preparation cannot overlap Borg archive creation while independent backup services can still run in parallel. Route scheduled and manual backups through the shared preparation step and remove obsolete separate schedules.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
