### PR TITLE
fix(checks): avoid backtracking in Markdown parsing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Weblate 2026.9.1
 * Borg backup passphrases are now recursively scrubbed from Sentry error reports, including when a custom event scrubber is configured.
 * Font overrides are now restricted to fonts uploaded to the same project.
 * Engage pages and status widgets no longer disclose Private or Custom projects unless :ref:`project-public_sharing` is enabled.
+* Prevented excessive CPU consumption while checking malformed Markdown and MDX syntax.
 
 .. rubric:: Bug fixes
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -25,7 +25,7 @@ documentation; ``*(maintainer)*`` means it was stated by a maintainer during
 this threat-model process; ``*(inferred)*`` means it was reasoned from the
 current project shape and needs maintainer confirmation.
 
-Provenance summary: 118 documented / 69 maintainer / 0 inferred claims.
+Provenance summary: 118 documented / 70 maintainer / 0 inferred claims.
 
 Weblate is a Django-based web localization platform. It accepts work from
 browser users, API clients, project-scoped tokens, repository webhooks, VCS
@@ -798,6 +798,14 @@ Security properties Weblate provides
      - Rate limiting is enabled and backed by a working datastore.
      - Requests exceeding configured thresholds continue to be processed.
      - Availability/security hardening depending on endpoint sensitivity.
+   * - Built-in translation quality checks must not permit user-controlled
+       content within configured size limits to monopolize synchronous request
+       workers through disproportionate resource consumption. *(maintainer)*
+     - The check is enabled and runs during a supported browser or API
+       translation write.
+     - A single accepted translation causes CPU or memory consumption
+       disproportionate to its size and stalls a request worker.
+     - Security-critical for single-request DoS; otherwise availability bug.
    * - Generic webhooks schedule repository updates only for eligible components
        whose repository URL exactly matches a repository URL from the payload,
        including documented URL variants. Components managed through an

--- a/weblate/checks/markup.py
+++ b/weblate/checks/markup.py
@@ -51,10 +51,9 @@ from weblate.utils.html import (
     MD_BROKEN_LINK,
     MD_LINK,
     MD_REFLINK,
-    MD_SYNTAX,
-    MD_SYNTAX_GROUPS,
     HTMLSanitizer,
     extract_html_attributes,
+    iter_markdown_syntax,
 )
 from weblate.utils.xml import parse_xml
 
@@ -569,30 +568,19 @@ class MarkdownSyntaxCheck(MarkdownBaseCheck):
     name = gettext_lazy("Markdown syntax")
     description = gettext_lazy("Markdown syntax does not match source.")
 
-    @staticmethod
-    def extract_match(match):
-        for i in range(6):
-            if match[i]:
-                return match[i]
-        return None
-
     def check_single(self, source: str, target: str, unit: Unit):
-        src_tags = {self.extract_match(x) for x in MD_SYNTAX.findall(source)}
-        tgt_tags = {self.extract_match(x) for x in MD_SYNTAX.findall(target)}
+        src_tags = {match.value for match in iter_markdown_syntax(source)}
+        tgt_tags = {match.value for match in iter_markdown_syntax(target)}
 
         return src_tags != tgt_tags
 
     def check_highlight(self, source: str, unit: Unit):
         if self.should_skip(unit):
             return
-        for match in MD_SYNTAX.finditer(source):
-            value = ""
-            for i in range(MD_SYNTAX_GROUPS):
-                value = match.group(i + 1)
-                if value:
-                    break
-            start = match.start()
-            end = match.end()
+        for match in iter_markdown_syntax(source):
+            value = match.value
+            start = match.start
+            end = match.end
             group = f"markdown:{start}:{end}"
             translatable = value != "<"
             forbidden_text = (value[0],) if translatable and len(value) > 1 else ()

--- a/weblate/checks/mdx.py
+++ b/weblate/checks/mdx.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from django.utils.translation import gettext_lazy
 
 from weblate.checks.base import TargetCheck
+from weblate.utils.html import iter_markdown_autolinks, iter_markdown_code_spans
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -138,31 +139,26 @@ def _scan_expression(text: str, start: int) -> int | None:  # ruff: ignore[compl
     return None
 
 
-def _skip_code_span(text: str, start: int) -> int | None:
-    """
-    Find the end of the Markdown inline code span opening at ``start``.
+def _get_markdown_code_span_ends(text: str) -> dict[int, int]:
+    """Return Markdown code span ends keyed by opening position."""
+    return {span.start: span.end for span in iter_markdown_code_spans(text)}
 
-    Returns the index of closing backtick or None if there is no matching closing run.
-    """
+
+def _get_markdown_autolink_ends(text: str) -> dict[int, int]:
+    """Return Markdown autolink ends keyed by opening position."""
+    return {span.start: span.end for span in iter_markdown_autolinks(text)}
+
+
+def _skip_markdown_code(text: str, start: int, code_span_ends: dict[int, int]) -> int:
+    """Skip a Markdown code span or one unmatched maximal backtick run."""
+    if end := code_span_ends.get(start):
+        return end
+
     length = len(text)
-    run_end = start
-    while run_end < length and text[run_end] == "`":
-        run_end += 1
-    run = run_end - start
-
-    i = run_end
-    while i < length:
-        if text[i] == "`":
-            close_end = i
-            while close_end < length and text[close_end] == "`":
-                close_end += 1
-            if close_end - i == run:
-                return close_end - 1
-            i = close_end
-        else:
-            i += 1
-
-    return None
+    end = start + 1
+    while end < length and text[end] == "`":
+        end += 1
+    return end
 
 
 def _scan_jsx_tag(
@@ -211,6 +207,8 @@ def _scan_jsx_tag(
 
 def _iter_jsx_tags(text: str) -> Iterator[tuple[bool, str, bool]]:
     """Yield closed JSX tags while ignoring expressions and code spans."""
+    code_span_ends = _get_markdown_code_span_ends(text)
+    autolink_ends = _get_markdown_autolink_ends(text)
     i = 0
     length = len(text)
     while i < length:
@@ -219,16 +217,18 @@ def _iter_jsx_tags(text: str) -> Iterator[tuple[bool, str, bool]]:
             i += 2
             continue
         if char == "`":
-            close = _skip_code_span(text, i)
-            if close is not None:
-                i = close + 1
-                continue
+            i = _skip_markdown_code(text, i, code_span_ends)
+            continue
         if char == "{":
             close = _scan_expression(text, i)
-            if close is not None:
-                i = close + 1
-                continue
+            if close is None:
+                break
+            i = close + 1
+            continue
         if char == "<":
+            if end := autolink_ends.get(i):
+                i = end
+                continue
             tag = _scan_jsx_tag(text, i)
             if tag is not None:
                 closing, tag_name, self_closing, end = tag
@@ -242,6 +242,9 @@ def _iter_jsx_tags(text: str) -> Iterator[tuple[bool, str, bool]]:
 
 def _find_unclosed_jsx_tag(text: str, start: int) -> tuple[int, str] | None:
     """Find an opening JSX tag containing ``start``."""
+    prefix = text[:start]
+    code_span_ends = _get_markdown_code_span_ends(prefix)
+    autolink_ends = _get_markdown_autolink_ends(prefix)
     i = 0
     while i < start:
         char = text[i]
@@ -249,16 +252,18 @@ def _find_unclosed_jsx_tag(text: str, start: int) -> tuple[int, str] | None:
             i += 2
             continue
         if char == "`":
-            close = _skip_code_span(text, i)
-            if close is not None and close < start:
-                i = close + 1
-                continue
+            i = _skip_markdown_code(text, i, code_span_ends)
+            continue
         if char == "{":
             close = _scan_expression(text, i)
-            if close is not None and close < start:
-                i = close + 1
-                continue
+            if close is None or close >= start:
+                return None
+            i = close + 1
+            continue
         if char == "<":
+            if end := autolink_ends.get(i):
+                i = end
+                continue
             tag = _scan_jsx_tag(text, i, start)
             if tag is not None:
                 closing, tag_name, _self_closing, end = tag
@@ -321,6 +326,8 @@ class SafeMDXCheck(TargetCheck):
         self, text: str
     ) -> Iterator[tuple[str, str, tuple[str, ...], str]]:
         """Extract JSX expressions together with their syntactic context."""
+        code_span_ends = _get_markdown_code_span_ends(text)
+        autolink_ends = _get_markdown_autolink_ends(text)
         stack: list[str] = []
         open_tag: tuple[int, bool, str, bool, int | None] | None = None
         pending_attr: str | None = None
@@ -344,20 +351,21 @@ class SafeMDXCheck(TargetCheck):
                     pending_attr = _find_attribute_name(text, i)
                 elif char == "{":
                     close = _scan_expression(text, i)
-                    if close is not None:
-                        tag_stack = (*tuple(stack), tag)
-                        if pending_attr is None:
-                            yield ("tag", "", tag_stack, text[i : close + 1])
-                        else:
-                            yield (
-                                "attribute",
-                                pending_attr,
-                                tag_stack,
-                                text[i : close + 1],
-                            )
-                            pending_attr = None
-                        i = close + 1
-                        continue
+                    if close is None:
+                        break
+                    tag_stack = (*tuple(stack), tag)
+                    if pending_attr is None:
+                        yield ("tag", "", tag_stack, text[i : close + 1])
+                    else:
+                        yield (
+                            "attribute",
+                            pending_attr,
+                            tag_stack,
+                            text[i : close + 1],
+                        )
+                        pending_attr = None
+                    i = close + 1
+                    continue
                 elif i == end and char == ">":
                     if closing:
                         for index in range(len(stack) - 1, -1, -1):
@@ -375,11 +383,12 @@ class SafeMDXCheck(TargetCheck):
                 i += 2
                 continue
             if char == "`":
-                close = _skip_code_span(text, i)
-                if close is not None:
-                    i = close + 1
-                    continue
+                i = _skip_markdown_code(text, i, code_span_ends)
+                continue
             if char == "<":
+                if autolink_end := autolink_ends.get(i):
+                    i = autolink_end
+                    continue
                 scanned = _scan_jsx_tag(text, i)
                 if scanned is not None:
                     closing, tag, self_closing, end = scanned
@@ -388,10 +397,11 @@ class SafeMDXCheck(TargetCheck):
                     continue
             if char == "{":
                 close = _scan_expression(text, i)
-                if close is not None:
-                    yield ("text", "", tuple(stack), text[i : close + 1])
-                    i = close + 1
-                    continue
+                if close is None:
+                    break
+                yield ("text", "", tuple(stack), text[i : close + 1])
+                i = close + 1
+                continue
             i += 1
 
     def get_jsx_expression_context(
@@ -428,6 +438,8 @@ class SafeMDXCheck(TargetCheck):
             yield expression
 
     def _iter_jsx_expressions(self, text: str) -> Iterator[tuple[int, str]]:
+        code_span_ends = _get_markdown_code_span_ends(text)
+        autolink_ends = _get_markdown_autolink_ends(text)
         i = 0
         length = len(text)
         while i < length:
@@ -438,15 +450,17 @@ class SafeMDXCheck(TargetCheck):
                 continue
             if char == "`":
                 # Markdown inline code span
-                close = _skip_code_span(text, i)
-                if close is not None:
-                    i = close + 1
-                    continue
+                i = _skip_markdown_code(text, i, code_span_ends)
+                continue
+            if char == "<" and (end := autolink_ends.get(i)):
+                i = end
+                continue
             if char == "{":
                 # JSX expression
                 close = _scan_expression(text, i)
-                if close is not None:
-                    yield i, text[i : close + 1]
-                    i = close + 1
-                    continue
+                if close is None:
+                    break
+                yield i, text[i : close + 1]
+                i = close + 1
+                continue
             i += 1

--- a/weblate/checks/tests/test_markup_checks.py
+++ b/weblate/checks/tests/test_markup_checks.py
@@ -386,6 +386,27 @@ class MarkdownSyntaxCheckTest(CheckTestCase):
             ],
         )
 
+    def test_code_span_delimiter(self) -> None:
+        self.do_test(True, ("`code`", "``code``", "md-text"))
+
+    def test_code_span_in_autolink(self) -> None:
+        self.do_test(
+            False,
+            (
+                "<https://example.com/`path`>",
+                "<https://example.com/path>",
+                "md-text",
+            ),
+        )
+
+    def test_partially_escaped_code_span(self) -> None:
+        self.do_test(True, (r"\``{danger}`", "{danger}", "md-text"))
+
+    def test_incomplete_code_span(self) -> None:
+        for length in (400, 800, 1600, 100_000):
+            with self.subTest(length=length):
+                self.do_test(False, ("", "`" * length + "X", "md-text"))
+
 
 class URLCheckTest(CheckTestCase):
     check = URLCheck()

--- a/weblate/checks/tests/test_mdx.py
+++ b/weblate/checks/tests/test_mdx.py
@@ -100,6 +100,18 @@ class SafeMDXCheckTest(CheckTestCase):
             "Test \\{{count1} `{inside_thiings}` and then {count2}",
             ["{count1}", "{count2}"],
         )
+        self.check_jsx_expression_matches(
+            "```prefix ``{ignored}`` {real}",
+            ["{real}"],
+        )
+        self.check_jsx_expression_matches(
+            r"\` `code` {real} `",
+            ["{real}"],
+        )
+        self.check_jsx_expression_matches(
+            r"\``{ignored}` {real}",
+            ["{real}"],
+        )
         # Nested destructuring with a default object literal.
         self.check_jsx_expression_matches(
             "{({ a = { x: 1 } }) => a}",
@@ -136,6 +148,33 @@ class SafeMDXCheckTest(CheckTestCase):
             list(self.check.get_jsx_expression_matches(text)),
             expected,
         )
+
+    def test_incomplete_code_span(self) -> None:
+        for length in (400, 800, 1600, 100_000):
+            with self.subTest(length=length):
+                text = "`" * length + "X{expression}"
+                self.check_jsx_expression_matches(text, ["{expression}"])
+        self.do_test(False, ("", "`" * 100_000 + "X", "safe-mdx"))
+
+    def test_incomplete_expression(self) -> None:
+        for length in (400, 800, 1600, 100_000):
+            with self.subTest(length=length):
+                text = "{" * length
+                self.check_jsx_expression_matches(text, [])
+                self.assertEqual(
+                    list(self.check.get_jsx_expression_signatures(text)), []
+                )
+                self.assertEqual(self.check.get_jsx_element_stack(text), ())
+        self.do_test(False, ("", "{" * 100_000, "safe-mdx"))
+
+    def test_autolink_literal_brace(self) -> None:
+        source = "<https://example.com/{path>"
+        target = "<https://example.com/{path> {evil}"
+        self.check_jsx_expression_matches(target, ["{evil}"])
+        self.do_test(True, (source, target, "safe-mdx"))
+
+    def test_partially_escaped_code_span(self) -> None:
+        self.do_test(True, (r"\``{danger}`", "{danger}", "safe-mdx"))
 
     def test_expression_signatures_include_context(self) -> None:
         self.assertEqual(

--- a/weblate/utils/html.py
+++ b/weblate/utils/html.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import re
 import threading
 from collections import defaultdict
+from heapq import merge
 from html.parser import HTMLParser as StdHTMLParser
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -18,7 +19,7 @@ from lxml.etree import HTMLParser
 from lxml.html.defs import tags as lxml_html_tags
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from django.utils.safestring import SafeString
     from lxml.etree import ParserTarget
@@ -60,17 +61,177 @@ MD_SYNTAX = re.compile(
     |
     (\*)(?:(?:\*\*|[^\*])+?)\*(?!\*)    # *word*
     |
-    (`+)\s*(?:[\s\S]*?[^`])\s*\5(?!`)   # `code`
-    |
     (~~)(?=\S)(?:[\s\S]*?\S)~~          # ~~word~~
-    |
-    (<)(?:https?://[^>]+)>              # URL
-    |
-    (<)(?:[^>]+@[^>]+\.[^>]+)>          # E-mail
     """,
     re.VERBOSE,
 )
-MD_SYNTAX_GROUPS = 8
+
+
+class MarkdownSyntax(NamedTuple):
+    start: int
+    end: int
+    value: str
+
+
+def _is_markdown_autolink(value: str) -> bool:
+    """Return whether an angle-delimited value is a supported autolink."""
+    if value.startswith("http://"):
+        return len(value) > 7
+    if value.startswith("https://"):
+        return len(value) > 8
+
+    has_at = False
+    characters_after_at = 0
+    for position, character in enumerate(value):
+        if not has_at:
+            if character == "@" and position > 0:
+                has_at = True
+        else:
+            if character == "." and characters_after_at and position + 1 < len(value):
+                return True
+            characters_after_at += 1
+    return False
+
+
+def iter_markdown_autolinks(text: str) -> Iterator[MarkdownSyntax]:
+    """Yield supported Markdown autolinks in one pass."""
+    opening: int | None = None
+    backslashes = 0
+    for position, character in enumerate(text):
+        if character == "\\":
+            backslashes += 1
+            continue
+        escaped = backslashes % 2 == 1
+        backslashes = 0
+        if character == "<" and not escaped:
+            opening = position
+        elif character == ">" and opening is not None:
+            if _is_markdown_autolink(text[opening + 1 : position]):
+                yield MarkdownSyntax(opening, position + 1, "<")
+            opening = None
+
+
+def _iter_markdown_code_spans(
+    text: str, excluded_opening_ranges: Iterable[tuple[int, int]]
+) -> Iterator[MarkdownSyntax]:
+    """Yield Markdown code spans without reconsidering backtick runs."""
+    runs: list[tuple[int, int, bool, bool]] = []
+    position = 0
+    length = len(text)
+    backslashes = 0
+    while position < length:
+        if text[position] != "`":
+            if text[position] == "\\":
+                backslashes += 1
+            else:
+                backslashes = 0
+            position += 1
+            continue
+        end = position + 1
+        while end < length and text[end] == "`":
+            end += 1
+        if backslashes % 2:
+            # A backslash escapes the first tick outside a code span. Preserve
+            # the maximal run as a possible closer, where escapes are literal,
+            # and expose the remaining suffix as a possible opener.
+            runs.append((position, end, False, True))
+            if position + 1 < end:
+                runs.append((position + 1, end, True, False))
+        else:
+            runs.append((position, end, True, True))
+        position = end
+        backslashes = 0
+
+    next_run: list[int | None] = [None] * len(runs)
+    last_by_length: dict[int, int] = {}
+    for index in range(len(runs) - 1, -1, -1):
+        start, end, _can_open, can_close = runs[index]
+        run_length = end - start
+        next_run[index] = last_by_length.get(run_length)
+        if can_close:
+            last_by_length[run_length] = index
+
+    excluded_ranges = iter(excluded_opening_ranges)
+    excluded_start, excluded_end = next(excluded_ranges, (length, length))
+    index = 0
+    while index < len(runs):
+        start, opening_end, can_open, _can_close = runs[index]
+        while excluded_end <= start:
+            excluded_start, excluded_end = next(excluded_ranges, (length, length))
+        if not can_open or excluded_start <= start < excluded_end:
+            index += 1
+            continue
+        closing_index = next_run[index]
+        if closing_index is None:
+            index += 1
+            continue
+        _closing_start, end, _can_open, _can_close = runs[closing_index]
+        yield MarkdownSyntax(start, end, text[start:opening_end])
+        index = closing_index + 1
+        while index < len(runs) and runs[index][0] < end:
+            index += 1
+
+
+def iter_markdown_code_spans(text: str) -> Iterator[MarkdownSyntax]:
+    """Yield Markdown code spans without reconsidering backtick runs."""
+    autolinks = list(iter_markdown_autolinks(text))
+    yield from _iter_markdown_code_spans(
+        text, ((match.start, match.end) for match in autolinks)
+    )
+
+
+def iter_markdown_syntax(text: str) -> Iterator[MarkdownSyntax]:
+    """Yield Markdown syntax while treating code spans as opaque text."""
+    autolinks = list(iter_markdown_autolinks(text))
+    code_spans = list(
+        _iter_markdown_code_spans(
+            text, ((match.start, match.end) for match in autolinks)
+        )
+    )
+    code_span_index = 0
+    visible_autolinks: list[MarkdownSyntax] = []
+    for autolink in autolinks:
+        while (
+            code_span_index < len(code_spans)
+            and code_spans[code_span_index].end <= autolink.start
+        ):
+            code_span_index += 1
+        if (
+            code_span_index < len(code_spans)
+            and code_spans[code_span_index].start
+            < autolink.start
+            < code_spans[code_span_index].end
+        ):
+            # A code span starting before an apparent autolink takes precedence.
+            continue
+        visible_autolinks.append(autolink)
+
+    opaque_syntax = list(
+        merge(code_spans, visible_autolinks, key=lambda match: match.start)
+    )
+    if opaque_syntax:
+        masked_parts: list[str] = []
+        position = 0
+        for span in opaque_syntax:
+            masked_parts.extend(
+                (text[position : span.start], "x" * (span.end - span.start))
+            )
+            position = span.end
+        masked_parts.append(text[position:])
+        masked = "".join(masked_parts)
+    else:
+        masked = text
+
+    regex_syntax = (
+        MarkdownSyntax(
+            match.start(),
+            match.end(),
+            next((group for group in match.groups() if group), ""),
+        )
+        for match in MD_SYNTAX.finditer(masked)
+    )
+    yield from merge(regex_syntax, opaque_syntax, key=lambda match: match.start)
+
 
 AUTO_SAFE_HTML_START = re.compile(r"<(?=[!/?A-Za-z])")
 AUTO_SAFE_HTML_SEGMENT = re.compile(

--- a/weblate/utils/tests/test_html.py
+++ b/weblate/utils/tests/test_html.py
@@ -15,6 +15,9 @@ from weblate.utils.html import (
     extract_html_attributes,
     extract_html_tags,
     is_auto_safe_html_source,
+    iter_markdown_autolinks,
+    iter_markdown_code_spans,
+    iter_markdown_syntax,
     list_to_tuples,
     mail_quote_value,
     serialize_mdx_void_elements,
@@ -59,6 +62,83 @@ class HTMLSanitizerTestCase(SimpleTestCase):
                     serialize_mdx_void_elements(f'<{tag} title="test">'),
                     f'<{tag} title="test" />',
                 )
+
+
+class MarkdownSyntaxTestCase(SimpleTestCase):
+    def test_code_spans(self) -> None:
+        text = "`one` ``two ` inner`` ```three\nlines```"
+        self.assertEqual(
+            [
+                (text[span.start : span.end], span.value)
+                for span in iter_markdown_code_spans(text)
+            ],
+            [
+                ("`one`", "`"),
+                ("``two ` inner``", "``"),
+                ("```three\nlines```", "```"),
+            ],
+        )
+
+    def test_unmatched_code_spans(self) -> None:
+        text = "```a` and ``b``"
+        self.assertEqual(
+            [text[span.start : span.end] for span in iter_markdown_code_spans(text)],
+            ["``b``"],
+        )
+
+    def test_escaped_code_span(self) -> None:
+        text = r"\` `code` {expression} `"
+        self.assertEqual(
+            [text[span.start : span.end] for span in iter_markdown_code_spans(text)],
+            ["`code`"],
+        )
+
+    def test_escaped_code_span_closer(self) -> None:
+        text = r"`code\`"
+        self.assertEqual(
+            [text[span.start : span.end] for span in iter_markdown_code_spans(text)],
+            [text],
+        )
+
+    def test_partially_escaped_code_span(self) -> None:
+        text = r"\``{expression}`"
+        self.assertEqual(
+            [text[span.start : span.end] for span in iter_markdown_code_spans(text)],
+            ["`{expression}`"],
+        )
+
+    def test_autolinks(self) -> None:
+        text = "See <https://example.com/path> and <noreply@example.com>."
+        self.assertEqual(
+            [text[span.start : span.end] for span in iter_markdown_autolinks(text)],
+            ["<https://example.com/path>", "<noreply@example.com>"],
+        )
+
+    def test_code_spans_are_opaque(self) -> None:
+        text = "**before `*literal*` after**"
+        self.assertEqual(
+            [syntax.value for syntax in iter_markdown_syntax(text)],
+            ["**", "`"],
+        )
+
+    def test_code_spans_in_autolinks(self) -> None:
+        text = "<https://example.com/`path`>"
+        self.assertEqual(
+            [syntax.value for syntax in iter_markdown_syntax(text)],
+            ["<"],
+        )
+
+    def test_incomplete_autolinks(self) -> None:
+        text = "<a@b." * 20_000
+        self.assertEqual(list(iter_markdown_autolinks(text)), [])
+        self.assertEqual(list(iter_markdown_syntax(text)), [])
+
+    def test_incomplete_code_span(self) -> None:
+        for length in (400, 800, 1600, 100_000):
+            with self.subTest(length=length):
+                text = "`" * length + "X"
+                self.assertEqual(list(iter_markdown_code_spans(text)), [])
+                self.assertEqual(list(iter_markdown_syntax(text)), [])
 
 
 class HtmlTestCase(SimpleTestCase):


### PR DESCRIPTION
Replace backreference-based code span matching with a shared maximal-run scanner. Reuse it in Markdown and MDX checks so malformed backtick runs have bounded processing cost.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
