### PR TITLE
fix(fonts): prevent cross-project font overrides

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Weblate 2026.9.1
 .. rubric:: Security fixes
 
 * Borg backup passphrases are now recursively scrubbed from Sentry error reports, including when a custom event scrubber is configured.
+* Font overrides are now restricted to fonts uploaded to the same project.
 
 .. rubric:: Bug fixes
 

--- a/weblate/fonts/forms.py
+++ b/weblate/fonts/forms.py
@@ -4,12 +4,15 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from django import forms
 
 from weblate.fonts.models import Font, FontGroup, FontOverride
 from weblate.utils.forms import AssetFileField
+
+if TYPE_CHECKING:
+    from weblate.trans.models import Project
 
 
 class FontForm(forms.ModelForm):
@@ -34,3 +37,8 @@ class FontOverrideForm(forms.ModelForm):
     class Meta:
         model = FontOverride
         fields = ("language", "font")
+
+    def __init__(self, data=None, *, project: Project, **kwargs) -> None:
+        super().__init__(data, **kwargs)
+        field = cast("forms.ModelChoiceField", self.fields["font"])
+        field.queryset = field.queryset.filter(project=project)  # type: ignore[union-attr]

--- a/weblate/fonts/migrations/0002_remove_cross_project_font_overrides.py
+++ b/weblate/fonts/migrations/0002_remove_cross_project_font_overrides.py
@@ -1,0 +1,24 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+def remove_cross_project_font_overrides(apps, schema_editor) -> None:
+    font_override = apps.get_model("fonts", "FontOverride")
+    font_override.objects.exclude(
+        font__project_id=models.F("group__project_id")
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [("fonts", "0001_squashed_weblate_5")]
+
+    operations = [
+        migrations.RunPython(
+            remove_cross_project_font_overrides, migrations.RunPython.noop
+        )
+    ]

--- a/weblate/fonts/models.py
+++ b/weblate/fonts/models.py
@@ -160,3 +160,22 @@ class FontOverride(models.Model):
 
     def __str__(self) -> str:
         return f"{self.group}:{self.font}:{self.language}"
+
+    def save(self, *args, **kwargs) -> None:
+        self.clean()
+        super().save(*args, **kwargs)
+
+    def clean(self) -> None:
+        super().clean()
+        if (
+            self.group_id
+            and self.font_id
+            and self.group.project_id != self.font.project_id
+        ):
+            raise ValidationError(
+                {
+                    "font": gettext_lazy(
+                        "Font has to be in the same project as the font group."
+                    )
+                }
+            )

--- a/weblate/fonts/tests/test_models.py
+++ b/weblate/fonts/tests/test_models.py
@@ -2,9 +2,15 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from weblate.fonts.models import FONT_STORAGE
+from importlib import import_module
+
+from django.apps import apps
+from django.core.exceptions import ValidationError
+
+from weblate.fonts.models import FONT_STORAGE, Font, FontGroup, FontOverride
 from weblate.fonts.tasks import cleanup_font_files
 from weblate.fonts.tests.utils import FontComponentTestCase
+from weblate.trans.models import Project
 
 
 class FontModelTest(FontComponentTestCase):
@@ -32,3 +38,53 @@ class FontModelTest(FontComponentTestCase):
         self.assert_font_files(1)
         cleanup_font_files()
         self.assert_font_files(0)
+
+    def test_override_project_scope(self) -> None:
+        local_font = self.add_font()
+        private_project = Project.objects.create(name="Private", slug="private")
+        private_font = Font.objects.create(
+            family="Private font",
+            style="Regular",
+            font=local_font.font.name,
+            project=private_project,
+            user=self.user,
+        )
+        group = FontGroup.objects.create(
+            name="font-group", font=local_font, project=self.project
+        )
+
+        with self.assertRaisesMessage(
+            ValidationError, "Font has to be in the same project as the font group."
+        ):
+            FontOverride.objects.create(
+                group=group,
+                language=self.translation.language,
+                font=private_font,
+            )
+
+    def test_remove_cross_project_font_overrides(self) -> None:
+        local_font = self.add_font()
+        private_project = Project.objects.create(name="Private", slug="private")
+        private_font = Font.objects.create(
+            family="Private font",
+            style="Regular",
+            font=local_font.font.name,
+            project=private_project,
+            user=self.user,
+        )
+        group = FontGroup.objects.create(
+            name="font-group", font=local_font, project=self.project
+        )
+        override = FontOverride.objects.create(
+            group=group,
+            language=self.translation.language,
+            font=local_font,
+        )
+        FontOverride.objects.filter(pk=override.pk).update(font=private_font)
+
+        migration = import_module(
+            "weblate.fonts.migrations.0002_remove_cross_project_font_overrides"
+        )
+        migration.remove_cross_project_font_overrides(apps, None)
+
+        self.assertFalse(FontOverride.objects.filter(pk=override.pk).exists())

--- a/weblate/fonts/tests/test_views.py
+++ b/weblate/fonts/tests/test_views.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from weblate.fonts.models import Font, FontGroup
 from weblate.fonts.tests.utils import FONT, FONT_BOLD, FontTestCase
 from weblate.lang.models import Language
+from weblate.trans.models import Project
 
 
 class FontViewTest(FontTestCase):
@@ -122,3 +123,45 @@ class FontViewTest(FontTestCase):
         # Remove font
         self.client.post(font.get_absolute_url(), {"delete": 1})
         self.assertEqual(Font.objects.count(), 0)
+
+    def test_override_project_scope(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        local_font = self.add_font()
+        private_project = Project.objects.create(
+            name="Private",
+            slug="private",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        private_font = Font.objects.create(
+            family="Private font",
+            style="Regular",
+            font=local_font.font.name,
+            project=private_project,
+            user=self.user,
+        )
+        group = FontGroup.objects.create(
+            name="font-group", font=local_font, project=self.project
+        )
+        language = Language.objects.get(code="zh_Hant")
+
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("project.edit", self.project))
+        self.assertFalse(self.user.can_access_project(private_project))
+        self.assertNotContains(
+            self.client.get(group.get_absolute_url()), "Private font"
+        )
+
+        response = self.client.post(
+            group.get_absolute_url(),
+            {"language": language.pk, "font": private_font.pk},
+        )
+        self.assertContains(response, "Select a valid choice.")
+        self.assertEqual(group.fontoverride_set.count(), 0)
+
+        response = self.client.post(
+            group.get_absolute_url(),
+            {"language": language.pk, "font": local_font.pk},
+        )
+        self.assertRedirects(response, group.get_absolute_url())
+        override = group.fontoverride_set.get()
+        self.assertEqual(override.font, local_font)

--- a/weblate/fonts/views.py
+++ b/weblate/fonts/views.py
@@ -167,8 +167,8 @@ class FontDetailView(ProjectViewMixin, DetailView):
 @method_decorator(login_required, name="dispatch")
 class FontGroupDetailView(ProjectViewMixin, DetailView):
     model = FontGroup
-    _form: FontOverrideForm | FontGroupForm | None = None
-    _override_form = None
+    _form: FontGroupForm | None = None
+    _override_form: FontOverrideForm | None = None
 
     def get_queryset(self):
         return self.project.fontgroup_set.all()
@@ -178,7 +178,9 @@ class FontGroupDetailView(ProjectViewMixin, DetailView):
         result["form"] = self._form or FontGroupForm(
             instance=self.object, project=self.project
         )
-        result["override_form"] = self._override_form or FontOverrideForm()
+        result["override_form"] = self._override_form or FontOverrideForm(
+            project=self.project
+        )
         result["can_edit"] = self.request.user.has_perm("project.edit", self.project)
         return result
 
@@ -206,7 +208,9 @@ class FontGroupDetailView(ProjectViewMixin, DetailView):
                     return redirect(self.object)
             return self.get(request, **kwargs)
         if "language" in request.POST:
-            form = self._form = FontOverrideForm(request.POST)
+            form = self._override_form = FontOverrideForm(
+                request.POST, project=self.project
+            )
             if form.is_valid():
                 instance = form.save(commit=False)
                 instance.group = self.object


### PR DESCRIPTION
Scope override choices and enforce project ownership so private fonts cannot be referenced or rendered from another project. Remove existing invalid relationships and add defensive renderer checks.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
