### PR TITLE
fix(alerts): group duplicate cleanup actions by translation file

### DIFF
--- a/weblate/templates/trans/alert/duplicatestring.html
+++ b/weblate/templates/trans/alert/duplicatestring.html
@@ -4,44 +4,53 @@
 
 <p>{% translate "The following occurrences were found:" %}</p>
 
-<table class="table table-sm">
-  <thead>
-    <tr>
-      <th>{% translate "Language" %}</th>
-      <th>{% translate "File" %}</th>
-      <th>{% translate "Source" %}</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for occurrence in occurrences %}
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
       <tr>
-        <td>{{ occurrence.language }}</td>
-        <td>{% if occurrence.unit %}{{ occurrence.unit.translation.filename }}{% endif %}</td>
-        <td>
-          {% if occurrence.unit %}
-            <a href="{{ occurrence.unit.get_absolute_url }}">{% format_unit_source occurrence.unit %}</a>
-          {% else %}
-            {{ occurrence.source }}
-          {% endif %}
-        </td>
+        <th scope="col">{% translate "Language" %}</th>
+        <th scope="col">{% translate "File" %}</th>
+        <th scope="col">{% translate "Source" %}</th>
+        <th scope="col">{% translate "Actions" %}</th>
       </tr>
-    {% endfor %}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {% for group in analysis.translation_groups %}
+        <tr>
+          <th scope="row">{{ group.language }}</th>
+          <td>{% if group.translation %}{{ group.translation.filename }}{% endif %}</td>
+          <td>
+            <ul class="list-unstyled mb-0">
+              {% for occurrence in group.occurrences %}
+                <li>
+                  {% if occurrence.unit %}
+                    <a href="{{ occurrence.unit.get_absolute_url }}">{% format_unit_source occurrence.unit %}</a>
+                  {% else %}
+                    {{ occurrence.source }}
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </td>
+          <td>
+            {% if group.can_cleanup %}
+              {% perm "vcs.reset" group.translation as user_can_cleanup_translation %}
+              {% if user_can_cleanup_translation %}
+                <button type="button"
+                        class="btn btn-danger link-post"
+                        aria-label="{% blocktranslate with language=group.language filename=group.translation.filename %}Remove duplicate strings from {{ language }} ({{ filename }}){% endblocktranslate %}"
+                        data-href="{% url "remove_duplicate_units" path=group.translation.get_url_path %}">{% translate "Remove duplicate strings" %}</button>
+              {% endif %}
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 
 <p>
   {% translate "Please fix this by removing duplicated strings with same identifier from the translation files." %}
 </p>
-
-{% for translation in analysis.cleanup_translations %}
-  {% perm "vcs.reset" translation as user_can_cleanup_translation %}
-  {% if user_can_cleanup_translation %}
-    <p>
-      <a href="#"
-         class="btn btn-danger link-post"
-         data-href="{% url "remove_duplicate_units" path=translation.get_url_path %}">{% translate "Remove duplicate strings" %}</a>
-    </p>
-  {% endif %}
-{% endfor %}
 
 {% include "trans/alert/occurrences-limit.html" %}

--- a/weblate/trans/alerts/files.py
+++ b/weblate/trans/alerts/files.py
@@ -39,24 +39,37 @@ class DuplicateString(MultiAlert):
         )
 
     def get_analysis(self) -> dict[str, Any]:
-        translations = []
-        seen = set()
+        groups: list[dict[str, Any]] = []
+        translations: dict[int, dict[str, Any]] = {}
         for occurrence in self.occurrences:
             unit = occurrence.get("unit")
             if unit is None:
+                groups.append(
+                    {
+                        "translation": None,
+                        "language": occurrence.get(
+                            "language", occurrence.get("language_code", "")
+                        ),
+                        "occurrences": [occurrence],
+                        "can_cleanup": False,
+                    }
+                )
                 continue
             translation = unit.translation
-            if (
-                not translation.filename
-                or translation.pk in seen
-                or not translation.supports_remove_duplicate_units(
-                    translation.component
-                )
-            ):
-                continue
-            seen.add(translation.pk)
-            translations.append(translation)
-        return {"cleanup_translations": translations}
+            if translation.pk not in translations:
+                group = {
+                    "translation": translation,
+                    "language": translation.language,
+                    "occurrences": [],
+                    "can_cleanup": bool(translation.filename)
+                    and translation.supports_remove_duplicate_units(
+                        translation.component
+                    ),
+                }
+                translations[translation.pk] = group
+                groups.append(group)
+            translations[translation.pk]["occurrences"].append(occurrence)
+        return {"translation_groups": groups}
 
 
 @register

--- a/weblate/trans/tests/test_alert.py
+++ b/weblate/trans/tests/test_alert.py
@@ -32,6 +32,7 @@ from weblate.auth.models import Group, Permission, Role
 from weblate.lang.models import Language
 from weblate.trans.actions import ActionEvents
 from weblate.trans.alerts.base import AlertSeverity, MultiAlert
+from weblate.trans.alerts.files import DuplicateString
 from weblate.trans.alerts.registry import update_alerts
 from weblate.trans.alerts.vcs import RepositoryErrorAlert, UpdateFailure
 from weblate.trans.diagnostics import DIAGNOSTICS_LINK_LIMIT, get_diagnostics_context
@@ -40,6 +41,7 @@ from weblate.trans.models import (
     Component,
     ComponentLink,
     Project,
+    Translation,
     Unit,
 )
 from weblate.trans.models.alert import Alert
@@ -55,6 +57,8 @@ from weblate.workspaces.models import Workspace
 
 if TYPE_CHECKING:
     from unittest.mock import Mock
+
+    from weblate.auth.models import User
 
 
 class WebsiteAlertSettingTest(ViewTestCase):
@@ -589,6 +593,91 @@ class AlertTest(ViewTestCase):
                 "BrokenProjectURL",
             },
         )
+
+    def test_duplicate_cleanup_groups(self) -> None:
+        component = self._create_component(
+            "po", "po/*.po", name="Grouped", project=self.project
+        )
+        translations = list(
+            component.translation_set.exclude(filename="").order_by("pk")[:2]
+        )
+        self.assertEqual(len(translations), 2)
+        first, second = [translation.unit_set.first() for translation in translations]
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+        assert first is not None
+        assert second is not None
+        occurrences = [
+            {"unit_pk": first.pk, "language_code": first.translation.language.code},
+            {"unit_pk": second.pk, "language_code": second.translation.language.code},
+            {"unit_pk": first.pk, "language_code": first.translation.language.code},
+            {"unit_pk": -1, "language_code": "cs", "source": "Missing unit source"},
+        ]
+        component.add_alert("DuplicateString", occurrences=occurrences)
+        instance = component.alert_set.get(name="DuplicateString")
+        all_translations = {translation.pk for translation in translations}
+        for supported, allowed in (
+            (True, all_translations),
+            (True, {translations[0].pk}),
+            (False, all_translations),
+            (True, set()),
+        ):
+            with (
+                self.subTest(supported=supported, allowed=allowed),
+                patch.object(
+                    Translation,
+                    "supports_remove_duplicate_units",
+                    return_value=supported,
+                ),
+                translation_override("en"),
+            ):
+                user = SimpleNamespace(
+                    has_perm=lambda permission, obj, allowed=allowed: (
+                        permission == "vcs.reset" and obj.pk in allowed
+                    )
+                )
+                alert = DuplicateString(instance, instance.details["occurrences"])
+                rendered = render_to_string(
+                    "trans/alert/duplicatestring.html",
+                    alert.get_context(cast("User", user)),
+                )
+                rows = (
+                    rendered.split("<tbody>")[1].split("</tbody>")[0].split("<tr>")[1:]
+                )
+                self.assertEqual(len(rows), 3)
+                for row, translation, unit, count in zip(
+                    rows, translations, (first, second), (2, 1), strict=False
+                ):
+                    self.assertIn(translation.filename, row)
+                    self.assertIn(str(translation.language), row)
+                    self.assertEqual(
+                        row.count(f'href="{unit.get_absolute_url()}"'), count
+                    )
+                    cleanup_url = reverse(
+                        "remove_duplicate_units",
+                        kwargs={"path": translation.get_url_path()},
+                    )
+                    if supported and translation.pk in allowed:
+                        self.assertIn(f'data-href="{cleanup_url}"', row)
+                        self.assertIn(
+                            f'aria-label="Remove duplicate strings from {translation.language} ({translation.filename})"',
+                            row,
+                        )
+                        self.assertEqual(
+                            row.count('class="btn btn-danger link-post"'), 1
+                        )
+                    else:
+                        self.assertNotIn("link-post", row)
+                self.assertIn("Missing unit source", rows[2])
+                self.assertNotIn("link-post", rows[2])
+
+    def test_duplicate_cleanup_missing_filename(self) -> None:
+        instance = self.component.alert_set.get(name="DuplicateString")
+        alert = DuplicateString(instance, instance.details["occurrences"])
+        alert.occurrences[0]["unit"].translation.filename = ""
+        group = alert.get_analysis()["translation_groups"][0]
+        self.assertFalse(group["can_cleanup"])
+        self.assertEqual(len(group["occurrences"]), 1)
 
     def test_unused_enforced(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
Show each cleanup action beside its language, filename, and duplicate sources so its scope is clear. Preserve per-translation permissions and add regression coverage for grouping and cleanup eligibility.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
