### PR TITLE
fix(security): reject case-folded VCS metadata paths

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ Weblate 2026.10
 
 .. rubric:: Security fixes
 
+* Prevented component ZIP imports from overwriting version control metadata on case-insensitive filesystems.
+
 .. rubric:: Bug fixes
 
 * Fixed :ref:`Docker startup warning checks <docker-startup-warnings>` failing when the warning directory is missing or inaccessible.

--- a/weblate/utils/files.py
+++ b/weblate/utils/files.py
@@ -32,7 +32,7 @@ SCRIPTS_DIR = os.path.join(BASE_DIR, "scripts")
 CLIENT_DIR = os.path.join(BASE_DIR, "client")
 EXAMPLES_DIR = os.path.join(BASE_DIR, "weblate", "examples")
 
-PATH_EXCLUDES = [f"/{exclude}/" for exclude in EXCLUDES]
+PATH_EXCLUDES = [f"/{exclude.casefold()}/" for exclude in EXCLUDES]
 VCS_METADATA_DIRS = frozenset((".git", ".hg"))
 REPO_TEMP_DIRNAME = "weblate-tmp"
 
@@ -99,7 +99,7 @@ def should_skip(location: str | os.PathLike[str]) -> bool:
 
 def is_excluded(path: str) -> bool:
     """Whether path should be excluded from zip extraction."""
-    normalized = path.replace("\\", "/")
+    normalized = path.replace("\\", "/").casefold()
     return any(
         exclude in f"/{normalized}/" for exclude in PATH_EXCLUDES
     ) or is_unsafe_path(path)
@@ -120,7 +120,7 @@ def is_unsafe_path(path: str) -> bool:
 
 def is_vcs_metadata_path(path: str) -> bool:
     """Whether path points to VCS metadata."""
-    normalized = path.replace("\\", "/")
+    normalized = path.replace("\\", "/").casefold()
     return any(part in VCS_METADATA_DIRS for part in PurePosixPath(normalized).parts)
 
 

--- a/weblate/utils/tests/test_files.py
+++ b/weblate/utils/tests/test_files.py
@@ -84,6 +84,26 @@ class FilesTestCase(SimpleTestCase):
     def test_is_excluded_allows_regular_relative_paths(self) -> None:
         self.assertFalse(is_excluded("locale/cs/messages.po"))
 
+    def test_is_excluded_rejects_casefolded_paths(self) -> None:
+        for path in (
+            ".GIT/config",
+            ".Git/CONFIG",
+            "nested/.gIt/config",
+            ".HG/HGRC",
+            r"nested\.Hg\hgrc",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(is_excluded(path))
+
+    def test_is_excluded_preserves_mixed_case_excludes(self) -> None:
+        self.assertTrue(is_excluded(".DS_Store"))
+        self.assertTrue(is_excluded("__MACOSX/metadata"))
+
+    def test_is_excluded_allows_similar_names(self) -> None:
+        for path in (".gitignore", ".hgignore", "docs/.gitish/config"):
+            with self.subTest(path=path):
+                self.assertFalse(is_excluded(path))
+
     def test_is_unsafe_path(self) -> None:
         self.assertTrue(is_unsafe_path("../outside.po"))
         self.assertTrue(is_unsafe_path("/etc/passwd"))
@@ -93,8 +113,11 @@ class FilesTestCase(SimpleTestCase):
     def test_is_vcs_metadata_path(self) -> None:
         self.assertTrue(is_vcs_metadata_path(".git/config"))
         self.assertTrue(is_vcs_metadata_path("path/.hg/hgrc"))
+        self.assertTrue(is_vcs_metadata_path(".GIT/CONFIG"))
+        self.assertTrue(is_vcs_metadata_path(r"path\.Hg\hgrc"))
         self.assertFalse(is_vcs_metadata_path("build/translation.txt"))
         self.assertFalse(is_vcs_metadata_path("node_modules/translation.txt"))
+        self.assertFalse(is_vcs_metadata_path("docs/.gitish/config"))
 
     def test_is_path_within_directory_accepts_descendants(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/weblate/utils/tests/test_validators.py
+++ b/weblate/utils/tests/test_validators.py
@@ -180,12 +180,18 @@ class FilenameTest(SimpleTestCase):
     def test_prohibited(self) -> None:
         with self.assertRaises(ValidationError):
             validate_filename(".git/config")
+        with self.assertRaises(ValidationError):
+            validate_filename(".GIT/CONFIG")
         validate_filename(".git/config", check_prohibited=False)
+        validate_filename(".GIT/CONFIG", check_prohibited=False)
 
     def test_prohibited_subdir(self) -> None:
         with self.assertRaises(ValidationError):
             validate_filename("path/.git/config")
+        with self.assertRaises(ValidationError):
+            validate_filename(r"path\.Hg\hgrc")
         validate_filename("path/.git/config", check_prohibited=False)
+        validate_filename(r"path\.Hg\hgrc", check_prohibited=False)
 
 
 class RegexTest(SimpleTestCase):

--- a/weblate/vcs/tests/test_vcs.py
+++ b/weblate/vcs/tests/test_vcs.py
@@ -5507,6 +5507,24 @@ remove the file manually to continue.
             LocalRepository.from_zip(target, archive)
         self.assertFalse(os.path.exists(target))
 
+    def test_from_zip_excludes_casefolded_vcs_metadata(self) -> None:
+        archive = BytesIO()
+        with ZipFile(archive, "w") as zipfile:
+            zipfile.writestr(".GIT/config", "[casefold]\nsentinel = true\n")
+            zipfile.writestr(".HG/hgrc", "casefold sentinel")
+            zipfile.writestr("locale/cs.po", "msgid ''\nmsgstr ''\n")
+        archive.seek(0)
+        target = Path(self.tempdir) / "from-zip-casefolded-metadata"
+
+        repo = LocalRepository.from_zip(str(target), archive)
+
+        self.assertTrue(repo.is_valid())
+        self.assertTrue((target / "locale" / "cs.po").is_file())
+        self.assertNotIn(
+            "casefold", (target / ".git" / "config").read_text(encoding="utf-8")
+        )
+        self.assertFalse((target / ".hg" / "hgrc").exists())
+
     def test_from_zip_rejects_too_many_entries(self) -> None:
         archive = BytesIO()
         with ZipFile(archive, "w") as zipfile:


### PR DESCRIPTION
Normalize archive exclusions and VCS metadata checks consistently so mixed-case paths cannot overwrite repository configuration on case-insensitive filesystems.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
