### PR TITLE
fix(checks): skip duplicate words for South Asian languages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,7 @@ Weblate 2026.10
 
 .. rubric:: Bug fixes
 
+* Fixed false positives from the :ref:`consecutive duplicated words check <check-duplicate>` in South Asian languages with grammatical word repetition.
 * Fixed :ref:`Docker startup warning checks <docker-startup-warnings>` failing when the warning directory is missing or inaccessible.
 * Fixed an :ref:`upgrade <generic-upgrade-instructions>` failure when migrating dismissed component alerts from releases before 2026.8.
 

--- a/docs/snippets/checks-autogenerated.rst
+++ b/docs/snippets/checks-autogenerated.rst
@@ -150,6 +150,11 @@ Consecutive duplicated words
 Checks that no consecutive duplicate words occur in a translation. This usually
 indicates a mistake in the translation.
 
+The check is skipped for Assamese, Bengali, Gujarati, Hindi, Kannada, Malayalam,
+Marathi, Nepali, Odia, Punjabi, Sindhi, Sinhala, Tamil, Telugu, Toki Pona, and Urdu,
+including their language variants, because word repetition carries grammatical
+meaning in these languages.
+
 .. hint::
 
    This check includes language specific rules to avoid false positives. In

--- a/weblate/checks/duplicate.py
+++ b/weblate/checks/duplicate.py
@@ -42,8 +42,27 @@ class DuplicateCheck(TargetCheck):
     version_added = "4.1"
 
     def should_skip(self, unit: Unit) -> bool:
-        # Ignore the check for Toki Pona which often uses repeating words
-        if unit.translation.language.is_base({"tok"}):
+        # These languages productively repeat words for grammatical meaning.
+        if unit.translation.language.is_base(
+            {
+                "as",  # Assamese
+                "bn",  # Bengali
+                "gu",  # Gujarati
+                "hi",  # Hindi
+                "kn",  # Kannada
+                "ml",  # Malayalam
+                "mr",  # Marathi
+                "ne",  # Nepali
+                "or",  # Odia
+                "pa",  # Punjabi
+                "sd",  # Sindhi
+                "si",  # Sinhala
+                "ta",  # Tamil
+                "te",  # Telugu; codespell:ignore
+                "tok",  # Toki Pona
+                "ur",  # Urdu
+            }
+        ):
             return True
         return super().should_skip(unit)
 

--- a/weblate/checks/tests/test_duplicate_checks.py
+++ b/weblate/checks/tests/test_duplicate_checks.py
@@ -4,9 +4,11 @@
 
 """Tests for duplicate checks."""
 
+from __future__ import annotations
+
 from weblate.checks.duplicate import DuplicateCheck
 from weblate.checks.tests.test_checks import CheckTestCase
-from weblate.trans.tests.factories import make_check, make_unit
+from weblate.trans.tests.factories import make_check, make_language, make_unit
 
 
 class DuplicateCheckTest(CheckTestCase):
@@ -17,6 +19,72 @@ class DuplicateCheckTest(CheckTestCase):
 
     def test_no_duplicated_token(self) -> None:
         self.assertFalse(self._run_check("I have two lemons"))
+
+    def test_reduplicating_languages(self) -> None:
+        for code in (
+            "as",
+            "bn",
+            "gu",
+            "hi",
+            "kn",
+            "ml",
+            "mr",
+            "ne",
+            "or",
+            "pa",
+            "sd",
+            "si",
+            "ta",
+            "te",  # codespell:ignore
+            "tok",
+            "ur",
+            "pa_PK",
+            "pa-PK",
+            "bn_BD",
+            "ur_PK",
+        ):
+            with self.subTest(code=code):
+                unit = make_unit(code=code, source="string", target="word word")
+                self.assertFalse(
+                    self.check.check_target([unit.source], [unit.target], unit)
+                )
+                self.assertFalse(
+                    self.check.check_target_with_flags(
+                        [unit.source], [unit.target], unit, unit.all_flags
+                    )
+                )
+
+    def test_punjabi_reduplication(self) -> None:
+        examples = (
+            ("anyone", "ਜਿਹੜੇ ਜਿਹੜੇ", "جہڑے جہڑے"),
+            ("in small parts", "ਥੋੜ੍ਹਾ ਥੋੜ੍ਹਾ", "تھوڑھا تھوڑھا"),
+            ("continuously", "ਰਹਿ ਰਹਿ ਕੇ", "رہ رہ کے"),
+            ("slowly", "ਸਣੇ ਸਣੇ", "سݨے سݨے"),
+            ("intermittently", "ਠਹਿਰ ਠਹਿਰ ਕੇ", "ٹھیر ٹھیر کے"),
+        )
+        for source, gurmukhi, shahmukhi in examples:
+            for code, target in (("pa", gurmukhi), ("pa_PK", shahmukhi)):
+                with self.subTest(code=code, target=target):
+                    unit = make_unit(code=code, source=source, target=target)
+                    self.assertFalse(self.check.check_target([source], [target], unit))
+
+    def test_target_language_and_flags(self) -> None:
+        for code in ("en", "cs"):
+            for flags in ("", "ignore-duplicate"):
+                with self.subTest(code=code, flags=flags):
+                    unit = make_unit(
+                        code=code, flags=flags, source="string", target="word word"
+                    )
+                    self.assertEqual(
+                        self.check.check_target([unit.source], [unit.target], unit),
+                        not flags,
+                    )
+
+    def test_hindi_source_exception(self) -> None:
+        unit = make_unit(code="en", source="कर कर", target="word word")
+        unit.translation.component.source_language = make_language("hi")
+        # Ignored source repetitions must not mask duplicates in other languages.
+        self.assertTrue(self.check.check_target([unit.source], [unit.target], unit))
 
     def test_check_respects_boundaries_suffix(self) -> None:
         # 'lemon lemon' is a false duplicate.


### PR DESCRIPTION
Avoid false positives for languages where word repetition carries grammatical meaning. Cover language variants and preserve source-word exceptions with regression tests.

Fixes #8224

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
