### PR TITLE
fix(api): reject unsupported authentication schemes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,7 +31,9 @@ throttled (by default to 100 requests per day), so it is recommended to use
 authentication.
 
 The authentication uses a token, which you can get in your profile. Use it in
-the ``Authorization`` header:
+the ``Authorization`` header with the ``Token`` or ``Bearer`` scheme.
+Unsupported schemes, such as ``Basic``, return :http:statuscode:`401`, even
+for public endpoints or when you are signed in using a browser session.
 
 .. http:any:: /
 
@@ -66,6 +68,7 @@ the ``Authorization`` header:
     :status 201: when a new object was created successfully
     :status 204: when an object was deleted successfully
     :status 400: when form parameters are missing
+    :status 401: when authentication credentials are invalid or the authentication scheme is unsupported
     :status 403: when access is denied
     :status 429: when throttling is in place
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,7 @@ Weblate 2026.10
 .. rubric:: Compatibility
 
 * API throttles now read :setting:`API_RATELIMIT_ANON` and :setting:`API_RATELIMIT_USER` directly; ``REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]`` is no longer used by Weblate's throttle classes.
+* :ref:`API authentication <api-generic>` now rejects unsupported authentication schemes, such as Basic, with HTTP 401, including when a valid browser session is present.
 
 .. rubric:: Upgrading
 

--- a/weblate/api/authentication.py
+++ b/weblate/api/authentication.py
@@ -10,16 +10,49 @@ from typing import TYPE_CHECKING
 from django.utils.translation import gettext
 from drf_spectacular.authentication import SessionScheme
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import (
+    BaseAuthentication,
+    TokenAuthentication,
+    get_authorization_header,
+)
+from rest_framework.exceptions import AuthenticationFailed
 
 if TYPE_CHECKING:
     from drf_spectacular.openapi import AutoSchema
+    from rest_framework.request import Request
 
 
 class BearerAuthentication(TokenAuthentication):
     """RFC 6750 compatible Bearer authentication."""
 
     keyword = "Bearer"
+
+
+class RejectAuthorizationAuthentication(BaseAuthentication):
+    """Reject authorization headers not handled by preceding authenticators."""
+
+    def authenticate(self, request: Request) -> None:
+        if get_authorization_header(request).split():
+            msg = "Unsupported authentication scheme. Use Token or Bearer."
+            raise AuthenticationFailed(msg)
+
+
+class RejectAuthorizationScheme(OpenApiAuthenticationExtension):
+    """Exclude the rejection step from advertised authentication schemes."""
+
+    target_class = "weblate.api.authentication.RejectAuthorizationAuthentication"
+
+    def __init__(self, target: BaseAuthentication) -> None:
+        super().__init__(target)
+        self.name = []
+
+    def get_security_requirement(
+        self, auto_schema: AutoSchema
+    ) -> list[dict[str, list[str]]]:
+        return []
+
+    def get_security_definition(self, auto_schema: AutoSchema) -> list[dict[str, str]]:
+        return []
 
 
 class WeblateSessionScheme(SessionScheme):

--- a/weblate/api/spectacular.py
+++ b/weblate/api/spectacular.py
@@ -277,6 +277,8 @@ def get_drf_settings(*, require_login: bool) -> dict[str, Any]:
         "DEFAULT_AUTHENTICATION_CLASSES": (
             "rest_framework.authentication.TokenAuthentication",
             "weblate.api.authentication.BearerAuthentication",
+            # Reject unhandled headers before a browser session can authenticate them.
+            "weblate.api.authentication.RejectAuthorizationAuthentication",
             "rest_framework.authentication.SessionAuthentication",
         ),
         "DEFAULT_THROTTLE_CLASSES": (

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -163,6 +163,79 @@ class SettingsAPIFieldsTest(APITestCase):
                 )
 
 
+class AuthenticationAPITest(APITestCase):
+    user: User
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.user = User.objects.create_user("apiauth", "apiauth@example.org", "x")
+
+    def test_unsupported_scheme(self) -> None:
+        for signed_in in (False, True):
+            if signed_in:
+                self.client.force_login(self.user)
+            for header in (
+                "Basic dXNlcjpwYXNzd29yZA==",
+                "bAsIc dXNlcjpwYXNzd29yZA==",
+                "Basic",
+                "Digest credentials",
+                "Unknown credentials",
+                "Unknown",
+            ):
+                with self.subTest(signed_in=signed_in, header=header):
+                    self.client.credentials(HTTP_AUTHORIZATION=header)
+                    response = self.client.get(reverse("api:api-root"))
+                    self.assertEqual(response.status_code, 401)
+                    self.assertEqual(response["WWW-Authenticate"], "Token")
+                    self.assertEqual(
+                        response.data["errors"][0]["detail"],
+                        "Unsupported authentication scheme. Use Token or Bearer.",
+                    )
+                    self.assertEqual(
+                        response.data["errors"][0]["code"], "authentication_failed"
+                    )
+
+    def test_token_schemes(self) -> None:
+        for scheme in ("Token", "Bearer", "tOkEn", "bEaReR"):
+            with self.subTest(scheme=scheme):
+                self.client.credentials(
+                    HTTP_AUTHORIZATION=f"{scheme} {self.user.auth_token.key}"
+                )
+                response = self.client.get(reverse("api:api-root"))
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.wsgi_request.user, self.user)
+
+    def test_invalid_token(self) -> None:
+        for scheme in ("Token", "Bearer"):
+            for credentials in ("", "invalid", "invalid extra"):
+                with self.subTest(scheme=scheme, credentials=credentials):
+                    self.client.credentials(
+                        HTTP_AUTHORIZATION=f"{scheme} {credentials}"
+                    )
+                    response = self.client.get(reverse("api:api-root"))
+                    self.assertEqual(response.status_code, 401)
+                    self.assertEqual(response["WWW-Authenticate"], "Token")
+
+    def test_without_scheme(self) -> None:
+        for signed_in in (False, True):
+            if signed_in:
+                self.client.force_login(self.user)
+            for header in (None, "", " \t "):
+                with self.subTest(signed_in=signed_in, header=header):
+                    if header is None:
+                        self.client.credentials()
+                    else:
+                        self.client.credentials(HTTP_AUTHORIZATION=header)
+                    response = self.client.get(reverse("api:api-root"))
+                    self.assertEqual(response.status_code, 200)
+                    user = response.wsgi_request.user
+                    if signed_in:
+                        self.assertEqual(user, self.user)
+                    else:
+                        self.assertFalse(user.is_authenticated)
+
+
 class APIBaseTest(APITestCase, RepoTestMixin):
     CREATE_GLOSSARIES: bool = True
 


### PR DESCRIPTION
Reject unhandled Authorization headers before session authentication so unsupported schemes consistently return HTTP 401. Preserve Token and Bearer authentication, document the behavior, and cover it with API regression tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
