### PR TITLE
fix(reports): make report permission authoritative

### DIFF
--- a/docs/admin/access.rst
+++ b/docs/admin/access.rst
@@ -511,6 +511,14 @@ the following rules:
   operation is denied when none of the project's repositories are available to
   it.
 
+- The :guilabel:`Manage reports` permission applies to the complete selected
+  report scope. It grants access to report data from restricted components and,
+  at workspace scope, private projects even when those descendants are not
+  otherwise visible to the user. Grant it only to users trusted with all report
+  data in that scope. Complete workspace reports are unavailable to regular
+  users until they configure two-factor authentication when any project in the
+  workspace enforces it. Superusers and bot accounts are exempt.
+
 - The :guilabel:`Edit component settings` permission allows administrative
   operations that can affect repository contents. For example, users can choose
   files through component settings or install and configure component add-ons.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3375,7 +3375,9 @@ Reports
 
     Lists stored reports accessible to the authenticated user. The optional
     ``kind``, ``workspace``, ``project``, ``category``, and ``component`` query
-    parameters filter the result.
+    parameters filter the result. The :guilabel:`Manage reports` permission is
+    authoritative for the selected scope and includes reports containing data
+    from private projects and restricted components below that scope.
 
 .. http:post:: /api/reports/
 
@@ -3384,7 +3386,9 @@ Reports
     ``credits``, ``contributor_stats``, ``cost_estimate``, or ``translator_work``.
     Specify at most one of ``workspace``, ``project``, ``category``, or
     ``component``; omitting all of them creates a global report. Contribution
-    reports require ``start`` and ``end`` ISO 8601 timestamps.
+    reports require ``start`` and ``end`` ISO 8601 timestamps. A workspace can
+    be selected when the user has :guilabel:`Manage reports` for it, even without
+    access to the regular workspace page.
 
 .. http:get:: /api/reports/(int:id)/
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Weblate 2026.9.1
 
 .. rubric:: Improvements
 
+* The :guilabel:`Manage reports` permission now consistently grants access to complete :doc:`translation reports </devel/reporting>` for the selected scope, including private projects and restricted components below it.
 * Docker deployments now use a combined :ref:`Celery <celery>` worker by default, reducing memory usage while increasing task throughput. Use :envvar:`CELERY_WORKER_MODE` to select the combined, split, or single worker setup.
 * Improved :ref:`Billing <billing>` detail page loading performance by batching related project, invoice, and audit log queries.
 * Further reduced :ref:`Celery <celery>` worker memory usage by sharing preloaded URL configuration between worker processes and loading bitmap widget rendering dependencies only when needed.

--- a/docs/devel/reporting.rst
+++ b/docs/devel/reporting.rst
@@ -12,6 +12,18 @@ Reports are generated in the background. Weblate shows the generation progress
 and opens the stored report when it is ready. Previously generated reports remain
 available on the same page according to :setting:`REPORT_EXPIRY`.
 
+.. warning::
+
+   The :guilabel:`Manage reports` permission applies to the complete selected
+   report scope. Reports for a project or category include restricted
+   components, and reports for a workspace include private projects, even when
+   the user can not otherwise access those descendants. Grant this permission
+   only to users trusted with all report data in that scope.
+
+   Complete workspace reports require two-factor authentication for regular
+   users when any project in the workspace enforces it. Superusers and bot
+   accounts are exempt.
+
 .. image:: /screenshots/report-view.webp
 
 Several reporting tools are available on this page, all of which can produce output

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -61,8 +61,10 @@ Scope and intended use
      - Report forms and :http:get:`/api/reports/` endpoints
      - Database snapshots and background tasks
      - In scope as authenticated, permission-checked contributor data with
-       operator-configured retention. *(documented)* (source:
-       :doc:`/devel/reporting`, :doc:`/api`)
+       operator-configured retention. The selected report scope is the
+       authorization boundary, including private projects and restricted
+       components below it. *(documented)* (source: :doc:`/devel/reporting`,
+       :doc:`/api`)
    * - Authentication, sessions, and authorization
      - Login, 2FA, SSO, teams, permissions, project access, API tokens
      - Database, identity providers, browser cookies
@@ -692,7 +694,12 @@ Security properties Weblate provides
        permission against the current linked-component scope in the worker
        before mutation. Weblate's normal background commit and push of
        authorized translation changes does not require the editor to have
-       these VCS permissions. Translation memory
+       these VCS permissions. The ``reports.view`` permission authorizes all
+       report data in the selected scope, including private projects and
+       restricted components below it. Complete workspace-level report access
+       requires two-factor authentication for regular users if any project in
+       the workspace enforces it. Superusers and bot accounts are exempt.
+       Translation memory
        attributed to an existing restricted component follows that component's
        access rules.
        Unattributed automatic memory, including unmatched legacy entries and
@@ -981,6 +988,11 @@ Known non-findings
 * A report that a project manager can change repository settings, VCS
   credentials, or project configuration is not a vulnerability when the actor
   has the documented permission for that action. *(documented)* (source: :doc:`/admin/access`)
+* A report containing private-project or restricted-component data is not a
+  vulnerability when the user has effective ``reports.view`` permission on the
+  selected parent scope. That permission intentionally authorizes the complete
+  report scope. *(documented)* (source: :doc:`/devel/reporting`,
+  :doc:`/admin/access`)
 * A report that a project manager can configure Gerrit review push options is
   not a vulnerability by itself. Gerrit interprets these options as the
   configured Weblate Gerrit account and enforces Gerrit-side permissions.

--- a/docs/snippets/permissions.rst
+++ b/docs/snippets/permissions.rst
@@ -98,7 +98,7 @@ List of privileges
 |                       +-------------------------------------------+---------------------------------------+
 |                       | Manage project access                     | :guilabel:`Administration`            |
 +-----------------------+-------------------------------------------+---------------------------------------+
-| Reports               | Download reports                          | :guilabel:`Administration`            |
+| Reports               | Manage reports                            | :guilabel:`Administration`            |
 |                       |                                           +---------------------------------------+
 |                       |                                           | :guilabel:`Workspace administration`  |
 +-----------------------+-------------------------------------------+---------------------------------------+

--- a/docs/snippets/roles.rst
+++ b/docs/snippets/roles.rst
@@ -26,7 +26,7 @@ List of built-in roles
        * :guilabel:`Edit translation memory`
        * :guilabel:`Edit project settings`
        * :guilabel:`Manage project access`
-       * :guilabel:`Download reports`
+       * :guilabel:`Manage reports`
        * :guilabel:`Add screenshot`
        * :guilabel:`Delete screenshot`
        * :guilabel:`Edit screenshot`
@@ -196,7 +196,7 @@ List of built-in roles
        * :guilabel:`View upstream repository location`
 
    * - `Workspace administration`
-     - * :guilabel:`Download reports`
+     - * :guilabel:`Manage reports`
        * :guilabel:`Add projects to workspace`
        * :guilabel:`Edit workspace settings`
        * :guilabel:`Manage workspace access`

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -2488,7 +2488,8 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Reset'
     post:
       operationId: api_categories_reports_create
-      description: Schedule report generation using the endpoint object as scope.
+      description: Schedule report generation using the endpoint object as the complete
+        report scope.
       parameters:
       - in: path
         name: id
@@ -7612,7 +7613,8 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Reset'
     post:
       operationId: api_components_reports_create
-      description: Schedule report generation using the endpoint object as scope.
+      description: Schedule report generation using the endpoint object as the complete
+        report scope.
       parameters:
       - in: path
         name: project__slug
@@ -19641,7 +19643,8 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Reset'
     post:
       operationId: api_reports_create
-      description: Schedule generation of a stored report.
+      description: Schedule generation of a stored report. The reports.view permission
+        authorizes the complete selected scope.
       tags:
       - reports
       requestBody:

--- a/weblate/api/serializers.py
+++ b/weblate/api/serializers.py
@@ -254,7 +254,11 @@ class ReportCreateSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 gettext_lazy("Invalid workspace.")
             ) from error
-        if self.request_user is not None and not workspace.can_view(self.request_user):
+        if (
+            self.request_user is not None
+            and not workspace.can_view(self.request_user)
+            and not self.request_user.has_perm("reports.view", workspace)
+        ):
             raise serializers.ValidationError(gettext_lazy("Invalid workspace."))
         return workspace
 

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -1899,7 +1899,7 @@ def validate_report_scope_access(user, scope) -> None:
     if scope is None:
         return
     if isinstance(scope, Workspace):
-        allowed = scope.can_view(user)
+        allowed = scope.can_view(user) or user.has_perm("reports.view", scope)
     elif isinstance(scope, Project):
         allowed = user.allowed_projects.filter(pk=scope.pk).exists()
     elif isinstance(scope, Category):
@@ -1948,7 +1948,10 @@ class ReportsMixin(APIViewSetMixin):
     )
     @extend_schema(
         methods=["post"],
-        description="Schedule report generation using the endpoint object as scope.",
+        description=(
+            "Schedule report generation using the endpoint object as the complete "
+            "report scope."
+        ),
         request=ScopedReportCreateSerializer,
         responses={HTTP_202_ACCEPTED: REPORT_TASK_RESPONSE_SERIALIZER},
     )
@@ -5009,7 +5012,10 @@ class Search(APIView):
         parameters=REPORT_LIST_FILTER_PARAMETERS,
     ),
     create=extend_schema(
-        description="Schedule generation of a stored report.",
+        description=(
+            "Schedule generation of a stored report. The reports.view permission "
+            "authorizes the complete selected scope."
+        ),
         request=ReportCreateSerializer,
         responses={HTTP_202_ACCEPTED: REPORT_TASK_RESPONSE_SERIALIZER},
     ),

--- a/weblate/auth/data.py
+++ b/weblate/auth/data.py
@@ -50,7 +50,7 @@ PERMISSIONS = (
     # Translators: Permission name
     ("project.permissions", gettext_noop("Manage project access")),
     # Translators: Permission name
-    ("reports.view", gettext_noop("Download reports")),
+    ("reports.view", gettext_noop("Manage reports")),
     # Translators: Permission name
     ("screenshot.add", gettext_noop("Add screenshot")),
     # Translators: Permission name

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -1292,6 +1292,13 @@ def check_possibly_global(
 ) -> bool | PermissionResult:
     if obj is None or isinstance(obj, Language):
         return user.is_superuser
+    if (
+        permission == "reports.view"
+        and isinstance(obj, Workspace)
+        and not (user.is_superuser or user.is_bot or user.profile.has_2fa)
+        and obj.projects.filter(enforced_2fa=True).exists()
+    ):
+        return False
     return check_permission(user, permission, obj)
 
 

--- a/weblate/auth/tests/test_permissions.py
+++ b/weblate/auth/tests/test_permissions.py
@@ -149,6 +149,23 @@ class PermissionsTest(FixtureComponentTestCase):
         self.assertTrue(self.user.has_perm("workspace.edit", workspace))
         self.assertTrue(self.user.has_perm("reports.view", workspace))
 
+    def test_workspace_reports_permission_requires_project_2fa(self) -> None:
+        workspace = Workspace.objects.create(name="Workspace with enforced 2FA")
+        self.project.workspace = workspace
+        self.project.enforced_2fa = True
+        self.project.save(update_fields=["workspace", "enforced_2fa"])
+        workspace.add_owner(self.user)
+        self.user.clear_permissions_cache()
+
+        self.assertTrue(self.superuser.has_perm("reports.view", workspace))
+        self.assertTrue(self.user.has_perm("workspace.edit", workspace))
+        self.assertFalse(self.user.has_perm("reports.view", workspace))
+
+        TOTPDevice.objects.create(user=self.user)
+        user = User.objects.get(pk=self.user.pk)
+
+        self.assertTrue(user.has_perm("reports.view", workspace))
+
     def test_reports_role_is_assignable_to_workspace_team(self) -> None:
         role = Role.objects.create(name="Workspace report viewer")
         role.permissions.add(Permission.objects.get(codename="reports.view"))

--- a/weblate/memory/machine.py
+++ b/weblate/memory/machine.py
@@ -17,8 +17,10 @@ from weblate.memory.models import (
 )
 
 if TYPE_CHECKING:
+    from django.db.models import Q
+
     from weblate.machinery.base import DownloadTranslations
-    from weblate.machinery.types import TranslationResultDict
+    from weblate.machinery.types import SettingsDict, TranslationResultDict
 
 PENDING_MEMORY_PENALTY_FACTOR = 0.7
 DIFFERENT_CONTEXT_PENALTY_FACTOR = 0.95
@@ -30,6 +32,15 @@ class WeblateMemory(InternalMachineTranslation):
     name = "Weblate Translation Memory"
     rank_boost = 2
     same_languages = True
+
+    def __init__(
+        self,
+        configuration: SettingsDict,
+        *,
+        additional_component_access: Q | None = None,
+    ) -> None:
+        super().__init__(configuration)
+        self.additional_component_access = additional_component_access
 
     def get_quality(self, text: str, result: Memory, unit) -> int:
         quality = self.comparer.similarity(text, result.source)
@@ -72,6 +83,7 @@ class WeblateMemory(InternalMachineTranslation):
             user,
             project,
             project.use_shared_tm,
+            additional_component_access=self.additional_component_access,
         )
         if threshold >= self.max_score:
             scored_results = []

--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -131,6 +131,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         *,
         user: User | None = None,
         access_user: User | None = None,
+        additional_component_access: Q | None = None,
         project: Project | None = None,
         workspace: Workspace | None = None,
         use_shared: bool = False,
@@ -139,6 +140,15 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         check_component_access: bool,
     ) -> Q:
         query = Q(pk__isnull=True)
+        component_access = Q()
+        shared_component_access = Q()
+        if check_component_access:
+            component_access = self.get_component_access_query(access_user)
+            shared_component_access = self.get_shared_component_access_query()
+            if additional_component_access is not None:
+                if component_access:
+                    component_access |= additional_component_access
+                shared_component_access |= additional_component_access
         if from_file:
             query |= Q(scope=MemoryScope.SCOPE_GLOBAL_FILE)
         if use_shared:
@@ -147,12 +157,12 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
                 source_project__contribute_shared_tm=True,
             )
             if check_component_access:
-                shared_query &= self.get_shared_component_access_query()
+                shared_query &= shared_component_access
             query |= shared_query
         if project:
             project_query = Q(scope=MemoryScope.SCOPE_PROJECT, project=project)
             if check_component_access:
-                project_query &= self.get_component_access_query(access_user)
+                project_query &= component_access
             query |= project_query
             query |= Q(scope=MemoryScope.SCOPE_PROJECT_FILE, project=project)
             if use_workspace and project.effective_use_workspace_tm:
@@ -165,7 +175,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
                     source_project__workspace__contribute_workspace_tm=True,
                 )
                 if check_component_access:
-                    workspace_query &= self.get_component_access_query(access_user)
+                    workspace_query &= component_access
                 query |= workspace_query
         if workspace:
             workspace_query = Q(
@@ -173,7 +183,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
                 workspace=workspace,
             )
             if check_component_access:
-                workspace_query &= self.get_component_access_query(access_user)
+                workspace_query &= component_access
             query |= workspace_query
         if user:
             query |= Q(scope=MemoryScope.SCOPE_USER, user=user)
@@ -185,6 +195,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         *,
         user: User | None = None,
         access_user: User | None = None,
+        additional_component_access: Q | None = None,
         project: Project | None = None,
         workspace: Workspace | None = None,
         use_shared: bool = False,
@@ -195,6 +206,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         return self._get_type_scope_query(
             user=user,
             access_user=access_user,
+            additional_component_access=additional_component_access,
             project=project,
             workspace=workspace,
             use_shared=use_shared,
@@ -225,6 +237,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         *,
         user: User | None = None,
         access_user: User | None = None,
+        additional_component_access: Q | None = None,
         project: Project | None = None,
         workspace: Workspace | None = None,
         use_shared: bool = False,
@@ -238,6 +251,7 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
             base.get_type_scope_query(
                 user=user,
                 access_user=access_user,
+                additional_component_access=additional_component_access,
                 project=project,
                 workspace=workspace,
                 use_shared=use_shared,
@@ -544,11 +558,14 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
         user,
         project,
         use_shared,
+        *,
+        additional_component_access: Q | None = None,
     ) -> Self:
         return (
             self.filter_type(
                 user=user,
                 access_user=user,
+                additional_component_access=additional_component_access,
                 project=project,
                 use_shared=use_shared,
                 from_file=True,

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -5314,6 +5314,7 @@ class LookupPolicyTest(SimpleTestCase):
         filter_type.assert_called_once_with(
             user=None,
             access_user=None,
+            additional_component_access=None,
             project=None,
             use_shared=False,
             from_file=True,
@@ -5351,6 +5352,7 @@ class LookupPolicyTest(SimpleTestCase):
         filter_type.assert_called_once_with(
             user=None,
             access_user=None,
+            additional_component_access=None,
             project=None,
             use_shared=False,
             from_file=True,
@@ -5402,6 +5404,7 @@ class LookupPolicyTest(SimpleTestCase):
             None,
             project,
             False,
+            additional_component_access=None,
         )
         queryset.get_scored_fuzzy_candidates.assert_called_once()
         call_args = queryset.get_scored_fuzzy_candidates.call_args
@@ -5461,6 +5464,7 @@ class LookupPolicyTest(SimpleTestCase):
         filter_type.assert_called_once_with(
             user=None,
             access_user=None,
+            additional_component_access=None,
             project=None,
             use_shared=False,
             from_file=True,

--- a/weblate/trans/models/report.py
+++ b/weblate/trans/models/report.py
@@ -58,6 +58,9 @@ class ReportQuerySet(models.QuerySet["Report", "Report"]):
             ).distinct()
 
         has_2fa = user.is_bot or user.profile.has_2fa
+        report_workspaces = user.workspaces_with_perm("reports.view")
+        if not has_2fa:
+            report_workspaces = report_workspaces.exclude(projects__enforced_2fa=True)
         report_projects = user.projects_with_perm("reports.view").order_by()
         if not has_2fa:
             report_projects = report_projects.filter(enforced_2fa=False)
@@ -92,13 +95,16 @@ class ReportQuerySet(models.QuerySet["Report", "Report"]):
             | Q(component__in=accessible_components)
         )
         permission_access = (
-            Q(workspace_id__in=user.workspace_ids_with_perm("reports.view"))
-            | Q(project__in=report_projects)
+            Q(project__in=report_projects)
             | Q(category__project__in=report_projects)
             | Q(component__in=report_components)
         )
+        workspace_permission_access = Q(workspace__in=report_workspaces)
         creator_access = Q(creator=user, parameters__own_data=True)
-        return self.filter(scope_access & (creator_access | permission_access))
+        return self.filter(
+            (scope_access & (creator_access | permission_access))
+            | workspace_permission_access
+        )
 
 
 class Report(models.Model):
@@ -202,6 +208,12 @@ class Report(models.Model):
     def can_access(self, user: User) -> bool:
         if not user.is_authenticated:
             return False
+        report_permission = bool(user.has_perm("reports.view", self.scope))
+        if self.workspace is not None and report_permission:
+            return True
+        creator_access = (
+            self.creator_id == user.pk and self.parameters.get("own_data") is True
+        )
         if self.workspace is not None and not self.workspace.can_view(user):
             return False
         if (
@@ -216,10 +228,7 @@ class Report(models.Model):
             return False
         if self.component is not None and not user.can_access_component(self.component):
             return False
-        creator_access = (
-            self.creator_id == user.pk and self.parameters.get("own_data") is True
-        )
-        return creator_access or bool(user.has_perm("reports.view", self.scope))
+        return creator_access or report_permission
 
 
 REPORT_KIND_CHOICES = Report.Kind.choices

--- a/weblate/trans/tests/test_reports.py
+++ b/weblate/trans/tests/test_reports.py
@@ -9,8 +9,8 @@ from unittest.mock import patch
 from django.urls import reverse
 from django.utils import timezone
 
-from weblate.auth.models import User
-from weblate.memory.models import Memory
+from weblate.auth.models import Group, User
+from weblate.memory.models import Memory, MemoryScope
 from weblate.trans.forms import (
     MIN_COST_ESTIMATE_TM_THRESHOLD,
     CountsReportsForm,
@@ -387,6 +387,66 @@ class ReportsTest(BaseReportsTest):
         self.assertEqual(buckets["tm_100"]["count"], 1)
         self.assertEqual(buckets["tm_100"]["words"], unit.num_words)
         self.assertEqual(buckets["tm_100"]["cost"], "0")
+
+    def test_cost_estimate_restricted_component_memory(self) -> None:
+        unit = self.get_unit("Thank you for using Weblate.")
+        self.add_memory(unit.source)
+        Memory.objects.get(source=unit.source).scopes.update(
+            source_component=self.component
+        )
+        self.component.restricted = True
+        self.component.save(update_fields=["restricted"])
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.groups.add(Group.objects.get(name="Managers"))
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("reports.view", self.project))
+        self.assertFalse(self.user.can_access_component(self.component))
+
+        data = self.generate_cost_data(entity=self.project)
+        buckets = {bucket["slug"]: bucket for bucket in data["buckets"]}
+
+        self.assertEqual(buckets["tm_100"]["count"], 1)
+        self.assertEqual(buckets["tm_100"]["words"], unit.num_words)
+
+    def test_cost_estimate_excludes_unrelated_restricted_memory(self) -> None:
+        unit = self.get_unit("Thank you for using Weblate.")
+        self.project.use_shared_tm = True
+        self.project.save(update_fields=["use_shared_tm"])
+        other_project = self.create_project(
+            name="Other memory project",
+            slug="other-memory-project",
+            contribute_shared_tm=True,
+        )
+        other_component = self.create_po(
+            project=other_project,
+            name="Other memory component",
+        )
+        other_component.restricted = True
+        other_component.save(update_fields=["restricted"])
+        memory = Memory.objects.create(
+            source_language=self.component.source_language,
+            target_language=self.translation.language,
+            source=unit.source,
+            target="Unrelated restricted memory result",
+            origin=other_component.full_slug,
+            status=Memory.STATUS_ACTIVE,
+        )
+        MemoryScope.objects.create(
+            memory=memory,
+            scope=MemoryScope.SCOPE_SHARED,
+            source_project=other_project,
+            source_component=other_component,
+        )
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.groups.add(Group.objects.get(name="Managers"))
+        self.user.clear_permissions_cache()
+
+        data = self.generate_cost_data(entity=self.project)
+        buckets = {bucket["slug"]: bucket for bucket in data["buckets"]}
+
+        self.assertEqual(buckets["tm_100"]["count"], 0)
 
     def test_cost_estimate_fuzzy_memory(self) -> None:
         self.add_memory("Thank you for using Weblate!")

--- a/weblate/trans/tests/test_stored_reports.py
+++ b/weblate/trans/tests/test_stored_reports.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.formats import date_format
+from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from weblate.auth.models import Group
+from weblate.auth.models import Group, Permission, Role, User, UserBlock
 from weblate.trans.models import Project, Report
 from weblate.trans.tasks import cleanup_reports, generate_report
 from weblate.trans.tests.test_reports import BaseReportsTest
@@ -21,6 +23,55 @@ from weblate.workspaces.models import Workspace
 
 
 class StoredReportsTest(BaseReportsTest):
+    def generate_scoped_report(self, kind: str, scope_type: str, scope) -> Report:
+        now = timezone.now()
+        parameters: dict[str, Any] = {"language": "", "own_data": False}
+        if kind in {Report.Kind.CREDITS, Report.Kind.CONTRIBUTOR_STATS}:
+            parameters.update(
+                {
+                    "start": (now - timedelta(days=1)).isoformat(),
+                    "end": (now + timedelta(days=1)).isoformat(),
+                    "sort_by": "count",
+                    "sort_order": "descending",
+                    "counting_mode": "unique",
+                }
+            )
+        elif kind == Report.Kind.COST_ESTIMATE:
+            parameters.update(
+                {
+                    "q": "state:<translated",
+                    "base_rate": "0.1",
+                    "tm_threshold": 80,
+                    **{key: str(value) for key, value in self.get_cost_rates().items()},
+                }
+            )
+        else:
+            parameters.update(
+                {
+                    "start": (now - timedelta(days=1)).isoformat(),
+                    "end": (now + timedelta(days=1)).isoformat(),
+                    "min_changes": 0,
+                    "max_changes": 1000,
+                    "max_words": 10000,
+                }
+            )
+        generate_report(
+            kind=kind,
+            parameters=parameters,
+            user_id=self.user.pk,
+            scope_type=scope_type,
+            scope_id=str(scope.pk),
+        )
+        return Report.objects.latest("pk")
+
+    def assert_report_contains_scope_data(self, report: Report) -> None:
+        if report.kind in {Report.Kind.CREDITS, Report.Kind.CONTRIBUTOR_STATS}:
+            self.assertIn(self.user.email, str(report.data))
+        elif report.kind == Report.Kind.COST_ESTIMATE:
+            self.assertGreater(report.data["total"]["count"], 0)
+        else:
+            self.assertEqual(report.data["user_days"]["included"], 1)
+
     def test_filter_access_preserves_queryset(self) -> None:
         other_user = create_another_user("-reports")
         self.user.is_superuser = False
@@ -88,6 +139,40 @@ class StoredReportsTest(BaseReportsTest):
             [own_report],
         )
 
+    def test_generation_uses_scheduling_authorization(self) -> None:
+        contributor = create_another_user("-scheduled-contributor")
+        self.change_unit("Nazdar svete!\n", user=contributor)
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        managers = Group.objects.get(name="Managers")
+        self.user.groups.add(managers)
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("reports.view", self.project))
+
+        parameters = {
+            "start": (timezone.now() - timedelta(days=1)).isoformat(),
+            "end": (timezone.now() + timedelta(days=1)).isoformat(),
+            "language": "",
+            "sort_by": "count",
+            "sort_order": "descending",
+            "own_data": False,
+        }
+        self.user.groups.remove(managers)
+        self.user.clear_permissions_cache()
+        self.assertFalse(self.user.has_perm("reports.view", self.project))
+
+        generate_report(
+            kind=Report.Kind.CREDITS,
+            parameters=parameters,
+            user_id=self.user.pk,
+            scope_type="project",
+            scope_id=str(self.project.pk),
+        )
+
+        report = Report.objects.get()
+        self.assertIn(contributor.email, str(report.data))
+        self.assertFalse(report.can_access(self.user))
+
     def test_filter_access_with_reports_permission(self) -> None:
         other_user = create_another_user("-reports")
         self.user.is_superuser = False
@@ -119,6 +204,43 @@ class StoredReportsTest(BaseReportsTest):
         self.assertTrue(self.user.has_perm("reports.view", workspace))
         self.assertTrue(report.can_access(self.user))
         self.assertEqual(list(Report.objects.filter_access(self.user)), [report])
+
+    def test_blocked_project_excludes_reports(self) -> None:
+        other_user = create_another_user("-blocked-reports")
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.groups.add(Group.objects.get(name="Managers"))
+        self.user.clear_permissions_cache()
+        category = self.create_category(project=self.project)
+        reports = [
+            Report.objects.create(
+                creator=other_user,
+                kind=Report.Kind.CREDITS,
+                project=self.project,
+            ),
+            Report.objects.create(
+                creator=other_user,
+                kind=Report.Kind.CREDITS,
+                category=category,
+            ),
+            Report.objects.create(
+                creator=other_user,
+                kind=Report.Kind.CREDITS,
+                component=self.component,
+            ),
+        ]
+        self.assertTrue(all(report.can_access(self.user) for report in reports))
+        self.assertCountEqual(Report.objects.filter_access(self.user), reports)
+
+        UserBlock.objects.create(user=self.user, project=self.project)
+        self.user.clear_permissions_cache()
+
+        self.assertFalse(any(report.can_access(self.user) for report in reports))
+        self.assertFalse(
+            Report.objects.filter_access(self.user)
+            .filter(pk__in=[report.pk for report in reports])
+            .exists()
+        )
 
     def test_api_report_list_pagination(self) -> None:
         Report.objects.bulk_create(
@@ -380,7 +502,7 @@ class StoredReportsTest(BaseReportsTest):
         self.assertEqual(web.status_code, 200)
         self.assertContains(web, html.content.decode(), html=True)
 
-    def test_translator_work_excludes_inaccessible_components(self) -> None:
+    def test_project_reports_include_restricted_components(self) -> None:
         self.add_change()
         self.component.restricted = True
         self.component.save(update_fields=["restricted"])
@@ -390,25 +512,162 @@ class StoredReportsTest(BaseReportsTest):
         self.user.clear_permissions_cache()
         self.assertTrue(self.user.has_perm("reports.view", self.project))
         self.assertFalse(self.user.can_access_component(self.component))
-        now = timezone.now()
 
-        generate_report(
-            kind=Report.Kind.TRANSLATOR_WORK,
-            parameters={
-                "start": (now - timedelta(days=1)).isoformat(),
-                "end": (now + timedelta(days=1)).isoformat(),
-                "language": "",
-                "min_changes": 0,
-                "max_changes": 1000,
-                "max_words": 10000,
-                "own_data": False,
-            },
-            user_id=self.user.pk,
-            scope_type="project",
-            scope_id=str(self.project.pk),
+        for kind in Report.Kind:
+            with self.subTest(kind=kind):
+                report = self.generate_scoped_report(kind, "project", self.project)
+                self.assert_report_contains_scope_data(report)
+
+    def test_workspace_reports_include_private_projects(self) -> None:
+        self.add_change()
+        workspace = Workspace.objects.create(name="Private reporting workspace")
+        self.project.workspace = workspace
+        self.project.access_control = Project.ACCESS_PRIVATE
+        self.project.save(update_fields=["workspace", "access_control"])
+        workspace.add_owner(self.user)
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("reports.view", workspace))
+        self.assertFalse(self.user.allowed_projects.filter(pk=self.project.pk).exists())
+
+        for kind in Report.Kind:
+            with self.subTest(kind=kind):
+                report = self.generate_scoped_report(kind, "workspace", workspace)
+                self.assert_report_contains_scope_data(report)
+
+    @patch("weblate.api.views.generate_report.delay")
+    def test_workspace_reports_only_access(self, mocked_delay) -> None:
+        mocked_delay.return_value = SimpleNamespace(id="report-task")
+        workspace = Workspace.objects.create(name="Reports-only workspace")
+        user = create_another_user("-reports-only")
+        role = Role.objects.create(name="Workspace reports only")
+        role.permissions.add(Permission.objects.get(codename="reports.view"))
+        group = Group.objects.create(
+            name="Reports only",
+            defining_workspace=workspace,
+        )
+        group.roles.add(role)
+        user.groups.add(group)
+        user.clear_permissions_cache()
+        report = Report.objects.create(
+            creator=self.user,
+            kind=Report.Kind.CREDITS,
+            parameters={"own_data": False},
+            data=[],
+            workspace=workspace,
         )
 
-        self.assertEqual(Report.objects.get().data["user_days"]["included"], 0)
+        self.assertFalse(workspace.can_view(user))
+        self.assertTrue(user.has_perm("reports.view", workspace))
+        self.assertTrue(report.can_access(user))
+        self.assertEqual(list(Report.objects.filter_access(user)), [report])
+
+        self.client.force_login(user)
+        self.assertEqual(
+            self.client.get(workspace.get_absolute_url()).status_code,
+            404,
+        )
+        response = self.client.post(
+            reverse("api:report-list"),
+            {
+                "kind": Report.Kind.CREDITS,
+                "workspace": workspace.pk,
+                "start": (timezone.now() - timedelta(days=1)).isoformat(),
+                "end": timezone.now().isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, 202)
+        self.assertFalse(mocked_delay.call_args.kwargs["parameters"]["own_data"])
+        listing = self.client.get(reverse("api:report-list"))
+        self.assertEqual(listing.status_code, 200)
+        self.assertEqual(
+            [item["id"] for item in listing.json()["results"]],
+            [report.pk],
+        )
+        self.assertEqual(
+            self.client.get(reverse("api:report-detail", args=[report.pk])).status_code,
+            200,
+        )
+        for style in ("json", "html", "rst"):
+            with self.subTest(style=style):
+                self.assertEqual(
+                    self.client.get(
+                        reverse(f"api:report-{style}", args=[report.pk])
+                    ).status_code,
+                    200,
+                )
+        self.assertEqual(
+            self.client.get(reverse("report", args=[report.pk])).status_code,
+            200,
+        )
+
+    @patch("weblate.api.views.generate_report.delay")
+    def test_workspace_report_access_requires_project_2fa(self, mocked_delay) -> None:
+        mocked_delay.return_value = SimpleNamespace(id="report-task")
+        workspace = Workspace.objects.create(name="2FA reporting workspace")
+        self.project.workspace = workspace
+        self.project.enforced_2fa = True
+        self.project.save(update_fields=["workspace", "enforced_2fa"])
+        workspace.add_owner(self.user)
+        report = Report.objects.create(
+            creator=create_another_user("-2fa-report"),
+            kind=Report.Kind.CREDITS,
+            parameters={"own_data": False},
+            data=[],
+            workspace=workspace,
+        )
+
+        self.assertTrue(self.user.is_superuser)
+        self.assertTrue(self.user.has_perm("reports.view", workspace))
+        self.assertTrue(report.can_access(self.user))
+        self.assertIn(report, Report.objects.filter_access(self.user))
+        self.client.force_login(self.user)
+        for data in (
+            {"kind": Report.Kind.COST_ESTIMATE},
+            {"kind": Report.Kind.COST_ESTIMATE, "workspace": workspace.pk},
+        ):
+            response = self.client.post(reverse("api:report-list"), data)
+            self.assertEqual(response.status_code, 202)
+            self.assertFalse(mocked_delay.call_args.kwargs["parameters"]["own_data"])
+        self.assertEqual(mocked_delay.call_count, 2)
+        mocked_delay.reset_mock()
+
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.clear_permissions_cache()
+        self.assertFalse(self.user.has_perm("reports.view", workspace))
+        self.assertFalse(report.can_access(self.user))
+        self.assertNotIn(report, Report.objects.filter_access(self.user))
+        self.client.force_login(self.user)
+        self.assertEqual(
+            self.client.get(reverse("api:report-detail", args=[report.pk])).status_code,
+            404,
+        )
+        response = self.client.post(
+            reverse("api:report-list"),
+            {"kind": Report.Kind.COST_ESTIMATE, "workspace": workspace.pk},
+        )
+        self.assertEqual(response.status_code, 403)
+        mocked_delay.assert_not_called()
+
+        TOTPDevice.objects.create(user=self.user)
+        user = User.objects.get(pk=self.user.pk)
+
+        self.assertTrue(user.has_perm("reports.view", workspace))
+        self.assertTrue(report.can_access(user))
+        self.assertIn(report, Report.objects.filter_access(user))
+        self.client.force_login(user)
+        self.assertEqual(
+            self.client.get(reverse("api:report-detail", args=[report.pk])).status_code,
+            200,
+        )
+        response = self.client.post(
+            reverse("api:report-list"),
+            {"kind": Report.Kind.COST_ESTIMATE, "workspace": workspace.pk},
+        )
+        self.assertEqual(response.status_code, 202)
+        mocked_delay.assert_called_once()
 
     def test_workspace_collection(self) -> None:
         workspace = Workspace.objects.create(name="Reporting workspace")

--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -15,6 +15,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db.models import Q
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils.html import format_html, format_html_join
@@ -211,7 +212,6 @@ def collect_report_data(
             scope=scope,
             language=parameters.get("language", ""),
             user=report_user,
-            access_user=creator,
             min_changes=parameters["min_changes"],
             max_changes=parameters["max_changes"],
             max_words=parameters["max_words"],
@@ -282,11 +282,10 @@ def get_cost_bucket_name(bucket: str) -> str:
 
 
 def get_cost_estimate_units(
-    user: User,
     language_code: str,
     entity: Workspace | Project | Component | Category | None,
 ):
-    translations = Translation.objects.exclude_source().filter_access(user)
+    translations = Translation.objects.exclude_source()
     if language_code:
         translations = translations.filter(language__code=language_code)
 
@@ -301,6 +300,21 @@ def get_cost_estimate_units(
     return Unit.objects.filter(translation__in=translations).exclude(
         state=STATE_READONLY
     )
+
+
+def get_cost_estimate_memory_access(
+    entity: Workspace | Project | Component | Category | None,
+) -> Q:
+    """Return the memory component access authorized by the report scope."""
+    if isinstance(entity, Workspace):
+        return Q(source_component__project__workspace=entity)
+    if isinstance(entity, Project):
+        return Q(source_component__project=entity)
+    if isinstance(entity, Category):
+        return Q(source_component_id__in=entity.all_component_ids)
+    if isinstance(entity, Component):
+        return Q(source_component=entity)
+    return Q(source_component__isnull=False)
 
 
 def get_match_quality(unit: Unit) -> int:
@@ -398,10 +412,13 @@ def generate_cost_estimate(
     }
     seen_sources: set[tuple[int, int, int]] = set()
     match_batches: dict[tuple[int, int, int], list[Unit]] = defaultdict(list)
-    service = WeblateMemory({})
+    service = WeblateMemory(
+        {},
+        additional_component_access=get_cost_estimate_memory_access(entity),
+    )
 
     for unit in (
-        get_cost_estimate_units(user, language_code, entity)
+        get_cost_estimate_units(language_code, entity)
         .search(q, parser="unit")
         .prefetch()
         .order()


### PR DESCRIPTION
Treat the Manage reports permission as access to the complete selected scope for report generation and stored results. Enforce descendant project 2FA for workspace reports and document the scheduling-time authorization boundary.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
