### PR TITLE
fix(docker): handle startup warning directory listing errors

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,8 @@ Weblate 2026.10
 
 .. rubric:: Bug fixes
 
+* Fixed :ref:`Docker startup warning checks <docker-startup-warnings>` failing when the warning directory is missing or inaccessible.
+
 .. rubric:: Compatibility
 
 .. rubric:: Upgrading

--- a/weblate/utils/docker.py
+++ b/weblate/utils/docker.py
@@ -63,7 +63,10 @@ def read_report_file(path: Path, limit: int = DOCKER_WARNING_MAX_SIZE) -> str | 
 
 def iter_active_docker_reports(root: Path, now: float) -> Iterator[tuple[float, Path]]:
     """Yield active Docker reports with their heartbeat timestamps."""
-    reports = root.iterdir()
+    try:
+        reports = root.iterdir()
+    except OSError:
+        return
     while True:
         try:
             report = next(reports)

--- a/weblate/utils/tests/test_checks.py
+++ b/weblate/utils/tests/test_checks.py
@@ -295,6 +295,29 @@ class FilesystemLatencyTestCase(SimpleTestCase):
 
 
 class DockerStartupWarningsCheckTestCase(SimpleTestCase):
+    @tempdir_setting("DATA_DIR")
+    def test_missing_directory(self) -> None:
+        with patch.dict(os.environ, {DOCKER_CONTAINER_ENV: "1"}):
+            errors = list(
+                check_docker_startup_warnings(app_configs=None, databases=None)
+            )
+
+        self.assertEqual(errors, [])
+
+    @tempdir_setting("DATA_DIR")
+    def test_directory_listing_error(self) -> None:
+        for error in (FileNotFoundError, PermissionError):
+            with (
+                self.subTest(error=error),
+                patch.dict(os.environ, {DOCKER_CONTAINER_ENV: "1"}),
+                patch("weblate.utils.docker.Path.iterdir", side_effect=error),
+            ):
+                errors = list(
+                    check_docker_startup_warnings(app_configs=None, databases=None)
+                )
+
+                self.assertEqual(errors, [])
+
     def create_report(
         self,
         name: str,


### PR DESCRIPTION
Catch filesystem errors when creating the directory iterator as well as when consuming it, so missing or inaccessible warning directories do not crash deployment checks. Add regression coverage for both missing directories and immediate listing failures.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
