### PR TITLE
fix(trans): clarify review policy and language workflows

### DIFF
--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -352,6 +352,27 @@ the same rule using :ref:`project-source_review`.
 Components linked to a repository in another project follow their own project's
 commit policy.
 
+If the editor shows “Only approved translations are written to the translation
+file.” or “Approval is required before this translation can be written to the
+translation file.”, the quality filter prevents writing the translation to the
+file until it is approved. This notice does not confirm that your current edit
+was saved; resolve any validation errors before leaving the editor. The project
+policy description qualifies this as “For languages with reviews enabled, only
+approved translations are written to the translation file.” Having permission
+to approve translations does not automatically approve your edits.
+
+For a language that does not use reviews, open its page in the project and
+choose :guilabel:`Settings`. Enable :guilabel:`Customize translation workflow for
+this language in this project`, then turn :guilabel:`Enable reviews` off. This
+requires permission to edit project settings. See :ref:`workflow-customization`.
+With the approved-only policy, this makes all translation states eligible for
+writing to files for that language, including those needing editing.
+
+If reviews are needed, users with both review and bulk-edit permissions can use
+:ref:`bulk-edit` to approve existing translations they have reviewed. Eligibility
+for writing to a translation file does not mean the change is immediately
+committed or pushed; see :ref:`lazy-commit` and :ref:`component-push_on_commit`.
+
 
 .. _project-enable_hooks:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,7 @@ Weblate 2026.10
 .. rubric:: Improvements
 
 * Added a :ref:`keyboard shortcut <keyboard>` to approve a translation and save and continue.
+* Clarified :ref:`translation quality filter <project-commit_policy>` explanations and effective per-language review settings, with links to workflow configuration.
 
 .. rubric:: Security fixes
 

--- a/weblate/templates/language-project.html
+++ b/weblate/templates/language-project.html
@@ -167,6 +167,12 @@
     </div>
 
     <div class="tab-pane" id="information">
+      <div class="card">
+        <div class="card-header">
+          <h4 class="card-title">{% translate "Translation workflow" %}</h4>
+        </div>
+        <div class="card-body">{% include "snippets/review-workflow.html" with workflow_translation=object %}</div>
+      </div>
       {% show_info project=project language=language stats=language_stats metrics=object|metrics show_full_language=False %}
     </div>
 

--- a/weblate/templates/snippets/commit-policy-warning.html
+++ b/weblate/templates/snippets/commit-policy-warning.html
@@ -1,0 +1,33 @@
+{% load i18n icons permissions translations %}
+
+{% if unit.is_blocked_by_commit_policy %}
+  {% get_review_workflow unit.translation as review_workflow %}
+  <div class="list-group-item check check-item">
+    <h5>
+      {% documentation_icon 'admin/projects' 'project-commit-policy' right=True %}
+      {% icon "file-sync-outline.svg" %}
+      {% translate "Translation quality filter" %}
+    </h5>
+    <p class="list-group-item-text check-description">
+      {% if review_workflow.approved_only %}
+        {% translate "Approval is required before this translation can be written to the translation file." %}
+      {% else %}
+        {% translate "Resolve this translation’s needs-editing state before it can be written to the translation file." %}
+      {% endif %}
+    </p>
+    <p class="list-group-item-text">
+      {% documentation 'admin/projects' 'project-commit-policy' as policy_url %}
+      {% blocktranslate %}Learn how the <a href="{{ policy_url }}">translation quality filter</a> controls which translations are written to files.{% endblocktranslate %}
+    </p>
+    {% perm review_workflow.project_language.settings_permission review_workflow.project_language as can_configure_workflow %}
+    {% if can_configure_workflow %}
+      <p class="list-group-item-text list-buttons">
+        {% if review_workflow.approved_only %}
+          <a href="{% url 'settings' path=review_workflow.project_language.get_url_path %}">{% translate "Configure language workflow" %}</a>
+        {% else %}
+          <a href="{% url 'settings' path=review_workflow.project.get_url_path %}">{% translate "Configure translation quality filter" %}</a>
+        {% endif %}
+      </p>
+    {% endif %}
+  </div>
+{% endif %}

--- a/weblate/templates/snippets/info.html
+++ b/weblate/templates/snippets/info.html
@@ -118,7 +118,7 @@
                       <li>{% translate "Translation suggestions are turned off." %}</li>
                     {% endif %}
                   {% endif %}
-                  {% if workflow_flags.translation_review %}
+                  {% if workflow_flags.translation_review and not translation %}
                     <li>{% translate "Translations are reviewed by dedicated reviewers." %}</li>
                   {% endif %}
                   {% if component.project.access_control %}
@@ -136,8 +136,11 @@
                   {% else %}
                     <li>{% translate "The translation uses bilingual files." %}</li>
                   {% endif %}
-                  {% if component.project.commit_policy %}<li>{{ component.project.get_commit_policy_description }}</li>{% endif %}
+                  {% if component.project.commit_policy and not translation %}<li>{{ component.project.get_commit_policy_description }}</li>{% endif %}
                 </ul>
+                {% if translation %}
+                  {% include "snippets/review-workflow.html" with workflow_translation=translation %}
+                {% endif %}
               </td>
             </tr>
 

--- a/weblate/templates/snippets/review-workflow.html
+++ b/weblate/templates/snippets/review-workflow.html
@@ -1,0 +1,39 @@
+{% load i18n permissions translations %}
+
+{% get_review_workflows workflow_translation as review_workflows %}
+{% for review_workflow in review_workflows %}
+  {% if review_workflow.role %}
+    <h5>
+      {% if review_workflow.show_project %}{{ review_workflow.project }} —{% endif %}
+      {{ review_workflow.role }}
+    </h5>
+  {% endif %}
+  <p>
+    {% if review_workflow.enabled %}
+      {% translate "Reviews are enabled for this language." %}
+    {% else %}
+      {% translate "Reviews are disabled for this language." %}
+    {% endif %}
+    {% blocktranslate with origin=review_workflow.origin %}Review setting: {{ origin }}.{% endblocktranslate %}
+  </p>
+  <p>{{ review_workflow.policy }}</p>
+  <p>
+    {% documentation 'workflows' 'workflow-customization' as workflow_url %}
+    {% blocktranslate %}Learn how to <a href="{{ workflow_url }}">customize the workflow for this language</a>.{% endblocktranslate %}
+  </p>
+  {% perm review_workflow.settings_object.settings_permission review_workflow.settings_object as can_configure_workflow %}
+  {% if can_configure_workflow %}
+    <p>
+      <a href="{{ review_workflow.settings_url }}">{{ review_workflow.settings_label }}</a>
+    </p>
+  {% endif %}
+{% empty %}
+  {% documentation 'workflows' 'workflow-customization' as workflow_url %}
+  <p><a href="{{ workflow_url }}">{% translate "Learn how to customize translation workflows." %}</a></p>
+  {% perm workflow_translation.project.settings_permission workflow_translation.project as can_configure_workflow %}
+  {% if can_configure_workflow %}
+    <p>
+      <a href="{% url 'settings' path=workflow_translation.project.get_url_path %}#workflow">{% translate "Configure translation workflow" %}</a>
+    </p>
+  {% endif %}
+{% endfor %}

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -741,16 +741,7 @@
               {% endif %}
 
 
-              {% if unit.is_blocked_by_commit_policy %}
-                <div class="list-group-item check check-item">
-                  <h5>
-                    {% documentation_icon 'admin/projects' 'project-commit-policy' right=True %}
-                    {% icon "file-sync-outline.svg" %}
-                    {% translate "Translation quality filter" %}
-                  </h5>
-                  <p class="list-group-item-text check-description">{{ project.get_commit_policy_description }}</p>
-                </div>
-              {% endif %}
+              {% include "snippets/commit-policy-warning.html" %}
 
             </div>
           </div>

--- a/weblate/trans/forms.py
+++ b/weblate/trans/forms.py
@@ -804,14 +804,6 @@ class TranslationForm(UnitForm):
         else:
             self.fields["explanation"].widget = forms.HiddenInput()
 
-        if component.project.commit_policy and (
-            component.project.commit_policy != CommitPolicyChoices.APPROVED_ONLY
-            or translation.enable_review
-        ):
-            commit_policy = f" {component.project.get_commit_policy_description()}"
-            self.fields["review"].help_text += commit_policy
-            self.fields["fuzzy"].help_text += commit_policy
-
     def clean(self) -> None:
         super().clean()
 

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -43,6 +43,7 @@ from weblate.trans.models import (
     Translation,
     Unit,
 )
+from weblate.trans.models.project import CommitPolicyChoices
 from weblate.trans.models.translation import GhostTranslation
 from weblate.trans.util import translation_percent
 from weblate.utils.docs import get_doc_url
@@ -880,6 +881,90 @@ def get_workflow_flags(translation: Translation | None, component: Component):
         "restrict_direct_editing": False,
         "translation_review": component.project.translation_review,
     }
+
+
+@register.simple_tag
+def get_review_workflow(translation: Translation) -> dict:
+    """Describe the effective review workflow using the existing policy resolver."""
+    project = translation.component.project
+    project_review = (
+        project.source_review if translation.is_source else project.translation_review
+    )
+    workflow = translation.workflow_settings
+    if not project_review or workflow is None:
+        origin = gettext("Project settings")
+    elif workflow.project_id is None:
+        origin = gettext("Site-wide language customization")
+    else:
+        origin = gettext("Project-language customization")
+    reviews = translation.enable_review
+    policy = project.get_commit_policy_description()
+    approved_only = project.commit_policy == CommitPolicyChoices.APPROVED_ONLY
+    if approved_only and reviews:
+        policy = gettext(
+            "Only approved translations are written to the translation file."
+        )
+    elif project.commit_policy == CommitPolicyChoices.ALL or approved_only:
+        policy = gettext(
+            "All translation states, including those needing editing, "
+            "are eligible to be written to the translation file."
+        )
+    project_language = project.project_languages[translation.language]
+    settings_object = project_language if project_review else project
+    settings_url = reverse("settings", kwargs={"path": settings_object.get_url_path()})
+    if project_review:
+        settings_label = gettext("Configure language workflow")
+    else:
+        settings_url += "#workflow"
+        settings_label = (
+            gettext("Configure source reviews")
+            if translation.is_source
+            else gettext("Configure translation reviews")
+        )
+    return {
+        "enabled": reviews,
+        "origin": origin,
+        "policy": policy,
+        "approved_only": approved_only,
+        "project": project,
+        "project_language": project_language,
+        "settings_object": settings_object,
+        "settings_url": settings_url,
+        "settings_label": settings_label,
+    }
+
+
+@register.simple_tag
+def get_review_workflows(obj: Translation | ProjectLanguage) -> list[dict]:
+    """Group language-page workflows by owning project and source/target role."""
+    if isinstance(obj, Translation):
+        return [get_review_workflow(obj)]
+    representatives: dict[tuple[int, bool], Translation] = {}
+    for translation in obj.translation_set:
+        representatives.setdefault(
+            (translation.component.project_id, translation.is_source), translation
+        )
+    show_project = any(
+        project_id != obj.project.pk for project_id, _ in representatives
+    )
+    return [
+        {
+            **get_review_workflow(translation),
+            "role": gettext("Source strings")
+            if translation.is_source
+            else gettext("Translations"),
+            "show_project": show_project,
+        }
+        for translation in sorted(
+            representatives.values(),
+            key=lambda item: (
+                item.component.project_id != obj.project.pk,
+                item.component.project.name,
+                item.component.project_id,
+                item.is_source,
+            ),
+        )
+    ]
 
 
 @register.simple_tag

--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -36,6 +36,7 @@ from weblate.trans.models import (
     Translation,
     Unit,
 )
+from weblate.trans.models.project import CommitPolicyChoices
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.trans.util import join_plural
 from weblate.trans.views.edit import (
@@ -940,6 +941,41 @@ class EditAccessTest(ViewTestCase):
 
 
 class EditValidationTest(ViewTestCase):
+    def test_failed_edit_does_not_claim_translation_was_saved(self) -> None:
+        self.project.translation_review = True
+        self.project.save()
+        unit = self.get_unit()
+        unit.state = STATE_FUZZY
+        unit.save(update_fields=["state"])
+        original_target = unit.target
+        for policy in (
+            CommitPolicyChoices.APPROVED_ONLY,
+            CommitPolicyChoices.WITHOUT_NEEDS_EDITING,
+        ):
+            with self.subTest(policy=policy):
+                self.project.commit_policy = policy
+                self.project.save()
+                response = self.client.post(
+                    unit.translation.get_translate_url(),
+                    {
+                        "unit_id": unit.pk,
+                        "checksum": unit.checksum,
+                        "contentsum": hash_to_checksum(unit.content_hash),
+                        "translationsum": "invalid",
+                        "target_0": "Unsaved review regression draft",
+                        "review": STATE_TRANSLATED,
+                    },
+                    follow=True,
+                )
+                self.assertContains(response, "Unsaved review regression draft")
+                self.assertTrue(response.context["form"].errors)
+                self.assertContains(response, "Translation quality filter")
+                self.assertNotContains(
+                    response, "This translation is saved in Weblate."
+                )
+                unit.refresh_from_db()
+                self.assertEqual(unit.target, original_target)
+
     def edit(self, **kwargs):
         """Editing with no specific params."""
         unit = self.get_unit()

--- a/weblate/trans/tests/test_workflowsetting.py
+++ b/weblate/trans/tests/test_workflowsetting.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 from datetime import timedelta
 from itertools import product
 
+from django.core.paginator import Paginator
 from django.db import connection
+from django.template.loader import render_to_string
 from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
 from django.utils import timezone
 
 from weblate.auth.data import SELECTION_ALL
@@ -26,7 +29,8 @@ from weblate.trans.models import (
     WorkflowSetting,
 )
 from weblate.trans.models.project import CommitPolicyChoices
-from weblate.trans.tests.test_views import FixtureComponentTestCase
+from weblate.trans.templatetags.translations import get_review_workflows
+from weblate.trans.tests.test_views import FixtureComponentTestCase, ViewTestCase
 from weblate.utils.state import STATE_APPROVED, STATE_FUZZY, STATE_TRANSLATED
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
 
@@ -51,14 +55,265 @@ class WorkflowSettingsTestCase(FixtureComponentTestCase):
                 unit = translation.unit_set.order_by("pk")[0]
                 form = TranslationForm(self.user, unit)
                 for name in ("fuzzy", "review"):
-                    self.assertEqual(
-                        "only approved translations" in form.fields[name].help_text,
-                        review,
+                    self.assertNotIn(
+                        "only approved translations", form.fields[name].help_text
                     )
         self.assertIn(
             "For languages with reviews enabled",
             self.project.get_commit_policy_description(),
         )
+
+    def test_commit_policy_form_help_needs_editing(self) -> None:
+        self.project.commit_policy = CommitPolicyChoices.WITHOUT_NEEDS_EDITING
+        self.project.save()
+        unit = self.translation.unit_set.order_by("pk")[0]
+        form = TranslationForm(self.user, unit)
+        for name in ("fuzzy", "review"):
+            self.assertNotIn(
+                self.project.get_commit_policy_description(),
+                form.fields[name].help_text,
+            )
+
+    def test_review_workflow_summary(self) -> None:
+        for is_source, project_review, global_review, local_review in product(
+            (False, True), (False, True), (None, False, True), (None, False, True)
+        ):
+            with self.subTest(
+                is_source=is_source,
+                project_review=project_review,
+                global_review=global_review,
+                local_review=local_review,
+            ):
+                self.project.translation_review = (
+                    project_review if not is_source else False
+                )
+                self.project.source_review = project_review if is_source else False
+                self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+                self.project.save()
+                translation = (
+                    self.component.source_translation if is_source else self.translation
+                )
+                WorkflowSetting.objects.all().delete()
+                for project_id, review in (
+                    (None, global_review),
+                    (self.project.pk, local_review),
+                ):
+                    if review is not None:
+                        WorkflowSetting.objects.create(
+                            project_id=project_id,
+                            language=translation.language,
+                            translation_review=review,
+                        )
+                translation = Translation.objects.get(pk=translation.pk)
+                override = local_review if local_review is not None else global_review
+                enabled = project_review and override is not False
+                if not project_review or override is None:
+                    origin = "Project settings"
+                elif local_review is not None:
+                    origin = "Project-language customization"
+                else:
+                    origin = "Site-wide language customization"
+                for obj in (
+                    translation,
+                    ProjectLanguage(
+                        translation.component.project, translation.language
+                    ),
+                ):
+                    rendered = render_to_string(
+                        "snippets/review-workflow.html",
+                        {"workflow_translation": obj, "user": self.user},
+                    )
+                    state = "enabled" if enabled else "disabled"
+                    self.assertIn(f"Reviews are {state} for this language.", rendered)
+                    self.assertIn(f"Review setting: {origin}.", rendered)
+                    self.assertEqual(
+                        "Only approved translations are written" in rendered, enabled
+                    )
+                    self.assertEqual(
+                        "All translation states, including those needing editing"
+                        in rendered,
+                        not enabled,
+                    )
+
+    def test_commit_policy_warning(self) -> None:
+        self.project.translation_review = True
+        self.project.source_review = True
+        self.project.save()
+        for policy, review, is_source, state in product(
+            CommitPolicyChoices,
+            (False, True),
+            (False, True),
+            (STATE_FUZZY, STATE_TRANSLATED, STATE_APPROVED),
+        ):
+            with self.subTest(
+                policy=policy, review=review, is_source=is_source, state=state
+            ):
+                self.project.commit_policy = policy
+                self.project.save()
+                translation = (
+                    self.component.source_translation if is_source else self.translation
+                )
+                WorkflowSetting.objects.update_or_create(
+                    project=self.project,
+                    language=translation.language,
+                    defaults={"translation_review": review},
+                )
+                unit = Translation.objects.get(pk=translation.pk).unit_set.order_by(
+                    "pk"
+                )[0]
+                unit.state = state
+                rendered = render_to_string(
+                    "snippets/commit-policy-warning.html",
+                    {"unit": unit, "user": self.user},
+                )
+                blocked = (
+                    policy == CommitPolicyChoices.APPROVED_ONLY
+                    and review
+                    and state != STATE_APPROVED
+                ) or (
+                    policy == CommitPolicyChoices.WITHOUT_NEEDS_EDITING
+                    and state == STATE_FUZZY
+                )
+                self.assertEqual("Translation quality filter" in rendered, blocked)
+                self.assertNotIn("This translation is saved in Weblate.", rendered)
+                if blocked:
+                    self.assertIn("translation quality filter</a>", rendered)
+                    expected = (
+                        "Approval is required"
+                        if policy == CommitPolicyChoices.APPROVED_ONLY
+                        else "Resolve this translation’s needs-editing state"
+                    )
+                    self.assertIn(expected, rendered)
+
+    def test_review_workflow_configuration_links(self) -> None:
+        self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        self.project.translation_review = True
+        self.project.save()
+        translation = Translation.objects.get(pk=self.translation.pk)
+        unit = translation.unit_set.order_by("pk")[0]
+        unit.state = STATE_TRANSLATED
+        project_language = ProjectLanguage(
+            translation.component.project, translation.language
+        )
+        workflow_url = reverse(
+            "settings", kwargs={"path": project_language.get_url_path()}
+        )
+        for manager in (False, True):
+            with self.subTest(manager=manager):
+                self.user.is_superuser = manager
+                for template, context in (
+                    (
+                        "snippets/review-workflow.html",
+                        {"workflow_translation": translation},
+                    ),
+                    ("snippets/commit-policy-warning.html", {"unit": unit}),
+                ):
+                    rendered = render_to_string(
+                        template, {**context, "user": self.user}
+                    )
+                    self.assertEqual(f'href="{workflow_url}"' in rendered, manager)
+                translation.component.project.commit_policy = (
+                    CommitPolicyChoices.WITHOUT_NEEDS_EDITING
+                )
+                unit.state = STATE_FUZZY
+                rendered = render_to_string(
+                    "snippets/commit-policy-warning.html",
+                    {"unit": unit, "user": self.user},
+                )
+                project_url = reverse(
+                    "settings", kwargs={"path": self.project.get_url_path()}
+                )
+                self.assertEqual(f'href="{project_url}"' in rendered, manager)
+                translation.component.project.commit_policy = (
+                    CommitPolicyChoices.APPROVED_ONLY
+                )
+                unit.state = STATE_TRANSLATED
+
+    def test_review_workflow_pages(self) -> None:
+        self.client.force_login(self.user)
+        self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+        self.project.translation_review = True
+        self.project.save()
+        project_language = ProjectLanguage(self.project, self.translation.language)
+        for review in (False, True):
+            with self.subTest(review=review):
+                WorkflowSetting.objects.update_or_create(
+                    project=self.project,
+                    language=self.translation.language,
+                    defaults={"translation_review": review},
+                )
+                for obj in (self.translation, project_language):
+                    response = self.client.get(obj.get_absolute_url())
+                    state = "enabled" if review else "disabled"
+                    self.assertContains(
+                        response, f"Reviews are {state} for this language."
+                    )
+                    self.assertContains(
+                        response, "Review setting: Project-language customization."
+                    )
+                    if review:
+                        self.assertContains(
+                            response, "Only approved translations are written"
+                        )
+                    else:
+                        self.assertNotContains(response, "only approved translations")
+                        self.assertNotContains(response, "Only approved translations")
+                        self.assertContains(
+                            response,
+                            "All translation states, including those needing editing",
+                        )
+                response = self.client.get(self.component.get_absolute_url())
+                self.assertContains(response, "For languages with reviews enabled")
+
+    def test_project_disabled_review_links(self) -> None:
+        for is_source, project_enabled, manager in product((False, True), repeat=3):
+            with self.subTest(
+                is_source=is_source, project_enabled=project_enabled, manager=manager
+            ):
+                self.project.source_review = project_enabled if is_source else True
+                self.project.translation_review = (
+                    project_enabled if not is_source else True
+                )
+                self.project.save()
+                original = (
+                    self.component.source_translation if is_source else self.translation
+                )
+                WorkflowSetting.objects.update_or_create(
+                    project=self.project,
+                    language=original.language,
+                    defaults={"translation_review": False},
+                )
+                translation = Translation.objects.get(pk=original.pk)
+                self.user.is_superuser = manager
+                rendered = render_to_string(
+                    "snippets/review-workflow.html",
+                    {"workflow_translation": translation, "user": self.user},
+                )
+                project_url = (
+                    reverse("settings", kwargs={"path": self.project.get_url_path()})
+                    + "#workflow"
+                )
+                language_url = reverse(
+                    "settings",
+                    kwargs={
+                        "path": ProjectLanguage(
+                            self.project, translation.language
+                        ).get_url_path()
+                    },
+                )
+                self.assertEqual(
+                    f'href="{project_url}"' in rendered, manager and not project_enabled
+                )
+                self.assertEqual(
+                    f'href="{language_url}"' in rendered, manager and project_enabled
+                )
+                if manager and not project_enabled:
+                    label = (
+                        "Configure source reviews"
+                        if is_source
+                        else "Configure translation reviews"
+                    )
+                    self.assertIn(label, rendered)
 
     def test_commit_policy_effective_reviews(self) -> None:
         self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
@@ -331,3 +586,92 @@ class WorkflowSettingsTestCase(FixtureComponentTestCase):
         self.assertTrue(source.stats.has_review)
         self.assertFalse(target.enable_review)
         self.assertFalse(target.stats.has_review)
+
+
+class MixedReviewWorkflowTest(ViewTestCase):
+    def test_mixed_roles_and_linked_projects(self) -> None:
+        language = self.translation.language
+        self.create_po(name="Source", project=self.project, source_language=language)
+        other_project = Project.objects.create(name="Other policy", slug="other-policy")
+        linked = self.create_po(name="Linked", project=other_project)
+        ComponentLink.objects.create(component=linked, project=self.project)
+        for source_review, target_review, override in product(
+            (False, True), (False, True), (None, False, True)
+        ):
+            with self.subTest(
+                source_review=source_review,
+                target_review=target_review,
+                override=override,
+            ):
+                self.project.source_review = source_review
+                self.project.translation_review = target_review
+                self.project.commit_policy = CommitPolicyChoices.APPROVED_ONLY
+                self.project.save()
+                WorkflowSetting.objects.filter(
+                    project=self.project, language=language
+                ).delete()
+                if override is not None:
+                    WorkflowSetting.objects.create(
+                        project=self.project,
+                        language=language,
+                        translation_review=override,
+                    )
+                obj = ProjectLanguage(Project.objects.get(pk=self.project.pk), language)
+                summaries = get_review_workflows(obj)
+                self.assertEqual(len(summaries), 3)
+                expected = [
+                    (
+                        self.project.pk,
+                        "Translations",
+                        target_review and override is not False,
+                    ),
+                    (
+                        self.project.pk,
+                        "Source strings",
+                        source_review and override is not False,
+                    ),
+                    (other_project.pk, "Translations", False),
+                ]
+                self.assertEqual(
+                    [
+                        (item["project"].pk, item["role"], item["enabled"])
+                        for item in summaries
+                    ],
+                    expected,
+                )
+                for item in summaries:
+                    self.assertTrue(item["show_project"])
+                    self.assertEqual(
+                        "Only approved translations" in item["policy"], item["enabled"]
+                    )
+                # The summary uses all translations even when a component list is paginated.
+                paginator = Paginator(obj.translation_set, 1)
+                rendered_pages = [
+                    render_to_string(
+                        "snippets/review-workflow.html",
+                        {
+                            "workflow_translation": obj,
+                            "translations": paginator.page(number),
+                            "user": self.user,
+                        },
+                    )
+                    for number in paginator.page_range
+                ]
+                self.assertTrue(
+                    all(page == rendered_pages[0] for page in rendered_pages)
+                )
+                self.assertIn("Other policy", rendered_pages[0])
+                self.assertIn("Source strings", rendered_pages[0])
+
+    def test_empty_language_summary(self) -> None:
+        obj = ProjectLanguage(self.project, Language.objects.get(code="fr"))
+        self.assertEqual(obj.translation_set, [])
+        for manager in (False, True):
+            self.user.is_superuser = manager
+            rendered = render_to_string(
+                "snippets/review-workflow.html",
+                {"workflow_translation": obj, "user": self.user},
+            )
+            self.assertNotIn("Reviews are", rendered)
+            self.assertNotIn("written to the translation file", rendered)
+            self.assertEqual("Configure translation workflow" in rendered, manager)


### PR DESCRIPTION
Explain why saved translations are blocked from files and link managers to workflow settings. Show effective language review settings and their origin, remove repeated editor help, and document how to resolve the warning.

Fixes #20885

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
