### PR TITLE
test(celery): guard URL preload imports

### DIFF
--- a/weblate/utils/tests/test_celery.py
+++ b/weblate/utils/tests/test_celery.py
@@ -155,6 +155,9 @@ worker_before_create_process.send(sender=app)
 print(json.dumps({
     "urls_loaded_before_fork": urls_loaded_before_fork,
     "urls_loaded_after_fork": "weblate.urls" in sys.modules,
+    "font_rendering_loaded": "weblate.fonts.render" in sys.modules,
+    "matplotlib_loaded": "matplotlib" in sys.modules,
+    "numpy_loaded": "numpy" in sys.modules,
     "tesserocr_loaded": "tesserocr" in sys.modules,
 }))
 """
@@ -165,6 +168,9 @@ print(json.dumps({
             {
                 "urls_loaded_before_fork": False,
                 "urls_loaded_after_fork": True,
+                "font_rendering_loaded": False,
+                "matplotlib_loaded": False,
+                "numpy_loaded": False,
                 "tesserocr_loaded": False,
             },
         )


### PR DESCRIPTION
Ensure pre-fork URL loading does not pull in the font rendering stack, Matplotlib, or NumPy.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
