### PR TITLE
perf(urls): share resolver cache across languages

### DIFF
--- a/weblate/__init__.py
+++ b/weblate/__init__.py
@@ -1,3 +1,10 @@
 # Copyright © Michal Čihař <michal@weblate.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from weblate.utils.urls import use_language_independent_url_resolver
+
+# URLResolver selects its cache key before importing ROOT_URLCONF, so install
+# the override as soon as the Weblate package is imported.
+# ruff: ignore[non-empty-init-module]
+use_language_independent_url_resolver()

--- a/weblate/utils/tests/test_urls.py
+++ b/weblate/utils/tests/test_urls.py
@@ -1,0 +1,83 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import django.urls.resolvers
+from django.test import SimpleTestCase
+from django.urls import URLPattern, URLResolver, get_resolver, reverse
+from django.urls.resolvers import LocalePrefixPattern, RegexPattern, RoutePattern
+from django.utils.translation import override
+
+from weblate.utils.urls import get_url_language
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def iter_url_patterns(
+    patterns: list[URLPattern | URLResolver],
+) -> Iterator[URLPattern | URLResolver]:
+    for pattern in patterns:
+        yield pattern
+        if isinstance(pattern, URLResolver):
+            yield from iter_url_patterns(pattern.url_patterns)
+
+
+class LanguageIndependentURLTest(SimpleTestCase):
+    def test_shared_resolver_cache(self) -> None:
+        resolver = get_resolver()
+
+        with override("en"):
+            english_urls = (reverse("home"), reverse("admin:index"))
+            english_caches = (
+                resolver.reverse_dict,
+                resolver.namespace_dict,
+                resolver.app_dict,
+            )
+
+        with override("cs"):
+            czech_urls = (reverse("home"), reverse("admin:index"))
+            czech_caches = (
+                resolver.reverse_dict,
+                resolver.namespace_dict,
+                resolver.app_dict,
+            )
+
+        self.assertEqual(english_urls, czech_urls)
+        for english_cache, czech_cache in zip(
+            english_caches, czech_caches, strict=True
+        ):
+            self.assertIs(english_cache, czech_cache)
+
+        self.assertIs(
+            django.urls.resolvers.get_language,  # type: ignore[attr-defined]
+            get_url_language,
+        )
+        # ruff: ignore[private-member-access]
+        self.assertEqual(set(resolver._reverse_dict), {None})
+        # ruff: ignore[private-member-access]
+        self.assertEqual(
+            set(resolver._namespace_dict),  # type: ignore[attr-defined]
+            {None},
+        )
+        # ruff: ignore[private-member-access]
+        self.assertEqual(set(resolver._app_dict), {None})  # type: ignore[attr-defined]
+
+    def test_patterns_are_language_independent(self) -> None:
+        for url_pattern in iter_url_patterns(get_resolver().url_patterns):
+            pattern = url_pattern.pattern
+            with self.subTest(pattern=pattern):
+                self.assertNotIsInstance(pattern, LocalePrefixPattern)
+                if isinstance(pattern, RoutePattern):
+                    # ruff: ignore[private-member-access]
+                    source = pattern._route  # type: ignore[attr-defined]
+                elif isinstance(pattern, RegexPattern):
+                    # ruff: ignore[private-member-access]
+                    source = pattern._regex  # type: ignore[attr-defined]
+                else:
+                    self.fail(f"Unsupported URL pattern type: {type(pattern)!r}")
+                self.assertIsInstance(source, str)

--- a/weblate/utils/urls.py
+++ b/weblate/utils/urls.py
@@ -2,12 +2,32 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
+import django.urls.resolvers
 from django.urls import register_converter
 from django.urls.converters import PathConverter, StringConverter
 
 from weblate.trans.defines import CATEGORY_DEPTH
 
 URL_DEPTH = CATEGORY_DEPTH + 3
+
+
+def get_url_language() -> None:
+    """Return the language used to cache URL resolver data."""
+    return
+
+
+def use_language_independent_url_resolver() -> None:
+    """Avoid per-language resolver caches for language-independent URLs."""
+    # Django uses this module-level function to key its reverse, namespace, and
+    # application resolver dictionaries. Weblate does not translate or prefix
+    # routes, so using the active language only creates an identical, sizable
+    # resolver table for every language. A stable None key lets all languages
+    # share one table without changing Django's translation state. The URL tests
+    # reject lazy-translated and language-prefixed patterns that would invalidate
+    # this assumption.
+    django.urls.resolvers.get_language = get_url_language  # type: ignore[attr-defined]
 
 
 class WeblateSlugConverter(StringConverter):


### PR DESCRIPTION
Avoid duplicating Django's reverse URL tables for every active language. Guard the optimization with tests that reject language-dependent route patterns.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
