### PR TITLE
fix(trans): prefer matching context in automatic translation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Weblate 2026.10
 
 .. rubric:: Improvements
 
+* :ref:`Automatic translation <auto-translation>` using other components now prefers translations with matching source text and context.
 * Added monthly instance activity to the :ref:`data sent with support integration <support-data>` for activity monitoring and discovery ranking.
 * Improved :ref:`repository maintenance <repository-maintenance>` with disabled push controls when push configuration is missing and direct links to component VCS settings.
 * The :ref:`automatic translation add-on <addon-weblate.autotranslate.autotranslate>` can create approved strings, falling back to translated strings when reviews are disabled for the target language.

--- a/docs/user/translating.rst
+++ b/docs/user/translating.rst
@@ -469,9 +469,14 @@ Two modes of operation are possible:
 - Using selected machine translation services with translations above a certain
   quality threshold.
 
-When using other components as the source, Weblate applies translations only
-when plural forms are compatible. If the source component uses different plural
-rules, pluralized strings are skipped and Weblate shows a warning, while
+When using other components as the source, Weblate first looks for an exact match
+of both source text and context, including empty context. If none exists, it uses
+a translation matching only the source text. Context matches take precedence over
+source component order; component order breaks ties between equally matching
+candidates.
+
+Weblate applies translations only when plural forms are compatible. If the source
+component uses different plural rules, pluralized strings are skipped and Weblate shows a warning, while
 single-form strings are still translated.
 
 You can also choose which strings are to be auto-translated.

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -3483,11 +3483,11 @@ class ComponentCopyTest(APITestCase):
             def order_by(self, *_args):
                 return self
 
-            def values_list(self, *_args) -> list[tuple[int, str, str, int, int]]:
+            def values_list(self, *_args) -> list[tuple[int, str, str, str, int, int]]:
                 return [
-                    (1, "Hello", "first", 10, 1),
-                    (2, "Hello", "second", 20, 1),
-                    (1, "Hello", "later", 30, 1),
+                    (1, "Hello", "", "first", 10, 1),
+                    (2, "Hello", "", "second", 20, 1),
+                    (1, "Hello", "", "later", 30, 1),
                 ]
 
         class EmptyComponents:
@@ -3509,7 +3509,9 @@ class ComponentCopyTest(APITestCase):
         ):
             translations = auto.collect_other_translations(FilteredSources(), [1, 2])
 
-        self.assertEqual(translations, {"Hello": ["first"]})
+        self.assertEqual(
+            translations, ({("Hello", ""): ["first"]}, {"Hello": ["first"]})
+        )
 
 
 class RoleAPITest(APIBaseTest):

--- a/weblate/trans/autotranslate.py
+++ b/weblate/trans/autotranslate.py
@@ -261,67 +261,61 @@ class AutoTranslate(BaseAutoTranslate):
 
     def collect_other_translations(
         self, filtered_sources, component_ids: list[int]
-    ) -> dict[str, list[str]]:
-        """Collect candidate translations while preserving source priority."""
+    ) -> tuple[dict[tuple[str, str], list[str]], dict[str, list[str]]]:
+        """Collect context matches and source fallbacks preserving source priority."""
         translations: dict[str, list[str]] = {}
+        context_translations: dict[tuple[str, str], list[str]] = {}
+        translation_priority: dict[str, int] = {}
+        context_priority: dict[tuple[str, str], int] = {}
+        component_priority = {
+            component_id: index for index, component_id in enumerate(component_ids)
+        }
         mismatched_translation_ids: set[int] = set()
         target_plural_id = self.translation.plural_id
 
         if component_ids:
-            component_priority = {
-                component_id: index for index, component_id in enumerate(component_ids)
-            }
-            translation_priority: dict[str, int] = {}
-            source_units = (
-                filtered_sources.annotate(
-                    component_priority=Case(
-                        *[
-                            When(
-                                translation__component_id=component_id,
-                                then=priority,
-                            )
-                            for component_id, priority in component_priority.items()
-                        ],
-                        output_field=IntegerField(),
-                    )
+            filtered_sources = filtered_sources.annotate(
+                component_priority=Case(
+                    *[
+                        When(translation__component_id=component_id, then=priority)
+                        for component_id, priority in component_priority.items()
+                    ],
+                    output_field=IntegerField(),
                 )
-                .order_by("component_priority", "translation_id")
-                .values_list(
-                    "translation__component_id",
-                    "source",
-                    "target",
-                    "translation_id",
-                    "translation__plural_id",
-                )
-            )
-            for (
-                component_id,
-                source,
-                target,
-                translation_id,
-                plural_id,
-            ) in source_units:
-                if plural_id != target_plural_id and (
-                    is_plural(source) or is_plural(target)
-                ):
-                    mismatched_translation_ids.add(translation_id)
-                    continue
-                priority = component_priority[component_id]
-                if priority >= translation_priority.get(source, len(component_ids)):
-                    continue
-                translations[source] = split_plural(target)
-                translation_priority[source] = priority
+            ).order_by("component_priority", "translation_id", "pk")
         else:
-            source_units = filtered_sources.values_list(
-                "source", "target", "translation_id", "translation__plural_id"
-            ).order_by("translation_id")
-            for source, target, translation_id, plural_id in source_units:
-                if plural_id != target_plural_id and (
-                    is_plural(source) or is_plural(target)
-                ):
-                    mismatched_translation_ids.add(translation_id)
-                    continue
-                translations.setdefault(source, split_plural(target))
+            filtered_sources = filtered_sources.order_by("translation_id", "pk")
+
+        source_units = filtered_sources.values_list(
+            "translation__component_id",
+            "source",
+            "context",
+            "target",
+            "translation_id",
+            "translation__plural_id",
+        )
+        for (
+            component_id,
+            source,
+            context,
+            target,
+            translation_id,
+            plural_id,
+        ) in source_units:
+            if plural_id != target_plural_id and (
+                is_plural(source) or is_plural(target)
+            ):
+                mismatched_translation_ids.add(translation_id)
+                continue
+            priority = component_priority.get(component_id, 0)
+            context_key = (source, context)
+            target_plurals = split_plural(target)
+            if priority < translation_priority.get(source, len(component_ids) + 1):
+                translations[source] = target_plurals
+                translation_priority[source] = priority
+            if priority < context_priority.get(context_key, len(component_ids) + 1):
+                context_translations[context_key] = target_plurals
+                context_priority[context_key] = priority
 
         mismatched_components = (
             Component.objects.filter(translation__in=mismatched_translation_ids)
@@ -339,7 +333,7 @@ class AutoTranslate(BaseAutoTranslate):
                 % {"component": component}
             )
 
-        return translations
+        return context_translations, translations
 
     @transaction.atomic
     def process_others(self, source_component_ids: list[int] | None) -> None:
@@ -395,7 +389,9 @@ class AutoTranslate(BaseAutoTranslate):
 
         # Fetch available translations
         filtered_sources = sources.filter(source__lower__md5__in=source_md5s)
-        translations = self.collect_other_translations(filtered_sources, component_ids)
+        context_translations, translations = self.collect_other_translations(
+            filtered_sources, component_ids
+        )
 
         # Fetch translated unit IDs
         # Cannot use get_units() directly as SELECT FOR UPDATE cannot be used with JOIN
@@ -419,7 +415,9 @@ class AutoTranslate(BaseAutoTranslate):
         for pos, unit in enumerate(units):
             # Get update
             try:
-                target = translations[unit.source]
+                target = context_translations.get(
+                    (unit.source, unit.context), translations[unit.source]
+                )
             except KeyError:
                 # Happens due to case-insensitive lookup
                 continue

--- a/weblate/trans/tests/test_autotranslate.py
+++ b/weblate/trans/tests/test_autotranslate.py
@@ -26,7 +26,7 @@ from weblate.configuration.models import Setting, SettingCategory
 from weblate.lang.models import Language, Plural
 from weblate.machinery.dummy import DummyTranslation
 from weblate.trans.actions import ActionEvents
-from weblate.trans.autotranslate import BatchAutoTranslate
+from weblate.trans.autotranslate import AutoTranslate, BatchAutoTranslate
 from weblate.trans.forms import AutoForm
 from weblate.trans.models import (
     Change,
@@ -41,7 +41,12 @@ from weblate.trans.models.component import ComponentQuerySet
 from weblate.trans.tasks import auto_translate, auto_translate_component
 from weblate.trans.tests.test_views import ViewTestCase
 from weblate.utils.celery import get_task_metadata, get_task_metadata_key
-from weblate.utils.state import STATE_APPROVED, STATE_READONLY, STATE_TRANSLATED
+from weblate.utils.state import (
+    STATE_APPROVED,
+    STATE_EMPTY,
+    STATE_READONLY,
+    STATE_TRANSLATED,
+)
 from weblate.utils.stats import ProjectLanguage
 from weblate.workspaces.models import Workspace
 
@@ -235,6 +240,126 @@ class AutoTranslationTest(ViewTestCase):
     def test_different(self) -> None:
         """Test for automatic translation with different content."""
         self.perform_auto()
+
+    def test_context_matches_and_fallback(self) -> None:
+        source_units = list(self.translation.unit_set.order_by("pk")[:4])
+        for unit, context, target in zip(
+            source_units,
+            ("verb", "adjective", "", "adjective"),
+            ("Otevřít", "Otevřeno", "Prázdný kontext", "Later match"),
+            strict=True,
+        ):
+            Unit.objects.filter(pk=unit.pk).update(
+                source="Open", context=context, target=target, state=STATE_TRANSLATED
+            )
+        translation = self.component2.translation_set.get(language_code="cs")
+        target_unit = translation.unit_set.earliest("pk")
+        for mode in ("translate", "suggest"):
+            for context, expected in (
+                ("verb", "Otevřít"),
+                ("adjective", "Otevřeno"),
+                ("", "Prázdný kontext"),
+                ("unknown", "Otevřít"),
+                ("Adjective", "Otevřít"),
+            ):
+                with self.subTest(mode=mode, context=context):
+                    target_unit.suggestion_set.all().delete()
+                    Unit.objects.filter(pk=target_unit.pk).update(
+                        source="Open", context=context, target="", state=STATE_EMPTY
+                    )
+                    auto = AutoTranslate(
+                        translation=translation,
+                        user=self.user,
+                        q="",
+                        mode=mode,
+                        unit_ids=[target_unit.pk],
+                    )
+                    auto.process_others(
+                        [self.component.pk] if self.use_component_id else None
+                    )
+                    self.assertEqual(auto.updated, 1)
+                    target_unit.refresh_from_db()
+                    if mode == "suggest":
+                        self.assertEqual(
+                            target_unit.suggestion_set.get().target, expected
+                        )
+                    else:
+                        self.assertEqual(target_unit.target, expected)
+
+    def test_context_precedes_component_priority(self) -> None:
+        first = self.get_unit("Hello, world!\n")
+        translation = self.component2.translation_set.get(language_code="cs")
+        second = translation.unit_set.earliest("pk")
+        Unit.objects.filter(pk=first.pk).update(
+            source="Open", context="verb", target="Otevřít", state=STATE_TRANSLATED
+        )
+        Unit.objects.filter(pk=second.pk).update(
+            source="Open",
+            context="adjective",
+            target="Otevřeno",
+            state=STATE_TRANSLATED,
+        )
+        auto = AutoTranslate(
+            translation=translation, user=self.user, q="", mode="translate"
+        )
+        sources = Unit.objects.filter(pk__in=[first.pk, second.pk])
+        for component_ids in (
+            [self.component.pk, self.component2.pk],
+            [self.component2.pk, self.component.pk],
+        ):
+            with self.subTest(component_ids=component_ids):
+                with self.assertNumQueries(1):
+                    contexts, fallback = auto.collect_other_translations(
+                        sources, component_ids
+                    )
+                self.assertEqual(contexts["Open", "adjective"], ["Otevřeno"])
+                self.assertEqual(
+                    fallback["Open"],
+                    [
+                        "Otevřít"
+                        if component_ids[0] == self.component.pk
+                        else "Otevřeno"
+                    ],
+                )
+        target_unit = translation.unit_set.exclude(pk=second.pk).earliest("pk")
+        Unit.objects.filter(pk=target_unit.pk).update(
+            source="Open", context="adjective", target="", state=STATE_EMPTY
+        )
+        auto.unit_ids = [target_unit.pk]
+        auto.process_others([self.component.pk, self.component2.pk])
+        target_unit.refresh_from_db()
+        self.assertEqual(target_unit.target, "Otevřeno")
+
+        Unit.objects.filter(pk=first.pk).update(context="adjective")
+        contexts, _fallback = auto.collect_other_translations(
+            sources, [self.component.pk, self.component2.pk]
+        )
+        self.assertEqual(contexts["Open", "adjective"], ["Otevřít"])
+
+    def test_context_match_skips_incompatible_plurals(self) -> None:
+        self.set_mismatched_plural()
+        self.translate_plural_source()
+        source_unit = self.get_unit("Orangutan has %d banana.\n")
+        translation = self.component2.translation_set.get(language_code="cs")
+        compatible_unit = self.get_unit(
+            "Orangutan has %d banana.\n", translation=translation
+        )
+        target = ["Jeden banán\n", "Dva banány\n", "Pět banánů\n"]
+        compatible_unit.translate(self.user, target, STATE_TRANSLATED, propagate=False)
+        Unit.objects.filter(pk=source_unit.pk).update(context="matching")
+        Unit.objects.filter(pk=compatible_unit.pk).update(context="fallback")
+        auto = AutoTranslate(
+            translation=translation, user=self.user, q="", mode="translate"
+        )
+        contexts, fallback = auto.collect_other_translations(
+            Unit.objects.filter(pk__in=[source_unit.pk, compatible_unit.pk]),
+            [self.component.pk, self.component2.pk],
+        )
+        self.assertNotIn((source_unit.source, "matching"), contexts)
+        self.assertEqual(contexts[source_unit.source, "fallback"], target)
+        self.assertEqual(fallback[source_unit.source], target)
+        self.assertEqual(len(auto.warnings), 1)
+        self.assertIn("do not match the target translation", auto.warnings[0])
 
     def restrict_direct_editing(self) -> Translation:
         self.user.is_superuser = False


### PR DESCRIPTION
Prefer exact source and context matches across eligible components before falling back to source-only translations. Preserve component priority within each match category and skip incompatible plural forms.

Fixes #5308

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
