### PR TITLE
fix(accounts): avoid nested notification controls

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -2241,10 +2241,10 @@ onReady(() => {
 
   /* Notifications removal */
   document
-    .querySelectorAll(".nav-pills > li > a > button.btn-close")
+    .querySelectorAll(".nav-pills > li > button.btn-close")
     .forEach((button) => {
       button.addEventListener("click", (_e) => {
-        const link = button.parentElement;
+        const link = button.parentElement.querySelector("a[data-bs-target]");
         document
           .querySelectorAll(`${link.getAttribute("data-bs-target")} select`)
           .forEach((select) => {
@@ -2253,10 +2253,11 @@ onReady(() => {
         //      document.getElementById(link.getAttribute("href").substring(1)).remove();
         /* Activate watched tab */
         const watched = document.querySelector(
-          'a[data-bs-target="#notifications__1"',
+          'a[data-bs-target="#notifications__1"]',
         );
         bootstrap.Tab.getOrCreateInstance(watched).show();
         link.parentElement.remove();
+        watched.focus();
         addAlert(
           gettext(
             "Notification settings removed, please do not forget to save the changes.",

--- a/weblate/static/styles/main.css
+++ b/weblate/static/styles/main.css
@@ -1257,13 +1257,10 @@ th.number {
   background: none;
 }
 
-.nav-pills > li > a > button.btn-close {
+.nav-pills > li > button.btn-close {
   height: 14px;
   width: 14px;
   margin: 0 10px;
-}
-.nav-pills > li.active > a > button.btn-close {
-  color: var(--wl-color-translate-bg);
 }
 
 .bread-icon path,

--- a/weblate/templates/accounts/profile.html
+++ b/weblate/templates/accounts/profile.html
@@ -131,19 +131,18 @@
 
             <ul class="nav nav-pills">
               {% for form in notification_forms %}
-                <li class="nav-item">
+                <li class="nav-item d-flex align-items-center">
                   <a class="nav-link{% if form.is_active %} active{% endif %}"
                      data-bs-toggle="tab"
                      data-bs-target="#{{ form.prefix }}"
                      role="tab"
-                     href="#">
-                    {{ form.get_name }}
-                    {% if form.removable %}
-                      <button type="button"
-                              class="btn-close"
-                              title="{% translate "Remove this notification setting" %}"></button>
-                    {% endif %}
-                  </a>
+                     href="#">{{ form.get_name }}</a>
+                  {% if form.removable %}
+                    <button type="button"
+                            class="btn-close"
+                            aria-label="{% translate "Remove this notification setting" %}"
+                            title="{% translate "Remove this notification setting" %}"></button>
+                  {% endif %}
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
Move notification removal buttons beside tab links to resolve H054 and provide accessible labels. Update the removal handler and restore keyboard focus after removal.

Identified by djLint.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
