### PR TITLE
feat(docker): expose startup warnings as deployment checks

### DIFF
--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -461,6 +461,23 @@ You can find example setup in the ``docker-compose`` repo as
 `docker-compose-split.yml
 <https://github.com/WeblateOrg/docker-compose/blob/main/docker-compose-split.yml>`__.
 
+.. _docker-startup-warnings:
+
+Startup configuration warnings
+------------------------------
+
+The Docker container records actionable configuration warnings from startup
+in the shared :file:`/app/data` volume. They are shown by
+:command:`weblate check --deploy` and in the :ref:`manage-performance`
+management interface, in addition to being written to the container log.
+
+Each container reports its warnings separately. This keeps warnings from
+containers with different :envvar:`WEBLATE_SERVICE` roles visible in a
+horizontally scaled deployment. Reports are refreshed while their container is
+running and are removed during an orderly container shutdown. Reports left by
+an abrupt shutdown expire after five minutes, and stale report files are
+cleaned up automatically by later container startups.
+
 .. _docker-environment:
 
 Docker environment variables

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.9.1
 
 * Improved :ref:`Billing <billing>` detail page loading performance by batching related project, invoice, and audit log queries.
 * Further reduced :ref:`Celery <celery>` worker memory usage by sharing preloaded URL configuration between worker processes and loading bitmap widget rendering dependencies only when needed.
+* Docker startup configuration warnings are now available as :ref:`deployment checks <docker-startup-warnings>`, including in horizontally scaled deployments.
 
 .. rubric:: Security fixes
 

--- a/weblate/utils/apps.py
+++ b/weblate/utils/apps.py
@@ -46,6 +46,7 @@ from .db import (
     get_invalid_database_statistics,
     measure_database_latency,
 )
+from .docker import DOCKER_WARNING_MAX_DISPLAY_SOURCES, get_docker_startup_warnings
 from .encoding import get_filesystem_encoding, get_locale_encoding, get_python_encoding
 from .errors import init_error_collection
 from .filesystem import (
@@ -607,6 +608,31 @@ def check_filesystem_latency(
                 "weblate.W048",
                 f"The filesystem at {paths[name]} seems slow; metadata lookups "
                 f"took {latency:g} milliseconds (configured by {name}).",
+                DjangoWarning,
+            )
+        )
+    return errors
+
+
+@register(deploy=True)
+def check_docker_startup_warnings(
+    *,
+    app_configs: Sequence[AppConfig] | None,
+    databases: Sequence[str] | None,
+    **kwargs,
+) -> Iterable[CheckMessage]:
+    """Report actionable warnings emitted during Docker container startup."""
+    errors: list[CheckMessage] = []
+    for warning, sources in get_docker_startup_warnings().items():
+        displayed_sources = sources[:DOCKER_WARNING_MAX_DISPLAY_SOURCES]
+        omitted_sources = len(sources) - len(displayed_sources)
+        source = ", ".join(displayed_sources)
+        if omitted_sources:
+            source = f"{source}, and {omitted_sources} more"
+        errors.append(
+            weblate_check(
+                "weblate.W049",
+                f"Docker startup warning from {source}: {warning}",
                 DjangoWarning,
             )
         )

--- a/weblate/utils/checks.py
+++ b/weblate/utils/checks.py
@@ -85,6 +85,7 @@ DOC_LINKS: dict[str, str | tuple[str] | tuple[str, str]] = {
     "weblate.C045": ("admin/install", "production-database"),
     "weblate.C047": ("admin/install", "production-database"),
     "weblate.W048": ("admin/install", "hardware"),
+    "weblate.W049": ("admin/install/docker", "docker-startup-warnings"),
 }
 
 

--- a/weblate/utils/docker.py
+++ b/weblate/utils/docker.py
@@ -1,0 +1,116 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Docker container helpers."""
+
+from __future__ import annotations
+
+import os
+import stat
+import time
+from collections import defaultdict
+from heapq import nlargest
+from itertools import islice
+from operator import itemgetter
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+DOCKER_CONTAINER_ENV = "WEBLATE_DOCKER_CONTAINER"
+DOCKER_WARNING_DIRECTORY = ".docker-startup-warnings"
+DOCKER_WARNING_MAX_AGE = 300
+DOCKER_WARNING_MAX_DISPLAY_SOURCES = 10
+DOCKER_WARNING_MAX_LINE_SIZE = 4096
+DOCKER_WARNING_MAX_REPORTS = 1000
+DOCKER_WARNING_MAX_SIZE = 64 * 1024
+DOCKER_WARNING_MAX_LINES = 1000
+
+
+def is_docker_container() -> bool:
+    """Return whether Weblate is running in the official Docker container."""
+    return os.environ.get(DOCKER_CONTAINER_ENV) == "1"
+
+
+def read_report_file(path: Path, limit: int = DOCKER_WARNING_MAX_SIZE) -> str | None:
+    """Read a bounded regular file from a Docker warning report."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        file_stat = os.fstat(descriptor)
+    except OSError:
+        os.close(descriptor)
+        return None
+    if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_size > limit:
+        os.close(descriptor)
+        return None
+    try:
+        with os.fdopen(descriptor, encoding="utf-8") as handle:
+            result = handle.read(limit + 1)
+    except (OSError, UnicodeError):
+        return None
+    if len(result) > limit:
+        return None
+    return result
+
+
+def iter_active_docker_reports(root: Path, now: float) -> Iterator[tuple[float, Path]]:
+    """Yield active Docker reports with their heartbeat timestamps."""
+    reports = root.iterdir()
+    while True:
+        try:
+            report = next(reports)
+        except (OSError, StopIteration):
+            return
+        try:
+            report_stat = report.lstat()
+            heartbeat_stat = (report / "heartbeat").lstat()
+        except OSError:
+            continue
+        if not stat.S_ISDIR(report_stat.st_mode) or not stat.S_ISREG(
+            heartbeat_stat.st_mode
+        ):
+            continue
+        if now - heartbeat_stat.st_mtime > DOCKER_WARNING_MAX_AGE:
+            continue
+        yield heartbeat_stat.st_mtime, report
+
+
+def get_docker_startup_warnings() -> dict[str, tuple[str, ...]]:
+    """Collect active Docker startup warnings and their sources."""
+    if not is_docker_container():
+        return {}
+
+    root = Path(settings.DATA_DIR) / DOCKER_WARNING_DIRECTORY
+    now = time.time()
+    reports = nlargest(
+        DOCKER_WARNING_MAX_REPORTS,
+        iter_active_docker_reports(root, now),
+        key=itemgetter(0),
+    )
+    warnings: defaultdict[str, set[str]] = defaultdict(set)
+    for _, report in reports:
+        content = read_report_file(report / "warnings")
+        if not content:
+            continue
+        hostname = read_report_file(report / "hostname", 255)
+        service = read_report_file(report / "service", 255)
+        hostname = (hostname.splitlines()[0].strip() if hostname else "") or "unknown"
+        service = (service.splitlines()[0].strip() if service else "") or "all"
+        source = f"{hostname} ({service})"
+        for warning in islice(content.splitlines(), DOCKER_WARNING_MAX_LINES):
+            warning = warning.strip()
+            if not warning or len(warning) > DOCKER_WARNING_MAX_LINE_SIZE:
+                continue
+            warnings[warning].add(source)
+
+    return {
+        warning: tuple(sorted(sources)) for warning, sources in sorted(warnings.items())
+    }

--- a/weblate/utils/tests/test_checks.py
+++ b/weblate/utils/tests/test_checks.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -24,6 +25,7 @@ from weblate.utils.apps import (
     check_data_writable,
     check_database,
     check_database_size,
+    check_docker_startup_warnings,
     check_errors,
     check_filesystem_latency,
     check_settings,
@@ -31,6 +33,12 @@ from weblate.utils.apps import (
 )
 from weblate.utils.celery import is_celery_queue_long
 from weblate.utils.classloader import ClassLoader
+from weblate.utils.docker import (
+    DOCKER_CONTAINER_ENV,
+    DOCKER_WARNING_DIRECTORY,
+    DOCKER_WARNING_MAX_AGE,
+    DOCKER_WARNING_MAX_SIZE,
+)
 from weblate.utils.filesystem import (
     FILESYSTEM_LATENCY_PREFIX,
     filesystem_latency_snapshot,
@@ -276,6 +284,126 @@ class FilesystemLatencyTestCase(SimpleTestCase):
         self.assertIn("CACHE_DIR", errors[1].msg)
         latency_mock.assert_called_once_with()
         paths_mock.assert_called_once_with()
+
+
+class DockerStartupWarningsCheckTestCase(SimpleTestCase):
+    def create_report(
+        self,
+        name: str,
+        warnings: str,
+        *,
+        hostname: str = "container-1",
+        service: str = "web",
+        age: float = 0,
+    ) -> Path:
+        report = Path(settings.DATA_DIR) / DOCKER_WARNING_DIRECTORY / name
+        report.mkdir(parents=True)
+        (report / "hostname").write_text(hostname, encoding="utf-8")
+        (report / "service").write_text(service, encoding="utf-8")
+        (report / "warnings").write_text(warnings, encoding="utf-8")
+        heartbeat = report / "heartbeat"
+        heartbeat.touch()
+        if age:
+            timestamp = time.time() - age
+            os.utime(heartbeat, (timestamp, timestamp))
+        return report
+
+    @tempdir_setting("DATA_DIR")
+    def test_disabled_outside_docker(self) -> None:
+        self.create_report("report", "Ignored configuration")
+
+        with patch.dict(os.environ, clear=True):
+            errors = list(
+                check_docker_startup_warnings(app_configs=None, databases=None)
+            )
+
+        self.assertEqual(errors, [])
+
+    @tempdir_setting("DATA_DIR")
+    def test_active_warnings(self) -> None:
+        self.create_report("first", "First warning\nShared warning")
+        self.create_report(
+            "second",
+            "Shared warning",
+            hostname="container-2",
+            service="celery-notify",
+        )
+
+        with patch.dict(os.environ, {DOCKER_CONTAINER_ENV: "1"}):
+            errors = list(
+                check_docker_startup_warnings(app_configs=None, databases=None)
+            )
+
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(all(isinstance(error, DjangoWarning) for error in errors))
+        self.assertTrue(all(error.id == "weblate.W049" for error in errors))
+        self.assertEqual(
+            errors[0].msg,
+            "Docker startup warning from container-1 (web): First warning",
+        )
+        self.assertIn("container-1 (web)", errors[1].msg)
+        self.assertIn("container-2 (celery-notify)", errors[1].msg)
+        self.assertEqual(errors[1].msg.count("Shared warning"), 1)
+
+    @tempdir_setting("DATA_DIR")
+    def test_inactive_warnings(self) -> None:
+        self.create_report(
+            "stale",
+            "Stale warning",
+            age=DOCKER_WARNING_MAX_AGE + 1,
+        )
+        self.create_report("empty", "")
+
+        with patch.dict(os.environ, {DOCKER_CONTAINER_ENV: "1"}):
+            errors = list(
+                check_docker_startup_warnings(app_configs=None, databases=None)
+            )
+
+        self.assertEqual(errors, [])
+
+    @tempdir_setting("DATA_DIR")
+    def test_stale_reports_do_not_hide_active_report(self) -> None:
+        stale = self.create_report(
+            "stale",
+            "Stale warning",
+            age=DOCKER_WARNING_MAX_AGE + 1,
+        )
+        active = self.create_report("active", "Active warning")
+
+        with (
+            patch.dict(os.environ, {DOCKER_CONTAINER_ENV: "1"}),
+            patch("weblate.utils.docker.DOCKER_WARNING_MAX_REPORTS", 1),
+            patch(
+                "weblate.utils.docker.Path.iterdir",
+                return_value=iter((stale, active)),
+            ),
+        ):
+            errors = list(
+                check_docker_startup_warnings(app_configs=None, databases=None)
+            )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Active warning", errors[0].msg)
+
+    @tempdir_setting("DATA_DIR")
+    def test_unsafe_warning_files(self) -> None:
+        oversized = self.create_report("oversized", "")
+        (oversized / "warnings").write_text(
+            "x" * (DOCKER_WARNING_MAX_SIZE + 1), encoding="utf-8"
+        )
+        symlinked = self.create_report("symlinked", "")
+        target = Path(settings.DATA_DIR) / "warning-target"
+        target.write_text("Symlink warning", encoding="utf-8")
+        warning_file = symlinked / "warnings"
+        warning_file.unlink()
+        warning_file.symlink_to(target)
+
+        with patch.dict(os.environ, {DOCKER_CONTAINER_ENV: "1"}):
+            errors = list(
+                check_docker_startup_warnings(app_configs=None, databases=None)
+            )
+
+        self.assertEqual(errors, [])
 
 
 class DatabaseSizeCheckTestCase(SimpleTestCase):


### PR DESCRIPTION
Collect active per-container warning reports from the shared data directory so Docker configuration problems are visible outside container logs.

Companion to https://github.com/WeblateOrg/docker/pull/4739

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
