### PR TITLE
fix(docs): add clickable changelog rubric permalinks

### DIFF
--- a/docs/_ext/rubric_permalinks.py
+++ b/docs/_ext/rubric_permalinks.py
@@ -1,0 +1,66 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Add discoverable changelog permalinks without adding sections to the TOC."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docutils import nodes
+
+# Sphinx exposes its documentation translation helper under this name.
+from sphinx.locale import _  # ruff: ignore[import-private-name]
+from sphinx.transforms import SphinxTransform
+from sphinx.writers.html5 import HTML5Translator
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+    from sphinx.util.typing import ExtensionMetadata
+
+
+class ChangelogRubricIDs(SphinxTransform):
+    # Run before Locale (20), so translated titles do not change the URLs.
+    default_priority = 15
+
+    def apply(self, **kwargs: object) -> None:
+        if self.env.docname != "changes":
+            return
+
+        for node in self.document.findall(nodes.rubric):
+            section = node.parent
+            while section is not None and not isinstance(section, nodes.section):
+                section = section.parent
+            if section is None:
+                continue
+
+            node["classes"].append("changelog-rubric")
+            if node["ids"]:
+                continue
+
+            base_id = nodes.make_id(f"{section[0].astext()} {node.astext()}")
+            anchor = base_id
+            suffix = 2
+            while anchor in self.document.ids:
+                anchor = f"{base_id}-{suffix}"
+                suffix += 1
+            node["ids"].append(anchor)
+            self.document.set_id(node)
+
+
+def depart_rubric(translator: HTML5Translator, node: nodes.rubric) -> None:
+    if "changelog-rubric" in node["classes"]:
+        translator.add_permalink_ref(node, _("Link to this heading"))
+    HTML5Translator.depart_rubric(translator, node)
+
+
+def setup(app: Sphinx) -> ExtensionMetadata:
+    app.add_transform(ChangelogRubricIDs)
+    app.add_node(
+        nodes.rubric,
+        override=True,
+        html=(HTML5Translator.visit_rubric, depart_rubric),
+    )
+    app.add_css_file("rubric-permalinks.css")
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/_ext/static/rubric-permalinks.css
+++ b/docs/_ext/static/rubric-permalinks.css
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Michal Čihař <michal@weblate.org>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.changelog-rubric > .headerlink {
+  margin-left: 0.5rem;
+  opacity: 0;
+}
+
+.changelog-rubric:hover > .headerlink,
+.changelog-rubric:focus-within > .headerlink {
+  opacity: 1;
+}
+
+.changelog-rubric > .headerlink:focus-visible {
+  outline: auto;
+}
+
+@media (hover: none) {
+  .changelog-rubric > .headerlink {
+    opacity: 1;
+  }
+}

--- a/docs/_ext/test_rubric_permalinks.py
+++ b/docs/_ext/test_rubric_permalinks.py
@@ -1,0 +1,142 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Build documentation to verify rubric permalinks and navigation."""
+
+from __future__ import annotations
+
+import runpy
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from babel.messages.catalog import Catalog
+from babel.messages.mofile import write_mo
+from bs4 import BeautifulSoup
+from docutils import nodes
+from sphinx.testing.util import SphinxTestApp
+
+SOURCE = """\
+Weblate 2026.10
+===============
+
+.. rubric:: New features
+   :name: weblate-2026-10-features
+
+* See `details <https://example.com/details>`_.
+
+.. rubric:: Bug fixes
+
+.. rubric:: Bug fixes
+
+.. rubric:: Reserved anchor
+   :name: weblate-2026-10-bug-fixes-2
+
+Weblate 2026.9
+==============
+
+.. rubric:: Bug fixes
+"""
+
+
+@pytest.mark.parametrize("permalinks", [True, False])
+@pytest.mark.parametrize("language", ["en", "cs"])
+def test_rubric_permalinks(
+    tmp_path: Path,
+    permalinks: bool,
+    language: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    extension_dir = Path(__file__).parent
+    (tmp_path / "conf.py").write_text(
+        f"""\
+import sys
+sys.path.insert(0, {str(extension_dir)!r})
+extensions = ['rubric_permalinks']
+root_doc = 'index'
+html_theme = 'furo'
+html_static_path = [{str(extension_dir / "static")!r}]
+locale_dirs = ['locales']
+language = {language!r}
+html_permalinks = {permalinks!r}
+html_permalinks_icon = 'LINK'
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "index.rst").write_text(
+        "Documentation\n=============\n\n.. toctree::\n\n   changes\n   other\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "changes.rst").write_text(SOURCE, encoding="utf-8")
+    (tmp_path / "other.rst").write_text(
+        "Other\n=====\n\n.. rubric:: Bug fixes\n   :name: other-fixes\n",
+        encoding="utf-8",
+    )
+    catalog = Catalog(locale="cs")
+    catalog.add("Bug fixes", "Opravy chyb")
+    catalog.add("Weblate 2026.10", "Vydání Weblate 2026.10")
+    translations = tmp_path / "locales" / "cs" / "LC_MESSAGES"
+    translations.mkdir(parents=True)
+    with (translations / "changes.mo").open("wb") as handle:
+        write_mo(handle, catalog)
+
+    warnings = StringIO()
+    app = SphinxTestApp(srcdir=tmp_path, warning=warnings, freshenv=True)
+    try:
+        app.build()
+        assert not warnings.getvalue()
+        soup = BeautifulSoup(
+            (app.outdir / "changes.html").read_text(encoding="utf-8"), "html.parser"
+        )
+        rubrics = soup.select(".changelog-rubric")
+        anchors = [rubric["id"] for rubric in rubrics]
+        assert anchors == [
+            "weblate-2026-10-features",
+            "weblate-2026-10-bug-fixes",
+            "weblate-2026-10-bug-fixes-3",
+            "weblate-2026-10-bug-fixes-2",
+            "weblate-2026-9-bug-fixes",
+        ]
+        assert all(rubric.name == "p" for rubric in rubrics)
+        if language == "cs":
+            assert "Opravy chyb" in rubrics[1].get_text()
+            assert "Vydání Weblate 2026.10" in soup.get_text()
+        for rubric in rubrics:
+            links = rubric.select("a.headerlink")
+            assert len(links) == int(permalinks)
+            if permalinks:
+                assert links[0]["href"] == f"#{rubric['id']}"
+                assert links[0].get_text() == "LINK"
+                assert links[0]["title"]
+        toc = app.env.tocs["changes"]
+        assert all(
+            reference.get("anchorname") not in {f"#{anchor}" for anchor in anchors}
+            for reference in toc.findall(nodes.reference)
+        )
+        other = BeautifulSoup(
+            (app.outdir / "other.html").read_text(encoding="utf-8"), "html.parser"
+        )
+        assert not other.select(".rubric .headerlink, .changelog-rubric")
+        assert (app.outdir / "_static" / "rubric-permalinks.css").is_file()
+        release_input = tmp_path / "docs" / "_build" / "html"
+        release_input.mkdir(parents=True)
+        (release_input / "changes.html").write_bytes(
+            (app.outdir / "changes.html").read_bytes()
+        )
+        extractor = extension_dir.parent.parent / "scripts" / "extract-release-notes.py"
+        monkeypatch.chdir(tmp_path)
+        for version, expected_rubrics in (([], rubrics[:4]), (["2026.9"], rubrics[4:])):
+            monkeypatch.setattr(sys, "argv", [str(extractor), *version])
+            runpy.run_path(str(extractor), run_name="__main__")
+            notes = BeautifulSoup(capsys.readouterr().out, "html.parser")
+            assert [heading.get_text() for heading in notes.select("h3")] == [
+                rubric.contents[0] for rubric in expected_rubrics
+            ]
+            assert not notes.select(".headerlink, .rubric")
+            if not version:
+                assert notes.select_one('a[href="https://example.com/details"]')
+    finally:
+        app.cleanup()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ release = "2026.10"
 # ones.
 extensions = [
     "djangodocs",
+    "rubric_permalinks",
     "sphinxcontrib.httpdomain",
     "sphinx.ext.autodoc",
     "autodoc_signature_filter",
@@ -168,7 +169,7 @@ if os.environ.get("READTHEDOCS", "") == "True":
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["../weblate/static/"]
+html_static_path = ["../weblate/static/", "_ext/static"]
 
 html_logo = "images/logo-text.svg"
 

--- a/scripts/extract-release-notes.py
+++ b/scripts/extract-release-notes.py
@@ -4,22 +4,29 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path
 
-RUBRIC_RE = re.compile(r'<p class="rubric">([^<\n]*)</p>')
+RUBRIC_RE = re.compile(
+    r'<p\b(?=[^>]*\bclass="(?:[^" ]+ )*rubric(?: [^"]*)?")[^>]*>(.*?)</p>',
+    re.DOTALL,
+)
+PERMALINK_RE = re.compile(r'<a\b[^>]*\bclass="headerlink"[^>]*>.*?</a>', re.DOTALL)
 
 version = '[^"]*'
 if len(sys.argv) == 2:
     version = sys.argv[1].replace(".", "-")
 
-tag = f'<section id="weblate-{version}">.+?<h1>(.+?)<a(.+?)</a></h1>(.+?)</section>'
+tag = f'<section id="weblate-{version}">.+?<h1>(.+?)</h1>(.+?)</section>'
 
 data = Path("docs/_build/html/changes.html").read_text(encoding="utf-8")
+data = PERMALINK_RE.sub("", data)
 
 for match in re.findall(tag, data, re.MULTILINE | re.DOTALL):
     print(match[0])
     print()
-    print(RUBRIC_RE.sub(r"<h3>\1</h3>", match[2]))
+    print(RUBRIC_RE.sub(r"<h3>\1</h3>", match[1]))
     break


### PR DESCRIPTION
Make changelog categories easy to link to without adding sections to the table of contents. Generate stable release-specific anchors and provide keyboard-accessible permalink icons.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
