### PR TITLE
test(trans): select failing checks deterministically

### DIFF
--- a/weblate/trans/tests/test_component.py
+++ b/weblate/trans/tests/test_component.py
@@ -1028,7 +1028,7 @@ class ComponentTest(RepoTestCase):
         """Setting of check_flags changes checks for related units."""
         component = self.create_component()
         self.assertEqual(Check.objects.count(), 3)
-        check = Check.objects.all()[0]
+        check = Check.objects.filter(name="same")[0]
         component.check_flags = f"ignore-{check.name}"
         with self.captureOnCommitCallbacks(execute=True):
             component.save()
@@ -1038,7 +1038,7 @@ class ComponentTest(RepoTestCase):
         """Moving to category changes checks inherited by related units."""
         component = self.create_component()
         self.assertEqual(Check.objects.count(), 3)
-        check = Check.objects.all()[0]
+        check = Check.objects.filter(name="same")[0]
         category = component.project.category_set.create(
             name="Checks", slug="checks", check_flags=f"ignore-{check.name}"
         )

--- a/weblate/trans/tests/test_models.py
+++ b/weblate/trans/tests/test_models.py
@@ -1568,7 +1568,7 @@ class SourceUnitTest(ModelTestCase):
     def test_check_flags(self) -> None:
         """Setting of Source check_flags changes checks for related units."""
         self.assertEqual(Check.objects.count(), 3)
-        check = Check.objects.all()[0]
+        check = Check.objects.filter(name="same")[0]
         unit = check.unit
         # reload component to clear stats cache
         self.component = unit.translation.component


### PR DESCRIPTION
Select the same check explicitly when testing inherited ignore flags. Unordered queries could select multiple_failures instead, producing an invalid ignore flag and intermittent failures.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
