### PR TITLE
fix(checks): render ellipsis examples as inline code

### DIFF
--- a/docs/snippets/checks-autogenerated.rst
+++ b/docs/snippets/checks-autogenerated.rst
@@ -1542,7 +1542,7 @@ pixels:
 Mismatched \\n
 ~~~~~~~~~~~~~~
 
-:Summary: Number of \\n literals in translation does not match source.
+:Summary: Number of ``\n`` literals in translation does not match source.
 :Scope: translated strings
 :Check class: ``weblate.checks.chars.EscapedNewlineCountingCheck``
 :Check identifier: ``escaped_newline``
@@ -1809,7 +1809,7 @@ Non‑standard characters in Kabyle
 
 .. versionadded:: 5.12
 
-:Summary: Use standardized Latin Kabyle characters (e.g. ɣ instead of Greek γ; ɛ instead of ε).
+:Summary: Use standardized Latin Kabyle characters (e.g. ``ɣ`` instead of Greek ``γ``; ``ɛ`` instead of ``ε``).
 :Scope: translated strings
 :Check class: ``weblate.checks.chars.KabyleCharactersCheck``
 :Check identifier: ``kabyle-characters``
@@ -2352,7 +2352,7 @@ Source checks can help developers improve the quality of source strings.
 Ellipsis
 ~~~~~~~~
 
-:Summary: The string uses three dots ``(...)`` instead of an ellipsis character ``(…)``.
+:Summary: The string uses three dots ``...`` instead of an ellipsis character ``…``.
 :Scope: source strings
 :Check class: ``weblate.checks.source.EllipsisCheck``
 :Check identifier: ``ellipsis``

--- a/weblate/checks/base.py
+++ b/weblate/checks/base.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 import re
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from html import unescape
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 
 from django.http import Http404
-from django.utils.html import format_html, format_html_join
-from django.utils.safestring import mark_safe
+from django.utils.html import escape, format_html, format_html_join, strip_tags
+from django.utils.safestring import SafeData, mark_safe
 from django.utils.translation import gettext
 from lxml import etree
 from siphashc import siphash
@@ -25,6 +26,7 @@ from weblate.utils.xml import parse_xml
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable
 
+    from django.utils.safestring import SafeString
     from django_stubs_ext import StrOrPromise
 
     from weblate.auth.models import AuthenticatedHttpRequest, User
@@ -254,6 +256,19 @@ class BaseCheck(ClassLoaderProtocol, DocVersionsMixin):
     def get_description(self, check_obj: Check) -> StrOrPromise:
         return self.description
 
+    def get_plain_description(self, check_obj: Check) -> str:
+        """Return description text suitable for an escaped HTML attribute."""
+        description = str(self.get_description(check_obj))
+        if isinstance(description, SafeData):
+            # Dynamic checks separate individual errors with HTML line breaks.
+            description = re.sub(r"<br\s*/?>", "\n", description, flags=re.IGNORECASE)
+            return unescape(strip_tags(description))
+        return description
+
+    def get_documentation_description(self) -> str:
+        """Return the description formatted for reStructuredText documentation."""
+        return str(self.description).replace("\\", "\\\\")
+
     def get_fixup(self, unit: Unit) -> Iterable[FixupType] | None:
         return None
 
@@ -298,6 +313,38 @@ class BaseCheck(ClassLoaderProtocol, DocVersionsMixin):
 
         return lambda text: pattern.sub(
             lambda m: replacements[m.group(0)], replacement(text)
+        )
+
+
+class CodeDescriptionMixin(BaseCheck):
+    """Render literal examples for HTML, plain text, and documentation."""
+
+    description_template: StrOrPromise
+    description_values: ClassVar[dict[str, str]]
+
+    def get_description(self, check_obj: Check) -> SafeString:
+        return format_html(
+            escape(self.description_template),
+            **{
+                key: format_html("<code>{}</code>", value)
+                for key, value in self.description_values.items()
+            },
+        )
+
+    def get_plain_description(self, check_obj: Check) -> str:
+        return str(self.description_template).format(**self.description_values)
+
+    def get_documentation_description(self) -> str:
+        # Backslashes are literal inside RST inline code, unlike surrounding prose.
+        return (
+            str(self.description_template)
+            .replace("\\", "\\\\")
+            .format(
+                **{
+                    key: f"``{value}``"
+                    for key, value in self.description_values.items()
+                }
+            )
         )
 
 

--- a/weblate/checks/chars.py
+++ b/weblate/checks/chars.py
@@ -11,9 +11,15 @@ from typing import TYPE_CHECKING, ClassVar
 
 import regex
 from django.utils.html import format_html
+from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy, ngettext
 
-from weblate.checks.base import CountingCheck, TargetCheck, TargetCheckParametrized
+from weblate.checks.base import (
+    CodeDescriptionMixin,
+    CountingCheck,
+    TargetCheck,
+    TargetCheckParametrized,
+)
 from weblate.checks.markup import strip_entities
 from weblate.checks.parser import single_value_flag
 from weblate.checks.utils import highlight_string
@@ -181,14 +187,22 @@ class BeginSpaceCheck(TargetCheck):
         return [("regex", "^ *", replacement, "u")]
 
 
-class KabyleCharactersCheck(TargetCheck):
+class KabyleCharactersCheck(CodeDescriptionMixin, TargetCheck):
     """Flag and suggest standard Kabyle characters instead of visually similar but incorrect ones."""
 
     check_id = "kabyle-characters"
     name = gettext_lazy("Non‑standard characters in Kabyle")
-    description = gettext_lazy(
-        "Use standardized Latin Kabyle characters (e.g. ɣ instead of Greek γ; ɛ instead of ε)."
+    # Translators: placeholders are Latin and Greek character examples, formatted for display.
+    description_template = gettext_lazy(
+        "Use standardized Latin Kabyle characters (e.g. {latin_gamma} instead of Greek {greek_gamma}; {latin_epsilon} instead of {greek_epsilon})."
     )
+    description_values: ClassVar[dict[str, str]] = {
+        "latin_gamma": "ɣ",
+        "greek_gamma": "γ",
+        "latin_epsilon": "ɛ",
+        "greek_epsilon": "ε",
+    }
+    description = format_lazy(description_template, **description_values)
     version_added = "5.12"
 
     confusable_to_standard: ClassVar[dict[str, str]] = {
@@ -486,15 +500,18 @@ class EndEllipsisCheck(TargetCheck):
         return self.check_chars(source, target, -1, {"…"})
 
 
-class EscapedNewlineCountingCheck(CountingCheck):
+class EscapedNewlineCountingCheck(CodeDescriptionMixin, CountingCheck):
     r"""Check whether there is same amount of escaped \n strings."""
 
     string = "\\n"
     check_id = "escaped_newline"
     name = gettext_lazy("Mismatched \\n")
-    description = gettext_lazy(
-        "Number of \\n literals in translation does not match source."
+    # Translators: newline is a literal backslash followed by n, formatted for display.
+    description_template = gettext_lazy(
+        "Number of {newline} literals in translation does not match source."
     )
+    description_values: ClassVar[dict[str, str]] = {"newline": r"\n"}
+    description = format_lazy(description_template, **description_values)
 
     ignore_re = re.compile(r"[A-Z]:\\\\[^\\ ]+(\\[^\\ ]+)+")
 

--- a/weblate/checks/management/commands/list_checks.py
+++ b/weblate/checks/management/commands/list_checks.py
@@ -93,7 +93,8 @@ class Command(DocGeneratorCommand):
             lines.append("~" * len(name))
         if version_lines := check.get_versions_rst_lines():
             lines.extend(version_lines)
-        lines.extend(("", f":Summary: {escape(check.description)}"))
+        description = check.get_documentation_description()
+        lines.extend(("", f":Summary: {description}"))
         if scope := get_scope(check):
             lines.append(f":Scope: {scope}")
         lines.extend(

--- a/weblate/checks/models.py
+++ b/weblate/checks/models.py
@@ -123,6 +123,11 @@ class Check(models.Model):
             return self.check_obj.get_description(self)
         return self.name
 
+    def get_plain_description(self) -> str:
+        if self.check_obj:
+            return self.check_obj.get_plain_description(self)
+        return self.name
+
     def get_fixup(self) -> Iterable[FixupType] | None:
         if self.check_obj:
             return self.check_obj.get_fixup(self.unit)

--- a/weblate/checks/source.py
+++ b/weblate/checks/source.py
@@ -7,14 +7,15 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from django.db.models import Count, F, Q
 from django.utils import timezone
 from django.utils.html import format_html, format_html_join
+from django.utils.text import format_lazy
 from django.utils.translation import gettext, gettext_lazy
 
-from weblate.checks.base import BatchCheckMixin, SourceCheck
+from weblate.checks.base import BatchCheckMixin, CodeDescriptionMixin, SourceCheck
 from weblate.utils.html import format_html_join_comma
 from weblate.utils.state import FUZZY_STATES, STATE_EMPTY
 
@@ -42,14 +43,17 @@ class OptionalPluralCheck(SourceCheck):
         return len(PLURAL_MATCH.findall(sources[0])) > 0
 
 
-class EllipsisCheck(SourceCheck):
+class EllipsisCheck(CodeDescriptionMixin, SourceCheck):
     """Check for using "..." instead of "…"."""
 
     check_id = "ellipsis"
     name = gettext_lazy("Ellipsis")
-    description = gettext_lazy(
-        "The string uses three dots ``(...)`` instead of an ellipsis character ``(…)``."
+    # Translators: dots and ellipsis are punctuation examples, formatted for display.
+    description_template = gettext_lazy(
+        "The string uses three dots {dots} instead of an ellipsis character {ellipsis}."
     )
+    description_values: ClassVar[dict[str, str]] = {"dots": "...", "ellipsis": "…"}
+    description = format_lazy(description_template, **description_values)
 
     def check_source_unit(self, sources: list[str], unit: Unit):
         return "..." in sources[0]

--- a/weblate/checks/tests/test_chars_checks.py
+++ b/weblate/checks/tests/test_chars_checks.py
@@ -4,6 +4,9 @@
 
 """Tests for char based quality checks."""
 
+from __future__ import annotations
+
+from django.template import Context, Template
 from django.test import SimpleTestCase
 
 from weblate.checks.chars import (
@@ -30,8 +33,38 @@ from weblate.checks.chars import (
     PunctuationSpacingCheck,
     ZeroWidthSpaceCheck,
 )
+from weblate.checks.models import Check
 from weblate.checks.tests.test_checks import CheckTestCase
 from weblate.trans.tests.factories import make_check, make_unit
+
+
+class CharacterDescriptionTest(SimpleTestCase):
+    def test_rendering_contexts(self) -> None:
+        for name, plain, html in (
+            (
+                "escaped_newline",
+                r"Number of \n literals in translation does not match source.",
+                r"Number of <code>\n</code> literals in translation does not match source.",
+            ),
+            (
+                "kabyle-characters",
+                "Use standardized Latin Kabyle characters (e.g. ɣ instead of Greek γ; ɛ instead of ε).",
+                "Use standardized Latin Kabyle characters (e.g. <code>ɣ</code> instead of Greek <code>γ</code>; <code>ɛ</code> instead of <code>ε</code>).",
+            ),
+        ):
+            with self.subTest(check=name):
+                check = Check(name=name)
+                context = Context({"check": check})
+                self.assertEqual(
+                    Template("{{ check.get_description }}").render(context), html
+                )
+                self.assertEqual(check.get_plain_description(), plain)
+                self.assertEqual(
+                    Template(
+                        '<span title="{{ check.get_plain_description|force_escape }}"></span>'
+                    ).render(context),
+                    f'<span title="{plain}"></span>',
+                )
 
 
 class AcceleratorKeyCheckTest(CheckTestCase):

--- a/weblate/checks/tests/test_commands.py
+++ b/weblate/checks/tests/test_commands.py
@@ -4,12 +4,18 @@
 
 """Test for management commands."""
 
+from __future__ import annotations
+
 from io import StringIO
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import SimpleTestCase
 
+from weblate.checks.chars import EscapedNewlineCountingCheck, KabyleCharactersCheck
+from weblate.checks.management.commands.list_checks import Command
+from weblate.checks.source import EllipsisCheck, OptionalPluralCheck
 from weblate.trans.tests.test_commands import WeblateComponentCommandTestCase
 from weblate.trans.tests.test_models import RepoTestCase
 
@@ -31,6 +37,40 @@ class UpdateChecksTest(WeblateComponentCommandTestCase):
 
 
 class ListTestCase(SimpleTestCase):
+    def test_character_summaries(self) -> None:
+        for check, summary in (
+            (
+                EscapedNewlineCountingCheck(),
+                r":Summary: Number of ``\n`` literals in translation does not match source.",
+            ),
+            (
+                KabyleCharactersCheck(),
+                ":Summary: Use standardized Latin Kabyle characters (e.g. ``ɣ`` instead of Greek ``γ``; ``ɛ`` instead of ``ε``).",
+            ),
+        ):
+            with self.subTest(check=check.check_id):
+                self.assertIn(summary, Command().build_check_section(check))
+
+    def test_ellipsis_summary(self) -> None:
+        self.assertIn(
+            ":Summary: The string uses three dots ``...`` instead of an ellipsis character ``…``.",
+            Command().build_check_section(EllipsisCheck()),
+        )
+
+    def test_summary_escaping(self) -> None:
+        check = OptionalPluralCheck()
+        for description, expected in (
+            ("Plain description.", "Plain description."),
+            (r"Use \n.", r"Use \\n."),
+        ):
+            with (
+                self.subTest(description=description),
+                patch.object(check, "description", description),
+            ):
+                self.assertIn(
+                    f":Summary: {expected}", Command().build_check_section(check)
+                )
+
     def test_list_checks(self) -> None:
         output = StringIO()
         call_command("list_checks", stdout=output)

--- a/weblate/checks/tests/test_models.py
+++ b/weblate/checks/tests/test_models.py
@@ -4,6 +4,8 @@
 
 """Tests for unitdata models."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -27,6 +29,36 @@ from weblate.utils.lock import WeblateLock
 
 
 class CheckLintTestCase(SimpleTestCase):
+    def test_plain_description(self) -> None:
+        check = Check(name="same")
+        for description, expected in (
+            ("Plain <tag> &amp; text.", "Plain <tag> &amp; text."),
+            (
+                format_html("Use <code>{}</code>.", '<tag> & "quote"'),
+                'Use <tag> & "quote".',
+            ),
+            (
+                format_html(
+                    "{}<br />{}<br>{}<BR/>{}", "First", "Second", "Third", "Fourth"
+                ),
+                "First\nSecond\nThird\nFourth",
+            ),
+            (
+                format_html("<code>{}</code>", "<br />"),
+                "<br />",
+            ),
+        ):
+            with (
+                self.subTest(description=description),
+                patch.object(
+                    check.check_obj, "get_description", return_value=description
+                ),
+            ):
+                self.assertEqual(check.get_plain_description(), expected)
+
+    def test_unknown_plain_description(self) -> None:
+        self.assertEqual(Check(name="-unknown-").get_plain_description(), "-unknown-")
+
     def test_check_id(self) -> None:
         for check in CHECKS.values():
             self.assertRegex(check.check_id, r"^[a-z][a-z0-9_-]*[a-z]$")

--- a/weblate/checks/tests/test_placeholders.py
+++ b/weblate/checks/tests/test_placeholders.py
@@ -72,6 +72,11 @@ class PlaceholdersTest(CheckTestCase):
             <span class="hlcheck" data-value="$FOO$">$FOO$</span>
             """,
         )
+        self.assertEqual(
+            self.check.get_plain_description(check),
+            "The following format strings are missing: $URL$\n"
+            "The following format strings are extra: $FOO$",
+        )
 
     def test_whitespace(self) -> None:
         unit = make_unit(

--- a/weblate/checks/tests/test_source_checks.py
+++ b/weblate/checks/tests/test_source_checks.py
@@ -4,9 +4,13 @@
 
 """Tests for source checks."""
 
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import cast
+from unittest.mock import patch
 
+from django.template import Context, Template
 from django.test import TestCase
 from django.utils import timezone
 
@@ -50,6 +54,42 @@ class EllipsisCheckTest(TestCase):
 
     def test_failing(self) -> None:
         self.assertTrue(self.check.check_source(["text..."], make_unit()))
+
+    def test_description_html(self) -> None:
+        check = Check(name="ellipsis")
+        rendered = Template("{{ check.get_description }}").render(
+            Context({"check": check})
+        )
+        self.assertEqual(
+            rendered,
+            "The string uses three dots <code>...</code> instead of an ellipsis character <code>…</code>.",
+        )
+
+    def test_description_contexts(self) -> None:
+        check = Check(name="ellipsis")
+        check_obj = cast("EllipsisCheck", check.check_obj)
+        with patch.object(
+            check_obj,
+            "description_template",
+            'Use {ellipsis}, not {dots}: "quotes" & <text>.',
+        ):
+            self.assertEqual(
+                check.get_description(),
+                "Use <code>…</code>, not <code>...</code>: &quot;quotes&quot; &amp; &lt;text&gt;.",
+            )
+            self.assertEqual(
+                check.get_plain_description(), 'Use …, not ...: "quotes" & <text>.'
+            )
+            self.assertEqual(
+                check_obj.get_documentation_description(),
+                'Use ``…``, not ``...``: "quotes" & <text>.',
+            )
+            self.assertEqual(
+                Template(
+                    '<span title="{{ check.get_plain_description|force_escape }}"></span>'
+                ).render(Context({"check": check})),
+                '<span title="Use …, not ...: &quot;quotes&quot; &amp; &lt;text&gt;."></span>',
+            )
 
 
 class SourceMaxLengthCheckTest(TestCase):

--- a/weblate/templates/snippets/suggestions.html
+++ b/weblate/templates/snippets/suggestions.html
@@ -116,7 +116,8 @@
             {% if suggestion_checks %}
               <p class="help-block">{% translate "Failing checks:" context "String state" %}</p>
               {% for check in suggestion_checks %}
-                <span class="badge badge-danger" title="{{ check.get_description }}">{{ check.get_name }}</span>
+                <span class="badge badge-danger"
+                      title="{{ check.get_plain_description|force_escape }}">{{ check.get_name }}</span>
               {% endfor %}
             {% endif %}
           {% endwith %}


### PR DESCRIPTION
Use HTML in the translatable description so the editor renders the punctuation examples correctly. Convert code tags to RST during documentation generation.

Fixes #21325

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
