### PR TITLE
docs(security): clarify sharing and report access boundaries

### DIFF
--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -270,9 +270,11 @@ Reachability preconditions:
   an in-scope Weblate surface or scheduled Weblate maintenance path.
   *(documented)* (source: :doc:`/admin/install`)
 * A stored-report finding is in model when an authenticated user can generate,
-  list, or render contributor data outside the creator or current
-  ``reports.view`` scope. *(documented)* (source: :doc:`/devel/reporting`,
-  :doc:`/api`)
+  list, or render contributor data outside the current authorized scope.
+  Creator access applies only to reports containing the creator's own data
+  (``own_data=True``) and still requires current access to the selected scope.
+  Full reports require current ``reports.view`` permission even for their
+  creator. *(documented)* (source: :doc:`/devel/reporting`, :doc:`/api`)
 * A user-profile API finding is in model when an authenticated user can read or
   mutate another user's profile preferences outside the documented
   ``user.view``, ``user.edit``, or self-service boundaries.
@@ -743,12 +745,17 @@ Security properties Weblate provides
      - Command injection or arbitrary code execution as the Weblate user.
      - Security-critical.
    * - Private project data other than documented generic webhook matching
-       diagnostics, user data, credentials, tokens, SSH keys, and 2FA secrets
-       are not disclosed to actors lacking permission. *(documented)* (source:
+       diagnostics and metadata published through :ref:`project-public_sharing`,
+       user data, credentials, tokens, SSH keys, and 2FA secrets are not
+       disclosed to actors lacking permission. *(documented)* (source:
        :doc:`/admin/access`, :doc:`/security/privacy-compliance`, :doc:`/vcs`)
      - Host, database, and storage permissions are intact. Generic webhook
        responses expose only the match counts, project/component slugs, and API
-       URLs documented in :ref:`hooks-target-matching`. Repository content
+       URLs documented in :ref:`hooks-target-matching`. Public sharing permits
+       unauthenticated access to engage pages and rendered status widgets,
+       exposing project and component names, including restricted components,
+       translation statistics, languages, and progress. It does not grant
+       access to project content or APIs. Repository content
        deliberately shared through linked components follows the linked
        repository trust boundary. Project repository permission diagnostics
        expose the paths of linked components that prevent an operation, but do
@@ -756,8 +763,8 @@ Security properties Weblate provides
        non-sensitive fields as public configuration; unlisted values are
        redacted from public change history.
      - Cross-project data leak not covered by the documented generic webhook
-       diagnostics or linked-repository trust boundary, credential exposure, or
-       unauthorized export.
+       diagnostics, public-sharing metadata, or linked-repository trust
+       boundary, credential exposure, or unauthorized export.
      - Security-critical.
    * - Backup import rejects archives exceeding documented upload, member,
        aggregate size, and suspicious compression thresholds. *(documented)* (source: :doc:`/admin/config`, :ref:`projectbackup`)


### PR DESCRIPTION
Align confidentiality exceptions with public-sharing metadata and clarify that report creator access requires own-data reports and current scope access.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
