### PR TITLE
feat(editor): add shortcut to approve and save

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,8 @@ Weblate 2026.10
 
 .. rubric:: Improvements
 
+* Added a :ref:`keyboard shortcut <keyboard>` to approve a translation and save and continue.
+
 .. rubric:: Security fixes
 
 .. rubric:: Bug fixes

--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -293,6 +293,10 @@ The following keyboard shortcuts can be utilized during translation:
 |                                           |                                                                       |
 | :kbd:`Cmd+Shift+Enter`                    |                                                                       |
 +-------------------------------------------+-----------------------------------------------------------------------+
+| :kbd:`Ctrl+Alt+Enter` or                  | Approve the translation and save and continue.                        |
+|                                           | Only available to reviewers.                                          |
+| :kbd:`Cmd+Alt+Enter`                      |                                                                       |
++-------------------------------------------+-----------------------------------------------------------------------+
 | :kbd:`Alt+Enter` or                       | Submit the string as a suggestion; this works the same as             |
 |                                           | pressing :guilabel:`Suggest` while editing translation.               |
 | :kbd:`Option+Enter`                       |                                                                       |

--- a/weblate/static/editor/full.js
+++ b/weblate/static/editor/full.js
@@ -171,6 +171,23 @@
       if (fuzzy) fuzzy.checked = false;
       return submitForm(e);
     });
+    hotkeys("ctrl+alt+enter,command+alt+enter", (e) => {
+      const approved = this.translationForm?.querySelector(
+        'input[type="radio"][name="review"][value="30"]',
+      );
+      const save = this.translationForm?.querySelector('button[name="save"]');
+      if (
+        !e.repeat &&
+        approved &&
+        !approved.matches(":disabled") &&
+        save &&
+        !save.matches(":disabled")
+      ) {
+        approved.click();
+        save.click();
+      }
+      return false;
+    });
     hotkeys("alt+enter", (e) => {
       return submitForm(e, null, 'button[name="suggest"]');
     });

--- a/weblate/templates/keyboard-shortcuts.html
+++ b/weblate/templates/keyboard-shortcuts.html
@@ -87,6 +87,14 @@
             </tr>
             <tr>
               <td>
+                <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Enter</kbd> {% translate "or" context "between keyboard shortcuts" %}
+                <br>
+                <kbd>Cmd</kbd> + <kbd>Alt</kbd> + <kbd>Enter</kbd>
+              </td>
+              <td>{% translate "Approve the translation and save and continue. Only available to reviewers." %}</td>
+            </tr>
+            <tr>
+              <td>
                 <kbd>Alt</kbd> + <kbd>Enter</kbd> {% translate "or" context "between keyboard shortcuts" %}
                 <br>
                 <kbd>Option</kbd> + <kbd>Enter</kbd>


### PR DESCRIPTION
Let reviewers explicitly approve the current string and continue with Ctrl/Cmd+Alt+Enter without adding controls or carrying approval across strings.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
