### PR TITLE
ci(dev): exclude duplicate Selenium tests from regular Docker job

### DIFF
--- a/.github/workflows/rundev.yml
+++ b/.github/workflows/rundev.yml
@@ -47,7 +47,8 @@ jobs:
     - run: ./rundev.sh compilemessages
     - name: Test asynchronous application journeys
       run: ./rundev.sh application-test
-    - run: ./rundev.sh test --exitfirst
+    - name: Run non-browser tests
+      run: ./rundev.sh test --exitfirst --ignore=weblate/trans/tests/test_selenium.py
     - run: ./rundev.sh test weblate/checks/tests/test_chars_checks.py
     - run: ./rundev.sh --all logs
       if: always()


### PR DESCRIPTION
Keep browser coverage in the dedicated ARM and amd64 jobs so the regular Docker suite stays fast. Preserve local test selection behavior.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
