### PR TITLE
feat(addons): generate component-wide locale lists

### DIFF
--- a/docs/admin/projects.rst
+++ b/docs/admin/projects.rst
@@ -1521,6 +1521,11 @@ The following variables are available in the component templates:
 ``{{ addon_name }}``
     Name of currently executed add-on, available only in the add-on commit message.
 
+The :ref:`Statistics generator <addon-weblate.generate.generate>` additionally
+supports a collection of languages and their statistics in component mode.
+Use the ``json`` or ``python`` filter to serialize template values into JSON or
+Python literals, including the necessary quoting and escaping.
+
 The following variables are available in the repository browser or editor templates:
 
 ``{{branch}}``

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Weblate 2026.10
 
 .. rubric:: New features
 
+* The :ref:`Statistics generator <addon-weblate.generate.generate>` can generate component-wide locale lists with native language names, text direction, and translation statistics.
+
 * Added an inherited :ref:`language creation policy <workflow-language-restrictions>` allowing existing project target languages while requesting maintainer approval for new languages.
 * Added configurable per-user and IP/network :ref:`API rate limits and exemptions <api-rate>`, including Docker configuration.
 

--- a/docs/snippets/addons-autogenerated.rst
+++ b/docs/snippets/addons-autogenerated.rst
@@ -866,13 +866,21 @@ Statistics generator
 --------------------
 
 :Add-on ID: ``weblate.generate.generate``
-:Configuration: +--------------+---------------------------+--+
-                | ``filename`` | Name of generated file    |  |
-                +--------------+---------------------------+--+
-                | ``template`` | Content of generated file |  |
-                +--------------+---------------------------+--+
+:Configuration: +--------------+---------------------------+------------------------------------+
+                | ``scope``    | Output scope              | .. list-table:: Available choices: |
+                |              |                           |    :width: 100%                    |
+                |              |                           |                                    |
+                |              |                           |    * - ``translation``             |
+                |              |                           |      - One file per translation    |
+                |              |                           |    * - ``component``               |
+                |              |                           |      - One file per component      |
+                +--------------+---------------------------+------------------------------------+
+                | ``filename`` | Name of generated file    |                                    |
+                +--------------+---------------------------+------------------------------------+
+                | ``template`` | Content of generated file |                                    |
+                +--------------+---------------------------+------------------------------------+
 
-:Triggers: :ref:`addon-event-add-on-installation`, :ref:`addon-event-repository-pre-commit`
+:Triggers: :ref:`addon-event-add-on-installation`, :ref:`addon-event-component-update`, :ref:`addon-event-repository-post-add`, :ref:`addon-event-repository-post-remove`, :ref:`addon-event-repository-pre-commit`
 
 Generates a file containing detailed info about the translation status.
 
@@ -895,6 +903,72 @@ Content
          "last_changed": "{{ stats.last_changed }}",
          "last_author": "{{ stats.last_author }}",
       }
+
+
+Component-wide output
+~~~~~~~~~~~~~~~~~~~~~
+
+Set :guilabel:`Output scope` to :guilabel:`One file per component` to maintain
+one locale list or statistics file for the entire component. The default,
+:guilabel:`One file per translation`, preserves existing configurations.
+
+Component output is generated on installation and configuration changes. It is
+updated when translations are committed, languages are added or removed, and
+component files are reloaded. Language metadata changes are included on the
+next such update or when the add-on is reconfigured. Unchanged output does not
+create a new commit.
+
+Both modes support component and project variables in filenames and content.
+In component mode, the content additionally receives ``translations``, ordered
+by repository language code. Each item provides:
+
+* ``language_code``: the language code used in the repository.
+* ``language_name``: the English language name.
+* ``language_native_name``: the name translated into its own language using
+  Weblate's catalogs, with an English fallback when unavailable.
+* ``language_direction``: ``ltr`` or ``rtl``.
+* ``filename`` and ``url``: the translation filename and Weblate URL.
+* ``is_source``: whether this is the component's source translation.
+* ``stats``: the same statistics available in translation mode.
+
+The source translation is included. Templates can exclude it using
+``{% if not item.is_source %}``. Statistics use Weblate's completion semantics.
+Custom language names are retained; there is no external locale-data lookup.
+
+For example, generate :file:`locales.json` for a website:
+
+.. code-block:: django
+
+   [
+   {% for item in translations %}
+     {
+       "code": {{ item.language_code|json }},
+       "file": {{ item.filename|json }},
+       "name": {{ item.language_native_name|json }},
+       "dir": {{ item.language_direction|json }}
+     }{% if not forloop.last %},{% endif %}
+   {% endfor %}
+   ]
+
+Or generate :file:`languages.py` for an application:
+
+.. code-block:: django
+
+   names = {
+   {% for item in translations %}
+       {{ item.language_code|python }}: {{ item.language_native_name|python }},
+   {% endfor %}
+   }
+   completeness = {
+   {% for item in translations %}
+       {{ item.language_code|python }}: {{ item.stats.translated_percent|python }},
+   {% endfor %}
+   }
+
+The ``json`` and ``python`` filters serialize complete values, including string
+quotes and escaping. Do not add quotes around their output. They also support
+lists and dictionaries; ``{{ translations|json }}`` exports all available data.
+Dates and times are serialized as ISO-formatted strings.
 
 
 .. seealso::

--- a/weblate/addons/base.py
+++ b/weblate/addons/base.py
@@ -874,12 +874,22 @@ class BaseAddon[StoredConfigurationT, ConfigurationT](DocVersionsMixin):
         return True
 
     def render_repo_filename(
-        self, template: str, translation: Translation
+        self,
+        template: str,
+        translation: Translation | None = None,
+        *,
+        component: Component | None = None,
     ) -> str | None:
-        component = translation.component
+        if translation is not None:
+            component = translation.component
+        if component is None:
+            msg = "A translation or component is required"
+            raise ValueError(msg)
 
         # Render the template
-        filename = render_template(template, translation=translation)
+        filename = render_template(
+            template, translation=translation, component=component
+        )
 
         # Validate filename (not absolute or linking to parent dir)
         try:

--- a/weblate/addons/forms.py
+++ b/weblate/addons/forms.py
@@ -46,7 +46,12 @@ from weblate.utils.forms import (
     WeblateServiceURLField,
 )
 from weblate.utils.regex import compile_regex, regex_match, regex_sub
-from weblate.utils.render import validate_render, validate_render_translation
+from weblate.utils.render import (
+    validate_render,
+    validate_render_mock,
+    validate_render_translation,
+)
+from weblate.utils.stats import DummyTranslationStats
 from weblate.utils.validators import (
     validate_fedora_messaging_url,
     validate_filename,
@@ -653,7 +658,20 @@ class SphinxExtractPotForm(BaseExtractPotForm):
 class GenerateForm(
     BaseAddonForm["GenerateFileAddonConfiguration", "GenerateFileAddon"]
 ):
-    public_configuration_fields = frozenset({"filename"})
+    public_configuration_fields = frozenset({"filename", "scope"})
+
+    scope = forms.ChoiceField(
+        label=gettext_lazy("Output scope"),
+        choices=(
+            ("translation", gettext_lazy("One file per translation")),
+            ("component", gettext_lazy("One file per component")),
+        ),
+        initial="translation",
+        required=False,
+    )
+
+    def clean_scope(self):
+        return self.cleaned_data["scope"] or "translation"
 
     filename = forms.CharField(
         label=gettext_lazy("Name of generated file"), required=True
@@ -668,6 +686,7 @@ class GenerateForm(
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
+            Field("scope"),
             Field("filename"),
             Field("template"),
             ContextDiv(
@@ -675,11 +694,30 @@ class GenerateForm(
             ),
         )
 
-    def test_render(self, value) -> None:
-        validate_render_translation(value)
+    def test_render(self, value: str, *, filename: bool = False) -> None:
+        if self.cleaned_data.get("scope") == "component" and filename:
+            validate_render_mock(value)
+        elif self.cleaned_data.get("scope") == "component":
+            validate_render_mock(
+                value,
+                translations=[
+                    {
+                        "language_code": "cs",
+                        "language_name": "Czech",
+                        "language_native_name": "Čeština",
+                        "language_direction": "ltr",
+                        "filename": "cs.po",
+                        "url": "https://example.com/cs/",
+                        "is_source": False,
+                        "stats": DummyTranslationStats(None).get_data(),
+                    }
+                ],
+            )
+        else:
+            validate_render_translation(value)
 
     def clean_filename(self):
-        self.test_render(self.cleaned_data["filename"])
+        self.test_render(self.cleaned_data["filename"], filename=True)
         validate_filename(self.cleaned_data["filename"])
         return self.cleaned_data["filename"]
 
@@ -689,6 +727,7 @@ class GenerateForm(
 
     def serialize_form(self) -> GenerateFileAddonConfiguration:
         return {
+            "scope": self.cleaned_data["scope"],
             "filename": self.cleaned_data["filename"],
             "template": self.cleaned_data["template"],
         }

--- a/weblate/addons/generate.py
+++ b/weblate/addons/generate.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, ClassVar, NotRequired, TypedDict, cast
 
 from django.db.models import F, Prefetch, Q
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, override, to_language
 
 from weblate.addons.base import BaseAddon
 from weblate.addons.events import (
@@ -21,12 +21,14 @@ from weblate.trans.actions import ActionEvents
 from weblate.trans.models import Translation
 from weblate.utils.errors import report_error
 from weblate.utils.render import render_template
+from weblate.utils.site import get_site_url
 from weblate.utils.state import (
     STATE_EMPTY,
     STATE_NEEDS_REWRITING,
     STATE_READONLY,
     STATE_TRANSLATED,
 )
+from weblate.utils.stats import prefetch_stats
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -38,6 +40,7 @@ if TYPE_CHECKING:
 class GenerateFileAddonConfiguration(TypedDict):
     filename: str
     template: str
+    scope: NotRequired[str]
 
 
 class GenerateFileAddon(
@@ -46,6 +49,9 @@ class GenerateFileAddon(
     events: ClassVar[set[AddonEvent]] = {
         AddonEvent.EVENT_PRE_COMMIT,
         AddonEvent.EVENT_INSTALL,
+        AddonEvent.EVENT_POST_ADD,
+        AddonEvent.EVENT_POST_REMOVE,
+        AddonEvent.EVENT_COMPONENT_UPDATE,
     }
     name = "weblate.generate.generate"
     verbose = gettext_lazy("Statistics generator")
@@ -55,6 +61,80 @@ class GenerateFileAddon(
     settings_form = GenerateForm
     multiple = True
     icon = "poll.svg"
+
+    def normalize_configuration(
+        self, configuration: GenerateFileAddonConfiguration
+    ) -> GenerateFileAddonConfiguration:
+        return {"scope": "translation", **configuration}
+
+    def generate_component(self, component: Component) -> str | None:
+        configuration = self.configuration
+        filename = self.render_repo_filename(
+            configuration["filename"], component=component
+        )
+        if filename is None:
+            return None
+        translations = []
+        for translation in prefetch_stats(
+            component.translation_set.select_related("language").order_by(
+                "language_code"
+            )
+        ):
+            language = translation.language
+            with override(to_language(language.code)):
+                native_name = language.get_localized_name()
+            translations.append(
+                {
+                    "language_code": translation.language_code,
+                    "language_name": language.get_name(),
+                    "language_native_name": native_name,
+                    "language_direction": language.direction,
+                    "filename": translation.filename,
+                    "url": get_site_url(translation.get_absolute_url()),
+                    "is_source": translation.is_source,
+                    "stats": translation.stats.get_data(),
+                }
+            )
+        content = render_template(
+            configuration["template"], component=component, translations=translations
+        )
+        self.write_repo_file(filename, content)
+        return filename
+
+    def sync_component(self, component: Component) -> AddonEventOutcome | None:
+        if self.configuration["scope"] != "component":
+            return AddonEventOutcome.skipped(AddonActivityLogReason.NOT_APPLICABLE)
+        with component.repository.lock:
+            filename = self.generate_component(component)
+            if filename is None:
+                return AddonEventOutcome.error(AddonActivityLogReason.INVALID_OUTPUT)
+            self.commit_and_push(component, files=[filename])
+        return None
+
+    def component_update(
+        self, component: Component, activity_log_id: int | None = None
+    ) -> AddonEventOutcome | None:
+        return self.sync_component(component)
+
+    def sync_translation(self, translation: Translation) -> AddonEventOutcome | None:
+        if self.configuration["scope"] != "component":
+            return AddonEventOutcome.skipped(AddonActivityLogReason.NOT_APPLICABLE)
+        with translation.component.repository.lock:
+            filename = self.generate_component(translation.component)
+            if filename is None:
+                return AddonEventOutcome.error(AddonActivityLogReason.INVALID_OUTPUT)
+            translation.addon_commit_files.append(filename)
+        return None
+
+    def post_add(
+        self, translation: Translation, activity_log_id: int | None = None
+    ) -> AddonEventOutcome | None:
+        return self.sync_translation(translation)
+
+    def post_remove(
+        self, translation: Translation, activity_log_id: int | None = None
+    ) -> AddonEventOutcome | None:
+        return self.sync_translation(translation)
 
     @classmethod
     def can_install(
@@ -77,6 +157,8 @@ class GenerateFileAddon(
         store_hash: bool,
         activity_log_id: int | None = None,
     ) -> AddonEventOutcome | None:
+        if self.configuration["scope"] == "component":
+            return self.sync_translation(translation)
         configuration = self.configuration
         filename = self.render_repo_filename(configuration["filename"], translation)
         if not filename:
@@ -95,6 +177,8 @@ class GenerateFileAddon(
         store_hash: bool,
         activity_log_id: int | None = None,
     ) -> AddonEventOutcome | None:
+        if self.configuration["scope"] == "component":
+            return self.sync_component(component)
         result = None
         for translation in component.translation_set.exclude(
             language_id=cast("int", component.source_language_id)

--- a/weblate/addons/management/commands/list_addons.py
+++ b/weblate/addons/management/commands/list_addons.py
@@ -181,7 +181,10 @@ class Command(DocGeneratorCommand):
             events = ", ".join(
                 f":ref:`{event_link(event)}`" for event in sorted_events(obj.events)
             )
-            if POST_CONFIGURE_EVENTS & set(obj.events):
+            if (
+                POST_CONFIGURE_EVENTS & set(obj.events)
+                and AddonEvent.EVENT_INSTALL not in obj.events
+            ):
                 events = f":ref:`addon-event-add-on-installation`, {events}"
             addon_lines.extend(
                 [

--- a/weblate/addons/tests.py
+++ b/weblate/addons/tests.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import ast
 import base64
 import contextlib
 import importlib
@@ -38,7 +39,7 @@ from django.core.management.commands.makemessages import (
 )
 from django.core.management.utils import find_command
 from django.db import connection
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -75,7 +76,7 @@ from weblate.trans.models import (
     WorkflowSetting,
 )
 from weblate.trans.tests.test_views import ComponentTestCase, ViewTestCase
-from weblate.trans.tests.utils import TEST_DATA, get_optional_path
+from weblate.trans.tests.utils import TEST_DATA, RepoTestMixin, get_optional_path
 from weblate.utils.celery import handle_task_failure
 from weblate.utils.site import get_site_url
 from weblate.utils.state import (
@@ -801,7 +802,14 @@ class GettextRepositoryPathValidationTest(SimpleTestCase):
         addon = self.build_fake_addon(BaseAddon, component)
         translation = SimpleNamespace(component=component)
 
-        self.assertIsNone(addon.render_repo_filename("stats/cs.json", translation))
+        for scope in ({"translation": translation}, {"component": component}):
+            with (
+                self.subTest(scope=next(iter(scope))),
+                patch(
+                    "weblate.addons.base.render_template", return_value="stats/cs.json"
+                ),
+            ):
+                self.assertIsNone(addon.render_repo_filename("stats/cs.json", **scope))
         self.assertFalse(outside_target.exists())
 
     def test_render_repo_filename_rejects_symlinked_parent_outside_repository(
@@ -820,7 +828,17 @@ class GettextRepositoryPathValidationTest(SimpleTestCase):
         addon = self.build_fake_addon(BaseAddon, component)
         translation = SimpleNamespace(component=component)
 
-        self.assertIsNone(addon.render_repo_filename("stats/new/cs.json", translation))
+        for scope in ({"translation": translation}, {"component": component}):
+            with (
+                self.subTest(scope=next(iter(scope))),
+                patch(
+                    "weblate.addons.base.render_template",
+                    return_value="stats/new/cs.json",
+                ),
+            ):
+                self.assertIsNone(
+                    addon.render_repo_filename("stats/new/cs.json", **scope)
+                )
         self.assertFalse((Path(outside_dir) / "new").exists())
 
     def test_meson_form_rejects_gettext_symlink_outside_repository(self) -> None:
@@ -4963,6 +4981,145 @@ msgstr ""
         self.assertIn("stats/cs.json", commit)
         self.assertIn('"translated": 25', commit)
 
+    def test_generate_translation_scope_skips_component_events(self) -> None:
+        addon = GenerateFileAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "filename": "stats/{{ language_code }}.json",
+                "template": "{{ stats.translated_percent }}",
+            },
+        )
+        translation = self.get_translation()
+        for event, method, scope in (
+            (AddonEvent.EVENT_COMPONENT_UPDATE, "component_update", self.component),
+            (AddonEvent.EVENT_POST_ADD, "post_add", translation),
+            (AddonEvent.EVENT_POST_REMOVE, "post_remove", translation),
+        ):
+            with self.subTest(event=event):
+                handle_addon_event(
+                    event,
+                    method,
+                    (scope,),
+                    component=self.component,
+                    addon_queryset=[addon.instance],
+                )
+                activity = AddonActivityLog.objects.filter(addon=addon.instance).latest(
+                    "pk"
+                )
+                self.assertEqual(activity.status, AddonActivityLog.Status.SKIPPED)
+                self.assertEqual(
+                    activity.details["reason"], AddonActivityLogReason.NOT_APPLICABLE
+                )
+        self.assertFalse((Path(self.component.full_path) / "stats").exists())
+
+    def test_generate_component(self) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            addon = GenerateFileAddon.create(
+                component=self.component,
+                configuration={
+                    "scope": "component",
+                    "filename": "locales.json",
+                    "template": "{{ translations|json }}",
+                },
+            )
+        output = Path(self.component.full_path) / "locales.json"
+        rows = json.loads(output.read_text())
+        codes = [row["language_code"] for row in rows]
+        self.assertEqual(codes, sorted(codes))
+        czech = next(row for row in rows if row["language_code"] == "cs")
+        self.assertEqual(czech["language_name"], "Czech")
+        self.assertEqual(czech["language_native_name"], "Čeština")
+        self.assertEqual(czech["language_direction"], "ltr")
+        self.assertEqual(czech["stats"]["translated_percent"], 0)
+        self.assertTrue(any(row["is_source"] for row in rows))
+        revision = self.component.repository.last_revision
+        addon.component_update(self.component)
+        self.assertEqual(self.component.repository.last_revision, revision)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.edit_unit("Hello, world!\n", "Nazdar svete!\n")
+        self.get_translation().commit_pending("test", None)
+        rows = json.loads(output.read_text())
+        self.assertEqual(
+            next(row for row in rows if row["language_code"] == "cs")["stats"][
+                "translated_percent"
+            ],
+            25,
+        )
+        self.assertIn(
+            "locales.json",
+            self.component.repository.show(self.component.repository.last_revision),
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            translation = self.component.add_new_language(
+                Language.objects.get(code="sk"), None
+            )
+        self.assertIsNotNone(translation)
+        self.assertIn(
+            "sk", [row["language_code"] for row in json.loads(output.read_text())]
+        )
+        self.get_translation().remove(self.user)
+        self.assertNotIn(
+            "cs", [row["language_code"] for row in json.loads(output.read_text())]
+        )
+        self.assertIn(
+            "locales.json",
+            self.component.repository.show(self.component.repository.last_revision),
+        )
+
+    def test_generate_component_python(self) -> None:
+        GenerateFileAddon.create(
+            component=self.component,
+            configuration={
+                "scope": "component",
+                "filename": "languages.py",
+                "template": "names = {\n{% for item in translations %}{{ item.language_code|python }}: {{ item.language_native_name|python }},\n{% endfor %}}\n",
+            },
+        )
+        output = (Path(self.component.full_path) / "languages.py").read_text()
+        statement = ast.parse(output).body[0]
+        self.assertIsInstance(statement, ast.Assign)
+        names = ast.literal_eval(cast("ast.Assign", statement).value)
+        self.assertEqual(names["cs"], "Čeština")
+
+    def test_generate_component_reconfigure(self) -> None:
+        addon = GenerateFileAddon.create(
+            component=self.component,
+            configuration={
+                "scope": "component",
+                "filename": "locales.json",
+                "template": "{{ translations|json }}",
+            },
+        )
+        addon.instance.configuration["template"] = (
+            "{% for item in translations %}{% if not item.is_source %}{{ item.language_code }}\n{% endif %}{% endfor %}"
+        )
+        addon.instance.save()
+        addon.post_configure_run()
+        output = Path(self.component.full_path) / "locales.json"
+        self.assertEqual(output.read_text().splitlines(), ["cs", "de", "it"])
+
+    def test_generate_component_metadata_refresh(self) -> None:
+        addon = GenerateFileAddon.create(
+            component=self.component,
+            configuration={
+                "scope": "component",
+                "filename": "locales.json",
+                "template": "{{ translations|json }}",
+            },
+        )
+        language = self.get_translation().language
+        language.name = "Custom language"
+        language.direction = "rtl"
+        language.save()
+        addon.component_update(self.component)
+        rows = json.loads((Path(self.component.full_path) / "locales.json").read_text())
+        row = next(row for row in rows if row["language_code"] == "cs")
+        self.assertEqual(row["language_native_name"], "Custom language")
+        self.assertEqual(row["language_direction"], "rtl")
+
     def test_generate_rejects_broken_leaf_symlink(self) -> None:
         if not hasattr(os, "symlink"):
             self.skipTest("symlinks are not supported")
@@ -4981,6 +5138,44 @@ msgstr ""
             configuration={
                 "filename": "stats/{{ language_code }}.json",
                 "template": "{{ language_code }}",
+            },
+        )
+
+        handle_addon_event(
+            AddonEvent.EVENT_INSTALL,
+            "post_install",
+            (self.component, True),
+            component=self.component,
+            addon_queryset=[addon.instance],
+        )
+
+        self.assertEqual(translation.addon_commit_files, [])
+        self.assertFalse(outside_target.exists())
+        activity = AddonActivityLog.objects.get(addon=addon.instance)
+        self.assertEqual(activity.status, AddonActivityLog.Status.ERROR)
+        self.assertEqual(
+            activity.details["reason"], AddonActivityLogReason.INVALID_OUTPUT
+        )
+
+    def test_generate_component_rejects_broken_leaf_symlink(self) -> None:
+        if not hasattr(os, "symlink"):
+            self.skipTest("symlinks are not supported")
+
+        translation = self.get_translation()
+        translation.addon_commit_files = []
+        output = Path(self.component.full_path) / "stats" / "cs.json"
+        outside_dir = tempfile.mkdtemp()
+        outside_target = Path(outside_dir) / "cs.json"
+        self.addCleanup(shutil.rmtree, outside_dir, True)
+        output.parent.mkdir(parents=True)
+        output.symlink_to(outside_target)
+        addon = GenerateFileAddon.create(
+            component=self.component,
+            run=False,
+            configuration={
+                "scope": "component",
+                "filename": "stats/cs.json",
+                "template": "{{ translations|json }}",
             },
         )
 
@@ -5112,6 +5307,32 @@ msgstr ""
 
         self.assertEqual(fetch_strings.call_count, 1)
         self.assertEqual(fetch_strings.call_args.args[0].pk, source_translation.pk)
+
+
+class GenerateComponentTransactionTest(RepoTestMixin, TransactionTestCase):
+    def setUp(self) -> None:
+        self.clone_test_repos()
+        super().setUp()
+
+    def test_generate_component_repository_update(self) -> None:
+        component = self.create_component()
+        GenerateFileAddon.create(
+            component=component,
+            configuration={
+                "scope": "component",
+                "filename": "locales.json",
+                "template": "{{ translations|json }}",
+            },
+        )
+        translation = component.translation_set.get(language_code="cs")
+        filename = Path(get_optional_path(translation.get_filename()))
+        with filename.open("a", encoding="utf-8") as handle:
+            handle.write('\nmsgid "Added upstream"\nmsgstr ""\n')
+        component.create_translations_immediate(force=True)
+        rows = json.loads((Path(component.full_path) / "locales.json").read_text())
+        self.assertEqual(
+            next(row for row in rows if row["language_code"] == "cs")["stats"]["all"], 5
+        )
 
 
 class AppStoreAddonTest(ComponentTestCase):
@@ -8857,6 +9078,7 @@ class AddonConfigurationUnitTest(SimpleTestCase):
         self.assertEqual(
             form.serialize_form(),
             {
+                "scope": "translation",
                 "filename": "stats-{{ language_code }}.txt",
                 "template": "{{ language_code }}",
             },
@@ -8875,6 +9097,7 @@ class AddonConfigurationUnitTest(SimpleTestCase):
         self.assertEqual(
             addon.configuration,
             {
+                "scope": "translation",
                 "filename": "stats-{{ language_code }}.txt",
                 "template": "{{ language_code }}",
             },

--- a/weblate/api/tests.py
+++ b/weblate/api/tests.py
@@ -15543,6 +15543,27 @@ class AddonAPITest(APIBaseTest):
             request=request,
         )
 
+    def test_generate_component_configuration(self) -> None:
+        configuration = {
+            "scope": "component",
+            "filename": "locales.json",
+            "template": "{{ translations|json }}",
+        }
+        self.create_addon(name="weblate.generate.generate", configuration=configuration)
+        self.assertEqual(self.component.addon_set.get().configuration, configuration)
+
+    def test_generate_component_invalid_template(self) -> None:
+        self.create_addon(
+            name="weblate.generate.generate",
+            code=400,
+            configuration={
+                "scope": "component",
+                "filename": "{{ language_code }}.json",
+                "template": "{{ translations|json }}",
+            },
+        )
+        self.assertFalse(self.component.addon_set.exists())
+
     def test_create(self) -> None:
         # Not authenticated user
         response = self.create_addon(code=403, superuser=False)

--- a/weblate/templates/addons/generate_help.html
+++ b/weblate/templates/addons/generate_help.html
@@ -4,6 +4,14 @@
 
 <p>{% translate "You can use Django templates markup in both filename and content, for example:" %}</p>
 
+<p>{% translate "In component mode, loop over translations to access each language’s metadata and statistics. Use the json or python filter to serialize values in generated files." %}</p>
+
+<pre>{% verbatim %}{% for item in translations %}
+{{ item.language_code }}: {{ item.stats.translated_percent }}
+{% endfor %}{% endverbatim %}</pre>
+
+<p>{% translate "The translation variables below are available directly in translation mode, or on each item in component mode. Component and project variables are available in both modes." %}</p>
+
 <dl>
   <dt>
     <code>

--- a/weblate/utils/templatetags/safe_render.py
+++ b/weblate/utils/templatetags/safe_render.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import json
 import os.path
 
 from django import template
+from django.core.serializers.json import DjangoJSONEncoder
 from django.template.defaulttags import do_for, do_if
 
 register = template.Library()
@@ -34,3 +36,15 @@ def parentdir(value: str) -> str:
 
 register.tag("if")(do_if)
 register.tag("for")(do_for)
+
+
+@register.filter(name="json")
+def json_literal(value: object) -> str:
+    """Serialize template data as a JSON literal."""
+    return json.dumps(value, ensure_ascii=False, cls=DjangoJSONEncoder)
+
+
+@register.filter(name="python")
+def python_literal(value: object) -> str:
+    """Serialize plain template data as a Python literal."""
+    return repr(json.loads(json_literal(value)))

--- a/weblate/utils/tests/test_render.py
+++ b/weblate/utils/tests/test_render.py
@@ -2,6 +2,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
+import ast
+import json
+from datetime import UTC, datetime
+
 from django.test import SimpleTestCase
 from django.utils.translation import override
 
@@ -44,4 +50,24 @@ class RenderTest(SimpleTestCase):
                 "{{ value|parentdir|parentdir }}", value="foo/bar/weblate/test.po"
             ),
             "weblate/test.po",
+        )
+
+    def test_serialization(self) -> None:
+        value = {"name": 'Čeština "quoted" \n \\', "enabled": True, "missing": None}
+        self.assertEqual(
+            json.loads(render_template("{{ value|json }}", value=value)), value
+        )
+        self.assertEqual(
+            ast.literal_eval(render_template("{{ value|python }}", value=value)), value
+        )
+
+    def test_serialization_datetime(self) -> None:
+        value = {"last_change": datetime(2026, 1, 1, tzinfo=UTC)}
+        expected = {"last_change": "2026-01-01T00:00:00Z"}
+        self.assertEqual(
+            json.loads(render_template("{{ value|json }}", value=value)), expected
+        )
+        self.assertEqual(
+            ast.literal_eval(render_template("{{ value|python }}", value=value)),
+            expected,
         )


### PR DESCRIPTION
Extend the statistics generator with component-scoped output so projects can maintain locale lists and language statistics through templates. Include native names, direction, and JSON/Python serialization while preserving per-translation output.

Refresh on relevant repository events and report scope mismatches as skipped. Document the configuration and cover generation, lifecycle events, and validation.

Fixes #12295

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
