### PR TITLE
feat(accounts): add user notification diagnostics

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Weblate 2026.9.1
 
 .. rubric:: New features
 
+* Added administrator :ref:`notification diagnostics <notifications>` with watched projects, notification languages, and explanations of effective subscriptions for object paths.
+
 .. rubric:: Improvements
 
 * The :guilabel:`Manage reports` permission now consistently grants access to complete :doc:`translation reports </devel/reporting>` for the selected scope, including private projects and restricted components below it.

--- a/docs/user/profile.rst
+++ b/docs/user/profile.rst
@@ -207,6 +207,20 @@ default value depends on :setting:`DEFAULT_AUTO_WATCH`.
     Sending out notifications is limited, you will not receive more than 1000
     e-mails per day. Any further notifications for you will be discarded.
 
+Administrators with permission to edit users can inspect a user's
+:guilabel:`Notifications` tab to see watched projects, notification languages,
+and subscriptions grouped by scope. Use :guilabel:`Notification debug` to enter
+an object path such as ``project/category/component/cs``. Project and category
+paths include their accessible components and translations. Results explain
+effective and overridden subscriptions for up to 50 targets per page, including
+project, component, and translation targets. Lists of more than five watched
+projects, notification languages, or matching targets show counts instead of
+individual links. Matching-target counts apply to the current results page.
+
+The debugger checks eligibility without sending e-mail. Notifications that
+depend on event details, such as mentions or alerts, are marked as conditional.
+Actual delivery also depends on the event author, digest content, and rate limits.
+
 .. image:: /screenshots/profile-subscriptions.webp
 
 .. _profile-account:

--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -16,8 +16,10 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth import authenticate, password_validation
 from django.contrib.auth.forms import SetPasswordForm as DjangoSetPasswordForm
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.forms import Script
+from django.http import Http404
 from django.middleware.csrf import rotate_token
 from django.utils.functional import cached_property
 from django.utils.html import escape, format_html
@@ -55,7 +57,7 @@ from weblate.lang.forms import LimitLanguagesField, get_language_code_choices
 from weblate.lang.models import Language
 from weblate.logger import LOGGER
 from weblate.trans.defines import FULLNAME_LENGTH
-from weblate.trans.models import Component, Project
+from weblate.trans.models import Category, Component, Project, Translation
 from weblate.utils import messages
 from weblate.utils.forms import (
     ContextDiv,
@@ -67,6 +69,7 @@ from weblate.utils.forms import (
 )
 from weblate.utils.ratelimit import check_rate_limit, get_rate_setting, reset_rate_limit
 from weblate.utils.validators import validate_fullname
+from weblate.utils.views import parse_path
 
 if TYPE_CHECKING:
     from altcha import Challenge
@@ -1314,3 +1317,30 @@ class TOTPTokenForm(OTPTokenForm):
                 "autocomplete": "one-time-code",
             }
         )
+
+
+class NotificationDebugForm(forms.Form):
+    notification_target = forms.CharField(
+        label=gettext_lazy("Project, category, component, or translation path"),
+        max_length=1000,
+        help_text=gettext_lazy(
+            "Enter slash-separated slugs, for example project/category/component/cs. Parent paths include their components and translations."
+        ),
+    )
+
+    def __init__(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.request = request
+
+    def clean_notification_target(self):
+        path = self.cleaned_data["notification_target"].strip("/").split("/")
+        if not all(path):
+            raise forms.ValidationError(gettext("Enter a valid object path."))
+        try:
+            return parse_path(
+                self.request, path, (Project, Category, Component, Translation)
+            )
+        except (Http404, PermissionDenied) as error:
+            raise forms.ValidationError(
+                gettext("The target does not exist or you cannot access it.")
+            ) from error

--- a/weblate/accounts/notification_debug.py
+++ b/weblate/accounts/notification_debug.py
@@ -1,0 +1,264 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Read-only explanations of notification subscription eligibility."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from django.core.paginator import Page, Paginator
+from django.db.models import F, Value
+from django.utils.translation import gettext
+
+from weblate.accounts.notifications import (
+    NOTIFICATIONS,
+    Notification,
+    NotificationFrequency,
+    NotificationScope,
+)
+from weblate.trans.models import Category, Component, Project, Translation
+
+if TYPE_CHECKING:
+    from django_stubs_ext import StrOrPromise
+
+    from weblate.accounts.models import Subscription
+    from weblate.auth.models import User
+
+
+NOTIFICATION_DETAIL_LIMIT = 5
+NOTIFICATION_TARGET_PAGE_SIZE = 50
+
+
+@dataclass
+class NotificationExplanation:
+    notification: type[Notification]
+    reason: StrOrPromise
+    subscription: Subscription | None = None
+    overridden: list[Subscription] = field(default_factory=list)
+    conditions: list[StrOrPromise] = field(default_factory=list)
+    targets: list[Project | Component | Translation] = field(default_factory=list)
+
+    @property
+    def name(self) -> StrOrPromise:
+        return self.notification.verbose
+
+
+class NotificationDebugger:
+    """Inspect subscriptions without constructing events or invoking delivery."""
+
+    def __init__(self, user: User) -> None:
+        self.user = user
+        self.handlers = [handler([], user_ids=[user.pk]) for handler in NOTIFICATIONS]
+        self.languages = set(user.profile.languages.values_list("pk", flat=True))
+        self.watched_projects = set(user.profile.watched.values_list("pk", flat=True))
+        self.scopes: dict[str, set[int]] = {}
+        for name, scope in user.subscription_set.values_list("notification", "scope"):
+            self.scopes.setdefault(name, set()).add(scope)
+
+    def explain(
+        self,
+        handler: Notification,
+        project: Project,
+        component: Component | None = None,
+        translation: Translation | None = None,
+    ) -> NotificationExplanation:
+        result = NotificationExplanation(
+            type(handler), gettext("No matching subscription.")
+        )
+        if not self.user.is_active or self.user.is_bot:
+            result.reason = gettext(
+                "Inactive users and bots do not receive notifications."
+            )
+            return result
+
+        # Share the delivery matcher, excluding only checks requiring an actual event.
+        subscriptions = list(
+            handler.get_scope_subscriptions(None, project, component, translation, None)
+        )
+        if subscriptions:
+            result.subscription = subscriptions[0]
+            result.overridden = subscriptions[1:]
+
+        if not handler.can_access_target(self.user, project, component):
+            result.reason = gettext("The user cannot access this target.")
+        elif (
+            language := handler.get_language_filter(None, translation)
+        ) is not None and language.pk not in self.languages:
+            result.reason = gettext(
+                "This language is not among the user’s notification languages."
+            )
+        elif not subscriptions:
+            scopes = self.scopes.get(handler.get_name(), set())
+            if NotificationScope.SCOPE_WATCHED in scopes:
+                if handler.ignore_watched:
+                    result.conditions.append(
+                        gettext(
+                            "This notification ignores watched-project subscriptions."
+                        )
+                    )
+                elif project.pk not in self.watched_projects:
+                    result.conditions.append(
+                        gettext("The user is not watching this project.")
+                    )
+            if NotificationScope.SCOPE_ADMIN in scopes:
+                result.conditions.append(
+                    gettext("No administered-project subscription matches this target.")
+                )
+            if scopes & {
+                NotificationScope.SCOPE_PROJECT,
+                NotificationScope.SCOPE_COMPONENT,
+            }:
+                result.conditions.append(
+                    gettext(
+                        "The project or component subscriptions apply to other targets."
+                    )
+                )
+        elif subscriptions[0].frequency == NotificationFrequency.FREQ_NONE:
+            result.reason = gettext("Disabled by the effective subscription.")
+        else:
+            result.reason = gettext(
+                "Eligible when the notification’s event conditions are met."
+            )
+            result.conditions = list(handler.debug_conditions)
+            if handler.required_attr:
+                result.conditions.append(
+                    gettext("Requires a corresponding event on this target.")
+                )
+            for notification in sorted(
+                handler.skip_when_notify, key=lambda item: item.get_name()
+            ):
+                result.conditions.append(
+                    gettext("Instant delivery can be suppressed by: %(notification)s.")
+                    % {"notification": notification.verbose}
+                )
+            if (
+                handler.filter_languages
+                and translation is None
+                and not handler.debug_conditions
+            ):
+                result.conditions.append(
+                    gettext(
+                        "Language-specific events require one of the user’s notification languages."
+                    )
+                )
+        return result
+
+    def inspect(
+        self,
+        target: Project | Category | Component | Translation,
+        viewer: User,
+        page_number: str | None,
+    ) -> tuple[list[NotificationExplanation], Page]:
+        """Group equivalent outcomes over one page of accessible descendants."""
+        page = self.get_target_page(target, viewer, page_number)
+
+        groups: dict[tuple, NotificationExplanation] = {}
+        for obj in page:
+            translation = None
+            component = None
+            if isinstance(obj, Translation):
+                translation = obj
+                component = obj.component
+                project = component.project
+            elif isinstance(obj, Component):
+                component = obj
+                project = obj.project
+            else:
+                project = obj
+            for handler in self.handlers:
+                result = self.explain(handler, project, component, translation)
+                key = (
+                    handler.get_name(),
+                    str(result.reason),
+                    result.subscription.pk if result.subscription else None,
+                    tuple(subscription.pk for subscription in result.overridden),
+                    tuple(str(condition) for condition in result.conditions),
+                )
+                if key not in groups:
+                    groups[key] = result
+                groups[key].targets.append(obj)
+        return sorted(
+            groups.values(), key=lambda result: str(result.notification.verbose)
+        ), page
+
+    @staticmethod
+    def get_target_page(
+        target: Project | Category | Component | Translation,
+        viewer: User,
+        page_number: str | None,
+    ) -> Page:
+        """Page identifiers before loading any component or translation objects."""
+        if isinstance(target, Translation):
+            components = Component.objects.filter(pk=target.component_id)
+        elif isinstance(target, Component):
+            components = Component.objects.filter(pk=target.pk)
+        elif isinstance(target, Category):
+            components = Component.objects.filter(
+                pk__in=target.get_component_ids_with_links()
+            )
+        else:
+            components = Component.objects.filter(project=target)
+        components = components.filter_access(viewer)
+        translations = Translation.objects.filter(component__in=components)
+        if isinstance(target, Translation):
+            translations = translations.filter(pk=target.pk)
+
+        # All branches have the same projection and no implicit model ordering.
+        # Ordering keeps each component immediately ahead of its translations.
+        translation_ids = (
+            translations.order_by()
+            .annotate(
+                target_component=F("component_id"),
+                target_kind=Value("translation"),
+                target_id=F("pk"),
+            )
+            .values_list("target_component", "target_kind", "target_id")
+        )
+        target_ids = translation_ids
+        if not isinstance(target, Translation):
+            component_ids = (
+                components.order_by()
+                .annotate(
+                    target_component=F("pk"),
+                    target_kind=Value("component"),
+                    target_id=F("pk"),
+                )
+                .values_list("target_component", "target_kind", "target_id")
+            )
+            target_ids = target_ids.union(component_ids)
+        if isinstance(target, Project):
+            project_ids = (
+                Project.objects.filter(pk=target.pk)
+                .order_by()
+                .annotate(
+                    target_component=Value(0),
+                    target_kind=Value("project"),
+                    target_id=F("pk"),
+                )
+                .values_list("target_component", "target_kind", "target_id")
+            )
+            target_ids = target_ids.union(project_ids)
+        target_ids = target_ids.order_by("target_component", "target_kind", "target_id")
+        page = Paginator(target_ids, NOTIFICATION_TARGET_PAGE_SIZE).get_page(
+            page_number
+        )
+        identifiers = list(page.object_list)
+        objects: dict[tuple[str, int], Project | Component | Translation] = {}
+        if isinstance(target, Project):
+            objects["project", target.pk] = target
+        for component in Component.objects.filter(
+            pk__in=[pk for _, kind, pk in identifiers if kind == "component"]
+        ).select_related("project", "category"):
+            objects["component", component.pk] = component
+        for translation in Translation.objects.filter(
+            pk__in=[pk for _, kind, pk in identifiers if kind == "translation"]
+        ).select_related("language", "component__project", "component__category"):
+            objects["translation", translation.pk] = translation
+        return Page(
+            [objects[kind, pk] for _, kind, pk in identifiers],
+            page.number,
+            page.paginator,
+        )

--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -77,11 +77,11 @@ class NotificationFrequency(IntegerChoices):
 
 
 class NotificationScope(IntegerChoices):
-    SCOPE_ALL = 0, "All"
-    SCOPE_WATCHED = 10, "Watched"
-    SCOPE_ADMIN = 20, "Administered"
-    SCOPE_PROJECT = 30, "Project"
-    SCOPE_COMPONENT = 40, "Component"
+    SCOPE_ALL = 0, gettext_lazy("All")
+    SCOPE_WATCHED = 10, gettext_lazy("Watched")
+    SCOPE_ADMIN = 20, gettext_lazy("Administered")
+    SCOPE_PROJECT = 30, gettext_lazy("Project")
+    SCOPE_COMPONENT = 40, gettext_lazy("Component")
 
 
 NOTIFICATIONS: list[type[Notification]] = []
@@ -145,6 +145,7 @@ class Notification:
     any_watched: bool = False
     required_attr: str | None = None
     batch_recipients = True
+    debug_conditions: ClassVar[tuple[StrOrPromise, ...]] = ()
     skip_when_notify: ClassVar[set[type[Notification]]] = set()
 
     def __init__(
@@ -217,7 +218,7 @@ class Notification:
             .prefetch_related("user__profile__languages")
         )
 
-    def get_subscriptions(
+    def get_scope_subscriptions(
         self,
         change: Change | None,
         project: Project | None,
@@ -225,6 +226,7 @@ class Notification:
         translation: Translation | None,
         users: list[int] | None,
     ) -> Iterable[Subscription]:
+        """Match account, scope, and language in descending subscription priority."""
         lang_filter: Language | None = self.get_language_filter(change, translation)
         cache_key: int | None = project.pk if project else None
         try:
@@ -253,6 +255,18 @@ class Notification:
                 continue
 
             yield subscription
+
+    def get_subscriptions(
+        self,
+        change: Change | None,
+        project: Project | None,
+        component: Component | None,
+        translation: Translation | None,
+        users: list[int] | None,
+    ) -> Iterable[Subscription]:
+        return self.get_scope_subscriptions(
+            change, project, component, translation, users
+        )
 
     def missing_required_attrs(self, change: Change | None) -> bool:
         if not self.required_attr:
@@ -1153,6 +1167,11 @@ class ComponentTranslatedNotificaton(Notification):
 
 @register_notification
 class NewCommentNotificaton(Notification):
+    debug_conditions = (
+        gettext_lazy(
+            "Source-string comments ignore notification languages; other comments require a matching language."
+        ),
+    )
     actions = (ActionEvents.COMMENT,)
     verbose = pgettext_lazy("Notification name", "Comment was added")
     verbose_plural = pgettext_lazy("Notification name", "Comments were added")
@@ -1163,13 +1182,14 @@ class NewCommentNotificaton(Notification):
     def get_language_filter(
         self, change: Change | None, translation: Translation | None
     ) -> Language | None:
-        if (
-            translation is not None
-            and change is not None
-            and not cast("Unit", change.unit).is_source
-        ):
-            return translation.language
-        return None
+        if translation is None:
+            return None
+        is_source = (
+            cast("Unit", change.unit).is_source
+            if change is not None
+            else translation.is_source
+        )
+        return None if is_source else translation.language
 
     def notify_immediate(self, change: Change) -> None:
         super().notify_immediate(change)
@@ -1182,6 +1202,7 @@ class NewCommentNotificaton(Notification):
 
 @register_notification
 class MentionCommentNotificaton(Notification):
+    debug_conditions = (gettext_lazy("The comment must mention this user."),)
     actions = (ActionEvents.COMMENT,)
     verbose = pgettext_lazy("Notification name", "You were mentioned in a comment")
     verbose_plural = pgettext_lazy(
@@ -1219,6 +1240,11 @@ class MentionCommentNotificaton(Notification):
 
 @register_notification
 class LastAuthorCommentNotificaton(Notification):
+    debug_conditions = (
+        gettext_lazy(
+            "The user must have contributed to the string or previously participated in its discussion."
+        ),
+    )
     actions = (ActionEvents.COMMENT,)
     verbose = pgettext_lazy(
         "Notification name",
@@ -1380,6 +1406,11 @@ class NewComponentNotificaton(Notification):
 
 @register_notification
 class NewAnnouncementNotificaton(Notification):
+    debug_conditions = (
+        gettext_lazy(
+            "The announcement must enable notifications. If it specifies a language, that language must match the user’s notification languages."
+        ),
+    )
     actions = (ActionEvents.ANNOUNCEMENT,)
     verbose = pgettext_lazy("Notification name", "Announcement was published")
     verbose_plural = pgettext_lazy("Notification name", "Announcements were published")
@@ -1400,6 +1431,11 @@ class NewAnnouncementNotificaton(Notification):
 
 @register_notification
 class NewAlertNotificaton(Notification):
+    debug_conditions = (
+        gettext_lazy(
+            "The alert must be at least a warning and the user must be able to act on it. Linked-component and project-wide alerts can be deduplicated."
+        ),
+    )
     actions = (ActionEvents.ALERT, ActionEvents.ALERT_REOPENED)
     verbose = pgettext_lazy("Notification name", "New alert emerged in a component")
     verbose_plural = pgettext_lazy(

--- a/weblate/accounts/tests/test_notification_debug.py
+++ b/weblate/accounts/tests/test_notification_debug.py
@@ -1,0 +1,563 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Notification diagnostics and their administrator interface."""
+
+from __future__ import annotations
+
+from copy import copy
+from typing import TYPE_CHECKING, cast
+from unittest.mock import patch
+
+from django.core.exceptions import PermissionDenied
+from django.template.loader import render_to_string
+from django.test import override_settings
+from django.test.html import Element, parse_html
+from django.utils.translation import override
+
+from weblate.accounts.models import Subscription
+from weblate.accounts.notification_debug import (
+    NotificationDebugger,
+    NotificationExplanation,
+)
+from weblate.accounts.notifications import (
+    NOTIFICATIONS,
+    MentionCommentNotificaton,
+    NewAlertNotificaton,
+    NewCommentNotificaton,
+    NewStringNotificaton,
+    Notification,
+    NotificationFrequency,
+    NotificationScope,
+    RepositoryNotification,
+)
+from weblate.accounts.views import UserPage
+from weblate.auth.models import User
+from weblate.lang.models import Language
+from weblate.trans.models import Category, Component, Project, Translation
+from weblate.trans.tests.test_views import FixtureTestCase
+
+if TYPE_CHECKING:
+    from weblate.auth.models import AuthenticatedHttpRequest
+
+
+@override_settings(SUPPORT_STATUS_CHECK=False)
+class NotificationDebugTest(FixtureTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.subscription_set.all().delete()
+        self.viewer = User.objects.create_superuser(
+            username="notification-admin",
+            email="admin@example.com",
+            password="testpassword",
+        )
+        self.client.force_login(self.viewer)
+
+    def subscribe(self, scope=NotificationScope.SCOPE_ALL, **kwargs):
+        return self.user.subscription_set.create(
+            scope=scope,
+            notification=kwargs.pop("notification", RepositoryNotification.get_name()),
+            frequency=kwargs.pop("frequency", NotificationFrequency.FREQ_INSTANT),
+            **kwargs,
+        )
+
+    def explain(self, notification=RepositoryNotification, translation=None):
+        return NotificationDebugger(self.user).explain(
+            notification([], user_ids=[self.user.pk]),
+            self.project,
+            self.component,
+            translation,
+        )
+
+    def debug(self, path=None, **kwargs):
+        return self.client.get(
+            self.user.get_absolute_url(),
+            {"notification_target": path or self.project.slug, **kwargs},
+        )
+
+    def test_precedence_and_disabled_subscription(self) -> None:
+        other = self.subscribe()
+        self.user.profile.watched.add(self.project)
+        watched = self.subscribe(NotificationScope.SCOPE_WATCHED)
+        project = self.subscribe(NotificationScope.SCOPE_PROJECT, project=self.project)
+        component = self.subscribe(
+            NotificationScope.SCOPE_COMPONENT,
+            component=self.component,
+            project=self.project,
+            frequency=NotificationFrequency.FREQ_NONE,
+        )
+        result = self.explain()
+        self.assertEqual(result.subscription, component)
+        self.assertEqual(result.overridden, [project, watched, other])
+        self.assertEqual(result.reason, "Disabled by the effective subscription.")
+
+    def test_watched_and_admin_scopes(self) -> None:
+        self.user.profile.watched.clear()
+        watched = self.subscribe(NotificationScope.SCOPE_WATCHED)
+        result = self.explain()
+        self.assertIsNone(result.subscription)
+        self.assertIn("The user is not watching this project.", result.conditions)
+        self.user.profile.watched.add(self.project)
+        self.assertEqual(self.explain().subscription, watched)
+        self.project.add_user(self.user, "Administration")
+        admin = self.subscribe(NotificationScope.SCOPE_ADMIN)
+        self.assertEqual(self.explain().subscription, admin)
+
+    def test_language_filter(self) -> None:
+        translation = self.component.translation_set.get(language__code="cs")
+        self.subscribe(notification=NewStringNotificaton.get_name())
+        self.user.profile.languages.clear()
+        result = self.explain(NewStringNotificaton, translation)
+        self.assertIsNone(result.subscription)
+        self.assertIn("notification languages", result.reason)
+        self.user.profile.languages.add(translation.language)
+        self.assertIsNotNone(
+            self.explain(NewStringNotificaton, translation).subscription
+        )
+
+    def test_comment_languages(self) -> None:
+        self.subscribe(notification=NewCommentNotificaton.get_name())
+        self.user.profile.languages.clear()
+        target = self.component.translation_set.get(language__code="cs")
+        result = self.explain(NewCommentNotificaton, target)
+        self.assertIn("notification languages", result.reason)
+        source = self.component.translation_set.get(
+            language=self.component.source_language
+        )
+        self.assertIsNotNone(self.explain(NewCommentNotificaton, source).subscription)
+
+    def test_ignored_watched_scope(self) -> None:
+        self.user.profile.watched.add(self.project)
+        self.subscribe(
+            NotificationScope.SCOPE_WATCHED,
+            notification=MentionCommentNotificaton.get_name(),
+        )
+        result = self.explain(MentionCommentNotificaton)
+        self.assertIsNone(result.subscription)
+        self.assertIn(
+            "This notification ignores watched-project subscriptions.",
+            result.conditions,
+        )
+
+    def test_event_dependent_notifications(self) -> None:
+        for notification in (
+            NewCommentNotificaton,
+            MentionCommentNotificaton,
+            NewAlertNotificaton,
+        ):
+            with self.subTest(notification=notification):
+                subscription = self.subscribe(notification=notification.get_name())
+                result = self.explain(notification)
+                self.assertEqual(result.subscription, subscription)
+                self.assertIn("Eligible", result.reason)
+                self.assertTrue(result.conditions)
+
+    def test_ineligible_accounts_and_access(self) -> None:
+        self.subscribe()
+        for attribute in ("is_active", "is_bot"):
+            with self.subTest(attribute=attribute):
+                original = getattr(self.user, attribute)
+                setattr(self.user, attribute, not original)
+                self.assertIn("Inactive users and bots", self.explain().reason)
+                setattr(self.user, attribute, original)
+        with patch.object(User, "can_access_component", return_value=False):
+            self.assertEqual(
+                self.explain().reason, "The user cannot access this target."
+            )
+
+    def test_debug_is_read_only(self) -> None:
+        subscription = self.subscribe(
+            NotificationScope.SCOPE_COMPONENT,
+            component=self.component,
+            project=self.project,
+            onetime=True,
+        )
+        before = list(Subscription.objects.values())
+        with (
+            patch.object(Notification, "send") as send,
+            patch("weblate.accounts.notifications.queue_mails") as queue,
+        ):
+            response = self.debug()
+        self.assertEqual(response.status_code, 200, response.headers)
+        send.assert_not_called()
+        queue.assert_not_called()
+        self.assertEqual(list(Subscription.objects.values()), before)
+        self.assertContains(response, f"#notification-subscription-{subscription.pk}")
+        self.assertContains(response, "Operation was performed in the repository")
+        self.assertEqual(
+            {
+                result.notification
+                for result in response.context["notification_results"]
+            },
+            set(NOTIFICATIONS),
+        )
+
+    def test_groups_and_languages(self) -> None:
+        self.subscribe()
+        self.user.profile.watched.add(self.project)
+        language = self.component.translation_set.get(language__code="cs").language
+        self.user.profile.languages.add(language)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(list(response.context["notification_languages"]), [language])
+        self.assertIn(self.project, response.context["notification_watched_projects"])
+        group = response.context["notification_subscription_groups"][0]
+        self.assertFalse(group["show_project"])
+        self.assertFalse(group["show_component"])
+        self.assertNotContains(response, "RepositoryNotification")
+        with override("cs"):
+            self.assertNotEqual(NotificationScope.SCOPE_PROJECT.label, "Project")
+
+    def test_invalid_paths(self) -> None:
+        for path in (
+            "",
+            "/",
+            "missing",
+            "a//b",
+            "<script>",
+            "test/no-such-component/cs",
+        ):
+            with self.subTest(path=path):
+                response = self.client.get(
+                    self.user.get_absolute_url(), {"notification_target": path}
+                )
+                self.assertEqual(response.status_code, 200, response.headers)
+                self.assertTrue(response.context["notification_form"].errors)
+                self.assertNotIn("notification_results", response.context)
+                self.assertContains(response, 'class="tab-pane active"\n')
+        self.assertNotContains(response, "<script>alert(")
+
+    def test_permission_required(self) -> None:
+        self.client.force_login(self.user)
+        response = self.debug()
+        self.assertEqual(response.status_code, 403)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertNotContains(response, "Notification debug")
+
+    def test_descendants_and_grouping(self) -> None:
+        subscription = self.subscribe()
+        response = self.debug()
+        results = [
+            result
+            for result in response.context["notification_results"]
+            if result.notification is RepositoryNotification
+        ]
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result.subscription, subscription)
+        self.assertIn(self.project, result.targets)
+        self.assertIn(self.component, result.targets)
+        self.assertTrue(
+            any(
+                target in result.targets
+                for target in self.component.translation_set.all()
+            )
+        )
+
+    def test_nested_category_and_translation_paths(self) -> None:
+        parent = Category(project=self.project, name="Parent", slug="parent")
+        Category.objects.bulk_create([parent])
+        child = Category(
+            project=self.project, category=parent, name="Child", slug="child"
+        )
+        Category.objects.bulk_create([child])
+        # Avoid repository operations: diagnostics need only the database hierarchy.
+        type(self.component).objects.filter(pk=self.component.pk).update(category=child)
+        path = f"{self.project.slug}/parent/child/{self.component.slug}/cs"
+        response = self.debug(path)
+        self.assertEqual(response.status_code, 200, response.headers)
+        self.assertEqual(
+            response.context["notification_debug_target"].language.code, "cs"
+        )
+        response = self.debug(f"{self.project.slug}/parent")
+        self.assertIn(self.component, response.context["notification_page"].object_list)
+
+    def test_empty_category(self) -> None:
+        Category.objects.bulk_create(
+            [Category(project=self.project, name="Empty", slug="empty")]
+        )
+        response = self.debug(f"{self.project.slug}/empty")
+        self.assertContains(response, "No accessible components or translations")
+        self.assertEqual(response.context["notification_page"].paginator.count, 0)
+
+    def test_pagination(self) -> None:
+        components = []
+        for index in range(51):
+            component = copy(self.component)
+            component.pk = None
+            component.slug = f"notification-{index}"
+            component.name = f"Notification {index}"
+            components.append(component)
+        Component.objects.bulk_create(components)
+        self.subscribe()
+        response = self.debug()
+        page = response.context["notification_page"]
+        self.assertEqual(len(page.object_list), 50)
+        self.assertEqual(
+            page.paginator.count, 53 + self.component.translation_set.count()
+        )
+        self.assertContains(
+            response, "?page=2&amp;limit=50&amp;notification_target=test#notifications"
+        )
+        second = self.debug(page="2")
+        self.assertEqual(
+            len(second.context["notification_page"].object_list),
+            page.paginator.count - 50,
+        )
+        self.assertFalse(
+            set(page.object_list) & set(second.context["notification_page"].object_list)
+        )
+        invalid = self.debug(page="invalid")
+        self.assertEqual(invalid.context["notification_page"].number, 1)
+
+    def test_inaccessible_target(self) -> None:
+        with patch.object(User, "check_access_component", side_effect=PermissionDenied):
+            response = self.debug(f"{self.project.slug}/{self.component.slug}")
+        self.assertContains(
+            response, "The target does not exist or you cannot access it."
+        )
+        self.assertNotIn("notification_results", response.context)
+
+    def test_descendants_require_viewer_access(self) -> None:
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        viewer = User.objects.create_user(username="limited-viewer")
+        results, page = NotificationDebugger(self.user).inspect(
+            self.project, viewer, None
+        )
+        self.assertEqual(page.paginator.count, 1)
+        self.assertEqual(page.object_list, [self.project])
+        self.assertTrue(all(result.targets == [self.project] for result in results))
+
+    def test_component_override_does_not_apply_to_project(self) -> None:
+        project = self.subscribe(NotificationScope.SCOPE_PROJECT, project=self.project)
+        component = self.subscribe(
+            NotificationScope.SCOPE_COMPONENT,
+            component=self.component,
+            frequency=NotificationFrequency.FREQ_NONE,
+        )
+        response = self.debug()
+        results = [
+            result
+            for result in response.context["notification_results"]
+            if result.notification is RepositoryNotification
+        ]
+        self.assertEqual(
+            {result.subscription.pk for result in results}, {project.pk, component.pk}
+        )
+        project_result = next(
+            result for result in results if result.subscription == project
+        )
+        self.assertEqual(project_result.targets, [self.project])
+
+    def test_translation_debug_renders_notification_names(self) -> None:
+        response = self.debug(f"{self.project.slug}/{self.component.slug}/cs")
+        self.assertContains(response, "Operation was performed in the repository")
+        self.assertTrue(
+            all(
+                len(result.targets) == 1
+                for result in response.context["notification_results"]
+            )
+        )
+
+    def notification_context(self, **params):
+        view = UserPage()
+        view.object = self.user
+        view.request = cast(
+            "AuthenticatedHttpRequest",
+            self.factory.get(self.user.get_absolute_url(), params),
+        )
+        view.request.user = self.viewer
+        return view.get_notification_context()
+
+    def render_notifications(self, context):
+        return render_to_string(
+            "accounts/notification_debug.html",
+            {**context, "page_user": self.user},
+            request=self.get_request(self.viewer),
+        )
+
+    def test_profile_list_summaries(self) -> None:
+        projects = Project.objects.bulk_create(
+            [
+                Project(
+                    name=f"Watched {index}",
+                    slug=f"watched-{index}",
+                    web="https://example.com/",
+                )
+                for index in range(6)
+            ]
+        )
+        languages = Language.objects.bulk_create(
+            [
+                Language(name=f"Notification language {index}", code=f"debug-{index}")
+                for index in range(6)
+            ]
+        )
+        for count in (0, 1, 5, 6):
+            with self.subTest(count=count):
+                self.user.profile.watched.set(projects[:count])
+                self.user.profile.languages.set(languages[:count])
+                context = self.notification_context()
+                self.assertEqual(context["notification_watched_count"], count)
+                self.assertEqual(context["notification_language_count"], count)
+                html = self.render_notifications(context)
+                if count > 5:
+                    self.assertEqual(context["notification_watched_projects"], [])
+                    self.assertEqual(context["notification_languages"], [])
+                    self.assertIn("6 watched projects.", html)
+                    self.assertIn("6 notification languages.", html)
+                    for obj in [*projects, *languages]:
+                        self.assertNotIn(f'href="{obj.get_absolute_url()}"', html)
+                else:
+                    self.assertCountEqual(
+                        context["notification_watched_projects"], projects[:count]
+                    )
+                    self.assertCountEqual(
+                        context["notification_languages"], languages[:count]
+                    )
+                    for obj in [*projects[:count], *languages[:count]]:
+                        self.assertIn(f'href="{obj.get_absolute_url()}"', html)
+                if not count:
+                    self.assertIn("No watched projects.", html)
+                    self.assertIn("No notification languages selected.", html)
+
+    def test_large_profile_lists_do_not_load_objects(self) -> None:
+        projects = Project.objects.bulk_create(
+            [
+                Project(
+                    name=f"Watched {index}",
+                    slug=f"watched-{index}",
+                    web="https://example.com/",
+                )
+                for index in range(6)
+            ]
+        )
+        languages = Language.objects.bulk_create(
+            [
+                Language(name=f"Debug {index}", code=f"debug-{index}")
+                for index in range(6)
+            ]
+        )
+        self.user.profile.watched.set(projects)
+        self.user.profile.languages.set(languages)
+        with (
+            patch.object(Project, "from_db", wraps=Project.from_db) as load_project,
+            patch.object(Language, "from_db", wraps=Language.from_db) as load_language,
+        ):
+            context = self.notification_context()
+        load_project.assert_not_called()
+        load_language.assert_not_called()
+        self.assertEqual(context["notification_watched_count"], 6)
+        self.assertEqual(context["notification_language_count"], 6)
+
+    def test_watched_count_respects_viewer_access(self) -> None:
+        private = Project.objects.create(
+            name="Private watched",
+            slug="private-watched",
+            web="https://example.com/",
+            access_control=Project.ACCESS_PRIVATE,
+        )
+        self.user.profile.watched.add(self.project, private)
+        self.viewer = User.objects.create_user(username="count-viewer")
+        context = self.notification_context()
+        self.assertEqual(context["notification_watched_count"], 1)
+        self.assertEqual(context["notification_watched_projects"], [self.project])
+
+    def test_result_target_summaries(self) -> None:
+        targets: list[Project | Component | Translation] = [
+            Project(pk=index, slug=f"target-{index}", name=f"Target {index}")
+            for index in range(1, 7)
+        ]
+        for count in (1, 5, 6):
+            with self.subTest(count=count):
+                context = self.notification_context()
+                context.update(
+                    {
+                        "notification_debug_target": self.project,
+                        "notification_page": NotificationDebugger.get_target_page(
+                            self.project, self.viewer, None
+                        ),
+                        "notification_results": [
+                            NotificationExplanation(
+                                RepositoryNotification, "", targets=targets[:count]
+                            )
+                        ],
+                    }
+                )
+                html = self.render_notifications(context)
+                for obj in targets[:count]:
+                    if count > 5:
+                        self.assertNotIn(f'href="{obj.get_absolute_url()}"', html)
+                    else:
+                        self.assertIn(f'href="{obj.get_absolute_url()}"', html)
+                if count > 5:
+                    self.assertIn("6 targets on this page", html)
+                self.assertNotIn("<details>", html)
+
+    def test_rendered_lists_have_valid_children(self) -> None:
+        self.user.profile.watched.add(self.project)
+        self.user.profile.languages.add(self.get_translation().language)
+        self.subscribe()
+        self.subscribe(NotificationScope.SCOPE_COMPONENT, component=self.component)
+        context = self.notification_context(notification_target=self.project.slug)
+        html = self.render_notifications(context)
+        elements = [parse_html(html)]
+        lists = 0
+        while elements:
+            element = elements.pop()
+            if element.name in {"ul", "ol"}:
+                lists += 1
+                for child in element.children:
+                    self.assertIsInstance(child, Element)
+                    self.assertIn(child.name, {"li", "script", "template", "style"})
+            elements.extend(
+                child for child in element.children if isinstance(child, Element)
+            )
+        self.assertGreater(lists, 2)
+
+    def test_large_component_bounds_translation_work(self) -> None:
+        languages = Language.objects.bulk_create(
+            [
+                Language(name=f"Debug {index}", code=f"debug-{index}")
+                for index in range(200)
+            ]
+        )
+        original = self.get_translation()
+        translations = []
+        for language in languages:
+            translation = copy(original)
+            translation.pk = None
+            translation.language = language
+            translation.language_code = language.code
+            translations.append(translation)
+        Translation.objects.bulk_create(translations)
+        debugger = NotificationDebugger(self.user)
+        with (
+            patch.object(debugger, "explain", wraps=debugger.explain) as explain,
+            patch.object(
+                Translation, "from_db", wraps=Translation.from_db
+            ) as load_translation,
+        ):
+            results, page = debugger.inspect(self.component, self.viewer, None)
+        self.assertEqual(len(page.object_list), 50)
+        self.assertEqual(explain.call_count, 50 * len(NOTIFICATIONS))
+        self.assertEqual(load_translation.call_count, 49)
+        self.assertEqual(
+            page.paginator.count, 1 + self.component.translation_set.count()
+        )
+        self.assertTrue(all(len(result.targets) <= 50 for result in results))
+        actual: list[tuple[type[Component | Translation], int]] = []
+        for number in page.paginator.page_range:
+            current = debugger.get_target_page(self.component, self.viewer, str(number))
+            self.assertLessEqual(len(current.object_list), 50)
+            actual.extend((type(obj), obj.pk) for obj in current)
+        expected = [
+            (Component, self.component.pk),
+            *[
+                (Translation, pk)
+                for pk in self.component.translation_set.order_by("pk").values_list(
+                    "pk", flat=True
+                )
+            ],
+        ]
+        self.assertEqual(actual, expected)

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -114,6 +114,7 @@ from weblate.accounts.forms import (
     GroupRemoveForm,
     LanguagesForm,
     LoginForm,
+    NotificationDebugForm,
     NotificationForm,
     OTPTokenForm,
     PasswordConfirmForm,
@@ -130,6 +131,10 @@ from weblate.accounts.forms import (
     WebAuthnTokenForm,
 )
 from weblate.accounts.models import AuditLog, Subscription, VerifiedEmail
+from weblate.accounts.notification_debug import (
+    NOTIFICATION_DETAIL_LIMIT,
+    NotificationDebugger,
+)
 from weblate.accounts.notifications import (
     NOTIFICATIONS,
     NotificationFrequency,
@@ -879,6 +884,70 @@ class UserPage(UpdateView):
         self.object.log_audit_state(self.request)
         return response
 
+    def get_notification_context(self) -> dict[str, Any]:
+        request = self.request
+        user = self.object
+        submitted = "notification_target" in request.GET
+        form = NotificationDebugForm(request, request.GET if submitted else None)
+        groups = []
+        subscriptions = list(
+            user.subscription_set.select_related(
+                "project", "component__project", "component__category"
+            ).order()
+        )
+        for scope in NotificationScope:
+            rows = [row for row in subscriptions if row.scope == scope]
+            if rows:
+                groups.append(
+                    {
+                        "label": scope.label,
+                        "subscriptions": rows,
+                        "show_project": scope >= NotificationScope.SCOPE_PROJECT,
+                        "show_component": scope == NotificationScope.SCOPE_COMPONENT,
+                    }
+                )
+        watched_projects = (
+            user.profile.watched.all() & request.user.allowed_projects
+        ).order()
+        languages = user.profile.languages.all().order()
+        watched_count = watched_projects.count()
+        language_count = languages.count()
+        context = {
+            "notification_form": form,
+            "notification_submitted": submitted,
+            "notification_subscription_groups": groups,
+            "notification_detail_limit": NOTIFICATION_DETAIL_LIMIT,
+            "notification_watched_count": watched_count,
+            "notification_language_count": language_count,
+            "notification_watched_projects": list(
+                watched_projects[:NOTIFICATION_DETAIL_LIMIT]
+            )
+            if watched_count <= NOTIFICATION_DETAIL_LIMIT
+            else [],
+            "notification_languages": list(languages[:NOTIFICATION_DETAIL_LIMIT])
+            if language_count <= NOTIFICATION_DETAIL_LIMIT
+            else [],
+        }
+        if submitted and form.is_valid():
+            target = form.cleaned_data["notification_target"]
+            results, page = NotificationDebugger(user).inspect(
+                target, request.user, request.GET.get("page")
+            )
+            context.update(
+                {
+                    "notification_debug_target": target,
+                    "notification_results": results,
+                    "notification_page": page,
+                    "notification_query_string": urlencode(
+                        {"notification_target": request.GET["notification_target"]}
+                    ),
+                    "notification_search_items": [
+                        ("notification_target", request.GET["notification_target"])
+                    ],
+                }
+            )
+        return context
+
     def get_context_data(self, **kwargs):
         """Create context for rendering page."""
         context = super().get_context_data(**kwargs)
@@ -904,6 +973,11 @@ class UserPage(UpdateView):
             )
             .order()
         )
+
+        if "notification_target" in request.GET:
+            check_management_access(request, "user.edit")
+        if request.user.has_perm("user.edit"):
+            context.update(self.get_notification_context())
 
         context["page_profile"] = user.profile
         context["can_edit_page_user"] = not user.is_internal

--- a/weblate/templates/accounts/notification_debug.html
+++ b/weblate/templates/accounts/notification_debug.html
@@ -1,0 +1,190 @@
+{% load crispy_forms_tags i18n %}
+
+<div class="row">
+  <div class="col-md-6">
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">{% translate "Watched projects" %}</h4>
+      </div>
+      <div class="card-body">
+        {% if notification_watched_count > notification_detail_limit %}
+          <p class="mb-0">{% blocktranslate count count=notification_watched_count %}{{ count }} watched project.{% plural %}{{ count }} watched projects.{% endblocktranslate %}</p>
+        {% else %}
+          <ul class="list-unstyled mb-0">
+            {% for project in notification_watched_projects %}
+              <li><a href="{{ project.get_absolute_url }}">{{ project }}</a></li>
+            {% empty %}
+              <li>{% translate "No watched projects." %}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">{% translate "Notification languages" %}</h4>
+      </div>
+      <div class="card-body">
+        {% if notification_language_count > notification_detail_limit %}
+          <p class="mb-0">{% blocktranslate count count=notification_language_count %}{{ count }} notification language.{% plural %}{{ count }} notification languages.{% endblocktranslate %}</p>
+        {% else %}
+          <ul class="list-unstyled mb-0">
+            {% for language in notification_languages %}
+              <li><a href="{{ language.get_absolute_url }}">{{ language }}</a></li>
+            {% empty %}
+              <li>{% translate "No notification languages selected. Language-filtered notifications will not be sent." %}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-header">
+    <h4 class="card-title">{% translate "Subscriptions" %}</h4>
+  </div>
+  <div class="card-body">
+    {% for group in notification_subscription_groups %}
+      <div class="table-responsive">
+        <table class="table table-listing">
+          <caption class="caption-top">{{ group.label }}</caption>
+          <thead>
+            <tr>
+              <th scope="col">{% translate "Notification" %}</th>
+              <th scope="col">{% translate "Frequency" %}</th>
+              {% if group.show_project %}
+                <th scope="col">{% translate "Project" %}</th>
+              {% endif %}
+              {% if group.show_component %}
+                <th scope="col">{% translate "Component" %}</th>
+                <th scope="col">{% translate "One-time" %}</th>
+              {% endif %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for subscription in group.subscriptions %}
+              <tr id="notification-subscription-{{ subscription.pk }}">
+                <th scope="row">{{ subscription.get_notification_display }}</th>
+                <td>{{ subscription.get_frequency_display }}</td>
+                {% if group.show_project %}
+                  <td>
+                    {% if subscription.project %}
+                      <a href="{{ subscription.project.get_absolute_url }}">{{ subscription.project }}</a>
+                    {% elif subscription.component %}
+                      <a href="{{ subscription.component.project.get_absolute_url }}">{{ subscription.component.project }}</a>
+                    {% endif %}
+                  </td>
+                {% endif %}
+                {% if group.show_component %}
+                  <td><a href="{{ subscription.component.get_absolute_url }}">{{ subscription.component }}</a></td>
+                  <td>
+                    {% if subscription.onetime %}
+                      {% translate "Yes" %}
+                    {% else %}
+                      {% translate "No" %}
+                    {% endif %}
+                  </td>
+                {% endif %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% empty %}
+      <p>{% translate "No subscriptions." %}</p>
+    {% endfor %}
+
+  </div>
+</div>
+
+<form method="get" action="{{ page_user.get_absolute_url }}#notifications">
+  <div class="card">
+    <div class="card-header">
+      <h4 class="card-title">{% translate "Notification debug" %}</h4>
+    </div>
+    <div class="card-body">
+      <p>{% translate "Check subscription eligibility for hypothetical events. This does not send notifications. The user’s own actions do not trigger notifications; event details, digest content, and delivery rate limits can also affect delivery." %}</p>
+      {{ notification_form|crispy }}
+    </div>
+    <div class="card-footer">
+      <button type="submit" class="btn btn-primary">{% translate "Check notifications" %}</button>
+    </div>
+  </div>
+</form>
+
+{% if notification_debug_target %}
+  <div class="card">
+    <div class="card-header">
+      <h4 class="card-title">{% blocktranslate with target=notification_debug_target %}Notification eligibility for {{ target }}{% endblocktranslate %}</h4>
+    </div>
+    <div class="card-body">
+      <p>{% blocktranslate count count=notification_page.paginator.count %}{{ count }} accessible target.{% plural %}{{ count }} accessible targets.{% endblocktranslate %}</p>
+      <div class="table-responsive">
+        <table class="table table-listing">
+          <thead>
+            <tr>
+              <th scope="col">{% translate "Notification" %}</th>
+              <th scope="col">{% translate "Eligibility" %}</th>
+              <th scope="col">{% translate "Effective subscription" %}</th>
+              <th scope="col">{% translate "Targets" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for result in notification_results %}
+              <tr>
+                <th scope="row">{{ result.name }}</th>
+                <td>
+                  <p>{{ result.reason }}</p>
+                  {% if result.conditions %}
+                    <ul>{% for condition in result.conditions %}<li>{{ condition }}</li>{% endfor %}</ul>
+                  {% endif %}
+                </td>
+                <td>
+                  {% if result.subscription %}
+                    <a href="#notification-subscription-{{ result.subscription.pk }}">{{ result.subscription.get_scope_display }}: {{ result.subscription.get_frequency_display }}</a>
+                    {% if result.overridden %}
+                      <details>
+                        <summary>{% translate "Overridden subscriptions" %}</summary>
+                        <ul>
+                          {% for subscription in result.overridden %}
+                            <li><a href="#notification-subscription-{{ subscription.pk }}">{{ subscription.get_scope_display }}: {{ subscription.get_frequency_display }}</a></li>
+                          {% endfor %}
+                        </ul>
+                      </details>
+                    {% endif %}
+                  {% else %}
+                    {% translate "None" %}
+                  {% endif %}
+                </td>
+                <td>
+                  {% if result.targets|length > notification_detail_limit %}
+                    {% blocktranslate count count=result.targets|length %}{{ count }} target on this page{% plural %}{{ count }} targets on this page{% endblocktranslate %}
+                  {% else %}
+                    <ul class="list-unstyled mb-0">
+                      {% for target in result.targets %}
+                        <li><a href="{{ target.get_absolute_url }}">{{ target }}</a></li>
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
+                </td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="4">{% translate "No accessible components or translations in this target." %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    {% if notification_page.has_other_pages %}
+      <div class="card-footer">
+        {% include "paginator.html" with page_obj=notification_page query_string=notification_query_string search_items=notification_search_items anchor="notifications" %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/weblate/templates/accounts/user.html
+++ b/weblate/templates/accounts/user.html
@@ -169,7 +169,7 @@
   <ul class="nav nav-pills justify-content-center">
     <li class="nav-item">
       {# Translators: Name of a tab which lists translations the user has contributed to #}
-      <a class="nav-link active"
+      <a class="nav-link{% if not notification_submitted %} active{% endif %}"
          data-bs-toggle="tab"
          data-bs-target="#contributed"
          href="#">{% translate "Translates" %}</a>
@@ -194,7 +194,7 @@
            href="#">{% translate "User identities" %}</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link"
+        <a class="nav-link{% if notification_submitted %} active{% endif %}"
            data-bs-toggle="tab"
            data-bs-target="#notifications"
            href="#">{% translate "Notifications" %}</a>
@@ -220,7 +220,8 @@
 
   <div class="tab-content">
 
-    <div class="tab-pane active" id="contributed">
+    <div class="tab-pane{% if not notification_submitted %} active{% endif %}"
+         id="contributed">
       <div class="list-group">
         {% include "snippets/list-objects.html" with objects=page_user_translations label=_("Translation") show_admin_badge=True name_source="translation" empty_message=_("No recent contributions found.") %}
         <a href="{% url 'user_contributions' user=page_user.username %}"
@@ -284,32 +285,8 @@
         </table>
       </div>
 
-      <div class="tab-pane" id="notifications">
-        <table class="table table-listing">
-          <thead>
-            <tr>
-              <th>{% translate "Notification" %}</th>
-              <th>{% translate "Scope" %}</th>
-              <th>{% translate "Frequency" %}</th>
-              <th>{% translate "Project" %}</th>
-              <th>{% translate "Component" %}</th>
-              <th>{% translate "One-time" %}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for subscription in page_user.subscription_set.prefetch.order %}
-              <tr>
-                <th>{{ subscription.notification }}</th>
-                <td>{{ subscription.get_scope_display }}</td>
-                <td>{{ subscription.get_frequency_display }}</td>
-                <td>{{ subscription.project }}</td>
-                <td>{{ subscription.component }}</td>
-                <td>{{ subscription.onetime }}</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
+      <div class="tab-pane{% if notification_submitted %} active{% endif %}"
+           id="notifications">{% include "accounts/notification_debug.html" %}</div>
 
       {% if page_user_billings %}
         <div class="tab-pane" id="billing">


### PR DESCRIPTION
Explain notification eligibility and effective subscriptions for object paths so administrators can diagnose delivery settings. Show watched projects and languages, localize scopes, and use the existing admin cards, crispy forms, and pagination.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
