### PR TITLE
feat(accounts): expose per-user notification diagnostics

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,7 @@ Weblate 2026.9.1
 
 .. rubric:: New features
 
-* Added administrator :ref:`notification diagnostics <notifications>` with watched projects, notification languages, and explanations of effective subscriptions for object paths.
+* Added per-user :ref:`notification diagnostics <notifications>` for users and administrators, with compact explanations of matching subscriptions for object paths.
 
 .. rubric:: Improvements
 

--- a/docs/user/profile.rst
+++ b/docs/user/profile.rst
@@ -207,17 +207,32 @@ default value depends on :setting:`DEFAULT_AUTO_WATCH`.
     Sending out notifications is limited, you will not receive more than 1000
     e-mails per day. Any further notifications for you will be discarded.
 
-Administrators with permission to edit users can inspect a user's
-:guilabel:`Notifications` tab to see watched projects, notification languages,
-and subscriptions grouped by scope. Use :guilabel:`Notification debug` to enter
-an object path such as ``project/category/component/cs``. Project and category
-paths include their accessible components and translations. Results explain
-effective and overridden subscriptions for up to 50 targets per page, including
-project, component, and translation targets. Lists of more than five watched
-projects, notification languages, or matching targets show counts instead of
-individual links. Matching-target counts apply to the current results page.
+Open :guilabel:`Notification diagnostics` from your notification settings to
+inspect your own subscriptions. Administrators with management access and
+permission to edit users can open the same page for another user from that
+user's :guilabel:`Edit` tab. The :guilabel:`Overview` tab includes watched
+projects, notification languages, and subscriptions grouped by scope and target.
+In the :guilabel:`Diagnostics` tab, enter an object path such as
+``project/category/component/cs``. Project and category paths summarize inherited
+project settings and exceptions across all accessible
+components. Equivalent component settings are grouped together, with counts and
+up to five example links to inspect individual components. Component paths show
+effective settings and language restrictions; translation paths check the selected
+language specifically. Broad summaries do not enumerate individual translations.
+Summaries are limited to 200 accessible components and 10 original projects
+(including the selected project). For larger scopes, choose a smaller category,
+a component, or a translation; partial summaries are not shown.
+Lists of more than five watched projects or notification languages show counts
+instead of individual links.
 
-The debugger checks eligibility without sending e-mail. Notifications that
+Only events with a matching subscription are shown, including disabled
+subscriptions and subscriptions blocked by language or account conditions.
+Event conditions and overridden subscriptions are shown directly. Subscription
+links highlight the matching row in the :guilabel:`Overview` tab. Component
+example links open diagnostics for that component. Shared components use
+subscriptions from their original project.
+
+The diagnostics check eligibility without sending e-mail. Notifications that
 depend on event details, such as mentions or alerts, are marked as conditional.
 Actual delivery also depends on the event author, digest content, and rate limits.
 

--- a/weblate/accounts/forms.py
+++ b/weblate/accounts/forms.py
@@ -1324,7 +1324,7 @@ class NotificationDebugForm(forms.Form):
         label=gettext_lazy("Project, category, component, or translation path"),
         max_length=1000,
         help_text=gettext_lazy(
-            "Enter slash-separated slugs, for example project/category/component/cs. Parent paths include their components and translations."
+            "Enter slash-separated slugs, for example project/category/component/cs. Project and category paths summarize inherited settings and component exceptions."
         ),
     )
 

--- a/weblate/accounts/notification_debug.py
+++ b/weblate/accounts/notification_debug.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from django.core.paginator import Page, Paginator
-from django.db.models import F, Value
+from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.utils.translation import gettext
 
 from weblate.accounts.notifications import (
@@ -29,7 +29,8 @@ if TYPE_CHECKING:
 
 
 NOTIFICATION_DETAIL_LIMIT = 5
-NOTIFICATION_TARGET_PAGE_SIZE = 50
+NOTIFICATION_COMPONENT_LIMIT = 200
+NOTIFICATION_PROJECT_LIMIT = 10
 
 
 @dataclass
@@ -39,11 +40,40 @@ class NotificationExplanation:
     subscription: Subscription | None = None
     overridden: list[Subscription] = field(default_factory=list)
     conditions: list[StrOrPromise] = field(default_factory=list)
-    targets: list[Project | Component | Translation] = field(default_factory=list)
+    exceptions: list[NotificationException] = field(default_factory=list)
 
     @property
     def name(self) -> StrOrPromise:
         return self.notification.verbose
+
+    @property
+    def behavior_key(self) -> tuple:
+        """Compare effective behavior without splitting equivalent subscriptions."""
+        subscription = self.subscription
+        return (
+            (subscription.scope, subscription.frequency, subscription.onetime)
+            if subscription
+            else None,
+            str(self.reason),
+            tuple(str(condition) for condition in self.conditions),
+        )
+
+
+@dataclass
+class NotificationException:
+    outcome: NotificationExplanation
+    count: int = 0
+    examples: list[Component] = field(default_factory=list)
+    subscription_id: int | None = None
+    shared_count: int = 0
+
+
+@dataclass
+class NotificationScopeSummary:
+    results: list[NotificationExplanation] = field(default_factory=list)
+    component_count: int = 0
+    broad: bool = False
+    empty: bool = False
 
 
 class NotificationDebugger:
@@ -68,19 +98,21 @@ class NotificationDebugger:
         result = NotificationExplanation(
             type(handler), gettext("No matching subscription.")
         )
+        # Share the delivery matcher, excluding only checks requiring an actual event.
+        subscriptions = list(
+            handler.get_scope_subscriptions(
+                None, project, component, translation, None, include_ineligible=True
+            )
+        )
+        if subscriptions:
+            result.subscription = subscriptions[0]
+            result.overridden = subscriptions[1:]
+
         if not self.user.is_active or self.user.is_bot:
             result.reason = gettext(
                 "Inactive users and bots do not receive notifications."
             )
             return result
-
-        # Share the delivery matcher, excluding only checks requiring an actual event.
-        subscriptions = list(
-            handler.get_scope_subscriptions(None, project, component, translation, None)
-        )
-        if subscriptions:
-            result.subscription = subscriptions[0]
-            result.overridden = subscriptions[1:]
 
         if not handler.can_access_target(self.user, project, component):
             result.reason = gettext("The user cannot access this target.")
@@ -150,115 +182,99 @@ class NotificationDebugger:
         self,
         target: Project | Category | Component | Translation,
         viewer: User,
-        page_number: str | None,
-    ) -> tuple[list[NotificationExplanation], Page]:
-        """Group equivalent outcomes over one page of accessible descendants."""
-        page = self.get_target_page(target, viewer, page_number)
-
-        groups: dict[tuple, NotificationExplanation] = {}
-        for obj in page:
-            translation = None
-            component = None
-            if isinstance(obj, Translation):
-                translation = obj
-                component = obj.component
-                project = component.project
-            elif isinstance(obj, Component):
-                component = obj
-                project = obj.project
-            else:
-                project = obj
-            for handler in self.handlers:
-                result = self.explain(handler, project, component, translation)
-                key = (
-                    handler.get_name(),
-                    str(result.reason),
-                    result.subscription.pk if result.subscription else None,
-                    tuple(subscription.pk for subscription in result.overridden),
-                    tuple(str(condition) for condition in result.conditions),
+    ) -> NotificationScopeSummary:
+        """Summarize inherited settings and exceptions across the accessible scope."""
+        if isinstance(target, (Component, Translation)):
+            component = target.component if isinstance(target, Translation) else target
+            if not viewer.can_access_component(component):
+                return NotificationScopeSummary(empty=True)
+            results = [
+                self.explain(
+                    handler,
+                    component.project,
+                    component,
+                    target if isinstance(target, Translation) else None,
                 )
-                if key not in groups:
-                    groups[key] = result
-                groups[key].targets.append(obj)
-        return sorted(
-            groups.values(), key=lambda result: str(result.notification.verbose)
-        ), page
+                for handler in self.handlers
+            ]
+            results.sort(key=lambda result: str(result.name))
+            return NotificationScopeSummary(
+                results=[result for result in results if result.subscription],
+                component_count=1,
+            )
 
-    @staticmethod
-    def get_target_page(
-        target: Project | Category | Component | Translation,
-        viewer: User,
-        page_number: str | None,
-    ) -> Page:
-        """Page identifiers before loading any component or translation objects."""
-        if isinstance(target, Translation):
-            components = Component.objects.filter(pk=target.component_id)
-        elif isinstance(target, Component):
-            components = Component.objects.filter(pk=target.pk)
-        elif isinstance(target, Category):
+        project = target.project if isinstance(target, Category) else target
+        if not viewer.can_access_project(project):
+            return NotificationScopeSummary(broad=True, empty=True)
+        if isinstance(target, Category):
             components = Component.objects.filter(
                 pk__in=target.get_component_ids_with_links()
             )
         else:
-            components = Component.objects.filter(project=target)
-        components = components.filter_access(viewer)
-        translations = Translation.objects.filter(component__in=components)
-        if isinstance(target, Translation):
-            translations = translations.filter(pk=target.pk)
-
-        # All branches have the same projection and no implicit model ordering.
-        # Ordering keeps each component immediately ahead of its translations.
-        translation_ids = (
-            translations.order_by()
-            .annotate(
-                target_component=F("component_id"),
-                target_kind=Value("translation"),
-                target_id=F("pk"),
+            components = Component.objects.filter(
+                Q(project=target) | Q(pk__in=target.shared_components.values("pk"))
             )
-            .values_list("target_component", "target_kind", "target_id")
+        components = (
+            components.filter_access(viewer)
+            .select_related("project", "category")
+            .order_by("project_id", "pk")
         )
-        target_ids = translation_ids
-        if not isinstance(target, Translation):
-            component_ids = (
-                components.order_by()
-                .annotate(
-                    target_component=F("pk"),
-                    target_kind=Value("component"),
-                    target_id=F("pk"),
+        # Bound both per-component explanations and per-project subscription
+        # queries before loading components or invoking notification handlers.
+        scope = list(
+            components.values_list("pk", "project_id")[
+                : NOTIFICATION_COMPONENT_LIMIT + 1
+            ]
+        )
+        if (
+            len(scope) > NOTIFICATION_COMPONENT_LIMIT
+            or len({project.pk, *(project_id for _, project_id in scope)})
+            > NOTIFICATION_PROJECT_LIMIT
+        ):
+            raise ValidationError(
+                gettext(
+                    "This scope is too large to check. Choose a smaller category, "
+                    "a component, or a translation."
+                ),
+                code="notification_scope_too_large",
+            )
+        results = [self.explain(handler, project) for handler in self.handlers]
+        groups: list[dict[tuple, NotificationException]] = [{} for _ in self.handlers]
+        summary = NotificationScopeSummary(broad=True)
+        for component in components.filter(pk__in=[pk for pk, _ in scope]):
+            summary.component_count += 1
+            for handler, inherited, exceptions in zip(
+                self.handlers, results, groups, strict=True
+            ):
+                # The matcher uses the component's own project, including linked
+                # components whose inherited settings differ from the selected scope.
+                outcome = self.explain(handler, component.project, component)
+                key = outcome.behavior_key
+                if key == inherited.behavior_key:
+                    continue
+                subscription_id = (
+                    outcome.subscription.pk if outcome.subscription else None
                 )
-                .values_list("target_component", "target_kind", "target_id")
-            )
-            target_ids = target_ids.union(component_ids)
-        if isinstance(target, Project):
-            project_ids = (
-                Project.objects.filter(pk=target.pk)
-                .order_by()
-                .annotate(
-                    target_component=Value(0),
-                    target_kind=Value("project"),
-                    target_id=F("pk"),
-                )
-                .values_list("target_component", "target_kind", "target_id")
-            )
-            target_ids = target_ids.union(project_ids)
-        target_ids = target_ids.order_by("target_component", "target_kind", "target_id")
-        page = Paginator(target_ids, NOTIFICATION_TARGET_PAGE_SIZE).get_page(
-            page_number
-        )
-        identifiers = list(page.object_list)
-        objects: dict[tuple[str, int], Project | Component | Translation] = {}
-        if isinstance(target, Project):
-            objects["project", target.pk] = target
-        for component in Component.objects.filter(
-            pk__in=[pk for _, kind, pk in identifiers if kind == "component"]
-        ).select_related("project", "category"):
-            objects["component", component.pk] = component
-        for translation in Translation.objects.filter(
-            pk__in=[pk for _, kind, pk in identifiers if kind == "translation"]
-        ).select_related("language", "component__project", "component__category"):
-            objects["translation", translation.pk] = translation
-        return Page(
-            [objects[kind, pk] for _, kind, pk in identifiers],
-            page.number,
-            page.paginator,
-        )
+                if key not in exceptions:
+                    exceptions[key] = NotificationException(
+                        outcome, subscription_id=subscription_id
+                    )
+                exception = exceptions[key]
+                if exception.subscription_id != subscription_id:
+                    exception.subscription_id = None
+                exception.count += 1
+                if component.project_id != project.pk:
+                    exception.shared_count += 1
+                if len(exception.examples) < NOTIFICATION_DETAIL_LIMIT:
+                    exception.examples.append(component)
+        if isinstance(target, Category) and not summary.component_count:
+            summary.empty = True
+            return summary
+        for result, exceptions in zip(results, groups, strict=True):
+            result.exceptions = list(exceptions.values())
+            if result.subscription or any(
+                item.outcome.subscription for item in result.exceptions
+            ):
+                summary.results.append(result)
+        summary.results.sort(key=lambda result: str(result.name))
+        return summary

--- a/weblate/accounts/notifications.py
+++ b/weblate/accounts/notifications.py
@@ -156,9 +156,9 @@ class Notification:
     ) -> None:
         self.outgoing: list[OutgoingEmail] = outgoing
         self.user_ids = user_ids
-        self.subscription_cache: OrderedDict[int | None, list[Subscription]] = (
-            OrderedDict()
-        )
+        self.subscription_cache: OrderedDict[
+            tuple[int | None, bool], list[Subscription]
+        ] = OrderedDict()
         self.child_notify: list[Notification] | None = None
 
     def get_language_filter(
@@ -184,7 +184,9 @@ class Notification:
     def get_periodic_actions(cls) -> Iterable[int]:
         return cls.actions
 
-    def filter_subscriptions(self, project: Project | None) -> list[Subscription]:
+    def filter_subscriptions(
+        self, project: Project | None, *, include_ineligible: bool = False
+    ) -> list[Subscription]:
         # ruff: ignore[import-outside-top-level]
         from weblate.accounts.models import Subscription
 
@@ -209,10 +211,12 @@ class Notification:
             query |= Q(scope=NotificationScope.SCOPE_ADMIN) & Q(
                 user__in=User.objects.all_admins(project)
             )
+        if not include_ineligible:
+            result = result.filter(user__is_bot=False, user__is_active=True)
         return list(
             result.filter(query)
-            # Inactive users and bots
-            .filter(Q(user__is_bot=False) & Q(user__is_active=True))
+            # The watched-project join can repeat subscriptions from other scopes.
+            .distinct()
             .order_by("user", "-scope")
             .select_related("user", "user__profile")
             .prefetch_related("user__profile__languages")
@@ -225,14 +229,23 @@ class Notification:
         component: Component | None,
         translation: Translation | None,
         users: list[int] | None,
+        *,
+        include_ineligible: bool = False,
     ) -> Iterable[Subscription]:
-        """Match account, scope, and language in descending subscription priority."""
+        """
+        Match subscriptions in descending priority.
+
+        Diagnostics can retain inactive accounts and unmatched languages to
+        explain why a subscription does not result in delivery.
+        """
         lang_filter: Language | None = self.get_language_filter(change, translation)
-        cache_key: int | None = project.pk if project else None
+        cache_key = (project.pk if project else None, include_ineligible)
         try:
             subscriptions = self.subscription_cache.pop(cache_key)
         except KeyError:
-            subscriptions = self.filter_subscriptions(project)
+            subscriptions = self.filter_subscriptions(
+                project, include_ineligible=include_ineligible
+            )
             if len(self.subscription_cache) >= SUBSCRIPTION_CACHE_SIZE:
                 self.subscription_cache.popitem(last=False)
         self.subscription_cache[cache_key] = subscriptions
@@ -243,7 +256,8 @@ class Notification:
 
             # Languages filter
             if (
-                lang_filter
+                not include_ineligible
+                and lang_filter
                 and lang_filter not in subscription.user.profile.languages.all()
             ):
                 continue

--- a/weblate/accounts/tests/test_notification_debug.py
+++ b/weblate/accounts/tests/test_notification_debug.py
@@ -14,12 +14,12 @@ from django.core.exceptions import PermissionDenied
 from django.template.loader import render_to_string
 from django.test import override_settings
 from django.test.html import Element, parse_html
+from django.urls import reverse
 from django.utils.translation import override
 
 from weblate.accounts.models import Subscription
 from weblate.accounts.notification_debug import (
     NotificationDebugger,
-    NotificationExplanation,
 )
 from weblate.accounts.notifications import (
     NOTIFICATIONS,
@@ -32,10 +32,11 @@ from weblate.accounts.notifications import (
     NotificationScope,
     RepositoryNotification,
 )
-from weblate.accounts.views import UserPage
+from weblate.accounts.views import UserNotifications
 from weblate.auth.models import User
 from weblate.lang.models import Language
 from weblate.trans.models import Category, Component, Project, Translation
+from weblate.trans.models.component import ComponentLink
 from weblate.trans.tests.test_views import FixtureTestCase
 
 if TYPE_CHECKING:
@@ -72,7 +73,7 @@ class NotificationDebugTest(FixtureTestCase):
 
     def debug(self, path=None, **kwargs):
         return self.client.get(
-            self.user.get_absolute_url(),
+            reverse("user_notifications", kwargs={"user": self.user.username}),
             {"notification_target": path or self.project.slug, **kwargs},
         )
 
@@ -104,12 +105,36 @@ class NotificationDebugTest(FixtureTestCase):
         admin = self.subscribe(NotificationScope.SCOPE_ADMIN)
         self.assertEqual(self.explain().subscription, admin)
 
+    def test_multiple_watched_projects_do_not_duplicate_subscriptions(self) -> None:
+        projects = Project.objects.bulk_create(
+            [
+                Project(
+                    name=f"Watched {index}",
+                    slug=f"watched-{index}",
+                    web="https://example.com/",
+                )
+                for index in range(3)
+            ]
+        )
+        self.user.profile.watched.add(self.project, *projects)
+        self.project.add_user(self.user, "Administration")
+        other = self.subscribe()
+        watched = self.subscribe(NotificationScope.SCOPE_WATCHED)
+        admin = self.subscribe(NotificationScope.SCOPE_ADMIN)
+        result = self.explain()
+        self.assertEqual(result.subscription, admin)
+        self.assertEqual(result.overridden, [watched, other])
+        handler = RepositoryNotification([], user_ids=[self.user.pk])
+        self.assertEqual(
+            handler.filter_subscriptions(self.project), [admin, watched, other]
+        )
+
     def test_language_filter(self) -> None:
         translation = self.component.translation_set.get(language__code="cs")
         self.subscribe(notification=NewStringNotificaton.get_name())
         self.user.profile.languages.clear()
         result = self.explain(NewStringNotificaton, translation)
-        self.assertIsNone(result.subscription)
+        self.assertIsNotNone(result.subscription)
         self.assertIn("notification languages", result.reason)
         self.user.profile.languages.add(translation.language)
         self.assertIsNotNone(
@@ -183,14 +208,16 @@ class NotificationDebugTest(FixtureTestCase):
         send.assert_not_called()
         queue.assert_not_called()
         self.assertEqual(list(Subscription.objects.values()), before)
-        self.assertContains(response, f"#notification-subscription-{subscription.pk}")
+        self.assertContains(
+            response, f'id="overview__notification-subscription-{subscription.pk}"'
+        )
         self.assertContains(response, "Operation was performed in the repository")
         self.assertEqual(
             {
                 result.notification
                 for result in response.context["notification_results"]
             },
-            set(NOTIFICATIONS),
+            {RepositoryNotification},
         )
 
     def test_groups_and_languages(self) -> None:
@@ -198,15 +225,51 @@ class NotificationDebugTest(FixtureTestCase):
         self.user.profile.watched.add(self.project)
         language = self.component.translation_set.get(language__code="cs").language
         self.user.profile.languages.add(language)
-        response = self.client.get(self.user.get_absolute_url())
+        response = self.client.get(
+            reverse("user_notifications", kwargs={"user": self.user.username})
+        )
         self.assertEqual(list(response.context["notification_languages"]), [language])
         self.assertIn(self.project, response.context["notification_watched_projects"])
         group = response.context["notification_subscription_groups"][0]
-        self.assertFalse(group["show_project"])
-        self.assertFalse(group["show_component"])
+        self.assertIsNone(group["target"])
         self.assertNotContains(response, "RepositoryNotification")
         with override("cs"):
             self.assertNotEqual(NotificationScope.SCOPE_PROJECT.label, "Project")
+
+    def test_subscription_groups_by_target(self) -> None:
+        global_subscription = self.subscribe()
+        project_subscription = self.subscribe(
+            NotificationScope.SCOPE_PROJECT, project=self.project
+        )
+        other_project = Project.objects.create(
+            name="Other subscriptions",
+            slug="other-subscriptions",
+            web="https://example.com/",
+        )
+        other_subscription = self.subscribe(
+            NotificationScope.SCOPE_PROJECT, project=other_project
+        )
+        component_subscription = self.subscribe(
+            NotificationScope.SCOPE_COMPONENT, component=self.component, onetime=True
+        )
+        context = self.notification_context()
+        groups = context["notification_subscription_groups"]
+        self.assertEqual(len(groups), 4)
+        self.assertEqual(
+            {
+                tuple(row.pk for row in group["subscriptions"]): group["target"]
+                for group in groups
+            },
+            {
+                (global_subscription.pk,): None,
+                (project_subscription.pk,): self.project,
+                (other_subscription.pk,): other_project,
+                (component_subscription.pk,): self.component,
+            },
+        )
+        html = self.render_notifications(context)
+        self.assertIn("One-time", html)
+        self.assertEqual(html.count('scope="rowgroup"'), 4)
 
     def test_invalid_paths(self) -> None:
         for path in (
@@ -219,40 +282,122 @@ class NotificationDebugTest(FixtureTestCase):
         ):
             with self.subTest(path=path):
                 response = self.client.get(
-                    self.user.get_absolute_url(), {"notification_target": path}
+                    reverse("user_notifications", kwargs={"user": self.user.username}),
+                    {"notification_target": path},
                 )
                 self.assertEqual(response.status_code, 200, response.headers)
                 self.assertTrue(response.context["notification_form"].errors)
                 self.assertNotIn("notification_results", response.context)
-                self.assertContains(response, 'class="tab-pane active"\n')
         self.assertNotContains(response, "<script>alert(")
+
+    def test_self_access(self) -> None:
+        self.client.force_login(self.user)
+        self.assertEqual(self.debug().status_code, 200)
+        response = self.client.get(reverse("profile"))
+        self.assertContains(
+            response, reverse("user_notifications", kwargs={"user": self.user.username})
+        )
 
     def test_permission_required(self) -> None:
         self.client.force_login(self.user)
-        response = self.debug()
+        response = self.client.get(
+            reverse("user_notifications", kwargs={"user": self.viewer.username})
+        )
         self.assertEqual(response.status_code, 403)
-        response = self.client.get(self.user.get_absolute_url())
-        self.assertNotContains(response, "Notification debug")
+        self.client.logout()
+        self.assertEqual(self.debug().status_code, 302)
 
-    def test_descendants_and_grouping(self) -> None:
-        subscription = self.subscribe()
+    def test_case_insensitive_username_access(self) -> None:
+        self.client.force_login(self.user)
+        for user, status in ((self.user, 200), (self.viewer, 403)):
+            with self.subTest(user=user.username):
+                response = self.client.get(
+                    reverse(
+                        "user_notifications", kwargs={"user": user.username.upper()}
+                    )
+                )
+                self.assertEqual(response.status_code, status)
+
+    def test_admin_link(self) -> None:
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertContains(
+            response, reverse("user_notifications", kwargs={"user": self.user.username})
+        )
+        self.assertNotIn("notification_results", response.context)
+
+    def test_matching_subscriptions_only(self) -> None:
         response = self.debug()
-        results = [
-            result
-            for result in response.context["notification_results"]
-            if result.notification is RepositoryNotification
-        ]
-        self.assertEqual(len(results), 1)
-        result = results[0]
-        self.assertEqual(result.subscription, subscription)
-        self.assertIn(self.project, result.targets)
-        self.assertIn(self.component, result.targets)
+        self.assertEqual(response.context["notification_results"], [])
+        self.assertContains(response, "No matching subscriptions in this scope.")
+        self.subscribe(frequency=NotificationFrequency.FREQ_NONE)
+        response = self.debug()
+        self.assertContains(response, "Disabled by the effective subscription.")
+        self.assertEqual(
+            {
+                result.notification
+                for result in response.context["notification_results"]
+            },
+            {RepositoryNotification},
+        )
+
+    def test_blocked_matches_remain_visible(self) -> None:
+        self.subscribe(notification=NewStringNotificaton.get_name())
+        response = self.debug(f"{self.project.slug}/{self.component.slug}/cs")
+        self.assertEqual(len(response.context["notification_results"]), 1)
+        self.assertContains(response, "notification languages")
+        self.user.is_active = False
+        self.user.save()
+        response = self.debug()
+        self.assertTrue(response.context["notification_results"])
+        self.assertContains(
+            response, "Inactive users and bots do not receive notifications."
+        )
+
+    def test_diagnostic_matching_does_not_change_delivery(self) -> None:
+        subscription = self.subscribe(notification=NewStringNotificaton.get_name())
+        handler = NewStringNotificaton([], user_ids=[self.user.pk])
+        translation = self.component.translation_set.get(language__code="cs")
+        self.user.profile.languages.clear()
+        args = (None, self.project, self.component, translation, None)
+        self.assertEqual(
+            list(handler.get_scope_subscriptions(*args, include_ineligible=True)),
+            [subscription],
+        )
+        self.assertEqual(list(handler.get_scope_subscriptions(*args)), [])
+        self.user.is_bot = True
+        self.user.save()
+        repository_handler = RepositoryNotification([], user_ids=[self.user.pk])
+        self.subscribe()
+        repository_args = (None, self.project, self.component, None, None)
         self.assertTrue(
-            any(
-                target in result.targets
-                for target in self.component.translation_set.all()
+            list(
+                repository_handler.get_scope_subscriptions(
+                    *repository_args, include_ineligible=True
+                )
             )
         )
+        self.assertEqual(
+            list(repository_handler.get_scope_subscriptions(*repository_args)), []
+        )
+
+    def test_overview_respects_viewer_access(self) -> None:
+        self.subscribe(NotificationScope.SCOPE_COMPONENT, component=self.component)
+        with patch.object(
+            Component.objects, "filter_access", return_value=Component.objects.none()
+        ):
+            context = self.notification_context()
+        self.assertEqual(context["notification_subscription_groups"], [])
+
+    def test_uniform_scope_settings(self) -> None:
+        subscription = self.subscribe()
+        response = self.debug()
+        results = response.context["notification_results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].subscription, subscription)
+        self.assertEqual(results[0].exceptions, [])
+        self.assertEqual(response.context["notification_summary"].component_count, 1)
+        self.assertContains(response, "Inherited project settings")
+        self.assertNotContains(response, "Inspected targets")
 
     def test_nested_category_and_translation_paths(self) -> None:
         parent = Category(project=self.project, name="Parent", slug="parent")
@@ -270,7 +415,7 @@ class NotificationDebugTest(FixtureTestCase):
             response.context["notification_debug_target"].language.code, "cs"
         )
         response = self.debug(f"{self.project.slug}/parent")
-        self.assertIn(self.component, response.context["notification_page"].object_list)
+        self.assertEqual(response.context["notification_summary"].component_count, 1)
 
     def test_empty_category(self) -> None:
         Category.objects.bulk_create(
@@ -278,37 +423,42 @@ class NotificationDebugTest(FixtureTestCase):
         )
         response = self.debug(f"{self.project.slug}/empty")
         self.assertContains(response, "No accessible components or translations")
-        self.assertEqual(response.context["notification_page"].paginator.count, 0)
+        self.assertTrue(response.context["notification_summary"].empty)
 
-    def test_pagination(self) -> None:
+    def test_summary_covers_all_components_and_ignores_pagination(self) -> None:
         components = []
-        for index in range(51):
+        for index in range(75):
             component = copy(self.component)
             component.pk = None
             component.slug = f"notification-{index}"
             component.name = f"Notification {index}"
             components.append(component)
         Component.objects.bulk_create(components)
-        self.subscribe()
+        inherited = self.subscribe()
+        for component in components:
+            self.subscribe(
+                NotificationScope.SCOPE_COMPONENT,
+                component=component,
+                frequency=NotificationFrequency.FREQ_NONE,
+            )
         response = self.debug()
-        page = response.context["notification_page"]
-        self.assertEqual(len(page.object_list), 50)
+        result = response.context["notification_results"][0]
+        self.assertEqual(result.subscription, inherited)
+        self.assertEqual(response.context["notification_summary"].component_count, 76)
+        self.assertEqual(len(result.exceptions), 1)
+        exception = result.exceptions[0]
+        self.assertEqual(exception.count, 75)
+        self.assertIsNone(exception.subscription_id)
+        self.assertEqual(exception.examples, components[:5])
+        self.assertContains(response, "Different settings in 75 components.")
+        self.assertContains(response, "Inspect example components:")
+        self.assertNotIn("notification_page", response.context)
+        second = self.debug(page="2", limit="1")
         self.assertEqual(
-            page.paginator.count, 53 + self.component.translation_set.count()
+            response.context["notification_summary"],
+            second.context["notification_summary"],
         )
-        self.assertContains(
-            response, "?page=2&amp;limit=50&amp;notification_target=test#notifications"
-        )
-        second = self.debug(page="2")
-        self.assertEqual(
-            len(second.context["notification_page"].object_list),
-            page.paginator.count - 50,
-        )
-        self.assertFalse(
-            set(page.object_list) & set(second.context["notification_page"].object_list)
-        )
-        invalid = self.debug(page="invalid")
-        self.assertEqual(invalid.context["notification_page"].number, 1)
+        self.assertNotContains(second, "Showing targets")
 
     def test_inaccessible_target(self) -> None:
         with patch.object(User, "check_access_component", side_effect=PermissionDenied):
@@ -318,15 +468,60 @@ class NotificationDebugTest(FixtureTestCase):
         )
         self.assertNotIn("notification_results", response.context)
 
+    @patch("weblate.accounts.notification_debug.NOTIFICATION_COMPONENT_LIMIT", 1)
+    def test_summary_component_limit(self) -> None:
+        self.subscribe()
+        self.assertEqual(
+            self.debug().context["notification_summary"].component_count, 1
+        )
+        component = copy(self.component)
+        component.pk = None
+        component.slug = "extra"
+        component.name = "Extra"
+        Component.objects.bulk_create([component])
+        with (
+            patch.object(NotificationDebugger, "explain") as explain,
+            patch.object(Component, "from_db", wraps=Component.from_db) as load,
+        ):
+            response = self.debug()
+        explain.assert_not_called()
+        load.assert_not_called()
+        self.assertContains(response, "This scope is too large to check.")
+        self.assertNotIn("notification_results", response.context)
+        self.assertEqual(
+            response.context["notification_form"]
+            .errors.as_data()["notification_target"][0]
+            .code,
+            "notification_scope_too_large",
+        )
+        response = self.debug(f"{self.project.slug}/{self.component.slug}")
+        self.assertEqual(response.context["notification_summary"].component_count, 1)
+        Component.objects.filter(pk=component.pk).update(restricted=True)
+        viewer = User.objects.create_user(username="scope-viewer")
+        summary = NotificationDebugger(self.user).inspect(self.project, viewer)
+        self.assertEqual(summary.component_count, 1)
+
+    @patch("weblate.accounts.notification_debug.NOTIFICATION_PROJECT_LIMIT", 1)
+    def test_summary_source_project_limit(self) -> None:
+        project = Project.objects.create(
+            name="Linked scope", slug="linked-scope", web="https://example.com/"
+        )
+        ComponentLink.objects.bulk_create(
+            [ComponentLink(component=self.component, project=project)]
+        )
+        with patch.object(NotificationDebugger, "explain") as explain:
+            response = self.debug(project.slug)
+        explain.assert_not_called()
+        self.assertContains(response, "This scope is too large to check.")
+        self.assertNotIn("notification_results", response.context)
+
     def test_descendants_require_viewer_access(self) -> None:
         Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.subscribe(NotificationScope.SCOPE_COMPONENT, component=self.component)
         viewer = User.objects.create_user(username="limited-viewer")
-        results, page = NotificationDebugger(self.user).inspect(
-            self.project, viewer, None
-        )
-        self.assertEqual(page.paginator.count, 1)
-        self.assertEqual(page.object_list, [self.project])
-        self.assertTrue(all(result.targets == [self.project] for result in results))
+        summary = NotificationDebugger(self.user).inspect(self.project, viewer)
+        self.assertEqual(summary.component_count, 0)
+        self.assertEqual(summary.results, [])
 
     def test_component_override_does_not_apply_to_project(self) -> None:
         project = self.subscribe(NotificationScope.SCOPE_PROJECT, project=self.project)
@@ -336,35 +531,150 @@ class NotificationDebugTest(FixtureTestCase):
             frequency=NotificationFrequency.FREQ_NONE,
         )
         response = self.debug()
-        results = [
-            result
-            for result in response.context["notification_results"]
-            if result.notification is RepositoryNotification
-        ]
+        results = response.context["notification_results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].subscription, project)
+        self.assertEqual(results[0].exceptions[0].outcome.subscription, component)
+        self.assertEqual(results[0].exceptions[0].examples, [self.component])
+        self.assertEqual(results[0].exceptions[0].subscription_id, component.pk)
+        url = reverse("user_notifications", kwargs={"user": self.user.username})
+        self.assertContains(
+            response, f"{url}?notification_target=test/test#notifications"
+        )
+
+    def test_component_only_subscription(self) -> None:
+        subscription = self.subscribe(
+            NotificationScope.SCOPE_COMPONENT, component=self.component
+        )
+        response = self.debug()
+        self.assertContains(response, "No inherited subscription.")
+        result = response.context["notification_results"][0]
+        self.assertIsNone(result.subscription)
+        self.assertEqual(result.exceptions[0].outcome.subscription, subscription)
+        self.assertEqual(result.exceptions[0].count, 1)
+
+    def test_subject_access_restriction_is_an_exception(self) -> None:
+        self.subscribe()
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        self.component.refresh_from_db()
+        with patch.object(self.user, "can_access_component", return_value=False):
+            summary = NotificationDebugger(self.user).inspect(self.project, self.viewer)
         self.assertEqual(
-            {result.subscription.pk for result in results}, {project.pk, component.pk}
+            summary.results[0].exceptions[0].outcome.reason,
+            "The user cannot access this target.",
         )
-        project_result = next(
-            result for result in results if result.subscription == project
+
+    def test_linked_components_use_their_own_project_settings(self) -> None:
+        project = Project.objects.create(
+            name="Linked project", slug="linked-project", web="https://example.com/"
         )
-        self.assertEqual(project_result.targets, [self.project])
+        category = Category(
+            project=project, name="Linked category", slug="linked-category"
+        )
+        Category.objects.bulk_create([category])
+        ComponentLink.objects.bulk_create(
+            [
+                ComponentLink(
+                    component=self.component, project=project, category=category
+                )
+            ]
+        )
+        inherited = self.subscribe(NotificationScope.SCOPE_PROJECT, project=project)
+        actual = self.subscribe(
+            NotificationScope.SCOPE_PROJECT,
+            project=self.project,
+            frequency=NotificationFrequency.FREQ_NONE,
+        )
+        for target in (project, category):
+            with self.subTest(target=target):
+                summary = NotificationDebugger(self.user).inspect(target, self.viewer)
+                self.assertEqual(summary.component_count, 1)
+                self.assertEqual(summary.results[0].subscription, inherited)
+                self.assertEqual(
+                    summary.results[0].exceptions[0].outcome.subscription, actual
+                )
+                self.assertEqual(
+                    summary.results[0].exceptions[0].examples, [self.component]
+                )
+        response = self.debug(project.slug)
+        self.assertContains(
+            response, "Shared components use subscriptions from their original project"
+        )
+        self.assertEqual(
+            response.context["notification_results"][0].exceptions[0].shared_count, 1
+        )
+        actual.delete()
+        response = self.debug(project.slug)
+        self.assertContains(
+            response,
+            "These components have no matching subscription, so this notification will not be sent.",
+        )
+        self.assertNotContains(response, "Delivery details")
+        Component.objects.filter(pk=self.component.pk).update(restricted=True)
+        viewer = User.objects.create_user(username="linked-viewer")
+        summary = NotificationDebugger(self.user).inspect(category, viewer)
+        self.assertTrue(summary.empty)
+        self.assertEqual(summary.results, [])
+
+    def test_broad_language_rules_and_exact_translation_checks(self) -> None:
+        self.subscribe(notification=NewStringNotificaton.get_name())
+        self.subscribe(notification=NewCommentNotificaton.get_name())
+        self.user.profile.languages.clear()
+        broad = NotificationDebugger(self.user).inspect(self.project, self.viewer)
+        comment = next(
+            result
+            for result in broad.results
+            if result.notification is NewCommentNotificaton
+        )
+        self.assertIn(
+            "Source-string comments ignore notification languages; other comments require a matching language.",
+            comment.conditions,
+        )
+        exact = NotificationDebugger(self.user).inspect(
+            self.get_translation(), self.viewer
+        )
+        self.assertTrue(
+            all("notification languages" in result.reason for result in exact.results)
+        )
+        source = self.component.source_translation
+        exact = NotificationDebugger(self.user).inspect(source, self.viewer)
+        comment = next(
+            result
+            for result in exact.results
+            if result.notification is NewCommentNotificaton
+        )
+        self.assertIn("Eligible", comment.reason)
+
+    def test_one_time_settings_are_distinct_exceptions(self) -> None:
+        self.subscribe()
+        other = copy(self.component)
+        other.pk = None
+        other.slug = "other"
+        other.name = "Other"
+        Component.objects.bulk_create([other])
+        self.subscribe(
+            NotificationScope.SCOPE_COMPONENT, component=self.component, onetime=True
+        )
+        self.subscribe(NotificationScope.SCOPE_COMPONENT, component=other)
+        summary = NotificationDebugger(self.user).inspect(self.project, self.viewer)
+        self.assertEqual(len(summary.results[0].exceptions), 2)
 
     def test_translation_debug_renders_notification_names(self) -> None:
+        self.subscribe()
         response = self.debug(f"{self.project.slug}/{self.component.slug}/cs")
         self.assertContains(response, "Operation was performed in the repository")
-        self.assertTrue(
-            all(
-                len(result.targets) == 1
-                for result in response.context["notification_results"]
-            )
-        )
+        self.assertFalse(response.context["notification_summary"].broad)
+        self.assertEqual(response.context["notification_results"][0].exceptions, [])
 
     def notification_context(self, **params):
-        view = UserPage()
+        view = UserNotifications()
         view.object = self.user
         view.request = cast(
             "AuthenticatedHttpRequest",
-            self.factory.get(self.user.get_absolute_url(), params),
+            self.factory.get(
+                reverse("user_notifications", kwargs={"user": self.user.username}),
+                params,
+            ),
         )
         view.request.user = self.viewer
         return view.get_notification_context()
@@ -463,37 +773,6 @@ class NotificationDebugTest(FixtureTestCase):
         self.assertEqual(context["notification_watched_count"], 1)
         self.assertEqual(context["notification_watched_projects"], [self.project])
 
-    def test_result_target_summaries(self) -> None:
-        targets: list[Project | Component | Translation] = [
-            Project(pk=index, slug=f"target-{index}", name=f"Target {index}")
-            for index in range(1, 7)
-        ]
-        for count in (1, 5, 6):
-            with self.subTest(count=count):
-                context = self.notification_context()
-                context.update(
-                    {
-                        "notification_debug_target": self.project,
-                        "notification_page": NotificationDebugger.get_target_page(
-                            self.project, self.viewer, None
-                        ),
-                        "notification_results": [
-                            NotificationExplanation(
-                                RepositoryNotification, "", targets=targets[:count]
-                            )
-                        ],
-                    }
-                )
-                html = self.render_notifications(context)
-                for obj in targets[:count]:
-                    if count > 5:
-                        self.assertNotIn(f'href="{obj.get_absolute_url()}"', html)
-                    else:
-                        self.assertIn(f'href="{obj.get_absolute_url()}"', html)
-                if count > 5:
-                    self.assertIn("6 targets on this page", html)
-                self.assertNotIn("<details>", html)
-
     def test_rendered_lists_have_valid_children(self) -> None:
         self.user.profile.watched.add(self.project)
         self.user.profile.languages.add(self.get_translation().language)
@@ -501,19 +780,24 @@ class NotificationDebugTest(FixtureTestCase):
         self.subscribe(NotificationScope.SCOPE_COMPONENT, component=self.component)
         context = self.notification_context(notification_target=self.project.slug)
         html = self.render_notifications(context)
-        elements = [parse_html(html)]
+        elements: list[tuple[Element, str | None]] = [(parse_html(html), None)]
         lists = 0
         while elements:
-            element = elements.pop()
+            element, parent = elements.pop()
+            if element.name == "li":
+                self.assertIsNotNone(parent)
+                self.assertIn(parent, {"ul", "ol", "menu"})
             if element.name in {"ul", "ol"}:
                 lists += 1
                 for child in element.children:
                     self.assertIsInstance(child, Element)
                     self.assertIn(child.name, {"li", "script", "template", "style"})
             elements.extend(
-                child for child in element.children if isinstance(child, Element)
+                (child, element.name)
+                for child in element.children
+                if isinstance(child, Element)
             )
-        self.assertGreater(lists, 2)
+        self.assertGreaterEqual(lists, 2)
 
     def test_large_component_bounds_translation_work(self) -> None:
         languages = Language.objects.bulk_create(
@@ -531,33 +815,23 @@ class NotificationDebugTest(FixtureTestCase):
             translation.language_code = language.code
             translations.append(translation)
         Translation.objects.bulk_create(translations)
-        debugger = NotificationDebugger(self.user)
-        with (
-            patch.object(debugger, "explain", wraps=debugger.explain) as explain,
-            patch.object(
-                Translation, "from_db", wraps=Translation.from_db
-            ) as load_translation,
-        ):
-            results, page = debugger.inspect(self.component, self.viewer, None)
-        self.assertEqual(len(page.object_list), 50)
-        self.assertEqual(explain.call_count, 50 * len(NOTIFICATIONS))
-        self.assertEqual(load_translation.call_count, 49)
-        self.assertEqual(
-            page.paginator.count, 1 + self.component.translation_set.count()
-        )
-        self.assertTrue(all(len(result.targets) <= 50 for result in results))
-        actual: list[tuple[type[Component | Translation], int]] = []
-        for number in page.paginator.page_range:
-            current = debugger.get_target_page(self.component, self.viewer, str(number))
-            self.assertLessEqual(len(current.object_list), 50)
-            actual.extend((type(obj), obj.pk) for obj in current)
-        expected = [
-            (Component, self.component.pk),
-            *[
-                (Translation, pk)
-                for pk in self.component.translation_set.order_by("pk").values_list(
-                    "pk", flat=True
+        self.subscribe()
+        for target in (self.component, self.project):
+            with self.subTest(target=target):
+                debugger = NotificationDebugger(self.user)
+                with (
+                    patch.object(
+                        debugger, "explain", wraps=debugger.explain
+                    ) as explain,
+                    patch.object(
+                        Translation, "from_db", wraps=Translation.from_db
+                    ) as load_translation,
+                ):
+                    summary = debugger.inspect(target, self.viewer)
+                self.assertEqual(summary.component_count, 1)
+                self.assertEqual(len(summary.results), 1)
+                self.assertEqual(
+                    explain.call_count,
+                    len(NOTIFICATIONS) * (2 if target == self.project else 1),
                 )
-            ],
-        ]
-        self.assertEqual(actual, expected)
+                load_translation.assert_not_called()

--- a/weblate/accounts/tests/test_notifications.py
+++ b/weblate/accounts/tests/test_notifications.py
@@ -147,7 +147,7 @@ class NotificationHeadersTest(SimpleTestCase):
                 )
 
         self.assertEqual(len(notification.subscription_cache), SUBSCRIPTION_CACHE_SIZE)
-        self.assertNotIn(0, notification.subscription_cache)
+        self.assertNotIn((0, False), notification.subscription_cache)
 
     @override_settings(VERSION_DISPLAY=VERSION_DISPLAY_SOFT, HIDE_VERSION=False)
     def test_soft_mode_keeps_x_mailer_version(self) -> None:

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -760,6 +760,100 @@ def trial(request: AuthenticatedHttpRequest):
     )
 
 
+@method_decorator(login_required, name="dispatch")
+class UserNotifications(DetailView):
+    model = User
+    template_name = "accounts/notification_debug.html"
+    slug_field = "username"
+    slug_url_kwarg = "user"
+    context_object_name = "page_user"
+    request: AuthenticatedHttpRequest
+
+    def get_object(self, queryset=None):
+        user = super().get_object(queryset)
+        if user.pk != self.request.user.pk:
+            check_management_access(self.request, "user.edit")
+        return user
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("profile")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["title"] = gettext("Notification diagnostics for %(user)s") % {
+            "user": self.object
+        }
+        context.update(self.get_notification_context())
+        return context
+
+    def get_notification_context(self) -> dict[str, Any]:
+        request = self.request
+        user = self.object
+        submitted = "notification_target" in request.GET
+        form = NotificationDebugForm(request, request.GET if submitted else None)
+        groups: list[dict[str, Any]] = []
+        subscriptions = list(
+            user.subscription_set.filter(
+                Q(project__isnull=True, component__isnull=True)
+                | Q(component__isnull=True, project__in=request.user.allowed_projects)
+                | Q(component__in=Component.objects.filter_access(request.user))
+            )
+            .select_related("project", "component__project", "component__category")
+            .order()
+        )
+        for scope in NotificationScope:
+            scoped_groups: dict[int | None, list[Subscription]] = defaultdict(list)
+            for subscription in subscriptions:
+                if subscription.scope != scope:
+                    continue
+                target = subscription.component or subscription.project
+                scoped_groups[target.pk if target else None].append(subscription)
+            groups.extend(
+                {
+                    "label": scope.label,
+                    "target": rows[0].component or rows[0].project,
+                    "subscriptions": rows,
+                }
+                for rows in scoped_groups.values()
+            )
+        watched_projects = (
+            user.profile.watched.all() & request.user.allowed_projects
+        ).order()
+        languages = user.profile.languages.all().order()
+        watched_count = watched_projects.count()
+        language_count = languages.count()
+        context = {
+            "notification_form": form,
+            "notification_subscription_groups": groups,
+            "notification_detail_limit": NOTIFICATION_DETAIL_LIMIT,
+            "notification_watched_count": watched_count,
+            "notification_language_count": language_count,
+            "notification_watched_projects": list(
+                watched_projects[:NOTIFICATION_DETAIL_LIMIT]
+            )
+            if watched_count <= NOTIFICATION_DETAIL_LIMIT
+            else [],
+            "notification_languages": list(languages[:NOTIFICATION_DETAIL_LIMIT])
+            if language_count <= NOTIFICATION_DETAIL_LIMIT
+            else [],
+        }
+        if submitted and form.is_valid():
+            target = form.cleaned_data["notification_target"]
+            try:
+                summary = NotificationDebugger(user).inspect(target, request.user)
+            except ValidationError as error:
+                form.add_error("notification_target", error)
+                return context
+            context.update(
+                {
+                    "notification_debug_target": target,
+                    "notification_results": summary.results,
+                    "notification_summary": summary,
+                }
+            )
+        return context
+
+
 class UserPage(UpdateView):
     model = User
     template_name = "accounts/user.html"
@@ -884,70 +978,6 @@ class UserPage(UpdateView):
         self.object.log_audit_state(self.request)
         return response
 
-    def get_notification_context(self) -> dict[str, Any]:
-        request = self.request
-        user = self.object
-        submitted = "notification_target" in request.GET
-        form = NotificationDebugForm(request, request.GET if submitted else None)
-        groups = []
-        subscriptions = list(
-            user.subscription_set.select_related(
-                "project", "component__project", "component__category"
-            ).order()
-        )
-        for scope in NotificationScope:
-            rows = [row for row in subscriptions if row.scope == scope]
-            if rows:
-                groups.append(
-                    {
-                        "label": scope.label,
-                        "subscriptions": rows,
-                        "show_project": scope >= NotificationScope.SCOPE_PROJECT,
-                        "show_component": scope == NotificationScope.SCOPE_COMPONENT,
-                    }
-                )
-        watched_projects = (
-            user.profile.watched.all() & request.user.allowed_projects
-        ).order()
-        languages = user.profile.languages.all().order()
-        watched_count = watched_projects.count()
-        language_count = languages.count()
-        context = {
-            "notification_form": form,
-            "notification_submitted": submitted,
-            "notification_subscription_groups": groups,
-            "notification_detail_limit": NOTIFICATION_DETAIL_LIMIT,
-            "notification_watched_count": watched_count,
-            "notification_language_count": language_count,
-            "notification_watched_projects": list(
-                watched_projects[:NOTIFICATION_DETAIL_LIMIT]
-            )
-            if watched_count <= NOTIFICATION_DETAIL_LIMIT
-            else [],
-            "notification_languages": list(languages[:NOTIFICATION_DETAIL_LIMIT])
-            if language_count <= NOTIFICATION_DETAIL_LIMIT
-            else [],
-        }
-        if submitted and form.is_valid():
-            target = form.cleaned_data["notification_target"]
-            results, page = NotificationDebugger(user).inspect(
-                target, request.user, request.GET.get("page")
-            )
-            context.update(
-                {
-                    "notification_debug_target": target,
-                    "notification_results": results,
-                    "notification_page": page,
-                    "notification_query_string": urlencode(
-                        {"notification_target": request.GET["notification_target"]}
-                    ),
-                    "notification_search_items": [
-                        ("notification_target", request.GET["notification_target"])
-                    ],
-                }
-            )
-        return context
-
     def get_context_data(self, **kwargs):
         """Create context for rendering page."""
         context = super().get_context_data(**kwargs)
@@ -973,11 +1003,6 @@ class UserPage(UpdateView):
             )
             .order()
         )
-
-        if "notification_target" in request.GET:
-            check_management_access(request, "user.edit")
-        if request.user.has_perm("user.edit"):
-            context.update(self.get_notification_context())
 
         context["page_profile"] = user.profile
         context["can_edit_page_user"] = not user.is_internal

--- a/weblate/static/js/accounts/notification-debug.js
+++ b/weblate/static/js/accounts/notification-debug.js
@@ -1,0 +1,60 @@
+// Copyright © Michal Čihař <michal@weblate.org>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+document.addEventListener("DOMContentLoaded", () => {
+  const overviewTab = document.getElementById("overview-tab");
+
+  function highlightSubscription(row) {
+    document
+      .querySelectorAll(".notification-subscription-highlight")
+      .forEach((previous) => {
+        previous.classList.remove("notification-subscription-highlight");
+      });
+    row.classList.add("notification-subscription-highlight");
+    row.focus({ preventScroll: true });
+    row.scrollIntoView({ block: "center" });
+    history.replaceState(null, "", `#${row.id}`);
+  }
+
+  function showSubscription(row) {
+    if (!overviewTab) {
+      return;
+    }
+    if (overviewTab.classList.contains("active")) {
+      highlightSubscription(row);
+    } else {
+      overviewTab.addEventListener(
+        "shown.bs.tab",
+        () => highlightSubscription(row),
+        { once: true },
+      );
+      bootstrap.Tab.getOrCreateInstance(overviewTab).show();
+    }
+  }
+
+  document
+    .querySelectorAll("a[data-notification-subscription]")
+    .forEach((link) => {
+      link.addEventListener("click", (event) => {
+        const row = document.getElementById(link.hash.slice(1));
+        if (!row || !overviewTab) {
+          return;
+        }
+        event.preventDefault();
+        showSubscription(row);
+      });
+    });
+
+  function showLinkedSubscription() {
+    if (location.hash.startsWith("#overview__notification-subscription-")) {
+      const row = document.getElementById(location.hash.slice(1));
+      if (row) {
+        showSubscription(row);
+      }
+    }
+  }
+
+  window.addEventListener("popstate", showLinkedSubscription);
+  showLinkedSubscription();
+});

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -1292,6 +1292,20 @@ thead th {
   text-align: center;
 }
 
+.notification-eligibility-table > thead > tr > th:first-child {
+  width: 25%;
+}
+@media (min-width: 80rem) {
+  .notification-eligibility-table > thead > tr > th:first-child {
+    width: 18rem;
+  }
+}
+.notification-subscription-highlight {
+  --bs-table-bg: var(--bs-info-bg-subtle);
+  outline: 2px solid currentColor;
+  outline-offset: -2px;
+}
+
 .table-scroll {
   overflow-x: auto;
   position: relative;

--- a/weblate/templates/accounts/notification_debug.html
+++ b/weblate/templates/accounts/notification_debug.html
@@ -1,190 +1,282 @@
-{% load crispy_forms_tags i18n %}
+{% extends "base.html" %}
 
-<div class="row">
-  <div class="col-md-6">
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title">{% translate "Watched projects" %}</h4>
-      </div>
-      <div class="card-body">
-        {% if notification_watched_count > notification_detail_limit %}
-          <p class="mb-0">{% blocktranslate count count=notification_watched_count %}{{ count }} watched project.{% plural %}{{ count }} watched projects.{% endblocktranslate %}</p>
-        {% else %}
-          <ul class="list-unstyled mb-0">
-            {% for project in notification_watched_projects %}
-              <li><a href="{{ project.get_absolute_url }}">{{ project }}</a></li>
-            {% empty %}
-              <li>{% translate "No watched projects." %}</li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-  <div class="col-md-6">
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title">{% translate "Notification languages" %}</h4>
-      </div>
-      <div class="card-body">
-        {% if notification_language_count > notification_detail_limit %}
-          <p class="mb-0">{% blocktranslate count count=notification_language_count %}{{ count }} notification language.{% plural %}{{ count }} notification languages.{% endblocktranslate %}</p>
-        {% else %}
-          <ul class="list-unstyled mb-0">
-            {% for language in notification_languages %}
-              <li><a href="{{ language.get_absolute_url }}">{{ language }}</a></li>
-            {% empty %}
-              <li>{% translate "No notification languages selected. Language-filtered notifications will not be sent." %}</li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-</div>
+{% load crispy_forms_tags i18n static %}
 
-<div class="card">
-  <div class="card-header">
-    <h4 class="card-title">{% translate "Subscriptions" %}</h4>
-  </div>
-  <div class="card-body">
-    {% for group in notification_subscription_groups %}
-      <div class="table-responsive">
-        <table class="table table-listing">
-          <caption class="caption-top">{{ group.label }}</caption>
-          <thead>
-            <tr>
-              <th scope="col">{% translate "Notification" %}</th>
-              <th scope="col">{% translate "Frequency" %}</th>
-              {% if group.show_project %}
-                <th scope="col">{% translate "Project" %}</th>
-              {% endif %}
-              {% if group.show_component %}
-                <th scope="col">{% translate "Component" %}</th>
-                <th scope="col">{% translate "One-time" %}</th>
-              {% endif %}
-            </tr>
-          </thead>
-          <tbody>
-            {% for subscription in group.subscriptions %}
-              <tr id="notification-subscription-{{ subscription.pk }}">
-                <th scope="row">{{ subscription.get_notification_display }}</th>
-                <td>{{ subscription.get_frequency_display }}</td>
-                {% if group.show_project %}
-                  <td>
-                    {% if subscription.project %}
-                      <a href="{{ subscription.project.get_absolute_url }}">{{ subscription.project }}</a>
-                    {% elif subscription.component %}
-                      <a href="{{ subscription.component.project.get_absolute_url }}">{{ subscription.component.project }}</a>
-                    {% endif %}
-                  </td>
+{% block extra_script %}
+  <script defer src="{% static 'js/accounts/notification-debug.js' %}"></script>
+{% endblock extra_script %}
+
+{% block breadcrumbs %}
+  <li class="breadcrumb-item"><a href="{{ page_user.get_absolute_url }}">{{ page_user }}</a></li>
+  <li class="breadcrumb-item">
+    <a href="{% url 'user_notifications' user=page_user.username %}">{% translate "Notification diagnostics" %}</a>
+  </li>
+{% endblock breadcrumbs %}
+
+{% block content %}
+  <ul class="nav nav-pills" role="tablist">
+    <li class="nav-item" role="presentation">
+      <a class="nav-link active"
+         id="diagnostics-tab"
+         data-bs-toggle="tab"
+         data-bs-target="#notifications"
+         href="#notifications"
+         role="tab"
+         aria-controls="notifications"
+         aria-selected="true">{% translate "Diagnostics" %}</a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <a class="nav-link"
+         id="overview-tab"
+         data-bs-toggle="tab"
+         data-bs-target="#overview"
+         href="#overview"
+         role="tab"
+         aria-controls="overview"
+         aria-selected="false"
+         tabindex="-1">{% translate "Overview" %}</a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane active"
+         id="notifications"
+         role="tabpanel"
+         aria-labelledby="diagnostics-tab">
+      <form method="get"
+            action="{% url 'user_notifications' user=page_user.username %}#notifications">
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title">{% translate "Notification diagnostics" %}</h2>
+          </div>
+          <div class="card-body">
+            <p>{% translate "Check subscription eligibility for hypothetical events. This does not send notifications. The user’s own actions do not trigger notifications; event details, digest content, and delivery rate limits can also affect delivery." %}</p>
+            {{ notification_form|crispy }}
+          </div>
+          <div class="card-footer">
+            <button type="submit" class="btn btn-primary">{% translate "Check notifications" %}</button>
+          </div>
+        </div>
+      </form>
+
+      {% if notification_debug_target %}
+        <section class="card" aria-labelledby="notification-results-heading">
+          <div class="card-header">
+            <h2 class="card-title" id="notification-results-heading">{% blocktranslate with target=notification_debug_target %}Notification eligibility for {{ target }}{% endblocktranslate %}</h2>
+          </div>
+          <div class="card-body">
+            {% if notification_summary.broad and not notification_summary.empty %}
+              <p class="form-text">{% translate "Inherited project settings are shown once, alongside differences across accessible components. Choose a component or translation path for detailed eligibility checks." %}</p>
+            {% endif %}
+            {% if notification_results %}
+              <div class="table-responsive"
+                   tabindex="0"
+                   role="region"
+                   aria-labelledby="notification-results-heading">
+                <table class="table table-listing table-striped overflow-wrap notification-eligibility-table">
+                  <thead>
+                    <tr>
+                      <th scope="col" class="fw-bold">{% translate "Notification" %}</th>
+                      <th scope="col" class="fw-bold">
+                        {% if notification_summary.broad %}
+                          {% translate "Inherited project settings" %}
+                        {% else %}
+                          {% translate "Settings and eligibility" %}
+                        {% endif %}
+                      </th>
+                      {% if notification_summary.broad %}
+                        <th scope="col" class="fw-bold">{% translate "Component exceptions" %}</th>
+                      {% endif %}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for result in notification_results %}
+                      <tr>
+                        <th scope="row" class="fw-normal">{{ result.name }}</th>
+                        <td>
+                          {% if result.subscription %}
+                            <p>
+                              <a data-notification-subscription
+                                 href="#overview__notification-subscription-{{ result.subscription.pk }}">{{ result.subscription.get_scope_display }}: {{ result.subscription.get_frequency_display }}</a>
+                              {% if result.subscription.onetime %}
+                                <span class="badge text-bg-secondary">{% translate "One-time" %}</span>
+                              {% endif %}
+                            </p>
+                            <p>{{ result.reason }}</p>
+                          {% elif notification_summary.broad %}
+                            <p>{% translate "No inherited subscription. Matching settings are listed under component exceptions." %}</p>
+                          {% endif %}
+                          {% if result.subscription and result.conditions or result.subscription and result.overridden %}
+                            {% if result.conditions %}<ul>{% for condition in result.conditions %}<li>{{ condition }}</li>{% endfor %}</ul>{% endif %}
+                            {% if result.overridden %}
+                              <p>{% translate "Overridden subscriptions" %}</p>
+                              <ul>
+                                {% for subscription in result.overridden %}
+                                  <li>
+                                    <a data-notification-subscription
+                                       href="#overview__notification-subscription-{{ subscription.pk }}">{{ subscription.get_scope_display }}: {{ subscription.get_frequency_display }}</a>
+                                  </li>
+                                {% endfor %}
+                              </ul>
+                            {% endif %}
+                          {% endif %}
+                        </td>
+                        {% if notification_summary.broad %}
+                          <td>
+                            {% if result.exceptions %}
+                              {% for exception in result.exceptions %}
+                                <div{% if not forloop.first %} class="border-top pt-2 mt-2"{% endif %}>
+                                  <p>{% blocktranslate count count=exception.count %}Different settings in {{ count }} component.{% plural %}Different settings in {{ count }} components.{% endblocktranslate %}</p>
+                                  {% if exception.outcome.subscription %}
+                                    <p>
+                                      {% if exception.subscription_id %}
+                                        <a data-notification-subscription
+                                           href="#overview__notification-subscription-{{ exception.subscription_id }}">{{ exception.outcome.subscription.get_scope_display }}: {{ exception.outcome.subscription.get_frequency_display }}</a>
+                                      {% else %}
+                                        {{ exception.outcome.subscription.get_scope_display }}: {{ exception.outcome.subscription.get_frequency_display }}
+                                      {% endif %}
+                                      {% if exception.outcome.subscription.onetime %}
+                                        <span class="badge text-bg-secondary">{% translate "One-time" %}</span>
+                                      {% endif %}
+                                    </p>
+                                  {% endif %}
+                                  {% if exception.outcome.subscription %}
+                                    <p>{{ exception.outcome.reason }}</p>
+                                  {% else %}
+                                    <p>{% translate "These components have no matching subscription, so this notification will not be sent." %}</p>
+                                  {% endif %}
+                                  {% if exception.shared_count %}
+                                    <p class="form-text">{% translate "Shared components use subscriptions from their original project, not this project’s subscriptions." %}</p>
+                                  {% endif %}
+                                  {% if exception.outcome.subscription and exception.outcome.conditions %}
+                                    <ul>{% for condition in exception.outcome.conditions %}<li>{{ condition }}</li>{% endfor %}</ul>
+                                  {% endif %}
+                                  <p class="mt-3 mb-1">
+                                    {% if exception.count > notification_detail_limit %}
+                                      {% translate "Inspect example components:" %}
+                                    {% else %}
+                                      {% translate "Inspect components:" %}
+                                    {% endif %}
+                                  </p>
+                                  <ul class="list-unstyled mb-0">
+                                    {% for component in exception.examples %}
+                                      <li><a href="{% url 'user_notifications' user=page_user.username %}?notification_target={{ component.get_url_path|join:'/'|urlencode }}#notifications">{{ component }}</a></li>
+                                    {% endfor %}
+                                  </ul>
+                                </div>
+                              {% endfor %}
+                            {% else %}
+                              {% translate "None" %}
+                            {% endif %}
+                          </td>
+                        {% endif %}
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            {% else %}
+              <p>
+                {% if notification_summary.empty %}
+                  {% translate "No accessible components or translations in this target." %}
+                {% else %}
+                  {% translate "No matching subscriptions in this scope." %}
                 {% endif %}
-                {% if group.show_component %}
-                  <td><a href="{{ subscription.component.get_absolute_url }}">{{ subscription.component }}</a></td>
-                  <td>
-                    {% if subscription.onetime %}
-                      {% translate "Yes" %}
-                    {% else %}
-                      {% translate "No" %}
-                    {% endif %}
-                  </td>
-                {% endif %}
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+              </p>
+            {% endif %}
+          </div>
+        </section>
+      {% endif %}
+    </div>
+    <div class="tab-pane" id="overview" role="tabpanel" aria-labelledby="overview-tab">
+      <div class="row">
+        <div class="col-md-6">
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">{% translate "Watched projects" %}</h2>
+            </div>
+            <div class="card-body">
+              {% if notification_watched_count > notification_detail_limit %}
+                <p class="mb-0">{% blocktranslate count count=notification_watched_count %}{{ count }} watched project.{% plural %}{{ count }} watched projects.{% endblocktranslate %}</p>
+              {% else %}
+                <ul class="list-unstyled mb-0">
+                  {% for project in notification_watched_projects %}
+                    <li><a href="{{ project.get_absolute_url }}">{{ project }}</a></li>
+                  {% empty %}
+                    <li>{% translate "No watched projects." %}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">{% translate "Notification languages" %}</h2>
+            </div>
+            <div class="card-body">
+              {% if notification_language_count > notification_detail_limit %}
+                <p class="mb-0">{% blocktranslate count count=notification_language_count %}{{ count }} notification language.{% plural %}{{ count }} notification languages.{% endblocktranslate %}</p>
+              {% else %}
+                <ul class="list-unstyled mb-0">
+                  {% for language in notification_languages %}
+                    <li><a href="{{ language.get_absolute_url }}">{{ language }}</a></li>
+                  {% empty %}
+                    <li>{% translate "No notification languages selected. Language-filtered notifications will not be sent." %}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
+          </div>
+        </div>
       </div>
-    {% empty %}
-      <p>{% translate "No subscriptions." %}</p>
-    {% endfor %}
 
-  </div>
-</div>
+      <div class="card">
+        <div class="card-header">
+          <h2 class="card-title">{% translate "Subscriptions" %}</h2>
+        </div>
+        <div class="card-body">
+          {% if notification_subscription_groups %}
+            <div class="table-responsive">
+              <table class="table table-listing">
+                <thead>
+                  <tr>
+                    <th scope="col" class="fw-bold">{% translate "Notification" %}</th>
+                    <th scope="col" class="fw-bold">{% translate "Frequency" %}</th>
+                  </tr>
+                </thead>
+                {% for group in notification_subscription_groups %}
+                  <tbody>
+                    <tr class="table-light">
+                      <th scope="rowgroup" colspan="2">
+                        {{ group.label }}
+                        {% if group.target %}
+                          — <a href="{{ group.target.get_absolute_url }}">{{ group.target }}</a>
+                        {% endif %}
+                      </th>
+                    </tr>
+                    {% for subscription in group.subscriptions %}
+                      <tr id="overview__notification-subscription-{{ subscription.pk }}" tabindex="-1">
+                        <th scope="row" class="fw-normal">{{ subscription.get_notification_display }}</th>
+                        <td>
+                          {{ subscription.get_frequency_display }}
+                          {% if subscription.onetime %}
+                            <span class="badge text-bg-secondary">{% translate "One-time" %}</span>
+                          {% endif %}
+                        </td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                {% endfor %}
+              </table>
+            </div>
+          {% else %}
+            <p>{% translate "No subscriptions." %}</p>
+          {% endif %}
 
-<form method="get" action="{{ page_user.get_absolute_url }}#notifications">
-  <div class="card">
-    <div class="card-header">
-      <h4 class="card-title">{% translate "Notification debug" %}</h4>
-    </div>
-    <div class="card-body">
-      <p>{% translate "Check subscription eligibility for hypothetical events. This does not send notifications. The user’s own actions do not trigger notifications; event details, digest content, and delivery rate limits can also affect delivery." %}</p>
-      {{ notification_form|crispy }}
-    </div>
-    <div class="card-footer">
-      <button type="submit" class="btn btn-primary">{% translate "Check notifications" %}</button>
-    </div>
-  </div>
-</form>
-
-{% if notification_debug_target %}
-  <div class="card">
-    <div class="card-header">
-      <h4 class="card-title">{% blocktranslate with target=notification_debug_target %}Notification eligibility for {{ target }}{% endblocktranslate %}</h4>
-    </div>
-    <div class="card-body">
-      <p>{% blocktranslate count count=notification_page.paginator.count %}{{ count }} accessible target.{% plural %}{{ count }} accessible targets.{% endblocktranslate %}</p>
-      <div class="table-responsive">
-        <table class="table table-listing">
-          <thead>
-            <tr>
-              <th scope="col">{% translate "Notification" %}</th>
-              <th scope="col">{% translate "Eligibility" %}</th>
-              <th scope="col">{% translate "Effective subscription" %}</th>
-              <th scope="col">{% translate "Targets" %}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for result in notification_results %}
-              <tr>
-                <th scope="row">{{ result.name }}</th>
-                <td>
-                  <p>{{ result.reason }}</p>
-                  {% if result.conditions %}
-                    <ul>{% for condition in result.conditions %}<li>{{ condition }}</li>{% endfor %}</ul>
-                  {% endif %}
-                </td>
-                <td>
-                  {% if result.subscription %}
-                    <a href="#notification-subscription-{{ result.subscription.pk }}">{{ result.subscription.get_scope_display }}: {{ result.subscription.get_frequency_display }}</a>
-                    {% if result.overridden %}
-                      <details>
-                        <summary>{% translate "Overridden subscriptions" %}</summary>
-                        <ul>
-                          {% for subscription in result.overridden %}
-                            <li><a href="#notification-subscription-{{ subscription.pk }}">{{ subscription.get_scope_display }}: {{ subscription.get_frequency_display }}</a></li>
-                          {% endfor %}
-                        </ul>
-                      </details>
-                    {% endif %}
-                  {% else %}
-                    {% translate "None" %}
-                  {% endif %}
-                </td>
-                <td>
-                  {% if result.targets|length > notification_detail_limit %}
-                    {% blocktranslate count count=result.targets|length %}{{ count }} target on this page{% plural %}{{ count }} targets on this page{% endblocktranslate %}
-                  {% else %}
-                    <ul class="list-unstyled mb-0">
-                      {% for target in result.targets %}
-                        <li><a href="{{ target.get_absolute_url }}">{{ target }}</a></li>
-                      {% endfor %}
-                    </ul>
-                  {% endif %}
-                </td>
-              </tr>
-            {% empty %}
-              <tr>
-                <td colspan="4">{% translate "No accessible components or translations in this target." %}</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+        </div>
       </div>
+
     </div>
-    {% if notification_page.has_other_pages %}
-      <div class="card-footer">
-        {% include "paginator.html" with page_obj=notification_page query_string=notification_query_string search_items=notification_search_items anchor="notifications" %}
-      </div>
-    {% endif %}
   </div>
-{% endif %}
+{% endblock content %}

--- a/weblate/templates/accounts/profile.html
+++ b/weblate/templates/accounts/profile.html
@@ -98,6 +98,11 @@
       </div>
 
       <div class="tab-pane" id="notifications">
+        <div class="alert alert-info">
+          {% translate "Check which subscriptions apply to a project, component, or translation and what can prevent notification delivery." %}
+          <a class="alert-link text-decoration-underline"
+             href="{% url 'user_notifications' user=user.username %}">{% translate "Open notification diagnostics" %}</a>
+        </div>
 
         <div class="card">
           <div class="card-header">

--- a/weblate/templates/accounts/user.html
+++ b/weblate/templates/accounts/user.html
@@ -169,7 +169,7 @@
   <ul class="nav nav-pills justify-content-center">
     <li class="nav-item">
       {# Translators: Name of a tab which lists translations the user has contributed to #}
-      <a class="nav-link{% if not notification_submitted %} active{% endif %}"
+      <a class="nav-link active"
          data-bs-toggle="tab"
          data-bs-target="#contributed"
          href="#">{% translate "Translates" %}</a>
@@ -193,12 +193,6 @@
            data-bs-target="#identities"
            href="#">{% translate "User identities" %}</a>
       </li>
-      <li class="nav-item">
-        <a class="nav-link{% if notification_submitted %} active{% endif %}"
-           data-bs-toggle="tab"
-           data-bs-target="#notifications"
-           href="#">{% translate "Notifications" %}</a>
-      </li>
       {% if page_user_billings %}
         <li class="nav-item">
           <a class="nav-link" data-bs-toggle="tab" data-bs-target="#billing" href="#">{% translate "Billing" %}</a>
@@ -220,8 +214,7 @@
 
   <div class="tab-content">
 
-    <div class="tab-pane{% if not notification_submitted %} active{% endif %}"
-         id="contributed">
+    <div class="tab-pane active" id="contributed">
       <div class="list-group">
         {% include "snippets/list-objects.html" with objects=page_user_translations label=_("Translation") show_admin_badge=True name_source="translation" empty_message=_("No recent contributions found.") %}
         <a href="{% url 'user_contributions' user=page_user.username %}"
@@ -284,9 +277,6 @@
           </tbody>
         </table>
       </div>
-
-      <div class="tab-pane{% if notification_submitted %} active{% endif %}"
-           id="notifications">{% include "accounts/notification_debug.html" %}</div>
 
       {% if page_user_billings %}
         <div class="tab-pane" id="billing">
@@ -407,6 +397,18 @@
               </div>
             </div>
           </form>
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title">{% translate "Notification diagnostics" %}</h4>
+            </div>
+            <div class="card-body">
+              {% translate "Check which subscriptions apply to a project, component, or translation and what can prevent notification delivery." %}
+            </div>
+            <div class="card-footer">
+              <a class="btn btn-primary"
+                 href="{% url 'user_notifications' user=page_user.username %}">{% translate "Check notifications" %}</a>
+            </div>
+          </div>
           <form method="post">
             {% csrf_token %}
             <div class="card">

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -1025,6 +1025,11 @@ real_patterns = [
     # User pages
     path("user/", weblate.accounts.views.UserList.as_view(), name="user_list"),
     path(
+        "user/<name:user>/notifications/",
+        weblate.accounts.views.UserNotifications.as_view(),
+        name="user_notifications",
+    ),
+    path(
         "user/<name:user>/", weblate.accounts.views.UserPage.as_view(), name="user_page"
     ),
     path(


### PR DESCRIPTION
Let users inspect their own notification settings and administrators inspect other accounts. Summarize inherited settings and component exceptions across the full accessible scope instead of paging through targets.

Separate diagnostics and subscription overview tabs, clarify delivery conditions, and highlight linked subscriptions. Deduplicate subscription matches from watched-project joins and cover access controls and summary behavior with regression tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
