### PR TITLE
feat(glossary): warn when string management is disabled

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,8 @@ Weblate 2026.9.1
 .. rubric:: Improvements
 
 * Added posting and displaying scoped :doc:`announcements </admin/announcements>` on category-language pages.
+* Added a dismissible diagnostic for :ref:`glossaries <glossary-terminology>` with disabled string management when they use a local repository or contain terminology.
+
 * Clarified :doc:`incident reporting </security/incident-reporting>`, reporting deadlines, and security notifications for hosted and self-hosted users.
 * The :guilabel:`Manage reports` permission now consistently grants access to complete :doc:`translation reports </devel/reporting>` for the selected scope, including private projects and restricted components below it.
 * Docker deployments now use a combined :ref:`Celery <celery>` worker by default, reducing memory usage while increasing task throughput. Use :envvar:`CELERY_WORKER_MODE` to select the combined, split, or single worker setup.

--- a/docs/devel/alerts.rst
+++ b/docs/devel/alerts.rst
@@ -26,6 +26,7 @@ Currently the following is covered:
 * Conflicting merge request repository setup
 * Component seems unused (configurable by :setting:`UNUSED_ALERT_DAYS`)
 * Unused glossary languages
+* Disabled string management in local glossaries or glossaries containing terminology
 
 The alerts are updated daily, or on related change (for example when
 :ref:`component` is changed or when repository is updated).

--- a/docs/user/glossary.rst
+++ b/docs/user/glossary.rst
@@ -174,6 +174,16 @@ bulk-editing, typing in the flag, or by using :guilabel:`Tools` ↓
 glossary. Use this for important terms that should be well thought out, and
 retain a consistent meaning across all languages.
 
+Enable :ref:`component-manage_units` on the glossary component to synchronize
+terminology. When it is disabled, Weblate does not create missing language
+entries, even for terms marked as terminology.
+
+Weblate shows a dismissible :ref:`diagnostic <alerts>` when string management is
+disabled for a glossary with no remote repository, or for another glossary that
+contains terminology. Enable string management to add terms directly in Weblate
+and synchronize terminology, or dismiss the warning if you maintain the glossary
+files separately.
+
 The terminology flag is ongoing state, not just a one-time action. While the
 flag remains on the source term, Weblate treats it as terminology and keeps an
 entry for it in every glossary language. If a language entry is removed, the

--- a/weblate/glossary/tests.py
+++ b/weblate/glossary/tests.py
@@ -25,6 +25,8 @@ from weblate.glossary.tasks import (
     sync_terminology,
 )
 from weblate.lang.models import Language
+from weblate.trans.alerts.base import AlertSeverity
+from weblate.trans.alerts.config import GlossaryStringManagementDisabled
 from weblate.trans.alerts.registry import update_alerts
 from weblate.trans.models import PendingUnitChange, Unit
 from weblate.trans.tests.test_views import ViewTestCase
@@ -803,6 +805,130 @@ class GlossaryTest(ViewTestCase):
         sync_terminology(unit.translation.component.id, unit.translation.component)
         self.assertEqual(Unit.objects.count(), start + 4)
         self.assertEqual(unit.unit_set.count(), 4)
+
+    def test_string_management_alert_local(self) -> None:
+        component = self.glossary_component
+        self.assertFalse(GlossaryStringManagementDisabled.check_component(component))
+        component.manage_units = False
+        self.assertTrue(GlossaryStringManagementDisabled.check_component(component))
+        component.is_glossary = False
+        self.assertFalse(GlossaryStringManagementDisabled.check_component(component))
+        component.is_glossary = True
+        component.manage_units = True
+        self.do_add_unit()
+        component.manage_units = False
+        self.assertTrue(GlossaryStringManagementDisabled.check_component(component))
+
+    def test_string_management_alert_remote(self) -> None:
+        self.do_add_unit()
+        component = self.glossary_component
+        component.manage_units = False
+        for repo in ("https://example.com/glossary.git", "weblate://test/test"):
+            with self.subTest(repo=repo):
+                component.repo = repo
+                self.assertFalse(
+                    GlossaryStringManagementDisabled.check_component(component)
+                )
+                self.glossary.unit_set.update(extra_flags="terminology")
+                self.assertFalse(
+                    GlossaryStringManagementDisabled.check_component(component)
+                )
+                sources = component.source_translation.unit_set
+                sources.update(extra_flags="terminology")
+                self.assertTrue(
+                    GlossaryStringManagementDisabled.check_component(component)
+                )
+                sources.update(extra_flags="")
+                self.assertFalse(
+                    GlossaryStringManagementDisabled.check_component(component)
+                )
+
+    def test_string_management_alert_inherited_flags(self) -> None:
+        self.do_add_unit()
+        component = self.glossary_component
+        for field in ("flags", "extra_flags", "translation", "component"):
+            with self.subTest(field=field):
+                if field in {"flags", "extra_flags"}:
+                    model = component.source_translation.unit_set
+                    values: dict[str, str] = {field: "terminology"}
+                elif field == "translation":
+                    model = component.translation_set.filter(
+                        pk=component.source_translation.pk
+                    )
+                    values = {"check_flags": "terminology"}
+                else:
+                    model = type(component).objects.filter(pk=component.pk)
+                    values = {"check_flags": "terminology"}
+                model.update(**values)
+                current = type(component).objects.get(pk=component.pk)
+                current.repo = "https://example.com/glossary.git"
+                current.manage_units = False
+                self.assertTrue(
+                    GlossaryStringManagementDisabled.check_component(current)
+                )
+                model.update(**dict.fromkeys(values, ""))
+
+    def test_string_management_alert_dismissal(self) -> None:
+        self.do_add_unit()
+        component = self.glossary_component
+        component.manage_units = False
+        component.save(update_fields=["manage_units"])
+        name = "GlossaryStringManagementDisabled"
+        update_alerts(component, {name})
+        alert = component.alert_set.get(name=name)
+        self.assertEqual(alert.severity, AlertSeverity.WARNING)
+        self.assertFalse(alert.is_problem)
+        self.assertTrue(alert.dismiss(self.user, "Maintained separately"))
+
+        component.source_translation.unit_set.update(extra_flags="terminology")
+        update_alerts(component, {name})
+        alert.refresh_from_db()
+        self.assertTrue(alert.is_dismissed)
+
+        component.repo = "https://example.com/glossary.git"
+        update_alerts(component, {name})
+        alert.refresh_from_db()
+        self.assertFalse(alert.is_dismissed)
+
+        component.source_translation.unit_set.update(extra_flags="")
+        update_alerts(component, {name})
+        self.assertFalse(component.alert_set.filter(name=name).exists())
+        component.repo = "local:"
+        update_alerts(component, {name})
+        alert = component.alert_set.get(name=name)
+        self.assertFalse(alert.is_dismissed)
+        component.manage_units = True
+        update_alerts(component, {name})
+        self.assertFalse(component.alert_set.filter(name=name).exists())
+
+    def test_string_management_alert_render(self) -> None:
+        component = self.glossary_component
+        component.manage_units = False
+        component.save(update_fields=["manage_units"])
+        name = "GlossaryStringManagementDisabled"
+        update_alerts(component, {name})
+        alert = component.alert_set.get(name=name)
+        self.assertFalse(alert.can_user_dismiss(self.user))
+        self.assertNotIn("Configure", alert.obj.render(self.user))
+        self.make_manager()
+        self.user.clear_permissions_cache()
+        self.assertTrue(alert.can_user_dismiss(self.user))
+        rendered = alert.obj.render(self.user)
+        self.assertIn("This glossary has no remote repository", rendered)
+        self.assertIn(
+            reverse("settings", kwargs={"path": component.get_url_path()})
+            + "#translation",
+            rendered,
+        )
+        self.assertIn(
+            "#glossary-terminology",
+            alert.obj.get_documentation_url(component, self.user),
+        )
+        alert.component.repo = "https://example.com/glossary.git"
+        self.assertIn(
+            "This glossary contains terms marked as terminology",
+            alert.obj.render(self.user),
+        )
 
     def test_terminology_explanation_sync(self) -> None:
         self.make_manager()

--- a/weblate/templates/trans/alert/glossarystringmanagementdisabled.html
+++ b/weblate/templates/trans/alert/glossarystringmanagementdisabled.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+{% if local_glossary %}
+  <p>{% translate "This glossary has no remote repository, and ‘Manage strings’ is disabled. You cannot add glossary terms directly in Weblate, and terminology entries are not automatically added to missing glossary languages." %}</p>
+{% else %}
+  <p>{% translate "This glossary contains terms marked as terminology, but ‘Manage strings’ is disabled. Weblate will not automatically add these terms to missing glossary languages." %}</p>
+{% endif %}
+
+<p>{% translate "Enable ‘Manage strings’ in the component settings to add terms and synchronize terminology. You can dismiss this warning if the glossary files are maintained separately." %}</p>
+
+{% if can_configure %}
+  <p>
+    <a class="btn btn-primary" href="{{ configure_url }}">{% translate "Configure" %}</a>
+  </p>
+{% endif %}

--- a/weblate/trans/alerts/config.py
+++ b/weblate/trans/alerts/config.py
@@ -491,6 +491,51 @@ class MonolingualGlossary(BaseAlert):
 
 
 @register
+class GlossaryStringManagementDisabled(BaseAlert):
+    verbose = gettext_lazy("Glossary string management is disabled")
+    severity = AlertSeverity.WARNING
+    dismissible = True
+    doc_page = "user/glossary"
+    doc_anchor = "glossary-terminology"
+
+    @classmethod
+    def get_url(cls, component: Component) -> str:
+        return (
+            reverse("settings", kwargs={"path": component.get_url_path()})
+            + "#translation"
+        )
+
+    def get_context(self, user: User) -> dict[str, Any]:
+        result = super().get_context(user)
+        component = self.instance.component
+        result.update(
+            local_glossary=component.repo == "local:",
+            can_configure=self.can_user_act(user, component),
+            configure_url=self.get_url(component),
+        )
+        return result
+
+    @classmethod
+    def get_dismissal_context(cls, component: Component, details: dict) -> dict:
+        return {
+            "details": details,
+            "repo": component.repo,
+            "source_language": component.source_language_id,
+        }
+
+    @staticmethod
+    def check_component(component: Component) -> bool:
+        if not component.is_glossary or component.manage_units:
+            return False
+        if component.repo == "local:":
+            return True
+        return any(
+            "terminology" in source.all_flags
+            for source in component.source_translation.unit_set.iterator()
+        )
+
+
+@register
 class UnusedGlossaryLanguage(MultiAlert):
     verbose = gettext_lazy("Unused glossary language.")
     doc_page = "user/glossary"


### PR DESCRIPTION
Explain why local glossaries cannot add terms and why unmanaged glossaries do not synchronize terminology. Provide a dismissible diagnostic with settings guidance and regression coverage.

Fixes #21048

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
