### PR TITLE
fix(billing): restrict self-service trial plans

### DIFF
--- a/docs/security/threat-model.rst
+++ b/docs/security/threat-model.rst
@@ -25,7 +25,7 @@ documentation; ``*(maintainer)*`` means it was stated by a maintainer during
 this threat-model process; ``*(inferred)*`` means it was reasoned from the
 current project shape and needs maintainer confirmation.
 
-Provenance summary: 118 documented / 70 maintainer / 0 inferred claims.
+Provenance summary: 118 documented / 71 maintainer / 0 inferred claims.
 
 Weblate is a Django-based web localization platform. It accepts work from
 browser users, API clients, project-scoped tokens, repository webhooks, VCS
@@ -822,6 +822,12 @@ Security properties Weblate provides
      - Security-critical when it blocks investigation of privileged changes or
        discloses retained personal data; privacy-impacting when data exceeds the
        configured retention; correctness-only for minor event gaps.
+   * - Self-service trial creation grants only the designated commercial trial
+       plan or the Libre setup plan. *(maintainer)*
+     - The deployment offers self-service hosting trials.
+     - An authenticated user can select another public, private, or internal
+       billing plan when creating a trial.
+     - Security-critical when this bypasses paid service limits.
    * - Rate-limited API and web actions enforce configured rate limits.
        *(documented)* (source: :doc:`/api`, :doc:`/admin/config`)
      - Rate limiting is enabled and backed by a working datastore.

--- a/weblate/accounts/tests/test_views.py
+++ b/weblate/accounts/tests/test_views.py
@@ -38,6 +38,7 @@ from weblate.accounts.notifications import (
 )
 from weblate.accounts.views import log_handled_auth_failure
 from weblate.auth.models import Group, Permission, Role, User
+from weblate.billing.defines import TRIAL_PLAN_SLUG
 from weblate.billing.models import Billing, Plan
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
@@ -225,7 +226,7 @@ class ViewTest(RepoTestCase):
     @override_settings(OFFER_HOSTING=True)
     def test_libre(self) -> None:
         """Test for hosting form with enabled hosting."""
-        self.get_user()
+        user = self.get_user()
         self.client.login(username="testuser", password="testpassword")
 
         Plan.objects.create(price=0, slug="libre", name="Libre")
@@ -236,6 +237,8 @@ class ViewTest(RepoTestCase):
         # Creating a trial
         response = self.client.post(reverse("trial"), {"plan": "libre"}, follow=True)
         self.assertContains(response, "Create project")
+        billing = Billing.objects.get(workspace__defined_groups__memberships__user=user)
+        self.assertEqual(billing.plan.slug, "libre")
 
     @override_settings(OFFER_HOSTING=False)
     def test_trial_disabled(self) -> None:
@@ -249,7 +252,7 @@ class ViewTest(RepoTestCase):
     @modify_settings(INSTALLED_APPS={"append": "weblate.billing"})
     def test_trial(self) -> None:
         """Test for trial form with disabled hosting."""
-        Plan.objects.create(price=1, slug="640k")
+        Plan.objects.create(price=1, slug=TRIAL_PLAN_SLUG)
         user = self.get_user()
         self.client.login(username="testuser", password="testpassword")
         response = self.client.get(reverse("trial"))
@@ -258,10 +261,37 @@ class ViewTest(RepoTestCase):
         self.assertContains(response, "Create project")
         billing = Billing.objects.get(workspace__defined_groups__memberships__user=user)
         self.assertTrue(billing.is_trial)
+        self.assertEqual(billing.plan.slug, TRIAL_PLAN_SLUG)
 
         # Repeated attempt should fail
         response = self.client.get(reverse("trial"))
         self.assertRedirects(response, f"{reverse('contact')}?t=trial")
+
+    @override_settings(OFFER_HOSTING=True)
+    @modify_settings(INSTALLED_APPS={"append": "weblate.billing"})
+    def test_trial_plan_validation(self) -> None:
+        Plan.objects.create(name="Trial", price=1, slug=TRIAL_PLAN_SLUG)
+        Plan.objects.create(name="Larger", price=2, slug="10M")
+        user = self.get_user()
+        self.client.login(username=user.username, password="testpassword")
+        billing_count = Billing.objects.count()
+        workspace_count = Workspace.objects.count()
+
+        for plan in ("10M", "missing"):
+            with self.subTest(plan=plan):
+                reset_rate_limit("trial", user=user)
+                response = self.client.post(reverse("trial"), {"plan": plan})
+                self.assertEqual(response.status_code, 400)
+                self.assertContains(response, "Invalid trial plan.", status_code=400)
+                self.assertEqual(Billing.objects.count(), billing_count)
+                self.assertEqual(Workspace.objects.count(), workspace_count)
+                self.assertFalse(user.auditlog_set.filter(activity="trial").exists())
+
+        reset_rate_limit("trial", user=user)
+        response = self.client.post(reverse("trial"), {"plan": TRIAL_PLAN_SLUG})
+        self.assertEqual(response.status_code, 302)
+        billing = Billing.objects.get(workspace__defined_groups__memberships__user=user)
+        self.assertEqual(billing.plan.slug, TRIAL_PLAN_SLUG)
 
     def test_contact_subject(self) -> None:
         # With set subject

--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -170,7 +170,7 @@ from weblate.auth.utils import (
     prefetch_membership_limit_languages,
     validate_team_assignable_user,
 )
-from weblate.billing.defines import TRIAL_DAYS
+from weblate.billing.defines import TRIAL_DAYS, TRIAL_PLAN_SLUG
 from weblate.logger import LOGGER
 from weblate.trans.models import Change, Component, Project, Suggestion, Translation
 from weblate.trans.models.component import translation_prefetch_tasks
@@ -715,7 +715,12 @@ def trial(request: AuthenticatedHttpRequest):
     if not settings.OFFER_HOSTING:
         return redirect("home")
 
-    plan = request.POST.get("plan", "640k")
+    plan = request.POST.get("plan", TRIAL_PLAN_SLUG)
+    if plan not in {"libre", TRIAL_PLAN_SLUG}:
+        return HttpResponseBadRequest(
+            gettext("Invalid trial plan."),
+            content_type="text/plain; charset=utf-8",
+        )
 
     # Avoid frequent requests for a trial for same user
     if plan != "libre" and request.user.auditlog_set.filter(activity="trial").exists():
@@ -756,6 +761,7 @@ def trial(request: AuthenticatedHttpRequest):
         {
             "title": gettext("Gratis trial"),
             "trial_days": TRIAL_DAYS,
+            "trial_plan": TRIAL_PLAN_SLUG,
         },
     )
 

--- a/weblate/billing/defines.py
+++ b/weblate/billing/defines.py
@@ -5,4 +5,5 @@
 from __future__ import annotations
 
 TRIAL_DAYS: int = 14
+TRIAL_PLAN_SLUG: str = "640k"
 REMOVAL_EXTENSION_DAYS: int = 14

--- a/weblate/templates/accounts/trial.html
+++ b/weblate/templates/accounts/trial.html
@@ -24,7 +24,7 @@
         <div class="card-body">
           <ul>
             <li>{% blocktranslate count days=trial_days %}Your trial will last {{ days }} day.{% plural %}Your trial will last {{ days }} days.{% endblocktranslate %}</li>
-            <li>{% translate "Your trial will run the 640k plan, but you can choose any plan later." %}</li>
+            <li>{% blocktranslate %}Your trial will run the {{ trial_plan }} plan, but you can choose any plan later.{% endblocktranslate %}</li>
             <li>{% translate "No credit card is needed, but you can set the payment method anytime." %}</li>
             <li>{% translate "All configuration will stay once you start paying." %}</li>
           </ul>


### PR DESCRIPTION
Prevent authenticated users from selecting arbitrary paid or internal plans when creating a trial. Centralize the designated trial plan for request validation and UI messaging.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
