### PR TITLE
feat(announcements): support category-language pages

### DIFF
--- a/docs/admin/announcements.rst
+++ b/docs/admin/announcements.rst
@@ -41,6 +41,17 @@ Category specified
 
     Shown within the category, including all its components and translations.
 
+Category and language specified
+
+    Shown on the category-language page and for translations in that language
+    within the category and its subcategories. Post these announcements from
+    the category-language page using :guilabel:`Operations` >
+    :guilabel:`Post announcement`.
+    This also applies to shared components linked into the category. Posting
+    and deleting these announcements requires permission for the category's
+    project and language. Announcements from linked categories are only shown
+    to users who can access the category's project.
+
 Component specified
 
     Shown for a given component and all its translations.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Weblate 2026.9.1
 
 .. rubric:: Improvements
 
+* Added posting and displaying scoped :doc:`announcements </admin/announcements>` on category-language pages.
 * Clarified :doc:`incident reporting </security/incident-reporting>`, reporting deadlines, and security notifications for hosted and self-hosted users.
 * The :guilabel:`Manage reports` permission now consistently grants access to complete :doc:`translation reports </devel/reporting>` for the selected scope, including private projects and restricted components below it.
 * Docker deployments now use a combined :ref:`Celery <celery>` worker by default, reducing memory usage while increasing task throughput. Use :envvar:`CELERY_WORKER_MODE` to select the combined, split, or single worker setup.

--- a/weblate/auth/permissions.py
+++ b/weblate/auth/permissions.py
@@ -299,6 +299,24 @@ def check_permission(
     """Check whether user has an object-specific permission."""
     if user.is_superuser:
         return True
+    if isinstance(obj, CategoryLanguage) and permission in {
+        "announcement.add",
+        "announcement.delete",
+    }:
+        # Announcements belong to the category's project, including when its
+        # translations are displayed through links to another project's components.
+        return (
+            check_enforced_2fa(user, obj.project)
+            and _has_project_language_permission(
+                user, permission, obj.project, obj.language.pk
+            )
+            and (
+                permission == "announcement.delete"
+                or obj.language.translation_set.filter(
+                    component_id__in=obj.category.get_component_ids_with_links()
+                ).exists()
+            )
+        )
     if isinstance(obj, (ProjectLanguage, CategoryLanguage)):
         return _check_language_scope_permission(
             user,
@@ -1453,7 +1471,13 @@ def check_billing_component_permissions(
 def check_announcement_delete(
     user: User,
     permission: str,
-    obj: Announcement | Project | ProjectLanguage | Category | Component | None,
+    obj: Announcement
+    | Project
+    | ProjectLanguage
+    | CategoryLanguage
+    | Category
+    | Component
+    | None,
 ) -> bool | PermissionResult:
     if isinstance(obj, Announcement):
         if obj.component_id is not None:
@@ -1466,8 +1490,12 @@ def check_announcement_delete(
                     return False
                 return check_permission(user, permission, translation)
             obj = obj.component
-        elif obj.category_id is not None:
-            obj = obj.category
+        elif obj.category is not None:
+            obj = (
+                CategoryLanguage(obj.category, obj.language)
+                if obj.language is not None
+                else obj.category
+            )
         elif obj.language_id is not None:
             if obj.project_id is not None:
                 obj = ProjectLanguage(obj.project, obj.language)

--- a/weblate/templates/category-language.html
+++ b/weblate/templates/category-language.html
@@ -70,8 +70,16 @@
                href="#">{% translate "Bulk edit" %}</a>
           </li>
         {% endif %}
+        {% if announcement_form %}
+          <li>
+            <a class="dropdown-item"
+               data-bs-target="#announcement"
+               data-bs-toggle="tab"
+               href="#">{% translate "Post announcement" %}</a>
+          </li>
+        {% endif %}
         {% if delete_form %}
-          {% if replace_form or bulk_state_form %}
+          {% if replace_form or bulk_state_form or announcement_form %}
             <li>
               <hr class="dropdown-divider">
             </li>
@@ -94,6 +102,8 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
+
+  {% announcements category=category language=language %}
 
   {% get_translate_url object as translate_url %}
   {% perm 'upload.perform' object as user_can_upload_translation %}
@@ -174,6 +184,31 @@
     {% if user_can_upload_translation %}
       <div class="tab-pane" id="upload">
         {% include "snippets/upload-placeholder.html" with upload_translation_tab="#components" upload_translation_label=_("Browse components") %}
+      </div>
+    {% endif %}
+
+    {% if announcement_form %}
+      <div class="tab-pane" id="announcement">
+        <form action="{% url 'announcement' path=object.get_url_path %}" method="post">
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title">
+                {% documentation_icon 'admin/announcements' right=True %}
+                {% translate "Post announcement" %}
+              </h4>
+            </div>
+            <div class="card-body">
+              {% csrf_token %}
+              {{ announcement_form|crispy }}
+              <p class="help-block">
+                {% translate "The message is shown for all translations in this language within the category and its subcategories, until its given expiry, or permanently until it is deleted." %}
+              </p>
+            </div>
+            <div class="card-footer">
+              <input type="submit" value="{% translate "Add" %}" class="btn btn-primary" />
+            </div>
+          </div>
+        </form>
       </div>
     {% endif %}
 

--- a/weblate/trans/models/announcement.py
+++ b/weblate/trans/models/announcement.py
@@ -94,6 +94,10 @@ class AnnouncementManager(models.Manager["Announcement"]):
 
         if component:
             category_filter = self._category_filter(component.category)
+            for link in component.componentlink_set.exclude(
+                category=None
+            ).select_related("category__category__category"):
+                category_filter |= self._category_filter(link.category)
             project_filter = (
                 Q(project=component.project)
                 & Q(category=None)
@@ -129,14 +133,13 @@ class AnnouncementManager(models.Manager["Announcement"]):
 
         if category:
             category_filter = self._category_filter(category)
+            language_filter = Q(language=None)
+            if language:
+                language_filter |= Q(language=language)
             return base.filter(
-                (category_filter & Q(component=None) & Q(language=None))
-                | (
-                    Q(project=category.project)
-                    & Q(category=None)
-                    & Q(component=None)
-                    & Q(language=None)
-                )
+                (category_filter | (Q(project=category.project) & Q(category=None)))
+                & Q(component=None)
+                & language_filter
             )
 
         if project:

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -419,7 +419,7 @@ def announcements(
                 component=component,
                 language=language,
                 category=category,
-            )
+            ).filter_access(user)
         ),
     )
 

--- a/weblate/trans/tests/test_manage.py
+++ b/weblate/trans/tests/test_manage.py
@@ -14,19 +14,20 @@ from unittest.mock import patch
 from django.core import mail
 from django.db import connection, transaction
 from django.urls import reverse
+from lxml.html import fromstring
 
 from weblate.auth.data import SELECTION_ALL, SELECTION_MANUAL
-from weblate.auth.models import Group, Role
+from weblate.auth.models import Group, Role, TeamMembership
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.forms import ComponentRenameForm
 from weblate.trans.models import Announcement, Category, Component, Project, Translation
-from weblate.trans.models.component import ComponentQuerySet
+from weblate.trans.models.component import ComponentLink, ComponentQuerySet
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.data import data_dir
 from weblate.utils.files import remove_tree
 from weblate.utils.lock import WeblateLockTimeoutError
-from weblate.utils.stats import ProjectLanguage
+from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 from weblate.vcs.base import RepositoryLock
 
 
@@ -770,6 +771,94 @@ class AnnouncementPermissionTestCase(ViewTestCase):
         self.assertEqual(announcement.category, category)
         self.assertIsNone(announcement.project)
 
+    def test_category_language(self) -> None:
+        parent = self.create_category(self.project)
+        category = self.create_category(self.project, category=parent)
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        obj = CategoryLanguage(category, Language.objects.get(code="cs"))
+        url = reverse("announcement", kwargs={"path": obj.get_url_path()})
+
+        response = self.client.get(obj.get_absolute_url())
+        self.assertNotContains(response, 'data-bs-target="#announcement"')
+        self.assertIsNone(response.context["announcement_form"])
+        self.perform_test(url)
+
+        announcement = Announcement.objects.get(message=self.data["message"])
+        self.assertEqual(announcement.category, category)
+        self.assertEqual(announcement.language, obj.language)
+        self.assertIsNone(announcement.project)
+        self.assertIsNone(announcement.component)
+        Announcement.objects.create(
+            category=parent, language=obj.language, message="Inherited announcement"
+        )
+        Announcement.objects.create(
+            project=self.project, message="Project announcement"
+        )
+        Announcement.objects.create(
+            category=category,
+            language=Language.objects.get(code="de"),
+            message="Other language announcement",
+        )
+        response = self.client.get(obj.get_absolute_url())
+        self.assertContains(response, 'data-bs-target="#announcement"')
+        self.assertIsNotNone(response.context["announcement_form"])
+        banners = fromstring(response.content).find_class("announcement")
+        self.assertEqual(len(banners), 3)
+        for banner, message in zip(
+            banners,
+            (self.data["message"], "Inherited announcement", "Project announcement"),
+            strict=True,
+        ):
+            self.assertIn(message, banner.text_content())
+
+    def test_category_language_invalid(self) -> None:
+        self.set_user_permissions()
+        parent = self.create_category(self.project)
+        category = self.create_category(self.project, category=parent)
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        obj = CategoryLanguage(category, Language.objects.get(code="cs"))
+        url = reverse("announcement", kwargs={"path": obj.get_url_path()})
+
+        response = self.client.post(url, {"severity": "warning"})
+
+        self.assertRedirects(response, f"{obj.get_absolute_url()}#announcement")
+        self.assertFalse(Announcement.objects.exists())
+
+    def test_category_language_limited_permissions(self) -> None:
+        category = self.create_category(self.project)
+        self.component.category = category
+        self.component.save(update_fields=["category"])
+        czech = Language.objects.get(code="cs")
+        group = Group.objects.create(
+            name="Czech announcement coordinators",
+            defining_project=self.project,
+            language_selection=SELECTION_MANUAL,
+        )
+        group.roles.add(Role.objects.get(name="Translation coordinator"))
+        group.projects.add(self.project)
+        group.languages.add(czech)
+        group.user_set.add(self.user)
+
+        for language in (Language.objects.get(code="de"), czech):
+            with self.subTest(language=language):
+                obj = CategoryLanguage(category, language)
+                response = self.client.get(obj.get_absolute_url())
+                self.assertEqual(
+                    response.context["announcement_form"] is not None,
+                    language == czech,
+                )
+                response = self.client.post(
+                    reverse("announcement", kwargs={"path": obj.get_url_path()}),
+                    {"message": "Scoped permission test", "severity": "info"},
+                )
+                if language == czech:
+                    self.assertRedirects(response, obj.get_absolute_url())
+                else:
+                    self.assertEqual(response.status_code, 403)
+                    self.assertFalse(Announcement.objects.exists())
+
     def test_delete_announcement(self) -> None:
         second_component = self.create_link_existing()
 
@@ -914,6 +1003,198 @@ class AnnouncementPermissionTestCase(ViewTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Announcement.objects.count(), 0)
+
+
+class CategoryLanguageAnnouncementTest(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.target_project = self.create_project("Shared", "shared")
+        self.parent = self.create_category(self.target_project)
+        self.category = self.create_category(self.target_project, category=self.parent)
+        ComponentLink.objects.create(
+            component=self.component,
+            project=self.target_project,
+            category=self.category,
+        )
+        self.czech = Language.objects.get(code="cs")
+        self.german = Language.objects.get(code="de")
+        self.group = Group.objects.create(
+            name="Category announcement coordinators",
+            defining_project=self.target_project,
+            language_selection=SELECTION_MANUAL,
+        )
+        self.group.roles.add(Role.objects.get(name="Translation coordinator"))
+        self.group.projects.add(self.target_project)
+        self.group.languages.add(self.czech)
+        self.group.user_set.add(self.user)
+
+    def test_shared_category_permissions(self) -> None:
+        obj = CategoryLanguage(self.category, self.czech)
+        self.assertFalse(obj.has_action_translations)
+        self.assertTrue(obj.translation_set)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertContains(response, 'data-bs-target="#announcement"')
+        self.assertIsNotNone(response.context["announcement_form"])
+
+        response = self.client.post(
+            reverse("announcement", kwargs={"path": obj.get_url_path()}),
+            {"message": "Shared category announcement", "severity": "info"},
+            follow=True,
+        )
+        self.assertRedirects(response, obj.get_absolute_url())
+        self.assertContains(response, "Shared category announcement")
+        announcement = Announcement.objects.get(message="Shared category announcement")
+        self.assertEqual(announcement.category, self.category)
+        self.assertEqual(announcement.language, self.czech)
+
+        # Source-project rights do not grant authority over a linking category.
+        self.group.projects.set([self.project])
+        self.user.clear_permissions_cache()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIsNone(response.context["announcement_form"])
+        response = self.client.post(
+            reverse("announcement", kwargs={"path": obj.get_url_path()}),
+            {"message": "Unauthorized announcement", "severity": "info"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(
+            Announcement.objects.filter(message="Unauthorized announcement").exists()
+        )
+        response = self.client.post(
+            reverse("announcement-delete", kwargs={"pk": announcement.pk})
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(Announcement.objects.filter(pk=announcement.pk).exists())
+
+    def test_delete_language_limits(self) -> None:
+        owned_category = self.create_category(self.project)
+        self.component.category = owned_category
+        self.component.save(update_fields=["category"])
+        self.group.projects.add(self.project)
+        membership = TeamMembership.objects.get(user=self.user, group=self.group)
+
+        for limit in ("team", "membership"):
+            if limit == "membership":
+                self.group.language_selection = SELECTION_ALL
+                self.group.save(update_fields=["language_selection"])
+                membership.limit_languages.add(self.czech)
+            for category in (owned_category, self.category):
+                for language in (self.german, self.czech):
+                    with self.subTest(
+                        limit=limit, category=category, language=language
+                    ):
+                        self.user.clear_permissions_cache()
+                        obj = CategoryLanguage(category, language)
+                        announcement = Announcement.objects.create(
+                            category=category,
+                            language=language,
+                            message="Scoped deletion",
+                        )
+                        url = reverse(
+                            "announcement-delete", kwargs={"pk": announcement.pk}
+                        )
+                        response = self.client.get(obj.get_absolute_url())
+                        self.assertEqual(
+                            response.context["announcement_form"] is not None,
+                            language == self.czech,
+                        )
+                        if language == self.czech:
+                            self.assertContains(response, f'data-action="{url}"')
+                        else:
+                            self.assertNotContains(response, f'data-action="{url}"')
+                        response = self.client.post(url)
+                        self.assertEqual(
+                            response.status_code, 200 if language == self.czech else 403
+                        )
+                        self.assertEqual(
+                            Announcement.objects.filter(pk=announcement.pk).exists(),
+                            language != self.czech,
+                        )
+
+    def test_delete_after_last_translation_unlinked(self) -> None:
+        announcements = [
+            Announcement.objects.create(
+                category=self.category,
+                language=language,
+                message="Orphaned announcement",
+            )
+            for language in (self.czech, self.german)
+        ]
+        ComponentLink.objects.filter(category=self.category).delete()
+        obj = CategoryLanguage(self.category, self.czech)
+        self.assertFalse(obj.translation_set)
+
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIsNone(response.context["announcement_form"])
+        response = self.client.post(
+            reverse("announcement", kwargs={"path": obj.get_url_path()}),
+            {"message": "Empty category announcement", "severity": "info"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(
+            Announcement.objects.filter(message="Empty category announcement").exists()
+        )
+
+        for language, announcement in zip(
+            (self.czech, self.german), announcements, strict=True
+        ):
+            with self.subTest(language=language):
+                url = reverse("announcement-delete", kwargs={"pk": announcement.pk})
+                obj = CategoryLanguage(self.category, language)
+                response = self.client.get(obj.get_absolute_url())
+                if language == self.czech:
+                    self.assertContains(response, f'data-action="{url}"')
+                else:
+                    self.assertNotContains(response, f'data-action="{url}"')
+                response = self.client.post(url)
+                allowed = language == self.czech
+                self.assertEqual(response.status_code, 200 if allowed else 403)
+                self.assertEqual(
+                    Announcement.objects.filter(pk=announcement.pk).exists(),
+                    not allowed,
+                )
+
+    def test_linked_translation_announcements(self) -> None:
+        for category in (self.parent, self.category):
+            for language in (None, self.czech, self.german):
+                Announcement.objects.create(
+                    category=category,
+                    language=language,
+                    message=f"Linked category {category.pk} {language}",
+                )
+        expected = [
+            f"Linked category {category.pk} {language}"
+            for category in (self.parent, self.category)
+            for language in (None, self.czech)
+        ]
+        self.assertCountEqual(
+            Announcement.objects.context_filter(
+                component=self.component, language=self.czech
+            ).values_list("message", flat=True),
+            expected,
+        )
+        translation = self.component.translation_set.get(language=self.czech)
+        response = self.client.get(translation.get_absolute_url())
+        banners = fromstring(response.content).find_class("announcement")
+        self.assertEqual(len(banners), len(expected))
+        for banner, message in zip(banners, expected, strict=True):
+            self.assertIn(message, banner.text_content())
+
+        # A link from a private project must not expose its announcements to
+        # users who can only access the original component.
+        self.target_project.access_control = Project.ACCESS_PRIVATE
+        self.target_project.save(update_fields=["access_control"])
+        self.group.user_set.remove(self.user)
+        self.user.clear_permissions_cache()
+        response = self.client.get(translation.get_absolute_url())
+        self.assertFalse(fromstring(response.content).find_class("announcement"))
+
+        self.group.user_set.add(self.user)
+        self.user.clear_permissions_cache()
+        response = self.client.get(translation.get_absolute_url())
+        self.assertEqual(
+            len(fromstring(response.content).find_class("announcement")), len(expected)
+        )
 
 
 class AnnouncementTest(AnnouncementPermissionTestCase):

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -1780,6 +1780,55 @@ class AnnouncementTest(ModelTestCase):
             ["test project"],
         )
 
+    def test_contextfilter_category_language(self) -> None:
+        parent = Category.objects.create(
+            project=self.component.project, name="Parent", slug="parent"
+        )
+        category = self.create_category(self.component.project, category=parent)
+        sibling = Category.objects.create(
+            project=self.component.project, name="Sibling", slug="sibling"
+        )
+        child = self.create_category(self.component.project, category=category)
+        foreign = self.create_category(self.second_project)
+        for scope in (parent, category, sibling, child, foreign):
+            for language in (None, self.czech, self.german):
+                Announcement.objects.create(
+                    category=scope,
+                    language=language,
+                    message=f"category {scope.pk} {language}",
+                )
+        Announcement.objects.create(
+            category=category,
+            language=self.czech,
+            expiry=timezone.now().date() - timedelta(days=1),
+            message="expired category announcement",
+        )
+        Announcement.objects.create(
+            project=self.component.project,
+            component=self.component,
+            language=self.czech,
+            message="component language announcement",
+        )
+
+        for language in (None, self.czech, self.german):
+            with self.subTest(language=language):
+                expected = ["test project"]
+                if language:
+                    expected.append(f"test project {language.code}")
+                expected.extend(
+                    f"category {scope.pk} {scope_language}"
+                    for scope in (parent, category)
+                    for scope_language in ((None, language) if language else (None,))
+                )
+                announcements = Announcement.objects.context_filter(
+                    category=category, language=language
+                )
+                self.assertCountEqual(
+                    [announcement.message for announcement in announcements], expected
+                )
+                ids = [announcement.pk for announcement in announcements]
+                self.assertEqual(ids, sorted(ids))
+
     def test_contextfilter_component(self) -> None:
         self.assertCountEqual(
             [

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -429,6 +429,9 @@ def show_category_language(
                 for category in obj.category.category_set.all()
             ),
             "title": f"{category_object} - {language_object}",
+            "announcement_form": optional_form(
+                AnnouncementForm, user, "announcement.add", obj
+            ),
             "search_form": SearchForm(
                 request=request,
                 language=language_object,

--- a/weblate/trans/views/settings.py
+++ b/weblate/trans/views/settings.py
@@ -535,7 +535,9 @@ def component_link_categories(request: AuthenticatedHttpRequest, path):
 @require_POST
 async def announcement(request: AuthenticatedHttpRequest, path):
     obj = await aparse_path(
-        request, path, (ProjectLanguage, Translation, Component, Project, Category)
+        request,
+        path,
+        (ProjectLanguage, CategoryLanguage, Translation, Component, Project, Category),
     )
 
     if not await sync_to_async(request.user.has_perm)("announcement.add", obj):
@@ -544,12 +546,15 @@ async def announcement(request: AuthenticatedHttpRequest, path):
     form = AnnouncementForm(request.POST)
     if not form.is_valid():
         show_form_errors(request, form)
-        return redirect_param(obj, "#announcement")
+        return await sync_to_async(redirect_param)(obj, "#announcement")
 
     # Scope specific attributes
     scope = {}
     if isinstance(obj, ProjectLanguage):
         scope["project"] = obj.project
+        scope["language"] = obj.language
+    elif isinstance(obj, CategoryLanguage):
+        scope["category"] = obj.category
         scope["language"] = obj.language
     elif isinstance(obj, Category):
         scope["category"] = obj
@@ -569,7 +574,8 @@ async def announcement(request: AuthenticatedHttpRequest, path):
         **form.cleaned_data,
     )
 
-    return redirect(obj)
+    # Resolving nested category URLs can load ancestors from the database.
+    return redirect(await sync_to_async(obj.get_absolute_url)())
 
 
 @login_required


### PR DESCRIPTION
    
    
Allow users to post and view announcements scoped to a category and language. Include inherited announcements, enforce scoped permissions, and resolve nested-category redirects safely in the async posting view.



<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
