### PR TITLE
fix(l10n): preserve `{{ component }}` in Vietnamese discovery docs

### DIFF
--- a/docs/locales/vi/LC_MESSAGES/docs.po
+++ b/docs/locales/vi/LC_MESSAGES/docs.po
@@ -50591,7 +50591,7 @@ msgid ""
 "discovered component."
 msgstr ""
 "Các trường mẫu được sử dụng để đặt tên hoặc định vị tệp theo từng thành phần "
-"phải bao gồm ``{{ thành phần }}``, do đó giá trị được hiển thị thực sự thay "
+"phải bao gồm ``{{ component }}``, do đó giá trị được hiển thị thực sự thay "
 "đổi đối với từng thành phần được phát hiện."
 
 msgid ""


### PR DESCRIPTION
### Motivation
- The Vietnamese translation accidentally replaced the reserved Django template variable `{{ component }}` with `{{ thành phần }}`, producing an invalid template expression for component discovery and causing configuration/validation failures for administrators.

### Description
- Update `docs/locales/vi/LC_MESSAGES/docs.po` to preserve the exact `{{ component }}` identifier in the discovery documentation text so the documented template expression remains valid.

### Testing
- Ran `git diff --check`, `msgfmt --check --check-format -o /dev/null docs/locales/vi/LC_MESSAGES/docs.po`, and `uv run prek run --files docs/locales/vi/LC_MESSAGES/docs.po`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa120d7a2288329a1dd59b33367606d)