### PR TITLE
fix(security): gate private project sharing

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -67,6 +67,10 @@ project.
 
 The default can also be changed by setting :setting:`DEFAULT_ACCESS_CONTROL`.
 
+Private and Custom projects can make their :ref:`project-public_sharing`
+engage pages and status widgets anonymously accessible without making the rest
+of the project public. Public sharing is disabled by default for these projects.
+
 .. _statistics-access-filtering:
 
 .. note::

--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -269,6 +269,27 @@ Configure per project access control, see :ref:`acl` for more details.
 
 The default value can be changed by :setting:`DEFAULT_ACCESS_CONTROL`.
 
+.. _project-public_sharing:
+
+Public sharing
+++++++++++++++
+
+Allow anonymous access to the project's engage pages and rendered status
+widgets. This setting applies to :guilabel:`Private` and :guilabel:`Custom`
+projects; :guilabel:`Public` and :guilabel:`Protected` projects are always
+publicly shareable.
+
+Public sharing exposes project and component names, including restricted
+components, together with translation statistics, languages, and progress. It
+does not grant access to project pages, translations, repositories, or the API.
+
+Changing this setting requires the :guilabel:`Manage project access`
+permission. The status widget configuration page continues to use normal
+project access control.
+
+When :setting:`REQUIRE_LOGIN` is enabled, :setting:`PUBLIC_ENGAGE` must also be
+enabled for anonymous access to engage pages.
+
 .. _project-enforced_2fa:
 
 Enforced two-factor authentication

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -989,6 +989,8 @@ Projects
     :type workspace: string
     :param access_control: :ref:`project-access_control`
     :type access_control: integer
+    :param public_sharing: :ref:`project-public_sharing`
+    :type public_sharing: boolean
     :param use_shared_tm: :ref:`project-use_shared_tm`
     :type use_shared_tm: boolean
     :param contribute_shared_tm: :ref:`project-contribute_shared_tm`
@@ -1028,6 +1030,7 @@ Projects
     :>json string language_aliases: :ref:`project-language_aliases`
     :>json string license: :ref:`project-license`
     :>json integer access_control: :ref:`project-access_control`
+    :>json boolean public_sharing: :ref:`project-public_sharing`
     :>json boolean use_shared_tm: :ref:`project-use_shared_tm`
     :>json boolean contribute_shared_tm: :ref:`project-contribute_shared_tm`
     :>json boolean use_workspace_tm: :ref:`project-use-workspace-tm`
@@ -1071,7 +1074,8 @@ Projects
             "access_control": 100
         }
 
-    Changing ``access_control`` requires permission to manage project access.
+    Changing ``access_control`` or ``public_sharing`` requires permission to
+    manage project access.
     Making a project publicly accessible can require licenses on its components
     when :setting:`LICENSE_REQUIRED` is enabled. On Hosted Weblate, Custom
     access control is unavailable and each translation-memory contribution
@@ -1092,6 +1096,8 @@ Projects
     :type license: string
     :param access_control: :ref:`project-access_control`
     :type access_control: integer
+    :param public_sharing: :ref:`project-public_sharing`
+    :type public_sharing: boolean
     :param use_shared_tm: :ref:`project-use_shared_tm`
     :type use_shared_tm: boolean
     :param contribute_shared_tm: :ref:`project-contribute_shared_tm`
@@ -1123,6 +1129,8 @@ Projects
     :type license: string
     :param access_control: :ref:`project-access_control`
     :type access_control: integer
+    :param public_sharing: :ref:`project-public_sharing`
+    :type public_sharing: boolean
     :param use_shared_tm: :ref:`project-use_shared_tm`
     :type use_shared_tm: boolean
     :param contribute_shared_tm: :ref:`project-contribute_shared_tm`

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Weblate 2026.9.1
 
 * Borg backup passphrases are now recursively scrubbed from Sentry error reports, including when a custom event scrubber is configured.
 * Font overrides are now restricted to fonts uploaded to the same project.
+* Engage pages and status widgets no longer disclose Private or Custom projects unless :ref:`project-public_sharing` is enabled.
 
 .. rubric:: Bug fixes
 
@@ -27,6 +28,8 @@ Weblate 2026.9.1
 * Backup services now start only after settings and database backup files are fully updated, while backups to different Borg repositories can run in parallel.
 
 .. rubric:: Compatibility
+
+* Anonymous access to engage pages and status widgets is now disabled by default for Private and Custom projects. Enable :ref:`project-public_sharing` to preserve existing shared links after upgrading. Public and Protected projects are unchanged.
 
 .. rubric:: Upgrading
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -697,7 +697,12 @@ Security properties Weblate provides
        access rules.
        Unattributed automatic memory, including unmatched legacy entries and
        memory retained after component removal, follows its remaining
-       translation-memory scope.
+       translation-memory scope. Private and Custom project engage pages and
+       rendered status widgets follow project access control unless a trusted
+       access manager enables :ref:`project-public_sharing`. That explicit
+       opt-in publishes project and component names, including restricted
+       components, together with translation statistics, languages, and
+       progress, but does not grant access to project content or APIs.
      - User or token can read or mutate data outside assigned scope.
      - Security-critical when private data or privileged mutation is exposed.
    * - Project-scoped API tokens are limited by assigned project/team

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -36126,6 +36126,10 @@ components:
           description: How to restrict access to this project is detailed in the documentation.
           minimum: -2147483648
           maximum: 2147483647
+        public_sharing:
+          type: boolean
+          description: Allows anonymous access to the engage pages and status widgets
+            for Private and Custom projects.
         use_shared_tm:
           type: boolean
           title: Use shared translation memory
@@ -37051,6 +37055,10 @@ components:
           description: How to restrict access to this project is detailed in the documentation.
           minimum: -2147483648
           maximum: 2147483647
+        public_sharing:
+          type: boolean
+          description: Allows anonymous access to the engage pages and status widgets
+            for Private and Custom projects.
         use_shared_tm:
           type: boolean
           title: Use shared translation memory

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -1715,6 +1715,7 @@ class ProjectSerializer(serializers.ModelSerializer[Project]):
             "enable_hooks",
             "language_aliases",
             "access_control",
+            "public_sharing",
             "use_shared_tm",
             "contribute_shared_tm",
             "use_workspace_tm",
@@ -1910,6 +1911,23 @@ class ProjectSerializer(serializers.ModelSerializer[Project]):
                     raise serializers.ValidationError({"workspace": error})
 
         Project.apply_hosted_tm_contribution(attrs, defaults=self.instance)
+
+        if (
+            self.instance is not None
+            and "public_sharing" in attrs
+            and attrs["public_sharing"] != self.instance.public_sharing
+        ):
+            request = self.context.get("request")
+            if request is None or not request.user.has_perm(
+                "billing:project.permissions", self.instance
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "public_sharing": (
+                            "You do not have permission to change project access settings."
+                        )
+                    }
+                )
 
         access_control_provided = "access_control" in (
             attrs if self.instance is not None else getattr(self, "initial_data", {})

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -3613,6 +3613,7 @@ class ProjectAPITest(APIBaseTest):
             "http://example.com/api/projects/test/metrics/",
         )
         self.assertEqual(response.data["access_control"], self.project.access_control)
+        self.assertFalse(response.data["public_sharing"])
         self.assertEqual(response.data["use_shared_tm"], self.project.use_shared_tm)
         self.assertEqual(
             response.data["contribute_shared_tm"], self.project.contribute_shared_tm
@@ -5520,6 +5521,52 @@ class ProjectAPITest(APIBaseTest):
         self.assertEqual(response.data["access_control"], Project.ACCESS_PRIVATE)
         self.assertEqual(self.project.access_control, Project.ACCESS_PRIVATE)
 
+    def test_patch_public_sharing(self) -> None:
+        response = self.do_request(
+            "api:project-detail",
+            self.project_kwargs,
+            method="patch",
+            superuser=True,
+            code=200,
+            format="json",
+            request={"public_sharing": True},
+        )
+
+        self.project.refresh_from_db()
+        self.assertTrue(response.data["public_sharing"])
+        self.assertTrue(self.project.public_sharing)
+
+    def test_patch_public_sharing_requires_permission(self) -> None:
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        self.do_request(
+            "api:project-detail",
+            self.project_kwargs,
+            method="patch",
+            code=400,
+            format="json",
+            request={"public_sharing": True},
+        )
+
+        self.project.refresh_from_db()
+        self.assertFalse(self.project.public_sharing)
+
+    def test_patch_unchanged_public_sharing_without_permission(self) -> None:
+        self.grant_perm_to_user("project.edit", project=self.project)
+        self.user.clear_permissions_cache()
+
+        response = self.do_request(
+            "api:project-detail",
+            self.project_kwargs,
+            method="patch",
+            code=200,
+            format="json",
+            request={"public_sharing": False},
+        )
+
+        self.assertFalse(response.data["public_sharing"])
+
     def test_patch_access_control_requires_permission(self) -> None:
         self.grant_perm_to_user("project.edit", project=self.project)
         self.user.clear_permissions_cache()
@@ -5651,6 +5698,24 @@ class ProjectAPITest(APIBaseTest):
         self.assertEqual(
             response.data["access_control"], settings.DEFAULT_ACCESS_CONTROL
         )
+
+    def test_create_public_sharing(self) -> None:
+        self.grant_perm_to_user("project.add")
+        response = self.do_request(
+            "api:project-list",
+            method="post",
+            code=201,
+            format="json",
+            request={
+                "name": "Shared project",
+                "slug": "shared-project",
+                "web": "https://weblate.org/",
+                "public_sharing": True,
+            },
+        )
+
+        self.assertTrue(response.data["public_sharing"])
+        self.assertTrue(Project.objects.get(slug="shared-project").public_sharing)
 
     def test_create_access_control_requires_superuser(self) -> None:
         self.grant_perm_to_user("project.add")
@@ -17488,6 +17553,13 @@ class OpenAPITest(APIBaseTest):
                     ],
                     expected_pattern,
                 )
+
+    def test_project_public_sharing_field(self) -> None:
+        schemas = self.get_schema()["components"]["schemas"]
+        for schema_name in ("Project", "PatchedProject"):
+            with self.subTest(schema_name=schema_name):
+                field = schemas[schema_name]["properties"]["public_sharing"]
+                self.assertEqual(field["type"], "boolean")
 
     def test_metrics_version_is_optional(self) -> None:
         schema = self.get_schema()

--- a/weblate/templates/category.html
+++ b/weblate/templates/category.html
@@ -148,7 +148,7 @@
         {% endif %}
       </ul>
     </li>
-    {% include "snippets/share-menu.html" with object=object.project %}
+    {% include "snippets/share-menu.html" with object=object.project project=object.project %}
     {% include "snippets/watch-dropdown.html" with project=object.project %}
   </ul>
 {% endblock nav_pills %}

--- a/weblate/templates/component.html
+++ b/weblate/templates/component.html
@@ -187,7 +187,7 @@
         {% endif %}
       </ul>
     </li>
-    {% include "snippets/share-menu.html" with object=object %}
+    {% include "snippets/share-menu.html" with object=object project=object.project %}
     {% include "snippets/watch-dropdown.html" with project=object.project component=object %}
   </ul>
 {% endblock nav_pills %}

--- a/weblate/templates/language-project.html
+++ b/weblate/templates/language-project.html
@@ -121,7 +121,7 @@
         {% endif %}
       </ul>
     </li>
-    {% include "snippets/share-menu.html" with object=object %}
+    {% include "snippets/share-menu.html" with object=object project=object.project %}
     {% include "snippets/watch-dropdown.html" %}
   </ul>
 {% endblock nav_pills %}

--- a/weblate/templates/project.html
+++ b/weblate/templates/project.html
@@ -226,7 +226,7 @@
         {% endif %}
       </ul>
     </li>
-    {% include "snippets/share-menu.html" with object=object %}
+    {% include "snippets/share-menu.html" with object=object project=object %}
     {% include "snippets/watch-dropdown.html" with project=object %}
   </ul>
 {% endblock nav_pills %}

--- a/weblate/templates/snippets/share-menu.html
+++ b/weblate/templates/snippets/share-menu.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-{% if enable_sharing %}
+{% if enable_sharing and project.is_publicly_shared %}
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#">{% translate "Community" %}</a>
     <ul class="dropdown-menu shadow">

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -131,7 +131,7 @@
         {% endif %}
       </ul>
     </li>
-    {% include "snippets/share-menu.html" with object=object %}
+    {% include "snippets/share-menu.html" with object=object project=object.project %}
     {% include "snippets/watch-dropdown.html" with project=object.component.project component=object.component %}
   </ul>
 {% endblock nav_pills %}

--- a/weblate/trans/backups.py
+++ b/weblate/trans/backups.py
@@ -107,6 +107,7 @@ ModelT = TypeVar("ModelT", bound="Model")
 PROJECTBACKUP_PREFIX = "projectbackups"
 BackupValue = str | int | bool | dict[str, Any] | list[Any] | None
 PROJECT_BACKUP_FIELDS = (
+    "public_sharing",
     "use_workspace_tm",
     "contribute_workspace_tm",
     "autoclean_tm",

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -3531,6 +3531,7 @@ class ProjectSettingsForm(
             "inherit_secondary_language",
             "secondary_language",
             "access_control",
+            "public_sharing",
             "enforced_2fa",
             "translation_review",
             "source_review",
@@ -3578,12 +3579,24 @@ class ProjectSettingsForm(
         access = data["access_control"]
 
         self.changed_access = access != self.instance.access_control
+        self.changed_public_sharing = (
+            data.get("public_sharing", self.instance.public_sharing)
+            != self.instance.public_sharing
+        )
 
         if self.changed_access and not self.user_can_change_access:
             raise ValidationError(
                 {
                     "access_control": gettext(
                         "You do not have permission to change project access control."
+                    )
+                }
+            )
+        if self.changed_public_sharing and not self.user_can_change_access:
+            raise ValidationError(
+                {
+                    "public_sharing": gettext(
+                        "You do not have permission to change project access settings."
                     )
                 }
             )
@@ -3657,6 +3670,7 @@ class ProjectSettingsForm(
             "billing:project.permissions", self.instance
         )
         self.changed_access = False
+        self.changed_public_sharing = False
         self.helper.form_tag = False
         if not self.user_can_change_access:
             disabled = {"disabled": True}
@@ -3664,6 +3678,7 @@ class ProjectSettingsForm(
             self.fields["access_control"].help_text = gettext(
                 "You do not have permission to change project access control."
             )
+            self.fields["public_sharing"].disabled = True
         else:
             disabled = {}
         self.helper.layout = Layout(
@@ -3694,6 +3709,7 @@ class ProjectSettingsForm(
                         template="%s/layout/radioselect_access.html",
                         **disabled,
                     ),
+                    "public_sharing",
                     "enforced_2fa",
                     css_id="access",
                 ),

--- a/weblate/trans/migrations/0103_project_public_sharing.py
+++ b/weblate/trans/migrations/0103_project_public_sharing.py
@@ -1,0 +1,27 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import django.utils.translation
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0102_migrate_json_sort_keys_to_choice"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="project",
+            name="public_sharing",
+            field=models.BooleanField(
+                default=False,
+                help_text=django.utils.translation.gettext_lazy(
+                    "Allows anonymous access to the engage pages and status widgets "
+                    "for Private and Custom projects."
+                ),
+                verbose_name=django.utils.translation.gettext_lazy("Public sharing"),
+            ),
+        ),
+    ]

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -213,6 +213,7 @@ def prefetch_project_flags(projects: Iterable[Project]) -> Iterable[Project]:
 
 class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
     AUDIT_SETTINGS: ClassVar[tuple[str, ...]] = (
+        "public_sharing",
         "enforced_2fa",
         "translation_review",
         "source_review",
@@ -316,6 +317,14 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
         verbose_name=gettext_lazy("Access control"),
         help_text=gettext_lazy(
             "How to restrict access to this project is detailed in the documentation."
+        ),
+    )
+    public_sharing = models.BooleanField(
+        verbose_name=gettext_lazy("Public sharing"),
+        default=False,
+        help_text=gettext_lazy(
+            "Allows anonymous access to the engage pages and status widgets "
+            "for Private and Custom projects."
         ),
     )
 
@@ -956,6 +965,18 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
     def get_share_url(self) -> str:
         """Return absolute URL usable for sharing."""
         return get_site_url(reverse("engage", kwargs={"path": self.get_url_path()}))
+
+    @property
+    def is_publicly_shared(self) -> bool:
+        """Whether engage pages and widgets are publicly accessible."""
+        return (
+            self.access_control
+            in {
+                self.ACCESS_PUBLIC,
+                self.ACCESS_PROTECTED,
+            }
+            or self.public_sharing
+        )
 
     @cached_property
     def locked(self) -> bool:

--- a/weblate/trans/tests/test_backups.py
+++ b/weblate/trans/tests/test_backups.py
@@ -1011,9 +1011,17 @@ class BackupsTest(ViewTestCase):
     def test_backup_settings(self) -> None:
         project = self.project
         project.autoclean_tm = not project.autoclean_tm
+        project.public_sharing = True
         project.enforced_2fa = True
         project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
-        project.save(update_fields=["autoclean_tm", "enforced_2fa", "commit_policy"])
+        project.save(
+            update_fields=[
+                "autoclean_tm",
+                "public_sharing",
+                "enforced_2fa",
+                "commit_policy",
+            ]
+        )
         component = self.create_po_mono(project=project, name="Backup-settings")
         component.hide_glossary_matches = True
         component.contribute_project_tm = False
@@ -1042,6 +1050,7 @@ class BackupsTest(ViewTestCase):
             )["component"]
 
         self.assertEqual(project_data["autoclean_tm"], project.autoclean_tm)
+        self.assertTrue(project_data["public_sharing"])
         self.assertTrue(project_data["enforced_2fa"])
         self.assertEqual(
             project_data["commit_policy"], CommitPolicyChoices.APPROVED_ONLY
@@ -1064,6 +1073,7 @@ class BackupsTest(ViewTestCase):
         restored_component = restored.component_set.get(slug=component.slug)
 
         self.assertEqual(restored.autoclean_tm, project.autoclean_tm)
+        self.assertTrue(restored.public_sharing)
         self.assertTrue(restored.enforced_2fa)
         self.assertEqual(restored.commit_policy, CommitPolicyChoices.APPROVED_ONLY)
         self.assertTrue(restored_component.hide_glossary_matches)

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -2674,6 +2674,17 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
             self.screenshot("user-add-project.png")
             with self.wait_for_page_load():
                 self.driver.find_element(By.ID, "id_name").submit()
+
+            project = Project.objects.get(name="WeblateOrg")
+            self.assertEqual(project.access_control, Project.ACCESS_PRIVATE)
+            project.public_sharing = True
+            project.save(update_fields=["public_sharing"])
+            with self.wait_for_page_load():
+                self.driver.refresh()
+
+            self.assertTrue(
+                self.driver.find_element(By.LINK_TEXT, "Community").is_displayed()
+            )
             self.screenshot("user-add-project-done.png")
             self.assertIn("WeblateOrg", self.driver.title)
 

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -51,6 +51,16 @@ from weblate.workspaces.models import Workspace
 
 
 class SettingsTest(ViewTestCase):
+    def test_public_sharing_permission(self) -> None:
+        form = ProjectSettingsForm(self.get_request(), instance=self.project)
+        self.assertTrue(form.fields["public_sharing"].disabled)
+
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+        self.user.clear_permissions_cache()
+        form = ProjectSettingsForm(self.get_request(), instance=self.project)
+        self.assertFalse(form.fields["public_sharing"].disabled)
+
     @override_settings(OFFER_HOSTING=True)
     def test_hosted_restricted_component_rejects_shared_memory(self) -> None:
         self.component.restricted = True
@@ -1066,9 +1076,30 @@ class SettingsTest(ViewTestCase):
         # Check change details display
         self.assertEqual(change.get_details_display(), "Protected")
 
+    def test_change_public_sharing(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        url = reverse("settings", kwargs={"path": self.project.get_url_path()})
+        response = self.client.get(url)
+        data = get_form_data(response.context["form"].initial)
+        data["public_sharing"] = True
+
+        response = self.client.post(url, data, follow=True)
+        self.assertRedirects(response, url)
+        self.project.refresh_from_db()
+        self.assertFalse(self.project.public_sharing)
+
+        billing = create_test_billing(self.user)
+        billing.add_project(self.project)
+        response = self.client.post(url, data, follow=True)
+        self.assertRedirects(response, url)
+
+        self.project.refresh_from_db()
+        self.assertTrue(self.project.public_sharing)
+
     def test_project_audit_settings(self) -> None:
         self.project.acting_user = self.user
         self.project.access_control = Project.ACCESS_PRIVATE
+        self.project.public_sharing = True
         self.project.enforced_2fa = True
         self.project.translation_review = True
         self.project.source_review = True

--- a/weblate/trans/tests/test_widgets.py
+++ b/weblate/trans/tests/test_widgets.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import patch
 
 from django.http import HttpResponse
-from django.test import RequestFactory, SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.urls import reverse
 from PIL import Image
 
@@ -24,7 +24,7 @@ from weblate.fonts.render import (
 )
 from weblate.trans.checklists import TranslationChecklistMixin
 from weblate.trans.filter import FILTERS
-from weblate.trans.models import Translation
+from weblate.trans.models import Project, Translation
 from weblate.trans.tests.test_views import FixtureTestCase
 from weblate.trans.views.widgets import WIDGETS
 from weblate.trans.widgets import (
@@ -345,6 +345,157 @@ class WidgetsTest(FixtureTestCase):
                 for call in mocked_draw_text.call_args_list
             )
         )
+
+
+class PublicSharingTest(FixtureTestCase):
+    def get_sharing_urls(self) -> list[str]:
+        return [
+            reverse("engage", kwargs={"path": self.project.get_url_path()}),
+            reverse(
+                "engage",
+                kwargs={"path": [*self.project.get_url_path(), "-", "cs"]},
+            ),
+            reverse(
+                "widget-image",
+                kwargs={
+                    "path": self.project.get_url_path(),
+                    "widget": "svg",
+                    "color": "badge",
+                    "extension": "svg",
+                },
+            ),
+            reverse(
+                "widget-image",
+                kwargs={
+                    "path": self.component.get_url_path(),
+                    "widget": "svg",
+                    "color": "badge",
+                    "extension": "svg",
+                },
+            ),
+            reverse(
+                "widget-image",
+                kwargs={
+                    "path": self.translation.get_url_path(),
+                    "widget": "svg",
+                    "color": "badge",
+                    "extension": "svg",
+                },
+            ),
+        ]
+
+    def set_project_access(self, access_control: int, public_sharing: bool) -> None:
+        self.project.access_control = access_control
+        self.project.public_sharing = public_sharing
+        self.project.save(update_fields=["access_control", "public_sharing"])
+
+    def test_public_and_protected_projects_are_shared(self) -> None:
+        self.client.logout()
+        for access_control in (Project.ACCESS_PUBLIC, Project.ACCESS_PROTECTED):
+            with self.subTest(access_control=access_control):
+                self.set_project_access(access_control, public_sharing=False)
+                self.assertTrue(self.project.is_publicly_shared)
+                for url in self.get_sharing_urls():
+                    self.assertEqual(self.client.get(url).status_code, 200)
+
+    def test_private_and_custom_projects_require_public_sharing(self) -> None:
+        self.client.logout()
+        for access_control in (Project.ACCESS_PRIVATE, Project.ACCESS_CUSTOM):
+            with self.subTest(access_control=access_control):
+                self.set_project_access(access_control, public_sharing=False)
+                self.assertFalse(self.project.is_publicly_shared)
+                for url in self.get_sharing_urls():
+                    self.assertEqual(self.client.get(url).status_code, 404)
+
+                self.set_project_access(access_control, public_sharing=True)
+                self.assertTrue(self.project.is_publicly_shared)
+                for url in self.get_sharing_urls():
+                    self.assertEqual(self.client.get(url).status_code, 200)
+
+    def test_public_sharing_value_survives_access_control_changes(self) -> None:
+        self.set_project_access(Project.ACCESS_PRIVATE, public_sharing=True)
+        self.project.access_control = Project.ACCESS_PUBLIC
+        self.project.save(update_fields=["access_control"])
+        self.project.refresh_from_db()
+        self.assertTrue(self.project.public_sharing)
+
+        self.project.access_control = Project.ACCESS_PRIVATE
+        self.project.save(update_fields=["access_control"])
+        self.project.refresh_from_db()
+        self.assertTrue(self.project.is_publicly_shared)
+
+    def test_authorized_user_can_access_private_sharing_pages(self) -> None:
+        self.project.add_user(self.user, "Administration")
+        self.user.clear_permissions_cache()
+        self.set_project_access(Project.ACCESS_PRIVATE, public_sharing=False)
+
+        for url in self.get_sharing_urls():
+            self.assertEqual(self.client.get(url).status_code, 200)
+
+        response = self.client.get(self.get_sharing_urls()[0])
+        self.assertContains(response, '<meta name="robots" content="noindex,nofollow"')
+
+    def test_restricted_component_widget_follows_project_sharing(self) -> None:
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        self.client.logout()
+        widget_url = self.get_sharing_urls()[3]
+
+        self.set_project_access(Project.ACCESS_PRIVATE, public_sharing=False)
+        self.assertEqual(self.client.get(widget_url).status_code, 404)
+
+        self.set_project_access(Project.ACCESS_PRIVATE, public_sharing=True)
+        self.assertEqual(self.client.get(widget_url).status_code, 200)
+
+    def test_widget_configuration_remains_access_controlled(self) -> None:
+        self.set_project_access(Project.ACCESS_PRIVATE, public_sharing=True)
+        self.client.logout()
+
+        response = self.client.get(
+            reverse("widgets", kwargs={"path": self.project.get_url_path()})
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_missing_sharing_paths_return_not_found(self) -> None:
+        self.client.logout()
+        self.assertEqual(
+            self.client.get(
+                reverse("engage", kwargs={"path": ["missing-project"]})
+            ).status_code,
+            404,
+        )
+        self.assertEqual(
+            self.client.get(
+                reverse(
+                    "widget-image",
+                    kwargs={
+                        "path": ["missing-project"],
+                        "widget": "svg",
+                        "color": "badge",
+                        "extension": "svg",
+                    },
+                )
+            ).status_code,
+            404,
+        )
+
+    @override_settings(ENABLE_SHARING=True)
+    def test_community_menu_follows_project_sharing(self) -> None:
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+
+        self.set_project_access(Project.ACCESS_PRIVATE, public_sharing=False)
+        response = self.client.get(self.project.get_absolute_url())
+        self.assertNotContains(response, ">Community<")
+
+        self.set_project_access(Project.ACCESS_PRIVATE, public_sharing=True)
+        response = self.client.get(self.project.get_absolute_url())
+        self.assertContains(response, ">Community<")
+
+        self.set_project_access(Project.ACCESS_PUBLIC, public_sharing=False)
+        response = self.client.get(self.project.get_absolute_url())
+        self.assertContains(response, ">Community<")
 
 
 class WidgetsMeta(type):

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -83,6 +83,7 @@ from weblate.utils.views import (
     get_paginator,
     optional_form,
     parse_path,
+    parse_path_for_public_sharing,
     show_form_errors,
     try_set_language,
 )
@@ -202,8 +203,7 @@ def show_engage(request: AuthenticatedHttpRequest, path):
     # Legacy URL
     if len(path) == 2:
         return redirect("engage", permanent=True, path=[path[0], "-", path[1]])
-    # Get project object, skipping ACL
-    obj = parse_path(None, path, (ProjectLanguage, Project))
+    obj = parse_path_for_public_sharing(request, path, (ProjectLanguage, Project))
 
     translate_object = None
     if isinstance(obj, ProjectLanguage):
@@ -231,7 +231,7 @@ def show_engage(request: AuthenticatedHttpRequest, path):
         request,
         "engage.html",
         {
-            "allow_index": True,
+            "allow_index": project.is_publicly_shared,
             "object": obj,
             "path_object": obj,
             "project": project,

--- a/weblate/trans/views/widgets.py
+++ b/weblate/trans/views/widgets.py
@@ -24,7 +24,12 @@ from weblate.trans.util import render
 from weblate.trans.widgets import WIDGETS, OpenGraphWidget
 from weblate.utils.site import get_site_url
 from weblate.utils.stats import ProjectLanguage
-from weblate.utils.views import parse_path, show_form_errors, try_set_language
+from weblate.utils.views import (
+    parse_path,
+    parse_path_for_public_sharing,
+    show_form_errors,
+    try_set_language,
+)
 
 if TYPE_CHECKING:
     from weblate.auth.models import AuthenticatedHttpRequest
@@ -157,9 +162,8 @@ def render_widget(
     color: str,
     extension: str,
 ):
-    # We intentionally skip ACL here to allow widget sharing
-    obj = parse_path(
-        None,
+    obj = parse_path_for_public_sharing(
+        request,
         path,
         (Component, ProjectLanguage, Project, Translation, Language, None),
     )

--- a/weblate/utils/views.py
+++ b/weblate/utils/views.py
@@ -19,6 +19,7 @@ from zipfile import ZipFile
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import EmptyPage, Paginator
+from django.db.models import Q
 from django.http import (
     FileResponse,
     Http404,
@@ -409,6 +410,23 @@ def parse_path(
 
     check_type(Unit)
     return get_object_or_404(translation.unit_set, pk=int(unitid))
+
+
+def parse_path_for_public_sharing(
+    request: AuthenticatedHttpRequest,
+    path: list[str] | tuple[str, ...] | None,
+    types: tuple[type[Model | BaseURLMixin] | None, ...],
+):
+    """Parse a path using ACL unless its project permits public sharing."""
+    if path and path[0] != "-":
+        is_publicly_shared = Project.objects.filter(
+            Q(access_control__in=(Project.ACCESS_PUBLIC, Project.ACCESS_PROTECTED))
+            | Q(public_sharing=True),
+            slug=path[0],
+        ).exists()
+        if not is_publicly_shared:
+            return parse_path(request, path, types)
+    return parse_path(None, path, types)
 
 
 async def _workspace_can_view(


### PR DESCRIPTION
Require Private and Custom projects to opt in before exposing Engage pages and rendered status widgets. Add the project setting to the UI, API, backups, documentation, and access-control tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
