### PR TITLE
fix(repository): disable unconfigured pushes and link VCS settings

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.10
 
 .. rubric:: Improvements
 
+* Improved :ref:`repository maintenance <repository-maintenance>` with disabled push controls when push configuration is missing and direct links to component VCS settings.
 * Whitespace characters are now rendered consistently in the source string display and the translation editor, and different kinds of whitespace are now distinguishable from each other.
 * Added a :ref:`keyboard shortcut <keyboard>` to approve a translation and save and continue.
 * Clarified :ref:`translation quality filter <project-commit_policy>` explanations and effective per-language review settings, with links to workflow configuration.

--- a/weblate/templates/js/git-status.html
+++ b/weblate/templates/js/git-status.html
@@ -88,10 +88,9 @@
     {% if supports_push %}
       <li class="list-group-item">
         {% if user_can_push_translation %}
-          <a href="#"
-             class="float-end link-post btn btn-primary"
-             data-href="{% url "push" path=object.get_url_path %}"
-             {% if not can_push %}disabled="disabled"{% endif %}>{% translate "Push" %}</a>
+          <button type="button"
+                  class="float-end btn btn-primary{% if can_push %} link-post{% endif %}"
+                  {% if can_push %}data-href="{% url "push" path=object.get_url_path %}"{% else %}disabled aria-describedby="push-disabled-reason"{% endif %}>{% translate "Push" %}</button>
         {% endif %}
         <h6 class="mb-1 fw-bold">
           {% blocktranslate count units=outgoing_commits with count=outgoing_commits|intcomma %}{{ count }} outgoing commit{% plural %}{{ count }} outgoing commits{% endblocktranslate %}
@@ -100,6 +99,11 @@
           {% endif %}
         </h6>
         <p class="mb-0">{{ push_label }}</p>
+        {% if not can_push %}
+          <p class="mb-0" id="push-disabled-reason">
+            {% translate "Pushing is disabled because no repository push URL is configured." %}
+          </p>
+        {% endif %}
       </li>
     {% endif %}
     <li class="list-group-item">
@@ -320,6 +324,15 @@
         </td>
       </tr>
     </table>
+    {% with repository_owner=component.effective_repo_component %}
+      {% perm 'component.edit' repository_owner as user_can_edit_repository %}
+      {% if user_can_edit_repository %}
+        <div class="card-footer">
+          <a class="btn btn-primary"
+             href="{% url 'settings' path=repository_owner.get_url_path %}#vcs">{% translate "Edit repository configuration" %}</a>
+        </div>
+      {% endif %}
+    {% endwith %}
   </div>
 {% endfor %}
 

--- a/weblate/trans/tests/test_git_views.py
+++ b/weblate/trans/tests/test_git_views.py
@@ -207,8 +207,130 @@ class GitNoChangeProjectTest(ViewTestCase):
             response = self.client.get(self.get_test_url("git_status"))
         self.assertContains(response, "Repository status")
 
+    def test_status_push_configuration(self) -> None:
+        for push, needs_push_url, can_push in (
+            ("", True, False),
+            (self.component.repo, True, True),
+            ("", False, True),
+        ):
+            with self.subTest(push=push, needs_push_url=needs_push_url):
+                Component.objects.filter(pk=self.component.pk).update(
+                    push=push, push_branch=""
+                )
+                with patch.object(
+                    self.component.repository_class, "needs_push_url", needs_push_url
+                ):
+                    response = self.client.get(self.get_test_url("git_status"))
+                self.assertEqual(response.context["can_push"], can_push)
+                if can_push:
+                    self.assertContains(
+                        response,
+                        '<button type="button" class="float-end btn btn-primary '
+                        f'link-post" data-href="{self.get_test_url("push")}">Push</button>',
+                        html=True,
+                    )
+                    self.assertNotContains(response, 'id="push-disabled-reason"')
+                else:
+                    self.assertContains(
+                        response,
+                        '<button type="button" class="float-end btn btn-primary" '
+                        'disabled aria-describedby="push-disabled-reason">Push</button>',
+                        html=True,
+                    )
+                    self.assertContains(
+                        response,
+                        "Pushing is disabled because no repository push URL is configured.",
+                    )
+
+    def test_status_repository_configuration_link(self) -> None:
+        response = self.client.get(self.get_test_url("git_status"))
+        settings_url = reverse(
+            "settings", kwargs={"path": self.component.get_url_path()}
+        )
+        self.assertContains(
+            response,
+            f'<a class="btn btn-primary" href="{settings_url}#vcs">'
+            "Edit repository configuration</a>",
+            html=True,
+        )
+
 
 class RepositoryPermissionScopeTest(ViewTestCase):
+    def test_status_repository_configuration_link_permissions(self) -> None:
+        self.user.groups.clear()
+        self.grant_permission("vcs.view", project=self.project)
+        self.grant_permission("vcs.push", project=self.project)
+        for obj in (self.project, self.component, self.translation):
+            with self.subTest(obj=obj):
+                response = self.client.get(
+                    reverse("git_status", kwargs={"path": obj.get_url_path()})
+                )
+                self.assertContains(response, "Repository status")
+                self.assertNotContains(response, "Edit repository configuration")
+
+    def test_status_linked_repository_configuration(self) -> None:
+        linked = self.create_link_existing()
+        self.user.groups.clear()
+        self.grant_permission("vcs.view", project=self.project)
+        self.grant_permission("vcs.push", project=self.project)
+        self.grant_permission("component.edit", component=self.component)
+        settings_url = reverse(
+            "settings", kwargs={"path": self.component.get_url_path()}
+        )
+        linked_settings_url = reverse(
+            "settings", kwargs={"path": linked.get_url_path()}
+        )
+        for obj in (self.project, linked):
+            with self.subTest(obj=obj):
+                response = self.client.get(
+                    reverse("git_status", kwargs={"path": obj.get_url_path()})
+                )
+                self.assertContains(response, f'href="{settings_url}#vcs"', count=1)
+                self.assertNotContains(response, f'href="{linked_settings_url}#vcs"')
+
+    def test_status_cross_project_repository_configuration(self) -> None:
+        other_project = self.create_project(name="Other", slug="other")
+        linked = self.create_link_existing(project=other_project)
+        self.user.groups.clear()
+        self.grant_permission("vcs.view", project=self.project)
+        self.grant_permission("vcs.view", project=other_project)
+        self.grant_permission("vcs.push", project=self.project)
+        self.grant_permission("vcs.push", project=other_project)
+        self.grant_permission("component.edit", component=linked)
+        settings_url = reverse(
+            "settings", kwargs={"path": self.component.get_url_path()}
+        )
+        linked_settings_url = reverse(
+            "settings", kwargs={"path": linked.get_url_path()}
+        )
+        status_url = reverse(
+            "git_status", kwargs={"path": other_project.get_url_path()}
+        )
+
+        response = self.client.get(status_url)
+        self.assertContains(response, "Repository status")
+        self.assertEqual(list(response.context["repositories"]), [linked])
+        self.assertNotContains(response, "Edit repository configuration")
+        self.assertNotContains(response, f'href="{linked_settings_url}#vcs"')
+
+        self.grant_permission("component.edit", component=self.component)
+        response = self.client.get(status_url)
+        self.assertContains(response, f'href="{settings_url}#vcs"', count=1)
+        self.assertNotContains(response, f'href="{linked_settings_url}#vcs"')
+
+    def test_status_mixed_push_configuration(self) -> None:
+        independent = self.create_po(project=self.project, name="Independent")
+        Component.objects.filter(pk=self.component.pk).update(push="")
+        Component.objects.filter(pk=independent.pk).update(push=independent.repo)
+        self.user.groups.clear()
+        self.grant_permission("vcs.view", project=self.project)
+        self.grant_permission("vcs.push", project=self.project)
+        response = self.client.get(
+            reverse("git_status", kwargs={"path": self.project.get_url_path()})
+        )
+        self.assertTrue(response.context["can_push"])
+        self.assertNotContains(response, 'id="push-disabled-reason"')
+
     def grant_permission(
         self,
         permission: str,


### PR DESCRIPTION
Prevent no-op push actions when the VCS requires a missing push URL, and explain why pushing is disabled. Add permission-aware links to repository configuration on component and project status pages.

Fixes #21539

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
