### PR TITLE
fix(api): enforce translation length limits

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 2026.9.1
 
 .. rubric:: Bug fixes
 
+* REST API unit updates now enforce the same translation text length limit as the web editor.
 * The :http:post:`autotranslate API endpoint </api/translations/(string:project)/(string:component)/(string:language)/autotranslate/>` now correctly describes its accepted request body fields (``q``, ``mode``, ``auto_source``, ``component``, ``engines``, ``threshold``) in the OpenAPI schema instead of incorrectly reflecting the Translation resource.
 * Links outside tab navigation now correctly activate their target tabs, fixing upload links for missing translations and new components.
 * Error reporting integrations now distinguish informational messages from exceptions and reliably report the explicitly handled exception.

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -92,7 +92,7 @@ from weblate.trans.models.translation import NewUnitParams
 from weblate.trans.util import check_upload_method_permissions, cleanup_repo_url
 from weblate.trans.validators import (
     SUGGESTION_REJECTION_REASON_LENGTH,
-    get_translation_text_max_length,
+    validate_translation_text_length,
 )
 from weblate.trans.workspace_move import (
     get_project_move_billing_error,
@@ -3350,11 +3350,7 @@ class SuggestionSerializer(serializers.Serializer[Suggestion]):
         if unit is None:
             return value
 
-        max_length = get_translation_text_max_length(unit)
-        for text in value:
-            if len(text) > max_length:
-                msg = gettext_lazy("Translation text too long!")
-                raise serializers.ValidationError(msg)
+        validate_translation_text_length(unit, value)
 
         if unit.translation.component.is_multivalue:
             return value
@@ -3679,6 +3675,11 @@ class UnitWriteSerializer(serializers.ModelSerializer[Unit]):
         if isinstance(data, dict) and data.get("state") in {0, "0"}:
             self.fields["target"].child.allow_blank = True
         return super().to_internal_value(data)
+
+    def validate_target(self, value: list[str]) -> list[str]:
+        if self.instance is not None:
+            validate_translation_text_length(self.instance, value)
+        return value
 
 
 class NewUnitSerializer(serializers.Serializer):

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -112,7 +112,10 @@ from weblate.trans.tests.utils import (
     get_test_file,
 )
 from weblate.trans.util import join_plural
-from weblate.trans.validators import SUGGESTION_REJECTION_REASON_LENGTH
+from weblate.trans.validators import (
+    SUGGESTION_REJECTION_REASON_LENGTH,
+    get_translation_text_max_length,
+)
 from weblate.utils.celery import get_task_metadata_key
 from weblate.utils.data import data_dir
 from weblate.utils.lock import WeblateLockTimeoutError
@@ -12973,6 +12976,28 @@ class UnitAPITest(APIBaseTest):
         # The auto fixer adds the trailing newline
         self.assertEqual(unit.target, "Test translation\n")
 
+    def test_translate_unit_too_long(self) -> None:
+        unit = Unit.objects.get(
+            translation__language_code="cs", source="Hello, world!\n"
+        )
+        original_target = unit.target
+        target = "x" * (get_translation_text_max_length(unit) + 1)
+
+        response = self.do_request(
+            "api:unit-detail",
+            kwargs={"pk": unit.pk},
+            method="patch",
+            code=400,
+            request={"state": "20", "target": target},
+        )
+
+        self.assertEqual(
+            response.data["errors"][0]["detail"], "Translation text too long!"
+        )
+        self.assertEqual(response.data["errors"][0]["attr"], "target")
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, original_target)
+
     def test_translate_unit_deleted_mid_request(self) -> None:
         """Unit removed between get_object() and the locking re-fetch."""
         unit = Unit.objects.get(
@@ -13872,7 +13897,7 @@ class SuggestionAPITest(APIBaseTest):
 
     def test_add_suggestion_too_long(self) -> None:
         unit = self._get_unit()
-        max_length = 10 * (unit.get_max_length() + 100)
+        max_length = get_translation_text_max_length(unit)
         response = self._add_suggestion(unit, "x" * (max_length + 1), code=400)
         self.assertEqual(
             response.data["errors"][0]["detail"], "Translation text too long!"

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -93,8 +93,8 @@ from weblate.trans.models import (
 from weblate.trans.specialchars import RTL_CHARS_DATA, get_special_chars
 from weblate.trans.util import check_upload_method_permissions, is_repo_link
 from weblate.trans.validators import (
-    get_translation_text_max_length,
     validate_check_flags,
+    validate_translation_text_length,
 )
 from weblate.trans.workspace_move import (
     PROJECT_MOVE_WORKSPACE_SELECT_LIMIT,
@@ -819,10 +819,7 @@ class TranslationForm(UnitForm):
 
         fuzzy_state = unit.state if unit.state in FUZZY_STATES else STATE_FUZZY
 
-        max_length = get_translation_text_max_length(unit)
-        for text in self.cleaned_data["target"]:
-            if len(text) > max_length:
-                raise ValidationError(gettext("Translation text too long!"))
+        validate_translation_text_length(unit, self.cleaned_data["target"])
         if self.user.has_perm(
             "unit.review", unit.translation
         ) and self.cleaned_data.get("review"):

--- a/weblate/trans/validators.py
+++ b/weblate/trans/validators.py
@@ -34,6 +34,13 @@ def get_translation_text_max_length(unit: Unit) -> int:
     return 10 * (max_length + 100)
 
 
+def validate_translation_text_length(unit: Unit, target: list[str]) -> None:
+    """Validate translation text length for a unit."""
+    max_length = get_translation_text_max_length(unit)
+    if any(len(text) > max_length for text in target):
+        raise ValidationError(gettext("Translation text too long!"))
+
+
 def validate_filemask(val) -> None:
     """Validate that the filemask contains *."""
     if "*" not in val:


### PR DESCRIPTION
Share translation target length validation between web edits, suggestions, and unit API updates so all entry points reject oversized values consistently.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
