### PR TITLE
refactor(urls): make redirect trust boundaries explicit

### DIFF
--- a/weblate/trans/tests/test_edit.py
+++ b/weblate/trans/tests/test_edit.py
@@ -442,6 +442,7 @@ class SearchRecoveryTest(ViewTestCase):
         self.assertEqual(response.context["filter_pos"], 1)
         self.assertEqual(response.context["filter_count"], len(ids) - 1)
         self.assertNotContains(response, self.recovery_message)
+        self.assertTrue(response.redirect_chain[-1][0].startswith("?"))
         self.assertNotIn("refresh=", response.redirect_chain[-1][0])
         response = self.client.get(
             self.url, {"q": self.query, "sort_by": "source", "offset": "1"}

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -539,7 +539,7 @@ class SearchNavigation:
         result = self.page(include_count=True, page_size=page_size)
         if isinstance(result, HttpResponse):
             return result
-        return redirect(f"{self.request.path}?{self.search_url}&offset=1")
+        return HttpResponseRedirect(f"?{self.search_url}&offset=1")
 
     def get_reordered_cached_session_data(
         self, source: CachedSearchSnapshot, *, reset_offset_to_last_viewed: bool

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -71,11 +71,24 @@ handler403 = weblate.trans.views.error.denied
 handler404 = weblate.trans.views.error.not_found
 handler500 = weblate.trans.views.error.server_error
 
+STATIC_ICON_REDIRECTS = {
+    "192": "weblate-192.png",
+    "512": "weblate-512.png",
+}
+
 
 def redirect_static(
-    _request: django.http.HttpRequest | None, filename: str, **kwargs: str
+    _request: django.http.HttpRequest | None,
+    filename: str,
+    *,
+    size: str | None = None,
 ) -> django.http.HttpResponsePermanentRedirect:
-    stable_url = f"{settings.STATIC_URL.rstrip('/')}/{filename % kwargs}"
+    if size is not None:
+        try:
+            filename = STATIC_ICON_REDIRECTS[size]
+        except KeyError as error:
+            raise django.http.Http404 from error
+    stable_url = f"{settings.STATIC_URL.rstrip('/')}/{filename}"
     return redirect(stable_url, permanent=True)
 
 

--- a/weblate/utils/tests/test_static.py
+++ b/weblate/utils/tests/test_static.py
@@ -12,6 +12,7 @@ from tempfile import TemporaryDirectory
 
 from django.core.files.storage import storages
 from django.core.management import call_command
+from django.http import Http404
 from django.test import SimpleTestCase, override_settings
 
 from weblate.urls import redirect_static
@@ -164,3 +165,14 @@ class ManifestStaticFilesTest(SimpleTestCase):
 
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response.url, "/assets/favicon.ico")
+
+    @override_settings(STATIC_URL="/assets/")
+    def test_permanent_static_redirect_uses_allowed_size(self) -> None:
+        response = redirect_static(None, "weblate-%(size)s.png", size="192")
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.url, "/assets/weblate-192.png")
+
+    def test_permanent_static_redirect_rejects_invalid_size(self) -> None:
+        with self.assertRaises(Http404):
+            redirect_static(None, "weblate-%(size)s.png", size="//example.com")


### PR DESCRIPTION
Use a query-relative search redirect and map constrained icon sizes to trusted filenames. This addresses conservative CodeQL findings; the existing Django routes did not expose attacker-controlled external redirect targets.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
