### PR TITLE
refactor(templates): use querystring tag for navigation links

### DIFF
--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -38,6 +38,7 @@ from django.http import (
     HttpResponseBadRequest,
     HttpResponseRedirect,
     JsonResponse,
+    QueryDict,
 )
 from django.middleware.csrf import rotate_token
 from django.shortcuts import get_object_or_404, redirect, render
@@ -2263,11 +2264,10 @@ class UserList(ListView):
         context["sort_query"] = self.sort_query
         context["sort_name"] = self.form.sort_choices[self.sort_query.strip("-")]
         context["sort_choices"] = self.form.sort_choices
-        context["search_items"] = (
-            ("q", self.form.cleaned_data.get("q", "").strip()),
-            ("sort_by", self.sort_query),
+        context["query_params"] = QueryDict(mutable=True)
+        context["query_params"].update(
+            q=self.form.cleaned_data.get("q", "").strip(), sort_by=self.sort_query
         )
-        context["query_string"] = urlencode(context["search_items"])
         return context
 
 

--- a/weblate/screenshots/views.py
+++ b/weblate/screenshots/views.py
@@ -14,7 +14,7 @@ import httpx2
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count
-from django.http import FileResponse, JsonResponse
+from django.http import FileResponse, JsonResponse, QueryDict
 from django.shortcuts import aget_object_or_404, get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -456,8 +456,7 @@ class ScreenshotList(PathViewMixin, ListView):  # type: ignore[misc]
         result["sort_name"] = self.search_form.sort_choices["name"]
         result["sort_choices"] = self.search_form.sort_choices
         result["sort_desc"] = False
-        result["query_string"] = ""
-        result["search_items"] = []
+        result["query_params"] = QueryDict()
         if self.search_form.is_valid():
             result["active_query"] = self.search_form.cleaned_data["q"]
             result["sort_query"] = self.search_form.cleaned_data["sort_by"]
@@ -465,8 +464,7 @@ class ScreenshotList(PathViewMixin, ListView):  # type: ignore[misc]
                 result["sort_query"].removeprefix("-")
             ]
             result["sort_desc"] = result["sort_query"].startswith("-")
-            result["query_string"] = self.search_form.urlencode()
-            result["search_items"] = self.search_form.items()
+            result["query_params"] = QueryDict(self.search_form.urlencode())
         result["screenshot_search_presets"] = self.get_search_presets()
         for preset in result["screenshot_search_presets"]:
             if preset["query"] == result["active_query"]:

--- a/weblate/templates/paginator.html
+++ b/weblate/templates/paginator.html
@@ -1,9 +1,10 @@
-{% load i18n icons %}
+{% load i18n icons translations %}
 
 {% if page_obj.paginator.num_pages > 1 %}
+  {% get_pagination_query page_obj as pagination_query %}
   <ul class="pagination">
     <li class="page-item{% if page_obj.number == 1 %} disabled{% endif %}">
-      <a href="?page=1&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+      <a href="{% querystring pagination_query.params page=1 limit=page_obj.paginator.per_page %}{% if anchor %}#{{ anchor }}{% endif %}"
          class="page-link green">
         {% if LANGUAGE_BIDI %}
           {% icon "page-last.svg" %}
@@ -14,7 +15,7 @@
     </li>
     <li class="page-item{% if not page_obj.has_previous %} disabled{% endif %}">
       <a {% if page_obj.has_previous %}rel="prev" {# djlint:off #}
-          href="?page={{ page_obj.previous_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+          href="{% querystring pagination_query.params page=page_obj.previous_page_number limit=page_obj.paginator.per_page %}{% if anchor %}#{{ anchor }}{% endif %}"
           {# djlint:on #}{% endif %}
          class="page-link green">
         {% if LANGUAGE_BIDI %}
@@ -34,12 +35,16 @@
         {# djlint:off #}
         {% if not paginator_form %}<form method="get"{% if anchor %} action="#{{ anchor }}"{% endif %}>{% endif %}
         {# djlint:on #}
-        {% for key, value in search_items %}
-          <input {% if paginator_form %}form="{{ paginator_form }}"{% endif %}
-                 type="hidden"
-                 name="{{ key }}"
-                 value="{{ value }}"
-                 aria-label="{{ value }}" />
+        {% for key, values in pagination_query.items %}
+          {% if key != "page" and key != "limit" %}
+            {% for value in values %}
+              <input {% if paginator_form %}form="{{ paginator_form }}"{% endif %}
+                     type="hidden"
+                     name="{{ key }}"
+                     value="{{ value }}"
+                     aria-label="{{ value }}" />
+            {% endfor %}
+          {% endif %}
         {% endfor %}
         <input {% if paginator_form %}form="{{ paginator_form }}"{% endif %}
                type="hidden"
@@ -68,7 +73,7 @@
     </li>
     <li class="page-item{% if not page_obj.has_next %} disabled{% endif %}">
       <a {% if page_obj.has_next %}rel="next" {# djlint:off #}
-          href="?page={{ page_obj.next_page_number }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+          href="{% querystring pagination_query.params page=page_obj.next_page_number limit=page_obj.paginator.per_page %}{% if anchor %}#{{ anchor }}{% endif %}"
           {# djlint:on #}{% endif %}
          class="page-link green">
         {% if not LANGUAGE_BIDI %}
@@ -79,7 +84,7 @@
       </a>
     </li>
     <li class="page-item{% if page_obj.paginator.num_pages == page_obj.number %} disabled{% endif %}">
-      <a href="?page={{ page_obj.paginator.num_pages }}&amp;limit={{ page_obj.paginator.per_page }}{% if page_obj.paginator.sort_by %}&amp;sort_by={{ page_obj.paginator.sort_by }}{% endif %}{% if query_string %}&amp;{{ query_string }}{% endif %}{% if anchor %}#{{ anchor }}{% endif %}"
+      <a href="{% querystring pagination_query.params page=page_obj.paginator.num_pages limit=page_obj.paginator.per_page %}{% if anchor %}#{{ anchor }}{% endif %}"
          class="page-link green">
         {% if not LANGUAGE_BIDI %}
           {% icon "page-last.svg" %}

--- a/weblate/templates/snippets/embed-units.html
+++ b/weblate/templates/snippets/embed-units.html
@@ -1,6 +1,7 @@
 {% load i18n icons translations %}
 
 {% any_unit_has_context units as any_unit_has_context %}
+{% get_embed_unit_query as embed_query %}
 
 <table class="table table-sm table-embed-units">
   <thead>
@@ -86,6 +87,7 @@
   <tbody class="unit-listing-body">
 
     {% for unit in units %}
+      {% querystring embed_query checksum=unit.checksum as unit_query %}
       <tr class="{% if current_unit.id == unit.id %}current_translation{% endif %}">
         {% if selection_template %}
           <td class="unit-selection-cell">{% include selection_template %}</td>
@@ -106,7 +108,7 @@
         {% if not hide_context and any_unit_has_context %}
           <td>
             {% if unit.context %}
-              <a href="{{ unit.get_absolute_url }}{% if include_search and search_url %}&amp;{{ search_url }}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
+              <a href="{{ unit.translation.get_translate_url }}{{ unit_query }}">
                 {% format_source_string unit.context unit wrap=True search_match=search_query %}
               </a>
             {% endif %}
@@ -114,13 +116,13 @@
         {% endif %}
         {% if force_source or not hide_source and not unit.is_source %}
           <td>
-            <a href="{{ unit.get_absolute_url }}{% if include_search and search_url %}&amp;{{ search_url }}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
+            <a href="{{ unit.translation.get_translate_url }}{{ unit_query }}">
               {% format_unit_source unit search_match=search_query %}
             </a>
           </td>
         {% endif %}
         <td>
-          <a href="{{ unit.get_absolute_url }}{% if include_search and search_url %}&amp;{{ search_url }}{% elif sort_query %}&amp;sort_by={{ sort_query }}{% endif %}">
+          <a href="{{ unit.translation.get_translate_url }}{{ unit_query }}">
             {% format_unit_target unit search_match=search_query %}
           </a>
         </td>

--- a/weblate/templates/snippets/last-changes-content.html
+++ b/weblate/templates/snippets/last-changes-content.html
@@ -21,7 +21,7 @@
             <div class="btn-float">
               {% if item.permissions.can_revert %}
                 <a class="btn btn-link"
-                   href="{{ translate_url|default:item.change.translation.get_translate_url }}?{% if search_url %}{{ search_url }}&amp;offset={{ offset }}&amp;{% endif %}checksum={{ item.change.unit.checksum }}&amp;revert={{ item.change.id }}"
+                   href="{{ translate_url|default:item.change.translation.get_translate_url }}{% querystring query_params offset=offset checksum=item.change.unit.checksum revert=item.change.id %}"
                    title="{% translate "Revert" %}">{% icon "undo.svg" %}</a>
               {% endif %}
               {% if item.permissions.can_block_user %}

--- a/weblate/templates/snippets/list-objects.html
+++ b/weblate/templates/snippets/list-objects.html
@@ -1,6 +1,9 @@
 {% load humanize i18n icons permissions translations %}
 
 {% if objects or list_categories %}
+  {% if objects.paginator.num_pages > 1 %}
+    {% get_pagination_query objects as pagination_query %}
+  {% endif %}
   {% get_listing_columns user as listing_columns %}
   {% if user.is_authenticated and user.profile.wide_tables %}
     <div class="table-listing-wrapper table-scroll"
@@ -54,7 +57,7 @@
             </th>
             <th title="{% translate "Sort this column" %}" class="sort-cell">
               {% if objects.paginator.num_pages > 1 %}
-                <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "name" %}-{% endif %}name{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="name"|toggle_sort:objects.paginator.sort_by %}">
               {% endif %}
               {{ label|default:_("Project") }}
               <span class="sort-icon {% if objects.paginator.sort_by == "name" %}sort-down{% elif objects.paginator.sort_by == "-name" %}sort-up{% endif %}" />
@@ -70,7 +73,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-540 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "approved" %}-{% endif %}approved{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="approved"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "approved" %}sort-down{% elif objects.paginator.sort_by == "-approved" %}sort-up{% endif %}"> </span>
                 {% translate "Approved" %}
@@ -79,7 +82,7 @@
             {% endif %}
             <th title="{% translate "Sort this column" %}" class="number sort-cell">
               {% if objects.paginator.num_pages > 1 %}
-                <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "translated" %}-{% endif %}translated{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="translated"|toggle_sort:objects.paginator.sort_by %}">
               {% endif %}
               <span class="sort-icon {% if objects.paginator.sort_by == "translated" %}sort-down{% elif objects.paginator.sort_by == "-translated" %}sort-up{% endif %}"> </span>
               {% translate "Translated" %}
@@ -89,7 +92,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-640 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "unreviewed" %}-{% endif %}unreviewed{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="unreviewed"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "unreviewed" %}sort-down{% elif objects.paginator.sort_by == "-unreviewed" %}sort-up{% endif %}"> </span>
                 {% translate "Unreviewed" %}
@@ -100,7 +103,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-640 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "total" %}-{% endif %}total{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="total"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "total" %}sort-down{% elif objects.paginator.sort_by == "-total" %}sort-up{% endif %}"> </span>
                 {% translate "Total strings" %}
@@ -111,7 +114,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-640 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated" %}-{% endif %}untranslated{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="untranslated"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "untranslated" %}sort-down{% elif objects.paginator.sort_by == "-untranslated" %}sort-up{% endif %}"> </span>
                 {% translate "Unfinished" %}
@@ -122,7 +125,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-720 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated_words" %}-{% endif %}untranslated_words{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="untranslated_words"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "untranslated_words" %}sort-down{% elif objects.paginator.sort_by == "-untranslated_words" %}sort-up{% endif %}"> </span>
                 {% translate "Unfinished words" %}
@@ -133,7 +136,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-1200 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "untranslated_chars" %}-{% endif %}untranslated_chars{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="untranslated_chars"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "untranslated_chars" %}sort-down{% elif objects.paginator.sort_by == "-untranslated_chars" %}sort-up{% endif %}"> </span>
                 {% translate "Unfinished characters" %}
@@ -144,7 +147,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-1400 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "nottranslated" %}-{% endif %}nottranslated{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="nottranslated"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "nottranslated" %}sort-down{% elif objects.paginator.sort_by == "-nottranslated" %}sort-up{% endif %}"> </span>
                 {% translate "Untranslated" %}
@@ -155,7 +158,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-768 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "checks" %}-{% endif %}checks{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="checks"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "checks" %}sort-down{% elif objects.paginator.sort_by == "-checks" %}sort-up{% endif %}"> </span>
                 {% translate "Checks" %}
@@ -166,7 +169,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-900 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "suggestions" %}-{% endif %}suggestions{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="suggestions"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "suggestions" %}sort-down{% elif objects.paginator.sort_by == "-suggestions" %}sort-up{% endif %}"> </span>
                 {% translate "Suggestions" %}
@@ -177,7 +180,7 @@
               <th title="{% translate "Sort this column" %}"
                   class="number zero-width-1000 sort-cell">
                 {% if objects.paginator.num_pages > 1 %}
-                  <a href="?page={{ objects.number }}&amp;sort_by={% if objects.paginator.sort_by == "comments" %}-{% endif %}comments{% if query_string %}&amp;{{ query_string }}{% endif %}">
+                  <a href="{% querystring pagination_query.params page=objects.number limit=objects.paginator.per_page sort_by="comments"|toggle_sort:objects.paginator.sort_by %}">
                 {% endif %}
                 <span class="sort-icon {% if objects.paginator.sort_by == "comments" %}sort-down{% elif objects.paginator.sort_by == "-comments" %}sort-up{% endif %}"> </span>
                 {% translate "Comments" %}

--- a/weblate/templates/trans/change_list.html
+++ b/weblate/templates/trans/change_list.html
@@ -6,22 +6,22 @@
   {% if path_object %}
     {% path_object_breadcrumbs path_object %}
     <li class="breadcrumb-item">
-      <a href="{% url 'changes' path=path_object.get_url_path %}?{{ query_string }}">{% translate "Changes" %}</a>
+      <a href="{% url 'changes' path=path_object.get_url_path %}{% querystring query_params %}">{% translate "Changes" %}</a>
     </li>
   {% else %}
     <li class="breadcrumb-item">
-      <a href="{% url 'changes' %}?{{ query_string }}">{% translate "Changes" %}</a>
+      <a href="{% url 'changes' %}{% querystring query_params %}">{% translate "Changes" %}</a>
     </li>
   {% endif %}
 
   <div class="btn-group ms-auto btn-group-settings" role="group">
     {% if debug %}
       {% if path_object %}
-        <a href="{% url 'changes' path=path_object.get_url_path %}?{{ query_string }}&amp;digest=1"
+        <a href="{% url 'changes' path=path_object.get_url_path %}{% querystring query_params digest=1 %}"
            title="{% translate "View notification" %}"
            class="btn btn-link">{% icon "bell.svg" %}</a>
       {% else %}
-        <a href="{% url 'changes' %}?{{ query_string }}&amp;digest=1"
+        <a href="{% url 'changes' %}{% querystring query_params digest=1 %}"
            title="{% translate "View notification" %}"
            class="btn btn-link">{% icon "bell.svg" %}</a>
       {% endif %}
@@ -29,16 +29,16 @@
     {% perm 'change.download' path_object as user_can_download_changes %}
     {% if user_can_download_changes %}
       {% if path_object %}
-        <a href="{% url 'changes-csv' path=path_object.get_url_path %}?{{ query_string }}"
+        <a href="{% url 'changes-csv' path=path_object.get_url_path %}{% querystring query_params %}"
            title="{% translate "Download latest changes as CSV" %}"
            class="btn btn-link">{% icon "download.svg" %}</a>
       {% else %}
-        <a href="{% url 'changes-csv' %}?{{ query_string }}"
+        <a href="{% url 'changes-csv' %}{% querystring query_params %}"
            title="{% translate "Download latest changes as CSV" %}"
            class="btn btn-link">{% icon "download.svg" %}</a>
       {% endif %}
     {% endif %}
-    <a href="{{ changes_rss }}{% if query_string %}?{{ query_string }}{% endif %}"
+    <a href="{{ changes_rss }}{% querystring query_params %}"
        title="{% translate "Follow using RSS" %}"
        class="btn btn-link">{% icon "rss.svg" %}</a>
   </div>

--- a/weblate/templates/translate.html
+++ b/weblate/templates/translate.html
@@ -47,7 +47,7 @@
   {% perm 'unit.add' unit.translation as user_can_add_unit %}
 
   <div class="btn-group float-end btn-group-settings" role="group">
-    <a href="{% url 'zen' path=object.get_url_path %}?offset={{ offset }}&amp;{{ search_url }}"
+    <a href="{% url 'zen' path=object.get_url_path %}{% querystring query_params offset=offset %}"
        data-params="{{ search_url }}"
        title="{% translate "Open in Zen mode" %}"
        class="btn btn-link">{% icon "flash.svg" %} {% translate "Zen" %}</a>
@@ -407,7 +407,7 @@
                 <p class="help-block">{% translate "Showing only subset of the strings as there were too many matches." %}</p>
               {% endif %}
               <form method="post"
-                    action="{{ unit.translation.get_translate_url }}?{{ search_url }}&amp;offset={{ offset }}&amp;checksum={{ unit.checksum }}&amp;unit_id={{ unit.pk }}">
+                    action="{{ unit.translation.get_translate_url }}{% querystring query_params offset=offset checksum=unit.checksum unit_id=unit.pk %}">
                 {% csrf_token %}
                 <table class="table table-sm">
                   <thead>

--- a/weblate/templates/zen-units.html
+++ b/weblate/templates/zen-units.html
@@ -19,7 +19,7 @@
              title="{% translate "Copy permalink" %}"
              tabindex="-1">{% icon "link.svg" %}</a>
           <a class="btn btn-link btn-xs"
-             href="{% url 'translate' path=object.get_url_path %}?{{ search_url }}&amp;offset={{ item.offset }}"
+             href="{% url 'translate' path=object.get_url_path %}{% querystring query_params offset=item.offset %}"
              title="{% translate "Open in full editor" %}"
              tabindex="-1">{% icon "pencil-mini.svg" %}</a>
         </div>

--- a/weblate/templates/zen.html
+++ b/weblate/templates/zen.html
@@ -31,7 +31,7 @@
 
   <div class="btn-group float-end btn-group-settings" role="group">
 
-    <a href="{% url 'translate' path=object.get_url_path %}?{{ search_url }}"
+    <a href="{% url 'translate' path=object.get_url_path %}{% querystring query_params %}"
        data-params="{{ search_url }}"
        title="{% translate "Edit in single string mode" %}"
        class="btn btn-link">{% icon "close.svg" %} {% translate "Exit Zen" %}</a>
@@ -56,7 +56,7 @@
       <tr>
         <td colspan="3" class="loading-icon">
           {% loading_icon "next" %}
-          <a href="{% url 'load_zen' path=object.get_url_path %}?{{ search_url }}"
+          <a href="{% url 'load_zen' path=object.get_url_path %}{% querystring query_params %}"
              class="hidden"
              id="zen-load"
              data-offset="{{ offset }}"></a>

--- a/weblate/trans/templatetags/translations.py
+++ b/weblate/trans/templatetags/translations.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from django import template
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.http import QueryDict
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
@@ -67,6 +68,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from django import forms
+    from django.core.paginator import Page
     from django.db.models import QuerySet
     from django.template.context import Context
     from django.utils.safestring import SafeString
@@ -811,6 +813,12 @@ def hash_text(name: str) -> str:
     return hash_to_checksum(siphash("Weblate URL hash", name.encode()))
 
 
+@register.filter
+def toggle_sort(column: str, current: str | None) -> str:
+    """Reverse an ascending column, or select a column in ascending order."""
+    return f"-{column}" if current == column else column
+
+
 @register.simple_tag
 def sort_choices():
     return SORT_CHOICES.items()
@@ -824,6 +832,17 @@ def render_alert(context: Context, alert: Alert) -> str:
 @register.simple_tag
 def get_message_kind(tags) -> str:
     return get_message_kind_impl(tags)
+
+
+@register.simple_tag(takes_context=True)
+def get_embed_unit_query(context: Context) -> QueryDict:
+    """Select search filters or fallback sorting for embedded unit links."""
+    if context.get("include_search") and (params := context.get("query_params")):
+        return params
+    params = QueryDict(mutable=True)
+    if sort_query := context.get("sort_query"):
+        params["sort_by"] = sort_query
+    return params
 
 
 @register.simple_tag
@@ -1119,6 +1138,25 @@ def format_headers(value: dict[str, str]) -> str:
     return format_html_join(mark_safe("<br>"), "<b>{}</b>: {}", value.items())
 
 
+class PaginationQuery(NamedTuple):
+    params: QueryDict
+    items: list[tuple[str, list[str]]]
+
+
+@register.simple_tag(takes_context=True)
+def get_pagination_query(context: Context, page: Page) -> PaginationQuery:
+    """Share effective filters and sorting between pagination links and forms."""
+    params = context.get("query_params")
+    if params is None:
+        request = context.get("request")
+        params = request.GET if request is not None else QueryDict()
+    params = params.copy()
+    if sort_by := getattr(page.paginator, "sort_by", None):
+        params["sort_by"] = sort_by
+    # Resolve lists in Python so a query parameter named "lists" cannot shadow it.
+    return PaginationQuery(params, list(params.lists()))
+
+
 @register.inclusion_tag("snippets/last-changes-content.html")
 def format_last_changes_content(
     last_changes: Iterable[Change],
@@ -1171,8 +1209,8 @@ def format_last_changes_content(
         "changes_with_context": processed_changes,
         "in_email": in_email,
         "debug": debug,
-        "search_url": search_url,
-        "offset": offset,
+        "query_params": QueryDict(search_url or ""),
+        "offset": offset if search_url else None,
         "translate_url": translate_url,
     }
 

--- a/weblate/trans/tests/test_changes.py
+++ b/weblate/trans/tests/test_changes.py
@@ -11,10 +11,12 @@ from html import escape
 from typing import cast
 from unittest.mock import patch
 
+from django.http import QueryDict
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import urlencode
+from lxml import html
 
 from weblate.lang.models import Language
 from weblate.screenshots.models import Screenshot
@@ -505,11 +507,13 @@ class ChangesTest(ViewTestCase):
         start = end - timedelta(days=1)
         period = f"{start.strftime('%m/%d/%Y')} - {end.strftime('%m/%d/%Y')}"
         response = self.client.get(reverse("changes"), {"period": period})
-        query_string = urlencode({"page": 2, "limit": 20, "period": period})
-        self.assertContains(response, escape(query_string))
-        response = self.client.get(
-            reverse("changes"), {"page": 2, "limit": 20, "period": period}
+        document = html.fromstring(response.content)
+        next_url = document.xpath('//a[@rel="next"]/@href')[0]
+        self.assertEqual(
+            QueryDict(next_url.removeprefix("?")),
+            QueryDict(urlencode({"page": 2, "limit": 20, "period": period})),
         )
+        response = self.client.get(f"{reverse('changes')}{next_url}")
         self.assertContains(response, "String added in the upload")
 
     def test_rss_link_keeps_query_string(self) -> None:

--- a/weblate/trans/tests/test_querystring.py
+++ b/weblate/trans/tests/test_querystring.py
@@ -1,0 +1,309 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for query strings in navigation templates."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+from django.core.paginator import Paginator
+from django.http import QueryDict
+from django.template.loader import render_to_string
+from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.urls import reverse
+from lxml import html
+
+from weblate.trans.models import Project
+from weblate.trans.templatetags.translations import format_last_changes_content
+from weblate.trans.tests.test_views import ViewTestCase
+
+
+class SortedPaginator(Paginator):
+    sort_by = "-name"
+
+
+class PaginatorQueryTest(SimpleTestCase):
+    def render_paginator(self, query: str, **context: object) -> html.HtmlElement:
+        request = RequestFactory().get(f"/?{query}")
+        paginator = SortedPaginator(range(60), 20)
+        return html.fromstring(
+            render_to_string(
+                "paginator.html",
+                {
+                    "page_obj": paginator.page(2),
+                    "anchor": "results",
+                    "request": request,
+                    **context,
+                },
+            )
+        )
+
+    def test_links_and_jump_form_preserve_repeated_filters(self) -> None:
+        params = QueryDict(mutable=True)
+        params.setlist("type", ["all", "todo"])
+        params.update({"q": 'Žluťoučký & "<text>"', "page": "99", "limit": "500"})
+        params.setlist("sort_by", ["name", "translated"])
+        document = self.render_paginator(params.urlencode())
+        links = document.xpath('//a[contains(@class, "page-link")][@href!="#"]')
+        self.assertEqual(len(links), 4)
+        for link, page in zip(links, (1, 1, 3, 3), strict=True):
+            with self.subTest(page=page):
+                url = urlsplit(link.get("href"))
+                self.assertEqual(url.fragment, "results")
+                self.assertEqual(
+                    parse_qs(url.query),
+                    {
+                        "q": [params["q"]],
+                        "type": ["all", "todo"],
+                        "page": [str(page)],
+                        "limit": ["20"],
+                        "sort_by": ["-name"],
+                    },
+                )
+        form = document.xpath("//form")[0]
+        self.assertEqual(form.get("action"), "#results")
+        fields = list(form.form_values())
+        self.assertEqual(fields.count(("type", "all")), 1)
+        self.assertEqual(fields.count(("type", "todo")), 1)
+        self.assertEqual([value for key, value in fields if key == "page"], ["2"])
+        self.assertEqual([value for key, value in fields if key == "limit"], ["20"])
+        self.assertEqual(
+            [value for key, value in fields if key == "sort_by"], ["-name"]
+        )
+        self.assertIn(("q", params["q"]), fields)
+
+    def test_empty_validated_filters_do_not_fall_back_to_request(self) -> None:
+        document = self.render_paginator(
+            "q=invalid&checksum=stale", query_params=QueryDict()
+        )
+        for link in document.xpath('//a[@href!="#"]/@href'):
+            self.assertNotIn("q", parse_qs(urlsplit(link).query))
+            self.assertNotIn("checksum", parse_qs(urlsplit(link).query))
+        self.assertFalse(document.xpath('//input[@name="q" or @name="checksum"]'))
+
+    def test_filter_names_do_not_shadow_dictionary_methods(self) -> None:
+        document = self.render_paginator("lists=all&lists=todo&items=value")
+        fields = list(document.xpath("//form")[0].form_values())
+        self.assertIn(("lists", "all"), fields)
+        self.assertIn(("lists", "todo"), fields)
+        self.assertIn(("items", "value"), fields)
+
+    def test_external_form_and_validated_filters(self) -> None:
+        params = QueryDict("type=all&type=todo")
+        document = self.render_paginator(
+            "q=ignored", query_params=params, paginator_form="paginator-form"
+        )
+        self.assertFalse(document.xpath("//form"))
+        fields = document.xpath("//input")
+        self.assertTrue(fields)
+        self.assertTrue(all(field.get("form") == "paginator-form" for field in fields))
+        self.assertEqual(params, QueryDict("type=all&type=todo"))
+
+
+class NavigationQueryTest(ViewTestCase):
+    def test_editor_links_use_validated_search_and_destination_position(self) -> None:
+        self.create_link_existing()
+        unit = self.get_unit("Thank you for using Weblate.")
+        response = self.client.get(
+            self.translation.get_translate_url(),
+            {
+                "q": "source:Weblate",
+                "checksum": unit.checksum,
+                "offset": 99,
+                "unrelated": "drop",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        document = html.fromstring(response.content)
+        zen_path = reverse("zen", kwargs={"path": self.translation.get_url_path()})
+        zen_url = next(
+            url for url in document.xpath("//a/@href") if urlsplit(url).path == zen_path
+        )
+        self.assertEqual(
+            parse_qs(urlsplit(zen_url).query),
+            {"q": ["source:Weblate"], "offset": [str(response.context["offset"])]},
+        )
+        actions = document.xpath('//form[contains(@action, "unit_id=")]/@action')
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(
+            parse_qs(urlsplit(actions[0]).query),
+            {
+                "q": ["source:Weblate"],
+                "offset": [str(response.context["offset"])],
+                "checksum": [unit.checksum],
+                "unit_id": [str(unit.pk)],
+            },
+        )
+        self.assertEqual(response.context["search_form"].data["offset"], "1")
+        self.assertEqual(response.context["search_form"].data["checksum"], "")
+        response = self.client.get(zen_url)
+        self.assertEqual(response.status_code, 200)
+        document = html.fromstring(response.content)
+        editor_url = next(
+            url
+            for url in document.xpath("//a/@href")
+            if urlsplit(url).path == self.translation.get_translate_url()
+        )
+        self.assertEqual(
+            parse_qs(urlsplit(editor_url).query), {"q": ["source:Weblate"]}
+        )
+
+    def test_embedded_links_replace_request_checksum(self) -> None:
+        unit = self.get_unit("Thank you for using Weblate.")
+        response = self.client.get(
+            reverse("search", kwargs={"path": self.translation.get_url_path()}),
+            {
+                "q": "source:Weblate",
+                "checksum": unit.checksum,
+                "offset": 99,
+                "unrelated": "drop",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        document = html.fromstring(response.content)
+        links = document.xpath('//a[contains(@href, "checksum=")]/@href')
+        self.assertTrue(links)
+        checksums = set()
+        for link in links:
+            params = parse_qs(urlsplit(link).query)
+            self.assertEqual(set(params), {"q", "checksum"})
+            self.assertEqual(params["q"], ["source:Weblate"])
+            self.assertEqual(len(params["checksum"]), 1)
+            checksums.add(params["checksum"][0])
+        self.assertEqual(
+            checksums,
+            {
+                unit.checksum
+                for unit in self.translation.unit_set.filter(source__contains="Weblate")
+            },
+        )
+
+    def test_embedded_links_with_fallback_sorting(self) -> None:
+        unit = self.get_unit("Thank you for using Weblate.")
+        unit.context = "String context"
+        for include_search, params in (
+            (False, QueryDict("q=ignored")),
+            (True, QueryDict()),
+        ):
+            for sort_query in (None, "-source"):
+                with self.subTest(include_search=include_search, sort_query=sort_query):
+                    document = html.fromstring(
+                        render_to_string(
+                            "snippets/embed-units.html",
+                            {
+                                "units": [unit],
+                                "translation": self.translation,
+                                "include_search": include_search,
+                                "query_params": params,
+                                "sort_query": sort_query,
+                                "search_query": "",
+                                "force_source": True,
+                                "request": RequestFactory().get(
+                                    "/?q=unrelated&checksum=stale"
+                                ),
+                            },
+                        )
+                    )
+                    links = document.xpath(
+                        '//tbody//a[contains(@href, "checksum=")]/@href'
+                    )
+                    self.assertEqual(len(links), 3)
+                    expected = {"checksum": [unit.checksum]}
+                    if sort_query:
+                        expected["sort_by"] = [sort_query]
+                    for link in links:
+                        self.assertEqual(
+                            urlsplit(link).path, self.translation.get_translate_url()
+                        )
+                        self.assertEqual(parse_qs(urlsplit(link).query), expected)
+
+    def test_revert_links_without_request_context(self) -> None:
+        unit = self.change_unit("Changed target", user=self.user)
+        change = unit.change_set.latest("timestamp")
+        for search_url, expected in (
+            (None, {}),
+            ("q=source%3AWeblate", {"q": ["source:Weblate"], "offset": ["2"]}),
+        ):
+            with self.subTest(search_url=search_url):
+                document = html.fromstring(
+                    render_to_string(
+                        "snippets/last-changes-content.html",
+                        format_last_changes_content(
+                            [change], self.user, search_url=search_url, offset=2
+                        ),
+                    )
+                )
+                links = document.xpath('//a[contains(@href, "revert=")]/@href')
+                self.assertEqual(len(links), 1)
+                self.assertEqual(
+                    parse_qs(urlsplit(links[0]).query),
+                    {
+                        **expected,
+                        "checksum": [unit.checksum],
+                        "revert": [str(change.pk)],
+                    },
+                )
+
+    def test_project_sort_links(self) -> None:
+        for index in range(10):
+            Project.objects.create(name=f"Project {index}", slug=f"project-{index}")
+        for current, expected in (
+            ("name", "-name"),
+            ("-name", "name"),
+            ("translated", "name"),
+        ):
+            with self.subTest(current=current):
+                response = self.client.get(
+                    reverse("projects"),
+                    {"sort_by": current, "limit": "10", "page": "2"},
+                )
+                self.assertEqual(response.status_code, 200)
+                document = html.fromstring(response.content)
+                links = document.xpath('//th//a[contains(@href, "sort_by=")]/@href')
+                self.assertTrue(links)
+                self.assertEqual(
+                    parse_qs(urlsplit(links[0]).query),
+                    {"page": ["2"], "limit": ["10"], "sort_by": [expected]},
+                )
+                for link in links:
+                    self.assertEqual(len(parse_qs(urlsplit(link).query)["sort_by"]), 1)
+
+    @override_settings(DEBUG=True, INTERNAL_IPS=["127.0.0.1"])
+    def test_history_links_keep_only_validated_filters(self) -> None:
+        self.user.is_superuser = True
+        self.user.save(update_fields=["is_superuser"])
+        response = self.client.get(
+            reverse("changes"),
+            {
+                "user": self.user.username,
+                "page": "1",
+                "limit": "25",
+                "unrelated": "drop",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        document = html.fromstring(response.content)
+        destinations = {
+            reverse("changes"),
+            reverse("changes-csv"),
+            reverse("changes-rss"),
+        }
+        links = [
+            url
+            for url in document.xpath("//a/@href")
+            if urlsplit(url).path in destinations
+        ]
+        self.assertTrue(links)
+        self.assertEqual({urlsplit(url).path for url in links}, destinations)
+        self.assertTrue(any("digest=1" in url for url in links))
+        for link in links:
+            params = parse_qs(urlsplit(link).query)
+            # The Changes entry in the global navigation has no filters.
+            if not params:
+                continue
+            expected = {"user": [self.user.username]}
+            if "digest" in params:
+                expected["digest"] = ["1"]
+            self.assertEqual(params, expected)

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -11,11 +11,10 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_not_required, login_required
 from django.db import transaction
 from django.db.models import Q
-from django.http import HttpResponse
+from django.http import HttpResponse, QueryDict
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.http import urlencode
 from django.utils.translation import gettext, ngettext
 from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
@@ -109,20 +108,18 @@ class _ComponentChangeSet(Protocol):
 @never_cache
 def list_projects(request: AuthenticatedHttpRequest):
     """List all projects."""
-    query_string = ""
+    query_params = QueryDict(mutable=True)
     projects = request.user.allowed_projects
     form = ProjectFilterForm(request.GET)
     if form.is_valid():
-        query = {}
         if form.cleaned_data["owned"]:
             user = form.cleaned_data["owned"]
-            query["owned"] = user.username
+            query_params["owned"] = user.username
             projects = (user.owned_projects & projects.distinct()).order()
         elif form.cleaned_data["watched"]:
             user = form.cleaned_data["watched"]
-            query["watched"] = user.username
+            query_params["watched"] = user.username
             projects = (user.watched_projects & projects).order()
-        query_string = urlencode(query)
     else:
         show_form_errors(request, form)
 
@@ -144,7 +141,7 @@ def list_projects(request: AuthenticatedHttpRequest):
                 )
             ),
             "title": gettext("Projects"),
-            "query_string": query_string,
+            "query_params": query_params,
             "show_review_columns": show_review_columns,
         },
     )

--- a/weblate/trans/views/changes.py
+++ b/weblate/trans/views/changes.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse
+from django.http import HttpResponse, QueryDict
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
@@ -105,9 +105,9 @@ class ChangesView(PathViewMixin, ListView):
         context["title"] = self.get_title()
         context["changes_rss"] = self.get_changes_url("changes-rss")
 
+        context["query_params"] = QueryDict()
         if self.changes_form.is_valid():
-            context["query_string"] = self.changes_form.urlencode()
-            context["search_items"] = self.changes_form.items()
+            context["query_params"] = QueryDict(self.changes_form.urlencode())
             if period := self.changes_form.cleaned_data.get("period"):
                 self.changes_form.fields["period"].widget.attrs["data-start-date"] = (
                     period["start_date"].strftime("%m/%d/%Y")

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -21,6 +21,7 @@ from django.http import (
     HttpResponseBadRequest,
     HttpResponseRedirect,
     JsonResponse,
+    QueryDict,
 )
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -1465,7 +1466,7 @@ def translate(request: AuthenticatedHttpRequest, path: list[str]) -> HttpRespons
             "can_go_next_section": offset + user.profile.nearby_strings <= num_results,
             "others": get_other_units(unit) if user.is_authenticated else {"total": 0},
             "search_url": search_result["url"],
-            "search_items": search_result["items"],
+            "query_params": QueryDict(search_result["url"]),
             "search_query": search_result["query"],
             "offset": offset,
             "filter_count": num_results,
@@ -1794,6 +1795,7 @@ def zen(request: AuthenticatedHttpRequest, path):
             "filter_pos": search_result["offset"],
             "last_section": search_result["last_section"],
             "search_url": search_result["url"],
+            "query_params": QueryDict(search_result["url"]),
             "offset": search_result["offset"],
             "search_form": search_result["form"].reset_offset(),
             "can_refresh_search": True,
@@ -1825,7 +1827,7 @@ def load_zen(request: AuthenticatedHttpRequest, path):
             "component": obj.component if isinstance(obj, Translation) else None,
             "unitdata": unitdata,
             "search_query": search_result["query"],
-            "search_url": search_result["url"],
+            "query_params": QueryDict(search_result["url"]),
             "last_section": search_result["last_section"],
         },
     )
@@ -1971,7 +1973,7 @@ def browse(request: AuthenticatedHttpRequest, path):
             "component": obj.component if isinstance(obj, Translation) else None,
             "units": units,
             "search_query": search_result["query"],
-            "search_url": search_result["url"],
+            "query_params": QueryDict(search_result["url"]),
             "search_form": search_result["form"].reset_offset(),
             "filter_count": num_results,
             "filter_pos": offset,

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -10,6 +10,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Sum
+from django.http import QueryDict
 from django.shortcuts import redirect
 from django.utils.translation import gettext, ngettext
 from django.views.decorators.cache import never_cache
@@ -214,10 +215,8 @@ def search(request: AuthenticatedHttpRequest, path=None):
                 "page_obj": units,
                 "path_object": obj,
                 "title": gettext("Search for %s") % (search_form.cleaned_data["q"]),
-                "query_string": search_form.urlencode(),
-                "search_url": search_form.urlencode(),
+                "query_params": QueryDict(search_form.urlencode()),
                 "search_query": search_form.cleaned_data["q"],
-                "search_items": search_form.items(),
                 "total_strings": total_strings,
                 "total_words": total_words,
             }

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -31,6 +31,7 @@ from django.test.utils import CaptureQueriesContext, modify_settings, override_s
 from django.urls import reverse
 from django.utils import timezone
 from django_celery_beat.models import IntervalSchedule, PeriodicTask, PeriodicTasks
+from lxml import html
 
 from weblate.accounts.models import AuditLog
 from weblate.auth.models import Group, Invitation, Permission, Role
@@ -1176,7 +1177,19 @@ class AdminTest(ViewTestCase):
             set(response.context["object_list"]),
             set(workspaces[:50]),
         )
-        self.assertContains(response, "sort_by=-translated&amp;q=localization")
+        document = html.fromstring(response.content)
+        self.assertIn(
+            {
+                "q": ["localization"],
+                "sort_by": ["-translated"],
+                "page": ["1"],
+                "limit": ["50"],
+            },
+            [
+                parse_qs(urlparse(href).query)
+                for href in document.xpath("//th//a/@href")
+            ],
+        )
         self.assertEqual(
             response.context["object_list"].paginator.sort_by,
             "translated",
@@ -1211,7 +1224,7 @@ class AdminTest(ViewTestCase):
         self.assertNotContains(response, "Documentation workspace")
         self.assertEqual(list(response.context["object_list"]), [workspace])
         self.assertEqual(response.context["search_query"], "local")
-        self.assertEqual(response.context["query_string"], "q=local")
+        self.assertEqual(response.context["query_params"].urlencode(), "q=local")
 
         response = self.client.get(reverse("manage-workspaces"), {"q": "missing"})
 

--- a/weblate/workspaces/views.py
+++ b/weblate/workspaces/views.py
@@ -13,7 +13,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Count, Exists, OuterRef, Prefetch, ProtectedError, Q
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, QueryDict
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -178,7 +178,6 @@ class WorkspaceListBase(ListView):
         search_query = ""
         if self.search_form.is_valid():
             search_query = self.search_form.cleaned_data["q"].strip()
-        search_items = (("q", search_query),) if search_query else ()
         result["billing_enabled"] = self.include_billing()
         result["workspace_creation_enabled"] = (
             "weblate.billing" not in settings.INSTALLED_APPS
@@ -186,8 +185,9 @@ class WorkspaceListBase(ListView):
         result["can_add_workspace"] = self.request.user.has_perm("workspace.add")
         result["search_form"] = self.search_form
         result["search_query"] = search_query
-        result["search_items"] = search_items
-        result["query_string"] = urlencode(search_items)
+        result["query_params"] = QueryDict(mutable=True)
+        if search_query:
+            result["query_params"]["q"] = search_query
         result["show_review_columns"] = (
             Project.objects.filter(workspace__in=queryset)
             .filter(Q(source_review=True) | Q(translation_review=True))
@@ -266,7 +266,7 @@ def detail(request: AuthenticatedHttpRequest, pk) -> HttpResponse:
                 )
             ),
             "title": workspace.name,
-            "query_string": "",
+            "query_params": QueryDict(),
             "show_review_columns": show_review_columns,
             "search_form": SearchForm(
                 request=request,


### PR DESCRIPTION
Replace manual query-string assembly with the Django template tag while preserving validated filters, search caching, form resets, and pagination controls. Share embedded-link parameters and sort-direction handling, and cover navigation with regression tests.

Fixes #13638

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
