### PR TITLE
fix(docs): avoid EU site linkcheck failures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -386,6 +386,10 @@ nitpick_ignore = [
 # Number of retries and timeout for linkcheck
 linkcheck_retries = 10
 linkcheck_timeout = 10
+linkcheck_anchors_ignore_for_url = [
+    # JavaScript robot checks prevent verifying article anchors
+    r"https://eur-lex\.europa\.eu/",
+]
 linkcheck_ignore = [
     # Local URL to Weblate
     "http://127.0.0.1:8080/",
@@ -411,6 +415,7 @@ linkcheck_ignore = [
     "https://platform.openai.com/docs/models",
     "https://translate.systran.net/en/account",
     "https://api.sap.com/api/translationhub/overview",
+    r"https://www\.enisa\.europa\.eu/topics/product-security/single-reporting-platform-srp/cra-srp-glossary$",
     # Anchor is not there for linkcheck
     "https://hub.docker.com/_/postgres#pgdata",
     "https://github.com/SAML-Toolkits/python3-saml#settings",


### PR DESCRIPTION
Skip EUR-Lex anchor checks blocked by JavaScript robot verification and ignore the ENISA glossary URL returning HTTP 403. Keep URL availability checks for EUR-Lex and leave Sentry checking unchanged.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
