### PR TITLE
fix(uwsgi): configure Python executable for helper processes

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -1383,6 +1383,15 @@ Configuration for uWSGI (:file:`weblate/examples/weblate.uwsgi.ini` in the sourc
 .. literalinclude:: ../../weblate/examples/weblate.uwsgi.ini
     :language: ini
 
+Set ``py-executable`` to the absolute path of :file:`bin/python` inside the
+environment configured by ``virtualenv``. Weblate uses Python's
+``sys.executable`` to launch helper processes, including the SSH connection
+proxy used for Git repositories. uWSGI can otherwise set this value to its own
+executable, causing repository operations to fail with an error such as
+``/usr/bin/uwsgi-core: invalid option -- 'I'``. Setting ``virtualenv`` alone does
+not ensure that ``sys.executable`` points to Python. Restart uWSGI after updating
+the configuration.
+
 .. seealso::
 
     :doc:`django:howto/deployment/wsgi/uwsgi`

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Weblate 2026.9.1
 
 .. rubric:: Bug fixes
 
+* Fixed the :ref:`uWSGI configuration example <uwsgi>` to use the virtual environment's Python when launching helpers for SSH repository operations.
 * Fixed language context and links in change history for scoped :doc:`announcements <admin/announcements>` and other language-specific events.
 * Restored :ref:`mt-deepl` API v1 translation support while retaining modern API language discovery and glossary improvements.
 * REST API unit updates now enforce the same translation text length limit as the web editor.

--- a/weblate/examples/weblate.uwsgi.ini
+++ b/weblate/examples/weblate.uwsgi.ini
@@ -22,6 +22,9 @@ wsgi-file     = /home/weblate/weblate-env/lib/python3.12/site-packages/weblate/w
 # Path to the Python environment
 virtualenv = /home/weblate/weblate-env
 
+# Set sys.executable so Python helpers run with the virtual environment's Python
+py-executable = /home/weblate/weblate-env/bin/python
+
 # Needed for OAuth/OpenID
 buffer-size   = 8192
 


### PR DESCRIPTION
Set py-executable to the virtual environment Python so SSH helpers do not invoke the uWSGI binary. Document why virtualenv alone is insufficient and how to update existing installations.

Fixes #21497

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
