### PR TITLE
fix(translations): remove duplicate new unit radio IDs

### DIFF
--- a/weblate/static/loader-bootstrap.js
+++ b/weblate/static/loader-bootstrap.js
@@ -2455,37 +2455,23 @@ onReady(() => {
             });
         };
         const selected = this.value;
-        if (selected === "singular") {
-          document
-            .querySelectorAll("input[name='new-unit-form-type']")
-            .forEach((input) => {
-              input.removeAttribute("checked");
-            });
-          const showSingular = document.querySelector(
-            "#new-singular #show-singular",
-          );
-          if (showSingular !== null) {
-            showSingular.checked = true;
-          }
-          setContextValue("#new-singular", "#new-plural");
-          transferTextareaInputs("#new-plural", "#new-singular");
-          document.querySelector("#new-plural")?.classList.add("hidden");
-          document.querySelector("#new-singular")?.classList.remove("hidden");
-        } else if (selected === "plural") {
-          document
-            .querySelectorAll("input[name='new-unit-form-type']")
-            .forEach((input) => {
-              input.removeAttribute("checked");
-            });
-          const showPlural = document.querySelector("#new-plural #show-plural");
-          if (showPlural !== null) {
-            showPlural.checked = true;
-          }
-          setContextValue("#new-plural", "#new-singular");
-          transferTextareaInputs("#new-singular", "#new-plural");
-          document.querySelector("#new-singular")?.classList.add("hidden");
-          document.querySelector("#new-plural")?.classList.remove("hidden");
+        if (selected !== "singular" && selected !== "plural") {
+          return;
         }
+        const previous = selected === "singular" ? "plural" : "singular";
+        document
+          .querySelectorAll("input[name='new-unit-form-type']")
+          .forEach((input) => {
+            input.removeAttribute("checked");
+          });
+        const selectedInput = document.getElementById(`show-${selected}`);
+        if (selectedInput !== null) {
+          selectedInput.checked = true;
+        }
+        setContextValue(`#new-${selected}`, `#new-${previous}`);
+        transferTextareaInputs(`#new-${previous}`, `#new-${selected}`);
+        document.getElementById(`new-${previous}`)?.classList.add("hidden");
+        document.getElementById(`new-${selected}`)?.classList.remove("hidden");
       });
     });
 

--- a/weblate/templates/translation.html
+++ b/weblate/templates/translation.html
@@ -285,7 +285,7 @@
                     {% translate "Singular" %}
                   </label>
                   <label class="radio-inline">
-                    <input type="radio" name="new-unit-form-type" id="show-plural" value="plural">
+                    <input type="radio" name="new-unit-form-type" value="plural">
                     {% translate "Plural" %}
                   </label>
                 {% endif %}
@@ -310,7 +310,7 @@
                   {% csrf_token %}
                   {{ new_unit_plural_form|crispy }}
                   <label class="radio-inline">
-                    <input type="radio" name="new-unit-form-type" id="show-singular" value="singular">
+                    <input type="radio" name="new-unit-form-type" value="singular">
                     {% translate "Singular" %}
                   </label>
                   <label class="radio-inline">


### PR DESCRIPTION
Keep only the IDs used to select the active singular and plural controls to resolve template lint errors. Simplify the switcher into a shared flow using direct ID lookups.

Identified by djLint.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
