### PR TITLE
fix(mdx): preserve self-closing void elements

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,7 @@ Weblate 2026.9.1
 .. rubric:: Bug fixes
 
 * REST API unit updates now enforce the same translation text length limit as the web editor.
+* HTML void elements in :ref:`mdx` translations are now kept self-closing after sanitization, preventing invalid MDX output.
 * The :http:post:`autotranslate API endpoint </api/translations/(string:project)/(string:component)/(string:language)/autotranslate/>` now correctly describes its accepted request body fields (``q``, ``mode``, ``auto_source``, ``component``, ``engines``, ``threshold``) in the OpenAPI schema instead of incorrectly reflecting the Translation resource.
 * Links outside tab navigation now correctly activate their target tabs, fixing upload links for missing translations and new components.
 * Error reporting integrations now distinguish informational messages from exceptions and reliably report the explicitly handled exception.

--- a/weblate/trans/tests/test_autofix.py
+++ b/weblate/trans/tests/test_autofix.py
@@ -100,6 +100,16 @@ class AutoFixTest(TestCase):
             (["<https://weblate.org>"], False),
         )
 
+    def test_html_mdx_void_element(self) -> None:
+        value = "Paragraph.<br />"
+        fix = BleachHTML()
+        unit = make_unit(source=value, flags="auto-safe-html,md-text,safe-mdx")
+        self.assertEqual(fix.fix_target([value], unit), ([value], False))
+        self.assertEqual(
+            fix.fix_target(["Paragraph.<br>"], unit),
+            ([value], True),
+        )
+
     def test_auto_safe_html(self) -> None:
         fix = BleachHTML()
         unit = make_unit(source="link", flags="auto-safe-html")

--- a/weblate/utils/html.py
+++ b/weblate/utils/html.py
@@ -337,6 +337,27 @@ def is_auto_safe_html_roundtrip_stable(source: str, cleaned: str) -> bool:
     return source_pos == len(source_events) and cleaned_pos == len(cleaned_events)
 
 
+def serialize_mdx_void_elements(text: str) -> str:
+    """Serialize HTML void elements as self-closing JSX elements."""
+
+    def replace(match: re.Match) -> str:
+        segment = match.group(0)
+        if segment.startswith("</"):
+            return segment
+
+        tag_match = AUTO_SAFE_HTML_TAG_NAME.match(segment)
+        if (
+            tag_match is None
+            or tag_match.group("name").lower() not in AUTO_SAFE_HTML_VOID_TAGS
+        ):
+            return segment
+
+        opening = segment[:-1].rstrip().removesuffix("/").rstrip()
+        return f"{opening} />"
+
+    return AUTO_SAFE_HTML_SEGMENT.sub(replace, text)
+
+
 class HTMLSanitizer:
     def __init__(self) -> None:
         self.current = 0
@@ -358,6 +379,9 @@ class HTMLSanitizer:
                 attributes=attributes,
                 clean_content_tags=CLEAN_CONTENT_TAGS - tags,
             )
+
+        if "safe-mdx" in flags and "ignore-safe-mdx" not in flags:
+            text = serialize_mdx_void_elements(text)
 
         return self.add_back_special(text)
 

--- a/weblate/utils/tests/test_html.py
+++ b/weblate/utils/tests/test_html.py
@@ -8,6 +8,7 @@ from django.test import SimpleTestCase
 
 from weblate.checks.flags import Flags
 from weblate.utils.html import (
+    AUTO_SAFE_HTML_VOID_TAGS,
     HTML2Text,
     HTMLAttribute,
     HTMLSanitizer,
@@ -16,6 +17,7 @@ from weblate.utils.html import (
     is_auto_safe_html_source,
     list_to_tuples,
     mail_quote_value,
+    serialize_mdx_void_elements,
 )
 
 
@@ -32,6 +34,31 @@ class HTMLSanitizerTestCase(SimpleTestCase):
             self.sanitize("<style>translation</style>", "<style>text</style>"),
             "<style>translation</style>",
         )
+
+    def test_clean_mdx_void_element(self) -> None:
+        value = 'Paragraph.<br /><img src="test.png" onerror="alert(1)" />'
+        self.assertEqual(
+            self.sanitize(
+                value,
+                'Paragraph.<br /><img src="test.png" />',
+                "safe-mdx",
+            ),
+            'Paragraph.<br /><img src="test.png" />',
+        )
+
+    def test_clean_html_void_element(self) -> None:
+        self.assertEqual(
+            self.sanitize("Paragraph.<br />", "Paragraph.<br />"),
+            "Paragraph.<br>",
+        )
+
+    def test_serialize_mdx_void_elements(self) -> None:
+        for tag in AUTO_SAFE_HTML_VOID_TAGS:
+            with self.subTest(tag=tag):
+                self.assertEqual(
+                    serialize_mdx_void_elements(f'<{tag} title="test">'),
+                    f'<{tag} title="test" />',
+                )
 
 
 class HtmlTestCase(SimpleTestCase):


### PR DESCRIPTION
Serialize sanitized HTML void elements in JSX-compatible form for MDX units so nh3 normalization does not produce invalid output. Preserve existing HTML sanitization behavior for non-MDX content.

Fixes #21346

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
