### PR TITLE
fix(migrations): backfill alert dismissals using historical models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,15 @@ For application-developer workflows and broader product integration guidance, us
 
 ## Testing and linting instructions
 
+- Complex data migrations must have populated upgrade tests in `ci/run-migrate`:
+  add old-version setup and post-upgrade assertion scripts in
+  `ci/migrate-scripts/`, gated to applicable source releases. Seed data that
+  exercises conditional branches and cross-app relationships, and verify the
+  resulting data, not just successful migration execution. Empty-database runs
+  and helper tests against the latest schema do not detect missing migration
+  dependencies or premature access to future columns. Use historical models
+  from `apps.get_model()` and declare dependencies for the models accessed.
+  Keep migration database access independent of current model helpers.
 - For an isolated worktree environment, use the development container workflow
   in `docs/contributing/start.rst` (`devcontainer` section). Run
   `./scripts/devcontainer up`, then use `./scripts/devcontainer exec --` before

--- a/ci/migrate-scripts/assert-alerts.py
+++ b/ci/migrate-scripts/assert-alerts.py
@@ -1,0 +1,34 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Verify populated alert lifecycle migration results after upgrading."""
+
+from __future__ import annotations
+
+from weblate.trans.models import Alert
+
+alerts = Alert.objects.filter(component_id=1, details__migration_test=True)
+assert alerts.count() == 19, "Migration test alerts were lost"
+for alert in alerts:
+    assert alert.details == {
+        "migration_test": True,
+        "error": "migration failure",
+        "occurrences": [
+            {"addon": "weblate.gettext.msgmerge", "addon_id": "123", "error": "failure"}
+        ],
+    }, f"Alert details changed: {alert.name}"
+    assert alert.dismissed_by_id is None
+    assert not alert.dismissal_reason
+    if alert.name == "DuplicateString":
+        assert alert.dismissed_at is None
+        assert not alert.dismissal_fingerprint
+    else:
+        assert alert.dismissed_at is not None, f"Dismissal lost: {alert.name}"
+        assert alert.dismissed_at >= alert.timestamp
+        assert (
+            alert.dismissal_fingerprint
+            == alert.alert_class.get_dismissal_fingerprint(
+                alert.component, alert.details
+            )
+        ), f"Dismissal context changed: {alert.name}"

--- a/ci/migrate-scripts/setup-alerts.py
+++ b/ci/migrate-scripts/setup-alerts.py
@@ -1,0 +1,93 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Populate the branches of the alert lifecycle migration on the old schema."""
+
+from __future__ import annotations
+
+from weblate.addons.models import Addon
+from weblate.lang.models import Language
+from weblate.screenshots.models import Screenshot
+from weblate.trans.models import Alert, Component, Translation
+
+component = Component.objects.get(pk=1)
+source = component.source_translation
+unit = source.unit_set.order_by("pk").first()
+source.unit_set.filter(pk=unit.pk).update(
+    source='Migration <a href="https://example.com/">link</a>', extra_flags="safe-html"
+)
+# Include both used and unused screenshots, and source units without screenshots.
+for name in ("migration-used", "migration-unused"):
+    screenshot = Screenshot.objects.create(
+        name=name, translation=source, image="screenshots/migration.png"
+    )
+    if name == "migration-used":
+        screenshot.units.add(unit)
+
+# Avoid runtime translation/add-on initialization and external repository work.
+Translation.objects.bulk_create(
+    [
+        Translation(
+            component=component,
+            language=Language.objects.get(code="ku"),
+            language_code="ku",
+            plural=source.plural,
+            filename="ku.po",
+        )
+    ]
+)
+Addon.objects.bulk_create(
+    [
+        Addon(component=component, name="weblate.gettext.xgettext", configuration={}),
+        Addon(
+            project=component.project, name="weblate.gettext.msgmerge", configuration={}
+        ),
+    ]
+)
+
+# These names are stored as data even on releases predating the alert classes.
+# Exercise every distinct context, including the default and normalization cases.
+names = (
+    "MissingLicense",
+    "MissingRepositoryHook",
+    "MissingPushURL",
+    "MissingTranslationInstructions",
+    "BrokenProjectURL",
+    "MonolingualGlossary",
+    "GlossaryStringManagementDisabled",
+    "RepositoryChanges",
+    "GitHubAppMigration",
+    "MissingScreenshots",
+    "MissingTranslationFlags",
+    "MissingSafeHTMLFlag",
+    "UnusedScreenshot",
+    "AmbiguousLanguage",
+    "RecommendedLanguageConsistencyAddon",
+    "ExtractPotMissingMsgmerge",
+    "MsgmergeAddonError",
+    "UpdateFailure",
+)
+for name in (*names, "DuplicateString"):
+    Alert.objects.update_or_create(
+        component=component,
+        name=name,
+        defaults={
+            "dismissed": name != "DuplicateString",  # type: ignore[misc]
+            "details": {
+                "migration_test": True,
+                "error": "migration failure",
+                "occurrences": [
+                    {
+                        "addon": "weblate.gettext.msgmerge",
+                        "addon_id": "123",
+                        "error": "failure",
+                    }
+                ],
+            },
+        },
+    )
+# The old schema has a dismissed field which is absent from current type stubs.
+assert Alert.objects.filter(  # type: ignore[misc]
+    component=component, details__migration_test=True, dismissed=True
+).count() == len(names)

--- a/ci/run-migrate
+++ b/ci/run-migrate
@@ -153,6 +153,14 @@ if [ "$gettext_header_settings_migrate" -eq 0 ]; then
     check
 fi
 
+# Exercise the alert lifecycle backfill with dismissed alerts in the old schema.
+semver_compare "$1" "<" "2026.8"
+alert_lifecycle_migrate=$?
+if [ "$alert_lifecycle_migrate" -eq 0 ]; then
+    ./manage.py shell < "$MIGRATE_DIR/migrate-scripts/setup-alerts.py"
+    check
+fi
+
 git reset --hard
 check
 git checkout "$HEAD_COMMIT"
@@ -231,5 +239,10 @@ fi
 if [ "$gettext_header_settings_migrate" -eq 0 ]; then
     # check that the gettext file format header settings have been migrated
     uv run --all-extras ./manage.py shell < "$MIGRATE_DIR/migrate-scripts/assert-gettext-header-settings.py"
+    check
+fi
+
+if [ "$alert_lifecycle_migrate" -eq 0 ]; then
+    uv run --all-extras ./manage.py shell < "$MIGRATE_DIR/migrate-scripts/assert-alerts.py"
     check
 fi

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@ Weblate 2026.10
 .. rubric:: Bug fixes
 
 * Fixed :ref:`Docker startup warning checks <docker-startup-warnings>` failing when the warning directory is missing or inaccessible.
+* Fixed an :ref:`upgrade <generic-upgrade-instructions>` failure when migrating dismissed component alerts from releases before 2026.8.
 
 .. rubric:: Compatibility
 

--- a/weblate/trans/alerts/base.py
+++ b/weblate/trans/alerts/base.py
@@ -4,9 +4,7 @@
 
 from __future__ import annotations
 
-import json
 from collections import defaultdict
-from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 from django.db import models
@@ -14,6 +12,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy
 
 from weblate.utils.docs import get_doc_url
+from weblate.utils.hash import calculate_json_fingerprint
 
 if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
@@ -116,10 +115,7 @@ class BaseAlert:
     @classmethod
     def get_dismissal_fingerprint(cls, component, details: dict[str, Any]) -> str:
         context = cls.get_dismissal_context(component, details)
-        serialized = json.dumps(
-            context, sort_keys=True, separators=(",", ":"), default=str
-        )
-        return sha256(serialized.encode()).hexdigest()
+        return calculate_json_fingerprint(context)
 
     @classmethod
     def can_user_act_for(cls, user: User, component, _details: dict[str, Any]) -> bool:

--- a/weblate/trans/migrations/0094_alert_lifecycle.py
+++ b/weblate/trans/migrations/0094_alert_lifecycle.py
@@ -11,42 +11,226 @@ from django.conf import settings
 from django.db import migrations, models
 from django.utils import timezone
 
+from weblate.utils.hash import calculate_json_fingerprint
+
 if TYPE_CHECKING:
     from django.db.backends.base.schema import BaseDatabaseSchemaEditor
     from django.db.migrations.state import StateApps
 
 
-def backfill_dismissals(alerts) -> None:
-    # Import the current model because historical migration models do not expose
-    # the component helpers used by alert-specific dismissal contexts.
-    # ruff: ignore[import-outside-top-level]
-    from weblate.trans.alerts.registry import get_alert_class
-    from weblate.trans.models.component import (  # ruff: ignore[import-outside-top-level]
-        Component,
+# Keep these contexts local to the migration: runtime alert classes and model
+# helpers can start querying fields which do not exist at this migration state.
+def get_addon_names(apps: StateApps, component, database: str) -> list[str]:
+    Addon = apps.get_model("addons", "Addon")
+    category_ids = []
+    category = component.category
+    while category is not None:
+        category_ids.append(category.pk)
+        category = category.category
+    query = (
+        models.Q(component_id=component.pk)
+        | models.Q(project_id=component.project_id)
+        | models.Q(category_id__in=category_ids)
+        | models.Q(component__isnull=True, category__isnull=True, project__isnull=True)
+    )
+    if component.linked_component_id:
+        query |= models.Q(component_id=component.linked_component_id, repo_scope=True)
+    return sorted(
+        Addon.objects.using(database).filter(query).values_list("name", flat=True)
     )
 
+
+def get_unit_context(apps: StateApps, component, name: str, database: str) -> dict:
+    context: dict = {}
+    Unit = apps.get_model("trans", "Unit")
+    units = (
+        Unit.objects.using(database)
+        .filter(
+            translation__component_id=component.pk,
+            translation__language_id=component.source_language_id,
+        )
+        .order_by("pk")
+    )
+    if name == "MissingScreenshots":
+        context["units_without_screenshots"] = list(
+            units.filter(screenshots__isnull=True).values_list("pk", flat=True)
+        )
+    else:
+        context["check_flags"] = component.check_flags
+        if name == "MissingTranslationFlags":
+            context["flags"] = list(
+                units.exclude(extra_flags="").values_list("pk", "extra_flags")
+            )
+        else:
+            context["units"] = list(
+                units.filter(source__contains="<a ").values_list("pk", "extra_flags")
+            )
+    return context
+
+
+def get_addon_error_context(details: dict) -> dict:
+    context = {"details": details}
+    occurrences = details.get("occurrences")
+    if isinstance(occurrences, list):
+        context["details"] = {
+            **details,
+            "occurrences": [
+                {key: value for key, value in occurrence.items() if key != "addon_id"}
+                if isinstance(occurrence, dict)
+                else occurrence
+                for occurrence in occurrences
+            ],
+        }
+    return context
+
+
+def get_repository_error_context(details: dict) -> dict:
+    context: dict = {}
+    # This formatter does not access the database.
+    from weblate.vcs.base import format_stored_repository_error  # ruff: ignore[import-outside-top-level]
+
+    context["details"] = {
+        key: value
+        for key, value in details.items()
+        if key not in {"diagnoses", "error"}
+    }
+    if error := details.get("error"):
+        context["details"]["error"] = format_stored_repository_error(error).replace(
+            "repository URL", "..."
+        )
+    return context
+
+
+def get_dismissal_context(
+    apps: StateApps, component, name: str, details: dict, database: str
+) -> dict:
+    context: dict = {"details": details}
+    match name:
+        case "MissingRepositoryHook":
+            context["repo"] = component.repo
+        case "MissingPushURL":
+            context.update(repo=component.repo, push=component.push)
+        case "MissingTranslationInstructions":
+            context.update(
+                access_control=component.project.access_control,
+                instructions=component.project.instructions,
+            )
+        case "BrokenProjectURL":
+            context["web"] = component.project.web
+        case "MonolingualGlossary":
+            context["template"] = component.template
+        case "GlossaryStringManagementDisabled":
+            context.update(
+                repo=component.repo, source_language=component.source_language_id
+            )
+        case "RepositoryChanges":
+            context.update(
+                branch=component.branch,
+                local_revision=component.local_revision,
+                repo=component.repo,
+            )
+        case "GitHubAppMigration":
+            context.update(
+                repo=component.repo,
+                vcs=component.vcs,
+                workspace=str(component.project.workspace_id or ""),
+            )
+        case "MissingScreenshots" | "MissingTranslationFlags" | "MissingSafeHTMLFlag":
+            context.update(get_unit_context(apps, component, name, database))
+        case "UnusedScreenshot":
+            Screenshot = apps.get_model("screenshots", "Screenshot")
+            context["screenshots"] = list(
+                Screenshot.objects.using(database)
+                .filter(translation__component_id=component.pk, units__isnull=True)
+                .order_by("pk")
+                .values_list("pk", flat=True)
+            )
+        case "AmbiguousLanguage":
+            Translation = apps.get_model("trans", "Translation")
+            context["languages"] = list(
+                Translation.objects.using(database)
+                .filter(component_id=component.pk, language__code__in=("ku", "kur"))
+                .order_by("language__code")
+                .values_list("language__code", flat=True)
+            )
+        case (
+            "RecommendedLanguageConsistencyAddon"
+            | "RecommendedLinguasAddon"
+            | "RecommendedConfigureAddon"
+            | "RecommendedCleanupAddon"
+            | "RecommendedGenerateMoAddon"
+            | "RecommendedXgettextAddon"
+            | "RecommendedMesonAddon"
+            | "RecommendedDjangoAddon"
+            | "RecommendedSphinxAddon"
+            | "ExtractPotMissingMsgmerge"
+        ):
+            addons = get_addon_names(apps, component, database)
+            if name == "ExtractPotMissingMsgmerge":
+                addons = [
+                    addon
+                    for addon in addons
+                    if addon
+                    in {
+                        "weblate.gettext.xgettext",
+                        "weblate.gettext.meson",
+                        "weblate.gettext.django",
+                        "weblate.gettext.sphinx",
+                        "weblate.gettext.msgmerge",
+                    }
+                ]
+            else:
+                context["new_base"] = component.new_base
+            context.update(addons=addons, file_format=component.file_format)
+        case (
+            "AddonScriptError"
+            | "CDNAddonError"
+            | "MsgmergeAddonError"
+            | "ExtractPotAddonError"
+        ):
+            context.update(get_addon_error_context(details))
+        case (
+            "MergeFailure"
+            | "RepositoryOperationFailure"
+            | "PushFailure"
+            | "UpdateFailure"
+            | "AutomergeFailure"
+        ):
+            context.update(get_repository_error_context(details))
+    return context
+
+
+def backfill_dismissals(apps: StateApps, alerts) -> None:
+    Component = apps.get_model("trans", "Component")
     dismissed_at = timezone.now()
     components = Component.objects.using(alerts.db).in_bulk(
         alerts.values_list("component_id", flat=True).distinct()
     )
     for alert in alerts.iterator():
+        context = get_dismissal_context(
+            apps, components[alert.component_id], alert.name, alert.details, alerts.db
+        )
         alert.dismissed_at = dismissed_at
-        alert.dismissal_fingerprint = get_alert_class(
-            alert.name
-        ).get_dismissal_fingerprint(components[alert.component_id], alert.details)
-        alert.save(update_fields=("dismissed_at", "dismissal_fingerprint"))
+        alert.dismissal_fingerprint = calculate_json_fingerprint(context)
+        alert.save(
+            using=alerts.db, update_fields=("dismissed_at", "dismissal_fingerprint")
+        )
 
 
 def backfill_dismissed_at(
     apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
 ) -> None:
     Alert = apps.get_model("trans", "Alert")
-    backfill_dismissals(Alert.objects.filter(dismissed=True))
+    backfill_dismissals(
+        apps, Alert.objects.using(schema_editor.connection.alias).filter(dismissed=True)
+    )
 
 
 def restore_dismissed(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
     Alert = apps.get_model("trans", "Alert")
-    Alert.objects.filter(dismissed_at__isnull=False).update(dismissed=True)
+    Alert.objects.using(schema_editor.connection.alias).filter(
+        dismissed_at__isnull=False
+    ).update(dismissed=True)
 
 
 class Migration(migrations.Migration):

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
+from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import connection
 from django.http import QueryDict
@@ -971,7 +972,9 @@ class AlertTest(ViewTestCase):
         self.component.add_alert("BrokenProjectURL", error="failure")
         alert = self.component.alert_set.get(name="BrokenProjectURL")
 
-        migration.backfill_dismissals(self.component.alert_set.filter(pk=alert.pk))
+        migration.backfill_dismissals(
+            apps, self.component.alert_set.filter(pk=alert.pk)
+        )
         self.component.add_alert("BrokenProjectURL", error="failure")
 
         alert.refresh_from_db()
@@ -1006,7 +1009,9 @@ class AlertTest(ViewTestCase):
         self.component.add_alert("MsgmergeAddonError", occurrences=[occurrence])
         alert = self.component.alert_set.get(name="MsgmergeAddonError")
 
-        migration.backfill_dismissals(self.component.alert_set.filter(pk=alert.pk))
+        migration.backfill_dismissals(
+            apps, self.component.alert_set.filter(pk=alert.pk)
+        )
         self.component.add_alert(
             "MsgmergeAddonError",
             occurrences=[{**occurrence, "addon_id": "123"}],

--- a/weblate/utils/hash.py
+++ b/weblate/utils/hash.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import json
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 from siphashc import siphash
@@ -54,3 +56,14 @@ def checksum_to_hash(checksum: str) -> int:
 def hash_to_checksum(id_hash: int) -> str:
     """Convert id_hash (signed 64-bit int) to unsigned hex."""
     return format(id_hash + 2**63, "016x")
+
+
+def calculate_json_fingerprint(context: dict[str, Any]) -> str:
+    """
+    Hash a JSON context, preserving the format used by stored alert dismissals.
+
+    Historical migrations use this helper too. Keep its serialization stable
+    and independent of models or database access.
+    """
+    serialized = json.dumps(context, sort_keys=True, separators=(",", ":"), default=str)
+    return sha256(serialized.encode()).hexdigest()

--- a/weblate/utils/tests/test_hash.py
+++ b/weblate/utils/tests/test_hash.py
@@ -2,12 +2,17 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
+from uuid import UUID
+
 from django.test import SimpleTestCase
 
 from weblate.utils.hash import (
     calculate_checksum,
     calculate_dict_hash,
     calculate_hash,
+    calculate_json_fingerprint,
     checksum_to_hash,
     hash_to_checksum,
 )
@@ -58,4 +63,34 @@ class HashTest(SimpleTestCase):
         self.assertNotEqual(
             calculate_dict_hash({"a": 2, "b": 2}),
             calculate_dict_hash({"a": 1, "b": 2}),
+        )
+
+    def test_json_fingerprint_compatibility(self) -> None:
+        """Stored dismissals and historical migrations need stable serialization."""
+        self.assertEqual(
+            calculate_json_fingerprint(
+                {
+                    "details": {"label": "Čeština", "count": 2},
+                    "ids": [3, 1],
+                    "revision": UUID("12345678-1234-5678-1234-567812345678"),
+                }
+            ),
+            "4f210e9e14ee189de65e17fa4e261b87b122ba4eadbdc40bc31c9512202004cc",
+        )
+
+    def test_json_fingerprint_ordering(self) -> None:
+        fingerprint = calculate_json_fingerprint(
+            {"details": {"a": 1, "b": 2}, "ids": [3, 1]}
+        )
+        self.assertEqual(
+            fingerprint,
+            calculate_json_fingerprint({"ids": [3, 1], "details": {"b": 2, "a": 1}}),
+        )
+        self.assertNotEqual(
+            fingerprint,
+            calculate_json_fingerprint({"ids": [1, 3], "details": {"a": 1, "b": 2}}),
+        )
+        self.assertNotEqual(
+            fingerprint,
+            calculate_json_fingerprint({"ids": [3, 1], "details": {"a": 1, "b": "2"}}),
         )


### PR DESCRIPTION
Avoid querying current model fields before their migrations run. Share stable fingerprint serialization, exercise populated alert contexts in upgrade CI, and require complex migration coverage in AGENTS.md.

Fixes #21554

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
