### PR TITLE
feat(support): submit monthly instance activity metrics

### DIFF
--- a/docs/admin/support.rst
+++ b/docs/admin/support.rst
@@ -28,6 +28,16 @@ Info sent to the Weblate
 * The version you are running
 * Tallies of projects, components, languages, source strings, and users
 * The public SSH key of your instance
+* Monthly activity summaries from the instance statistics for the last 24 completed
+  months, used to monitor subscription activity and rank
+  servers in Discover Weblate. Months without stored metrics are reported as zero.
+
+Monthly activity uses the same cached summaries as the instance statistics page
+at :file:`/stats/`. These are trend indicators grouped by metric collection
+month. Each daily metric counts the preceding day's changes, so the September
+summary covers changes from August 31 through September 29. This keeps completed
+monthly summaries independent of the collection job on the first day of the
+following month. Use :doc:`/devel/reporting` for reports over exact date ranges.
 
 Additionally, if you turn on :ref:`discover-weblate`:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.10
 
 .. rubric:: Improvements
 
+* Added monthly instance activity to the :ref:`data sent with support integration <support-data>` for activity monitoring and discovery ranking.
 * Improved :ref:`repository maintenance <repository-maintenance>` with disabled push controls when push configuration is missing and direct links to component VCS settings.
 * Whitespace characters are now rendered consistently in the source string display and the translation editor, and different kinds of whitespace are now distinguishable from each other.
 * Added a :ref:`keyboard shortcut <keyboard>` to approve a translation and save and continue.

--- a/weblate/metrics/wrapper.py
+++ b/weblate/metrics/wrapper.py
@@ -268,6 +268,7 @@ class MetricsWrapper:
         return f"{self.cache_key_prefix}:month:{year}:{month}"
 
     def get_month_date_range(self, year: int, month: int) -> tuple[date, date]:
+        """Return collection dates for a monthly activity trend summary."""
         return (
             date(year, month, 1),
             date(year, month, monthrange(year, month)[1]),
@@ -291,6 +292,9 @@ class MetricsWrapper:
             .filter(date__range=(min(starts), max(ends)))
             .values_list("date", "changes")
         ):
+            # Each metric counts the preceding day's changes. Keep grouping by
+            # collection month for trend summaries, so a completed month does
+            # not depend on the first collection job of the following month.
             totals[metric_date.year, metric_date.month] += changes
 
         cache_updates = {}
@@ -302,30 +306,32 @@ class MetricsWrapper:
         # Cache for one year
         cache.set_many(cache_updates, 365 * 24 * 3600)
 
-    def get_month_activity(
-        self, year: int, month: int, cached_results: dict[str, int]
-    ) -> int:
-        return cached_results[self.get_month_cache_key(year, month)]
-
     @cached_property
-    def monthly_activity(self) -> list[dict[str, int | date | str | Promise]]:
+    def monthly_activity_totals(self) -> dict[tuple[int, int], int]:
+        """Return 24 completed collection months, oldest first, zero-filled."""
         months: list[tuple[int, int]] = []
-        activity_months: list[tuple[int, int]] = []
         last_month_date = timezone.now().date().replace(day=1) - timedelta(days=1)
         month = last_month_date.month
         year = last_month_date.year
-        for _dummy in range(12):
+        for _dummy in range(24):
             months.append((year, month))
-            activity_months.extend(((year, month), (year - 1, month)))
             month -= 1
             if month < 1:
                 month = 12
                 year -= 1
 
         cached_results: dict[str, int] = cache.get_many(
-            list(starmap(self.get_month_cache_key, activity_months))
+            list(starmap(self.get_month_cache_key, months))
         )
-        self.populate_month_activity_cache(activity_months, cached_results)
+        self.populate_month_activity_cache(months, cached_results)
+        return {
+            (year, month): cached_results[self.get_month_cache_key(year, month)]
+            for year, month in reversed(months)
+        }
+
+    @cached_property
+    def monthly_activity(self) -> list[dict[str, int | date | str | Promise]]:
+        totals = self.monthly_activity_totals
         result: list[dict[str, int | date | str | Promise]] = [
             {
                 "month": month,
@@ -338,10 +344,10 @@ class MetricsWrapper:
                 "previous_end_date": date(
                     year - 1, month, monthrange(year - 1, month)[1]
                 ),
-                "current": self.get_month_activity(year, month, cached_results),
-                "previous": self.get_month_activity(year - 1, month, cached_results),
+                "current": totals[year, month],
+                "previous": totals[year - 1, month],
             }
-            for year, month in reversed(months)
+            for year, month in list(totals)[-12:]
         ]
 
         maximum = max(1, *(max(item["current"], item["previous"]) for item in result))  # type: ignore[call-overload]

--- a/weblate/trans/tests/test_charts.py
+++ b/weblate/trans/tests/test_charts.py
@@ -4,6 +4,8 @@
 
 """Test for charts and widgets."""
 
+from __future__ import annotations
+
 from calendar import monthrange
 from datetime import date, timedelta
 
@@ -30,6 +32,7 @@ class ChartsTest(FixtureTestCase):
 
         last_month = timezone.now().date().replace(day=1) - timedelta(days=1)
         month_start = date(last_month.year, last_month.month, 1)
+        zero_month = month_start - timedelta(days=1)
         previous_year = last_month.year - 1
         previous_month_end = date(
             previous_year,
@@ -64,6 +67,13 @@ class ChartsTest(FixtureTestCase):
                     date=previous_month_end,
                     changes=4,
                 ),
+                Metric(
+                    scope=Metric.SCOPE_TRANSLATION,
+                    relation=self.translation.pk,
+                    secondary=0,
+                    date=zero_month,
+                    changes=0,
+                ),
             ]
         )
 
@@ -77,3 +87,21 @@ class ChartsTest(FixtureTestCase):
 
         self.assertEqual(activity[-1]["current"], 5)
         self.assertEqual(activity[-1]["previous"], 4)
+        self.assertEqual(activity[-2]["current"], 0)
+        self.assertEqual(activity[-2]["previous"], 0)
+
+        warm_wrapper = MetricsWrapper(
+            self.translation, Metric.SCOPE_TRANSLATION, self.translation.pk
+        )
+        with self.assertNumQueries(0):
+            self.assertEqual(warm_wrapper.monthly_activity, activity)
+            totals = warm_wrapper.monthly_activity_totals
+        self.assertEqual(totals[zero_month.year, zero_month.month], 0)
+        self.assertEqual(totals[zero_month.year - 1, zero_month.month], 0)
+
+        cache.delete(wrapper.get_month_cache_key(last_month.year, last_month.month))
+        partial_wrapper = MetricsWrapper(
+            self.translation, Metric.SCOPE_TRANSLATION, self.translation.pk
+        )
+        with self.assertNumQueries(1):
+            self.assertEqual(partial_wrapper.monthly_activity, activity)

--- a/weblate/wladmin/models.py
+++ b/weblate/wladmin/models.py
@@ -20,6 +20,8 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy
 
 from weblate.auth.models import User
+from weblate.metrics.models import Metric
+from weblate.metrics.wrapper import MetricsWrapper
 from weblate.trans.models import Component, Project
 from weblate.utils.backup import (
     BackupError,
@@ -195,6 +197,7 @@ class SupportStatus(models.Model):
 
     def refresh(self, *, site_url: str | None = None) -> None:
         stats = GlobalStats()
+        metrics = MetricsWrapper(None, Metric.SCOPE_GLOBAL, 0)
         data = {
             "secret": self.secret,
             "site_url": site_url or get_site_url(),
@@ -206,6 +209,19 @@ class SupportStatus(models.Model):
             "source_strings": stats.source_strings,
             "strings": stats.all,
             "words": stats.all_words,
+            "activity": json.dumps(
+                [
+                    {
+                        "year": year,
+                        "month": month,
+                        "changes": changes,
+                    }
+                    for (
+                        year,
+                        month,
+                    ), changes in metrics.monthly_activity_totals.items()
+                ]
+            ),
         }
         if self.discoverable:
             data["discoverable"] = 1

--- a/weblate/wladmin/tests.py
+++ b/weblate/wladmin/tests.py
@@ -8,7 +8,7 @@ import importlib
 import json
 import os
 from contextlib import contextmanager
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from io import StringIO
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -21,6 +21,7 @@ import httpx2
 from django.apps import apps
 from django.conf import settings
 from django.core import mail
+from django.core.cache import cache
 from django.core.checks import Critical
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -36,6 +37,8 @@ from lxml import html
 from weblate.accounts.models import AuditLog
 from weblate.auth.models import Group, Invitation, Permission, Role
 from weblate.memory.models import Memory, MemoryScope, MemoryScopeMigrationState
+from weblate.metrics.models import Metric
+from weblate.metrics.wrapper import MetricsWrapper
 from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Announcement, Change, Project
 from weblate.trans.tests.test_views import ViewTestCase
@@ -2383,6 +2386,110 @@ class AdminTest(ViewTestCase):
         )
         self.assertNotIn("discoverable", refresh_body)
         self.assertNotIn("public_projects", refresh_body)
+
+    @http_mock.activate
+    def test_support_refresh_activity(self) -> None:
+        http_mock.register(
+            "POST",
+            get_support_url(),
+            text=json.dumps(
+                {
+                    "name": "community",
+                    "backup_repository": "",
+                    "expiry": timezone.now(),
+                    "in_limits": True,
+                    "has_subscription": False,
+                    "limits": {},
+                },
+                cls=DjangoJSONEncoder,
+            ),
+        )
+        months = [
+            date(2024 + offset // 12, offset % 12 + 1, 1) for offset in range(8, 32)
+        ]
+        for available_months in (months, [months[0], months[-1]], []):
+            cache.clear()
+            Metric.objects.filter(scope=Metric.SCOPE_GLOBAL).delete()
+            Metric.objects.bulk_create(
+                [
+                    Metric(
+                        scope=Metric.SCOPE_GLOBAL,
+                        relation=0,
+                        date=month,
+                        changes=index,
+                    )
+                    for index, month in enumerate(available_months)
+                ]
+            )
+            changes_by_month = {
+                month: index for index, month in enumerate(available_months)
+            }
+            expected = [
+                {
+                    "year": month.year,
+                    "month": month.month,
+                    "changes": changes_by_month.get(month, 0),
+                }
+                for month in months
+            ]
+            if available_months:
+                Metric.objects.create(
+                    scope=Metric.SCOPE_GLOBAL,
+                    relation=0,
+                    date=available_months[-1].replace(day=15),
+                    changes=42,
+                )
+                expected[-1]["changes"] += 42
+            # Neither out-of-window data nor other scopes/relations contribute.
+            for metric_date, scope, relation, secondary in (
+                (date(2024, 8, 31), Metric.SCOPE_GLOBAL, 0, 0),
+                (date(2026, 9, 1), Metric.SCOPE_GLOBAL, 0, 0),
+                (date(2026, 10, 1), Metric.SCOPE_GLOBAL, 0, 0),
+                (date(2026, 8, 20), Metric.SCOPE_PROJECT, self.project.pk, 0),
+                (date(2026, 8, 20), Metric.SCOPE_GLOBAL, 1, 0),
+                (date(2026, 8, 20), Metric.SCOPE_GLOBAL, 0, 1),
+            ):
+                Metric.objects.update_or_create(
+                    scope=scope,
+                    relation=relation,
+                    secondary=secondary,
+                    date=metric_date,
+                    defaults={"changes": 1000},
+                )
+            for status in (
+                SupportStatus(secret="secret-123", has_subscription=True),
+                SupportStatus(secret="secret-123", discoverable=True),
+                SupportStatus(
+                    secret="secret-123", has_subscription=True, enabled=False
+                ),
+            ):
+                with (
+                    self.subTest(
+                        months=len(available_months),
+                        subscribed=status.has_subscription,
+                        discoverable=status.discoverable,
+                        enabled=status.enabled,
+                    ),
+                    patch(
+                        "weblate.wladmin.models.timezone.now",
+                        return_value=datetime(2026, 9, 10, tzinfo=UTC),
+                    ),
+                ):
+                    # The statistics chart and support refresh share the cache.
+                    chart = MetricsWrapper(
+                        None, Metric.SCOPE_GLOBAL, 0
+                    ).monthly_activity
+                    self.assertEqual(len(chart), 12)
+                    with CaptureQueriesContext(connection) as queries:
+                        status.refresh()
+                    self.assertFalse(
+                        any(
+                            '"metrics_metric"' in query["sql"]
+                            for query in queries.captured_queries
+                        )
+                    )
+                    body = parse_qs(get_response_call_body(-1))
+                    self.assertEqual(json.loads(body["activity"][0]), expected)
 
     @http_mock.activate
     def test_support_refresh_includes_discoverable_projects(self) -> None:


### PR DESCRIPTION
Share cached monthly totals with the statistics chart and report the last 24 completed months on every support refresh. This provides activity history for subscription monitoring and discovery ranking while preserving existing cache entries and zero-filled missing months.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
