### PR TITLE
fix(html): avoid br tags used for spacing

### DIFF
--- a/weblate/templates/auth/team.html
+++ b/weblate/templates/auth/team.html
@@ -102,12 +102,9 @@
           </p>
           {{ auto_formset|crispy }}
           <div class="multiFieldEmpty hidden">{{ auto_formset.empty_form|crispy }}</div>
-          <button class="btn btn-info add-multifield" data-prefix="autogroup_set" type="button">
+          <button class="btn btn-info add-multifield mb-4" data-prefix="autogroup_set" type="button">
             {% translate "Add automatic assignment" %}
           </button>
-          <br />
-          <br />
-          <br />
         </div>
       {% endif %}
       {% if user_can_edit_team_users %}

--- a/weblate/templates/auth/team.html
+++ b/weblate/templates/auth/team.html
@@ -102,9 +102,9 @@
           </p>
           {{ auto_formset|crispy }}
           <div class="multiFieldEmpty hidden">{{ auto_formset.empty_form|crispy }}</div>
-          <button class="btn btn-info add-multifield mb-4" data-prefix="autogroup_set" type="button">
-            {% translate "Add automatic assignment" %}
-          </button>
+          <button class="btn btn-info add-multifield mb-4"
+                  data-prefix="autogroup_set"
+                  type="button">{% translate "Add automatic assignment" %}</button>
         </div>
       {% endif %}
       {% if user_can_edit_team_users %}

--- a/weblate/templates/keyboard-shortcuts.html
+++ b/weblate/templates/keyboard-shortcuts.html
@@ -51,7 +51,6 @@
                 <kbd>Alt</kbd> + <kbd>↑</kbd> {% translate "or" context "between keyboard shortcuts" %}
                 <br>
                 <kbd>Cmd</kbd> + <kbd>↑</kbd> {% translate "or" context "between keyboard shortcuts" %}
-                <br>
               </td>
               <td>{% translate "Navigate to the previous translation in the current search." %}</td>
             </tr>
@@ -64,7 +63,6 @@
                 <kbd>Alt</kbd> + <kbd>↓</kbd> {% translate "or" context "between keyboard shortcuts" %}
                 <br>
                 <kbd>Cmd</kbd> + <kbd>↓</kbd> {% translate "or" context "between keyboard shortcuts" %}
-                <br>
               </td>
               <td>{% translate "Navigate to the next translation in the current search." %}</td>
             </tr>

--- a/weblate/templates/snippets/git-info.html
+++ b/weblate/templates/snippets/git-info.html
@@ -44,7 +44,6 @@
           <br />
           {% comment %}Translators: For example: "nijel authored five days ago"{% endcomment %}
           {% blocktranslate with author=commit|format_commit_author date=commit.authordate|naturaltime %}{{ author }} authored {{ date }}{% endblocktranslate %}
-          <br />
         </td>
       </tr>
     {% endif %}
@@ -64,7 +63,6 @@
           <br />
           {% comment %}Translators: For example: "nijel authored five days ago"{% endcomment %}
           {% blocktranslate with author=commit|format_commit_author date=commit.authordate|naturaltime %}{{ author }} authored {{ date }}{% endblocktranslate %}
-          <br />
         </td>
       </tr>
     {% endif %}


### PR DESCRIPTION
Remove no-op trailing line breaks and replace repeated breaks with a Bootstrap spacing utility so current djLint accepts the templates without changing their layout.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
