### PR TITLE
fix(search): align filters with the string status overview

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Weblate 2026.10
 .. rubric:: Improvements
 
 * :ref:`Automatic translation <auto-translation>` using other components now prefers translations with matching source text and context.
+* Aligned :ref:`string search filters <search-strings>` with the status overview's order and colors, and added an :guilabel:`All strings` option to clear the query.
 * Added monthly instance activity to the :ref:`data sent with support integration <support-data>` for activity monitoring and discovery ranking.
 * Improved :ref:`repository maintenance <repository-maintenance>` with disabled push controls when push configuration is missing and direct links to component VCS settings.
 * The :ref:`automatic translation add-on <addon-weblate.autotranslate.autotranslate>` can create approved strings, falling back to translated strings when reviews are disabled for the target language.

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -137,6 +137,11 @@ String search supports the shared query syntax above.
 
 When no field is defined, the lookup happens on source, target, and context strings.
 
+Select :guilabel:`All strings` at the top of the :guilabel:`Filters` menu to
+clear the query within the current search scope. If the form does not submit
+automatically, submit it to show all strings. Shared filters follow the order
+and status colors used in the strings status overview.
+
 .. image:: /screenshots/search.webp
 
 Simple search

--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -169,7 +169,6 @@ function insertAtCaret(element, myValue) {
   element.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
-// biome-ignore lint/correctness/noUnusedVariables: global helper used by editor/base.js and editor/full.js
 function replaceValue(element, myValue) {
   element.value = myValue;
   element.dispatchEvent(new Event("input", { bubbles: true }));
@@ -1921,18 +1920,20 @@ onReady(() => {
       }
 
       if (group.classList.contains("query-field")) {
+        const textarea = group.querySelector("textarea[name=q]");
         if (
           document.querySelector(".search-toolbar") === null &&
           link.closest(".result-page-form") !== null
         ) {
-          const textarea = group.querySelector("textarea[name=q]");
-          textarea.value = link.dataset.field ?? "";
-          textarea.dispatchEvent(new Event("change", { bubbles: true }));
+          replaceValue(textarea, link.dataset.field ?? "");
           const form = link.closest("form");
           form.querySelectorAll("input[name=offset]").forEach((input) => {
             input.disabled = true;
           });
           form.submit();
+        } else if (link.dataset.filter === "all") {
+          replaceValue(textarea, "");
+          textarea.focus();
         } else {
           insertAtCaret(
             group.querySelector("textarea[name=q]"),
@@ -1941,7 +1942,7 @@ onReady(() => {
         }
       }
       const dropdownToggle = link
-        .closest(".dropdown, .btn-group")
+        .closest(".dropdown, .btn-group, .query-field")
         ?.querySelector('[data-bs-toggle="dropdown"]');
       if (dropdownToggle) {
         bootstrap.Dropdown.getOrCreateInstance(dropdownToggle).hide();

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -239,10 +239,18 @@ ul.legend li {
 
 .legend .progress {
   width: 14px;
+  height: 14px;
+  border-radius: 3px;
 }
 
 .legend .progress-bar {
   width: 14px;
+}
+
+.filter-marker {
+  display: inline-block;
+  margin-inline-end: 0.5rem;
+  vertical-align: -1px;
 }
 
 .translatetext {

--- a/weblate/templates/snippets/query-field.html
+++ b/weblate/templates/snippets/query-field.html
@@ -12,11 +12,19 @@
       <span class="search-label">{% translate "Filters" %}</span>
     </button>
     <ul class="dropdown-menu shadow">
-      {% for _, name, query in custom_filter_list %}
+      {% for key, name, query, color in custom_filter_list %}
         <li>
-          <a class="dropdown-item"
-             href="#"
-             data-field="{{ query }}"><span class="title">{{ name }}</span> • <code>{{ query }}</code></a>
+          <a class="dropdown-item" href="#" data-filter="{{ key }}" data-field="{{ query }}">
+            <span class="legend filter-marker" aria-hidden="true">
+              <span class="progress">
+                {% if color %}
+                  <span class="progress-bar{% if color != "primary" %} progress-bar-{{ color }}{% endif %}"></span>
+                {% endif %}
+              </span>
+            </span>
+            <span class="title">{{ name }}</span>
+            {% if query %}• <code>{{ query }}</code>{% endif %}
+          </a>
         </li>
       {% endfor %}
     </ul>

--- a/weblate/trans/checklists.py
+++ b/weblate/trans/checklists.py
@@ -60,28 +60,26 @@ class TranslationChecklistMixin:
     @cached_property
     def list_translation_checks(self: TranslationProtocol) -> TranslationChecklist:
         """Return list of failing checks on current translation."""
-        result = TranslationChecklist()
+        result = TranslationChecklist(enable_review=self.enable_review)
 
         # All strings
         result.add(self.stats, "all", "")
 
-        result.add_if(
-            self.stats, "readonly", "primary" if self.enable_review else "success"
-        )
+        result.add_if(self.stats, "readonly", "")
 
         if not self.is_readonly:
             if self.enable_review:
-                result.add_if(self.stats, "approved", "primary")
+                result.add_if(self.stats, "approved", "")
 
             # Count of translated strings
-            result.add_if(self.stats, "translated", "success")
+            result.add_if(self.stats, "translated", "")
 
             # To approve
             if self.enable_review:
-                result.add_if(self.stats, "unapproved", "success")
+                result.add_if(self.stats, "unapproved", "")
 
                 # Approved with suggestions
-                result.add_if(self.stats, "approved_suggestions", "primary")
+                result.add_if(self.stats, "approved_suggestions", "")
 
             # Unfinished strings
             result.add_if(self.stats, "todo", "")
@@ -127,11 +125,19 @@ class TranslationChecklistMixin:
             if has_label:
                 result.add_if(self.stats, "unlabeled", "")
 
+        result.sort(
+            key=lambda item: FILTERS.get_filter_order(result.filter_ids[item[0]])
+        )
         return result
 
 
 class TranslationChecklist(UserList):
     """Simple list wrapper for translation checklist."""
+
+    def __init__(self, *, enable_review: bool = False) -> None:
+        super().__init__()
+        self.enable_review = enable_review
+        self.filter_ids: dict[str, str] = {}
 
     def add_if(self, stats, name, level) -> bool:
         """Add to list if there are matches."""
@@ -142,6 +148,9 @@ class TranslationChecklist(UserList):
 
     def add(self, stats, name, level) -> None:
         """Add item to the list."""
+        self.filter_ids[FILTERS.get_filter_query(name)] = name
+        if not name.startswith("label:"):
+            level = FILTERS.get_filter_color(name, enable_review=self.enable_review)
         self.append(
             (
                 FILTERS.get_filter_query(name),

--- a/weblate/trans/filter.py
+++ b/weblate/trans/filter.py
@@ -18,6 +18,46 @@ if TYPE_CHECKING:
 
 class FilterRegistry:
     @cached_property
+    def status_order(self) -> tuple[str, ...]:
+        return (
+            "all",
+            "readonly",
+            "approved",
+            "translated",
+            "unapproved",
+            "approved_suggestions",
+            "todo",
+            "nottranslated",
+            "fuzzy",
+            "suggestions",
+            "nosuggestions",
+            "allchecks",
+            "translated_checks",
+            "dismissed_checks",
+            *(CHECKS[check].url_id for check in CHECKS),
+            "comments",
+            "unlabeled",
+        )
+
+    @cached_property
+    def status_ranks(self) -> dict[str, int]:
+        return {name: index for index, name in enumerate(self.status_order)}
+
+    def get_filter_order(self, name: str) -> int:
+        if name.startswith("label:"):
+            name = "unlabeled"
+        return self.status_ranks.get(name, len(self.status_order))
+
+    def get_filter_color(self, name: str, *, enable_review: bool = False) -> str:
+        if name in {"approved", "approved_suggestions"}:
+            return "primary"
+        if name == "readonly":
+            return "primary" if enable_review else "success"
+        if name in {"translated", "unapproved"}:
+            return "success"
+        return ""
+
+    @cached_property
     def full_list(self):
         result: list[tuple[str, StrOrPromise, str]] = [
             ("all", gettext_lazy("All strings"), ""),

--- a/weblate/trans/tests/test_search.py
+++ b/weblate/trans/tests/test_search.py
@@ -4,6 +4,8 @@
 
 """Test for search views."""
 
+from __future__ import annotations
+
 import re
 from types import SimpleNamespace
 from unittest.mock import ANY, patch
@@ -18,6 +20,7 @@ from weblate.checks.models import Check
 from weblate.screenshots.models import Screenshot
 from weblate.trans.actions import ActionEvents
 from weblate.trans.bulk import bulk_perform
+from weblate.trans.forms import AutoForm, BulkEditForm
 from weblate.trans.models import (
     Change,
     Comment,
@@ -28,6 +31,7 @@ from weblate.trans.models import (
     WorkflowSetting,
 )
 from weblate.trans.tests.test_views import ViewTestCase
+from weblate.utils.forms import SearchField
 from weblate.utils.ratelimit import reset_rate_limit
 from weblate.utils.state import (
     STATE_APPROVED,
@@ -294,6 +298,21 @@ class SearchViewTest(ViewTestCase):
 
         self.assertEqual(self.get_search_result_count('comment_author:="testuser"'), 1)
         self.assertEqual(self.get_search_result_count("has:comment"), 1)
+
+    def test_mass_action_filters_require_a_query(self) -> None:
+        for form in (
+            AutoForm(self.component, user=self.user),
+            BulkEditForm(self.user, self.translation),
+        ):
+            with self.subTest(form=type(form).__name__):
+                choices = SearchField("q").get_search_query_choices(form)
+                self.assertNotIn("all", [choice[0] for choice in choices])
+                self.assertTrue(all(choice[2] for choice in choices))
+                self.assertIn("translated", [choice[0] for choice in choices])
+                # Use the bound field's requirement, including runtime overrides.
+                form.fields["q"].required = False
+                choices = SearchField("q").get_search_query_choices(form)
+                self.assertEqual(choices[0][:3], ("all", "All strings", ""))
 
     def test_search_filter_dropdown_includes_comments_by_me(self) -> None:
         response = self.client.get(

--- a/weblate/trans/tests/test_selenium.py
+++ b/weblate/trans/tests/test_selenium.py
@@ -1322,6 +1322,108 @@ class SeleniumTests(BaseLiveServerTestCase, RegistrationTestMixin, TempDirMixin)
         unit.refresh_from_db()
         self.assertEqual(unit.get_target_plurals(), drafts)
 
+    def test_all_strings_filter(self) -> None:
+        fixture = RepoTestMixin()
+        fixture.clone_test_repos()
+        project = Project.objects.create(name="Search filters", slug="search-filters")
+        component = fixture.create_po(project=project)
+        translation = component.translation_set.get(language_code="cs")
+        self.do_login(superuser=True)
+        search_url = f"{self.live_server_url}{reverse('search', kwargs={'path': translation.get_url_path()})}"
+        with self.wait_for_page_load():
+            self.driver.get(search_url)
+        query_input = self.driver.find_element(By.ID, "id_q")
+        query_input.send_keys("state:empty")
+        self.click(htmlid="query-dropdown")
+        option = self.driver.find_element(By.CSS_SELECTOR, '[data-filter="all"]')
+        option.send_keys(Keys.ENTER)
+        self.assertEqual(query_input.get_attribute("value"), "")
+        self.assertEqual(self.driver.current_url, search_url)
+        self.assertEqual(self.driver.switch_to.active_element, query_input)
+        self.assertEqual(
+            self.driver.find_element(By.ID, "query-dropdown").get_attribute(
+                "aria-expanded"
+            ),
+            "false",
+        )
+        original_dark_mode = self.driver.execute_script(
+            "return matchMedia('(prefers-color-scheme: dark)').matches;"
+        )
+        try:
+            for theme in ("light", "dark"):
+                self.driver.execute_cdp_cmd(
+                    "Emulation.setEmulatedMedia",
+                    {"features": [{"name": "prefers-color-scheme", "value": theme}]},
+                )
+                for width in (1280, 480):
+                    self.driver.set_window_size(width, 900)
+                    self.click(htmlid="query-dropdown")
+                    marker = self.driver.find_element(
+                        By.CSS_SELECTOR, '[data-filter="translated"] .filter-marker'
+                    )
+                    self.assertTrue(marker.is_displayed())
+                    self.assertEqual(marker.get_attribute("aria-hidden"), "true")
+                    self.screenshot_viewport(
+                        f"search-filters-{theme}-{width}.png", width, 900
+                    )
+                    self.driver.find_element(
+                        By.CSS_SELECTOR, '[data-filter="all"]'
+                    ).send_keys(Keys.ESCAPE)
+                self.driver.set_window_size(1280, 900)
+        finally:
+            self.driver.execute_cdp_cmd("Emulation.setEmulatedMedia", {"features": []})
+        self.assertEqual(
+            self.driver.execute_script(
+                "return matchMedia('(prefers-color-scheme: dark)').matches;"
+            ),
+            original_dark_mode,
+        )
+        # Ordinary filters still insert at the cursor in the query builder.
+        query_input.send_keys("state:empty")
+        self.click(htmlid="query-dropdown")
+        self.driver.find_element(By.CSS_SELECTOR, '[data-filter="suggestions"]').click()
+        self.assertEqual(
+            query_input.get_attribute("value"), "state:empty has:suggestion "
+        )
+        self.click(htmlid="query-dropdown")
+        self.driver.find_element(By.CSS_SELECTOR, '[data-filter="all"]').click()
+        with self.wait_for_page_load():
+            query_input.submit()
+        self.assertEqual(
+            self.driver.find_element(By.ID, "id_q").get_attribute("value"), ""
+        )
+
+        # Results and the editor apply the empty query immediately.
+        for url in (
+            search_url,
+            f"{self.live_server_url}{translation.get_translate_url()}",
+        ):
+            with self.subTest(url=url):
+                with self.wait_for_page_load():
+                    self.driver.get(
+                        f"{url}?{urlencode({'q': 'state:<translated', 'sort_by': 'source', 'offset': 2})}"
+                    )
+                self.click(htmlid="query-dropdown")
+                with self.wait_for_page_load():
+                    self.driver.find_element(
+                        By.CSS_SELECTOR, '[data-filter="all"]'
+                    ).send_keys(Keys.ENTER)
+                self.assertEqual(
+                    self.driver.find_element(By.ID, "id_q").get_attribute("value"), ""
+                )
+                self.assertEqual(
+                    self.driver.find_element(By.NAME, "sort_by").get_attribute("value"),
+                    "source",
+                )
+                self.assertNotIn("offset=2", self.driver.current_url)
+                if url != search_url:
+                    count = (
+                        self.driver.find_element(By.CSS_SELECTOR, ".position-input")
+                        .text.split("/")[-1]
+                        .strip()
+                    )
+                    self.assertEqual(int(count), translation.unit_set.count())
+
     def test_translation_search_refresh(self) -> None:
         """Refresh and query Enter replace results; navigation preserves them."""
         fixture = RepoTestMixin()

--- a/weblate/trans/tests/test_widgets.py
+++ b/weblate/trans/tests/test_widgets.py
@@ -36,6 +36,7 @@ from weblate.trans.widgets import (
     OpenGraphWidget,
     PNGBadgeWidget,
 )
+from weblate.utils.forms import QueryField, SearchField
 from weblate.utils.state import STATE_TRANSLATED
 from weblate.utils.xml import parse_xml
 
@@ -47,6 +48,9 @@ class EngageTaskObject(TranslationChecklistMixin):
     def __init__(self, stats, enable_review: bool = True) -> None:
         self.stats = stats
         self.enable_review = enable_review
+        self.is_readonly = False
+        self.is_source = False
+        self.project = SimpleNamespace(label_set=SimpleNamespace(order=list))
 
     def get_translate_url(self) -> str:
         return "/translate/"
@@ -86,6 +90,88 @@ class EngageTaskChecklistTest(SimpleTestCase):
         tasks = self.get_engage_tasks(enable_review=True)
 
         self.assertEqual(tasks, [])
+
+
+class FilterPresentationTest(SimpleTestCase):
+    def test_search_matches_status_overview(self) -> None:
+        stats = SimpleNamespace(
+            **{
+                f"{key}{suffix}": 1
+                for key in FILTERS.id_query
+                for suffix in ("", "_words", "_chars")
+            }
+        )
+        for review in (False, True):
+            with self.subTest(review=review):
+                obj = EngageTaskObject(stats, enable_review=review)
+                overview = cast("Any", obj).list_translation_checks
+                choices = SearchField("q").get_search_query_choices(
+                    SimpleNamespace(fields={"q": QueryField()})
+                )
+                self.assertEqual(choices[0][:3], ("all", "All strings", ""))
+                queries = {choice[2] for choice in choices}
+                shared = [entry for entry in overview if entry[0] in queries]
+                overview_queries = {entry[0] for entry in shared}
+                self.assertEqual(
+                    [
+                        (choice[2], choice[3])
+                        for choice in choices
+                        if choice[2] in overview_queries
+                    ],
+                    [(entry[0], entry[3]) for entry in shared],
+                )
+                self.assertEqual(
+                    next(
+                        entry[3] for entry in overview if entry[0] == "state:read-only"
+                    ),
+                    "primary" if review else "success",
+                )
+                self.assertEqual("state:approved" in overview_queries, review)
+
+    def test_status_visibility_and_label_order(self) -> None:
+        label_name = "label:Example"
+        stats = SimpleNamespace(
+            **{
+                f"{key}{suffix}": 1
+                for key in (*FILTERS.id_query, label_name)
+                for suffix in ("", "_words", "_chars")
+            }
+        )
+        for readonly, source in ((True, False), (False, True)):
+            with self.subTest(readonly=readonly, source=source):
+                obj = EngageTaskObject(stats)
+                obj.is_readonly = readonly
+                obj.is_source = source
+                obj.project.label_set.order = lambda: [
+                    SimpleNamespace(name="Example", color="blue")
+                ]
+                overview = cast("Any", obj).list_translation_checks
+                queries = [entry[0] for entry in overview]
+                self.assertEqual("state:>=translated" in queries, not readonly)
+                self.assertEqual(
+                    "has:check AND state:>=translated" in queries, not source
+                )
+                self.assertEqual(queries[-2:], ['label:"Example"', "NOT has:label"])
+                self.assertEqual(overview[-2][3], "label label-blue")
+
+    def test_empty_statuses_remain_searchable(self) -> None:
+        obj = EngageTaskObject(
+            SimpleNamespace(
+                **{
+                    f"{key}{suffix}": 0
+                    for key in FILTERS.id_query
+                    for suffix in ("", "_words", "_chars")
+                }
+            )
+        )
+        self.assertEqual(len(cast("Any", obj).list_translation_checks), 1)
+        choices = SearchField("q").get_search_query_choices(
+            SimpleNamespace(fields={"q": QueryField()})
+        )
+        self.assertIn("nottranslated", [choice[0] for choice in choices])
+        self.assertEqual(
+            next(choice[3] for choice in choices if choice[0] == "context"), ""
+        )
 
 
 class WidgetsTest(FixtureTestCase):

--- a/weblate/utils/forms.py
+++ b/weblate/utils/forms.py
@@ -316,9 +316,16 @@ class SearchField(Field):
             "approved",
             "unapproved",
         ]
+        if not form.fields[self.fields[0]].required:
+            filter_keys.insert(0, "all")
         result = [
-            (key, FILTERS.get_filter_name(key), FILTERS.get_filter_query(key))
-            for key in filter_keys
+            (
+                key,
+                FILTERS.get_filter_name(key),
+                FILTERS.get_filter_query(key),
+                FILTERS.get_filter_color(key),
+            )
+            for key in sorted(filter_keys, key=FILTERS.get_filter_order)
         ]
         user: User | None = getattr(form, "user", None)
         if user is not None and user.is_authenticated:
@@ -328,11 +335,13 @@ class SearchField(Field):
                         "comments_by_me",
                         gettext_lazy("Strings with comments by me"),
                         f'comment_author:="{user.username}"',
+                        "",
                     ),
                     (
                         "source_comments_by_me",
                         gettext_lazy("Strings with source comments by me"),
                         f'source_comment_author:="{user.username}"',
+                        "",
                     ),
                 )
             )


### PR DESCRIPTION
Share status ordering and legend colors across search filters and the status overview. Add All strings to clear the query while preserving each form’s submission behavior, and show a grey marker for categories without a status color.

Fixes #4788
Fixes #4789

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
