### PR TITLE
refactor(memory): remove unused full-source lookup wrapper

### DIFF
--- a/weblate/memory/models.py
+++ b/weblate/memory/models.py
@@ -596,24 +596,6 @@ class MemoryQuerySet(models.QuerySet["Memory", "Memory"]):
 
         return queryset.get_fuzzy_candidates(text)
 
-    def lookup_full_source(
-        self,
-        source_language,
-        target_language,
-        text: str,
-        user,
-        project,
-        use_shared,
-        *,
-        threshold: int = MACHINERY_DEFAULT_THRESHOLD,
-        exclude_ids: Iterable[int] = (),
-    ) -> Iterator[Memory]:
-        return self.get_lookup_queryset(
-            source_language, target_language, user, project, use_shared
-        ).get_full_source_fuzzy_candidates(
-            text, threshold=threshold, exclude_ids=exclude_ids
-        )
-
     def prefetch_lang(self) -> Self:
         return self.prefetch_related("source_language", "target_language")
 

--- a/weblate/memory/tests.py
+++ b/weblate/memory/tests.py
@@ -5327,46 +5327,6 @@ class LookupPolicyTest(SimpleTestCase):
         )
         typed_base.get_fuzzy_candidates.assert_called_once_with("Username")
 
-    def test_lookup_full_source_uses_scoped_full_source_candidates(self) -> None:
-        base = MagicMock()
-        typed_base = MagicMock()
-        base.prefetch_scopes.return_value = base
-        base.filter.return_value = typed_base
-        typed_base.get_full_source_fuzzy_candidates.return_value = []
-
-        with patch.object(
-            MemoryQuerySet, "filter_type", return_value=base
-        ) as filter_type:
-            results = Memory.objects.lookup_full_source(
-                "en",
-                "cs",
-                "Username",
-                None,
-                None,
-                False,
-                threshold=80,
-                exclude_ids=[1, 2],
-            )
-
-        self.assertEqual(list(results), [])
-        filter_type.assert_called_once_with(
-            user=None,
-            access_user=None,
-            additional_component_access=None,
-            project=None,
-            use_shared=False,
-            from_file=True,
-            use_workspace=True,
-        )
-        base.prefetch_scopes.assert_called_once_with()
-        base.filter.assert_called_once_with(
-            source_language="en",
-            target_language="cs",
-        )
-        typed_base.get_full_source_fuzzy_candidates.assert_called_once_with(
-            "Username", threshold=80, exclude_ids=[1, 2]
-        )
-
     def test_weblate_memory_uses_scored_model_candidates(self) -> None:
         text = "x" * (MEMORY_LOOKUP_PREFIX_LENGTH + 1)
         accepted = MagicMock()


### PR DESCRIPTION
Remove the unused lookup_full_source wrapper and its delegation test. Production fallback already calls get_full_source_fuzzy_candidates directly.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
