### PR TITLE
fix(ux): distinguish History View and Revert icons

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Weblate 2026.10
 * The :ref:`automatic translation add-on <addon-weblate.autotranslate.autotranslate>` can create approved strings, falling back to translated strings when reviews are disabled for the target language.
 * Whitespace characters are now rendered consistently in the source string display and the translation editor, and different kinds of whitespace are now distinguishable from each other.
 * History :guilabel:`View details` and :guilabel:`Revert` actions are larger, more widely spaced, and show a hover and focus background.
+* History :guilabel:`View details` now uses a distinct eye icon, and :guilabel:`Revert` is shown in red to make the two actions easier to tell apart.
 * Added a :ref:`keyboard shortcut <keyboard>` to approve a translation and save and continue.
 * Clarified :ref:`translation quality filter <project-commit_policy>` explanations and effective per-language review settings, with links to workflow configuration.
 

--- a/weblate/templates/snippets/last-changes-content.html
+++ b/weblate/templates/snippets/last-changes-content.html
@@ -20,7 +20,7 @@
           {% if not in_email %}
             <div class="btn-float">
               {% if item.permissions.can_revert %}
-                <a class="btn btn-link"
+                <a class="btn btn-link red"
                    href="{{ translate_url|default:item.change.translation.get_translate_url }}{% querystring query_params offset=offset checksum=item.change.unit.checksum revert=item.change.id %}"
                    title="{% translate "Revert" %}">{% icon "undo.svg" %}</a>
               {% endif %}
@@ -36,7 +36,7 @@
               {% endif %}
               <a class="btn btn-link"
                  href="{{ item.change.get_absolute_url }}"
-                 title="{% translate "View details" %}">{% icon "magnify-plus-outline.svg" %}</a>
+                 title="{% translate "View details" %}">{% icon "eye.svg" %}</a>
             </div>
           {% endif %}
           <div class="comment-content">


### PR DESCRIPTION
Closes #8259

## What changed
In the translation History tab, the **View details** and **Revert**
actions previously used a magnifying-glass-plus icon and an undo icon
that were only distinguishable by hovering to read the tooltip:
- `View details` now uses an eye icon instead of the magnifying-glass
  icon, which read more like "zoom/search" than "view".
- `Revert` is now styled in red, matching the destructive-action
  styling already used elsewhere (e.g. Block user, Mark as spam), to
  signal it's a state-changing action.

## Why
#8259 was reopened after #21573 (larger buttons, spacing, hover/focus
states) addressed accidental clicks from proximity, but not the
underlying issue that the two icons don't read as distinct actions at
a glance. This change makes View and Revert visually distinguishable
by both icon shape and color, without adding new strings or changing
layout/spacing further.

## Testing
Verified manually in a local dev instance: hover/focus states still
work, tooltips unchanged ("View details" / "Revert"), tested in light
theme.
