### PR TITLE
fix(history): preserve language scope in change rendering

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,8 +25,8 @@ Weblate 2026.9.1
 
 .. rubric:: Bug fixes
 
+* Fixed language context and links in change history for scoped :doc:`announcements <admin/announcements>` and other language-specific events.
 * Restored :ref:`mt-deepl` API v1 translation support while retaining modern API language discovery and glossary improvements.
-
 * REST API unit updates now enforce the same translation text length limit as the web editor.
 * HTML void elements in :ref:`mdx` translations are now kept self-closing after sanitization, preventing invalid MDX output.
 * The :http:post:`autotranslate API endpoint </api/translations/(string:project)/(string:component)/(string:language)/autotranslate/>` now correctly describes its accepted request body fields (``q``, ``mode``, ``auto_source``, ``component``, ``engines``, ``threshold``) in the OpenAPI schema instead of incorrectly reflecting the Translation resource.

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -824,7 +824,7 @@ class Change(models.Model, UserDisplayMixin):
         if self.component is not None:
             if self.language is not None:
                 translation = self.component.translation_set.filter(
-                    language_id=self.language_id
+                    language=self.language
                 ).first()
                 if translation is not None:
                     translation.component = self.component

--- a/weblate/trans/models/change.py
+++ b/weblate/trans/models/change.py
@@ -16,6 +16,7 @@ from django.db.models import Count, F, OuterRef, Q, Subquery
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy
 from rapidfuzz.distance import DamerauLevenshtein
 
@@ -37,6 +38,7 @@ from weblate.trans.util import split_plural
 from weblate.utils.const import WEBLATE_UUID_NAMESPACE
 from weblate.utils.decorators import disable_for_loaddata
 from weblate.utils.state import StringState
+from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.utils.tracing import start_span
 
 if TYPE_CHECKING:
@@ -780,16 +782,8 @@ class Change(models.Model, UserDisplayMixin):
             return self.unit.get_absolute_url()
         if self.screenshot is not None:
             return self.screenshot.get_absolute_url()
-        if self.translation is not None:
-            return self.translation.get_absolute_url()
-        if self.component is not None:
-            return self.component.get_absolute_url()
-        if self.category is not None:
-            return self.category.get_absolute_url()
-        if self.project is not None:
-            return self.project.get_absolute_url()
-        if self.workspace is not None:
-            return self.workspace.get_absolute_url()
+        if self.path_object is not None:
+            return self.path_object.get_absolute_url()
         return "/"
 
     def log_event(self) -> None:
@@ -810,19 +804,43 @@ class Change(models.Model, UserDisplayMixin):
             else:
                 LOGGER.info("%s", message)
 
-    @property
+    @cached_property
     def path_object(
         self,
-    ) -> Translation | Component | Category | Project | Workspace | None:
+    ) -> (
+        Translation
+        | Component
+        | Category
+        | Project
+        | Workspace
+        | ProjectLanguage
+        | CategoryLanguage
+        | Language
+        | None
+    ):
         """Object linked from the change path."""
         if self.translation is not None:
             return self.translation
         if self.component is not None:
+            if self.language is not None:
+                translation = self.component.translation_set.filter(
+                    language_id=self.language_id
+                ).first()
+                if translation is not None:
+                    translation.component = self.component
+                    translation.language = self.language
+                    return translation
             return self.component
         if self.category is not None:
+            if self.language is not None:
+                return CategoryLanguage(self.category, self.language)
             return self.category
         if self.project is not None:
+            if self.language is not None:
+                return ProjectLanguage(self.project, self.language)
             return self.project
+        if self.language is not None:
+            return self.language
         if self.workspace is not None:
             return self.workspace
         return None

--- a/weblate/trans/tests/test_changes.py
+++ b/weblate/trans/tests/test_changes.py
@@ -4,18 +4,121 @@
 
 """Tests for changes browsing."""
 
+from __future__ import annotations
+
 from datetime import timedelta
 from html import escape
+from typing import cast
+from unittest.mock import patch
 
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import urlencode
 
+from weblate.lang.models import Language
+from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.feeds import ChangeFeedScope, TranslationChangesFeed
-from weblate.trans.models import Change, Project, Unit
+from weblate.trans.models import Announcement, Change, Project, Translation, Unit
+from weblate.trans.templatetags.translations import format_last_changes_content
 from weblate.trans.tests.test_views import FixtureTestCase, ViewTestCase
+from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.utils.xml import parse_xml
+
+
+class ChangeScopeTest(ViewTestCase):
+    def test_language_scoped_history(self) -> None:
+        language = self.translation.language
+        category = self.create_category(self.project)
+        scopes: tuple[
+            tuple[
+                dict[str, object],
+                ProjectLanguage | Translation | CategoryLanguage | Language,
+            ],
+            ...,
+        ] = (
+            ({"project": self.project}, ProjectLanguage(self.project, language)),
+            (
+                {"project": self.project, "component": self.component},
+                self.translation,
+            ),
+            ({"category": category}, CategoryLanguage(category, language)),
+            ({}, language),
+        )
+        for scope, expected in scopes:
+            for action in (ActionEvents.ANNOUNCEMENT, ActionEvents.COMMENT):
+                with self.subTest(scope=scope, action=action):
+                    if action == ActionEvents.ANNOUNCEMENT:
+                        announcement = Announcement.objects.create(
+                            language=language, message="Scoped announcement", **scope
+                        )
+                        change = Change.objects.get(announcement=announcement)
+                    else:
+                        change = Change(action=action, language=language, **scope)
+                    self.assertIsNone(change.translation_id)
+                    content = render_to_string(
+                        "snippets/last-changes-content.html",
+                        format_last_changes_content([change], self.user),
+                    )
+                    url = expected.get_absolute_url()
+                    self.assertInHTML(
+                        f'<li class="breadcrumb-item"><a href="{url}">{escape(str(language))}</a></li>',
+                        content,
+                    )
+                    self.assertIn(f'href="{url}"\n', content)
+                    self.assertEqual(change.get_absolute_url(), url)
+                    self.assertIsNone(change.translation_id)
+
+    def test_component_language_resolution_is_cached(self) -> None:
+        Translation.objects.filter(pk=self.translation.pk).update(
+            language_code="custom"
+        )
+        change = Change(component=self.component, language=self.translation.language)
+        with self.assertNumQueries(1):
+            resolved = change.path_object
+        self.assertEqual(resolved, self.translation)
+        self.assertEqual(cast("Translation", resolved).language_code, "custom")
+        expected_url = self.translation.get_absolute_url()
+        with self.assertNumQueries(0):
+            self.assertIs(change.path_object, resolved)
+            self.assertEqual(change.get_absolute_url(), expected_url)
+        self.assertIsNone(change.translation_id)
+
+    def test_missing_translation_falls_back_to_component(self) -> None:
+        language = Language.objects.exclude(
+            pk__in=self.component.translation_set.values("language_id")
+        ).first()
+        self.assertIsNotNone(language)
+        change = Change(component=self.component, language=language)
+        self.assertEqual(change.path_object, self.component)
+        self.assertEqual(change.get_absolute_url(), self.component.get_absolute_url())
+
+    def test_existing_destinations(self) -> None:
+        category = self.create_category(self.project)
+        for field, obj in (
+            ("translation", self.translation),
+            ("component", self.component),
+            ("category", category),
+            ("project", self.project),
+        ):
+            with self.subTest(field=field):
+                change = Change(**{field: obj})
+                self.assertEqual(change.path_object, obj)
+                self.assertEqual(change.get_absolute_url(), obj.get_absolute_url())
+        self.assertEqual(Change().get_absolute_url(), "/")
+
+    def test_detail_destinations_take_precedence(self) -> None:
+        change = Change(translation=self.translation)
+        for field, model in (("unit", Unit), ("screenshot", Screenshot)):
+            with self.subTest(field=field):
+                detail = model()
+                setattr(change, field, detail)
+                with patch.object(
+                    detail, "get_absolute_url", return_value=f"/{field}/"
+                ):
+                    self.assertEqual(change.get_absolute_url(), f"/{field}/")
+                setattr(change, field, None)
 
 
 class FeedQueriesTest(FixtureTestCase):


### PR DESCRIPTION
Resolve language-scoped history contexts for breadcrumbs and details links so announcements lead to the page where they are visible. Reuse the resolved context and fall back safely when a translation no longer exists.

Fixes #21340

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
