### PR TITLE
perf(stats): aggregate translation statistics in SQL

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.9.1
 
 * :ref:`Docker development tests <dev-docker>` now automatically prepare an isolated test environment without requiring application startup or the Dev Container CLI.
 * Added a :ref:`development container <devcontainer>` for tests and lint, with an optional :ref:`application QA profile <dev-docker>`, isolated storage per Git worktree, dynamically allocated localhost application and mailbox ports, and Chromium diagnostics and mandatory browser test commands.
+* Improved :ref:`translation statistics <stats>` calculation performance and avoided redundant parent updates when loading check and label details.
 * Added posting and displaying scoped :doc:`announcements </admin/announcements>` on category-language pages.
 * Added a dismissible diagnostic for :ref:`glossaries <glossary-terminology>` with disabled string management when they use a local repository or contain terminology.
 

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -4,11 +4,15 @@
 
 """Test for translation models."""
 
+from __future__ import annotations
+
 import importlib
 import os
 from contextlib import ExitStack
 from datetime import timedelta
+from itertools import product
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 from asgiref.sync import async_to_sync
@@ -78,10 +82,19 @@ from weblate.utils.state import (
     STATE_NEEDS_REWRITING,
     STATE_READONLY,
     STATE_TRANSLATED,
+    StringState,
 )
-from weblate.utils.stats import CategoryLanguage, GlobalStats, ProjectLanguage
+from weblate.utils.stats import (
+    CategoryLanguage,
+    GlobalStats,
+    ProjectLanguage,
+    TranslationStats,
+)
 from weblate.utils.version import GIT_VERSION
 from weblate.workspaces.models import Workspace
+
+if TYPE_CHECKING:
+    from weblate.utils.stats import UnitSnapshot
 
 
 class BaseTestCase(TestCase):
@@ -839,6 +852,179 @@ class TranslationTest(RepoTestCase):
         ):
             self.assertIn(f'FROM "{table}"', unit_query)
             self.assertNotIn(f'JOIN "{table}"', unit_query)
+
+    def test_grouped_stats_match_unit_buckets(self) -> None:
+        component = self.create_component()
+        translation = component.translation_set.get(language_code="cs")
+        translation.unit_set.all().delete()
+        label = component.project.label_set.create(name="Grouped", color="red")
+        units: list[Unit] = []
+        snapshots: list[UnitSnapshot] = []
+        expected = dict.fromkeys(TranslationStats.UNIT_DELTA_KEYS, 0)
+        for state in StringState:
+            for flags in range(32):
+                # Different sizes in the same group catch accidental multiplication
+                # of word/character sums by the number of strings.
+                for source, words in (("", 0), ("Žluťoučký 🐈", 2), ("one\x1emany", 3)):
+                    snapshot: UnitSnapshot = {
+                        "state": state,
+                        "num_words": words,
+                        "num_chars": len(source),
+                        "active_checks_count": flags & 1,
+                        "dismissed_checks_count": flags & 2,
+                        "suggestion_count": flags & 4,
+                        "label_count": flags & 8,
+                        "comment_count": flags & 16,
+                    }
+                    snapshots.append(snapshot)
+                    for key, value in TranslationStats.snapshot_to_bucket(
+                        snapshot
+                    ).items():
+                        expected[key] += value
+                    units.append(
+                        Unit(
+                            translation=translation,
+                            id_hash=len(units),
+                            position=len(units),
+                            source=source,
+                            num_words=words,
+                            state=state,
+                        )
+                    )
+        Unit.objects.bulk_create(units)
+        for unit in units:
+            unit.source_unit = unit
+        Unit.objects.bulk_update(units, ["source_unit"])
+        checks = []
+        suggestions = []
+        comments = []
+        labels = []
+        for unit, snapshot in zip(units, snapshots, strict=True):
+            for dismissed, present in (
+                (False, snapshot["active_checks_count"]),
+                (True, snapshot["dismissed_checks_count"]),
+            ):
+                if present:
+                    checks.append(
+                        Check(
+                            unit=unit,
+                            name="ellipsis" if dismissed else "same",
+                            dismissed=dismissed,
+                        )
+                    )
+            if snapshot["suggestion_count"]:
+                suggestions.append(Suggestion(unit=unit, target="Suggestion"))
+            if snapshot["comment_count"]:
+                comments.append(Comment(unit=unit, comment="Comment"))
+            if snapshot["label_count"]:
+                labels.append(Unit.labels.through(unit_id=unit.pk, label_id=label.pk))
+        Check.objects.bulk_create(checks)
+        Suggestion.objects.bulk_create(suggestions)
+        Comment.objects.bulk_create(comments)
+        Unit.labels.through.objects.bulk_create(labels)
+
+        stats = TranslationStats(translation)
+        stats.calculate_basic()
+        self.assertEqual({key: stats.aggregate_get(key) for key in expected}, expected)
+
+    def test_detail_stats_save_without_updating_parents(self) -> None:
+        component = self.create_component()
+        translation = component.translation_set.get(language_code="cs")
+        component.project.label_set.create(name="Detail", color="red")
+        for lazy, eager, (name, method), direct in product(
+            (False, True),
+            (False, True),
+            (("check:same", "calculate_checks"), ("label:Detail", "calculate_labels")),
+            (False, True),
+        ):
+            with (
+                self.subTest(lazy=lazy, eager=eager, name=name, direct=direct),
+                override_settings(STATS_LAZY=lazy, CELERY_TASK_ALWAYS_EAGER=eager),
+            ):
+                stats = TranslationStats(translation)
+                stats.clear()
+                stats.calculate_basic()
+                stats.save(update_parents=False)
+                stats = TranslationStats(translation)
+                with (
+                    patch.object(stats, "save", wraps=stats.save) as save,
+                    patch.object(stats, "update_parents") as parents,
+                    patch(
+                        "weblate.utils.tasks.update_translation_stats_parents.delay_on_commit"
+                    ) as task,
+                    self.captureOnCommitCallbacks(execute=True),
+                ):
+                    if direct:
+                        getattr(stats, method)()
+                    else:
+                        getattr(stats, name)
+                    save.assert_called_once_with(update_parents=False)
+                    with self.assertNumQueries(0):
+                        getattr(stats, name)
+                    save.assert_called_once()
+                parents.assert_not_called()
+                task.assert_not_called()
+
+    def test_basic_stats_miss_still_updates_parents(self) -> None:
+        component = self.create_component()
+        translation = component.translation_set.get(language_code="cs")
+        for lazy in (False, True):
+            with self.subTest(lazy=lazy), override_settings(STATS_LAZY=lazy):
+                stats = TranslationStats(translation)
+                stats.delete()
+                with (
+                    patch.object(stats, "save", wraps=stats.save) as save,
+                    patch.object(stats, "update_parents") as parents,
+                    self.captureOnCommitCallbacks(execute=True),
+                ):
+                    self.assertGreater(stats.all, 0)
+                save.assert_called_once_with()
+                parents.assert_called_once_with()
+
+    def test_parent_details_are_lazy_and_invalidated(self) -> None:
+        component = self.create_component()
+        translation = component.translation_set.get(language_code="cs")
+        category = Category.objects.create(
+            project=component.project, name="Details", slug="details"
+        )
+        Component.objects.filter(pk=component.pk).update(category=category)
+        component.refresh_from_db()
+        unit = translation.unit_set.first()
+        if unit is None:
+            self.fail("Expected at least one unit")
+        label = component.project.label_set.create(name="Detail", color="red")
+        for lazy in (False, True):
+            with self.subTest(lazy=lazy), override_settings(STATS_LAZY=lazy):
+                with self.captureOnCommitCallbacks(execute=True):
+                    Check.objects.filter(unit__translation=translation).delete()
+                    Check.objects.create(unit=unit, name="same", dismissed=False)
+                    unit.source_unit.labels.add(label)
+                scopes = (
+                    ProjectLanguage(component.project, translation.language),
+                    CategoryLanguage(category, translation.language),
+                )
+                for scope in scopes:
+                    self.assertGreater(scope.stats.all, 0)
+                with (
+                    patch(
+                        "weblate.utils.stats.TranslationStats.update_parents"
+                    ) as parents,
+                    self.captureOnCommitCallbacks(execute=True),
+                ):
+                    for scope in scopes:
+                        self.assertEqual(getattr(scope.stats, "check:same"), 1)
+                        self.assertEqual(getattr(scope.stats, "label:Detail"), 1)
+                parents.assert_not_called()
+
+                with self.captureOnCommitCallbacks(execute=True):
+                    Check.objects.filter(unit=unit, name="same").delete()
+                    unit.source_unit.labels.remove(label)
+                for scope in (
+                    ProjectLanguage(component.project, translation.language),
+                    CategoryLanguage(category, translation.language),
+                ):
+                    self.assertEqual(getattr(scope.stats, "check:same"), 0)
+                    self.assertEqual(getattr(scope.stats, "label:Detail"), 0)
 
     def test_commit_grouping(self) -> None:
         component = self.create_component()

--- a/weblate/utils/stats.py
+++ b/weblate/utils/stats.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
-from django.db.models import Count, Exists, F, OuterRef, Q
+from django.db.models import Count, Exists, F, OuterRef, Q, Sum
 from django.db.models.functions import Length
 from django.urls import reverse
 from django.utils import timezone
@@ -220,7 +220,6 @@ class BaseStats:
         self._object = obj
         self._data: StatDict = {}
         self._loaded: bool = False
-        self._pending_save: bool = False
         self.last_change_cache: Change | None = None
         self._collected_update_objects: list[BaseStats] | None = None
 
@@ -384,16 +383,11 @@ class BaseStats:
 
         # Calculate missing data
         if name not in self._data:
-            was_pending = self._pending_save
-            self._pending_save = True
+            # Calculators persist their results, including any nested calculations.
             self.calculate_by_name(name)
             if name not in self._data:
                 msg = f"Unsupported stats for {self}: {name}"
-                self._pending_save = was_pending
                 raise AttributeError(msg)
-            if not was_pending:
-                self.save()
-                self._pending_save = False
 
         return self._data[name]
 
@@ -683,7 +677,15 @@ class TranslationStats(BaseStats):
         bucket[f"{prefix}_chars"] = bucket.get(f"{prefix}_chars", 0) + num_chars
 
     @classmethod
-    def snapshot_to_bucket(cls, snapshot: UnitSnapshot) -> dict[str, int]:
+    def snapshot_to_bucket(
+        cls, snapshot: UnitSnapshot, *, count: int = 1
+    ) -> dict[str, int]:
+        """
+        Classify units with identical state and relation presence into buckets.
+
+        For grouped query results, count is the number of units and the snapshot
+        contains summed word and character counts, not per-unit averages.
+        """
         bucket: dict[str, int] = {}
         state = snapshot["state"]
         num_words = snapshot["num_words"]
@@ -742,6 +744,11 @@ class TranslationStats(BaseStats):
             has_suggestions and state == STATE_APPROVED,
         )
         cls._update_bucket(bucket, "comments", num_words, num_chars, has_comments)
+        # Grouped snapshots already contain summed words and characters, but
+        # each populated string counter represents all units in the group.
+        if count != 1:
+            for key in BASICS.intersection(bucket):
+                bucket[key] = count
         return bucket
 
     def can_apply_delta(self) -> bool:
@@ -779,19 +786,17 @@ class TranslationStats(BaseStats):
 
         values = (
             "state",
-            "num_words",
             "active_checks_count",
             "dismissed_checks_count",
             "suggestion_count",
             "label_count",
             "comment_count",
-            "num_chars",
         )
 
-        # These are independent to-many relations. Joining and counting all of
-        # them in one query multiplies rows and can produce incorrect presence
-        # results as well as poor query plans. Statistics only need presence.
-        units = self._object.unit_set.annotate(
+        # Only relation presence affects the buckets. Independent Exists
+        # expressions avoid joins that multiply unit rows and inflate totals.
+        # Clear ordering so it cannot introduce extra grouping columns.
+        units = self._object.unit_set.order_by().annotate(
             active_checks_count=Exists(
                 Check.objects.filter(unit_id=OuterRef("pk"), dismissed=False)
             ),
@@ -805,20 +810,28 @@ class TranslationStats(BaseStats):
             comment_count=Exists(
                 Comment.objects.filter(unit_id=OuterRef("pk"), resolved=False)
             ),
-            num_chars=Length("source"),
-        ).values_list(*values)
+        )
+        # Group by state and five presence flags, not by word or character count.
+        # This bounds the rows sent to Python regardless of translation size and
+        # avoids repeating Exists expressions for each conditional bucket sum.
+        groups = units.values(*values).annotate(
+            num_units=Count("pk"),
+            num_words=Sum("num_words"),
+            num_chars=Sum(Length("source")),
+        )
 
         totals = dict.fromkeys(self.UNIT_DELTA_KEYS, 0)
         for (
             state,
-            num_words,
             active_checks_count,
             dismissed_checks_count,
             suggestion_count,
             label_count,
             comment_count,
+            num_units,
+            num_words,
             num_chars,
-        ) in units.iterator(chunk_size=STATS_PREFETCH_CHUNK_SIZE):
+        ) in groups.values_list(*values, "num_units", "num_words", "num_chars"):
             bucket = self.snapshot_to_bucket(
                 {
                     "state": state,
@@ -829,7 +842,8 @@ class TranslationStats(BaseStats):
                     "suggestion_count": suggestion_count,
                     "label_count": label_count,
                     "comment_count": comment_count,
-                }
+                },
+                count=num_units,
             )
             for key, value in bucket.items():
                 totals[key] += value
@@ -909,7 +923,7 @@ class TranslationStats(BaseStats):
             self.calculate_labels()
 
     def calculate_checks(self) -> None:
-        """Prefetch check stats."""
+        """Calculate and cache all per-check totals for this translation."""
         self.ensure_loaded()
         allchecks = {check.url_id for check in CHECKS.values()}
         stats = (
@@ -920,7 +934,6 @@ class TranslationStats(BaseStats):
         for check, strings, words, chars in stats.values_list(
             "check__name", "strings", "words", "chars"
         ):
-            # Filtering here is way more effective than in SQL
             if check is None:
                 continue
             check = f"check:{check}"
@@ -932,10 +945,12 @@ class TranslationStats(BaseStats):
             self.store(check, 0)
             self.store(f"{check}_words", 0)
             self.store(f"{check}_chars", 0)
-        self.save()
+        # Filling missing details does not change totals already held by parents.
+        # Underlying edits, rather than these reads, invalidate parent statistics.
+        self.save(update_parents=False)
 
     def calculate_labels(self) -> None:
-        """Prefetch check stats."""
+        """Calculate and cache all per-label totals for this translation."""
         self.ensure_loaded()
         alllabels = set(
             self._object.component.project.label_set.values_list("name", flat=True)
@@ -947,7 +962,7 @@ class TranslationStats(BaseStats):
         )
 
         for label_name, strings, words, chars in stats:
-            # Filtering here is way more effective than in SQL
+            # The outer join also produces a group for unlabeled units.
             if label_name is None:
                 continue
             label = f"label:{label_name}"
@@ -960,7 +975,7 @@ class TranslationStats(BaseStats):
             self.store(label, 0)
             self.store(f"{label}_words", 0)
             self.store(f"{label}_chars", 0)
-        self.save()
+        self.save(update_parents=False)
 
 
 class AggregatingStats(BaseStats):
@@ -1329,6 +1344,7 @@ class ChecklistStats(SingleLanguageStats):
             self.calculate_labels()
 
     def aggregate_stats(self, keys: Iterable[str]) -> None:
+        """Aggregate details, calculating missing child details on demand."""
         self.ensure_loaded()
         all_stats: list[BaseStats] = self.aggregated_stats
         suffixes: tuple[str, ...] = ("", "_words", "_chars")
@@ -1343,11 +1359,11 @@ class ChecklistStats(SingleLanguageStats):
         self.save()
 
     def calculate_checks(self) -> None:
-        """Prefetch check stats."""
+        """Aggregate all per-check totals from child statistics."""
         self.aggregate_stats(check.url_id for check in CHECKS.values())
 
     def calculate_labels(self) -> None:
-        """Prefetch check stats."""
+        """Aggregate all per-label totals from child statistics."""
         self.aggregate_stats(
             f"label:{name}"
             for name in self._object.project.label_set.values_list("name", flat=True)


### PR DESCRIPTION
Group units by state and relation presence before calculating statistics buckets in Python, reducing transferred rows and per-unit processing. Keep independent Exists queries to avoid multiplying related records.

Remove duplicate saves during attribute access and avoid scheduling parent updates when filling check or label details. Preserve lazy detail aggregation and invalidation after edits, and clarify the query comments.

Local PostgreSQL benchmarks, median full recalculation time over seven measured runs after warm-up, comparing the previous and grouped queries:

- 20,000 strings: 75.18 ms -> 13.73 ms (5.5x faster).
- 20,000 strings with checks, suggestions, comments, and a source label: 124.92 ms -> 37.30 ms (3.3x faster).
- 1,000 strings: 5.96 ms -> 4.95 ms.
- 4 strings: 2.43 ms -> 2.58 ms (0.15 ms overhead).

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
