### PR TITLE
feat(trans): allow creation of existing project languages

### DIFF
--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -998,6 +998,11 @@ Point to translation instructions URL
 Create new language file
     User can select language and Weblate automatically creates the file for it
     and translation can begin.
+Create existing project languages; contact maintainers for new languages
+    Users can create translations for languages already used as target languages
+    in another non-glossary component in the project. Other languages are requested
+    from maintainers, who approve them by creating the first target translation.
+    See :ref:`workflow-language-restrictions` for eligibility and API behavior.
 Disable adding new translations
     There will be no option for user to start new translation.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Weblate 2026.10
 
 .. rubric:: New features
 
+* Added an inherited :ref:`language creation policy <workflow-language-restrictions>` allowing existing project target languages while requesting maintainer approval for new languages.
 * Added configurable per-user and IP/network :ref:`API rate limits and exemptions <api-rate>`, including Docker configuration.
 
 .. rubric:: Improvements

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -34528,12 +34528,14 @@ components:
       - contact
       - url
       - add
+      - existing
       - none
       type: string
       description: |-
         * `contact` - Contact maintainers
         * `url` - Point to translation instructions URL
         * `add` - Create new language file
+        * `existing` - Create existing project languages; contact maintainers for new languages
         * `none` - Disable adding new translations
     NewUnitRequest:
       oneOf:

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -60,6 +60,31 @@ Control requests for languages that do not exist yet
     :ref:`component-new_lang` individually or automate the changes using
     :http:patch:`/api/components/(string:project)/(string:component)/`.
 
+    To allow existing project languages while requesting approval for new ones,
+    select :guilabel:`Create existing project languages; contact maintainers for new languages`.
+    A language qualifies when any non-glossary component in the project has a
+    target translation for it, even with no translated strings. Source-only
+    languages and glossary translations do not qualify. This applies across
+    categories, including shared components and components the contributor cannot
+    access.
+
+    Maintainers approve a language by creating its first target translation.
+    Removing the last qualifying translation removes eligibility. Component
+    overrides that allow unrestricted language creation can also introduce an
+    eligible language. Project and category submissions use the languages present
+    at the start of the operation, so component processing order does not affect
+    the result.
+
+    Project and category submissions modify only components owned by that project
+    or category. To add a language to a shared component, use its own language
+    creation page; the owning project's eligibility and permissions apply there.
+
+    The REST translation creation endpoint returns HTTP 403 for languages requiring
+    approval; submit these requests through the web interface. The permission to
+    add several languages does not bypass this policy. Maintainers and trusted
+    add-ons retain their existing creation permissions, and repository file
+    discovery is unaffected.
+
     Disabling new translations controls user requests. It does not stop
     discovery of translation files added to the repository or
     :ref:`automatic glossary language synchronization <glossary-language-sync>`.

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -5839,6 +5839,25 @@ class ProjectAPITest(APIBaseTest):
             )
         self.assertFalse(Project.objects.filter(slug="billing-acl-conflict").exists())
 
+    def test_patch_existing_language_policy(self) -> None:
+        self.do_request(
+            "api:project-detail",
+            self.project_kwargs,
+            method="patch",
+            code=403,
+            request={"new_lang": "existing"},
+        )
+        response = self.do_request(
+            "api:project-detail",
+            self.project_kwargs,
+            method="patch",
+            superuser=True,
+            request={"new_lang": "existing"},
+        )
+        self.assertEqual(response.data["effective_new_lang"], "existing")
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.new_lang, "existing")
+
     def test_patch_inherited_setting_disables_inheritance(self) -> None:
         workspace = Workspace.objects.create(
             name="API workspace", commit_message="Workspace commit"
@@ -9334,6 +9353,47 @@ class ComponentAPITest(APIBaseTest):
         self.component.new_lang = "add"
         self.component.new_base = "po/hello.pot"
         self.component.save()
+        self.do_request(
+            "api:component-translations",
+            self.component_kwargs,
+            method="post",
+            code=201,
+            request={"language_code": "fa"},
+        )
+
+    def test_create_translation_existing_policy(self) -> None:
+        self.component.new_lang = "existing"
+        self.component.inherit_new_lang = False
+        self.component.new_base = "po/hello.pot"
+        self.component.save()
+        response = self.do_request(
+            "api:component-translations",
+            self.component_kwargs,
+            method="post",
+            code=403,
+            request={"language_code": "fa"},
+        )
+        self.assertIn(
+            "requires maintainer approval", response.data["errors"][0]["detail"]
+        )
+        self.assertFalse(
+            self.component.translation_set.filter(language_code="fa").exists()
+        )
+        self.assertFalse(
+            self.component.change_set.filter(
+                action=ActionEvents.REQUESTED_LANGUAGE
+            ).exists()
+        )
+        self.grant_perm_to_user("translation.add_more", project=self.project)
+        self.do_request(
+            "api:component-translations",
+            self.component_kwargs,
+            method="post",
+            code=403,
+            request={"language_code": "fa"},
+        )
+        source = self.create_po_new_base(name="other", project=self.project)
+        source.add_new_language(Language.objects.get(code="fa"), None)
         self.do_request(
             "api:component-translations",
             self.component_kwargs,

--- a/weblate/api/views.py
+++ b/weblate/api/views.py
@@ -3056,6 +3056,15 @@ class ComponentViewSet(
                 message = f"Could not add {language_code!r}!"
                 raise ValidationError({"language_code": message}) from error
 
+            if obj.get_new_language_action(request.user, language) != "add":
+                self.permission_denied(
+                    request,
+                    "This language requires maintainer approval. "
+                    "Request it using the web interface.",
+                )
+            if not obj.can_add_new_language(request.user, language=language):
+                self.permission_denied(request, message=obj.new_lang_error_message)
+
             if source_components:
                 auto_permission = check_auto_translate_permission(
                     request.user,

--- a/weblate/templates/new-language.html
+++ b/weblate/templates/new-language.html
@@ -55,6 +55,9 @@
               {% if new_lang == "contact" and not can_add %}
                 <p>{% translate "Project maintainers are notified of this request, prompting them to add the language manually." %}</p>
               {% endif %}
+              {% if new_lang == "existing" %}
+                <p>{% translate "Languages already used as target languages in this project can be added immediately. Other languages are requested from the project maintainers." %}</p>
+              {% endif %}
               {{ form|crispy }}
               {% if user_can_add_more_translation %}
                 {% if contact_form != "disabled" %}
@@ -69,7 +72,9 @@
               {% endif %}
               </div>
               <div class="card-footer">
-                {% if new_lang == "contact" %}
+                {% if new_lang == "existing" %}
+                  <input class="btn btn-primary" type="submit" value="{% translate "Submit" %}" />
+                {% elif new_lang == "contact" %}
                   <input class="btn btn-primary"
                          type="submit"
                          value="{% translate "Request new translation" %}" />

--- a/weblate/templates/new-project-or-category-language.html
+++ b/weblate/templates/new-project-or-category-language.html
@@ -17,6 +17,9 @@
         </div>
         <div class="card-body">
           <p>{% translate "Please choose the language you want to translate to." %}</p>
+          {% if has_existing_language_policy %}
+            <p>{% translate "Languages already used as target languages in this project can be added immediately. Other languages are requested from the project maintainers." %}</p>
+          {% endif %}
           {{ form|crispy }}
           {% if user_can_add_more_translation %}
             {% if contact_form != "disabled" %}
@@ -32,7 +35,7 @@
         </div>
         <input class="btn btn-primary"
                type="submit"
-               value="{% translate "Start new translation" %}" />
+               value="{% if has_existing_language_policy %}{% translate "Submit" %}{% else %}{% translate "Start new translation" %}{% endif %}" />
       </div>
     </form>
   </div>

--- a/weblate/trans/inherited_settings.py
+++ b/weblate/trans/inherited_settings.py
@@ -20,6 +20,13 @@ NEW_LANG_CHOICES = (
     # Translators: Action when adding new translation
     ("add", gettext_lazy("Create new language file")),
     # Translators: Action when adding new translation
+    (
+        "existing",
+        gettext_lazy(
+            "Create existing project languages; contact maintainers for new languages"
+        ),
+    ),
+    # Translators: Action when adding new translation
     ("none", gettext_lazy("Disable adding new translations")),
 )
 

--- a/weblate/trans/migrations/0104_existing_project_languages.py
+++ b/weblate/trans/migrations/0104_existing_project_languages.py
@@ -1,0 +1,76 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("trans", "0103_project_public_sharing"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="category",
+            name="new_lang",
+            field=models.CharField(
+                choices=[
+                    ("contact", "Contact maintainers"),
+                    ("url", "Point to translation instructions URL"),
+                    ("add", "Create new language file"),
+                    (
+                        "existing",
+                        "Create existing project languages; contact maintainers for new languages",
+                    ),
+                    ("none", "Disable adding new translations"),
+                ],
+                default="add",
+                help_text="How to handle requests for creating new translations.",
+                max_length=10,
+                verbose_name="Adding new translation",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="component",
+            name="new_lang",
+            field=models.CharField(
+                choices=[
+                    ("contact", "Contact maintainers"),
+                    ("url", "Point to translation instructions URL"),
+                    ("add", "Create new language file"),
+                    (
+                        "existing",
+                        "Create existing project languages; contact maintainers for new languages",
+                    ),
+                    ("none", "Disable adding new translations"),
+                ],
+                default="add",
+                help_text="How to handle requests for creating new translations.",
+                max_length=10,
+                verbose_name="Adding new translation",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="project",
+            name="new_lang",
+            field=models.CharField(
+                choices=[
+                    ("contact", "Contact maintainers"),
+                    ("url", "Point to translation instructions URL"),
+                    ("add", "Create new language file"),
+                    (
+                        "existing",
+                        "Create existing project languages; contact maintainers for new languages",
+                    ),
+                    ("none", "Disable adding new translations"),
+                ],
+                default="add",
+                help_text="How to handle requests for creating new translations.",
+                max_length=10,
+                verbose_name="Adding new translation",
+            ),
+        ),
+    ]

--- a/weblate/trans/models/component.py
+++ b/weblate/trans/models/component.py
@@ -5327,7 +5327,7 @@ class Component(  # ruff: ignore[too-many-public-methods]
         """Validate new language choices."""
         # Validate if new base is configured or language adding is set
         if (
-            not self.new_base and self.effective_new_lang != "add"
+            not self.new_base and self.effective_new_lang not in {"add", "existing"}
         ) or not self.file_format:
             return
         # File is valid or no file is needed
@@ -6423,25 +6423,52 @@ class Component(  # ruff: ignore[too-many-public-methods]
     def is_multivalue(self):
         return self.file_format_cls.has_multiple_strings
 
-    def can_add_new_language(self, user: User | None, fast: bool = False):
+    def get_new_language_action(
+        self,
+        user: User | None,
+        language: Language | None = None,
+        *,
+        existing_language_ids: set[int] | None = None,
+    ) -> str:
+        """Resolve creation policy, optionally using a bulk operation's snapshot."""
+        mode = self.effective_new_lang
+        # Preserve the existing CLI/add-on and component administrator exceptions.
+        if (
+            mode == "add"
+            or user is None
+            or (user.is_bot and user.username.startswith("addon:"))
+            or user.has_perm("component.edit", self)
+        ):
+            return "add"
+        if mode != "existing":
+            return mode
+        # Without a selected language, report general creation capability.
+        if language is None:
+            return "add"
+        if existing_language_ids is None:
+            existing_language_ids = self.project.get_existing_target_language_ids()
+        return "add" if language.pk in existing_language_ids else "contact"
+
+    def can_add_new_language(
+        self,
+        user: User | None,
+        fast: bool = False,
+        *,
+        language: Language | None = None,
+        existing_language_ids: set[int] | None = None,
+    ):
         """
         Check if a new language can be added.
 
         Generic users can add only if configured, in other situations it works if there
         is valid new base.
         """
-        # Consistency and possibly other add-ons
-        if user is not None and user.is_bot and user.username.startswith("addon:"):
-            user = None
-        # The user is None in case of consistency or cli invocation
-        # The component.edit permission is intentional here as it allows overriding
-        # of new_lang configuration for admins and add languages even if adding
-        # for users is not configured.
         self.new_lang_error_message = gettext("Could not add new translation file.")
         if (
-            self.effective_new_lang != "add"
-            and user is not None
-            and not user.has_perm("component.edit", self)
+            self.get_new_language_action(
+                user, language, existing_language_ids=existing_language_ids
+            )
+            != "add"
         ):
             self.new_lang_error_message = gettext(
                 "You do not have permissions to add new translation file."
@@ -6498,6 +6525,8 @@ class Component(  # ruff: ignore[too-many-public-methods]
         send_signal: bool = True,
         create_translations: bool = True,
         show_messages: bool = True,
+        *,
+        existing_language_ids: set[int] | None = None,
     ) -> Translation | None:
         """Create new language file."""
 
@@ -6505,7 +6534,11 @@ class Component(  # ruff: ignore[too-many-public-methods]
             if show_messages:
                 messages.error(request, message)
 
-        if not self.can_add_new_language(request.user if request else None):
+        if not self.can_add_new_language(
+            request.user if request else None,
+            language=language,
+            existing_language_ids=existing_language_ids,
+        ):
             fail_message(cast("str", self.new_lang_error_message))
             return None
 

--- a/weblate/trans/models/project.py
+++ b/weblate/trans/models/project.py
@@ -1497,17 +1497,36 @@ class Project(models.Model, PathMixin, CacheKeyMixin, LockMixin):
             for translation in self.label_cleanups:
                 translation.stats.remove_stats(f"label:{name}")
 
+    def get_existing_target_language_ids(self) -> set[int]:
+        """Languages qualifying for the existing-project-language creation policy."""
+        # ruff: ignore[import-outside-top-level]
+        from weblate.trans.models.translation import Translation
+
+        translations = Translation.objects.filter(
+            component__is_glossary=False
+        ).exclude_source()
+        own = translations.filter(component__project=self).values_list(
+            "language_id", flat=True
+        )
+        shared = translations.filter(component__links=self).values_list(
+            "language_id", flat=True
+        )
+        return set(own.union(shared))
+
     def components_user_can_add_new_language(self, user: User) -> ComponentQuerySet:
-        """Return a queryset of components within the project that the given user is allowed to add new languages to."""
+        """Return owned components available for language creation or requests."""
         filter_ = Q(is_glossary=True)
         check_effective_new_lang = not user.has_perm("project.edit", self)
         if check_effective_new_lang:
             filter_ |= get_disabled_component_new_language_filter()
 
-        def filter_callback(qs: ComponentQuerySet) -> ComponentQuerySet:
-            return qs.exclude(filter_)
-
-        return self.get_child_components_access(user, filter_callback)
+        return (
+            self.component_set.defer_huge()
+            .filter_access(user)
+            .exclude(filter_)
+            .prefetch()
+            .order()
+        )
 
     def needs_license(self, access_control: int | None = None) -> bool:
         """

--- a/weblate/trans/tests/test_settings.py
+++ b/weblate/trans/tests/test_settings.py
@@ -227,6 +227,26 @@ class SettingsTest(ViewTestCase):
             set(component.all_flags), {"safe-html", "strict-same", "ignore-same"}
         )
 
+    def test_existing_language_policy_inheritance(self) -> None:
+        workspace = Workspace.objects.create(
+            name="Policy workspace", new_lang="existing"
+        )
+        self.project.workspace = workspace
+        self.project.inherit_new_lang = True
+        self.project.save()
+        category = Category.objects.create(
+            name="Policy", slug="policy", project=self.project
+        )
+        self.component.category = category
+        self.component.inherit_new_lang = True
+        self.component.save()
+        component = Component.objects.get(pk=self.component.pk)
+        self.assertEqual(component.effective_new_lang, "existing")
+        component.inherit_new_lang = False
+        component.new_lang = "contact"
+        component.save()
+        self.assertEqual(component.effective_new_lang, "contact")
+
     def test_inherited_setting_widget_state(self) -> None:
         self.project.license = "MIT"
         self.project.save()

--- a/weblate/trans/tests/test_views.py
+++ b/weblate/trans/tests/test_views.py
@@ -40,6 +40,7 @@ from weblate.auth.models import (
     setup_project_groups,
 )
 from weblate.lang.models import Language
+from weblate.trans.actions import ActionEvents
 from weblate.trans.models import (
     Category,
     Component,
@@ -55,6 +56,7 @@ from weblate.trans.tests.utils import (
     create_test_user,
     wait_for_celery,
 )
+from weblate.trans.views.basic import add_languages_to_component
 from weblate.utils.hash import hash_to_checksum
 from weblate.utils.state import STATE_TRANSLATED
 from weblate.utils.stats import CategoryLanguage, ProjectLanguage
@@ -519,6 +521,208 @@ class TranslationManipulationTest(ViewTestCase):
             self.component.translation_set.filter(language_code="af").exists()
         )
 
+    def test_existing_language_policy(self) -> None:
+        self.component.new_lang = "existing"
+        self.component.inherit_new_lang = False
+        self.component.save()
+        language = Language.objects.get(code="af")
+        request = self.get_request()
+        self.assertIsNone(self.component.add_new_language(language, request))
+        source = self.create_po_new_base(name="other", project=self.project)
+        self.assertIsNotNone(source.add_new_language(language, None))
+        self.assertIsNotNone(self.component.add_new_language(language, request))
+
+    def test_existing_language_request(self) -> None:
+        self.project.new_lang = "existing"
+        self.project.inherit_new_lang = False
+        self.project.save()
+        self.component.inherit_new_lang = True
+        self.component.save()
+        url = reverse("new-language", kwargs={"path": self.component.get_url_path()})
+        response = self.client.get(url)
+        self.assertContains(response, "Other languages are requested")
+        response = self.client.post(url, {"lang": "af"}, follow=True)
+        self.assertIn(
+            "A request for a new translation has been sent to the project's maintainers.",
+            [message.message for message in response.context["messages"]],
+        )
+        self.assertFalse(
+            self.component.translation_set.filter(language_code="af").exists()
+        )
+        self.assertTrue(
+            self.component.change_set.filter(
+                action=ActionEvents.REQUESTED_LANGUAGE
+            ).exists()
+        )
+
+    def test_existing_language_mixed_submission_change_references(self) -> None:
+        self.component.new_lang = "existing"
+        self.component.inherit_new_lang = False
+        self.component.save()
+        existing_language = Language.objects.get(code="af")
+        requested_language = Language.objects.get(code="fa")
+        source = self.create_po_new_base(name="other", project=self.project)
+        source.add_new_language(existing_language, None)
+
+        group = Group.objects.create(
+            name="Multiple languages", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        role = Role.objects.create(name="Multiple languages")
+        role.permissions.add(Permission.objects.get(codename="translation.add_more"))
+        group.roles.add(role)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("translation.add_more", self.component))
+        self.assertFalse(self.user.has_perm("component.edit", self.component))
+
+        _, counts = add_languages_to_component(
+            self.get_request(),
+            self.user,
+            [existing_language, requested_language],
+            self.component,
+            show_messages=False,
+        )
+        self.assertEqual(counts["added_af"], 1)
+        self.assertEqual(counts["requested_fa"], 1)
+        created = self.component.translation_set.get(language=existing_language)
+        added = self.component.change_set.get(action=ActionEvents.ADDED_LANGUAGE)
+        self.assertEqual(added.translation, created)
+        self.assertEqual(added.language, existing_language)
+        self.assertEqual(added.details["language"], "af")
+        requested = self.component.change_set.get(
+            action=ActionEvents.REQUESTED_LANGUAGE
+        )
+        self.assertIsNone(requested.translation_id)
+        self.assertIsNone(requested.language_id)
+        self.assertEqual(requested.component, self.component)
+        self.assertEqual(requested.details["language"], "fa")
+        self.assertEqual(
+            requested.get_absolute_url(), self.component.get_absolute_url()
+        )
+        self.assertFalse(
+            self.component.translation_set.filter(language=requested_language).exists()
+        )
+
+    def test_existing_language_shared_membership(self) -> None:
+        self.component.new_lang = "existing"
+        self.component.inherit_new_lang = False
+        self.component.save()
+        owner = self.create_project(name="Owner", slug="owner")
+        shared = self.create_po_new_base(name="shared", project=owner)
+        language = Language.objects.get(code="af")
+        shared.add_new_language(language, None)
+        ComponentLink.objects.create(component=shared, project=self.project)
+
+        self.assertIn(language.pk, self.project.get_existing_target_language_ids())
+        self.assertNotIn(
+            shared.source_language_id, self.project.get_existing_target_language_ids()
+        )
+        shared.is_glossary = True
+        shared.save(update_fields=["is_glossary"])
+        self.assertNotIn(language.pk, self.project.get_existing_target_language_ids())
+        shared.is_glossary = False
+        shared.save(update_fields=["is_glossary"])
+        self.assertIsNotNone(
+            self.component.add_new_language(language, self.get_request())
+        )
+
+    def test_language_addition_requires_component_permission(self) -> None:
+        owner = self.create_project(name="Owner", slug="owner")
+        shared = self.create_po_new_base(name="shared", project=owner, new_lang="add")
+        ComponentLink.objects.create(component=shared, project=self.project)
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Local languages", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        role = Role.objects.create(name="Local languages")
+        role.permissions.add(Permission.objects.get(codename="translation.add"))
+        group.roles.add(role)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("translation.add", self.project))
+        self.assertFalse(self.user.has_perm("translation.add", shared))
+        language = Language.objects.get(code="af")
+        with patch.object(shared, "commit_pending") as commit_pending:
+            _, counts = add_languages_to_component(
+                self.get_request(), self.user, [language], shared, show_messages=False
+            )
+        commit_pending.assert_not_called()
+        self.assertEqual(counts["errors_af"], 1)
+        self.assertFalse(shared.translation_set.filter(language=language).exists())
+        self.assertFalse(
+            shared.change_set.filter(
+                action__in=[
+                    ActionEvents.ADDED_LANGUAGE,
+                    ActionEvents.REQUESTED_LANGUAGE,
+                ]
+            ).exists()
+        )
+
+    def test_existing_language_membership(self) -> None:
+        language = Language.objects.get(code="af")
+        self.assertNotIn(
+            self.component.source_language_id,
+            self.project.get_existing_target_language_ids(),
+        )
+        source = self.create_po_new_base(name="other", project=self.project)
+        translation = source.add_new_language(language, None)
+        assert translation is not None
+        self.assertIn(language.pk, self.project.get_existing_target_language_ids())
+        category = Category.objects.create(
+            name="Other category", slug="other-category", project=self.project
+        )
+        Component.objects.filter(pk=source.pk).update(category=category)
+        self.assertIn(language.pk, self.project.get_existing_target_language_ids())
+        other_project = self.create_project(name="Other", slug="other")
+        Component.objects.filter(pk=source.pk).update(
+            project=other_project, category=None
+        )
+        self.assertNotIn(language.pk, self.project.get_existing_target_language_ids())
+        Component.objects.filter(pk=source.pk).update(project=self.project)
+        source.is_glossary = True
+        source.save(update_fields=["is_glossary"])
+        self.assertNotIn(language.pk, self.project.get_existing_target_language_ids())
+        source.is_glossary = False
+        source.save(update_fields=["is_glossary"])
+        translation.delete()
+        self.assertNotIn(language.pk, self.project.get_existing_target_language_ids())
+
+    def test_existing_language_privileged_creation(self) -> None:
+        self.component.new_lang = "existing"
+        self.component.inherit_new_lang = False
+        self.component.save()
+        self.user.is_superuser = True
+        self.user.save()
+        self.assertIsNotNone(
+            self.component.add_new_language(
+                Language.objects.get(code="af"), self.get_request()
+            )
+        )
+        self.assertIsNotNone(
+            self.component.add_new_language(Language.objects.get(code="fa"), None)
+        )
+
+    def test_existing_language_snapshot_cannot_be_replaced_by_live_membership(
+        self,
+    ) -> None:
+        self.component.new_lang = "existing"
+        self.component.inherit_new_lang = False
+        self.component.save()
+        snapshot = self.project.get_existing_target_language_ids()
+        language = Language.objects.get(code="af")
+        source = self.create_po_new_base(name="other", project=self.project)
+        source.add_new_language(language, None)
+        self.assertIsNone(
+            self.component.add_new_language(
+                language, self.get_request(), existing_language_ids=snapshot
+            )
+        )
+        self.assertFalse(
+            self.component.translation_set.filter(language=language).exists()
+        )
+
     def test_model_add_duplicate(self) -> None:
         request = self.get_request()
         self.assertFalse(get_messages(request))
@@ -632,6 +836,76 @@ class ProjectLanguageAdditionTest(ViewTestCase):
             [
                 "Please fix errors in the form.",
             ],
+        )
+
+    def test_bulk_language_addition_excludes_shared_components(self) -> None:
+        owner = self.create_project(name="Owner", slug="owner")
+        shared = self.create_po_new_base(
+            name="shared", project=owner, new_lang="existing", inherit_new_lang=False
+        )
+        ComponentLink.objects.create(
+            component=shared,
+            project=self.project,
+            category=self.obj if isinstance(self.obj, Category) else None,
+        )
+        language = Language.objects.get(code="af")
+        self.component.add_new_language(language, None)
+        self.user.groups.clear()
+        group = Group.objects.create(
+            name="Local languages", language_selection=SELECTION_ALL
+        )
+        group.projects.add(self.project)
+        role = Role.objects.create(name="Local languages")
+        role.permissions.add(Permission.objects.get(codename="translation.add"))
+        group.roles.add(role)
+        self.user.groups.add(group)
+        self.user.clear_permissions_cache()
+        self.assertTrue(self.user.has_perm("translation.add", self.project))
+        self.assertFalse(self.user.has_perm("translation.add", shared))
+
+        response = self.client.post(self.url, {"lang": "af"}, follow=True)
+        self.assertRedirects(response, self.obj.get_absolute_url())
+        self.assertTrue(
+            self.components["add"].translation_set.filter(language=language).exists()
+        )
+        self.assertFalse(shared.translation_set.filter(language=language).exists())
+        self.assertFalse(
+            shared.change_set.filter(
+                action__in=[
+                    ActionEvents.ADDED_LANGUAGE,
+                    ActionEvents.REQUESTED_LANGUAGE,
+                ]
+            ).exists()
+        )
+        # Bulk operations exclude shared components even for their administrators.
+        self.user.is_superuser = True
+        self.user.save()
+        self.user.clear_permissions_cache()
+        self.assertNotIn(
+            shared, self.obj.components_user_can_add_new_language(self.user)
+        )
+
+    def test_existing_language_bulk_snapshot(self) -> None:
+        component = self.components["contact"]
+        component.new_lang = "existing"
+        component.inherit_new_lang = False
+        component.save()
+        # Force unrestricted creation first, to exercise the snapshot.
+        with patch.object(
+            type(self.obj),
+            "components_user_can_add_new_language",
+            return_value=Component.objects.filter(
+                pk__in=[self.components["add"].pk, component.pk]
+            ).order_by("-pk"),
+        ):
+            response = self.client.post(self.url, {"lang": "af"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            self.components["add"].translation_set.filter(language_code="af").exists()
+        )
+        self.assertFalse(component.translation_set.filter(language_code="af").exists())
+        self.assertTrue(
+            component.change_set.filter(action=ActionEvents.REQUESTED_LANGUAGE).exists()
         )
 
     def test_view_add_language(self) -> None:

--- a/weblate/trans/views/basic.py
+++ b/weblate/trans/views/basic.py
@@ -987,6 +987,9 @@ def new_project_or_category_language(
                 lang_code: Counter() for lang_code in language_map
             }
 
+            existing_language_ids = (
+                obj.project if isinstance(obj, Category) else obj
+            ).get_existing_target_language_ids()
             for component in eligible_components:
                 _, component_counts = add_languages_to_component(
                     request,
@@ -994,6 +997,7 @@ def new_project_or_category_language(
                     languages,
                     component,
                     show_messages=False,
+                    existing_language_ids=existing_language_ids,
                 )
 
                 for lang_code in language_map:
@@ -1059,6 +1063,10 @@ def new_project_or_category_language(
             "path_object": obj,
             "project": obj,
             "form": form,
+            "has_existing_language_policy": any(
+                component.effective_new_lang == "existing"
+                for component in eligible_components
+            ),
         },
     )
 
@@ -1069,28 +1077,41 @@ def add_languages_to_component(
     languages: list[Language],
     component: Component,
     show_messages: bool,
+    *,
+    existing_language_ids: set[int] | None = None,
 ) -> tuple[Component | Translation | str, Counter[str]]:
+    if not user.has_perm("translation.add", component):
+        return component, Counter(
+            {f"errors_{language.code}": 1 for language in languages}
+        )
+    if existing_language_ids is None:
+        existing_language_ids = component.project.get_existing_target_language_ids()
     added_codes: set[str] = set()
     result: Component | Translation | str = component
     change_set: _ComponentChangeSet = component.change_set
-    kwargs: LanguageChangeKwargs = {
-        "user": user,
-        "component": component,
-        "details": {},
-    }
     lang_counts: Counter[str] = Counter()
     with component.repository.lock:
         component.commit_pending("add language", None)
         for language in languages:
             lang_code = language.code
-            kwargs["details"]["language"] = lang_code
+            kwargs: LanguageChangeKwargs = {
+                "user": user,
+                "component": component,
+                "details": {"language": lang_code},
+            }
 
-            if component.can_add_new_language(user):
+            action = component.get_new_language_action(
+                user, language, existing_language_ids=existing_language_ids
+            )
+            if component.can_add_new_language(
+                user, language=language, existing_language_ids=existing_language_ids
+            ):
                 translation = component.add_new_language(
                     language,
                     request,
                     create_translations=False,
                     show_messages=show_messages,
+                    existing_language_ids=existing_language_ids,
                 )
                 if translation:
                     added_codes.add(translation.language_code)
@@ -1101,7 +1122,7 @@ def add_languages_to_component(
                     lang_counts[f"added_{lang_code}"] += 1
                     continue
 
-            elif component.effective_new_lang == "contact":
+            elif action == "contact":
                 if component.translation_set.filter(language_code=lang_code).exists():
                     continue
                 change_set.create(action=ActionEvents.REQUESTED_LANGUAGE, **kwargs)

--- a/weblate/workspaces/migrations/0005_existing_project_languages.py
+++ b/weblate/workspaces/migrations/0005_existing_project_languages.py
@@ -1,0 +1,36 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workspaces", "0004_workspace_metric_id"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="workspace",
+            name="new_lang",
+            field=models.CharField(
+                choices=[
+                    ("contact", "Contact maintainers"),
+                    ("url", "Point to translation instructions URL"),
+                    ("add", "Create new language file"),
+                    (
+                        "existing",
+                        "Create existing project languages; contact maintainers for new languages",
+                    ),
+                    ("none", "Disable adding new translations"),
+                ],
+                default="add",
+                help_text="How to handle requests for creating new translations.",
+                max_length=10,
+                verbose_name="Adding new translation",
+            ),
+        ),
+    ]


### PR DESCRIPTION
Let contributors add existing project target languages while requesting maintainer approval for new ones. Reuse inherited settings and enforce the policy in web and API creation, with stable bulk eligibility and separate per-language change records.

Fixes #4015

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
