### PR TITLE
docs(machinery): make score wording consistent

### DIFF
--- a/docs/snippets/machines-autogenerated.rst
+++ b/docs/snippets/machines-autogenerated.rst
@@ -9,7 +9,7 @@ Alibaba
 .. versionadded:: 5.3
 
 :Service ID: ``alibaba``
-:Maximal score: 80
+:Maximum score: 80
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -47,7 +47,7 @@ Anthropic
 .. versionadded:: 5.16
 
 :Service ID: ``anthropic``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`glossary-mt`
                     * :ref:`llm-translation-context`
 :Configuration: +---------------------------+--------------------------------+---------------------------------------------------------------------------------------------------------------------------+
@@ -124,7 +124,7 @@ Apertium APy
 ------------
 
 :Service ID: ``apertium-apy``
-:Maximal score: 88
+:Maximum score: 88
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -161,7 +161,7 @@ Amazon Translate
 ----------------
 
 :Service ID: ``aws``
-:Maximal score: 88
+:Maximum score: 88
 :Advanced features: * :ref:`glossary-mt`
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
@@ -229,7 +229,7 @@ Azure OpenAI
 .. versionadded:: 5.8
 
 :Service ID: ``azure-openai``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`glossary-mt`
                     * :ref:`llm-translation-context`
 :Configuration: +---------------------------+--------------------------------+---------------------------------------------------------------------------------------------------------------------------+
@@ -276,7 +276,7 @@ Baidu
 -----
 
 :Service ID: ``baidu``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -313,7 +313,7 @@ CyrTranslit
 .. versionadded:: 5.7
 
 :Service ID: ``cyrtranslit``
-:Maximal score: 100
+:Maximum score: 100
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -346,7 +346,7 @@ DeepL
 -----
 
 :Service ID: ``deepl``
-:Maximal score: 91
+:Maximum score: 91
 :Advanced features: * :ref:`placeables-mt`
                     * :ref:`glossary-mt`
 :Configuration: +---------------------+---------------------------+-------------------------------------------------------------------------------------+
@@ -413,7 +413,7 @@ Glosbe
 ------
 
 :Service ID: ``glosbe``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -447,7 +447,7 @@ Google Cloud Translation Basic
 ------------------------------
 
 :Service ID: ``google-translate``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -481,7 +481,7 @@ Google Cloud Translation Advanced
 ---------------------------------
 
 :Service ID: ``google-translate-api-v3``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`placeables-mt`
                     * :ref:`glossary-mt`
 :Configuration: +---------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------+
@@ -560,7 +560,7 @@ LibreTranslate
 .. versionadded:: 4.7.1
 
 :Service ID: ``libretranslate``
-:Maximal score: 89
+:Maximum score: 89
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -606,7 +606,7 @@ LTEngine
 .. versionadded:: 5.17.1
 
 :Service ID: ``ltengine``
-:Maximal score: 89
+:Maximum score: 89
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -639,7 +639,7 @@ Azure AI Translator
 -------------------
 
 :Service ID: ``microsoft-translator``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`placeables-mt`
                     * :ref:`glossary-mt`
 :Configuration: +---------------------+-------------------------------+---------------------------------------------------------------------------+
@@ -730,7 +730,7 @@ Mistral
 .. versionadded:: 2026.7
 
 :Service ID: ``mistral``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`glossary-mt`
                     * :ref:`llm-translation-context`
 :Configuration: +---------------------------+--------------------------------+---------------------------------------------------------------------------------------------------------------------------+
@@ -794,7 +794,7 @@ ModernMT
 .. versionadded:: 4.2
 
 :Service ID: ``modernmt``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`glossary-mt`
 :Configuration: +---------------------+---------------------------+-----------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                    |
@@ -831,7 +831,7 @@ MyMemory
 --------
 
 :Service ID: ``mymemory``
-:Maximal score: 100
+:Maximum score: 100
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -872,7 +872,7 @@ Netease Sight
 -------------
 
 :Service ID: ``netease-sight``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -910,7 +910,7 @@ Ollama
 .. versionadded:: 5.15
 
 :Service ID: ``ollama``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`glossary-mt`
                     * :ref:`llm-translation-context`
 :Configuration: +---------------------------+--------------------------------+---------------------------------------------------------------------------------------------------------------------------+
@@ -968,7 +968,7 @@ OpenAI
 .. versionadded:: 5.3
 
 :Service ID: ``openai``
-:Maximal score: 90
+:Maximum score: 90
 :Advanced features: * :ref:`glossary-mt`
                     * :ref:`llm-translation-context`
 :Configuration: +---------------------------+--------------------------------+---------------------------------------------------------------------------------------------------------------------------+
@@ -1077,7 +1077,7 @@ SAP Translation Hub
 -------------------
 
 :Service ID: ``sap-translation-hub``
-:Maximal score: 100
+:Maximum score: 100
 :Configuration: +---------------------+----------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
                 | ``source_language`` | Source language selection  | Available choices:                                                                                                                              |
                 |                     |                            |                                                                                                                                                 |
@@ -1133,7 +1133,7 @@ Systran
 -------
 
 :Service ID: ``systran``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -1162,7 +1162,7 @@ tmserver
 --------
 
 :Service ID: ``tmserver``
-:Maximal score: 100
+:Maximum score: 100
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -1197,7 +1197,7 @@ Weblate
 -------
 
 :Service ID: ``weblate``
-:Maximal score: 100
+:Maximum score: 100
 :Configuration: `This service has no configuration.`
 
 .. AUTOGENERATED END: weblate
@@ -1216,7 +1216,7 @@ Weblate Translation Memory
 --------------------------
 
 :Service ID: ``weblate-translation-memory``
-:Maximal score: 100
+:Maximum score: 100
 :Configuration: `This service has no configuration.`
 
 .. AUTOGENERATED END: weblate-translation-memory
@@ -1240,7 +1240,7 @@ Yandex
 ------
 
 :Service ID: ``yandex``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -1276,7 +1276,7 @@ Yandex v2
 .. versionadded:: 5.1
 
 :Service ID: ``yandex-v2``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |
@@ -1309,7 +1309,7 @@ Youdao Zhiyun
 -------------
 
 :Service ID: ``youdao-zhiyun``
-:Maximal score: 90
+:Maximum score: 90
 :Configuration: +---------------------+---------------------------+---------------------------------------------------------------------+
                 | ``source_language`` | Source language selection | Available choices:                                                  |
                 |                     |                           |                                                                     |

--- a/weblate/machinery/management/commands/list_machinery.py
+++ b/weblate/machinery/management/commands/list_machinery.py
@@ -43,7 +43,7 @@ class Command(DocGeneratorCommand):
                     *obj.get_versions_rst_lines(),
                     "",
                     f":Service ID: ``{obj.get_identifier()}``",
-                    f":Maximal score: {obj.max_score}",
+                    f":Maximum score: {obj.max_score}",
                 ]
             )
             features = []


### PR DESCRIPTION
The [docs section on priority](https://docs.weblate.org/en/latest/admin/machine.html#priority-of-machine-translation-and-translation-memory-services) calls it the maximum score.