### PR TITLE
fix(editor): improve search result refresh and expiry recovery

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.9.1
 
 .. rubric:: Improvements
 
+* Added explicit :ref:`search result refresh <search-results-cache>` in the translation editors and improved recovery when saved search results expire.
 * :ref:`Docker development tests <dev-docker>` now automatically prepare an isolated test environment without requiring application startup or the Dev Container CLI.
 * Added a :ref:`development container <devcontainer>` for tests and lint, with an optional :ref:`application QA profile <dev-docker>`, isolated storage per Git worktree, dynamically allocated localhost application and mailbox ports, and Chromium diagnostics and mandatory browser test commands.
 * Added posting and displaying scoped :doc:`announcements </admin/announcements>` on category-language pages.

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -1,6 +1,30 @@
 Searching
 =========
 
+.. _search-results-cache:
+
+Results while translating
++++++++++++++++++++++++++
+
+The translation editor keeps the current search results while you translate.
+For example, translating an untranslated string does not remove it from the
+list, so you can navigate back to it. Reloading a page with a saved position
+in its URL (``offset``) keeps this list. An initial search URL without a
+position runs the search again when reloaded.
+
+Select the :guilabel:`Refresh results` icon next to the query input or press
+:kbd:`Enter` in the filter field to
+run the search again and start at the first matching string. This also works
+in Zen mode. Changing the sort order keeps the current result list.
+
+After 30 minutes of inactivity, the saved search results expire. Weblate
+refreshes the results when you continue and displays a notice. Saving still
+applies to the string you were editing, subject to the usual checks for
+conflicting changes. If that string no longer matches the filters, it is kept
+at the start of the refreshed list so you can return to it.
+If results expire while scrolling in Zen mode, save any pending edits and
+select :guilabel:`Refresh results` to continue loading strings.
+
 Search query syntax
 +++++++++++++++++++
 

--- a/weblate/static/editor/base.js
+++ b/weblate/static/editor/base.js
@@ -119,10 +119,16 @@ WLT.Utils = (() => ({
    * @returns {boolean}
    */
   editorHasChanges: (e) => {
-    const editorArea = e
-      ? e.target.closest(".translation-editor")
-      : document.querySelector(".translator .translation-editor");
-    return editorArea?.classList.contains("has-changes") ?? false;
+    if (e) {
+      return (
+        e.target
+          .closest(".translation-editor")
+          ?.classList.contains("has-changes") ?? false
+      );
+    }
+    return !!document.querySelector(
+      ".translator .translation-editor.has-changes",
+    );
   },
 }))();
 
@@ -266,6 +272,13 @@ WLT.Editor = (() => {
     this.initHighlight();
     this.init();
 
+    // Retained edits need the same warning as text entered on this page.
+    for (const editorArea of this.translationArea) {
+      if (editorArea.closest('form[data-unsaved="true"]')) {
+        WLT.Utils.indicateChanges({ target: editorArea });
+      }
+    }
+
     this.translationArea[0]?.focus();
 
     // Show confirmation dialog if changes have been made
@@ -292,7 +305,10 @@ WLT.Editor = (() => {
 
     // Remove unsaved changes warning when submitting
     for (const editor of this.editors) {
-      editor.addEventListener("submit", () => {
+      editor.addEventListener("submit", (event) => {
+        if (event.target.matches(".result-page-form")) {
+          return;
+        }
         for (const el of document.querySelectorAll(
           ".translator .translation-editor",
         )) {

--- a/weblate/static/editor/zen.js
+++ b/weblate/static/editor/zen.js
@@ -35,12 +35,26 @@
           headers: { "X-Requested-With": "XMLHttpRequest" },
         })
           .then((response) => {
+            if (response.status === 409) {
+              loader.remove();
+              loadingNext.style.display = "none";
+              addAlert(
+                gettext(
+                  "Your previous search results are no longer available. Refresh results to continue.",
+                ),
+                "info",
+              );
+              return null;
+            }
             if (!response.ok) {
               throw new Error(`HTTP ${response.status}`);
             }
             return response.text();
           })
           .then((data) => {
+            if (data === null) {
+              return;
+            }
             loadingNext.style.display = "none";
 
             const tfoot = document.querySelector(".zen tfoot");

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -622,7 +622,13 @@ function initHighlight(root) {
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
         if (!event.repeat) {
-          event.target.form.requestSubmit();
+          const form = event.target.form;
+          const refresh = form.querySelector('button[name="refresh"]');
+          if (refresh !== null) {
+            form.requestSubmit(refresh);
+          } else {
+            form.requestSubmit();
+          }
         }
         event.preventDefault();
       }
@@ -1816,6 +1822,14 @@ onReady(() => {
   const positionInputEditableInput = document.getElementById(
     "position-input-editable-input",
   );
+  positionInputEditableInput?.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (!event.repeat) {
+        event.target.form.requestSubmit();
+      }
+    }
+  });
   const clickedOutsideEditableInput = (event) => {
     // Check if clicked outside of the input and the editable input
     if (

--- a/weblate/templates/snippets/query-field.html
+++ b/weblate/templates/snippets/query-field.html
@@ -1,6 +1,6 @@
-{% load crispy_forms_field i18n %}
+{% load crispy_forms_field i18n icons %}
 
-<div class="input-group search-group query-field me-5" role="group">
+<div class="input-group flex-nowrap search-group query-field" role="group">
   <div class="input-group-btn">
     <button type="button"
             id="query-dropdown"
@@ -22,6 +22,15 @@
     </ul>
   </div>
   <!-- /btn-group -->
-  <div class="flex-grow-1">{% crispy_field field 'aria-label' _('Query') 'class' 'form-control' %}</div>
+  {% crispy_field field 'aria-label' _('Query') 'class' 'form-control' %}
+  {% if can_refresh_search %}
+    <button type="submit"
+            name="refresh"
+            value="1"
+            class="btn btn-outline-primary"
+            title="{% translate 'Refresh results' %}"
+            aria-label="{% translate 'Refresh results' %}"
+            aria-describedby="search-cache-help">{% icon "refresh.svg" %}</button>
+  {% endif %}
 </div>
 {% include "bootstrap5/layout/help_text_and_errors.html" %}

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -60,15 +60,21 @@
   {% with variants=unit.variants %}
 
     <div class="query-container">
-      <form method="get" class="result-page-form">
+      <form method="get" class="result-page-form double-submission">
         {% crispy search_form %}
+        <p id="search-cache-help" class="form-text mb-0">
+          {% translate "Search results stay fixed while you translate. Refresh results to show strings matching the filters now." %}
+        </p>
       </form>
     </div>
 
     <div class="row">
       <div class="col-sm-9">
 
-        <form action="{{ this_unit_url }}" method="post" class="translation-form translator">
+        <form action="{{ this_unit_url }}"
+              method="post"
+              class="translation-form translator"
+              data-unsaved="{{ form.is_bound|yesno:'true,false' }}">
           <div class="card">
 
             <div class="card-header {% if unit.approved %}text-bg-success{% elif unit.is_source %}text-bg-warning{% endif %}">
@@ -387,6 +393,7 @@
             <div class="tab-pane" id="suggestions">
               <form action="{{ this_unit_url }}" method="post">
                 {% csrf_token %}
+                <input type="hidden" name="unit_id" value="{{ unit.pk }}" />
                 <input type="hidden" name="checksum" value="{{ unit.checksum }}" />
 
                 {% include "snippets/suggestions.html" with suggestions=unit.suggestions %}
@@ -400,7 +407,7 @@
                 <p class="help-block">{% translate "Showing only subset of the strings as there were too many matches." %}</p>
               {% endif %}
               <form method="post"
-                    action="{{ unit.translation.get_translate_url }}?{{ search_url }}&amp;offset={{ offset }}&amp;checksum={{ unit.checksum }}">
+                    action="{{ unit.translation.get_translate_url }}?{{ search_url }}&amp;offset={{ offset }}&amp;checksum={{ unit.checksum }}&amp;unit_id={{ unit.pk }}">
                 {% csrf_token %}
                 <table class="table table-sm">
                   <thead>

--- a/weblate/templates/zen.html
+++ b/weblate/templates/zen.html
@@ -42,8 +42,11 @@
   </div>
 
   <div class="query-container">
-    <form method="get" class="result-page-form">
+    <form method="get" class="result-page-form double-submission">
       {% crispy search_form %}
+      <p id="search-cache-help" class="form-text mb-0">
+        {% translate "Search results stay fixed while you translate. Refresh results to show strings matching the filters now." %}
+      </p>
     </form>
   </div>
 

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -397,6 +397,7 @@ class PluralTextarea(forms.Textarea):
     """Text-area extension which possibly handles plurals."""
 
     profile: Profile
+    unit: Unit
 
     def __init__(self, *args, **kwargs) -> None:
         self.is_source_plural: Literal[True] | None = None
@@ -514,7 +515,7 @@ class PluralTextarea(forms.Textarea):
 
     def render(self, name, value, attrs=None, renderer=None, **kwargs):
         """Render all textareas with correct plural labels."""
-        unit = value
+        unit = self.unit if isinstance(value, list) else value
         translation = unit.translation
         lang_label = lang = translation.language
         if self.is_source_plural:
@@ -523,6 +524,10 @@ class PluralTextarea(forms.Textarea):
         else:
             plurals = unit.get_source_plurals()
             values = unit.get_target_plurals()
+        if isinstance(value, list):
+            values = [
+                value[idx] if idx < len(value) else "" for idx in range(len(values))
+            ]
         if "zen-mode" in self.attrs:
             lang_label = format_html(
                 '<a class="language" href="{}" tabindex="-1">{}</a>',
@@ -631,10 +636,12 @@ class PluralField(forms.CharField):
 class ChecksumForm(forms.Form):
     """Form for handling checksum IDs for translation."""
 
+    unit_id = forms.IntegerField(required=False, min_value=1, widget=forms.HiddenInput)
     checksum = ChecksumField(required=True)
 
-    def __init__(self, unit_set, *args, **kwargs) -> None:
+    def __init__(self, unit_set, *args, require_unique: bool = False, **kwargs) -> None:
         self.unit_set = unit_set
+        self.require_unique = require_unique
         super().__init__(*args, **kwargs)
 
     def clean_checksum(self) -> str | None:
@@ -643,14 +650,24 @@ class ChecksumForm(forms.Form):
             return None
 
         unit_set = self.unit_set
+        if unit_id := self.cleaned_data.get("unit_id"):
+            unit_set = unit_set.filter(pk=unit_id)
 
         checksum = self.cleaned_data["checksum"]
-        try:
-            self.cleaned_data["unit"] = unit_set.filter(id_hash=checksum)[0]
-        except (Unit.DoesNotExist, IndexError) as error:
+        units = list(
+            unit_set.filter(id_hash=checksum)[: 2 if self.require_unique else 1]
+        )
+        if not units:
             raise ValidationError(
                 gettext("The string you wanted to translate is no longer available.")
-            ) from error
+            )
+        if len(units) > 1:
+            raise ValidationError(
+                gettext(
+                    "The string you wanted to translate could not be identified. Please reopen it and try again."
+                )
+            )
+        self.cleaned_data["unit"] = units[0]
         return checksum
 
 
@@ -676,6 +693,7 @@ class FuzzyField(forms.BooleanField):
 class TranslationForm(UnitForm):
     """Form used for translation of single string."""
 
+    unit_id = forms.IntegerField(required=False, min_value=1, widget=forms.HiddenInput)
     checksum = ChecksumField(required=True)
     contentsum = ChecksumField(required=True)
     translationsum = ChecksumField(required=True)
@@ -705,6 +723,7 @@ class TranslationForm(UnitForm):
         translation = unit.translation
         component = translation.component
         kwargs["initial"] = {
+            "unit_id": unit.pk,
             "checksum": unit.checksum,
             "contentsum": hash_to_checksum(unit.content_hash),
             "translationsum": hash_to_checksum(unit.get_target_hash()),
@@ -755,6 +774,7 @@ class TranslationForm(UnitForm):
         self.user_can_edit = user_can_edit
         self.user = user
         self.fields["target"].widget.profile = user.profile
+        self.fields["target"].widget.unit = unit
         # Avoid failing validation on untranslated string
         if args:
             self.fields["review"].choices.append((STATE_EMPTY, ""))
@@ -765,6 +785,7 @@ class TranslationForm(UnitForm):
         self.helper.layout = Layout(
             Field("target"),
             Field("fuzzy"),
+            Field("unit_id"),
             Field("checksum"),
             Field("contentsum"),
             Field("translationsum"),

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -79,6 +79,428 @@ class SearchSessionTest(TestCase):
         self.assertNotIn("search_invalid_ttl", session)
 
 
+class SearchRecoveryTest(ViewTestCase):
+    query = "state:<translated"
+    recovery_message = "Your previous search results are no longer available."
+
+    def prepare_search(self) -> tuple[Unit, list[int], str]:
+        self.url = self.translation.get_translate_url()
+        self.client.get(self.url, {"q": self.query})
+        session = self.client.session
+        session_keys = session.keys()
+        key = next(key for key in session_keys if key.startswith("search_"))
+        ids = session[key]["ids"]
+        unit = self.get_unit("Thank you for using Weblate.")
+        offset = ids.index(unit.pk) + 1
+        self.client.get(self.url, {"q": self.query, "offset": str(offset)})
+        return unit, ids, f"{self.url}?q=state:%3Ctranslated&offset={offset}"
+
+    def expire_search(self, *, missing: bool = False) -> None:
+        session = self.client.session
+        for key in list(session.keys()):
+            if key.startswith("search_"):
+                if missing:
+                    del session[key]
+                else:
+                    session[key] = {**session[key], "ttl": 0}
+        session.save()
+
+    def prepare_project_search(self) -> tuple[Unit, str]:
+        self.component.allow_translation_propagation = False
+        self.component.save(update_fields=["allow_translation_propagation"])
+        linked = self.create_link_existing(allow_translation_propagation=False)
+        unit = linked.translation_set.get(language_code="cs").unit_set.get(
+            source="Hello, world!\n"
+        )
+        self.url = reverse("translate", kwargs={"path": [self.project.slug, "-", "cs"]})
+        self.client.get(self.url, {"q": self.query})
+        ids = next(
+            value["ids"]
+            for key, value in self.client.session.items()
+            if key.startswith("search_")
+        )
+        url = f"{self.url}?q=state:%3Ctranslated&offset={ids.index(unit.pk) + 1}"
+        response = self.client.get(url)
+        self.assertEqual(response.context["unit"].pk, unit.pk)
+        self.assertContains(response, f'name="unit_id" value="{unit.pk}"')
+        return unit, url
+
+    @staticmethod
+    def translation_data(unit: Unit) -> dict[str, str]:
+        return {
+            "unit_id": str(unit.pk),
+            "checksum": unit.checksum,
+            "contentsum": hash_to_checksum(unit.content_hash),
+            "translationsum": hash_to_checksum(unit.get_target_hash()),
+            "target_0": "Díky za použití Weblate.",
+            "review": "20",
+        }
+
+    def test_expired_search_saves_submitted_unit_at_new_position(self) -> None:
+        unit, ids, url = self.prepare_search()
+        previous_ids = ids[: ids.index(unit.pk)]
+        self.assertTrue(previous_ids)
+        previous_targets = dict(
+            Unit.objects.filter(pk__in=previous_ids).values_list("pk", "target")
+        )
+        Unit.objects.filter(pk__in=previous_ids).update(state=STATE_TRANSLATED)
+        self.expire_search()
+
+        response = self.client.post(url, self.translation_data(unit), follow=True)
+
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "Díky za použití Weblate.")
+        self.assertContains(response, self.recovery_message)
+        self.assertNotContains(response, "The source string has changed meanwhile.")
+        self.assertIn("offset=2", response.redirect_chain[0][0])
+        self.assertContains(response, "The translation has come to an end.")
+        self.assertEqual(
+            dict(Unit.objects.filter(pk__in=previous_ids).values_list("pk", "target")),
+            previous_targets,
+        )
+
+    def test_expired_project_search_uses_exact_submitted_unit(self) -> None:
+        unit, url = self.prepare_project_search()
+        self.expire_search(missing=True)
+        data = {
+            **self.translation_data(unit),
+            "target_0": "Nazdar svete!\n",
+            "save-stay": "1",
+        }
+        response = self.client.post(url, data, follow=True)
+        self.assertEqual(response.context["unit"].pk, unit.pk)
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, data["target_0"])
+        self.assertEqual(self.get_unit().target, "")
+
+    def test_legacy_project_form_uses_cached_position(self) -> None:
+        unit, url = self.prepare_project_search()
+        data = {
+            **self.translation_data(unit),
+            "target_0": "Nazdar svete!\n",
+            "save-stay": "1",
+        }
+        del data["unit_id"]
+        response = self.client.post(url, data, follow=True)
+        self.assertEqual(response.context["unit"].pk, unit.pk)
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, data["target_0"])
+        self.assertEqual(self.get_unit().target, "")
+
+    def test_legacy_project_form_uses_lightweight_position(
+        self, *, expired: bool = False
+    ) -> None:
+        self.prepare_project_search()
+        self.expire_search(missing=True)
+        url = f"{self.url}?offset=1"
+        response = self.client.get(url)
+        unit = response.context["unit"]
+        duplicates = Unit.objects.filter(
+            translation__component__project=self.project,
+            translation__language=self.translation.language,
+            id_hash=unit.id_hash,
+        ).exclude(pk=unit.pk)
+        targets = dict(duplicates.values_list("pk", "target"))
+        self.assertTrue(targets)
+        snapshot = next(
+            value
+            for key, value in self.client.session.items()
+            if key.startswith("search_")
+        )
+        self.assertNotIn("ids", snapshot)
+        if expired:
+            self.expire_search()
+        data = {
+            **self.translation_data(unit),
+            "target_0": "Nazdar svete!\n",
+            "save-stay": "1",
+        }
+        del data["unit_id"]
+        original_target = unit.target
+
+        response = self.client.post(url, data, follow=True)
+
+        unit.refresh_from_db()
+        if expired:
+            self.assertContains(
+                response, "The string you wanted to translate could not be identified."
+            )
+            self.assertEqual(unit.target, original_target)
+        else:
+            self.assertEqual(response.context["unit"].pk, unit.pk)
+            self.assertEqual(unit.target, data["target_0"])
+        self.assertEqual(dict(duplicates.values_list("pk", "target")), targets)
+
+    def test_expired_legacy_project_form_rejects_lightweight_position(self) -> None:
+        self.test_legacy_project_form_uses_lightweight_position(expired=True)
+
+    def test_expired_legacy_project_form_rejects_ambiguous_checksum(self) -> None:
+        unit, url = self.prepare_project_search()
+        data = self.translation_data(unit)
+        del data["unit_id"]
+        self.expire_search()
+        response = self.client.post(url, data, follow=True)
+        self.assertContains(
+            response, "The string you wanted to translate could not be identified."
+        )
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "")
+        self.assertEqual(self.get_unit().target, "")
+
+    def test_submitted_unit_id_is_scoped_to_translation(self) -> None:
+        unit, _ids, url = self.prepare_search()
+        response = self.client.post(
+            url,
+            {**self.translation_data(unit), "unit_id": str(unit.source_unit_id)},
+            follow=True,
+        )
+        self.assertContains(
+            response, "The string you wanted to translate is no longer available."
+        )
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "")
+
+    def test_missing_search_keeps_nonmatching_submitted_unit(self) -> None:
+        unit, _ids, url = self.prepare_search()
+        Unit.objects.filter(pk=unit.pk).update(state=STATE_TRANSLATED)
+        self.expire_search(missing=True)
+        data = {**self.translation_data(unit), "save-stay": "1"}
+
+        response = self.client.post(url, data, follow=True)
+
+        self.assertContains(response, self.recovery_message)
+        self.assertEqual(response.context["unit"].pk, unit.pk)
+        self.assertEqual(response.context["filter_pos"], 1)
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, data["target_0"])
+        response = self.client.get(self.url, {"q": self.query, "offset": "2"})
+        self.assertNotEqual(response.context["unit"].pk, unit.pk)
+        response = self.client.get(self.url, {"q": self.query, "offset": "1"})
+        self.assertEqual(response.context["unit"].pk, unit.pk)
+
+    def test_expired_search_saves_when_no_strings_match(self) -> None:
+        unit, ids, url = self.prepare_search()
+        Unit.objects.filter(pk__in=ids).update(state=STATE_TRANSLATED)
+        self.expire_search()
+        response = self.client.post(
+            url, {**self.translation_data(unit), "save-stay": "1"}, follow=True
+        )
+        self.assertEqual(response.context["unit"].pk, unit.pk)
+        self.assertEqual(response.context["filter_count"], 1)
+        self.assertContains(response, self.recovery_message)
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "Díky za použití Weblate.")
+
+    def test_expired_search_preserves_text_on_conflict(self) -> None:
+        unit, _ids, url = self.prepare_search()
+        data = {**self.translation_data(unit), "contentsum": "aaa"}
+        self.expire_search()
+
+        response = self.client.post(url, data)
+
+        self.assertContains(response, "The source string has changed meanwhile.")
+        self.assertContains(response, data["target_0"])
+        self.assertEqual(response.context["unit"].pk, unit.pk)
+        self.assertTrue(response.context["form"].is_bound)
+        self.assertContains(response, 'data-unsaved="true"')
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "")
+
+        response = self.client.post(
+            url, {**self.translation_data(unit), "save-stay": "1"}, follow=True
+        )
+        self.assertContains(response, 'data-unsaved="false"')
+
+    def test_translation_conflict_retry_preserves_other_users_translation(self) -> None:
+        unit, _ids, url = self.prepare_search()
+        data = {**self.translation_data(unit), "save-stay": "1"}
+        competing_target = "Překlad jiného uživatele."
+        unit.translate(
+            self.anotheruser, competing_target, STATE_TRANSLATED, propagate=False
+        )
+
+        for expired in (False, True):
+            with self.subTest(expired=expired):
+                if expired:
+                    self.expire_search()
+                for _attempt in range(2):
+                    response = self.client.post(url, data)
+                    self.assertContains(
+                        response,
+                        "The translation of the string has changed meanwhile.",
+                    )
+                    self.assertContains(response, data["target_0"])
+                    self.assertContains(response, 'data-unsaved="true"')
+                    unit.refresh_from_db()
+                    self.assertEqual(unit.target, competing_target)
+                    # Retry using the hidden values actually rendered to the user.
+                    document = html.fromstring(response.content)
+                    fields = document.xpath(
+                        '//form[@data-unsaved="true"]//input[@type="hidden"]'
+                    )
+                    self.assertTrue(fields)
+                    for field in fields:
+                        data[field.get("name")] = field.get("value", "")
+                    self.assertNotEqual(
+                        data["translationsum"], hash_to_checksum(unit.get_target_hash())
+                    )
+
+    def test_expired_search_preserves_all_plural_values(self) -> None:
+        _unit, ids, _url = self.prepare_search()
+        unit = self.translation.unit_set.get(source__contains="Orangutan")
+        data = {
+            **self.translation_data(unit),
+            "contentsum": "aaa",
+            "target_0": "První návrh",
+            "target_1": "Druhý návrh",
+            "target_2": "Třetí návrh",
+        }
+        self.expire_search()
+        response = self.client.post(
+            f"{self.url}?q=state:%3Ctranslated&offset={ids.index(unit.pk) + 1}", data
+        )
+        for idx in range(3):
+            self.assertContains(response, data[f"target_{idx}"])
+        self.assertContains(response, 'data-unsaved="true"')
+
+    def test_expired_search_rejects_unavailable_checksum(self) -> None:
+        unit, _ids, url = self.prepare_search()
+        other = self.component.source_translation.unit_set.get(id_hash=unit.id_hash)
+        # Use a checksum that is valid but outside the translation's unit set.
+        other.id_hash = calculate_hash("unavailable string", "")
+        other.save(update_fields=["id_hash"], run_checks=False)
+        self.expire_search()
+        response = self.client.post(
+            url,
+            {**self.translation_data(unit), "checksum": other.checksum},
+            follow=True,
+        )
+        self.assertContains(
+            response, "The string you wanted to translate is no longer available."
+        )
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "")
+
+    def test_expired_search_get_recovers_out_of_range_offset(self) -> None:
+        _unit, ids, _url = self.prepare_search()
+        Unit.objects.filter(pk__in=ids[1:]).update(state=STATE_TRANSLATED)
+        self.expire_search()
+        response = self.client.get(self.url, {"q": self.query, "offset": str(len(ids))})
+        self.assertContains(response, self.recovery_message)
+        self.assertEqual(response.context["unit"].pk, ids[0])
+        self.assertEqual(response.context["filter_pos"], 1)
+
+    def test_expired_search_rejects_deleted_unit(self) -> None:
+        unit, _ids, url = self.prepare_search()
+        data = self.translation_data(unit)
+        unit.delete()
+        targets = dict(self.translation.unit_set.values_list("pk", "target"))
+        self.expire_search()
+        response = self.client.post(url, data, follow=True)
+        self.assertContains(
+            response, "The string you wanted to translate is no longer available."
+        )
+        self.assertEqual(
+            dict(self.translation.unit_set.values_list("pk", "target")), targets
+        )
+
+    def test_expired_search_rejects_malformed_checksum(self) -> None:
+        unit, _ids, url = self.prepare_search()
+        self.expire_search()
+        response = self.client.post(
+            url,
+            {**self.translation_data(unit), "checksum": "invalid"},
+            follow=True,
+        )
+        self.assertContains(response, "Invalid checksum specified!")
+        unit.refresh_from_db()
+        self.assertEqual(unit.target, "")
+
+    def test_expired_search_get_empty_results(self) -> None:
+        _unit, ids, _url = self.prepare_search()
+        Unit.objects.filter(pk__in=ids).update(state=STATE_TRANSLATED)
+        self.expire_search()
+        response = self.client.get(
+            self.url, {"q": self.query, "offset": "2"}, follow=True
+        )
+        self.assertContains(response, self.recovery_message)
+        self.assertContains(response, "No strings found!")
+        self.assertNotContains(response, "The translation has come to an end.")
+
+    def test_refresh_replaces_all_sort_variants(self) -> None:
+        unit, ids, url = self.prepare_search()
+        self.client.get(self.url, {"q": self.query, "sort_by": "source", "offset": "1"})
+        Unit.objects.filter(pk=unit.pk).update(state=STATE_TRANSLATED)
+        response = self.client.get(url)
+        self.assertEqual(response.context["filter_count"], len(ids))
+        self.assertContains(response, "Refresh results")
+
+        response = self.client.get(
+            self.url, {"q": self.query, "offset": "2", "refresh": "1"}, follow=True
+        )
+        self.assertEqual(response.context["filter_pos"], 1)
+        self.assertEqual(response.context["filter_count"], len(ids) - 1)
+        self.assertNotContains(response, self.recovery_message)
+        self.assertNotIn("refresh=", response.redirect_chain[-1][0])
+        response = self.client.get(
+            self.url, {"q": self.query, "sort_by": "source", "offset": "1"}
+        )
+        self.assertEqual(response.context["filter_count"], len(ids) - 1)
+        for key, value in self.client.session.items():
+            if key.startswith("search_"):
+                self.assertNotIn(unit.pk, value["ids"])
+
+    def test_zen_refresh_replaces_results(self) -> None:
+        unit, ids, _url = self.prepare_search()
+        url = reverse("zen", kwargs=self.kw_translation)
+        Unit.objects.filter(pk=unit.pk).update(state=STATE_TRANSLATED)
+        response = self.client.get(url, {"q": self.query, "offset": "1"})
+        self.assertEqual(response.context["filter_count"], len(ids))
+        self.assertContains(response, "Refresh results")
+        response = self.client.get(url, {"q": self.query, "refresh": "1"}, follow=True)
+        self.assertEqual(response.context["filter_count"], len(ids) - 1)
+        self.assertNotIn(
+            unit.pk, [item["unit"].pk for item in response.context["unitdata"]]
+        )
+
+    def test_refresh_preserves_invalid_query(self) -> None:
+        query = 'source:r"^(hello"'
+        for view in ("translate", "zen"):
+            with self.subTest(view=view):
+                url = reverse(view, kwargs={"path": self.translation.get_url_path()})
+                response = self.client.get(url, {"q": query, "refresh": "1"})
+                self.assertEqual(response.status_code, 200)
+                form = response.context["search_form"]
+                self.assertIn("q", form.errors)
+                document = html.fromstring(response.content)
+                self.assertEqual(
+                    document.xpath('//textarea[@name="q"]/text()'), [f"\n{query}"]
+                )
+
+    def test_refresh_empty_results(self) -> None:
+        _unit, ids, _url = self.prepare_search()
+        Unit.objects.filter(pk__in=ids).update(state=STATE_TRANSLATED)
+        response = self.client.get(
+            self.url,
+            {"q": self.query, "offset": "2", "refresh": "1"},
+            follow=True,
+        )
+        self.assertContains(response, "No strings found!")
+        self.assertNotContains(response, "The translation has come to an end.")
+        self.assertNotContains(response, self.recovery_message)
+
+    def test_expired_zen_scroll_requires_refresh(self) -> None:
+        self.prepare_search()
+        self.expire_search()
+        response = self.client.get(
+            reverse("load_zen", kwargs=self.kw_translation),
+            {"q": self.query, "offset": "21"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.content, b"")
+
+
 class EditScreenshotContextTest(ViewTestCase):
     def test_screenshot_context_has_documentation_link(self) -> None:
         self.make_manager()

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -74,6 +74,7 @@ from weblate.trans.tests.browser import create_browser
 from weblate.trans.tests.test_models import BaseLiveServerTestCase
 from weblate.trans.tests.test_views import RegistrationTestMixin
 from weblate.trans.tests.utils import (
+    RepoTestMixin,
     TempDirMixin,
     create_another_user,
     create_test_billing,
@@ -85,6 +86,7 @@ from weblate.trans.tests.utils import (
 from weblate.trans.widgets import WIDGETS
 from weblate.utils.data import data_dir
 from weblate.utils.files import remove_tree
+from weblate.utils.state import STATE_EMPTY, STATE_TRANSLATED
 from weblate.utils.stats import GlobalStats, ProjectLanguage
 from weblate.vcs.ssh import ssh_file
 from weblate.wladmin.models import BackupService, ConfigurationError, SupportStatus
@@ -1108,6 +1110,224 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
                 hidden_input.get_attribute("value")
                 == f"{regex_flag}, max-length:100, priority:10, "
                 'placeholders:"a,b", ignore-same'
+            )
+        )
+
+    def test_retained_translation_is_unsaved(self) -> None:
+        """Retained plural drafts warn on navigation without further input."""
+        fixture = RepoTestMixin()
+        fixture.clone_test_repos()
+        project = Project.objects.create(name="Retained edits", slug="retained-edits")
+        component = fixture.create_po(project=project)
+        unit = component.translation_set.get(language_code="cs").unit_set.get(
+            source__contains="Orangutan"
+        )
+        self.do_login(superuser=True)
+        with self.wait_for_page_load():
+            self.driver.get(f"{self.live_server_url}{unit.get_absolute_url()}")
+
+        selector = ".translation-form .translation-editor"
+        self.assertFalse(
+            self.driver.execute_script("return WLT.Utils.editorHasChanges();")
+        )
+        editors = self.driver.find_elements(By.CSS_SELECTOR, selector)
+        self.assertEqual(len(editors), 3)
+        drafts = [f"Překlad %d {idx}\n" for idx in range(3)]
+        for editor, draft in zip(editors, drafts, strict=True):
+            editor.clear()
+            editor.send_keys(draft)
+        self.driver.execute_script(
+            "document.querySelector('.translation-form input[name=contentsum]').value = 'aaa';"
+        )
+        with self.wait_for_page_load():
+            self.driver.find_element(By.NAME, "save-stay").send_keys(Keys.ENTER)
+
+        self.assert_text_contains(
+            ".alert-danger", "The source string has changed meanwhile."
+        )
+        editors = self.driver.find_elements(By.CSS_SELECTOR, selector)
+        self.assertEqual([editor.get_attribute("value") for editor in editors], drafts)
+        for editor in editors:
+            self.assertIn("has-changes", editor.get_attribute("class") or "")
+        self.assertEqual(
+            len(self.driver.find_elements(By.CSS_SELECTOR, "#unsaved-label")), 3
+        )
+        # Exercise both ordinary navigation and Refresh's submit listeners
+        # without relying on WebDriver's handling of native browser dialogs.
+        for submit_search in (False, True):
+            self.assertTrue(
+                self.driver.execute_script(
+                    """
+                    if (arguments[0]) {
+                        document.querySelector('.result-page-form').dispatchEvent(
+                            new Event('submit', {bubbles: true, cancelable: true})
+                        );
+                    }
+                    const event = new Event('beforeunload', {cancelable: true});
+                    window.dispatchEvent(event);
+                    return WLT.Utils.editorHasChanges() && event.defaultPrevented;
+                    """,
+                    submit_search,
+                )
+            )
+
+        with self.wait_for_page_load():
+            self.driver.find_element(By.NAME, "save-stay").send_keys(Keys.ENTER)
+        self.assertFalse(
+            self.driver.execute_script("return WLT.Utils.editorHasChanges();")
+        )
+        self.assertEqual(
+            self.driver.find_elements(By.CSS_SELECTOR, "#unsaved-label"), []
+        )
+        unit.refresh_from_db()
+        self.assertEqual(unit.get_target_plurals(), drafts)
+
+    def test_translation_search_refresh(self) -> None:
+        """Refresh and query Enter replace results; navigation preserves them."""
+        fixture = RepoTestMixin()
+        fixture.clone_test_repos()
+        project = Project.objects.create(
+            name="Search navigation", slug="search-navigation"
+        )
+        component = fixture.create_po(project=project)
+        translation = component.translation_set.get(language_code="cs")
+        self.do_login(superuser=True)
+        query = "state:<translated"
+        url = f"{self.live_server_url}{translation.get_translate_url()}?{urlencode({'q': query})}"
+        with self.wait_for_page_load():
+            self.driver.get(url)
+
+        def assert_compact_refresh() -> None:
+            original_size = self.driver.get_window_size()
+            for width in (1280, 768, 480):
+                self.driver.set_window_size(width, 900)
+                refresh = self.driver.find_element(
+                    By.CSS_SELECTOR, '.query-field button[name="refresh"]'
+                )
+                query_input = self.driver.find_element(By.CSS_SELECTOR, '[name="q"]')
+                self.assertEqual(refresh.get_attribute("aria-label"), "Refresh results")
+                self.assertAlmostEqual(
+                    refresh.rect["y"], query_input.rect["y"], delta=1
+                )
+                self.assertLess(refresh.rect["width"], 60)
+                self.assertGreater(query_input.rect["width"], 100)
+            self.driver.set_window_size(original_size["width"], original_size["height"])
+
+        assert_compact_refresh()
+
+        def current_checksum() -> str:
+            value = self.driver.find_element(
+                By.CSS_SELECTOR, '.translation-form input[name="checksum"]'
+            ).get_attribute("value")
+            self.assertIsNotNone(value)
+            return cast("str", value)
+
+        def result_count() -> int:
+            return int(
+                self.driver.find_element(By.CSS_SELECTOR, ".position-input")
+                .text.split("/")[-1]
+                .strip()
+            )
+
+        checksum = current_checksum()
+        unit = next(
+            unit for unit in translation.unit_set.all() if unit.checksum == checksum
+        )
+        count = result_count()
+        Unit.objects.filter(pk=unit.pk).update(state=STATE_TRANSLATED)
+        # Use a navigation URL, as initial searches intentionally omit offset.
+        with self.wait_for_page_load():
+            self.click(htmlid="button-first")
+        self.assertEqual(current_checksum(), checksum)
+        with self.wait_for_page_load():
+            self.driver.refresh()
+        self.assertEqual(result_count(), count)
+        self.assertEqual(current_checksum(), checksum)
+
+        self.click(htmlid="query-sort-dropdown")
+        with self.wait_for_page_load():
+            self.driver.find_element(By.CSS_SELECTOR, 'a[data-sort="source"]').click()
+        self.assertEqual(result_count(), count)
+        self.assertEqual(current_checksum(), checksum)
+
+        # Enter in the position field is navigation, not a fresh search.
+        self.driver.find_element(By.CSS_SELECTOR, ".position-input").click()
+        position = self.driver.find_element(By.ID, "position-input-editable-input")
+        position.clear()
+        position.send_keys("2")
+        with self.wait_for_page_load():
+            position.send_keys(Keys.ENTER)
+        self.assertEqual(result_count(), count)
+
+        with self.wait_for_page_load():
+            self.driver.find_element(By.ID, "id_q").send_keys(Keys.ENTER)
+        self.assertEqual(result_count(), count - 1)
+        self.assertNotEqual(current_checksum(), checksum)
+        self.assertNotIn("refresh=", self.driver.current_url)
+
+        # Refresh must retain the editor's unsaved-changes protection.
+        editor = self.driver.find_element(
+            By.CSS_SELECTOR, ".translator .translation-editor"
+        )
+        editor.send_keys("Unsaved translation")
+        refresh = self.driver.find_element(By.CSS_SELECTOR, 'button[name="refresh"]')
+        # Check the real listeners without relying on WebDriver's handling of
+        # native browser dialogs.
+        self.assertTrue(
+            self.driver.execute_script(
+                """
+                document.querySelector(".result-page-form").dispatchEvent(
+                    new Event("submit", {bubbles: true, cancelable: true})
+                );
+                const event = new Event("beforeunload", {cancelable: true});
+                window.dispatchEvent(event);
+                return WLT.Utils.editorHasChanges() && event.defaultPrevented;
+                """
+            )
+        )
+        self.assertEqual(editor.get_attribute("value"), "Unsaved translation")
+        self.driver.execute_script(
+            "arguments[0].value = ''; arguments[0].classList.remove('has-changes');",
+            editor,
+        )
+        with self.wait_for_page_load():
+            refresh.send_keys(Keys.ENTER)
+        self.assertEqual(result_count(), count - 1)
+
+        zen_url = reverse("zen", kwargs={"path": translation.get_url_path()})
+        with self.wait_for_page_load():
+            self.driver.get(
+                f"{self.live_server_url}{zen_url}?{urlencode({'q': query, 'offset': 1})}"
+            )
+        self.assertEqual(result_count(), count - 1)
+        Unit.objects.filter(pk=unit.pk).update(state=STATE_EMPTY)
+        with self.wait_for_page_load():
+            self.driver.find_element(By.CSS_SELECTOR, 'button[name="refresh"]').click()
+        self.assertEqual(result_count(), count)
+
+        assert_compact_refresh()
+
+        # Pending edits in later Zen rows must warn before autosave starts.
+        self.assertTrue(
+            self.driver.execute_script(
+                """
+                const editors = document.querySelectorAll(
+                    ".translator .translation-editor"
+                );
+                const editor = editors[1];
+                editor.focus();
+                editor.value = "Pending Zen translation";
+                editor.dispatchEvent(new Event("input", {bubbles: true}));
+                document.querySelector('button[name="refresh"]').focus();
+                document.querySelector(".result-page-form").dispatchEvent(
+                    new Event("submit", {bubbles: true, cancelable: true})
+                );
+                const event = new Event("beforeunload", {cancelable: true});
+                window.dispatchEvent(event);
+                return !editors[0].classList.contains("has-changes")
+                    && WLT.Utils.editorHasChanges()
+                    && event.defaultPrevented;
+                """
             )
         )
 

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -423,6 +423,8 @@ class SearchNavigation:
         self.request = request
         self.blank = blank
         self.use_cache = use_cache
+        self.recovered = False
+        self.refreshing = False
 
         self.form = PositionSearchForm(
             request=request, data=request.GET, show_builder=False, obj=base
@@ -453,7 +455,7 @@ class SearchNavigation:
 
     @property
     def can_use_session_snapshot(self) -> bool:
-        return self.use_cache and "offset" in self.request.GET
+        return self.use_cache and not self.refreshing and "offset" in self.request.GET
 
     @property
     def can_use_bounded_page_lookup(self) -> bool:
@@ -480,9 +482,6 @@ class SearchNavigation:
 
     def get_matching_full_snapshots(self) -> Iterator[CachedSearchSnapshot]:
         """Yield cached full snapshots for the same search ignoring ordering."""
-        if not self.can_use_session_snapshot:
-            return
-
         prefix = f"search_{self.base.cache_key}_"
         session_keys = list(self.request.session.keys())
         for key in session_keys:
@@ -509,11 +508,37 @@ class SearchNavigation:
 
     def get_latest_cached_full_snapshot(self) -> CachedSearchSnapshot | None:
         """Return the newest full snapshot for the same search."""
+        if not self.can_use_session_snapshot:
+            return None
         return max(
             self.get_matching_full_snapshots(),
             key=self.get_cached_snapshot_sort_key,
             default=None,
         )
+
+    def notify_recovery(self) -> None:
+        """Explain why navigation no longer uses the previous results."""
+        if not self.recovered:
+            messages.info(
+                self.request,
+                gettext(
+                    "Your previous search results are no longer available. "
+                    "The results have been refreshed."
+                ),
+            )
+            self.recovered = True
+
+    def refresh_results(self, *, page_size: int) -> HttpResponse:
+        """Replace all sort variants and redirect to reusable navigation."""
+        cleanup_session(self.request.session)
+        for snapshot in self.get_matching_full_snapshots():
+            del self.request.session[snapshot.key]
+        self.offset = 1
+        self.refreshing = True
+        result = self.page(include_count=True, page_size=page_size)
+        if isinstance(result, HttpResponse):
+            return result
+        return redirect(f"{self.request.path}?{self.search_url}&offset=1")
 
     def get_reordered_cached_session_data(
         self, source: CachedSearchSnapshot, *, reset_offset_to_last_viewed: bool
@@ -573,7 +598,7 @@ class SearchNavigation:
         return session_data
 
     def load_data(
-        self, *, reset_offset_to_last_viewed: bool = False
+        self, *, reset_offset_to_last_viewed: bool = False, anchor: Unit | None = None
     ) -> HttpResponse | SearchResult:
         """Load a cached full snapshot or perform and store a new search."""
         cleanup_session(self.request.session)
@@ -592,7 +617,11 @@ class SearchNavigation:
             if session_data is not None:
                 return session_data
 
+        if self.can_use_session_snapshot:
+            self.notify_recovery()
         unit_ids = self.get_ordered_unit_ids()
+        if anchor is not None and anchor.pk not in unit_ids:
+            unit_ids.insert(0, anchor.pk)
         if not unit_ids and not self.blank:
             messages.warning(self.request, gettext("No strings found!"))
             return redirect(
@@ -612,6 +641,8 @@ class SearchNavigation:
         cleanup_session(self.request.session)
         session_data = self.get_session_data(self.request.session, self.session_key)
         ordered_units = self.get_ordered_units()
+        if session_data is None and self.can_use_session_snapshot:
+            self.notify_recovery()
 
         total = None
         if include_count or self.offset < 1:
@@ -623,6 +654,8 @@ class SearchNavigation:
                 )
             if self.offset < 1:
                 self.offset = max(total - page_size + 1, 1)
+            elif self.recovered and self.offset > total:
+                self.offset = 1
 
         offset = self.offset - 1
         unit_ids = list(
@@ -704,6 +737,8 @@ class SearchNavigation:
                     total=0 if include_count else None,
                     last_section=True,
                 )
+            if self.recovered and self.offset > len(unit_ids):
+                self.offset = 1
             snapshot = self._get_ids_snapshot(unit_ids, self.offset, page_size)
             if snapshot is None:
                 return self.make_result(
@@ -722,21 +757,53 @@ class SearchNavigation:
                 last_section=snapshot.last_section,
             )
 
+    def get_legacy_post_unit_id(self) -> int | None:
+        """Disambiguate older forms using their still-valid cached position."""
+        if not self.can_use_session_snapshot or not self.form_valid:
+            return None
+        cleanup_session(self.request.session)
+        data = self.get_session_data(self.request.session, self.session_key)
+        ids = self._get_unit_ids(data) if data is not None else None
+        if ids is not None and 0 < self.offset <= len(ids):
+            return ids[self.offset - 1]
+        if (
+            data is not None
+            and "ids" not in data
+            and self.can_use_bounded_page_lookup
+            and self.offset > 0
+        ):
+            return next(
+                iter(
+                    self.get_ordered_units().values_list("id", flat=True)[
+                        self.offset - 1 : self.offset
+                    ]
+                ),
+                None,
+            )
+        return None
+
     def post_unit(self, unit: Unit) -> tuple[SearchResult, int] | None:
-        """Resolve POST search context using the submitted offset."""
+        """Resolve POST navigation around the submitted string."""
         if not self.form_valid or self.offset < 1:
             return None
         with start_span(op="unit.search", name=self.search_url):
             if self.can_use_bounded_page_lookup:
-                return self.limited_post_unit(unit)
-            data = self.load_data()
+                result = self.limited_post_unit(unit)
+                if result is not None:
+                    return result
+            data = self.load_data(anchor=unit)
             if isinstance(data, HttpResponse):
                 return None
             unit_ids = self._get_unit_ids(data)
             if unit_ids is None:
                 return None
+            if unit.pk not in unit_ids:
+                unit_ids.insert(0, unit.pk)
+                self.request.session[self.session_key] = data
+                self.notify_recovery()
+            self.offset = unit_ids.index(unit.pk) + 1
             snapshot = self._get_ids_snapshot(unit_ids, self.offset, 1)
-            if snapshot is None or snapshot.ids[0] != unit.id:
+            if snapshot is None:
                 return None
             return (
                 self.make_result(
@@ -939,7 +1006,7 @@ def handle_translate(
     form = TranslationForm(request.user, unit, request.POST)
     if not form.is_valid():
         show_form_errors(request, form)
-        return None
+        return form
 
     go_next = True
 
@@ -1197,22 +1264,31 @@ def get_translate_unit(
     unit_set: UnitQuerySet,
 ) -> HttpResponse | TranslateUnitResult:
     """Resolve search results and current unit for the translate view."""
+    navigation = SearchNavigation(obj, project, unit_set, request)
     if (
-        request.method == "POST"
-        and request.POST.get("checksum")
-        and request.GET.get("offset")
+        request.method == "GET"
+        and request.GET.get("refresh") == "1"
+        and navigation.form_valid
     ):
-        checksum_form = ChecksumForm(get_checksum_unit_set(unit_set), request.POST)
-        if checksum_form.is_valid():
-            unit = checksum_form.cleaned_data["unit"]
-            search_data = SearchNavigation(obj, project, unit_set, request).post_unit(
-                unit
-            )
-            if search_data is not None:
-                search_result, num_results = search_data
-                return TranslateUnitResult(
-                    search_result, num_results, search_result["offset"], unit
-                )
+        return navigation.refresh_results(page_size=1)
+    if request.method == "POST":
+        payload = request.GET if "merge" in request.POST else request.POST
+        checksum_units = get_checksum_unit_set(unit_set)
+        if (
+            not payload.get("unit_id")
+            and (cached_id := navigation.get_legacy_post_unit_id()) is not None
+        ):
+            checksum_units = checksum_units.filter(pk=cached_id)
+        checksum_form = ChecksumForm(checksum_units, payload, require_unique=True)
+        if not checksum_form.is_valid():
+            show_form_errors(request, checksum_form)
+            return redirect(obj)
+        unit = checksum_form.cleaned_data["unit"]
+        search_data = navigation.post_unit(unit)
+        if search_data is None:
+            return redirect(obj)
+        post_result, post_count = search_data
+        return TranslateUnitResult(post_result, post_count, post_result["offset"], unit)
 
     use_fast_search = (
         request.method == "GET"
@@ -1220,11 +1296,9 @@ def get_translate_unit(
         and "revert" not in request.GET
     )
     if use_fast_search:
-        search_result = SearchNavigation(obj, project, unit_set, request).page(
-            include_count=True, page_size=1
-        )
+        search_result = navigation.page(include_count=True, page_size=1)
     else:
-        search_result = SearchNavigation(obj, project, unit_set, request).search()
+        search_result = navigation.search()
 
     # Handle redirects
     if isinstance(search_result, HttpResponse):
@@ -1232,7 +1306,9 @@ def get_translate_unit(
 
     # Get number of results
     num_results = (
-        search_result["total"] if use_fast_search else len(search_result["ids"])
+        cast("int", search_result["total"])
+        if use_fast_search
+        else len(search_result["ids"])
     )
 
     # Search offset
@@ -1247,10 +1323,10 @@ def get_translate_unit(
             try:
                 offset = search_result["ids"].index(unit.id) + 1
             except ValueError:
-                offset = None
+                offset = 0
         else:
-            offset = None
-        if offset is None:
+            offset = 0
+        if not offset:
             messages.warning(request, gettext("No strings found!"))
             return redirect(obj)
     else:
@@ -1325,6 +1401,18 @@ def translate(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
     elif "revert" in request.GET:
         response = handle_revert(unit, request, this_unit_url)
 
+    # Keep submitted text when validation fails, including after cache recovery.
+    form = None
+    if isinstance(response, TranslationForm):
+        form = response
+        # The current source is shown, but the target still contains the draft.
+        # Preserve its translationsum so retrying cannot bypass a conflict.
+        form_data = request.POST.copy()
+        for name in ("unit_id", "checksum", "contentsum"):
+            form_data[name] = form.initial[name]
+        form.data = form_data
+        response = None
+
     # Pass possible redirect further
     if response is not None:
         return response
@@ -1333,7 +1421,8 @@ def translate(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
     secondary = unit.get_secondary_units(user) if user.is_authenticated else None
 
     # Prepare form
-    form = TranslationForm(user, unit)
+    if form is None:
+        form = TranslationForm(user, unit)
 
     screenshot_form = None
     if user.has_perm("screenshot.add", unit.translation):
@@ -1388,6 +1477,7 @@ def translate(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
             ),
             "context_form": ContextForm(instance=unit.source_unit, user=user),
             "search_form": search_result["form"].reset_offset(),
+            "can_refresh_search": True,
             "secondary": secondary,
             "locked": unit.translation.component.locked,
             "glossary": get_glossary_terms(unit, full=True),
@@ -1615,7 +1705,19 @@ def get_zen_unitdata(
 ):
     """Load unit data for zen mode."""
     # Search results
-    search_result = SearchNavigation(obj, project, unit_set, request).page(
+    navigation = SearchNavigation(obj, project, unit_set, request)
+    if request.GET.get("refresh") == "1" and navigation.form_valid:
+        return navigation.refresh_results(page_size=ZEN_PAGE_SIZE), None
+    if (
+        not include_count
+        and navigation.can_use_session_snapshot
+        and request.headers.get("X-Requested-With") == "XMLHttpRequest"
+    ):
+        # Appending a different snapshot can duplicate or skip rows already shown.
+        cleanup_session(request.session)
+        if navigation.get_latest_cached_full_snapshot() is None:
+            return HttpResponse(status=409), None
+    search_result = navigation.page(
         include_count=include_count, page_size=ZEN_PAGE_SIZE
     )
 
@@ -1694,6 +1796,7 @@ def zen(request: AuthenticatedHttpRequest, path):
             "search_url": search_result["url"],
             "offset": search_result["offset"],
             "search_form": search_result["form"].reset_offset(),
+            "can_refresh_search": True,
             "is_zen": True,
         },
     )


### PR DESCRIPTION
Add explicit refresh controls while preserving stable translation navigation. Recover expired searches using the submitted string identity and retain drafts when validation fails.

Fixes #21244

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
