### PR TITLE
fix(trans): respect language reviews in approved-only commits

### DIFF
--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -344,6 +344,14 @@ supports the following options:
   reviewer will be committed. This option requires :ref:`project-translation_review`
   to be enabled.
 
+The approved-only policy applies only to translations with reviews enabled.
+Languages with reviews disabled through :ref:`workflow-customization` commit all
+translations, including those marked as needing editing. Source strings follow
+the same rule using :ref:`project-source_review`.
+
+Components linked to a repository in another project follow their own project's
+commit policy.
+
 
 .. _project-enable_hooks:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,7 @@ Weblate 2026.9.1
 
 .. rubric:: Bug fixes
 
+* Fixed the approved-only :ref:`commit policy <project-commit_policy>` blocking commits for languages with reviews disabled by workflow settings.
 * Fixed the :ref:`uWSGI configuration example <uwsgi>` to use the virtual environment's Python when launching helpers for SSH repository operations.
 * Fixed language context and links in change history for scoped :doc:`announcements <admin/announcements>` and other language-specific events.
 * Restored :ref:`mt-deepl` API v1 translation support while retaining modern API language discovery and glossary improvements.

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -783,7 +783,10 @@ class TranslationForm(UnitForm):
         else:
             self.fields["explanation"].widget = forms.HiddenInput()
 
-        if component.project.commit_policy:
+        if component.project.commit_policy and (
+            component.project.commit_policy != CommitPolicyChoices.APPROVED_ONLY
+            or translation.enable_review
+        ):
             commit_policy = f" {component.project.get_commit_policy_description()}"
             self.fields["review"].help_text += commit_policy
             self.fields["fuzzy"].help_text += commit_policy

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -3885,6 +3885,30 @@ class Component(  # ruff: ignore[too-many-public-methods]
             translation = translation.component.source_translation
         return translation
 
+    @staticmethod
+    def preload_commit_workflows(translations: list[Translation]) -> None:
+        from weblate.trans.models.project import (  # ruff: ignore[import-outside-top-level]
+            CommitPolicyChoices,
+        )
+
+        by_project: dict[int, list[Translation]] = defaultdict(list)
+        for translation in translations:
+            by_project[translation.component.project_id].append(translation)
+
+        for project_translations in by_project.values():
+            project = project_translations[0].component.project
+            if project.commit_policy != CommitPolicyChoices.APPROVED_ONLY:
+                continue
+            languages = {
+                translation.language_id: project.project_languages[translation.language]
+                for translation in project_translations
+            }
+            project.project_languages.preload_workflow_settings(languages.values())
+            for translation in project_translations:
+                translation.__dict__["workflow_settings"] = languages[
+                    translation.language_id
+                ].workflow_settings
+
     @perform_on_link
     def commit_pending(
         self, reason: str, user: User | None, skip_push: bool = False
@@ -3906,7 +3930,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         translations = sorted(
             Translation.objects.filter(pk__in=pending_translation_ids)
             .distinct()
-            .prefetch_related("component"),
+            .prefetch_related("component__project", "language"),
             key=lambda translation: not translation.is_source,
         )
         components = {}
@@ -3918,13 +3942,19 @@ class Component(  # ruff: ignore[too-many-public-methods]
         if not translations:
             return True
 
+        translations = [
+            self.reuse_component_for_translation(translation, reuse_source=True)
+            for translation in translations
+        ]
+        # Populate the actual instances used below, including reused source translations.
+        # Per-translation policy checks can then use enable_review without querying
+        # workflow settings once for every language.
+        self.preload_commit_workflows(translations)
+
         # Commit pending changes
         with self.track_local_head_change():
             for translation in translations:
                 self.repository.lock.reacquire()
-                translation = self.reuse_component_for_translation(
-                    translation, reuse_source=True
-                )
                 component = translation.component
                 if component.pk in skipped:
                     # We already failed at this component

--- a/weblate/trans/models/pending.py
+++ b/weblate/trans/models/pending.py
@@ -13,6 +13,7 @@ from django.db.models import (
     BooleanField,
     Case,
     DateTimeField,
+    Exists,
     ExpressionWrapper,
     F,
     OuterRef,
@@ -57,11 +58,6 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
         # ruff: ignore[import-outside-top-level]
         from weblate.trans.models import (
             Component,
-        )
-
-        # ruff: ignore[import-outside-top-level]
-        from weblate.trans.models.project import (
-            CommitPolicyChoices,
         )
 
         pending_changes = self.all()
@@ -111,7 +107,23 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
         # This checks if ANY change passes the policy, not the full per-unit
         # latest-qualifying-change logic as we only need to check for the existence
         # of any eligible pending change.
-        policy_filter = (
+        pending_changes = pending_changes.filter(self._committable_states())
+
+        component_pks = list(
+            pending_changes.annotate(repo_owner_id=repo_owner_id)
+            .values_list("repo_owner_id", flat=True)
+            .distinct()
+        )
+        return Component.objects.filter(pk__in=component_pks)
+
+    def _committable_states(self) -> Q:
+        """Match changes using each translation's own project policy."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models.project import (
+            CommitPolicyChoices,
+        )
+
+        return (
             Q(
                 unit__translation__component__project__commit_policy=CommitPolicyChoices.ALL
             )
@@ -125,17 +137,9 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
                 Q(
                     unit__translation__component__project__commit_policy=CommitPolicyChoices.APPROVED_ONLY
                 )
-                & Q(state=STATE_APPROVED)
+                & self._approved_or_review_disabled()
             )
         )
-        pending_changes = pending_changes.filter(policy_filter)
-
-        component_pks = list(
-            pending_changes.annotate(repo_owner_id=repo_owner_id)
-            .values_list("repo_owner_id", flat=True)
-            .distinct()
-        )
-        return Component.objects.filter(pk__in=component_pks)
 
     def for_component(
         self, component: Component, *, apply_filters: bool, include_linked: bool = False
@@ -151,7 +155,7 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
             base_filter=component_filter,
             apply_filters=apply_filters,
             revision=None,
-            commit_policy=component.project.commit_policy,
+            commit_policy=None if include_linked else component.project.commit_policy,
         )
 
     def for_translation(self, translation: Translation, apply_filters: bool = True):
@@ -161,6 +165,7 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
             apply_filters=apply_filters,
             revision=translation.revision,
             commit_policy=translation.component.project.commit_policy,
+            translation=translation,
         )
 
     def _apply_filters(
@@ -168,13 +173,16 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
         base_filter: Q,
         apply_filters: bool,
         revision: str | None,
-        commit_policy: int,
+        commit_policy: int | None,
+        translation: Translation | None = None,
     ):
         qs = self.filter(base_filter)
         if not apply_filters:
             return qs
         qs = self._apply_retry_filter(qs, revision=revision, blocking_unit_filter=True)
-        return self._apply_commit_policy_filter(qs, commit_policy)
+        return self._apply_commit_policy_filter(
+            qs, commit_policy, translation=translation
+        )
 
     def _apply_retry_filter(
         self,
@@ -271,8 +279,26 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
 
         return self.filter(pk__in=eligible_pks)
 
+    @staticmethod
+    def _approved_or_review_disabled() -> Q:
+        from weblate.trans.models.translation import (  # ruff: ignore[import-outside-top-level]
+            Translation,
+        )
+
+        return Q(state=STATE_APPROVED) | Q(
+            ~Exists(
+                Translation.objects.with_review().filter(
+                    pk=OuterRef("unit__translation_id")
+                )
+            )
+        )
+
     def _apply_commit_policy_filter(
-        self, qs: PendingChangeQuerySet, commit_policy: int
+        self,
+        qs: PendingChangeQuerySet,
+        commit_policy: int | None,
+        *,
+        translation: Translation | None = None,
     ) -> PendingChangeQuerySet:
         """
         Filter pending changes based on the project's commit policy.
@@ -280,6 +306,9 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
         For policies other than ALL, this finds the latest qualifying change per unit
         and includes all changes up to that point. This ensures we commit changes in
         chronological order and don't skip intermediate changes.
+
+        When scoped to a translation, reuse its effective review setting instead of
+        resolving workflows in SQL. Aggregate queries resolve reviews per translation.
         """
         # ruff: ignore[import-outside-top-level]
         from weblate.trans.models.project import (
@@ -290,10 +319,19 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
             return qs
 
         filters = []
-        if commit_policy == CommitPolicyChoices.WITHOUT_NEEDS_EDITING:
+        if commit_policy is None:
+            # Repository-wide queries can include linked components from other projects.
+            filters.append(self._committable_states())
+        elif commit_policy == CommitPolicyChoices.WITHOUT_NEEDS_EDITING:
             filters.append(~Q(state__in=FUZZY_STATES))
         elif commit_policy == CommitPolicyChoices.APPROVED_ONLY:
-            filters.append(Q(state=STATE_APPROVED))
+            if translation is not None:
+                # Component.commit_pending preloads workflows on these instances.
+                if not translation.enable_review:
+                    return qs
+                filters.append(Q(state=STATE_APPROVED))
+            else:
+                filters.append(self._approved_or_review_disabled())
 
         # For each unit, finds the last change that makes it eligible for committing
         # based on the project's commit policy, and returns all changes up to and
@@ -354,7 +392,9 @@ class PendingChangeQuerySet(models.QuerySet["PendingUnitChange", "PendingUnitCha
         eligible_after_retry_filter = self._count_units_helper(qs)
         counts["errors_skipped"] = counts["total"] - eligible_after_retry_filter
 
-        qs = self._apply_commit_policy_filter(qs, commit_policy)
+        qs = self._apply_commit_policy_filter(
+            qs, commit_policy, translation=obj if isinstance(obj, Translation) else None
+        )
         eligible_after_commit_policy_filter = self._count_units_helper(qs)
         counts["commit_policy_skipped"] = (
             eligible_after_retry_filter - eligible_after_commit_policy_filter

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -1624,6 +1624,7 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
             )
         if self.commit_policy == CommitPolicyChoices.APPROVED_ONLY:
             return gettext(
-                "Only approved translations are written to the translation file."
+                "For languages with reviews enabled, only approved translations "
+                "are written to the translation file."
             )
         return ""

--- a/weblate/trans/models/translation.py
+++ b/weblate/trans/models/translation.py
@@ -17,7 +17,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import DatabaseError, IntegrityError, models, transaction
-from django.db.models import F, Q
+from django.db.models import F, OuterRef, Q, Subquery, Value
+from django.db.models.functions import Coalesce
 from django.db.models.signals import post_save
 from django.urls import reverse
 from django.utils import timezone
@@ -312,6 +313,27 @@ class TranslationQuerySet(models.QuerySet["Translation", "Translation"]):
         Database equivalent of Translation.is_source property.
         """
         return self.exclude(language=F("component__source_language"))
+
+    def with_review(self) -> TranslationQuerySet:
+        """Return translations whose effective workflow enables reviews."""
+        from weblate.trans.models.workflow import (  # ruff: ignore[import-outside-top-level]
+            WorkflowSetting,
+        )
+
+        workflow = WorkflowSetting.objects.filter(
+            Q(project=None) | Q(project=OuterRef("component__project_id")),
+            language=OuterRef("language_id"),
+        ).order_by(F("project").desc(nulls_last=True))
+        source = Q(language=F("component__source_language"))
+        return self.alias(
+            workflow_review=Coalesce(
+                Subquery(workflow.values("translation_review")[:1]), Value(True)
+            )
+        ).filter(
+            (source & Q(component__project__source_review=True))
+            | (~source & Q(component__project__translation_review=True)),
+            workflow_review=True,
+        )
 
 
 class Translation(

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -2873,6 +2873,8 @@ class Unit(models.Model, LoggerMixin):
         return not self.readonly and (
             (commit_policy == CommitPolicyChoices.WITHOUT_NEEDS_EDITING and self.fuzzy)
             or (
-                commit_policy == CommitPolicyChoices.APPROVED_ONLY and not self.approved
+                commit_policy == CommitPolicyChoices.APPROVED_ONLY
+                and self.translation.enable_review
+                and not self.approved
             )
         )

--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -21,7 +21,7 @@ from django.core.paginator import Paginator
 from django.db import close_old_connections, connection
 from django.db.models import F
 from django.test import SimpleTestCase, TransactionTestCase
-from django.test.utils import override_settings
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils import timezone
 from translate.storage.base import ParseError
 
@@ -39,6 +39,7 @@ from weblate.trans.models import (
     Project,
     Translation,
     Unit,
+    WorkflowSetting,
 )
 from weblate.trans.models.component import prefetch_tasks
 from weblate.trans.repository_context import (
@@ -55,7 +56,9 @@ from weblate.trans.tests.utils import RepoTestMixin, create_test_user
 from weblate.utils.files import remove_tree
 from weblate.utils.lock import WeblateLockTimeoutError
 from weblate.utils.state import (
+    STATE_APPROVED,
     STATE_EMPTY,
+    STATE_FUZZY,
     STATE_NEEDS_CHECKING,
     STATE_READONLY,
     STATE_TRANSLATED,
@@ -82,6 +85,161 @@ remote: Host key verification failed.
 
 class ComponentTest(RepoTestCase):
     """Component object testing."""
+
+    def test_commit_pending_uses_linked_project_policy(self) -> None:
+        component = self.create_component()
+        project = component.project
+        project.commit_policy = CommitPolicyChoices.WITHOUT_NEEDS_EDITING
+        project.save()
+        other_project = self.create_project(
+            name="Other",
+            slug="other",
+            commit_policy=CommitPolicyChoices.APPROVED_ONLY,
+            translation_review=True,
+        )
+        linked = Component.objects.create(
+            project=other_project,
+            name="Linked",
+            slug="linked",
+            repo=component.get_repo_link_url(),
+            file_format="po",
+            filemask="po-duplicates/*.dpo",
+        )
+        translation = linked.translation_set.get(language_code="cs")
+        WorkflowSetting.objects.create(
+            project=other_project,
+            language=translation.language,
+            translation_review=False,
+        )
+        user = create_test_user()
+        owner_unit = component.translation_set.get(
+            language_code="cs"
+        ).unit_set.order_by("pk")[0]
+        owner_unit.translate(user, "Owner needs editing\n", STATE_FUZZY)
+        unit = translation.unit_set.order_by("pk")[0]
+        unit.translate(user, "Linked needs editing\n", STATE_FUZZY)
+        reviewed_translation = linked.translation_set.get(language_code="de")
+        reviewed = reviewed_translation.unit_set.order_by("pk")[0]
+        reviewed.translate(user, "First translation\n", STATE_TRANSLATED)
+        reviewed.translate(user, "Approved translation\n", STATE_APPROVED)
+        reviewed.translate(user, "Unapproved update\n", STATE_FUZZY)
+
+        eligible = PendingUnitChange.objects.for_component(
+            component, apply_filters=True, include_linked=True
+        )
+        self.assertEqual(eligible.filter(unit=unit).count(), 1)
+        self.assertFalse(eligible.filter(unit=owner_unit).exists())
+        self.assertEqual(
+            list(
+                eligible.filter(unit=reviewed)
+                .order_by("timestamp")
+                .values_list("state", flat=True)
+            ),
+            [STATE_TRANSLATED, STATE_APPROVED],
+        )
+        self.assertTrue(
+            PendingUnitChange.objects.find_committable_components(hours=0)
+            .filter(pk=component.pk)
+            .exists()
+        )
+        component.commit_pending("test", user)
+        self.assertFalse(PendingUnitChange.objects.filter(unit=unit).exists())
+        self.assertTrue(PendingUnitChange.objects.filter(unit=owner_unit).exists())
+        self.assertEqual(PendingUnitChange.objects.filter(unit=reviewed).count(), 1)
+        for changed, expected in (
+            (unit, "Linked needs editing\n"),
+            (reviewed, "Approved translation\n"),
+        ):
+            fresh = Translation.objects.get(pk=changed.translation_id)
+            stored, _ = fresh.store.find_unit(changed.context, changed.source)
+            self.assertEqual(stored.target, expected)
+        self.assertFalse(
+            PendingUnitChange.objects.find_committable_components(hours=0)
+            .filter(pk=component.pk)
+            .exists()
+        )
+
+    def test_commit_pending_preloads_workflows(self) -> None:
+        component = self.create_component()
+        project = component.project
+        project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        project.translation_review = True
+        project.source_review = True
+        project.save()
+        other_project = self.create_project(
+            name="Other",
+            slug="other",
+            commit_policy=CommitPolicyChoices.APPROVED_ONLY,
+            translation_review=True,
+            source_review=False,
+        )
+        linked = Component.objects.create(
+            project=other_project,
+            name="Linked",
+            slug="linked",
+            repo=component.get_repo_link_url(),
+            file_format="po",
+            filemask="po-duplicates/*.dpo",
+        )
+        czech = Language.objects.get(code="cs")
+        german = Language.objects.get(code="de")
+        WorkflowSetting.objects.create(language=czech, translation_review=False)
+        WorkflowSetting.objects.create(language=german, translation_review=False)
+        local = WorkflowSetting.objects.create(
+            project=project, language=czech, translation_review=True
+        )
+        user = create_test_user()
+        translations = list(
+            Translation.objects.filter(component__in=[component, linked])
+        )
+        self.assertGreaterEqual(len(translations), 4)
+        for translation in translations:
+            PendingUnitChange.objects.create(
+                unit=translation.unit_set.order_by("pk")[0],
+                author=user,
+                state=STATE_APPROVED,
+            )
+
+        # Start with a fresh component and project-language cache, as background
+        # commits do. Check the actual instances passed into the commit loop.
+        component = Component.objects.get(pk=component.pk)
+        seen = set()
+
+        def check_workflow(translation, reason, author) -> bool:
+            with self.assertNumQueries(0):
+                setting = translation.workflow_settings
+                review = translation.enable_review
+            if translation.is_source or translation.language_id == czech.pk:
+                expected = translation.component.project_id == project.pk
+            else:
+                expected = translation.language_id != german.pk
+            self.assertEqual(review, expected, translation.full_slug)
+            if translation.component.project_id == project.pk:
+                if translation.language_id == czech.pk:
+                    self.assertEqual(setting, local)
+                elif translation.is_source:
+                    self.assertIsNone(setting)
+                    self.assertIs(translation, component.source_translation)
+            seen.add(translation.pk)
+            return False
+
+        with (
+            patch.object(
+                Translation,
+                "_commit_pending",
+                autospec=True,
+                side_effect=check_workflow,
+            ),
+            CaptureQueriesContext(connection) as queries,
+        ):
+            component.commit_pending("test", user)
+        self.assertEqual(seen, {translation.pk for translation in translations})
+        workflow_queries = [
+            query
+            for query in queries
+            if query["sql"].startswith('SELECT "trans_workflowsetting".')
+        ]
+        self.assertEqual(len(workflow_queries), 2)
 
     def test_prefetch_tasks_preserves_page(self) -> None:
         component = self.create_po()
@@ -2905,6 +3063,7 @@ class ResetReapplyMissingTranslationFileTest(ComponentTestCase):
 
     def test_file_sync_ignores_uncommittable_missing_translation_file(self) -> None:
         self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        self.project.translation_review = True
         self.project.save()
         self.prepare_missing_translation_file(
             self.de_translation,

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -56,6 +56,7 @@ from weblate.trans.models import (
     Translation,
     Unit,
     Vote,
+    WorkflowSetting,
 )
 from weblate.trans.models.change import ChangeQuerySet
 from weblate.trans.models.component import ComponentLink
@@ -962,6 +963,34 @@ class TranslationTest(RepoTestCase):
         # only adds pending change for target unit's translation file
         self.assertEqual(PendingUnitChange.objects.count(), 1)
 
+    def test_commit_without_language_reviews(self) -> None:
+        component = self.create_component()
+        project = component.project
+        user = create_test_user()
+        project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        project.translation_review = True
+        project.save()
+        translation = component.translation_set.get(language_code="cs")
+        unit = translation.unit_set.get(source="Hello, world!\n")
+        unit.translate(user, "Reviewed language", STATE_TRANSLATED)
+        translation.commit_pending("test", None)
+        self.assertTrue(PendingUnitChange.objects.filter(unit=unit).exists())
+
+        WorkflowSetting.objects.create(
+            project=project,
+            language=translation.language,
+            translation_review=False,
+        )
+        translation = Translation.objects.get(pk=translation.pk)
+        unit = translation.unit_set.get(pk=unit.pk)
+        unit.translate(user, "Language without reviews\n", STATE_FUZZY)
+        translation.commit_pending("test", None)
+        self.assertFalse(PendingUnitChange.objects.filter(unit=unit).exists())
+        translation = Translation.objects.get(pk=translation.pk)
+        stored, _ = translation.store.find_unit(unit.context, unit.source)
+        self.assertEqual(stored.target, "Language without reviews\n")
+        self.assertTrue(stored.is_fuzzy())
+
     def test_commit_policy(self) -> None:
         component = self.create_xliff()
         translation = component.translation_set.get(language_code="cs")
@@ -969,6 +998,7 @@ class TranslationTest(RepoTestCase):
 
         project = component.project
         project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        project.translation_review = True
         project.save()
 
         self.assertIn("approved", project.get_commit_policy_description())
@@ -1078,6 +1108,7 @@ class TranslationTest(RepoTestCase):
         component = self.create_ftl()
         project = component.project
         project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        project.translation_review = True
         project.save()
 
         translation = component.translation_set.get(language_code="cs")
@@ -2273,6 +2304,7 @@ class PendingUnitChangeTest(RepoTestCase):
         self.project.save()
 
         self.other_project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        self.other_project.translation_review = True
         self.other_project.save()
 
         translation = self.component.translation_set.get(language_code="cs")

--- a/weblate/trans/tests/test_workflowsetting.py
+++ b/weblate/trans/tests/test_workflowsetting.py
@@ -4,21 +4,139 @@
 
 """Test for categories."""
 
+from __future__ import annotations
+
+from datetime import timedelta
+from itertools import product
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
 from weblate.auth.data import SELECTION_ALL
 from weblate.auth.models import Group, Role
 from weblate.lang.models import Language
+from weblate.trans.forms import TranslationForm
 from weblate.trans.models import (
     Category,
     ComponentLink,
+    PendingUnitChange,
     Project,
     Translation,
     WorkflowSetting,
 )
+from weblate.trans.models.project import CommitPolicyChoices
 from weblate.trans.tests.test_views import FixtureComponentTestCase
+from weblate.utils.state import STATE_APPROVED, STATE_FUZZY, STATE_TRANSLATED
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 
 
 class WorkflowSettingsTestCase(FixtureComponentTestCase):
+    def test_commit_policy_form_help(self) -> None:
+        self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        self.project.translation_review = True
+        self.project.source_review = True
+        self.project.save()
+        for is_source, review in product((False, True), (False, True)):
+            with self.subTest(is_source=is_source, review=review):
+                translation = (
+                    self.component.source_translation if is_source else self.translation
+                )
+                WorkflowSetting.objects.update_or_create(
+                    project=self.project,
+                    language=translation.language,
+                    defaults={"translation_review": review},
+                )
+                translation = Translation.objects.get(pk=translation.pk)
+                unit = translation.unit_set.order_by("pk")[0]
+                form = TranslationForm(self.user, unit)
+                for name in ("fuzzy", "review"):
+                    self.assertEqual(
+                        "only approved translations" in form.fields[name].help_text,
+                        review,
+                    )
+        self.assertIn(
+            "For languages with reviews enabled",
+            self.project.get_commit_policy_description(),
+        )
+
+    def test_commit_policy_effective_reviews(self) -> None:
+        self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        self.project.save()
+        for is_source, project_review, global_review, local_review in product(
+            (False, True), (False, True), (None, False, True), (None, False, True)
+        ):
+            with self.subTest(
+                is_source=is_source,
+                project_review=project_review,
+                global_review=global_review,
+                local_review=local_review,
+            ):
+                self.project.source_review = project_review if is_source else False
+                self.project.translation_review = (
+                    project_review if not is_source else False
+                )
+                self.project.save()
+                translation = (
+                    self.component.source_translation if is_source else self.translation
+                )
+                WorkflowSetting.objects.all().delete()
+                for project_id, review in (
+                    (None, global_review),
+                    (self.project.pk, local_review),
+                ):
+                    if review is not None:
+                        WorkflowSetting.objects.create(
+                            project_id=project_id,
+                            language=translation.language,
+                            translation_review=review,
+                        )
+                translation = Translation.objects.get(pk=translation.pk)
+                override = local_review if local_review is not None else global_review
+                enabled = project_review and override is not False
+                self.assertEqual(translation.enable_review, enabled)
+                self.assertEqual(
+                    Translation.objects.with_review()
+                    .filter(pk=translation.pk)
+                    .exists(),
+                    enabled,
+                )
+                unit = translation.unit_set.order_by("pk")[0]
+                for state in (STATE_TRANSLATED, STATE_FUZZY, STATE_APPROVED):
+                    unit.state = state
+                    blocked = enabled and state != STATE_APPROVED
+                    self.assertEqual(unit.is_blocked_by_commit_policy, blocked)
+                    change = PendingUnitChange.objects.create(
+                        unit=unit,
+                        author=self.user,
+                        state=state,
+                        timestamp=timezone.now() - timedelta(hours=2),
+                    )
+                    with CaptureQueriesContext(connection) as queries:
+                        self.assertEqual(
+                            PendingUnitChange.objects.for_translation(
+                                translation
+                            ).exists(),
+                            not blocked,
+                        )
+                        PendingUnitChange.objects.detailed_count(translation)
+                    # The effective review setting is already cached on translation.
+                    for query in queries:
+                        self.assertNotIn("trans_workflowsetting", query["sql"])
+                    for obj in (translation, self.component, self.project):
+                        counts = PendingUnitChange.objects.detailed_count(obj)
+                        self.assertEqual(
+                            counts["eligible_for_commit"], int(not blocked)
+                        )
+                        self.assertEqual(counts["commit_policy_skipped"], int(blocked))
+                    self.assertEqual(
+                        PendingUnitChange.objects.find_committable_components(hours=1)
+                        .filter(pk=self.component.pk)
+                        .exists(),
+                        not blocked,
+                    )
+                    change.delete()
+
     def assert_workflow(self, **kwargs) -> None:
         self.assertFalse(self.translation.enable_review)
         self.assertTrue(self.translation.enable_suggestions)


### PR DESCRIPTION
Allow translations without reviews to commit under the approved-only policy. Reuse effective review settings for translation-scoped commits and counts, and resolve workflows for aggregate queries.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
