### PR TITLE
feat(api)!: add user and IP rate limit overrides

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -2181,6 +2181,69 @@ The default setting is:
     ]
 
 
+.. setting:: API_RATELIMIT_ANON
+
+API_RATELIMIT_ANON
+------------------
+
+.. versionadded:: 2026.10
+
+Default anonymous :ref:`API rate limit <api-rate>`. Defaults to ``"100/day"``.
+Rates use a request count and a period of seconds, minutes, hours, or days, for
+example ``"100/hour"``. A zero count rejects every request covered by this
+throttle; ``None`` disables this throttle. Anonymous requests without an IP
+override are also subject to :setting:`API_RATELIMIT_USER`.
+
+.. setting:: API_RATELIMIT_USER
+
+API_RATELIMIT_USER
+------------------
+
+.. versionadded:: 2026.10
+
+Default authenticated :ref:`API rate limit <api-rate>`. Defaults to
+``"5000/hour"``. Uses the same rate syntax as :setting:`API_RATELIMIT_ANON`.
+Authenticated requests are counted per user; anonymous requests are counted
+per client IP. Set ``None`` to disable this throttle.
+
+.. setting:: API_RATELIMIT_USER_OVERRIDES
+
+API_RATELIMIT_USER_OVERRIDES
+----------------------------
+
+.. versionadded:: 2026.10
+
+Mapping of exact usernames to API rate limits. Defaults to an empty dictionary.
+Override rates require a positive request count, or ``None`` for an exemption.
+These rules take precedence over :setting:`API_RATELIMIT_IP_OVERRIDES`.
+
+.. code-block:: python
+
+    API_RATELIMIT_USER_OVERRIDES = {"automation": "20000/hour"}
+
+.. setting:: API_RATELIMIT_IP_OVERRIDES
+
+API_RATELIMIT_IP_OVERRIDES
+--------------------------
+
+.. versionadded:: 2026.10
+
+Mapping of IPv4 or IPv6 addresses and CIDR networks to API rate limits. Defaults
+to an empty dictionary. The most specific matching network applies to both
+anonymous and authenticated requests, unless a username override matches.
+CIDRs must specify network addresses; duplicate normalized networks are rejected.
+Override rates require a positive request count, or ``None`` for an exemption.
+
+.. code-block:: python
+
+    API_RATELIMIT_IP_OVERRIDES = {
+        "192.0.2.42": None,
+        "198.51.100.0/24": "10000/hour",
+        "2001:db8::/48": "10000/hour",
+    }
+
+See :ref:`api-rate` for counting behavior and trusted proxy requirements.
+
 .. setting:: RATELIMIT_ATTEMPTS
 
 RATELIMIT_ATTEMPTS

--- a/docs/admin/install/docker.rst
+++ b/docs/admin/install/docker.rst
@@ -1227,12 +1227,35 @@ Generic settings
 
    .. versionadded:: 4.11
 
-   Configures API rate limiting. Defaults to ``100/day`` for anonymous and
+   Configures :setting:`API_RATELIMIT_ANON` and :setting:`API_RATELIMIT_USER`.
+   Defaults to ``100/day`` for anonymous and
    ``5000/hour`` for authenticated users.
 
    .. seealso::
 
       :ref:`api-rate`
+
+.. envvar:: WEBLATE_API_RATELIMIT_USER_OVERRIDES
+.. envvar:: WEBLATE_API_RATELIMIT_IP_OVERRIDES
+
+   .. versionadded:: 2026.10
+
+   JSON mappings configuring :setting:`API_RATELIMIT_USER_OVERRIDES` and
+   :setting:`API_RATELIMIT_IP_OVERRIDES`. Both default to empty objects.
+   Use JSON ``null`` to exempt a user, IP address, or network from API throttling.
+
+   For example, in :file:`compose.override.yaml`:
+
+   .. code-block:: yaml
+
+      services:
+        weblate:
+          environment:
+            WEBLATE_API_RATELIMIT_USER_OVERRIDES: '{"automation":"20000/hour"}'
+            WEBLATE_API_RATELIMIT_IP_OVERRIDES: '{"192.0.2.42":null,"198.51.100.0/24":"10000/hour"}'
+
+   Username rules take precedence over IP rules. See :ref:`api-rate` for
+   counting behavior and proxy configuration requirements.
 
 .. envvar:: WEBLATE_ENABLE_HOOKS
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -201,12 +201,45 @@ The API requests are rate limited; the default configuration limits it to 100
 requests per day for anonymous users and 5000 requests per hour for authenticated
 users.
 
-Rate limiting can be adjusted in the :file:`settings.py`; see
-`Throttling in Django REST framework documentation <https://www.django-rest-framework.org/api-guide/throttling/>`_
-for more details how to configure it.
+Configure the default limits in :file:`settings.py` using
+:setting:`API_RATELIMIT_ANON` and :setting:`API_RATELIMIT_USER`.
 
 In the Docker container this can be configured using
 :envvar:`WEBLATE_API_RATELIMIT_ANON` and :envvar:`WEBLATE_API_RATELIMIT_USER`.
+
+Use :setting:`API_RATELIMIT_USER_OVERRIDES` to give an automation account a
+different limit. Use :setting:`API_RATELIMIT_IP_OVERRIDES` for individual IP
+addresses or networks, including anonymous CI clients:
+
+.. code-block:: python
+
+    API_RATELIMIT_USER_OVERRIDES = {"automation": "20000/hour"}
+    API_RATELIMIT_IP_OVERRIDES = {
+        "192.0.2.42": None,
+        "198.51.100.0/24": "10000/hour",
+        "2001:db8::/48": "10000/hour",
+    }
+
+An explicit username override takes precedence over IP rules. Otherwise, the
+most specific matching network applies; an individual address is equivalent to
+a single-address network. A value of ``None`` exempts matching requests from API
+rate limits, including the anonymous limit. Authentication and permissions still
+apply: an exemption does not grant access to private projects or write operations.
+
+Limits are counted per authenticated user, or per client IP for anonymous
+requests. Clients within a network do not share a single budget. Each override
+rule and rate has a separate budget, so changing a rule or rate starts a new
+budget. Requests without an override use the default limits.
+
+IP rules use the client address resolved by Weblate. Behind a reverse proxy,
+configure :setting:`IP_BEHIND_REVERSE_PROXY`, :setting:`IP_PROXY_HEADER`, and
+:setting:`IP_PROXY_OFFSET` correctly. The trusted proxy must supply the client
+address, and untrusted clients must not be able to bypass it. Exempting a shared
+proxy address can exempt all clients using that proxy.
+
+In Docker, configure the equivalent JSON mappings using
+:envvar:`WEBLATE_API_RATELIMIT_USER_OVERRIDES` and
+:envvar:`WEBLATE_API_RATELIMIT_IP_OVERRIDES`. Use JSON ``null`` for exemptions.
 
 The status of rate limiting is reported in following headers:
 
@@ -217,6 +250,8 @@ The status of rate limiting is reported in following headers:
 +---------------------------+------------------------------------------------------+
 | ``X-RateLimit-Reset``     | Number of seconds until the rate-limit window resets |
 +---------------------------+------------------------------------------------------+
+
+Requests exempt from rate limiting do not include these headers.
 
 .. versionchanged:: 4.1
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Weblate 2026.10
 
 .. rubric:: New features
 
+* Added configurable per-user and IP/network :ref:`API rate limits and exemptions <api-rate>`, including Docker configuration.
+
 .. rubric:: Improvements
 
 * Whitespace characters are now rendered consistently in the source string display and the translation editor, and different kinds of whitespace are now distinguishable from each other.
@@ -17,7 +19,11 @@ Weblate 2026.10
 
 .. rubric:: Compatibility
 
+* API throttles now read :setting:`API_RATELIMIT_ANON` and :setting:`API_RATELIMIT_USER` directly; ``REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]`` is no longer used by Weblate's throttle classes.
+
 .. rubric:: Upgrading
+
+* In non-Docker settings, remove the ``anon_throttle`` and ``user_throttle`` arguments from ``get_drf_settings`` and assign those rates to :setting:`API_RATELIMIT_ANON` and :setting:`API_RATELIMIT_USER`. Migrate any custom ``REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["anon"]`` or ``["user"]`` values to these settings as well. Existing Docker rate-limit environment variables continue to work.
 
 Please follow :ref:`generic-upgrade-instructions` in order to perform update.
 

--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -393,13 +393,19 @@ Build-time and configuration variants
        tuning, not a security boundary. Operators choose a mode based on memory,
        capacity, and availability requirements. *(maintainer)*
    * - :envvar:`WEBLATE_API_RATELIMIT_ANON`,
-       :envvar:`WEBLATE_API_RATELIMIT_USER`, :setting:`RATELIMIT_ATTEMPTS`,
+       :envvar:`WEBLATE_API_RATELIMIT_USER`,
+       :setting:`API_RATELIMIT_USER_OVERRIDES`,
+       :setting:`API_RATELIMIT_IP_OVERRIDES`, :setting:`RATELIMIT_ATTEMPTS`,
        and ``RATELIMIT_GITHUB_SETUP_ATTEMPTS``
      - Rate limits are configurable. *(documented)* (source: :doc:`/api`,
        :doc:`/admin/config`)
      - Availability claims assume rate limits appropriate to deployment size
        and exposure. *(maintainer)*
-     - Disabling rate limits changes DoS triage from Weblate bug to deployment
+     - Operators can override or exempt users and IP networks, including
+       anonymous clients. IP exemptions rely on trusted proxy configuration;
+       they do not grant authentication or permissions. *(documented)*
+       (source: :ref:`api-rate`, :setting:`IP_BEHIND_REVERSE_PROXY`).
+       Disabling rate limits changes DoS triage from Weblate bug to deployment
        posture unless a single request violates a claimed property.
        *(maintainer)*
    * - :setting:`CSP_SCRIPT_SRC`, :setting:`CSP_IMG_SRC`,

--- a/weblate/api/apps.py
+++ b/weblate/api/apps.py
@@ -2,7 +2,28 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.apps import AppConfig
+from django.core.checks import Error, register
+from django.core.exceptions import ImproperlyConfigured
+
+from weblate.api.ratelimits import get_rate_policies
+from weblate.utils.checks import weblate_check
+
+if TYPE_CHECKING:
+    from django.core.checks import CheckMessage
+
+
+@register()
+def check_api_ratelimits(**kwargs: object) -> list[CheckMessage]:
+    try:
+        get_rate_policies()
+    except ImproperlyConfigured as error:
+        return [weblate_check("weblate.E050", str(error), Error)]
+    return []
 
 
 class ApiConfig(AppConfig):

--- a/weblate/api/ratelimits.py
+++ b/weblate/api/ratelimits.py
@@ -1,0 +1,115 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from ipaddress import IPv4Network, IPv6Network, ip_network
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+@dataclass(frozen=True)
+class RatePolicy:
+    key: str
+    rate: str | None
+    num_requests: int | None
+    duration: int | None
+
+
+def parse_rate(
+    name: str, value: object, *, override: bool = False
+) -> tuple[int | None, int | None]:
+    if value is None:
+        return None, None
+    msg = f"Invalid API rate limit in {name}: {value!r}. Use a rate such as '100/hour' or None."
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9]+/[smhd][^/]*", value):
+        raise ImproperlyConfigured(msg)
+    count, period = value.split("/")
+    try:
+        num_requests = int(count)
+    except ValueError as error:
+        raise ImproperlyConfigured(msg) from error
+    if override and num_requests == 0:
+        raise ImproperlyConfigured(msg)
+    return num_requests, {"s": 1, "m": 60, "h": 3600, "d": 86400}[period[0]]
+
+
+def freeze_overrides(name: str) -> tuple[tuple[str, str | None], ...]:
+    value = getattr(settings, name, {})
+    if not isinstance(value, Mapping) or any(
+        not isinstance(key, str)
+        or not key
+        or (rate is not None and not isinstance(rate, str))
+        for key, rate in value.items()
+    ):
+        msg = f"{name} must map nonempty strings to API rates or None."
+        raise ImproperlyConfigured(msg)
+    return tuple(value.items())
+
+
+@dataclass(frozen=True)
+class RatePolicies:
+    anon: RatePolicy
+    user: RatePolicy
+    users: Mapping[str, RatePolicy]
+    networks: tuple[tuple[IPv4Network | IPv6Network, RatePolicy], ...]
+
+
+@lru_cache(maxsize=32)
+def compile_policies(
+    anon: str | None,
+    user: str | None,
+    users: tuple[tuple[str, str | None], ...],
+    ips: tuple[tuple[str, str | None], ...],
+) -> RatePolicies:
+    user_policies = {
+        name: RatePolicy(
+            f"user:{name}",
+            rate,
+            *parse_rate("API_RATELIMIT_USER_OVERRIDES", rate, override=True),
+        )
+        for name, rate in users
+    }
+    networks: dict[IPv4Network | IPv6Network, RatePolicy] = {}
+    for address, rate in ips:
+        try:
+            network = ip_network(address)
+        except ValueError as error:
+            msg = f"Invalid network in API_RATELIMIT_IP_OVERRIDES: {address!r}."
+            raise ImproperlyConfigured(msg) from error
+        if network in networks:
+            msg = f"Duplicate network in API_RATELIMIT_IP_OVERRIDES: {address!r}."
+            raise ImproperlyConfigured(msg)
+        networks[network] = RatePolicy(
+            f"ip:{network}",
+            rate,
+            *parse_rate("API_RATELIMIT_IP_OVERRIDES", rate, override=True),
+        )
+    return RatePolicies(
+        RatePolicy("anon", anon, *parse_rate("API_RATELIMIT_ANON", anon)),
+        RatePolicy("user", user, *parse_rate("API_RATELIMIT_USER", user)),
+        user_policies,
+        tuple(
+            sorted(networks.items(), key=lambda item: item[0].prefixlen, reverse=True)
+        ),
+    )
+
+
+def get_rate_policies() -> RatePolicies:
+    anon = getattr(settings, "API_RATELIMIT_ANON", "100/day")
+    user = getattr(settings, "API_RATELIMIT_USER", "5000/hour")
+    # Validate before constructing the cache key, including unhashable values.
+    parse_rate("API_RATELIMIT_ANON", anon)
+    parse_rate("API_RATELIMIT_USER", user)
+    return compile_policies(
+        anon,
+        user,
+        freeze_overrides("API_RATELIMIT_USER_OVERRIDES"),
+        freeze_overrides("API_RATELIMIT_IP_OVERRIDES"),
+    )

--- a/weblate/api/spectacular.py
+++ b/weblate/api/spectacular.py
@@ -264,9 +264,7 @@ def get_drf_standardized_errors_settings() -> dict[str, Any]:
     }
 
 
-def get_drf_settings(
-    *, require_login: bool, anon_throttle: str, user_throttle: str
-) -> dict[str, Any]:
+def get_drf_settings(*, require_login: bool) -> dict[str, Any]:
     return {
         # Use Django's standard `django.contrib.auth` permissions,
         # or allow read-only access for unauthenticated users.
@@ -285,10 +283,6 @@ def get_drf_settings(
             "weblate.api.throttling.UserRateThrottle",
             "weblate.api.throttling.AnonRateThrottle",
         ),
-        "DEFAULT_THROTTLE_RATES": {
-            "anon": anon_throttle,
-            "user": user_throttle,
-        },
         "DEFAULT_RENDERER_CLASSES": [
             "rest_framework.renderers.JSONRenderer",
             "rest_framework.renderers.BrowsableAPIRenderer",

--- a/weblate/api/throttling.py
+++ b/weblate/api/throttling.py
@@ -4,36 +4,78 @@
 
 from __future__ import annotations
 
-from functools import wraps
+import contextlib
+from hashlib import sha256
+from ipaddress import ip_address
 from typing import TYPE_CHECKING
 
 from rest_framework.throttling import AnonRateThrottle as DRFAnonRateThrottle
+from rest_framework.throttling import SimpleRateThrottle
 from rest_framework.throttling import UserRateThrottle as DRFUserRateThrottle
+
+from weblate.api.ratelimits import get_rate_policies
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
+    from rest_framework.views import APIView
 
 
-def patch_throttle_request(func):
-    """Store throttling state in request to be picked up by ThrottlingMiddleware."""
+class RateOverrideThrottle(SimpleRateThrottle):
+    """Apply Weblate settings while retaining DRF's cache and window handling."""
 
-    @wraps(func)
-    def patched(self, request: Request, view):
-        result = func(self, request, view)
+    override_key: str | None = None
+
+    def get_rate(self) -> str | None:
+        policies = get_rate_policies()
+        return policies.anon.rate if self.scope == "anon" else policies.user.rate
+
+    def allow_request(self, request: Request, view: APIView) -> bool:
+        authenticated = bool(request.user and request.user.is_authenticated)
+        if self.scope == "anon" and authenticated:
+            return True
+
+        policies = get_rate_policies()
+        policy = policies.users.get(request.user.username) if authenticated else None
+        address = None
+        if policy is None and policies.networks:
+            with contextlib.suppress(ValueError):
+                address = ip_address(request.META.get("REMOTE_ADDR", ""))
+            if address is not None:
+                policy = next(
+                    (
+                        candidate
+                        for network, candidate in policies.networks
+                        if address in network
+                    ),
+                    None,
+                )
+        if policy is not None:
+            # Anonymous overrides are enforced only by AnonRateThrottle.
+            if not authenticated and self.scope == "user":
+                return True
+            self.rate = policy.rate
+            self.num_requests = policy.num_requests
+            self.duration = policy.duration
+            ident = str(request.user.pk) if authenticated else str(address)
+            key = f"{policy.key}:{policy.num_requests}:{policy.duration}:{ident}"
+            self.override_key = (
+                f"throttle_override_{self.scope}_{sha256(key.encode()).hexdigest()}"
+            )
+        result = super().allow_request(request, view)
+        # Expose throttling state to ThrottlingMiddleware for response headers.
         if hasattr(self, "history"):
             request.META["throttling_state"] = self
         return result
 
-    return patched
+    def get_cache_key(self, request: Request, view: APIView) -> str | None:
+        if self.override_key is not None:
+            return self.override_key
+        return super().get_cache_key(request, view)
 
 
-class AnonRateThrottle(DRFAnonRateThrottle):
-    @patch_throttle_request
-    def allow_request(self, request: Request, view):
-        return super().allow_request(request, view)
+class AnonRateThrottle(RateOverrideThrottle, DRFAnonRateThrottle):
+    pass
 
 
-class UserRateThrottle(DRFUserRateThrottle):
-    @patch_throttle_request
-    def allow_request(self, request: Request, view):
-        return super().allow_request(request, view)
+class UserRateThrottle(RateOverrideThrottle, DRFUserRateThrottle):
+    pass

--- a/weblate/settings_docker.py
+++ b/weblate/settings_docker.py
@@ -904,6 +904,7 @@ INSTALLED_APPS = [
     "customize",
     # Weblate apps on top to override Django locales and templates
     "weblate.addons",
+    "weblate.api",
     "weblate.auth",
     "weblate.checks",
     "weblate_fonts",
@@ -1370,11 +1371,11 @@ SESSION_ENGINE = get_env_str(
 MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
 
 # REST framework settings for API
-REST_FRAMEWORK = get_drf_settings(
-    require_login=REQUIRE_LOGIN,
-    anon_throttle=get_env_ratelimit("WEBLATE_API_RATELIMIT_ANON", "100/day"),
-    user_throttle=get_env_ratelimit("WEBLATE_API_RATELIMIT_USER", "5000/hour"),
-)
+API_RATELIMIT_ANON = get_env_ratelimit("WEBLATE_API_RATELIMIT_ANON", "100/day")
+API_RATELIMIT_USER = get_env_ratelimit("WEBLATE_API_RATELIMIT_USER", "5000/hour")
+API_RATELIMIT_USER_OVERRIDES = get_env_json("WEBLATE_API_RATELIMIT_USER_OVERRIDES", {})
+API_RATELIMIT_IP_OVERRIDES = get_env_json("WEBLATE_API_RATELIMIT_IP_OVERRIDES", {})
+REST_FRAMEWORK = get_drf_settings(require_login=REQUIRE_LOGIN)
 DRF_STANDARDIZED_ERRORS = get_drf_standardized_errors_settings()
 SPECTACULAR_SETTINGS = get_spectacular_settings(
     INSTALLED_APPS,

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -439,6 +439,7 @@ ROOT_URLCONF = "weblate.urls"
 INSTALLED_APPS = [
     # Weblate apps on top to override Django locales and templates
     "weblate.addons",
+    "weblate.api",
     "weblate.auth",
     "weblate.checks",
     "weblate_fonts",
@@ -921,11 +922,13 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
 
 # REST framework settings for API
-REST_FRAMEWORK = get_drf_settings(
-    require_login=REQUIRE_LOGIN,
-    anon_throttle="100/day",
-    user_throttle="5000/hour",
-)
+API_RATELIMIT_ANON = "100/day"
+API_RATELIMIT_USER = "5000/hour"
+API_RATELIMIT_USER_OVERRIDES: dict[str, str | None] = {}
+API_RATELIMIT_IP_OVERRIDES: dict[str, str | None] = {}
+# API_RATELIMIT_USER_OVERRIDES = {"automation": "20000/hour"}
+# API_RATELIMIT_IP_OVERRIDES = {"192.0.2.42": None, "198.51.100.0/24": "10000/hour"}
+REST_FRAMEWORK = get_drf_settings(require_login=REQUIRE_LOGIN)
 DRF_STANDARDIZED_ERRORS = get_drf_standardized_errors_settings()
 SPECTACULAR_SETTINGS = get_spectacular_settings(
     INSTALLED_APPS,

--- a/weblate/utils/checks.py
+++ b/weblate/utils/checks.py
@@ -86,6 +86,7 @@ DOC_LINKS: dict[str, str | tuple[str] | tuple[str, str]] = {
     "weblate.C047": ("admin/install", "production-database"),
     "weblate.W048": ("admin/install", "hardware"),
     "weblate.W049": ("admin/install/docker", "docker-startup-warnings"),
+    "weblate.E050": ("api", "api-rate"),
 }
 
 

--- a/weblate/utils/tests/test_api_ratelimits.py
+++ b/weblate/utils/tests/test_api_ratelimits.py
@@ -1,0 +1,278 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponseBase
+from django.test import SimpleTestCase, override_settings
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.views import APIView
+
+from weblate.api.apps import check_api_ratelimits
+from weblate.api.middleware import ThrottlingMiddleware
+from weblate.api.ratelimits import get_rate_policies
+from weblate.api.spectacular import get_drf_settings
+from weblate.api.throttling import AnonRateThrottle, UserRateThrottle
+from weblate.auth.models import User
+from weblate.middleware import ProxyMiddleware
+from weblate.utils.environment import get_env_json
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
+
+
+class RateLimitedView(APIView):
+    authentication_classes = ()
+    permission_classes = (AllowAny,)
+    throttle_classes = (UserRateThrottle, AnonRateThrottle)
+
+    def get(self, request: Request) -> Response:
+        return Response({"ok": True})
+
+
+@override_settings(
+    API_RATELIMIT_ANON="1/day",
+    API_RATELIMIT_USER="1/hour",
+    API_RATELIMIT_USER_OVERRIDES={},
+    API_RATELIMIT_IP_OVERRIDES={},
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class ApiRateLimitTest(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        self.factory = APIRequestFactory()
+        self.enterContext(
+            patch(
+                "rest_framework.throttling.SimpleRateThrottle.timer", return_value=1000
+            )
+        )
+
+    def request(
+        self,
+        address: str = "192.0.2.42",
+        *,
+        username: str | None = None,
+        user_id: int = 1,
+        forwarded: str | None = None,
+        proxy: bool = False,
+        protected: bool = False,
+    ) -> HttpResponseBase:
+        request = self.factory.get("/api/", REMOTE_ADDR=address)
+        if forwarded is not None:
+            request.META["HTTP_X_FORWARDED_FOR"] = forwarded
+        force_authenticate(
+            request,
+            user=User(username=username, pk=user_id) if username else AnonymousUser(),
+        )
+        if proxy:
+            ProxyMiddleware(lambda _request: Response()).process_request(request)
+        permissions = (IsAuthenticated,) if protected else (AllowAny,)
+        response = RateLimitedView.as_view(permission_classes=permissions)(request)
+        result = ThrottlingMiddleware(lambda _request: response)(request)
+        assert isinstance(result, HttpResponseBase)
+        return result
+
+    def test_defaults(self) -> None:
+        response = self.request()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["X-RateLimit-Limit"], "1")
+        self.assertEqual(self.request().status_code, 429)
+        self.assertEqual(self.request(username="automation").status_code, 200)
+        self.assertEqual(self.request(username="automation").status_code, 429)
+
+    @override_settings(API_RATELIMIT_ANON="2/day", API_RATELIMIT_USER="2/hour")
+    def test_direct_settings(self) -> None:
+        for username in (None, "automation"):
+            with self.subTest(username=username):
+                self.assertEqual(self.request(username=username).status_code, 200)
+                self.assertEqual(self.request(username=username).status_code, 200)
+                self.assertEqual(self.request(username=username).status_code, 429)
+
+    def test_drf_rates_unused(self) -> None:
+        drf = get_drf_settings(require_login=False)
+        self.assertNotIn("DEFAULT_THROTTLE_RATES", drf)
+        for rates in ({}, {"anon": "0/day", "user": "0/hour"}):
+            with (
+                self.subTest(rates=rates),
+                override_settings(
+                    REST_FRAMEWORK={**drf, "DEFAULT_THROTTLE_RATES": rates}
+                ),
+            ):
+                cache.clear()
+                self.assertEqual(self.request().status_code, 200)
+                self.assertEqual(self.request(username="automation").status_code, 200)
+
+    @override_settings(API_RATELIMIT_USER_OVERRIDES={"automation": "2/hour"})
+    def test_user_override_headers(self) -> None:
+        response = self.request(username="automation")
+        self.assertEqual(response["X-RateLimit-Limit"], "2")
+        self.assertEqual(response["X-RateLimit-Remaining"], "1")
+        self.assertEqual(response["X-RateLimit-Reset"], "3600")
+        self.assertEqual(
+            self.request("192.0.2.43", username="automation").status_code, 200
+        )
+        response = self.request(username="automation")
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response["Retry-After"], "3600")
+
+    @override_settings(API_RATELIMIT_IP_OVERRIDES={"192.0.2.0/24": "2/hour"})
+    def test_ip_override_budgets(self) -> None:
+        for address, username, user_id in (
+            ("192.0.2.42", None, 1),
+            ("192.0.2.43", None, 1),
+            ("192.0.2.42", "automation", 1),
+            ("192.0.2.42", "other", 2),
+        ):
+            with self.subTest(address=address, username=username):
+                for _ in range(2):
+                    response = self.request(address, username=username, user_id=user_id)
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(response["X-RateLimit-Limit"], "2")
+                self.assertEqual(
+                    self.request(
+                        address, username=username, user_id=user_id
+                    ).status_code,
+                    429,
+                )
+
+    @override_settings(API_RATELIMIT_IP_OVERRIDES={"192.0.2.42": None})
+    def test_ip_exemption(self) -> None:
+        for username in (None, "automation"):
+            for _ in range(3):
+                response = self.request(username=username)
+                self.assertEqual(response.status_code, 200)
+                self.assertNotIn("X-RateLimit-Limit", response)
+        self.assertEqual(self.request(protected=True).status_code, 403)
+
+    @override_settings(
+        API_RATELIMIT_IP_OVERRIDES={"192.0.2.42": None},
+        API_RATELIMIT_USER_OVERRIDES={"automation": "1/hour"},
+    )
+    def test_user_limit_over_ip_exemption(self) -> None:
+        self.assertEqual(self.request(username="automation").status_code, 200)
+        self.assertEqual(self.request(username="automation").status_code, 429)
+
+    @override_settings(
+        API_RATELIMIT_IP_OVERRIDES={"192.0.2.42": "1/hour"},
+        API_RATELIMIT_USER_OVERRIDES={"automation": None},
+    )
+    def test_user_exemption_over_ip_limit(self) -> None:
+        for _ in range(3):
+            response = self.request(username="automation")
+            self.assertEqual(response.status_code, 200)
+            self.assertNotIn("X-RateLimit-Limit", response)
+
+    @override_settings(
+        API_RATELIMIT_IP_OVERRIDES={
+            "192.0.2.0/24": None,
+            "192.0.2.128/25": "2/hour",
+            "192.0.2.255": "3/hour",
+        }
+    )
+    def test_longest_prefix(self) -> None:
+        self.assertNotIn("X-RateLimit-Limit", self.request("192.0.2.127"))
+        self.assertEqual(self.request("192.0.2.128")["X-RateLimit-Limit"], "2")
+        self.assertEqual(self.request("192.0.2.255")["X-RateLimit-Limit"], "3")
+        self.assertEqual(self.request("192.0.3.0")["X-RateLimit-Limit"], "1")
+
+    @override_settings(
+        API_RATELIMIT_IP_OVERRIDES={"2001:db8::/48": "2/hour", "2001:db8::42": None}
+    )
+    def test_ipv6(self) -> None:
+        self.assertNotIn("X-RateLimit-Limit", self.request("2001:0db8:0:0:0:0:0:42"))
+        self.assertEqual(self.request("2001:db8::43").status_code, 200)
+        self.assertEqual(self.request("2001:0db8:0:0:0:0:0:43").status_code, 200)
+        self.assertEqual(self.request("2001:db8::43").status_code, 429)
+        self.assertEqual(self.request("2001:db8:1::")["X-RateLimit-Limit"], "1")
+
+    def test_policy_changes(self) -> None:
+        self.assertEqual(self.request().status_code, 200)
+        with override_settings(API_RATELIMIT_IP_OVERRIDES={"192.0.2.42": "1/hour"}):
+            self.assertEqual(self.request().status_code, 200)
+            self.assertEqual(self.request().status_code, 429)
+        with override_settings(API_RATELIMIT_IP_OVERRIDES={"192.0.2.42": "2/day"}):
+            self.assertEqual(self.request()["X-RateLimit-Remaining"], "1")
+        self.assertEqual(self.request().status_code, 429)
+
+    @override_settings(
+        API_RATELIMIT_IP_OVERRIDES={"192.0.2.42": None},
+        IP_BEHIND_REVERSE_PROXY=True,
+        IP_PROXY_HEADER="HTTP_X_FORWARDED_FOR",
+        IP_PROXY_OFFSET=-1,
+    )
+    def test_proxy(self) -> None:
+        response = self.request("198.51.100.1", forwarded="192.0.2.42", proxy=True)
+        self.assertNotIn("X-RateLimit-Limit", response)
+        response = self.request("198.51.100.1", forwarded="192.0.2.42")
+        self.assertEqual(response["X-RateLimit-Limit"], "1")
+        response = self.request(
+            "198.51.100.1", forwarded="192.0.2.42, 198.51.100.2", proxy=True
+        )
+        self.assertEqual(response["X-RateLimit-Limit"], "1")
+
+    def test_invalid_configuration(self) -> None:
+        invalid: list[tuple[str, object]] = [
+            ("API_RATELIMIT_ANON", []),
+            ("API_RATELIMIT_USER", "1/"),
+            ("API_RATELIMIT_USER", "-1/hour"),
+            ("API_RATELIMIT_USER", "1/year"),
+            ("API_RATELIMIT_USER_OVERRIDES", []),
+            ("API_RATELIMIT_IP_OVERRIDES", None),
+            ("API_RATELIMIT_USER_OVERRIDES", {"": "1/hour"}),
+            ("API_RATELIMIT_USER_OVERRIDES", {"automation": []}),
+            ("API_RATELIMIT_USER_OVERRIDES", {"automation": "0/hour"}),
+            ("API_RATELIMIT_IP_OVERRIDES", {"invalid": None}),
+            ("API_RATELIMIT_IP_OVERRIDES", {"192.0.2.42/24": None}),
+            ("API_RATELIMIT_IP_OVERRIDES", {"192.0.2.42": None, "192.0.2.42/32": None}),
+        ]
+        for name, value in invalid:
+            with (
+                self.subTest(name=name, value=value),
+                override_settings(**{name: value}),
+            ):
+                with self.assertRaisesMessage(ImproperlyConfigured, name):
+                    get_rate_policies()
+                self.assertEqual(check_api_ratelimits()[0].id, "weblate.E050")
+        self.assertEqual(check_api_ratelimits(), [])
+
+    @override_settings(API_RATELIMIT_ANON=None, API_RATELIMIT_USER=None)
+    def test_disabled_defaults(self) -> None:
+        for _ in range(3):
+            self.assertNotIn("X-RateLimit-Limit", self.request())
+
+    @override_settings(API_RATELIMIT_ANON="0/day")
+    def test_zero_default(self) -> None:
+        self.assertEqual(self.request().status_code, 429)
+
+    def test_docker_json(self) -> None:
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "WEBLATE_API_RATELIMIT_USER_OVERRIDES": '{"automation":"2/hour"}',
+                    "WEBLATE_API_RATELIMIT_IP_OVERRIDES": '{"192.0.2.42":null}',
+                },
+            ),
+            override_settings(
+                API_RATELIMIT_USER_OVERRIDES=get_env_json(
+                    "WEBLATE_API_RATELIMIT_USER_OVERRIDES", {}
+                ),
+                API_RATELIMIT_IP_OVERRIDES=get_env_json(
+                    "WEBLATE_API_RATELIMIT_IP_OVERRIDES", {}
+                ),
+            ),
+        ):
+            self.assertNotIn("X-RateLimit-Limit", self.request())
+            self.assertEqual(
+                self.request(username="automation")["X-RateLimit-Limit"], "2"
+            )


### PR DESCRIPTION
Allow automation accounts and anonymous CI clients to use tailored API limits or exemptions through Weblate settings and Docker environment variables. Document configuration, validation, and migration for 2026.10.

BREAKING CHANGE: Weblate throttles now use API_RATELIMIT_ANON and API_RATELIMIT_USER instead of DEFAULT_THROTTLE_RATES. Remove anon_throttle and user_throttle arguments from get_drf_settings.

Fixes #21351

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
