### PR TITLE
fix(legal): make document prompts consistent

### DIFF
--- a/weblate/legal/templates/legal/confirm.html
+++ b/weblate/legal/templates/legal/confirm.html
@@ -41,8 +41,7 @@
           </div>
           {% if privacy_url %}
             <p>
-              {% translate "Please also read the Privacy Policy:" %}
-              <a href="{{ privacy_url }}">{% translate "Privacy Policy" %}</a>
+              {% blocktranslate %}Please also read the <a href="{{ privacy_url }}">Privacy Policy</a>.{% endblocktranslate %}
             </p>
           {% endif %}
         {% endif %}

--- a/weblate/legal/templates/legal/cookies.html
+++ b/weblate/legal/templates/legal/cookies.html
@@ -23,7 +23,13 @@
 
       {% if terms_url or privacy_url %}
         <p>
-          {% blocktranslate %}This page is based on the General Terms and Conditions and the Privacy Policy, you should still read the original documents to fully understand them:{% endblocktranslate %}
+          {% if terms_url and privacy_url %}
+            {% blocktranslate %}This page is based on the General Terms and Conditions and the Privacy Policy, you should still read the original documents to fully understand them:{% endblocktranslate %}
+          {% elif terms_url %}
+            {% blocktranslate %}This page is based on the General Terms and Conditions, you should still read the original document to fully understand it:{% endblocktranslate %}
+          {% else %}
+            {% blocktranslate %}This page is based on the Privacy Policy, you should still read the original document to fully understand it:{% endblocktranslate %}
+          {% endif %}
         </p>
 
         <ul>

--- a/weblate/legal/templates/legal/index.html
+++ b/weblate/legal/templates/legal/index.html
@@ -22,7 +22,13 @@
 
       {% if terms_url or privacy_url %}
         <p>
-          {% blocktranslate %}This page is based on the General Terms and Conditions and the Privacy Policy, you should still read the original documents to fully understand them:{% endblocktranslate %}
+          {% if terms_url and privacy_url %}
+            {% blocktranslate %}This page is based on the General Terms and Conditions and the Privacy Policy, you should still read the original documents to fully understand them:{% endblocktranslate %}
+          {% elif terms_url %}
+            {% blocktranslate %}This page is based on the General Terms and Conditions, you should still read the original document to fully understand it:{% endblocktranslate %}
+          {% else %}
+            {% blocktranslate %}This page is based on the Privacy Policy, you should still read the original document to fully understand it:{% endblocktranslate %}
+          {% endif %}
         </p>
 
         <ul>

--- a/weblate/legal/tests.py
+++ b/weblate/legal/tests.py
@@ -4,6 +4,10 @@
 
 """Test for legal stuff."""
 
+from __future__ import annotations
+
+from itertools import product
+
 from django.http import HttpRequest
 from django.test import TestCase
 from django.test.utils import modify_settings, override_settings
@@ -68,6 +72,75 @@ class LegalTest(TestCase, RegistrationTestMixin):
         self.assertNotContains(response, reverse("legal:terms"))
         self.assertNotContains(response, reverse("legal:privacy"))
 
+    def test_document_introduction(self) -> None:
+        cases = (
+            (
+                ("terms", "privacy"),
+                (
+                    "This page is based on the General Terms and Conditions and the "
+                    "Privacy Policy, you should still read the original documents "
+                    "to fully understand them:"
+                ),
+            ),
+            (
+                ("terms",),
+                (
+                    "This page is based on the General Terms and Conditions, you "
+                    "should still read the original document to fully understand it:"
+                ),
+            ),
+            (
+                ("privacy",),
+                (
+                    "This page is based on the Privacy Policy, you should still read "
+                    "the original document to fully understand it:"
+                ),
+            ),
+            ((), None),
+        )
+        for page, external, (documents, introduction) in product(
+            ("index", "cookies"), (False, True), cases
+        ):
+            with (
+                self.subTest(page=page, external=external, documents=documents),
+                override_settings(
+                    LEGAL_HIDDEN_DOCUMENTS=tuple(
+                        document
+                        for document in ("terms", "privacy")
+                        if external or document not in documents
+                    ),
+                    LEGAL_URL=(
+                        "https://example.com/terms/"
+                        if external and "terms" in documents
+                        else None
+                    ),
+                    PRIVACY_URL=(
+                        "https://example.com/privacy/"
+                        if external and "privacy" in documents
+                        else None
+                    ),
+                ),
+            ):
+                response = self.client.get(reverse(f"legal:{page}"))
+                if introduction:
+                    self.assertContains(
+                        response, f"<p>{introduction}</p>", count=1, html=True
+                    )
+                else:
+                    self.assertNotContains(response, "This page is based on")
+                for document in ("terms", "privacy"):
+                    internal_url = reverse(f"legal:{document}")
+                    external_url = f"https://example.com/{document}/"
+                    if document in documents:
+                        self.assertContains(
+                            response,
+                            f'href="{external_url if external else internal_url}"',
+                        )
+                    if external or document not in documents:
+                        self.assertNotContains(response, f'href="{internal_url}"')
+                    if not external or document not in documents:
+                        self.assertNotContains(response, f'href="{external_url}"')
+
     def test_contracts(self) -> None:
         response = self.client.get(reverse("legal:contracts"))
         self.assertContains(response, "Subcontractors")
@@ -100,8 +173,13 @@ class LegalTest(TestCase, RegistrationTestMixin):
             "You have to agree to the General Terms and Conditions and the Privacy Policy",
             count=1,
         )
-        self.assertContains(response, "Please also read the Privacy Policy")
-        self.assertContains(response, reverse("legal:privacy"))
+        self.assertContains(
+            response,
+            "<p>Please also read the "
+            f'<a href="{reverse("legal:privacy")}">Privacy Policy</a>.</p>',
+            count=1,
+            html=True,
+        )
 
     @override_settings(
         LEGAL_HIDDEN_DOCUMENTS=("terms", "privacy"),
@@ -150,7 +228,7 @@ class LegalTest(TestCase, RegistrationTestMixin):
             response,
             "I agree with the General Terms and Conditions and the Privacy Policy",
         )
-        self.assertNotContains(response, "Please also read the Privacy Policy")
+        self.assertNotContains(response, "Please also read the")
 
     @override_settings(LEGAL_HIDDEN_DOCUMENTS=("terms",), LEGAL_URL=None)
     def test_confirm_without_external_terms(self) -> None:


### PR DESCRIPTION
Remove duplicate privacy policy wording from confirmation and describe only available documents on the overview and cookies pages. Cover internal and external document links in regression tests.

Fixes #21232

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
