### PR TITLE
fix(machinery): restore DeepL API v1 support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,8 @@ Weblate 2026.9.1
 
 .. rubric:: Bug fixes
 
+* Restored :ref:`mt-deepl` API v1 translation support while retaining modern API language discovery and glossary improvements.
+
 * REST API unit updates now enforce the same translation text length limit as the web editor.
 * HTML void elements in :ref:`mdx` translations are now kept self-closing after sanitization, preventing invalid MDX output.
 * The :http:post:`autotranslate API endpoint </api/translations/(string:project)/(string:component)/(string:language)/autotranslate/>` now correctly describes its accepted request body fields (``q``, ``mode``, ``auto_source``, ``component``, ``engines``, ``threshold``) in the OpenAPI schema instead of incorrectly reflecting the Translation resource.

--- a/docs/snippets/machines-autogenerated.rst
+++ b/docs/snippets/machines-autogenerated.rst
@@ -377,10 +377,12 @@ You need to purchase :guilabel:`DeepL API` subscription.
 
 API URL to use with the DeepL service. Configure the base endpoint without an API
 version; Weblate selects the appropriate DeepL API version for each request.
+For a legacy subscription requiring API v1, configure
+``https://api.deepl.com/v1/`` instead.
 
-.. versionchanged:: 2026.7
+.. versionchanged:: 2026.9.1
 
-   DeepL API v1 is no longer supported.
+   Support for explicitly configured DeepL API v1 endpoints has been restored.
 
 ``https://api.deepl.com/`` (default in Weblate)
     Is meant for API usage on the paid plan, and the subscription is usage-based.
@@ -394,6 +396,7 @@ The translation context can optionally be specified to improve translations qual
 `DeepL translation context documentation <https://developers.deepl.com/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter>`_.
 
 The service automatically uses :ref:`glossary`, see :ref:`glossary-mt`.
+Glossary integration is not available with API v1.
 
 .. seealso::
 

--- a/weblate/machinery/deepl.py
+++ b/weblate/machinery/deepl.py
@@ -19,7 +19,6 @@ from .base import (
     GlossaryAlreadyExistsError,
     GlossaryDoesNotExistError,
     GlossaryMachineTranslationMixin,
-    MachineTranslationError,
     XMLMachineTranslationMixin,
 )
 from .forms import DeepLMachineryForm
@@ -63,6 +62,14 @@ class DeepLTranslation(
     glossary_languages_cache_version: ClassVar[int] = 2
 
     @property
+    def is_legacy_api(self) -> bool:
+        return urlsplit(self.settings["url"]).path.rstrip("/").endswith("/v1")
+
+    @property
+    def translation_api_version(self) -> str:
+        return "v1" if self.is_legacy_api else "v2"
+
+    @property
     def api_base_url(self):
         url = super().api_base_url
         parsed = urlsplit(url)
@@ -73,11 +80,12 @@ class DeepLTranslation(
             and path_parts[-1].startswith("v")
             and path_parts[-1][1:].isdigit()
         ):
-            if path_parts[-1] == "v1":
-                msg = "DeepL API v1 is no longer supported."
-                raise MachineTranslationError(msg)
             parsed = parsed._replace(path="/".join(path_parts[:-1]))
-        if self.settings["key"].endswith(":fx") and parsed.hostname == "api.deepl.com":
+        if (
+            not self.is_legacy_api
+            and self.settings["key"].endswith(":fx")
+            and parsed.hostname == "api.deepl.com"
+        ):
             return urlunsplit(parsed._replace(netloc="api-free.deepl.com"))
         return urlunsplit(parsed)
 
@@ -139,6 +147,9 @@ class DeepLTranslation(
         return super().get_error_message(exc)
 
     def download_languages(self):
+        if self.is_legacy_api:
+            return self.download_legacy_languages()
+
         response = self.request(
             "get",
             self.get_api_url("v3", "languages"),
@@ -172,6 +183,28 @@ class DeepLTranslation(
         """Check whether given language combination is supported."""
         return (source_language, target_language) in self.supported_languages
 
+    def download_legacy_languages(self) -> Iterator[tuple[str, str]]:
+        response = self.request(
+            "get", self.get_api_url("v1", "languages"), params={"type": "source"}
+        )
+        source_languages = {item["language"].upper() for item in response.json()}
+        response = self.request(
+            "get", self.get_api_url("v1", "languages"), params={"type": "target"}
+        )
+        # Plain English is not listed, but is supported.
+        target_languages = {"EN"}
+        for item in response.json():
+            language = item["language"].upper()
+            target_languages.add(language)
+            if item.get("supports_formality"):
+                target_languages.add(f"{language}@FORMAL")
+                target_languages.add(f"{language}@INFORMAL")
+        return (
+            (source, target)
+            for source in source_languages
+            for target in target_languages
+        )
+
     def download_multiple_translations(
         self,
         source_language,
@@ -186,7 +219,7 @@ class DeepLTranslation(
         )
         response = self.request(
             "post",
-            self.get_api_url("v2", "translate"),
+            self.get_api_url(self.translation_api_version, "translate"),
             json=params,
         )
         return self._parse_translations(texts, response.json())
@@ -205,7 +238,7 @@ class DeepLTranslation(
         )
         response = await self.arequest(
             "post",
-            self.get_api_url("v2", "translate"),
+            self.get_api_url(self.translation_api_version, "translate"),
             json=params,
         )
         return self._parse_translations(texts, response.json())
@@ -278,6 +311,9 @@ class DeepLTranslation(
         }
 
     def is_glossary_supported(self, source_language: str, target_language: str) -> bool:
+        if self.is_legacy_api:
+            return False
+
         cache_key = self.get_glossary_languages_cache_key()
         languages_cache = cache.get(cache_key)
         if languages_cache is not None:

--- a/weblate/machinery/forms.py
+++ b/weblate/machinery/forms.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import json
 import re
-from urllib.parse import urlsplit
 
 from django import forms
 from django.conf import settings
@@ -458,12 +457,6 @@ class DeepLMachineryForm(KeyURLMachineryForm):
         ),
         required=False,
     )
-
-    def clean_url(self) -> str:
-        url = self.cleaned_data["url"]
-        if urlsplit(url).path.rstrip("/").endswith("/v1"):
-            raise ValidationError(gettext("DeepL API v1 is no longer supported."))
-        return url
 
 
 class LLMBasicMachineryForm(BaseMachineryForm):

--- a/weblate/machinery/tests.py
+++ b/weblate/machinery/tests.py
@@ -2970,8 +2970,12 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         ):
             with self.subTest(url):
                 machine = self.MACHINE_CLS({"key": "KEY", "url": url})
-                with self.assertRaises(MachineTranslationError):
-                    _ = machine.api_base_url
+                self.assertTrue(machine.is_legacy_api)
+                self.assertEqual(machine.api_base_url, url.removesuffix("/v1/"))
+                self.assertEqual(
+                    machine.get_api_url(machine.translation_api_version, "translate"),
+                    f"{url}translate",
+                )
 
     @http_mock.activate
     def test_languages_map(self) -> None:
@@ -2985,6 +2989,120 @@ class DeepLTranslationTest(BaseMachineTranslationTest):
         self.assertEqual(machine.get_languages(lang_pt, lang_pt_br), ("PT", "PT-BR"))
         self.assertEqual(machine.get_languages(lang_en, lang_pt), ("EN", "PT-PT"))
         self.assertEqual(machine.get_languages(lang_en, lang_pt_pt), ("EN", "PT-PT"))
+
+
+class DeepLLegacyTranslationTest(BaseMachineTranslationTest):
+    MACHINE_CLS = DeepLTranslation
+    EXPECTED_LEN = 1
+    ENGLISH = "EN"
+    SUPPORTED = "DE"
+    NOTSUPPORTED = "CS"
+    CONFIGURATION: ClassVar[SettingsDict] = {
+        "key": "KEY",
+        "url": "https://api.deepl.com/v1/",
+    }
+
+    @staticmethod
+    def mock_languages(url: str = "https://api.deepl.com/v1") -> None:
+        http_mock.register(
+            "GET", f"{url}/languages?type=source", json=[{"language": "EN"}]
+        )
+        http_mock.register(
+            "GET",
+            f"{url}/languages?type=target",
+            json=[{"language": "DE", "supports_formality": True}, {"language": "FR"}],
+        )
+
+    def mock_response(self) -> None:
+        self.mock_languages()
+        http_mock.register(
+            "POST", "https://api.deepl.com/v1/translate", json=DEEPL_RESPONSE
+        )
+
+    def mock_error(self) -> None:
+        http_mock.register("GET", "https://api.deepl.com/v1/languages", status_code=500)
+        http_mock.register(
+            "POST", "https://api.deepl.com/v1/translate", status_code=500
+        )
+
+    def mock_empty(self) -> NoReturn:
+        self.skipTest("Not tested")
+
+    @http_mock.activate
+    def test_languages(self) -> None:
+        self.mock_languages()
+        self.assertEqual(
+            set(self.get_machine().download_languages()),
+            {
+                ("EN", target)
+                for target in ("EN", "DE", "DE@FORMAL", "DE@INFORMAL", "FR")
+            },
+        )
+
+    @http_mock.activate
+    def test_async_translate(self) -> None:
+        self.mock_response()
+        self.assert_async_translate(
+            self.SUPPORTED, self.SOURCE_TRANSLATED, self.EXPECTED_LEN
+        )
+
+    @http_mock.activate
+    @patch("weblate.glossary.models.get_glossary_tsv", return_value="foo\tbar")
+    def test_translation_without_glossary(self, glossary_tsv: Mock) -> None:
+        machine = self.get_machine()
+        machine.settings.update({"context": "Test context", "next_gen": True})
+        cache.set(machine.get_glossary_languages_cache_key(), ({"EN"}, {"DE"}))
+        for translate in (
+            machine.download_multiple_translations,
+            async_to_sync(machine.adownload_multiple_translations),
+        ):
+            for target, formality in (("DE@FORMAL", "more"), ("DE@INFORMAL", "less")):
+                with self.subTest(translate=translate, target=target):
+                    http_mock.register(
+                        "POST",
+                        "https://api.deepl.com/v1/translate",
+                        json={"translations": [{"text": "Hallo"}, {"text": "Welt"}]},
+                    )
+                    unit = make_unit(code="DE", source="Hello")
+                    result = translate("EN", target, [("Hello", unit), ("World", unit)])
+                    self.assertEqual(result["Hello"][0]["text"], "Hallo")
+                    self.assertEqual(result["World"][0]["text"], "Welt")
+                    request = http_mock.calls[-1].request
+                    self.assertEqual(
+                        request.headers["Authorization"], "DeepL-Auth-Key KEY"
+                    )
+                    self.assertEqual(
+                        load_request_json(request),
+                        {
+                            "text": ["Hello", "World"],
+                            "source_lang": "EN",
+                            "target_lang": "DE",
+                            "formality": formality,
+                            "tag_handling": "xml",
+                            "ignore_tags": ["x"],
+                            "context": "Test context",
+                            "model_type": "prefer_quality_optimized",
+                        },
+                    )
+        glossary_tsv.assert_not_called()
+        self.assertEqual(len(http_mock.calls), 4)
+
+    def test_legacy_url(self) -> None:
+        for url in (
+            "https://api.deepl.com/v1",
+            "https://api-free.deepl.com/v1",
+            "https://example.com/deepl/v1",
+        ):
+            for suffix in ("", "/", "///"):
+                with self.subTest(url=url, suffix=suffix):
+                    machine = self.MACHINE_CLS({"url": url + suffix, "key": "KEY:fx"})
+                    self.assertEqual(
+                        machine.get_api_url(
+                            machine.translation_api_version, "translate"
+                        ),
+                        f"{url}/translate",
+                    )
+                    self.assertFalse(machine.is_glossary_supported("EN", "DE"))
 
 
 class LibreTranslateTranslationTest(BaseMachineTranslationTest):
@@ -9092,7 +9210,8 @@ class MachineryValidationTest(TestCase):
         self.assertIn("site administrator", str(form.errors["__all__"]))
         self.assertIn("site-wide or allowlisted", str(form.errors["__all__"]))
 
-    def test_deepl_rejects_v1_url(self) -> None:
+    @http_mock.activate
+    def test_deepl_accepts_v1_url(self) -> None:
         for url in (
             "https://api.deepl.com/v1/",
             "https://api-free.deepl.com/v1/",
@@ -9105,10 +9224,9 @@ class MachineryValidationTest(TestCase):
                     data={"key": "x", "url": url},
                 )
 
-                self.assertFalse(form.is_valid())
-                self.assertIn(
-                    "DeepL API v1 is no longer supported.", form.errors["url"]
-                )
+                DeepLLegacyTranslationTest.mock_languages(url.rstrip("/"))
+                http_mock.register("POST", f"{url}translate", json=DEEPL_RESPONSE)
+                self.assertTrue(form.is_valid(), form.errors)
 
     @override_settings(OFFER_HOSTING=True)
     def test_project_machinery_rejects_private_url_on_hosted_site(self) -> None:


### PR DESCRIPTION
Restore language discovery and synchronous and asynchronous translation for explicitly configured v1 endpoints. Skip glossaries for v1 while preserving modern API routing and glossary improvements.

Fixes WEBLATE-3ANK

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
